### PR TITLE
Slightly more efficient way of storing duplicates

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -2430,7 +2430,7 @@ std::pair<std::unique_ptr<nano::pending_key>, std::unique_ptr<nano::pending_info
 		 */
 		if (pending_address_only)
 		{
-			if (deduplication.count (info.source) != 0)
+			if (!deduplication.insert (info.source).second)
 			{
 				/*
 				 * If the deduplication map gets too
@@ -2445,8 +2445,6 @@ std::pair<std::unique_ptr<nano::pending_key>, std::unique_ptr<nano::pending_info
 				}
 				continue;
 			}
-
-			deduplication.insert ({ info.source, true });
 		}
 
 		result.first = std::unique_ptr<nano::pending_key> (new nano::pending_key (key));

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -289,7 +289,7 @@ public:
 	std::shared_ptr<nano::bootstrap_server> connection;
 	std::unique_ptr<nano::bulk_pull_account> request;
 	std::shared_ptr<std::vector<uint8_t>> send_buffer;
-	std::unordered_map<nano::uint256_union, bool> deduplication;
+	std::unordered_set<nano::uint256_union> deduplication;
 	nano::pending_key current_key;
 	bool pending_address_only;
 	bool pending_include_address;


### PR DESCRIPTION
TODO:

- [x] Write test that covers the duplication of the results from pending-only
- [x] Verify that the correct boolean logic is used in deduplication