### PR TITLE
Lock ordering potential deadlock detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if (BOOST_ROOT)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 endif ()
 
-find_package (Boost 1.66.0 REQUIRED COMPONENTS filesystem log thread program_options stacktrace_basic)
+find_package (Boost 1.66.0 REQUIRED COMPONENTS filesystem log thread program_options)
 
 add_subdirectory(ed25519-donna)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if (BOOST_ROOT)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 endif ()
 
-find_package (Boost 1.66.0 REQUIRED COMPONENTS filesystem log thread program_options)
+find_package (Boost 1.66.0 REQUIRED COMPONENTS filesystem log thread program_options stacktrace_basic)
 
 add_subdirectory(ed25519-donna)
 

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -1435,7 +1435,7 @@ TEST (node, vote_replay)
 	}
 	{
 		auto transaction (system.nodes[0]->store.tx_begin ());
-		std::lock_guard<std::mutex> lock (boost::polymorphic_downcast<rai::mdb_store *> (system.nodes[0]->store_impl.get ())->cache_mutex);
+		std::lock_guard<rai::mutex> lock (boost::polymorphic_downcast<rai::mdb_store *> (system.nodes[0]->store_impl.get ())->cache_mutex);
 		auto vote (system.nodes[0]->store.vote_current (transaction, rai::test_genesis_key.pub));
 		ASSERT_EQ (nullptr, vote);
 	}
