### PR TITLE
Update to ask the database layer if the vote is a replay or not

### DIFF
--- a/rai/core_test/block_store.cpp
+++ b/rai/core_test/block_store.cpp
@@ -674,6 +674,7 @@ TEST (block_store, sequence_increment)
 	ASSERT_TRUE (!init);
 	rai::keypair key1;
 	rai::keypair key2;
+	rai::vote_code vote_code;
 	auto block1 (std::make_shared<rai::open_block> (0, 1, 0, rai::keypair ().prv, 0, 0));
 	auto transaction (store.tx_begin (true));
 	auto vote1 (store.vote_generate (transaction, key1.pub, key1.prv, block1));
@@ -685,11 +686,13 @@ TEST (block_store, sequence_increment)
 	auto vote4 (store.vote_generate (transaction, key2.pub, key2.prv, block1));
 	ASSERT_EQ (2, vote4->sequence);
 	vote1->sequence = 20;
-	auto seq5 (store.vote_max (transaction, vote1));
+	auto seq5 (store.vote_max (transaction, vote1, vote_code));
 	ASSERT_EQ (20, seq5->sequence);
+	ASSERT_EQ (vote_code, rai::vote_code::vote);
 	vote3->sequence = 30;
-	auto seq6 (store.vote_max (transaction, vote3));
+	auto seq6 (store.vote_max (transaction, vote3, vote_code));
 	ASSERT_EQ (30, seq6->sequence);
+	ASSERT_EQ (vote_code, rai::vote_code::vote);
 	auto vote5 (store.vote_generate (transaction, key1.pub, key1.prv, block1));
 	ASSERT_EQ (21, vote5->sequence);
 	auto vote6 (store.vote_generate (transaction, key2.pub, key2.prv, block1));

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1887,7 +1887,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_max (rai::transaction const & tr
 	std::lock_guard<std::mutex> lock (cache_mutex);
 	auto current (vote_current (transaction_a, vote_a->account));
 	auto result (vote_a);
-	if (current != nullptr && current->sequence > result->sequence)
+	if (current != nullptr && current->sequence >= result->sequence)
 	{
 		result = current;
 		result_code = rai::vote_code::replay;

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1882,7 +1882,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const
 	return result;
 }
 
-std::shared_ptr<rai::vote> rai::mdb_store::vote_max (rai::transaction const & transaction_a, std::shared_ptr<rai::vote> vote_a)
+std::shared_ptr<rai::vote> rai::mdb_store::vote_max (rai::transaction const & transaction_a, std::shared_ptr<rai::vote> vote_a, rai::vote_code & result_code)
 {
 	std::lock_guard<std::mutex> lock (cache_mutex);
 	auto current (vote_current (transaction_a, vote_a->account));
@@ -1890,6 +1890,11 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_max (rai::transaction const & tr
 	if (current != nullptr && current->sequence > result->sequence)
 	{
 		result = current;
+		result_code = rai::vote_code::replay;
+	}
+	else
+	{
+		result_code = rai::vote_code::vote;
 	}
 	vote_cache[vote_a->account] = result;
 	return result;

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -230,7 +230,7 @@ public:
 	std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::shared_ptr<rai::block>) override;
 	std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::vector<rai::block_hash>) override;
 	// Return either vote or the stored vote with a higher sequence number
-	std::shared_ptr<rai::vote> vote_max (rai::transaction const &, std::shared_ptr<rai::vote>) override;
+	std::shared_ptr<rai::vote> vote_max (rai::transaction const &, std::shared_ptr<rai::vote>, rai::vote_code &) override;
 	// Return latest vote for an account considering the vote cache
 	std::shared_ptr<rai::vote> vote_current (rai::transaction const &, rai::account const &) override;
 	void flush (rai::transaction const &) override;

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -816,8 +816,7 @@ rai::vote_code rai::vote_processor::vote_blocking (rai::transaction const & tran
 	auto result (rai::vote_code::invalid);
 	if (!vote_a->validate ())
 	{
-		auto max_vote (node.store.vote_max (transaction_a, vote_a));
-		result = rai::vote_code::replay;
+		auto max_vote (node.store.vote_max (transaction_a, vote_a, result));
 		if (!node.active.vote (vote_a))
 		{
 			result = rai::vote_code::vote;

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -817,9 +817,12 @@ rai::vote_code rai::vote_processor::vote_blocking (rai::transaction const & tran
 	if (!vote_a->validate ())
 	{
 		auto max_vote (node.store.vote_max (transaction_a, vote_a, result));
-		if (!node.active.vote (vote_a))
+		if (result != rai::vote_code::vote)
 		{
-			result = rai::vote_code::vote;
+			if (!node.active.vote (vote_a))
+			{
+				result = rai::vote_code::vote;
+			}
 		}
 		switch (result)
 		{

--- a/rai/secure/blockstore.hpp
+++ b/rai/secure/blockstore.hpp
@@ -242,7 +242,7 @@ public:
 	virtual std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::shared_ptr<rai::block>) = 0;
 	virtual std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::vector<rai::block_hash>) = 0;
 	// Return either vote or the stored vote with a higher sequence number
-	virtual std::shared_ptr<rai::vote> vote_max (rai::transaction const &, std::shared_ptr<rai::vote>) = 0;
+	virtual std::shared_ptr<rai::vote> vote_max (rai::transaction const &, std::shared_ptr<rai::vote>, rai::vote_code &) = 0;
 	// Return latest vote for an account considering the vote cache
 	virtual std::shared_ptr<rai::vote> vote_current (rai::transaction const &, rai::account const &) = 0;
 	virtual void flush (rai::transaction const &) = 0;


### PR DESCRIPTION
Fix of #1233, which is a fix of #964, which addresses a bug in #962 (introduced in #850).

In this patch we ask the database to tell us if the vote is a replay or not, since it's the layer that knows this answer.