### PR TITLE
Add support for failing tests when a release_assert fails

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -20,7 +20,8 @@ add_executable (core_test
 	versioning.cpp
 	wallet.cpp
 	wallets.cpp
-	work_pool.cpp)
+	work_pool.cpp
+	testutil.cpp)
 
 target_compile_definitions(core_test
 		PRIVATE

--- a/nano/core_test/testutil.cpp
+++ b/nano/core_test/testutil.cpp
@@ -1,0 +1,21 @@
+#if ACTIVE_NETWORK == nano_test_network
+#include <iostream>
+#include <nano/lib/utility.hpp>
+#include <gtest/gtest.h>
+
+/*
+ * If we are running under the test harness, mark this test as failed
+ * with additional information so that we can gather information
+ * about further tests
+ */
+
+void release_assert_internal (bool check, const char * check_expr, const char * file, unsigned int line)
+{
+	if (check)
+	{
+		return;
+	}
+
+	ASSERT_TRUE (false) << "Assertion (" << check_expr << ") failed at " << file << ":" << line;
+}
+#endif

--- a/nano/core_test/testutil.cpp
+++ b/nano/core_test/testutil.cpp
@@ -1,7 +1,7 @@
 #if ACTIVE_NETWORK == nano_test_network
+#include <gtest/gtest.h>
 #include <iostream>
 #include <nano/lib/utility.hpp>
-#include <gtest/gtest.h>
 
 /*
  * If we are running under the test harness, mark this test as failed

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -84,6 +84,14 @@ void nano::thread_attributes::set (boost::thread::attributes & attrs)
 /*
  * Backing code for "release_assert", which is itself a macro
  */
+#if ACTIVE_NETWORK == nano_test_network
+/*
+ * If we are running under the test harness, create this as a
+ * weak symbol so the one we provide as part of gtest can
+ * override it.
+ */
+#  pragma weak release_assert_internal
+#endif
 void release_assert_internal (bool check, const char * check_expr, const char * file, unsigned int line)
 {
 	if (check)
@@ -91,6 +99,6 @@ void release_assert_internal (bool check, const char * check_expr, const char * 
 		return;
 	}
 
-	std::cerr << "Assertion (" << check_expr << ") failed " << file << ":" << line << std::endl;
-	abort ();
+	std::cerr << "Assertion (" << check_expr << ") failed at " << file << ":" << line << std::endl;
+	abort();
 }

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -90,7 +90,7 @@ void nano::thread_attributes::set (boost::thread::attributes & attrs)
  * weak symbol so the one we provide as part of gtest can
  * override it.
  */
-#  pragma weak release_assert_internal
+#pragma weak release_assert_internal
 #endif
 void release_assert_internal (bool check, const char * check_expr, const char * file, unsigned int line)
 {


### PR DESCRIPTION
Rather than aborting the test suite when a "release_assert" fails, simply abort the current test.

This is only applied when compiling for the test network.