@@ -1448,7 +1448,7 @@ TEST (node, vote_replay)
 	{
 		auto ec = system.poll ();
 		auto transaction (system.nodes[0]->store.tx_begin ());
-		std::lock_guard<std::mutex> lock (boost::polymorphic_downcast<rai::mdb_store *> (system.nodes[0]->store_impl.get ())->cache_mutex);
+		std::lock_guard<rai::mutex> lock (boost::polymorphic_downcast<rai::mdb_store *> (system.nodes[0]->store_impl.get ())->cache_mutex);
 		auto vote (system.nodes[0]->store.vote_current (transaction, rai::test_genesis_key.pub));
 		done = vote && (vote->sequence >= 10000);
 		ASSERT_NO_ERROR (ec);

--- a/rai/core_test/processor_service.cpp
+++ b/rai/core_test/processor_service.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <rai/lib/mutex.hpp>
 #include <rai/node/node.hpp>
 
 #include <atomic>

--- a/rai/lib/CMakeLists.txt
+++ b/rai/lib/CMakeLists.txt
@@ -35,6 +35,23 @@ target_link_libraries (rai_lib
 	${CRYPTOPP_LIBRARY}
 	Boost::boost)
 
+string (TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+
+if (uppercase_CMAKE_BUILD_TYPE MATCHES "DEBUG")
+	set (RAI_DEADLOCK_DETECTION_default ON)
+else ()
+	set (RAI_DEADLOCK_DETECTION_default OFF)
+endif()
+
+option (RAI_DEADLOCK_DETECTION "Enable deadlock ordering issue detection" "${RAI_DEADLOCK_DETECTION_default}")
+
+if (RAI_DEADLOCK_DETECTION)
+	if (UNIX)
+		target_link_libraries (rai_lib dl)
+	endif ()
+	add_compile_definitions (RAI_DEADLOCK_DETECTION)
+endif ()
+
 target_compile_definitions(rai_lib
 	PUBLIC
 		-DACTIVE_NETWORK=${ACTIVE_NETWORK}

--- a/rai/lib/CMakeLists.txt
+++ b/rai/lib/CMakeLists.txt
@@ -49,7 +49,7 @@ if (RAI_DEADLOCK_DETECTION)
 	if (UNIX)
 		target_link_libraries (rai_lib dl)
 	endif ()
-	add_compile_definitions (RAI_DEADLOCK_DETECTION)
+	add_definitions (-DRAI_DEADLOCK_DETECTION)
 endif ()
 
 target_compile_definitions(rai_lib

--- a/rai/lib/CMakeLists.txt
+++ b/rai/lib/CMakeLists.txt
@@ -25,7 +25,9 @@ add_library (rai_lib
 	utility.cpp
 	utility.hpp
 	work.hpp
-	work.cpp)
+	work.cpp
+	mutex.hpp
+	mutex.cpp)
 
 target_link_libraries (rai_lib
 	xxhash

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -125,7 +125,7 @@ void rai::destroy_resource_lock_id (size_t id)
 	free_lock_ids.push_back (id);
 	for (auto & lock_info : locks_info)
 	{
-		lock_info.locked_after[id].store(nullptr, std::memory_order_relaxed);
+		lock_info.locked_after[id].store (nullptr, std::memory_order_relaxed);
 	}
 }
 

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -123,6 +123,10 @@ void rai::destroy_resource_lock_id (size_t id)
 {
 	std::unique_lock<std::shared_timed_mutex> locks_info_guard (lock_info_mutex);
 	free_lock_ids.push_back (id);
+	for (auto & lock_info : locks_info)
+	{
+		lock_info.locked_after[id].store(nullptr, std::memory_order_relaxed);
+	}
 }
 
 rai::mutex::mutex () noexcept :

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -79,7 +79,7 @@ void rai::notify_resource_locking (size_t id)
 			boost::stacktrace::stacktrace * expected (nullptr);
 			if (lock_info.locked_after[other_id].compare_exchange_strong (expected, backtrace_alloc, std::memory_order_acq_rel))
 			{
-				auto other_backtrace (locks_info[other_id].locked_after[id].load (std::memory_order_acq_rel));
+				auto other_backtrace (locks_info[other_id].locked_after[id].load (std::memory_order_acquire));
 				if (other_backtrace)
 				{
 					std::cerr << "Potential deadlock detected between resource ids " << id << " and " << other_id << std::endl;

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#define _GNU_SOURCE
+#endif
+
 #include <rai/lib/mutex.hpp>
 
 #ifdef RAI_DEADLOCK_DETECTION

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -1,6 +1,6 @@
-#ifndef RAI_DEADLOCK_DETECTION
-
 #include <rai/lib/mutex.hpp>
+
+#ifndef RAI_DEADLOCK_DETECTION
 
 #include <atomic>
 #include <boost/stacktrace.hpp>

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -1,6 +1,5 @@
-#ifdef __APPLE__
+// Needed for backtraces on MacOS
 #define _GNU_SOURCE
-#endif
 
 #include <rai/lib/mutex.hpp>
 

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -1,0 +1,159 @@
+#include <rai/lib/mutex.hpp>
+
+#include <boost/stacktrace.hpp>
+#include <cstdlib>
+#include <mutex>
+#include <shared_mutex>
+#include <iostream>
+#include <atomic>
+#include <thread>
+
+template <class T>
+class movable_atomic : public std::atomic<T>
+{
+public:
+    movable_atomic (T inner) :
+    std::atomic<T> (inner)
+    {
+    }
+
+    movable_atomic (movable_atomic & other) :
+    std::atomic<T> (static_cast<T> (other))
+    {
+    }
+};
+
+class lock_info
+{
+public:
+	std::vector<movable_atomic<boost::stacktrace::stacktrace *>> locked_after;
+	boost::stacktrace::stacktrace creation_backtrace;
+};
+
+static std::vector<lock_info> locks_info;
+static std::shared_timed_mutex locks_info_mutex;
+
+thread_local std::vector<std::pair<size_t, boost::stacktrace::stacktrace>> thread_has_locks;
+
+size_t rai::create_resource_lock_id ()
+{
+#ifndef NDEBUG
+	std::unique_lock<std::shared_timed_mutex> locks_info_guard (locks_info_mutex);
+	for (auto & lock_info : locks_info)
+	{
+		lock_info.locked_after.push_back (movable_atomic<boost::stacktrace::stacktrace *> (nullptr));
+	}
+	std::vector<movable_atomic<boost::stacktrace::stacktrace *>> locked_after (locks_info.size () + 1, movable_atomic<boost::stacktrace::stacktrace *> (nullptr));
+	locks_info.push_back (lock_info{ locked_after, boost::stacktrace::stacktrace () });
+	return locks_info.size () - 1;
+#else
+	return 0;
+#endif
+}
+
+void rai::notify_resource_locking (size_t id)
+{
+#ifndef NDEBUG
+	std::shared_lock<std::shared_timed_mutex> locks_info_guard (locks_info_mutex);
+	auto & lock_info (locks_info[id]);
+	for (auto & locked_after : thread_has_locks)
+	{
+		auto other_id (locked_after.first);
+		if (!lock_info.locked_after[other_id].load (std::memory_order_relaxed))
+		{
+			boost::stacktrace::stacktrace * backtrace_alloc (new boost::stacktrace::stacktrace (locked_after.second));
+            boost::stacktrace::stacktrace * expected (nullptr);
+			if (lock_info.locked_after[other_id].compare_exchange_strong (expected, backtrace_alloc, std::memory_order_acq_rel))
+			{
+				auto other_backtrace (locks_info[other_id].locked_after[id].load (std::memory_order_acq_rel));
+				if (other_backtrace)
+				{
+					std::cerr << "Potential deadlock detected between resource ids " << id << " and " << other_id << std::endl;
+					std::cerr << std::endl;
+					std::cerr << "Resource id " << id << " creation backtrace:" << std::endl;
+					std::cerr << lock_info.creation_backtrace << std::endl;
+					std::cerr << "Resource id " << other_id << " creation backtrace:" << std::endl;
+					std::cerr << locks_info[other_id].creation_backtrace << std::endl;
+					std::cerr << "Backtrace of " << id << " -> " << other_id << " locking:" << std::endl;
+					std::cerr << *other_backtrace << std::endl;
+					std::cerr << "Backtrace of " << other_id << " -> " << id << " locking:" << std::endl;
+					std::cerr << locked_after.second << std::endl;
+					abort ();
+				}
+			}
+			else
+			{
+				delete backtrace_alloc;
+			}
+		}
+	}
+	thread_has_locks.push_back (std::make_pair (id, boost::stacktrace::stacktrace ()));
+#endif
+}
+
+void rai::notify_resource_unlocking (size_t id)
+{
+#ifndef NDEBUG
+	auto it (thread_has_locks.end ());
+	auto end (thread_has_locks.begin ());
+	while (it != end)
+	{
+		--it;
+		if (it->first == id)
+		{
+			thread_has_locks.erase (it);
+            break;
+		}
+	}
+#endif
+}
+
+rai::mutex::mutex () noexcept :
+std::mutex (),
+resource_lock_id (create_resource_lock_id ())
+{
+}
+
+void rai::mutex::lock ()
+{
+	rai::notify_resource_locking (resource_lock_id);
+	std::mutex::lock ();
+}
+
+bool rai::mutex::try_lock ()
+{
+	auto locked (std::mutex::try_lock ());
+	if (locked)
+	{
+		rai::notify_resource_locking (resource_lock_id);
+	}
+	return locked;
+}
+
+void rai::mutex::unlock ()
+{
+	rai::notify_resource_unlocking (resource_lock_id);
+	std::mutex::unlock ();
+}
+
+rai::condition_variable::condition_variable () :
+std::condition_variable ()
+{
+}
+
+void rai::condition_variable::notify_one () noexcept
+{
+	std::condition_variable::notify_one ();
+}
+
+void rai::condition_variable::notify_all () noexcept
+{
+	std::condition_variable::notify_all ();
+}
+
+void rai::condition_variable::wait (std::unique_lock<rai::mutex> & lock)
+{
+    std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+	std::condition_variable::wait (std_lock);
+    std_lock.release ();
+}

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -1,4 +1,4 @@
-#ifndef NDEBUG
+#ifndef RAI_DEADLOCK_DETECTION
 
 #include <rai/lib/mutex.hpp>
 

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -86,16 +86,29 @@ void rai::notify_resource_locking (size_t id)
 				auto other_backtrace (locks_info[other_id].locked_after[id].load (std::memory_order_acquire));
 				if (other_backtrace)
 				{
-					std::cerr << "Potential deadlock detected between resource ids " << id << " and " << other_id << std::endl;
-					std::cerr << std::endl;
-					std::cerr << "Resource id " << id << " creation backtrace:" << std::endl;
-					std::cerr << lock_info.creation_backtrace << std::endl;
-					std::cerr << "Resource id " << other_id << " creation backtrace:" << std::endl;
-					std::cerr << locks_info[other_id].creation_backtrace << std::endl;
-					std::cerr << "Backtrace of " << id << " -> " << other_id << " locking:" << std::endl;
-					std::cerr << *other_backtrace << std::endl;
-					std::cerr << "Backtrace of " << other_id << " -> " << id << " locking:" << std::endl;
-					std::cerr << locked_after.second << std::endl;
+					if (id == other_id)
+					{
+						std::cerr << "Potential deadlock detected with resource id " << id << " attempted to be recursively locked" << std::endl;
+						std::cerr << "Resource id " << id << " creation backtrace:" << std::endl;
+						std::cerr << lock_info.creation_backtrace << std::endl;
+						std::cerr << "First lock backtrace" << std::endl;
+						std::cerr << locked_after.second << std::endl;
+						std::cerr << "Second lock backtrace" << std::endl;
+						std::cerr << boost::stacktrace::stacktrace () << std::endl;
+					}
+					else
+					{
+						std::cerr << "Potential deadlock detected between resource ids " << id << " and " << other_id << std::endl;
+						std::cerr << std::endl;
+						std::cerr << "Resource id " << id << " creation backtrace:" << std::endl;
+						std::cerr << lock_info.creation_backtrace << std::endl;
+						std::cerr << "Resource id " << other_id << " creation backtrace:" << std::endl;
+						std::cerr << locks_info[other_id].creation_backtrace << std::endl;
+						std::cerr << "Backtrace of " << id << " -> " << other_id << " locking:" << std::endl;
+						std::cerr << *other_backtrace << std::endl;
+						std::cerr << "Backtrace of " << other_id << " -> " << id << " locking:" << std::endl;
+						std::cerr << locked_after.second << std::endl;
+					}
 					abort ();
 				}
 			}

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -1,6 +1,6 @@
 #include <rai/lib/mutex.hpp>
 
-#ifndef RAI_DEADLOCK_DETECTION
+#ifdef RAI_DEADLOCK_DETECTION
 
 #include <atomic>
 #include <boost/stacktrace.hpp>

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -22,6 +22,7 @@ public:
 	{
 	}
 
+	//! WARNING: only use this if you are the only one accessing the atomic
 	movable_atomic (movable_atomic & other) :
 	std::atomic<T> (static_cast<T> (other))
 	{

--- a/rai/lib/mutex.cpp
+++ b/rai/lib/mutex.cpp
@@ -2,27 +2,27 @@
 
 #include <rai/lib/mutex.hpp>
 
+#include <atomic>
 #include <boost/stacktrace.hpp>
 #include <cstdlib>
+#include <iostream>
 #include <mutex>
 #include <shared_mutex>
-#include <iostream>
-#include <atomic>
 #include <thread>
 
 template <class T>
 class movable_atomic : public std::atomic<T>
 {
 public:
-    movable_atomic (T inner) :
-    std::atomic<T> (inner)
-    {
-    }
+	movable_atomic (T inner) :
+	std::atomic<T> (inner)
+	{
+	}
 
-    movable_atomic (movable_atomic & other) :
-    std::atomic<T> (static_cast<T> (other))
-    {
-    }
+	movable_atomic (movable_atomic & other) :
+	std::atomic<T> (static_cast<T> (other))
+	{
+	}
 };
 
 class lock_info
@@ -76,7 +76,7 @@ void rai::notify_resource_locking (size_t id)
 		if (!lock_info.locked_after[other_id].load (std::memory_order_relaxed))
 		{
 			boost::stacktrace::stacktrace * backtrace_alloc (new boost::stacktrace::stacktrace (locked_after.second));
-            boost::stacktrace::stacktrace * expected (nullptr);
+			boost::stacktrace::stacktrace * expected (nullptr);
 			if (lock_info.locked_after[other_id].compare_exchange_strong (expected, backtrace_alloc, std::memory_order_acq_rel))
 			{
 				auto other_backtrace (locks_info[other_id].locked_after[id].load (std::memory_order_acq_rel));
@@ -114,7 +114,7 @@ void rai::notify_resource_unlocking (size_t id)
 		if (it->first == id)
 		{
 			thread_has_locks.erase (it);
-            break;
+			break;
 		}
 	}
 }
@@ -175,9 +175,9 @@ void rai::condition_variable::notify_all () noexcept
 
 void rai::condition_variable::wait (std::unique_lock<rai::mutex> & lock)
 {
-    std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+	std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
 	std::condition_variable::wait (std_lock);
-    std_lock.release ();
+	std_lock.release ();
 }
 
 #endif

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -9,6 +9,7 @@ namespace rai
 size_t create_resource_lock_id ();
 void notify_resource_locking (size_t);
 void notify_resource_unlocking (size_t);
+void destroy_resource_lock_id (size_t);
 
 class condition_variable;
 
@@ -18,6 +19,7 @@ class mutex : std::mutex
 
 public:
 	mutex () noexcept;
+    ~mutex ();
 	void lock ();
 	bool try_lock ();
 	void unlock ();

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -22,7 +22,7 @@ class mutex : std::mutex
 
 public:
 	mutex () noexcept;
-    ~mutex ();
+	~mutex ();
 	void lock ();
 	bool try_lock ();
 	void unlock ();
@@ -40,39 +40,39 @@ public:
 	void wait (std::unique_lock<rai::mutex> &);
 	template <class Predicate>
 	void wait (std::unique_lock<rai::mutex> & lock, Predicate pred)
-    {
-        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
-        std::condition_variable::wait (std_lock, pred);
-        std_lock.release ();
-    }
+	{
+		std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+		std::condition_variable::wait (std_lock, pred);
+		std_lock.release ();
+	}
 	template <class Rep, class Period>
 	void wait_for (std::unique_lock<rai::mutex> & lock, const std::chrono::duration<Rep, Period> & rel_time)
-    {
-        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
-        std::condition_variable::wait_for (std_lock, rel_time);
-        std_lock.release ();
-    }
+	{
+		std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+		std::condition_variable::wait_for (std_lock, rel_time);
+		std_lock.release ();
+	}
 	template <class Rep, class Period, class Predicate>
 	void wait_for (std::unique_lock<rai::mutex> & lock, const std::chrono::duration<Rep, Period> & rel_time, Predicate pred)
-    {
-        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
-        std::condition_variable::wait_for (std_lock, rel_time, pred);
-        std_lock.release ();
-    }
+	{
+		std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+		std::condition_variable::wait_for (std_lock, rel_time, pred);
+		std_lock.release ();
+	}
 	template <class Clock, class Duration>
 	void wait_until (std::unique_lock<rai::mutex> & lock, const std::chrono::time_point<Clock, Duration> & abs_time)
-    {
-        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
-        std::condition_variable::wait_until (std_lock, abs_time);
-        std_lock.release ();
-    }
+	{
+		std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+		std::condition_variable::wait_until (std_lock, abs_time);
+		std_lock.release ();
+	}
 	template <class Clock, class Duration, class Predicate>
 	void wait_until (std::unique_lock<rai::mutex> & lock, const std::chrono::time_point<Clock, Duration> & abs_time, Predicate pred)
-    {
-        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
-        std::condition_variable::wait_until (std_lock, abs_time, pred);
-        std_lock.release ();
-    }
+	{
+		std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+		std::condition_variable::wait_until (std_lock, abs_time, pred);
+		std_lock.release ();
+	}
 };
 #else
 typedef std::mutex mutex;

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
+#ifndef NDEBUG
+#define RAI_DEADLOCK_DETECTION
+#endif
+
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
 
 namespace rai
 {
-#ifndef NDEBUG
-#define RAI_DEADLOCK_DETECTION
+#ifdef RAI_DEADLOCK_DETECTION
 
 size_t create_resource_lock_id ();
 void notify_resource_locking (size_t);

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -6,6 +6,7 @@
 
 namespace rai
 {
+#ifndef NDEBUG
 size_t create_resource_lock_id ();
 void notify_resource_locking (size_t);
 void notify_resource_unlocking (size_t);
@@ -71,4 +72,8 @@ public:
         std_lock.release ();
     }
 };
+#else
+typedef std::mutex mutex;
+typedef std::condition_variable condition_variable;
+#endif
 }

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifndef NDEBUG
-#define RAI_DEADLOCK_DETECTION
-#endif
-
 #include <chrono>
 #include <condition_variable>
 #include <mutex>

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+namespace rai
+{
+size_t create_resource_lock_id ();
+void notify_resource_locking (size_t);
+void notify_resource_unlocking (size_t);
+
+class condition_variable;
+
+class mutex : std::mutex
+{
+	friend condition_variable;
+
+public:
+	mutex () noexcept;
+	void lock ();
+	bool try_lock ();
+	void unlock ();
+
+protected:
+	size_t resource_lock_id;
+};
+
+class condition_variable : std::condition_variable
+{
+public:
+	condition_variable ();
+	void notify_one () noexcept;
+	void notify_all () noexcept;
+	void wait (std::unique_lock<rai::mutex> &);
+	template <class Predicate>
+	void wait (std::unique_lock<rai::mutex> & lock, Predicate pred)
+    {
+        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+        std::condition_variable::wait (std_lock, pred);
+        std_lock.release ();
+    }
+	template <class Rep, class Period>
+	void wait_for (std::unique_lock<rai::mutex> & lock, const std::chrono::duration<Rep, Period> & rel_time)
+    {
+        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+        std::condition_variable::wait_for (std_lock, rel_time);
+        std_lock.release ();
+    }
+	template <class Rep, class Period, class Predicate>
+	void wait_for (std::unique_lock<rai::mutex> & lock, const std::chrono::duration<Rep, Period> & rel_time, Predicate pred)
+    {
+        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+        std::condition_variable::wait_for (std_lock, rel_time, pred);
+        std_lock.release ();
+    }
+	template <class Clock, class Duration>
+	void wait_until (std::unique_lock<rai::mutex> & lock, const std::chrono::time_point<Clock, Duration> & abs_time)
+    {
+        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+        std::condition_variable::wait_until (std_lock, abs_time);
+        std_lock.release ();
+    }
+	template <class Clock, class Duration, class Predicate>
+	void wait_until (std::unique_lock<rai::mutex> & lock, const std::chrono::time_point<Clock, Duration> & abs_time, Predicate pred)
+    {
+        std::unique_lock<std::mutex> std_lock (static_cast<std::mutex &> (*lock.mutex ()), std::adopt_lock);
+        std::condition_variable::wait_until (std_lock, abs_time, pred);
+        std_lock.release ();
+    }
+};
+}

--- a/rai/lib/mutex.hpp
+++ b/rai/lib/mutex.hpp
@@ -7,6 +7,8 @@
 namespace rai
 {
 #ifndef NDEBUG
+#define RAI_DEADLOCK_DETECTION
+
 size_t create_resource_lock_id ();
 void notify_resource_locking (size_t);
 void notify_resource_unlocking (size_t);

--- a/rai/lib/utility.hpp
+++ b/rai/lib/utility.hpp
@@ -5,7 +5,7 @@
 #include <boost/thread/thread.hpp>
 
 #include <functional>
-#include <mutex>
+#include <rai/lib/mutex.hpp>
 #include <thread>
 #include <vector>
 
@@ -57,18 +57,18 @@ class observer_set
 public:
 	void add (std::function<void(T...)> const & observer_a)
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		observers.push_back (observer_a);
 	}
 	void notify (T... args)
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		for (auto & i : observers)
 		{
 			i (args...);
 		}
 	}
-	std::mutex mutex;
+	rai::mutex mutex;
 	std::vector<std::function<void(T...)>> observers;
 };
 }

