### PR TITLE
Move to random_pool for shuffling

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -351,7 +351,7 @@ void nano::network::broadcast_confirm_req (std::shared_ptr<nano::block> block_a)
 	 * if the votes for a block have not arrived in time.
 	 */
 	const size_t max_endpoints = 32;
-	std::random_shuffle (list->begin (), list->end ());
+	random_pool.Shuffle (list->begin (), list->end ());
 	if (list->size () > max_endpoints)
 	{
 		list->erase (list->begin () + max_endpoints, list->end ());

--- a/nano/node/peers.cpp
+++ b/nano/node/peers.cpp
@@ -92,7 +92,7 @@ std::deque<nano::endpoint> nano::peer_container::list ()
 	{
 		result.push_back (i->endpoint);
 	}
-	std::random_shuffle (result.begin (), result.end ());
+	random_pool.Shuffle (result.begin (), result.end ());
 	return result;
 }
 
@@ -115,7 +115,7 @@ std::vector<nano::peer_information> nano::peer_container::list_vector (size_t co
 	{
 		result.push_back (*i);
 	}
-	std::random_shuffle (result.begin (), result.end ());
+	random_pool.Shuffle (result.begin (), result.end ());
 	if (result.size () > count_a)
 	{
 		result.resize (count_a, nano::peer_information (nano::endpoint{}, 0));


### PR DESCRIPTION
This is part of https://github.com/nanocurrency/raiblocks/issues/1044, where `std::random_shuffle` is removed in C++17.