### PR TITLE
Store confirmation height in database to allow synchronously querying confirmation

### DIFF
--- a/rai/core_test/ledger.cpp
+++ b/rai/core_test/ledger.cpp
@@ -860,7 +860,7 @@ TEST (votes, add_existing)
 	auto & node1 (*system.nodes[0]);
 	rai::genesis genesis;
 	rai::keypair key1;
-	auto send1 (std::make_shared<rai::send_block> (genesis.hash (), key1.pub, rai::genesis_amount - rai::Gxrb_ratio, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<rai::send_block> (genesis.hash (), key1.pub, rai::genesis_amount / 50, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
 	{
 		auto transaction (node1.store.tx_begin (true));
 		ASSERT_EQ (rai::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -873,7 +873,7 @@ TEST (votes, add_existing)
 	ASSERT_FALSE (node1.active.publish (send1));
 	ASSERT_EQ (1, votes1->last_votes[rai::test_genesis_key.pub].sequence);
 	rai::keypair key2;
-	auto send2 (std::make_shared<rai::send_block> (genesis.hash (), key2.pub, rai::genesis_amount - rai::Gxrb_ratio, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<rai::send_block> (genesis.hash (), key2.pub, rai::genesis_amount / 50, rai::test_genesis_key.prv, rai::test_genesis_key.pub, 0));
 	auto vote2 (std::make_shared<rai::vote> (rai::test_genesis_key.pub, rai::test_genesis_key.prv, 2, send2));
 	// Pretend we've waited the timeout
 	votes1->last_votes[rai::test_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -1375,7 +1375,7 @@ TEST (rpc, pending)
 	rai::keypair key1;
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	auto block1 (system.wallet (0)->send_action (rai::test_genesis_key.pub, key1.pub, 100));
-	while (!system.nodes[0]->is_confirmed (block1->hash ()))
+	while (!system.nodes[0]->block_confirmed (block1->hash ()))
 	{
 		system.poll ();
 	}
@@ -2327,7 +2327,7 @@ TEST (rpc, accounts_pending)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	auto block1 (system.wallet (0)->send_action (rai::test_genesis_key.pub, key1.pub, 100));
 	auto iterations (0);
-	while (!system.nodes[0]->is_confirmed (block1->hash ()))
+	while (!system.nodes[0]->block_confirmed (block1->hash ()))
 	{
 		system.poll ();
 		++iterations;
@@ -2439,7 +2439,7 @@ TEST (rpc, wallet_info)
 	rai::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto send (system.wallet (0)->send_action (rai::test_genesis_key.pub, key.pub, 1));
-	while (!system.nodes[0]->is_confirmed (send->hash ()))
+	while (!system.nodes[0]->block_confirmed (send->hash ()))
 	{
 		system.poll ();
 	}
@@ -2526,7 +2526,7 @@ TEST (rpc, pending_exists)
 	system.wallet (0)->insert_adhoc (rai::test_genesis_key.prv);
 	auto hash0 (system.nodes[0]->latest (rai::genesis_account));
 	auto block1 (system.wallet (0)->send_action (rai::test_genesis_key.pub, key1.pub, 100));
-	while (!system.nodes[0]->is_confirmed (block1->hash ()))
+	while (!system.nodes[0]->block_confirmed (block1->hash ()))
 	{
 		system.poll ();
 	}
@@ -2562,7 +2562,7 @@ TEST (rpc, wallet_pending)
 	system0.wallet (0)->insert_adhoc (key1.prv);
 	auto block1 (system0.wallet (0)->send_action (rai::test_genesis_key.pub, key1.pub, 100));
 	auto iterations (0);
-	while (!system0.nodes[0]->is_confirmed (block1->hash ()))
+	while (!system0.nodes[0]->block_confirmed (block1->hash ()))
 	{
 		system0.poll ();
 		++iterations;

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -3720,13 +3720,13 @@ TEST (rpc, block_confirm_absent)
 	ASSERT_EQ ("Block not found", response.json.get<std::string> ("error"));
 }
 
-TEST (rpc, is_confirmed)
+TEST (rpc, block_confirmed)
 {
 	rai::system system (24000, 1);
 	rai::rpc rpc (system.service, *system.nodes[0], rai::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
-	request.put ("action", "is_confirmed");
+	request.put ("action", "block_confirmed");
 	request.put ("hash", "0");
 	test_response response (request, rpc, system.service);
 	while (response.status == 0)

--- a/rai/core_test/rpc.cpp
+++ b/rai/core_test/rpc.cpp
@@ -810,7 +810,7 @@ TEST (rpc, frontier)
 		{
 			rai::keypair key;
 			source[key.pub] = key.prv.data;
-			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, rai::epoch::epoch_0));
+			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, 0, rai::epoch::epoch_0));
 		}
 	}
 	rai::keypair key;
@@ -850,7 +850,7 @@ TEST (rpc, frontier_limited)
 		{
 			rai::keypair key;
 			source[key.pub] = key.prv.data;
-			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, rai::epoch::epoch_0));
+			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, 0, rai::epoch::epoch_0));
 		}
 	}
 	rai::keypair key;
@@ -880,7 +880,7 @@ TEST (rpc, frontier_startpoint)
 		{
 			rai::keypair key;
 			source[key.pub] = key.prv.data;
-			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, rai::epoch::epoch_0));
+			system.nodes[0]->store.account_put (transaction, key.pub, rai::account_info (key.prv.data, 0, 0, 0, 0, 0, 0, rai::epoch::epoch_0));
 		}
 	}
 	rai::keypair key;

--- a/rai/core_test/versioning.cpp
+++ b/rai/core_test/versioning.cpp
@@ -8,13 +8,14 @@ TEST (versioning, account_info_v1)
 	auto file (rai::unique_path ());
 	rai::account account (1);
 	rai::open_block open (1, 2, 3, nullptr);
+	rai::extended_block extended_block (std::make_unique<rai::open_block> (open), rai::block_sideband (1, 0), rai::epoch::epoch_0);
 	rai::account_info_v1 v1 (open.hash (), open.hash (), 3, 4);
 	{
 		auto error (false);
 		rai::mdb_store store (error, file);
 		ASSERT_FALSE (error);
 		auto transaction (store.tx_begin (true));
-		store.block_put (transaction, open.hash (), open);
+		store.block_put (transaction, open.hash (), extended_block);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, rai::mdb_val (account), v1.val (), 0));
 		ASSERT_EQ (0, status);
 		store.version_put (transaction, 1);

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -331,6 +331,11 @@ rai::account rai::send_block::representative () const
 	return 0;
 }
 