--- a/rai/lib/work.cpp
+++ b/rai/lib/work.cpp
@@ -64,7 +64,7 @@ void rai::work_pool::loop (uint64_t thread)
 	uint64_t output;
 	blake2b_state hash;
 	blake2b_init (&hash, sizeof (output));
-	std::unique_lock<std::mutex> lock (mutex);
+	std::unique_lock<rai::mutex> lock (mutex);
 	while (!done || !pending.empty ())
 	{
 		auto empty (pending.empty ());
@@ -124,7 +124,7 @@ void rai::work_pool::loop (uint64_t thread)
 
 void rai::work_pool::cancel (rai::uint256_union const & root_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	if (!pending.empty ())
 	{
 		if (pending.front ().first == root_a)
@@ -149,7 +149,7 @@ void rai::work_pool::cancel (rai::uint256_union const & root_a)
 
 void rai::work_pool::stop ()
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	done = true;
 	producer_condition.notify_all ();
 }
@@ -164,7 +164,7 @@ void rai::work_pool::generate (rai::uint256_union const & root_a, std::function<
 	}
 	if (!result)
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		pending.push_back (std::make_pair (root_a, callback_a));
 		producer_condition.notify_all ();
 	}

--- a/rai/lib/work.hpp
+++ b/rai/lib/work.hpp
@@ -3,11 +3,11 @@
 #include <boost/optional.hpp>
 #include <boost/thread/thread.hpp>
 #include <rai/lib/config.hpp>
+#include <rai/lib/mutex.hpp>
 #include <rai/lib/numbers.hpp>
 #include <rai/lib/utility.hpp>
 
 #include <atomic>
-#include <condition_variable>
 #include <memory>
 #include <thread>
 
@@ -32,8 +32,8 @@ public:
 	bool done;
 	std::vector<boost::thread> threads;
 	std::list<std::pair<rai::uint256_union, std::function<void(boost::optional<uint64_t> const &)>>> pending;
-	std::mutex mutex;
-	std::condition_variable producer_condition;
+	rai::mutex mutex;
+	rai::condition_variable producer_condition;
 	std::function<boost::optional<uint64_t> (rai::uint256_union const &)> opencl;
 	rai::observer_set<bool> work_observers;
 	// Local work threshold for rate-limiting publishing blocks. ~5 seconds of work.

--- a/rai/node/bootstrap.hpp
+++ b/rai/node/bootstrap.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <rai/lib/mutex.hpp>
 #include <rai/node/common.hpp>
 #include <rai/secure/blockstore.hpp>
 #include <rai/secure/ledger.hpp>
@@ -67,12 +68,12 @@ public:
 	bootstrap_attempt (std::shared_ptr<rai::node> node_a);
 	~bootstrap_attempt ();
 	void run ();
-	std::shared_ptr<rai::bootstrap_client> connection (std::unique_lock<std::mutex> &);
+	std::shared_ptr<rai::bootstrap_client> connection (std::unique_lock<rai::mutex> &);
 	bool consume_future (std::future<bool> &);
 	void populate_connections ();
-	bool request_frontier (std::unique_lock<std::mutex> &);
-	void request_pull (std::unique_lock<std::mutex> &);
-	void request_push (std::unique_lock<std::mutex> &);
+	bool request_frontier (std::unique_lock<rai::mutex> &);
+	void request_pull (std::unique_lock<rai::mutex> &);
+	void request_push (std::unique_lock<rai::mutex> &);
 	void add_connection (rai::endpoint const &);
 	void pool_connection (std::shared_ptr<rai::bootstrap_client>);
 	void stop ();
@@ -96,8 +97,8 @@ public:
 	std::atomic<uint64_t> total_blocks;
 	std::vector<std::pair<rai::block_hash, rai::block_hash>> bulk_push_targets;
 	bool stopped;
-	std::mutex mutex;
-	std::condition_variable condition;
+	rai::mutex mutex;
+	rai::condition_variable condition;
 };
 class frontier_req_client : public std::enable_shared_from_this<rai::frontier_req_client>
 {
@@ -187,8 +188,8 @@ private:
 	rai::node & node;
 	std::shared_ptr<rai::bootstrap_attempt> attempt;
 	bool stopped;
-	std::mutex mutex;
-	std::condition_variable condition;
+	rai::mutex mutex;
+	rai::condition_variable condition;
 	std::vector<std::function<void(bool)>> observers;
 	boost::thread thread;
 };
