### PR TITLE
adding support for rpm building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,13 +159,3 @@ Artful OPTIMIZED:
 
   script:
     - ./ci/build-gitlab.sh
-
-Centos:
-  stage: build
-  image: centos:centos7
-
-  before_script:
-    - ./util/build_prep/update-common && ./util/build_prep/centos/prep.sh
-
-  script:
-    - ./ci/build-centos.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,3 +160,12 @@ Artful OPTIMIZED:
   script:
     - ./ci/build-gitlab.sh
 
+Centos:
+  stage: build
+  image: centos:centos7
+
+  before_script:
+    - ./util/build_prep/update-common && ./util/build_prep/centos/prep.sh
+
+  script:
+    - ./ci/build-centos.sh

--- a/ci/build-centos.sh
+++ b/ci/build-centos.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+TAGS=`git describe --abbrev=0 --tags`
+VERSIONS=`echo $TAGS | sed 's/V//'`
+RELEASE=`echo $CI_JOB_ID`
+
+run_source() {
+    ./util/makesrc $TAGS
+}
+
+run_build() {
+    mkdir -p ~/rpmbuild/SOURCES/
+    mv -f ~/nano-${VERSIONS}.tar.gz ~/rpmbuild/SOURCES/.
+    scl enable llvm-toolset-7 devtoolset-7 'rpmbuild -ba nanocurrency.spec'
+    scl enable llvm-toolset-7 devtoolset-7 'rpmbuild -ba nanocurrency-beta.spec'
+}
+
+run_update() {
+    for file in ./nanocurrency*.in; do
+	outfile="$(echo "${file}" | sed 's@\.in$@@')"
+    
+    	echo "Updating \"${outfile}\"..."
+
+    	rm -f "${file}.new"
+    	awk -v srch="@VERSION@" -v repl="$VERSIONS" -v srch2="@RELEASE@" -v repl2="$RELEASE" '{ sub(srch,repl,$0); sub(srch2,repl2, $0); print $0}' < ${file} > ${file}.new
+    	rm -fr "${outfile}"
+    	cat "${file}.new" > "${outfile}"
+    	rm -f "${file}.new"
+    	chmod 755 "${outfile}"
+    done
+}
+
+run_update
+run_source
+run_build

--- a/etc/systemd/nanocurrency-beta.service
+++ b/etc/systemd/nanocurrency-beta.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Nano Daemon beta network
+After=network.target
+
+[Service]
+Type=simple
+User=nanocurrency
+WorkingDirectory=/var/nanocurrency/NanoBeta
+ExecStart=/usr/bin/nano_node-beta --daemon
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/nanocurrency.service
+++ b/etc/systemd/nanocurrency.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Nano Daemon live network
+After=network.target
+
+[Service]
+Type=simple
+User=nanocurrency
+WorkingDirectory=/var/nanocurrency/Nano
+ExecStart=/usr/bin/nano_node --daemon
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/nanocurrency-beta.spec.in
+++ b/nanocurrency-beta.spec.in
@@ -1,0 +1,63 @@
+Name:                   nanocurrency-beta
+Version:                @VERSION@ 
+Release:                @RELEASE@%{?dist}
+Summary:                Nanocurrency Beta Daemon
+License:                BSD-2-Clause
+URL:                    https://nano.org/
+Requires(pre):          /usr/sbin/useradd, /usr/bin/getent
+Requires(postun):       /usr/sbin/userdel
+BuildRequires:          make, libstdc++-static, glibc-devel, glibc-headers
+Source:                 nano-%{version}.tar.gz
+
+%description
+This is nanocurrency daemon.  Nano is a digital currency that is
+peer-to-peer, decentralized, and trustless. This package includes
+the nano daemon, and a service.
+
+%prep
+if [ ! -x "$(which cmake)" ]; then
+	echo "cmake must exist, try:" >&2
+	echo "      scl enable llvm-toolset-7 devtoolset-7 'rpmbuild ...'" >&2
+	exit 1
+fi
+if cc --std=c++14 --version 2>&1 >/dev/null | grep '^' >/dev/null; then
+	echo "Unsupported C++ compiler, try:" >&2
+	echo "      scl enable llvm-toolset-7 devtoolset-7 'rpmbuild ...'" >&2
+	exit 1
+fi
+if test ! -d /usr/local/boost; then
+	echo "Boost should be in /usr/local/boost" >&2
+	exit 1
+fi
+%autosetup -n nano-%{version}
+
+%build
+cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBOOST_ROOT=/usr/local/boost -DACTIVE_NETWORK=nano_beta_network .
+make nano_node %{?_smp_mflags}
+
+%install
+if [ ! %{buildroot} = "/" ]; then %{__rm} -rf %{buildroot}; fi
+mkdir -p %{buildroot}/usr/bin
+mkdir -p %{buildroot}/etc/systemd/system/
+cp nano_node %{buildroot}/usr/bin/nano_node-beta
+cp etc/systemd/nanocurrency-beta.service %{buildroot}/etc/systemd/system/nanocurrency-beta.service
+
+%clean
+if [ ! %{buildroot} = "/" ]; then %{__rm} -rf %{buildroot}; fi
+
+%files
+%defattr(755,root,root)
+%{_bindir}/nano_node-beta
+%attr(644,root,root) /etc/systemd/system/nanocurrency-beta.service
+
+%pre
+PATH="/usr/bin:/usr/sbin:/bin:/sbin:${PATH}"; export PATH
+mkdir -p /var/nanocurrency/Nano
+getent group nanocurrency >/dev/null || groupadd --system nanocurrency || exit 1
+getent passwd nanocurrency >/dev/null || useradd --system --create-home --home-dir /var/nanocurrency --shell /bin/bash --comment "Nanocurrency Daemon user" --gid nanocurrency nanocurrency || exit 1
+chown -R nanocurrency:nanocurrency /var/nanocurrency
+chmod 700 /var/nanocurrency
+
+%postun
+PATH="/usr/bin:/usr/sbin:/bin:/sbin:${PATH}"; export PATH
+userdel nanocurrency >/dev/null 2>/dev/null || :