+rai::account rai::send_block::potential_destination () const
+{
+	return hashables.destination;
+}
+
 rai::signature rai::send_block::block_signature () const
 {
 	return signature;
@@ -590,6 +595,12 @@ rai::account rai::open_block::representative () const
 	return hashables.representative;
 }
 
+rai::account rai::open_block::potential_destination () const
+{
+	assert (false && "potential_destination called on open block");
+	return 0;
+}
+
 rai::signature rai::open_block::block_signature () const
 {
 	return signature;
@@ -829,6 +840,12 @@ rai::block_hash rai::change_block::link () const
 rai::account rai::change_block::representative () const
 {
 	return hashables.representative;
+}
+
+rai::account rai::change_block::potential_destination () const
+{
+	assert (false && "potential_destination called on change block");
+	return 0;
 }
 
 rai::signature rai::change_block::block_signature () const
@@ -1133,6 +1150,11 @@ rai::block_hash rai::state_block::link () const
 rai::account rai::state_block::representative () const
 {
 	return hashables.representative;
+}
+
+rai::account rai::state_block::potential_destination () const
+{
+	return hashables.link;
 }
 
 rai::signature rai::state_block::block_signature () const
@@ -1467,6 +1489,12 @@ rai::block_hash rai::receive_block::link () const
 
 rai::account rai::receive_block::representative () const
 {
+	return 0;
+}
+
+rai::account rai::receive_block::potential_destination () const
+{
+	assert (false && "potential_destination called on receive block");
 	return 0;
 }
 

--- a/rai/lib/blocks.hpp
+++ b/rai/lib/blocks.hpp
@@ -57,6 +57,10 @@ public:
 	// Link field for state blocks, zero otherwise.
 	virtual rai::block_hash link () const = 0;
 	virtual rai::account representative () const = 0;
+	// If this is a block is a send (or a state send), it must be the destination.
+	// Otherwise, it may be any other value.
+	// Thus, it's best to call rai::ledger::is_send before this function.
+	virtual rai::account potential_destination () const = 0;
 	virtual void serialize (rai::stream &) const = 0;
 	virtual void serialize_json (std::string &) const = 0;
 	virtual void visit (rai::block_visitor &) const = 0;
@@ -94,6 +98,7 @@ public:
 	rai::block_hash root () const override;
 	rai::block_hash link () const override;
 	rai::account representative () const override;
+	rai::account potential_destination () const override;
 	void serialize (rai::stream &) const override;
 	void serialize_json (std::string &) const override;
 	bool deserialize (rai::stream &);
@@ -136,6 +141,7 @@ public:
 	rai::block_hash root () const override;
 	rai::block_hash link () const override;
 	rai::account representative () const override;
+	rai::account potential_destination () const override;
 	void serialize (rai::stream &) const override;
 	void serialize_json (std::string &) const override;
 	bool deserialize (rai::stream &);
@@ -180,6 +186,7 @@ public:
 	rai::block_hash root () const override;
 	rai::block_hash link () const override;
 	rai::account representative () const override;
+	rai::account potential_destination () const override;
 	void serialize (rai::stream &) const override;
 	void serialize_json (std::string &) const override;
 	bool deserialize (rai::stream &);
@@ -222,6 +229,7 @@ public:
 	rai::block_hash root () const override;
 	rai::block_hash link () const override;
 	rai::account representative () const override;
+	rai::account potential_destination () const override;
 	void serialize (rai::stream &) const override;
 	void serialize_json (std::string &) const override;
 	bool deserialize (rai::stream &);
@@ -276,6 +284,7 @@ public:
 	rai::block_hash root () const override;
 	rai::block_hash link () const override;
 	rai::account representative () const override;
+	rai::account potential_destination () const override;
 	void serialize (rai::stream &) const override;
 	void serialize_json (std::string &) const override;
 	bool deserialize (rai::stream &);

--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -2273,7 +2273,7 @@ void rai::bulk_push_server::received_block (boost::system::error_code const & ec
 rai::frontier_req_server::frontier_req_server (std::shared_ptr<rai::bootstrap_server> const & connection_a, std::unique_ptr<rai::frontier_req> request_a) :
 connection (connection_a),
 current (request_a->start.number () - 1),
-info (0, 0, 0, 0, 0, 0, rai::epoch::epoch_0),
+info (0, 0, 0, 0, 0, 0, 0, rai::epoch::epoch_0),
 request (std::move (request_a)),
 send_buffer (std::make_shared<std::vector<uint8_t>> ())
 {

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1455,7 +1455,6 @@ rai::extended_block rai::mdb_store::extended_block_get (rai::transaction const &
 	return result;
 }
 
-
 void rai::mdb_store::block_del (rai::transaction const & transaction_a, rai::block_hash const & hash_a)
 {
 	auto status (mdb_del (env.tx (transaction_a), state_blocks_v1, rai::mdb_val (hash_a), nullptr));

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -893,6 +893,8 @@ void rai::mdb_store::do_upgrades (rai::transaction const & transaction_a)
 		case 10:
 			upgrade_v10_to_v11 (transaction_a);
 		case 11:
+			upgrade_v11_to_v12 (transaction_a);
+		case 12:
 			break;
 		default:
 			assert (false);

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -37,6 +37,9 @@ public:
 	MDB_env * environment;
 };
 
+class account_info_v6;
+class pending_info_v4;
+
 /**
  * Encapsulates MDB_val and provides uint256_union conversion of the data.
  */
@@ -49,9 +52,11 @@ public:
 	};
 	mdb_val (rai::epoch = rai::epoch::unspecified);
 	mdb_val (rai::account_info const &);
+	mdb_val (rai::account_info_v6 const &);
 	mdb_val (rai::block_info const &);
 	mdb_val (MDB_val const &, rai::epoch = rai::epoch::unspecified);
 	mdb_val (rai::pending_info const &);
+    mdb_val (rai::pending_info_v4 const &);
 	mdb_val (rai::pending_key const &);
 	mdb_val (size_t, void *);
 	mdb_val (rai::uint128_union const &);
@@ -61,8 +66,10 @@ public:
 	void * data () const;
 	size_t size () const;
 	explicit operator rai::account_info () const;
+	explicit operator rai::account_info_v6 () const;
 	explicit operator rai::block_info () const;
 	explicit operator rai::pending_info () const;
+	explicit operator rai::pending_info_v4 () const;
 	explicit operator rai::pending_key () const;
 	explicit operator rai::uint128_union () const;
 	explicit operator rai::uint256_union () const;
@@ -152,10 +159,12 @@ public:
 	rai::transaction tx_begin (bool write = false) override;
 
 	void initialize (rai::transaction const &, rai::genesis const &) override;
-	void block_put (rai::transaction const &, rai::block_hash const &, rai::block const &, rai::block_hash const & = rai::block_hash (0), rai::epoch version = rai::epoch::epoch_0) override;
+	void block_put (rai::transaction const &, rai::block_hash const &, rai::extended_block const &) override;
 	rai::block_hash block_successor (rai::transaction const &, rai::block_hash const &) override;
+	uint64_t block_account_height (rai::transaction const &, rai::block_hash const &) override;
 	void block_successor_clear (rai::transaction const &, rai::block_hash const &) override;
 	std::unique_ptr<rai::block> block_get (rai::transaction const &, rai::block_hash const &) override;
+	rai::extended_block extended_block_get (rai::transaction const &, rai::block_hash const &) override;
 	std::unique_ptr<rai::block> block_random (rai::transaction const &) override;
 	void block_del (rai::transaction const &, rai::block_hash const &) override;
 	bool block_exists (rai::transaction const &, rai::block_hash const &) override;
@@ -368,7 +377,7 @@ private:
 	MDB_dbi block_database (rai::block_type, rai::epoch);
 	template <typename T>
 	std::unique_ptr<rai::block> block_random (rai::transaction const &, MDB_dbi);
-	MDB_val block_raw_get (rai::transaction const &, rai::block_hash const &, rai::block_type &);
+	MDB_val block_raw_get (rai::transaction const &, rai::block_hash const &, rai::block_type &, rai::epoch &);
 	void block_raw_put (rai::transaction const &, MDB_dbi, rai::block_hash const &, MDB_val);
 	void clear (MDB_dbi);
 };

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -56,7 +56,7 @@ public:
 	mdb_val (rai::block_info const &);
 	mdb_val (MDB_val const &, rai::epoch = rai::epoch::unspecified);
 	mdb_val (rai::pending_info const &);
-    mdb_val (rai::pending_info_v4 const &);
+	mdb_val (rai::pending_info_v4 const &);
 	mdb_val (rai::pending_key const &);
 	mdb_val (size_t, void *);
 	mdb_val (rai::uint128_union const &);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1119,7 +1119,7 @@ rai::process_return rai::block_processor::process_receive_one (rai::transaction 
 {
 	rai::process_return result;
 	auto hash (block_a->hash ());
-	result = node.ledger.process (transaction_a, *block_a, validated_state_block);
+	result = node.ledger.process (transaction_a, *block_a, false, validated_state_block);
 	switch (result.code)
 	{
 		case rai::process_result::progress:

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2407,10 +2407,9 @@ public:
 void rai::node::process_confirmed (std::shared_ptr<rai::block> block_a)
 {
 	auto hash (block_a->hash ());
-	bool exists (ledger.block_exists (hash));
-	// Attempt to process confirmed block if it's not in ledger yet
-	if (!exists)
+	bool exists;
 	{
+		// We always re-process the block to guarantee it's marked as confirmed
 		auto transaction (store.tx_begin_write ());
 		block_processor.process_receive_one (transaction, block_a, std::chrono::steady_clock::now (), true);
 		exists = store.block_exists (transaction, hash);
@@ -3171,8 +3170,7 @@ void rai::election::confirm_if_quorum (rai::transaction const & transaction_a)
 		sum += i.first;
 	}
 	auto confirmed (have_quorum (tally_l, sum));
-	// We always re-process the block when confirmed to store confirmation in the database
-	if (sum >= node.config.online_weight_minimum.number () && (block_l->hash () != status.winner->hash () || confirmed))
+	if (sum >= node.config.online_weight_minimum.number () && block_l->hash () != status.winner->hash ())
 	{
 		auto node_l (node.shared ());
 		node_l->block_processor.force (block_l, confirmed);

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -3215,14 +3215,13 @@ void rai::election::confirm_if_quorum (rai::transaction const & transaction_a)
 	{
 		sum += i.first;
 	}
-	auto confirmed (have_quorum (tally_l, sum));
 	if (sum >= node.config.online_weight_minimum.number () && block_l->hash () != status.winner->hash ())
 	{
 		auto node_l (node.shared ());
 		node_l->block_processor.force (block_l);
 		status.winner = block_l;
 	}
-	if (confirmed)
+	if (have_quorum (tally_l, sum))
 	{
 		if (node.config.logging.vote_logging () || blocks.size () > 1)
 		{

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -2312,9 +2312,9 @@ rai::uint128_t rai::node::delta ()
 	return result;
 }
 
-bool rai::node::is_confirmed (rai::block_hash const & hash_a)
+bool rai::node::block_confirmed (rai::block_hash const & hash_a)
 {
-	return ledger.is_confirmed (store.tx_begin_read (), hash_a);
+	return ledger.block_confirmed (store.tx_begin_read (), hash_a);
 }
 
 rai::uint128_t rai::node::account_pending (rai::transaction const & transaction_a, rai::account account_a, bool include_unconfirmed)
@@ -2322,7 +2322,7 @@ rai::uint128_t rai::node::account_pending (rai::transaction const & transaction_
 	rai::uint128_t result (0);
 	rai::account end (account_a.number () + 1);
 	auto add_pending ([&, this](rai::pending_key key, rai::pending_info info) {
-		if (include_unconfirmed || ledger.is_confirmed (transaction_a, key.hash))
+		if (include_unconfirmed || ledger.block_confirmed (transaction_a, key.hash))
 		{
 			result += info.amount.number ();
 		}

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -1104,7 +1104,11 @@ void rai::block_processor::process_receive_many (std::unique_lock<std::mutex> & 
 			{
 				// Replace our block with the winner and roll back any dependent blocks
 				BOOST_LOG (node.log) << boost::str (boost::format ("Rolling back %1% and replacing with %2%") % successor->hash ().to_string () % hash.to_string ());
-				node.ledger.rollback (transaction, successor->hash ());
+				if (node.ledger.rollback (transaction, successor->hash ()))
+				{
+					BOOST_LOG (node.log) << boost::str (boost::format ("Failed to roll back %1% because it or a successor was confirmed") % successor->hash ().to_string ());
+					release_assert (!confirmed);
+				}
 			}
 		}
 		/* Forced state blocks are not validated in verify_state_blocks () function

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -567,7 +567,7 @@ public:
 	void process_fork (rai::transaction const &, std::shared_ptr<rai::block>);
 	bool validate_block_by_previous (rai::transaction const &, std::shared_ptr<rai::block>);
 	rai::uint128_t delta ();
-	bool is_confirmed (rai::block_hash const &);
+	bool block_confirmed (rai::block_hash const &);
 	// If include_unconfirmed is false, block_confirm will be called on any unconfirmed blocks.
 	rai::uint128_t account_pending (rai::transaction const &, rai::account, bool include_unconfirmed);
 	boost::asio::io_service & service;

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -500,11 +500,11 @@ public:
 	void flush ();
 	bool full ();
 	void add (std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point);
-	void force (std::shared_ptr<rai::block>);
+	void force (std::shared_ptr<rai::block>, bool = false);
 	bool should_log ();
 	bool have_blocks ();
 	void process_blocks ();
-	rai::process_return process_receive_one (rai::transaction const &, std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point = std::chrono::steady_clock::now (), bool = false);
+	rai::process_return process_receive_one (rai::transaction const &, std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point = std::chrono::steady_clock::now (), bool = false, bool = false);
 
 private:
 	void queue_unchecked (rai::transaction const &, rai::block_hash const &);
@@ -516,7 +516,7 @@ private:
 	std::deque<std::pair<std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point>> blocks;
 	std::deque<std::pair<std::shared_ptr<rai::block>, std::chrono::steady_clock::time_point>> state_blocks;
 	std::unordered_set<rai::block_hash> blocks_hashes;
-	std::deque<std::shared_ptr<rai::block>> forced;
+	std::deque<std::pair<std::shared_ptr<rai::block>, bool>> forced;
 	std::condition_variable condition;
 	rai::node & node;
 	rai::vote_generator generator;

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -548,7 +548,7 @@ public:
 	rai::block_hash latest (rai::account const &);
 	rai::uint128_t balance (rai::account const &);
 	std::unique_ptr<rai::block> block (rai::block_hash const &);
-	std::pair<rai::uint128_t, rai::uint128_t> balance_pending (rai::account const &);
+	std::pair<rai::uint128_t, rai::uint128_t> balance_pending (rai::account const &, bool);
 	rai::uint128_t weight (rai::account const &);
 	rai::account representative (rai::account const &);
 	void ongoing_keepalive ();
@@ -567,6 +567,9 @@ public:
 	void process_fork (rai::transaction const &, std::shared_ptr<rai::block>);
 	bool validate_block_by_previous (rai::transaction const &, std::shared_ptr<rai::block>);
 	rai::uint128_t delta ();
+	bool is_confirmed (rai::block_hash const &);
+	// If include_unconfirmed is false, block_confirm will be called on any unconfirmed blocks.
+	rai::uint128_t account_pending (rai::transaction const &, rai::account, bool include_unconfirmed);
 	boost::asio::io_service & service;
 	rai::node_config config;
 	rai::alarm & alarm;

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -111,6 +111,7 @@ public:
 	// Is the root of this block in the roots container
 	bool active (rai::block const &);
 	std::deque<std::shared_ptr<rai::block>> list_blocks ();
+	void erase_root (rai::block_hash const &);
 	void erase (rai::block const &);
 	void stop ();
 	bool publish (std::shared_ptr<rai::block> block_a);

--- a/rai/node/node.hpp
+++ b/rai/node/node.hpp
@@ -540,7 +540,7 @@ public:
 	void stop ();
 	std::shared_ptr<rai::node> shared ();
 	int store_version ();
-	void process_confirmed (std::shared_ptr<rai::block>);
+	void process_confirmed (rai::transaction const &, std::shared_ptr<rai::block>);
 	void process_message (rai::message &, rai::endpoint const &);
 	void process_active (std::shared_ptr<rai::block>);
 	rai::process_return process (rai::block const &);

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -774,7 +774,7 @@ void rai::rpc_handler::accounts_pending ()
 			for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (i->first).account == account && peers_l.size () < count; ++i)
 			{
 				rai::pending_key key (i->first);
-				if (include_unconfirmed || node.ledger.is_confirmed (transaction, key.hash))
+				if (include_unconfirmed || node.ledger.block_confirmed (transaction, key.hash))
 				{
 					if (threshold.is_zero () && !source)
 					{
@@ -1587,7 +1587,7 @@ void rai::rpc_handler::block_confirmed ()
 		auto transaction (node.store.tx_begin_read ());
 		if (node.store.block_exists (transaction, hash))
 		{
-			auto confirmed (node.ledger.is_confirmed (transaction, hash));
+			auto confirmed (node.ledger.block_confirmed (transaction, hash));
 			response_l.put ("confirmed", confirmed);
 		}
 		else
@@ -2091,7 +2091,7 @@ void rai::rpc_handler::pending ()
 		for (auto i (node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (i->first).account == account && peers_l.size () < count; ++i)
 		{
 			rai::pending_key key (i->first);
-			if (include_unconfirmed || node.ledger.is_confirmed (transaction, key.hash))
+			if (include_unconfirmed || node.ledger.block_confirmed (transaction, key.hash))
 			{
 				if (threshold.is_zero () && !source && !min_version)
 				{
@@ -2147,7 +2147,7 @@ void rai::rpc_handler::pending_exists ()
 			{
 				exists = node.store.pending_exists (transaction, rai::pending_key (destination, hash));
 			}
-			exists = exists && (include_unconfirmed || node.ledger.is_confirmed (transaction, hash));
+			exists = exists && (include_unconfirmed || node.ledger.block_confirmed (transaction, hash));
 			response_l.put ("exists", exists ? "1" : "0");
 		}
 		else
@@ -3281,7 +3281,7 @@ void rai::rpc_handler::wallet_pending ()
 			for (auto ii (node.store.pending_begin (transaction, rai::pending_key (account, 0))); rai::pending_key (ii->first).account == account && peers_l.size () < count; ++ii)
 			{
 				rai::pending_key key (ii->first);
-				if (include_unconfirmed || node.ledger.is_confirmed (transaction, key.hash))
+				if (include_unconfirmed || node.ledger.block_confirmed (transaction, key.hash))
 				{
 					if (threshold.is_zero () && !source)
 					{

--- a/rai/node/rpc.cpp
+++ b/rai/node/rpc.cpp
@@ -1579,7 +1579,7 @@ void rai::rpc_handler::frontiers ()
 	response_errors ();
 }
 
-void rai::rpc_handler::is_confirmed ()
+void rai::rpc_handler::block_confirmed ()
 {
 	auto hash (hash_impl ());
 	if (!ec)
@@ -3874,9 +3874,9 @@ void rai::rpc_handler::process_request ()
 				request.put ("head", request.get<std::string> ("hash"));
 				account_history ();
 			}
-			else if (action == "is_confirmed")
+			else if (action == "block_confirmed")
 			{
-				is_confirmed ();
+				block_confirmed ();
 			}
 			else if (action == "keepalive")
 			{

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -156,7 +156,7 @@ public:
 	void delegators_count ();
 	void deterministic_key ();
 	void frontiers ();
-	void is_confirmed ();
+	void block_confirmed ();
 	void keepalive ();
 	void key_create ();
 	void key_expand ();

--- a/rai/node/rpc.hpp
+++ b/rai/node/rpc.hpp
@@ -156,7 +156,7 @@ public:
 	void delegators_count ();
 	void deterministic_key ();
 	void frontiers ();
-	void history ();
+	void is_confirmed ();
 	void keepalive ();
 	void key_create ();
 	void key_expand ();

--- a/rai/node/wallet.cpp
+++ b/rai/node/wallet.cpp
@@ -1157,7 +1157,7 @@ bool rai::wallet::search_pending ()
 					{
 						BOOST_LOG (wallets.node.log) << boost::str (boost::format ("Found a pending block %1% for account %2%") % hash.to_string () % pending.source.to_account ());
 						std::shared_ptr<rai::block> block (wallets.node.store.block_get (transaction, hash));
-						if (wallets.node.ledger.is_confirmed (transaction, hash))
+						if (wallets.node.ledger.block_confirmed (transaction, hash))
 						{
 							receive_async (block, representative, amount, [](std::shared_ptr<rai::block>) {});
 						}

--- a/rai/qt/qt.cpp
+++ b/rai/qt/qt.cpp
@@ -108,7 +108,7 @@ wallet (wallet_a)
 
 void rai_qt::self_pane::refresh_balance ()
 {
-	auto balance (wallet.node.balance_pending (wallet.account));
+	auto balance (wallet.node.balance_pending (wallet.account, true));
 	auto final_text (std::string ("Balance: ") + wallet.format_balance (balance.first));
 	if (!balance.second.is_zero ())
 	{
@@ -731,7 +731,7 @@ wallet (wallet_a)
 		{
 			show_line_ok (*account_line);
 			this->history.refresh ();
-			auto balance (this->wallet.node.balance_pending (account));
+			auto balance (this->wallet.node.balance_pending (account, true));
 			auto final_text (std::string ("Balance (NANO): ") + wallet.format_balance (balance.first));
 			if (!balance.second.is_zero ())
 			{

--- a/rai/secure/blockstore.hpp
+++ b/rai/secure/blockstore.hpp
@@ -163,8 +163,10 @@ class block_store
 public:
 	virtual ~block_store () = default;
 	virtual void initialize (rai::transaction const &, rai::genesis const &) = 0;
-	virtual void block_put (rai::transaction const &, rai::block_hash const &, rai::block const &, rai::block_hash const & = rai::block_hash (0), rai::epoch version = rai::epoch::epoch_0) = 0;
+	virtual void block_put (rai::transaction const &, rai::block_hash const &, rai::extended_block const &) = 0;
 	virtual rai::block_hash block_successor (rai::transaction const &, rai::block_hash const &) = 0;
+	virtual uint64_t block_account_height (rai::transaction const &, rai::block_hash const &) = 0;
+	virtual rai::extended_block extended_block_get (rai::transaction const &, rai::block_hash const &) = 0;
 	virtual void block_successor_clear (rai::transaction const &, rai::block_hash const &) = 0;
 	virtual std::unique_ptr<rai::block> block_get (rai::transaction const &, rai::block_hash const &) = 0;
 	virtual std::unique_ptr<rai::block> block_random (rai::transaction const &) = 0;

--- a/rai/secure/common.hpp
+++ b/rai/secure/common.hpp
@@ -227,6 +227,7 @@ public:
 	rai::amount amount;
 	rai::account pending_account;
 	boost::optional<bool> state_is_send;
+	uint64_t newly_confirmed_blocks;
 };
 enum class tally_result
 {

--- a/rai/secure/common.hpp
+++ b/rai/secure/common.hpp
@@ -69,7 +69,7 @@ class account_info
 public:
 	account_info ();
 	account_info (rai::account_info const &) = default;
-	account_info (rai::block_hash const &, rai::block_hash const &, rai::block_hash const &, rai::amount const &, uint64_t, uint64_t, epoch);
+	account_info (rai::block_hash const &, rai::block_hash const &, rai::block_hash const &, rai::amount const &, uint64_t, uint64_t, uint64_t, epoch);
 	void serialize (rai::stream &) const;
 	bool deserialize (rai::stream &);
 	bool operator== (rai::account_info const &) const;
@@ -82,6 +82,7 @@ public:
 	/** Seconds since posix epoch */
 	uint64_t modified;
 	uint64_t block_count;
+	uint64_t confirmation_height;
 	rai::epoch epoch;
 };
 
@@ -92,12 +93,13 @@ class pending_info
 {
 public:
 	pending_info ();
-	pending_info (rai::account const &, rai::amount const &, epoch);
+	pending_info (rai::account const &, rai::amount const &, uint64_t, epoch);
 	void serialize (rai::stream &) const;
 	bool deserialize (rai::stream &);
 	bool operator== (rai::pending_info const &) const;
 	rai::account source;
 	rai::amount amount;
+	uint64_t source_account_height;
 	rai::epoch epoch;
 };
 class pending_key
@@ -121,6 +123,30 @@ public:
 	bool operator== (rai::block_info const &) const;
 	rai::account account;
 	rai::amount balance;
+};
+class block_sideband
+{
+public:
+	block_sideband ();
+	block_sideband (uint64_t, rai::block_hash);
+	void serialize (rai::stream &) const;
+	bool deserialize (rai::stream &);
+	bool operator== (rai::block_sideband const &) const;
+	uint64_t account_height;
+	rai::block_hash successor;
+};
+class extended_block
+{
+public:
+	extended_block ();
+	extended_block (std::unique_ptr<rai::block>, rai::block_sideband, rai::epoch);
+	void serialize (rai::stream &) const;
+	bool deserialize (rai::stream &, rai::block_type);
+	bool operator== (rai::extended_block const &) const;
+	bool operator!= (rai::extended_block const &) const;
+	std::unique_ptr<rai::block> block;
+	rai::block_sideband sideband;
+	rai::epoch epoch;
 };
 class block_counts
 {

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -1049,3 +1049,17 @@ std::unique_ptr<rai::block> rai::ledger::forked_block (rai::transaction const & 
 	}
 	return result;
 }
+
+bool rai::ledger::is_confirmed (rai::transaction const & transaction_a, rai::block_hash const & hash_a)
+{
+	auto confirmed (false);
+	auto block_height (store.block_account_height (transaction_a, hash_a));
+	if (block_height) // 0 indicates block doesn't exist
+	{
+		auto account (this->account (transaction_a, hash_a));
+		rai::account_info info;
+		assert (!store.account_get (transaction_a, account, info));
+		confirmed = info.confirmation_height >= block_height;
+	}
+	return confirmed;
+}

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -1050,7 +1050,7 @@ std::unique_ptr<rai::block> rai::ledger::forked_block (rai::transaction const & 
 	return result;
 }
 
-bool rai::ledger::is_confirmed (rai::transaction const & transaction_a, rai::block_hash const & hash_a)
+bool rai::ledger::block_confirmed (rai::transaction const & transaction_a, rai::block_hash const & hash_a)
 {
 	auto confirmed (false);
 	auto block_height (store.block_account_height (transaction_a, hash_a));

--- a/rai/secure/ledger.cpp
+++ b/rai/secure/ledger.cpp
@@ -168,7 +168,7 @@ public:
 class ledger_processor : public rai::block_visitor
 {
 public:
-	ledger_processor (rai::ledger &, rai::transaction const &, bool = false);
+	ledger_processor (rai::ledger &, rai::transaction const &, bool, bool);
 	virtual ~ledger_processor () = default;
 	void send_block (rai::send_block const &) override;
 	void receive_block (rai::receive_block const &) override;
@@ -180,6 +180,7 @@ public:
 	rai::ledger & ledger;
 	rai::transaction const & transaction;
 	bool valid_signature;
+	bool confirmed;
 	rai::process_return result;
 };
 
@@ -316,7 +317,7 @@ void ledger_processor::state_block_impl (rai::state_block const & block_a)
 						ledger.store.pending_del (transaction, rai::pending_key (block_a.hashables.account, block_a.hashables.link));
 					}
 
-					ledger.change_latest (transaction, block_a.hashables.account, hash, hash, block_a.hashables.balance, info.block_count, true, epoch);
+					ledger.change_latest (transaction, block_a.hashables.account, hash, hash, block_a.hashables.balance, info.block_count, true, epoch, confirmed);
 					if (!ledger.store.frontier_get (transaction, info.head).is_zero ())
 					{
 						ledger.store.frontier_del (transaction, info.head);
@@ -380,7 +381,7 @@ void ledger_processor::epoch_block_impl (rai::state_block const & block_a)
 							ledger.store.block_put (transaction, hash, rai::extended_block (std::make_unique<rai::state_block> (block_a), rai::block_sideband (info.block_count, 0), rai::epoch::epoch_1));
 							result.account = block_a.hashables.account;
 							result.amount = 0;
-							ledger.change_latest (transaction, block_a.hashables.account, hash, hash, info.balance, info.block_count, true, rai::epoch::epoch_1);
+							ledger.change_latest (transaction, block_a.hashables.account, hash, hash, info.balance, info.block_count, true, rai::epoch::epoch_1, confirmed);
 							if (!ledger.store.frontier_get (transaction, info.head).is_zero ())
 							{
 								ledger.store.frontier_del (transaction, info.head);
@@ -423,7 +424,7 @@ void ledger_processor::change_block (rai::change_block const & block_a)
 						auto balance (ledger.balance (transaction, block_a.hashables.previous));
 						ledger.store.representation_add (transaction, hash, balance);
 						ledger.store.representation_add (transaction, info.rep_block, 0 - balance);
-						ledger.change_latest (transaction, account, hash, hash, info.balance, info.block_count);
+						ledger.change_latest (transaction, account, hash, hash, info.balance, info.block_count, false, rai::epoch::epoch_0, confirmed);
 						ledger.store.frontier_del (transaction, block_a.hashables.previous);
 						ledger.store.frontier_put (transaction, hash, account);
 						result.account = account;
@@ -468,7 +469,7 @@ void ledger_processor::send_block (rai::send_block const & block_a)
 							ledger.store.block_put (transaction, hash, rai::extended_block (std::make_unique<rai::send_block> (block_a), rai::block_sideband (info.block_count, 0), rai::epoch::epoch_0));
 							auto amount (info.balance.number () - block_a.hashables.balance.number ());
 							ledger.store.representation_add (transaction, info.rep_block, 0 - amount);
-							ledger.change_latest (transaction, account, hash, info.rep_block, block_a.hashables.balance, info.block_count);
+							ledger.change_latest (transaction, account, hash, info.rep_block, block_a.hashables.balance, info.block_count, false, rai::epoch::epoch_0, confirmed);
 							ledger.store.pending_put (transaction, rai::pending_key (block_a.hashables.destination, hash), { account, amount, info.block_count, rai::epoch::epoch_0 });
 							ledger.store.frontier_del (transaction, block_a.hashables.previous);
 							ledger.store.frontier_put (transaction, hash, account);
@@ -528,7 +529,7 @@ void ledger_processor::receive_block (rai::receive_block const & block_a)
 										auto error (ledger.store.account_get (transaction, pending.source, source_info));
 										assert (!error);
 										ledger.store.pending_del (transaction, key);
-										ledger.change_latest (transaction, account, hash, info.rep_block, new_balance, info.block_count);
+										ledger.change_latest (transaction, account, hash, info.rep_block, new_balance, info.block_count, false, rai::epoch::epoch_0, confirmed);
 										ledger.store.representation_add (transaction, info.rep_block, pending.amount.number ());
 										ledger.store.frontier_del (transaction, block_a.hashables.previous);
 										ledger.store.frontier_put (transaction, hash, account);
@@ -585,7 +586,7 @@ void ledger_processor::open_block (rai::open_block const & block_a)
 								auto error (ledger.store.account_get (transaction, pending.source, source_info));
 								assert (!error);
 								ledger.store.pending_del (transaction, key);
-								ledger.change_latest (transaction, block_a.hashables.account, hash, hash, pending.amount.number (), info.block_count);
+								ledger.change_latest (transaction, block_a.hashables.account, hash, hash, pending.amount.number (), info.block_count, false, rai::epoch::epoch_0, confirmed);
 								ledger.store.representation_add (transaction, hash, pending.amount.number ());
 								ledger.store.frontier_put (transaction, hash, block_a.hashables.account);
 								result.account = block_a.hashables.account;
@@ -600,9 +601,10 @@ void ledger_processor::open_block (rai::open_block const & block_a)
 	}
 }
 
-ledger_processor::ledger_processor (rai::ledger & ledger_a, rai::transaction const & transaction_a, bool valid_signature_a) :
+ledger_processor::ledger_processor (rai::ledger & ledger_a, rai::transaction const & transaction_a, bool confirmed_a, bool valid_signature_a) :
 ledger (ledger_a),
 transaction (transaction_a),
+confirmed (confirmed_a),
 valid_signature (valid_signature_a)
 {
 }
@@ -667,10 +669,21 @@ rai::uint128_t rai::ledger::account_pending (rai::transaction const & transactio
 	return result;
 }
 
-rai::process_return rai::ledger::process (rai::transaction const & transaction_a, rai::block const & block_a, bool valid_signature)
+rai::process_return rai::ledger::process (rai::transaction const & transaction_a, rai::block const & block_a, bool confirmed_a, bool valid_signature)
 {
-	ledger_processor processor (*this, transaction_a, valid_signature);
+	ledger_processor processor (*this, transaction_a, confirmed_a, valid_signature);
 	block_a.visit (processor);
+	if (confirmed_a && processor.result.code == rai::process_result::old)
+	{
+		auto hash (block_a.hash ());
+		auto block_height (store.block_account_height (transaction_a, hash));
+		assert (block_height > 0);
+		rai::account_info info;
+		rai::account account (this->account (transaction_a, hash));
+		release_assert (!store.account_get (transaction_a, account, info));
+		info.confirmation_height = std::max (info.confirmation_height, block_height);
+		store.account_put (transaction_a, account, info);
+	}
 	return processor.result;
 }
 
@@ -950,7 +963,7 @@ void rai::ledger::checksum_update (rai::transaction const & transaction_a, rai::
 	store.checksum_put (transaction_a, 0, 0, value);
 }
 
-void rai::ledger::change_latest (rai::transaction const & transaction_a, rai::account const & account_a, rai::block_hash const & hash_a, rai::block_hash const & rep_block_a, rai::amount const & balance_a, uint64_t block_count_a, bool is_state, rai::epoch epoch_a)
+void rai::ledger::change_latest (rai::transaction const & transaction_a, rai::account const & account_a, rai::block_hash const & hash_a, rai::block_hash const & rep_block_a, rai::amount const & balance_a, uint64_t block_count_a, bool is_state, rai::epoch epoch_a, bool confirmed)
 {
 	rai::account_info info;
 	auto exists (!store.account_get (transaction_a, account_a, info));
@@ -974,6 +987,11 @@ void rai::ledger::change_latest (rai::transaction const & transaction_a, rai::ac
 		{
 			// otherwise we'd end up with a duplicate
 			store.account_del (transaction_a, account_a);
+		}
+		release_assert (info.confirmation_height <= info.block_count);
+		if (confirmed)
+		{
+			info.confirmation_height = info.block_count;
 		}
 		info.epoch = epoch_a;
 		store.account_put (transaction_a, account_a, info);

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -27,7 +27,7 @@ public:
 	rai::uint128_t weight (rai::transaction const &, rai::account const &);
 	std::unique_ptr<rai::block> successor (rai::transaction const &, rai::block_hash const &);
 	std::unique_ptr<rai::block> forked_block (rai::transaction const &, rai::block const &);
-	bool is_confirmed (rai::transaction const &, rai::block_hash const &);
+	bool block_confirmed (rai::transaction const &, rai::block_hash const &);
 	rai::block_hash latest (rai::transaction const &, rai::account const &);
 	rai::block_hash latest_root (rai::transaction const &, rai::account const &);
 	rai::block_hash representative (rai::transaction const &, rai::block_hash const &);

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -40,7 +40,8 @@ public:
 	rai::block_hash block_source (rai::transaction const &, rai::block const &);
 	rai::process_return process (rai::transaction const &, rai::block const &, bool = false, bool = false);
 	void rollback (rai::transaction const &, rai::block_hash const &);
-	void change_latest (rai::transaction const &, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false, rai::epoch = rai::epoch::epoch_0, bool = false);
+	// Returns the number of newly confirmed blocks
+	uint64_t change_latest (rai::transaction const &, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false, rai::epoch = rai::epoch::epoch_0, bool = false);
 	void checksum_update (rai::transaction const &, rai::block_hash const &);
 	rai::checksum checksum (rai::transaction const &, rai::account const &, rai::account const &);
 	void dump_account_chain (rai::account const &);

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -39,7 +39,7 @@ public:
 	rai::block_hash block_destination (rai::transaction const &, rai::block const &);
 	rai::block_hash block_source (rai::transaction const &, rai::block const &);
 	rai::process_return process (rai::transaction const &, rai::block const &, bool = false, bool = false);
-	void rollback (rai::transaction const &, rai::block_hash const &);
+	bool rollback (rai::transaction const &, rai::block_hash const &);
 	// Returns the number of newly confirmed blocks
 	uint64_t change_latest (rai::transaction const &, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false, rai::epoch = rai::epoch::epoch_0, bool = false);
 	void checksum_update (rai::transaction const &, rai::block_hash const &);

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -27,6 +27,7 @@ public:
 	rai::uint128_t weight (rai::transaction const &, rai::account const &);
 	std::unique_ptr<rai::block> successor (rai::transaction const &, rai::block_hash const &);
 	std::unique_ptr<rai::block> forked_block (rai::transaction const &, rai::block const &);
+	bool is_confirmed (rai::transaction const &, rai::block_hash const &);
 	rai::block_hash latest (rai::transaction const &, rai::account const &);
 	rai::block_hash latest_root (rai::transaction const &, rai::account const &);
 	rai::block_hash representative (rai::transaction const &, rai::block_hash const &);

--- a/rai/secure/ledger.hpp
+++ b/rai/secure/ledger.hpp
@@ -37,9 +37,9 @@ public:
 	bool is_send (rai::transaction const &, rai::state_block const &);
 	rai::block_hash block_destination (rai::transaction const &, rai::block const &);
 	rai::block_hash block_source (rai::transaction const &, rai::block const &);
-	rai::process_return process (rai::transaction const &, rai::block const &, bool = false);
+	rai::process_return process (rai::transaction const &, rai::block const &, bool = false, bool = false);
 	void rollback (rai::transaction const &, rai::block_hash const &);
-	void change_latest (rai::transaction const &, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false, rai::epoch = rai::epoch::epoch_0);
+	void change_latest (rai::transaction const &, rai::account const &, rai::block_hash const &, rai::account const &, rai::uint128_union const &, uint64_t, bool = false, rai::epoch = rai::epoch::epoch_0, bool = false);
 	void checksum_update (rai::transaction const &, rai::block_hash const &);
 	rai::checksum checksum (rai::transaction const &, rai::account const &, rai::account const &);
 	void dump_account_chain (rai::account const &);

--- a/rai/secure/versioning.cpp
+++ b/rai/secure/versioning.cpp
@@ -106,6 +106,41 @@ rai::mdb_val rai::pending_info_v3::val () const
 	return rai::mdb_val (sizeof (*this), const_cast<rai::pending_info_v3 *> (this));
 }
 
+rai::pending_info_v4::pending_info_v4 () :
+source (0),
+amount (0),
+epoch (rai::epoch::epoch_0)
+{
+}
+
+rai::pending_info_v4::pending_info_v4 (rai::account const & source_a, rai::amount const & amount_a, rai::epoch epoch_a) :
+source (source_a),
+amount (amount_a),
+epoch (epoch_a)
+{
+}
+
+void rai::pending_info_v4::serialize (rai::stream & stream_a) const
+{
+	rai::write (stream_a, source.bytes);
+	rai::write (stream_a, amount.bytes);
+}
+
+bool rai::pending_info_v4::deserialize (rai::stream & stream_a)
+{
+	auto result (rai::read (stream_a, source.bytes));
+	if (!result)
+	{
+		result = rai::read (stream_a, amount.bytes);
+	}
+	return result;
+}
+
+bool rai::pending_info_v4::operator== (rai::pending_info_v4 const & other_a) const
+{
+	return source == other_a.source && amount == other_a.amount && epoch == other_a.epoch;
+}
+
 rai::account_info_v5::account_info_v5 () :
 head (0),
 rep_block (0),
@@ -165,4 +200,83 @@ bool rai::account_info_v5::deserialize (rai::stream & stream_a)
 rai::mdb_val rai::account_info_v5::val () const
 {
 	return rai::mdb_val (sizeof (*this), const_cast<rai::account_info_v5 *> (this));
+}
+
+rai::account_info_v6::account_info_v6 () :
+head (0),
+rep_block (0),
+open_block (0),
+balance (0),
+modified (0),
+block_count (0),
+epoch (rai::epoch::epoch_0)
+{
+}
+
+rai::account_info_v6::account_info_v6 (rai::block_hash const & head_a, rai::block_hash const & rep_block_a, rai::block_hash const & open_block_a, rai::amount const & balance_a, uint64_t modified_a, uint64_t block_count_a, rai::epoch epoch_a) :
+head (head_a),
+rep_block (rep_block_a),
+open_block (open_block_a),
+balance (balance_a),
+modified (modified_a),
+block_count (block_count_a),
+epoch (epoch_a)
+{
+}
+
+void rai::account_info_v6::serialize (rai::stream & stream_a) const
+{
+	write (stream_a, head.bytes);
+	write (stream_a, rep_block.bytes);
+	write (stream_a, open_block.bytes);
+	write (stream_a, balance.bytes);
+	write (stream_a, modified);
+	write (stream_a, block_count);
+}
+
+bool rai::account_info_v6::deserialize (rai::stream & stream_a)
+{
+	auto error (read (stream_a, head.bytes));
+	if (!error)
+	{
+		error = read (stream_a, rep_block.bytes);
+		if (!error)
+		{
+			error = read (stream_a, open_block.bytes);
+			if (!error)
+			{
+				error = read (stream_a, balance.bytes);
+				if (!error)
+				{
+					error = read (stream_a, modified);
+					if (!error)
+					{
+						error = read (stream_a, block_count);
+					}
+				}
+			}
+		}
+	}
+	return error;
+}
+
+bool rai::account_info_v6::operator== (rai::account_info_v6 const & other_a) const
+{
+	return head == other_a.head && rep_block == other_a.rep_block && open_block == other_a.open_block && balance == other_a.balance && modified == other_a.modified && block_count == other_a.block_count && epoch == other_a.epoch;
+}
+
+bool rai::account_info_v6::operator!= (rai::account_info_v6 const & other_a) const
+{
+	return !(*this == other_a);
+}
+
+size_t rai::account_info_v6::db_size () const
+{
+	assert (reinterpret_cast<const uint8_t *> (this) == reinterpret_cast<const uint8_t *> (&head));
+	assert (reinterpret_cast<const uint8_t *> (&head) + sizeof (head) == reinterpret_cast<const uint8_t *> (&rep_block));
+	assert (reinterpret_cast<const uint8_t *> (&rep_block) + sizeof (rep_block) == reinterpret_cast<const uint8_t *> (&open_block));
+	assert (reinterpret_cast<const uint8_t *> (&open_block) + sizeof (open_block) == reinterpret_cast<const uint8_t *> (&balance));
+	assert (reinterpret_cast<const uint8_t *> (&balance) + sizeof (balance) == reinterpret_cast<const uint8_t *> (&modified));
+	assert (reinterpret_cast<const uint8_t *> (&modified) + sizeof (modified) == reinterpret_cast<const uint8_t *> (&block_count));
+	return sizeof (head) + sizeof (rep_block) + sizeof (open_block) + sizeof (balance) + sizeof (modified) + sizeof (block_count);
 }

--- a/rai/secure/versioning.hpp
+++ b/rai/secure/versioning.hpp
@@ -35,6 +35,18 @@ public:
 	rai::amount amount;
 	rai::account destination;
 };
+class pending_info_v4
+{
+public:
+	pending_info_v4 ();
+	pending_info_v4 (rai::account const &, rai::amount const &, epoch);
+	void serialize (rai::stream &) const;
+	bool deserialize (rai::stream &);
+	bool operator== (rai::pending_info_v4 const &) const;
+	rai::account source;
+	rai::amount amount;
+	rai::epoch epoch;
+};
 // Latest information about an account
 class account_info_v5
 {
@@ -51,5 +63,25 @@ public:
 	rai::block_hash open_block;
 	rai::amount balance;
 	uint64_t modified;
+};
+class account_info_v6
+{
+public:
+	account_info_v6 ();
+	account_info_v6 (rai::account_info_v6 const &) = default;
+	account_info_v6 (rai::block_hash const &, rai::block_hash const &, rai::block_hash const &, rai::amount const &, uint64_t, uint64_t, epoch);
+	void serialize (rai::stream &) const;
+	bool deserialize (rai::stream &);
+	bool operator== (rai::account_info_v6 const &) const;
+	bool operator!= (rai::account_info_v6 const &) const;
+	size_t db_size () const;
+	rai::block_hash head;
+	rai::block_hash rep_block;
+	rai::block_hash open_block;
+	rai::amount balance;
+	/** Seconds since posix epoch */
+	uint64_t modified;
+	uint64_t block_count;
+	rai::epoch epoch;
 };
 }


### PR DESCRIPTION
As a byproduct, this results in all confirmed blocks being immediately cemented. Attempting to replace a confirmed block with a different confirmed block results in a crash (from `release_assert`).

New terminology:
- Block account height, aka block height or a block's account height: given a block, the block height of its account if the block was the frontier. For an open block, this is always 1.
- Block sideband: this is all the information stored alongside a block in the database. Previously, this was just the block's successor hash, but this PR also stores the block's account height.

New information in the database:
- `rai::account_info::confirmation_height`: the maximum account height of any confirmed block in the account. Any blocks in the account with an account height less than the confirmation height have been confirmed.
- `rai::pending_info::source_account_height`: the source block's account height. Used to check if a pending block has been confirmed.
- `rai::block_sideband::account_height`: the account height of the block. This is needed when we roll back a receive block and have to recreate the pending entry.

New node logic:
- When searching for pending incoming sends, we now always confirm_req the source's account frontier instead of the specific send block.
- `process_confirmed` is now recursively called for the confirmed block's previously unconfirmed dependencies, and this process also updates the confirmation_height of the account (note: this is not actually implemented with recursion to avoid running into a stack overflow).