@@ -201,7 +202,7 @@ public:
 	void stop ();
 	void accept_connection ();
 	void accept_action (boost::system::error_code const &, std::shared_ptr<rai::socket>);
-	std::mutex mutex;
+	rai::mutex mutex;
 	std::unordered_map<rai::bootstrap_server *, std::weak_ptr<rai::bootstrap_server>> connections;
 	rai::tcp_endpoint endpoint ();
 	boost::asio::ip::tcp::acceptor acceptor;
@@ -229,7 +230,7 @@ public:
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;
 	std::shared_ptr<rai::socket> socket;
 	std::shared_ptr<rai::node> node;
-	std::mutex mutex;
+	rai::mutex mutex;
 	std::queue<std::unique_ptr<rai::message>> requests;
 };
 class bulk_pull;

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -39,10 +39,12 @@ rai::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, i
 		error_a = true;
 		environment = nullptr;
 	}
+#ifndef NDEBUG
 	if (environment)
 	{
 		resource_lock_id = rai::create_resource_lock_id ();
 	}
+#endif
 }
 
 rai::mdb_env::~mdb_env ()
@@ -50,7 +52,9 @@ rai::mdb_env::~mdb_env ()
 	if (environment != nullptr)
 	{
 		mdb_env_close (environment);
+#ifndef NDEBUG
 		rai::destroy_resource_lock_id (resource_lock_id);
+#endif
 	}
 }
 