--- a/nanocurrency.spec.in
+++ b/nanocurrency.spec.in
@@ -1,0 +1,63 @@
+Name:                   nanocurrency
+Version:                @VERSION@ 
+Release:                @RELEASE@%{?dist}
+Summary:                Nanocurrency Daemon
+License:                BSD-2-Clause
+URL:                    https://nano.org/
+Requires(pre):          /usr/sbin/useradd, /usr/bin/getent
+Requires(postun):       /usr/sbin/userdel
+BuildRequires:          make, libstdc++-static, glibc-devel, glibc-headers
+Source:                 nano-%{version}.tar.gz
+
+%description
+This is nanocurrency daemon.  Nano is a digital currency that is
+peer-to-peer, decentralized, and trustless. This package includes
+the nano daemon, and a service.
+
+%prep
+if [ ! -x "$(which cmake)" ]; then
+	echo "cmake must exist, try:" >&2
+	echo "      scl enable llvm-toolset-7 devtoolset-7 'rpmbuild ...'" >&2
+	exit 1
+fi
+if cc --std=c++14 --version 2>&1 >/dev/null | grep '^' >/dev/null; then
+	echo "Unsupported C++ compiler, try:" >&2
+	echo "      scl enable llvm-toolset-7 devtoolset-7 'rpmbuild ...'" >&2
+	exit 1
+fi
+if test ! -d /usr/local/boost; then
+	echo "Boost should be in /usr/local/boost" >&2
+	exit 1
+fi
+%autosetup -n nano-%{version}
+
+%build
+cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBOOST_ROOT=/usr/local/boost .
+make nano_node %{?_smp_mflags}
+
+%install
+if [ ! %{buildroot} = "/" ]; then %{__rm} -rf %{buildroot}; fi
+mkdir -p %{buildroot}/usr/bin
+mkdir -p %{buildroot}/etc/systemd/system/
+cp nano_node %{buildroot}/usr/bin/nano_node
+cp etc/systemd/nanocurrency.service %{buildroot}/etc/systemd/system/nanocurrency.service
+
+%clean
+if [ ! %{buildroot} = "/" ]; then %{__rm} -rf %{buildroot}; fi
+
+%files
+%defattr(755,root,root)
+%{_bindir}/nano_node
+%attr(644,root,root) /etc/systemd/system/nanocurrency.service
+
+%pre
+PATH="/usr/bin:/usr/sbin:/bin:/sbin:${PATH}"; export PATH
+mkdir -p /var/nanocurrency/Nano
+getent group nanocurrency >/dev/null || groupadd --system nanocurrency || exit 1
+getent passwd nanocurrency >/dev/null || useradd --system --create-home --home-dir /var/nanocurrency --shell /bin/bash --comment "Nanocurrency Daemon user" --gid nanocurrency nanocurrency || exit 1
+chown -R nanocurrency:nanocurrency /var/nanocurrency
+chmod 700 /var/nanocurrency
+
+%postun
+PATH="/usr/bin:/usr/sbin:/bin:/sbin:${PATH}"; export PATH
+userdel nanocurrency >/dev/null 2>/dev/null || :

--- a/util/build_prep/centos/prep.sh.in
+++ b/util/build_prep/centos/prep.sh.in
@@ -1,0 +1,39 @@
+#! /usr/bin/env bash
+
+# -----BEGIN COMMON.SH-----
+# -----END COMMON.SH-----
+
+yes | yum update -y
+
+yes | yum install -y git wget openssl bzip2; # <boost>
+
+yes | yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; # epel 7
+yes | yum install -y jq || exit 1
+
+yes | yum install -y rpm-build || exit 1
+yes | yum install -y glibc-devel glibc-headers make which libstdc++-static || exit 1
+yes | yum install -y centos-release-scl || exit 1
+yes | yum install -y llvm-toolset-7-cmake devtoolset-7-llvm|| exit 1
+
+# Ensure we have a new enough Boost
+(
+	eval "$(scl enable llvm-toolset-7 devtoolset-7 "bash -c 'set | grep ^PATH='")"
+	if ! have boost; then
+		bootstrap_boost -m -k
+	fi
+
+	if ! have boost; then
+	        echo "Unable to install boost" >&2
+
+		exit 1
+	fi
+
+	if ! version_min 'boost --version' 1.65.999; then
+		echo "boost version too low (1.66.0+ required)" >&2
+	        exit 1
+	fi
+
+	exit 0
+) || exit 1
+
+exit 0

--- a/util/build_prep/centos/prep.sh.in
+++ b/util/build_prep/centos/prep.sh.in
@@ -19,7 +19,7 @@ yes | yum install -y llvm-toolset-7-cmake devtoolset-7-llvm|| exit 1
 (
 	eval "$(scl enable llvm-toolset-7 devtoolset-7 "bash -c 'set | grep ^PATH='")"
 	if ! have boost; then
-		bootstrap_boost -m -k
+		bootstrap_boost -m
 	fi
 
 	if ! have boost; then


### PR DESCRIPTION
This is a work in progress needing scripting and cleanup

- [x] rename spec to follow nanocurrency-<major>.<minor>.<patch>.<arch/os>.<ext> format
- [x] script to build from tags automatically
- [x] cleanup build script to include boost cmake gcc and other required dependencies
- [x] build for beta and live networks