@@ -285,21 +289,25 @@ rai::mdb_val::operator MDB_val const & () const
 
 rai::mdb_txn::mdb_txn (rai::mdb_env const & environment_a, bool write_a, size_t resource_lock_id_a)
 {
+#ifndef NDEBUG
 	if (write_a)
 	{
 		resource_lock_id = resource_lock_id_a;
 		rai::notify_resource_locking (resource_lock_id_a);
 	}
+#endif
 	auto status (mdb_txn_begin (environment_a, nullptr, write_a ? 0 : MDB_RDONLY, &handle));
 	release_assert (status == 0);
 }
 
 rai::mdb_txn::~mdb_txn ()
 {
+#ifndef NDEBUG
 	if (resource_lock_id)
 	{
 		rai::notify_resource_unlocking (*resource_lock_id);
 	}
+#endif
 	auto status (mdb_txn_commit (handle));
 	release_assert (status == 0);
 }

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1833,7 +1833,7 @@ void rai::mdb_store::flush (rai::transaction const & transaction_a)
 {
 	std::unordered_map<rai::account, std::shared_ptr<rai::vote>> sequence_cache_l;
 	{
-		std::lock_guard<std::mutex> lock (cache_mutex);
+		std::lock_guard<rai::mutex> lock (cache_mutex);
 		sequence_cache_l.swap (vote_cache);
 	}
 	for (auto i (sequence_cache_l.begin ()), n (sequence_cache_l.end ()); i != n; ++i)
@@ -1865,7 +1865,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_current (rai::transaction const 
 
 std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const & transaction_a, rai::account const & account_a, rai::raw_key const & key_a, std::shared_ptr<rai::block> block_a)
 {
-	std::lock_guard<std::mutex> lock (cache_mutex);
+	std::lock_guard<rai::mutex> lock (cache_mutex);
 	auto result (vote_current (transaction_a, account_a));
 	uint64_t sequence ((result ? result->sequence : 0) + 1);
 	result = std::make_shared<rai::vote> (account_a, key_a, sequence, block_a);
@@ -1875,7 +1875,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const
 
 std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const & transaction_a, rai::account const & account_a, rai::raw_key const & key_a, std::vector<rai::block_hash> blocks_a)
 {
-	std::lock_guard<std::mutex> lock (cache_mutex);
+	std::lock_guard<rai::mutex> lock (cache_mutex);
 	auto result (vote_current (transaction_a, account_a));
 	uint64_t sequence ((result ? result->sequence : 0) + 1);
 	result = std::make_shared<rai::vote> (account_a, key_a, sequence, blocks_a);
@@ -1885,7 +1885,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const
 
 std::shared_ptr<rai::vote> rai::mdb_store::vote_max (rai::transaction const & transaction_a, std::shared_ptr<rai::vote> vote_a)
 {
-	std::lock_guard<std::mutex> lock (cache_mutex);
+	std::lock_guard<rai::mutex> lock (cache_mutex);
 	auto current (vote_current (transaction_a, vote_a->account));
 	auto result (vote_a);
 	if (current != nullptr && current->sequence > result->sequence)

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -65,7 +65,11 @@ rai::mdb_env::operator MDB_env * () const
 
 rai::transaction rai::mdb_env::tx_begin (bool write_a) const
 {
+#ifdef RAI_DEADLOCK_DETECTION
 	return { std::make_unique<rai::mdb_txn> (*this, write_a, resource_lock_id) };
+#else
+	return { std::make_unique<rai::mdb_txn> (*this, write_a, 0) };
+#endif
 }
 
 MDB_txn * rai::mdb_env::tx (rai::transaction const & transaction_a) const

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -39,7 +39,7 @@ rai::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, i
 		error_a = true;
 		environment = nullptr;
 	}
-#ifndef NDEBUG
+#ifdef RAI_DEADLOCK_DETECTION
 	if (environment)
 	{
 		resource_lock_id = rai::create_resource_lock_id ();
@@ -52,7 +52,7 @@ rai::mdb_env::~mdb_env ()
 	if (environment != nullptr)
 	{
 		mdb_env_close (environment);
-#ifndef NDEBUG
+#ifdef RAI_DEADLOCK_DETECTION
 		rai::destroy_resource_lock_id (resource_lock_id);
 #endif
 	}
@@ -289,7 +289,7 @@ rai::mdb_val::operator MDB_val const & () const
 
 rai::mdb_txn::mdb_txn (rai::mdb_env const & environment_a, bool write_a, size_t resource_lock_id_a)
 {
-#ifndef NDEBUG
+#ifdef RAI_DEADLOCK_DETECTION
 	if (write_a)
 	{
 		resource_lock_id = resource_lock_id_a;
@@ -302,7 +302,7 @@ rai::mdb_txn::mdb_txn (rai::mdb_env const & environment_a, bool write_a, size_t 
 
 rai::mdb_txn::~mdb_txn ()
 {
-#ifndef NDEBUG
+#ifdef RAI_DEADLOCK_DETECTION
 	if (resource_lock_id)
 	{
 		rai::notify_resource_unlocking (*resource_lock_id);

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -4,6 +4,7 @@
 
 #include <lmdb/libraries/liblmdb/lmdb.h>
 
+#include <rai/lib/mutex.hpp>
 #include <rai/lib/numbers.hpp>
 #include <rai/secure/blockstore.hpp>
 #include <rai/secure/common.hpp>
@@ -236,7 +237,7 @@ public:
 	void flush (rai::transaction const &) override;
 	rai::store_iterator<rai::account, std::shared_ptr<rai::vote>> vote_begin (rai::transaction const &) override;
 	rai::store_iterator<rai::account, std::shared_ptr<rai::vote>> vote_end () override;
-	std::mutex cache_mutex;
+	rai::mutex cache_mutex;
 	std::unordered_map<rai::account, std::shared_ptr<rai::vote>> vote_cache;
 
 	void version_put (rai::transaction const &, int) override;

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -23,7 +23,7 @@ public:
 	rai::mdb_txn & operator= (rai::mdb_txn &&) = default;
 	operator MDB_txn * () const;
 	MDB_txn * handle;
-#ifndef NDEBUG
+#ifdef RAI_DEADLOCK_DETECTION
 	boost::optional<size_t> resource_lock_id;
 #endif
 };
@@ -39,7 +39,7 @@ public:
 	rai::transaction tx_begin (bool = false) const;
 	MDB_txn * tx (rai::transaction const &) const;
 	MDB_env * environment;
-#ifndef NDEBUG
+#ifdef RAI_DEADLOCK_DETECTION
 	size_t resource_lock_id;
 #endif
 };

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -23,7 +23,9 @@ public:
 	rai::mdb_txn & operator= (rai::mdb_txn &&) = default;
 	operator MDB_txn * () const;
 	MDB_txn * handle;
+#ifndef NDEBUG
 	boost::optional<size_t> resource_lock_id;
+#endif
 };
 /**
  * RAII wrapper for MDB_env
@@ -37,7 +39,9 @@ public:
 	rai::transaction tx_begin (bool = false) const;
 	MDB_txn * tx (rai::transaction const &) const;
 	MDB_env * environment;
+#ifndef NDEBUG
 	size_t resource_lock_id;
+#endif
 };
 
 /**

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -15,7 +15,7 @@ class mdb_env;
 class mdb_txn : public transaction_impl
 {
 public:
-	mdb_txn (rai::mdb_env const &, bool = false);
+	mdb_txn (rai::mdb_env const &, bool, size_t);
 	mdb_txn (rai::mdb_txn const &) = delete;
 	mdb_txn (rai::mdb_txn &&) = default;
 	~mdb_txn ();
@@ -23,6 +23,7 @@ public:
 	rai::mdb_txn & operator= (rai::mdb_txn &&) = default;
 	operator MDB_txn * () const;
 	MDB_txn * handle;
+	boost::optional<size_t> resource_lock_id;
 };
 /**
  * RAII wrapper for MDB_env
@@ -36,6 +37,7 @@ public:
 	rai::transaction tx_begin (bool = false) const;
 	MDB_txn * tx (rai::transaction const &) const;
 	MDB_env * environment;
+	size_t resource_lock_id;
 };
 
 /**

--- a/rai/node/openclwork.cpp
+++ b/rai/node/openclwork.cpp
@@ -718,7 +718,7 @@ rai::opencl_work::~opencl_work ()
 
 boost::optional<uint64_t> rai::opencl_work::generate_work (rai::uint256_union const & root_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	bool error (false);
 	uint64_t result (0);
 	unsigned thread_count (config.threads);

--- a/rai/node/openclwork.hpp
+++ b/rai/node/openclwork.hpp
@@ -6,7 +6,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <map>
-#include <mutex>
+#include <rai/lib/mutex.hpp>
 #include <vector>
 
 #ifdef __APPLE__
@@ -53,7 +53,7 @@ public:
 	boost::optional<uint64_t> generate_work (rai::uint256_union const &);
 	static std::unique_ptr<opencl_work> create (bool, rai::opencl_config const &, rai::logging &);
 	rai::opencl_config const & config;
-	std::mutex mutex;
+	rai::mutex mutex;
 	cl_context context;
 	cl_mem attempt_buffer;
 	cl_mem result_buffer;

--- a/rai/node/portmapping.cpp
+++ b/rai/node/portmapping.cpp
@@ -22,7 +22,7 @@ void rai::port_mapping::refresh_devices ()
 {
 	if (rai::rai_network != rai::rai_networks::rai_test_network)
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		int discover_error = 0;
 		freeUPNPDevlist (devices);
 		devices = upnpDiscover (2000, nullptr, nullptr, UPNP_LOCAL_PORT_ANY, false, 2, &discover_error);
@@ -49,7 +49,7 @@ void rai::port_mapping::refresh_mapping ()
 {
 	if (rai::rai_network != rai::rai_networks::rai_test_network)
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		auto node_port (std::to_string (node.network.endpoint ().port ()));
 
 		// We don't map the RPC port because, unless RPC authentication was added, this would almost always be a security risk
@@ -80,7 +80,7 @@ int rai::port_mapping::check_mapping ()
 	if (rai::rai_network != rai::rai_networks::rai_test_network)
 	{
 		// Long discovery time and fast setup/teardown make this impractical for testing
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		auto node_port (std::to_string (node.network.endpoint ().port ()));
 		for (auto & protocol : protocols)
 		{
@@ -153,7 +153,7 @@ void rai::port_mapping::check_mapping_loop ()
 void rai::port_mapping::stop ()
 {
 	on = false;
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	for (auto & protocol : protocols)
 	{
 		if (protocol.external_port != 0)

--- a/rai/node/portmapping.hpp
+++ b/rai/node/portmapping.hpp
@@ -2,8 +2,8 @@
 
 #include <boost/asio/ip/address_v4.hpp>
 #include <miniupnpc.h>
-#include <mutex>
 #include <rai/lib/config.hpp>
+#include <rai/lib/mutex.hpp>
 
 namespace rai
 {
@@ -35,7 +35,7 @@ private:
 	/** Refresh occasionally in case router loses mapping */
 	void check_mapping_loop ();
 	int check_mapping ();
-	std::mutex mutex;
+	rai::mutex mutex;
 	rai::node & node;
 	/** List of all UPnP devices */
 	UPNPDev * devices;

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -185,7 +185,7 @@ void rai::rpc::observer_action (rai::account const & account_a)
 {
 	std::shared_ptr<rai::payment_observer> observer;
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		auto existing (payment_observers.find (account_a));
 		if (existing != payment_observers.end ())
 		{
@@ -1377,7 +1377,7 @@ void rai::rpc_handler::confirmation_active ()
 	}
 	boost::property_tree::ptree elections;
 	{
-		std::lock_guard<std::mutex> lock (node.active.mutex);
+		std::lock_guard<rai::mutex> lock (node.active.mutex);
 		for (auto i (node.active.roots.begin ()), n (node.active.roots.end ()); i != n; ++i)
 		{
 			if (i->announcements >= announcements)
@@ -1396,7 +1396,7 @@ void rai::rpc_handler::confirmation_history ()
 {
 	boost::property_tree::ptree elections;
 	{
-		std::lock_guard<std::mutex> lock (node.active.mutex);
+		std::lock_guard<rai::mutex> lock (node.active.mutex);
 		for (auto i (node.active.confirmed.begin ()), n (node.active.confirmed.end ()); i != n; ++i)
 		{
 			boost::property_tree::ptree election;
@@ -1417,7 +1417,7 @@ void rai::rpc_handler::confirmation_info ()
 	rai::block_hash root;
 	if (!root.decode_hex (root_text))
 	{
-		std::lock_guard<std::mutex> lock (node.active.mutex);
+		std::lock_guard<rai::mutex> lock (node.active.mutex);
 		auto conflict_info (node.active.roots.find (root));
 		if (conflict_info != node.active.roots.end ())
 		{
@@ -2265,7 +2265,7 @@ void rai::rpc_handler::payment_wait ()
 			{
 				auto observer (std::make_shared<rai::payment_observer> (response, rpc, account, amount));
 				observer->start (timeout);
-				std::lock_guard<std::mutex> lock (rpc.mutex);
+				std::lock_guard<rai::mutex> lock (rpc.mutex);
 				assert (rpc.payment_observers.find (account) == rpc.payment_observers.end ());
 				rpc.payment_observers[account] = observer;
 			}
@@ -4194,7 +4194,7 @@ void rai::payment_observer::complete (rai::payment_status status)
 				break;
 			}
 		}
-		std::lock_guard<std::mutex> lock (rpc.mutex);
+		std::lock_guard<rai::mutex> lock (rpc.mutex);
 		assert (rpc.payment_observers.find (account) != rpc.payment_observers.end ());
 		rpc.payment_observers.erase (account);
 	}

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -71,7 +71,7 @@ public:
 	void stop ();
 	void observer_action (rai::account const &);
 	boost::asio::ip::tcp::acceptor acceptor;
-	std::mutex mutex;
+	rai::mutex mutex;
 	std::unordered_map<rai::account, std::shared_ptr<rai::payment_observer>> payment_observers;
 	rai::rpc_config config;
 	rai::node & node;
@@ -102,8 +102,8 @@ public:
 	void observe ();
 	void timeout ();
 	void complete (rai::payment_status);
-	std::mutex mutex;
-	std::condition_variable condition;
+	rai::mutex mutex;
+	rai::condition_variable condition;
 	rai::rpc & rpc;
 	rai::account account;
 	rai::amount amount;

--- a/rai/node/stats.cpp
+++ b/rai/node/stats.cpp
@@ -152,7 +152,7 @@ std::shared_ptr<rai::stat_entry> rai::stat::get_entry (uint32_t key)
 
 std::shared_ptr<rai::stat_entry> rai::stat::get_entry (uint32_t key, size_t interval, size_t capacity)
 {
-	std::unique_lock<std::mutex> lock (stat_mutex);
+	std::unique_lock<rai::mutex> lock (stat_mutex);
 	return get_entry_impl (key, interval, capacity);
 }
 
@@ -184,7 +184,7 @@ std::unique_ptr<rai::stat_log_sink> log_sink_file (std::string filename)
 
 void rai::stat::log_counters (stat_log_sink & sink)
 {
-	std::unique_lock<std::mutex> lock (stat_mutex);
+	std::unique_lock<rai::mutex> lock (stat_mutex);
 	log_counters_impl (sink);
 }
 
@@ -219,7 +219,7 @@ void rai::stat::log_counters_impl (stat_log_sink & sink)
 
 void rai::stat::log_samples (stat_log_sink & sink)
 {
-	std::unique_lock<std::mutex> lock (stat_mutex);
+	std::unique_lock<rai::mutex> lock (stat_mutex);
 	log_samples_impl (sink);
 }
 
@@ -262,7 +262,7 @@ void rai::stat::update (uint32_t key_a, uint64_t value)
 
 	auto now (std::chrono::steady_clock::now ());
 
-	std::unique_lock<std::mutex> lock (stat_mutex);
+	std::unique_lock<rai::mutex> lock (stat_mutex);
 	auto entry (get_entry_impl (key_a, config.interval, config.capacity));
 
 	// Counters

--- a/rai/node/stats.hpp
+++ b/rai/node/stats.hpp
@@ -428,6 +428,6 @@ private:
 	std::chrono::steady_clock::time_point log_last_sample_writeout{ std::chrono::steady_clock::now () };
 
 	/** All access to stat is thread safe, including calls from observers on the same thread */
-	std::mutex stat_mutex;
+	rai::mutex stat_mutex;
 };
 }

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -207,7 +207,7 @@ rai::fan::fan (rai::uint256_union const & key, size_t count_a)
 
 void rai::fan::value (rai::raw_key & prv_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	value_get (prv_a);
 }
 
@@ -223,7 +223,7 @@ void rai::fan::value_get (rai::raw_key & prv_a)
 
 void rai::fan::value_set (rai::raw_key const & value_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	rai::raw_key value_l;
 	value_get (value_l);
 	*(values[0]) ^= value_l.data;
@@ -722,7 +722,7 @@ void rai::wallet_store::upgrade_v3_v4 (rai::transaction const & transaction_a)
 
 void rai::kdf::phs (rai::raw_key & result_a, std::string const & password_a, rai::uint256_union const & salt_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	auto success (argon2_hash (1, rai::wallet_store::kdf_work, 1, password_a.data (), password_a.size (), salt_a.bytes.data (), salt_a.bytes.size (), result_a.data.bytes.data (), result_a.data.bytes.size (), NULL, 0, Argon2_d, 0x10));
 	assert (success == 0);
 	(void)success;
@@ -1342,7 +1342,7 @@ void rai::wallets::destroy (rai::uint256_union const & id_a)
 
 void rai::wallets::do_wallet_actions ()
 {
-	std::unique_lock<std::mutex> lock (mutex);
+	std::unique_lock<rai::mutex> lock (mutex);
 	while (!stopped)
 	{
 		if (!actions.empty ())
@@ -1365,7 +1365,7 @@ void rai::wallets::do_wallet_actions ()
 
 void rai::wallets::queue_wallet_action (rai::uint128_t const & amount_a, std::function<void()> const & action_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<rai::mutex> lock (mutex);
 	actions.insert (std::make_pair (amount_a, std::move (action_a)));
 	condition.notify_all ();
 }
@@ -1414,7 +1414,7 @@ bool rai::wallets::exists (rai::transaction const & transaction_a, rai::public_k
 void rai::wallets::stop ()
 {
 	{
-		std::lock_guard<std::mutex> lock (mutex);
+		std::lock_guard<rai::mutex> lock (mutex);
 		stopped = true;
 		condition.notify_all ();
 	}

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -7,8 +7,8 @@
 #include <rai/secure/blockstore.hpp>
 #include <rai/secure/common.hpp>
 
-#include <mutex>
 #include <queue>
+#include <rai/lib/mutex.hpp>
 #include <thread>
 #include <unordered_set>
 
@@ -24,7 +24,7 @@ public:
 	std::vector<std::unique_ptr<rai::uint256_union>> values;
 
 private:
-	std::mutex mutex;
+	rai::mutex mutex;
 	void value_get (rai::raw_key &);
 };
 class node_config;
@@ -32,7 +32,7 @@ class kdf
 {
 public:
 	void phs (rai::raw_key &, std::string const &, rai::uint256_union const &);
-	std::mutex mutex;
+	rai::mutex mutex;
 };
 enum class key_type
 {
@@ -180,8 +180,8 @@ public:
 	std::function<void(bool)> observer;
 	std::unordered_map<rai::uint256_union, std::shared_ptr<rai::wallet>> items;
 	std::multimap<rai::uint128_t, std::function<void()>, std::greater<rai::uint128_t>> actions;
-	std::mutex mutex;
-	std::condition_variable condition;
+	rai::mutex mutex;
+	rai::condition_variable condition;
 	rai::kdf kdf;
 	MDB_dbi handle;
 	MDB_dbi send_action_ids;

--- a/rai/secure/utility.hpp
+++ b/rai/secure/utility.hpp
@@ -2,7 +2,6 @@
 
 #include <array>
 #include <atomic>
-#include <condition_variable>
 #include <type_traits>
 
 #include <boost/filesystem.hpp>
@@ -14,6 +13,7 @@
 
 #include <rai/lib/config.hpp>
 #include <rai/lib/interface.h>
+#include <rai/lib/mutex.hpp>
 #include <rai/lib/numbers.hpp>
 
 namespace rai


### PR DESCRIPTION
This will identify lock ordering issues and print out helpful traces when such issues are identified. For the traces to be helpful, you'll need to compile with `CFLAGS=-rdynamic CXXFLAGS=-rdynamic LDFLAGS=-rdynamic`, and you may need to clear your cmake build directory first.