### PR TITLE
Add scalar support to wallets

### DIFF
--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -23,8 +23,8 @@
 	Generates a (extsk[0..31]) and aExt (extsk[32..63])
 */
 
-DONNA_INLINE static void
-ed25519_extsk(hash_512bits extsk, const ed25519_secret_key sk) {
+void
+ED25519_FN(ed25519_extend_secretkey) (ed25519_extsk extsk, const ed25519_secret_key sk) {
 	ed25519_hash(extsk, sk, 32);
 	extsk[0] &= 248;
 	extsk[31] &= 127;
@@ -42,13 +42,11 @@ ed25519_hram(hash_512bits hram, const ed25519_signature RS, const ed25519_public
 }
 
 void
-ED25519_FN(ed25519_publickey) (const ed25519_secret_key sk, ed25519_public_key pk) {
+ED25519_FN(ed25519_extsk_publickey) (const ed25519_extsk extsk, ed25519_public_key pk) {
 	bignum256modm a;
 	ge25519 ALIGN(16) A;
-	hash_512bits extsk;
 
 	/* A = aB */
-	ed25519_extsk(extsk, sk);
 	expand256_modm(a, extsk, 32);
 	ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);
 	ge25519_pack(pk, &A);
@@ -56,13 +54,11 @@ ED25519_FN(ed25519_publickey) (const ed25519_secret_key sk, ed25519_public_key p
 
 
 void
-ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_public_key pk, ed25519_signature RS) {
+ED25519_FN(ed25519_extsk_sign) (const unsigned char *m, size_t mlen, const ed25519_extsk extsk, const ed25519_public_key pk, ed25519_signature RS) {
 	ed25519_hash_context ctx;
 	bignum256modm r, S, a;
 	ge25519 ALIGN(16) R;
-	hash_512bits extsk, hashr, hram;
-
-	ed25519_extsk(extsk, sk);
+	hash_512bits hashr, hram;
 
 	/* r = H(aExt[32..64], m) */
 	ed25519_hash_init(&ctx);

--- a/ed25519-donna/ed25519.h
+++ b/ed25519-donna/ed25519.h
@@ -10,12 +10,14 @@ extern "C" {
 typedef unsigned char ed25519_signature[64];
 typedef unsigned char ed25519_public_key[32];
 typedef unsigned char ed25519_secret_key[32];
+typedef unsigned char ed25519_extsk[32];
 
 typedef unsigned char curved25519_key[32];
 
-void ed25519_publickey(const ed25519_secret_key sk, ed25519_public_key pk);
+void ed25519_extend_secretkey(ed25519_extsk extsk, const ed25519_secret_key);
+void ed25519_extsk_publickey(const ed25519_extsk sk, ed25519_public_key pk);
 int ed25519_sign_open(const unsigned char *m, size_t mlen, const ed25519_public_key pk, const ed25519_signature RS);
-void ed25519_sign(const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_public_key pk, ed25519_signature RS);
+void ed25519_extsk_sign(const unsigned char *m, size_t mlen, const ed25519_extsk sk, const ed25519_public_key pk, ed25519_signature RS);
 
 int ed25519_sign_open_batch(const unsigned char **m, size_t *mlen, const unsigned char **pk, const unsigned char **RS, size_t num, int *valid);
 

--- a/rai/core_test/block.cpp
+++ b/rai/core_test/block.cpp
@@ -10,13 +10,23 @@
 
 #include <ed25519-donna/ed25519.h>
 
+TEST (ed25519, extsk)
+{
+	rai::raw_key prv;
+	prv.data = rai::uint256_union (12345);
+	rai::uint256_union pub (rai::pub_key (prv.data));
+	ASSERT_EQ (pub, rai::pub_key (prv.data));
+	rai::raw_extsk extsk (rai::raw_extsk::from_private_key (prv));
+	ASSERT_EQ (extsk, rai::raw_extsk::from_private_key (prv));
+	ASSERT_EQ (pub, rai::pub_key (extsk));
+}
+
 TEST (ed25519, signing)
 {
-	rai::uint256_union prv (0);
-	rai::uint256_union pub (rai::pub_key (prv));
+	rai::raw_key prv;
+	rai::uint256_union pub (rai::pub_key (prv.data));
 	rai::uint256_union message (0);
-	rai::uint512_union signature;
-	ed25519_sign (message.bytes.data (), sizeof (message.bytes), prv.bytes.data (), pub.bytes.data (), signature.bytes.data ());
+	rai::uint512_union signature (rai::sign_message (prv, pub, message));
 	auto valid1 (ed25519_sign_open (message.bytes.data (), sizeof (message.bytes), pub.bytes.data (), signature.bytes.data ()));
 	ASSERT_EQ (0, valid1);
 	signature.bytes[32] ^= 0x1;

--- a/rai/core_test/node.cpp
+++ b/rai/core_test/node.cpp
@@ -987,7 +987,7 @@ TEST (node, fork_no_vote_quorum)
 	ASSERT_EQ (rai::process_result::progress, node3.process (send1).code);
 	auto key2 (system.wallet (2)->deterministic_insert ());
 	auto send2 (std::make_shared<rai::send_block> (block->hash (), key2, (rai::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2), rai::test_genesis_key.prv, rai::test_genesis_key.pub, system.work.generate (block->hash ())));
-	rai::raw_key key3;
+	rai::raw_extsk key3;
 	auto transaction (system.wallet (1)->wallets.tx_begin ());
 	ASSERT_FALSE (system.wallet (1)->store.fetch (transaction, key1, key3));
 	auto vote (std::make_shared<rai::vote> (key1, key3, 0, send2));

--- a/rai/lib/blocks.cpp
+++ b/rai/lib/blocks.cpp
@@ -230,7 +230,7 @@ bool rai::send_block::deserialize_json (boost::property_tree::ptree const & tree
 	return error;
 }
 
-rai::send_block::send_block (rai::block_hash const & previous_a, rai::account const & destination_a, rai::amount const & balance_a, rai::raw_key const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
+rai::send_block::send_block (rai::block_hash const & previous_a, rai::account const & destination_a, rai::amount const & balance_a, rai::extsk_source const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
 hashables (previous_a, destination_a, balance_a),
 signature (rai::sign_message (prv_a, pub_a, hash ())),
 work (work_a)
@@ -391,7 +391,7 @@ void rai::open_hashables::hash (blake2b_state & hash_a) const
 	blake2b_update (&hash_a, account.bytes.data (), sizeof (account.bytes));
 }
 
-rai::open_block::open_block (rai::block_hash const & source_a, rai::account const & representative_a, rai::account const & account_a, rai::raw_key const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
+rai::open_block::open_block (rai::block_hash const & source_a, rai::account const & representative_a, rai::account const & account_a, rai::extsk_source const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
 hashables (source_a, representative_a, account_a),
 signature (rai::sign_message (prv_a, pub_a, hash ())),
 work (work_a)
@@ -639,7 +639,7 @@ void rai::change_hashables::hash (blake2b_state & hash_a) const
 	blake2b_update (&hash_a, representative.bytes.data (), sizeof (representative.bytes));
 }
 
-rai::change_block::change_block (rai::block_hash const & previous_a, rai::account const & representative_a, rai::raw_key const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
+rai::change_block::change_block (rai::block_hash const & previous_a, rai::account const & representative_a, rai::extsk_source const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
 hashables (previous_a, representative_a),
 signature (rai::sign_message (prv_a, pub_a, hash ())),
 work (work_a)
@@ -913,7 +913,7 @@ void rai::state_hashables::hash (blake2b_state & hash_a) const
 	blake2b_update (&hash_a, link.bytes.data (), sizeof (link.bytes));
 }
 
-rai::state_block::state_block (rai::account const & account_a, rai::block_hash const & previous_a, rai::account const & representative_a, rai::amount const & balance_a, rai::uint256_union const & link_a, rai::raw_key const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
+rai::state_block::state_block (rai::account const & account_a, rai::block_hash const & previous_a, rai::account const & representative_a, rai::amount const & balance_a, rai::uint256_union const & link_a, rai::extsk_source const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
 hashables (account_a, previous_a, representative_a, balance_a, link_a),
 signature (rai::sign_message (prv_a, pub_a, hash ())),
 work (work_a)
@@ -1365,7 +1365,7 @@ void rai::receive_block::serialize_json (std::string & string_a) const
 	string_a = ostream.str ();
 }
 
-rai::receive_block::receive_block (rai::block_hash const & previous_a, rai::block_hash const & source_a, rai::raw_key const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
+rai::receive_block::receive_block (rai::block_hash const & previous_a, rai::block_hash const & source_a, rai::extsk_source const & prv_a, rai::public_key const & pub_a, uint64_t work_a) :
 hashables (previous_a, source_a),
 signature (rai::sign_message (prv_a, pub_a, hash ())),
 work (work_a)

--- a/rai/lib/blocks.hpp
+++ b/rai/lib/blocks.hpp
@@ -81,7 +81,7 @@ public:
 class send_block : public rai::block
 {
 public:
-	send_block (rai::block_hash const &, rai::account const &, rai::amount const &, rai::raw_key const &, rai::public_key const &, uint64_t);
+	send_block (rai::block_hash const &, rai::account const &, rai::amount const &, rai::extsk_source const &, rai::public_key const &, uint64_t);
 	send_block (bool &, rai::stream &);
 	send_block (bool &, boost::property_tree::ptree const &);
 	virtual ~send_block () = default;
@@ -123,7 +123,7 @@ public:
 class receive_block : public rai::block
 {
 public:
-	receive_block (rai::block_hash const &, rai::block_hash const &, rai::raw_key const &, rai::public_key const &, uint64_t);
+	receive_block (rai::block_hash const &, rai::block_hash const &, rai::extsk_source const &, rai::public_key const &, uint64_t);
 	receive_block (bool &, rai::stream &);
 	receive_block (bool &, boost::property_tree::ptree const &);
 	virtual ~receive_block () = default;
@@ -166,7 +166,7 @@ public:
 class open_block : public rai::block
 {
 public:
-	open_block (rai::block_hash const &, rai::account const &, rai::account const &, rai::raw_key const &, rai::public_key const &, uint64_t);
+	open_block (rai::block_hash const &, rai::account const &, rai::account const &, rai::extsk_source const &, rai::public_key const &, uint64_t);
 	open_block (rai::block_hash const &, rai::account const &, rai::account const &, std::nullptr_t);
 	open_block (bool &, rai::stream &);
 	open_block (bool &, boost::property_tree::ptree const &);
@@ -209,7 +209,7 @@ public:
 class change_block : public rai::block
 {
 public:
-	change_block (rai::block_hash const &, rai::account const &, rai::raw_key const &, rai::public_key const &, uint64_t);
+	change_block (rai::block_hash const &, rai::account const &, rai::extsk_source const &, rai::public_key const &, uint64_t);
 	change_block (bool &, rai::stream &);
 	change_block (bool &, boost::property_tree::ptree const &);
 	virtual ~change_block () = default;
@@ -263,7 +263,7 @@ public:
 class state_block : public rai::block
 {
 public:
-	state_block (rai::account const &, rai::block_hash const &, rai::account const &, rai::amount const &, rai::uint256_union const &, rai::raw_key const &, rai::public_key const &, uint64_t);
+	state_block (rai::account const &, rai::block_hash const &, rai::account const &, rai::amount const &, rai::uint256_union const &, rai::extsk_source const &, rai::public_key const &, uint64_t);
 	state_block (bool &, rai::stream &);
 	state_block (bool &, boost::property_tree::ptree const &);
 	virtual ~state_block () = default;

--- a/rai/lib/interface.cpp
+++ b/rai/lib/interface.cpp
@@ -82,11 +82,14 @@ void xrb_seed_key (xrb_uint256 seed, int index, xrb_uint256 destination)
 
 void xrb_key_account (const xrb_uint256 key, xrb_uint256 pub)
 {
-	ed25519_publickey (key, pub);
+	auto & key_l (*reinterpret_cast<rai::uint256_union *> (key));
+	auto extsk_l (rai::raw_extsk::from_private_key (key_l));
+	ed25519_extsk_publickey (extsk_l.data.bytes.data (), pub);
 }
 
 char * xrb_sign_transaction (const char * transaction, const xrb_uint256 private_key)
 {
+	auto & key_l (*reinterpret_cast<rai::uint256_union *> (private_key));
 	char * result (nullptr);
 	try
 	{
@@ -97,8 +100,7 @@ char * xrb_sign_transaction (const char * transaction, const xrb_uint256 private
 		auto block (rai::deserialize_block_json (block_l));
 		if (block != nullptr)
 		{
-			rai::uint256_union pub;
-			ed25519_publickey (private_key, pub.bytes.data ());
+			rai::uint256_union pub (rai::pub_key (key_l));
 			rai::raw_key prv;
 			prv.data = *reinterpret_cast<rai::uint256_union *> (private_key);
 			block->signature_set (rai::sign_message (prv, pub, block->hash ()));

--- a/rai/node/cli.cpp
+++ b/rai/node/cli.cpp
@@ -457,13 +457,20 @@ std::error_code rai::handle_node_options (boost::program_options::variables_map 
 						for (auto i (existing->second->store.begin (transaction)), m (existing->second->store.end ()); i != m; ++i)
 						{
 							rai::account account (i->first);
-							rai::raw_key key;
-							auto error (existing->second->store.fetch (transaction, account, key));
+							rai::raw_key prv;
+							auto error (existing->second->store.fetch_key (transaction, account, prv));
 							assert (!error);
-							std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key.data.to_string ());
-							if (rai::pub_key (key.data) != account)
+							if (rai::pub_key (prv.data) == account)
 							{
-								std::cerr << boost::str (boost::format ("Invalid private key %1%\n") % key.data.to_string ());
+								std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % prv.data.to_string ());
+							}
+							else if (rai::pub_key (rai::raw_extsk::from_scalar (prv.data)) == account)
+							{
+								std::cout << boost::str (boost::format ("Pub: %1% Scalar: %2%\n") % account.to_account () % prv.data.to_string ());
+							}
+							else
+							{
+								std::cout << boost::str (boost::format ("Pub: %1% Prv: %2% invalid!\n") % account.to_account () % prv.data.to_string ());
 							}
 						}
 					}

--- a/rai/node/lmdb.cpp
+++ b/rai/node/lmdb.cpp
@@ -1862,7 +1862,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_current (rai::transaction const 
 	return result;
 }
 
-std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const & transaction_a, rai::account const & account_a, rai::raw_key const & key_a, std::shared_ptr<rai::block> block_a)
+std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const & transaction_a, rai::account const & account_a, rai::extsk_source const & key_a, std::shared_ptr<rai::block> block_a)
 {
 	std::lock_guard<std::mutex> lock (cache_mutex);
 	auto result (vote_current (transaction_a, account_a));
@@ -1872,7 +1872,7 @@ std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const
 	return result;
 }
 
-std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const & transaction_a, rai::account const & account_a, rai::raw_key const & key_a, std::vector<rai::block_hash> blocks_a)
+std::shared_ptr<rai::vote> rai::mdb_store::vote_generate (rai::transaction const & transaction_a, rai::account const & account_a, rai::extsk_source const & key_a, std::vector<rai::block_hash> blocks_a)
 {
 	std::lock_guard<std::mutex> lock (cache_mutex);
 	auto result (vote_current (transaction_a, account_a));

--- a/rai/node/lmdb.hpp
+++ b/rai/node/lmdb.hpp
@@ -227,8 +227,8 @@ public:
 	// Return latest vote for an account from store
 	std::shared_ptr<rai::vote> vote_get (rai::transaction const &, rai::account const &) override;
 	// Populate vote with the next sequence number
-	std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::shared_ptr<rai::block>) override;
-	std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::vector<rai::block_hash>) override;
+	std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::extsk_source const &, std::shared_ptr<rai::block>) override;
+	std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::extsk_source const &, std::vector<rai::block_hash>) override;
 	// Return either vote or the stored vote with a higher sequence number
 	std::shared_ptr<rai::vote> vote_max (rai::transaction const &, std::shared_ptr<rai::vote>) override;
 	// Return latest vote for an account considering the vote cache

--- a/rai/node/node.cpp
+++ b/rai/node/node.cpp
@@ -257,7 +257,7 @@ bool confirm_block (rai::transaction const & transaction_a, rai::node & node_a, 
 	bool result (false);
 	if (node_a.config.enable_voting)
 	{
-		node_a.wallets.foreach_representative (transaction_a, [&result, &block_a, &list_a, &node_a, &transaction_a](rai::public_key const & pub_a, rai::raw_key const & prv_a) {
+		node_a.wallets.foreach_representative (transaction_a, [&result, &block_a, &list_a, &node_a, &transaction_a](rai::public_key const & pub_a, rai::raw_extsk const & prv_a) {
 			result = true;
 			auto hash (block_a->hash ());
 			auto vote (node_a.store.vote_generate (transaction_a, pub_a, prv_a, std::vector<rai::block_hash> (1, hash)));
@@ -2588,7 +2588,7 @@ void rai::election::compute_rep_votes (rai::transaction const & transaction_a)
 {
 	if (node.config.enable_voting)
 	{
-		node.wallets.foreach_representative (transaction_a, [this, &transaction_a](rai::public_key const & pub_a, rai::raw_key const & prv_a) {
+		node.wallets.foreach_representative (transaction_a, [this, &transaction_a](rai::public_key const & pub_a, rai::raw_extsk const & prv_a) {
 			auto vote (this->node.store.vote_generate (transaction_a, pub_a, prv_a, status.winner));
 			this->node.vote_processor.vote (vote, this->node.network.endpoint ());
 		});

--- a/rai/node/voting.cpp
+++ b/rai/node/voting.cpp
@@ -47,7 +47,7 @@ void rai::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 	lock_a.unlock ();
 	{
 		auto transaction (node.store.tx_begin_read ());
-		node.wallets.foreach_representative (transaction, [this, &hashes_l, &transaction](rai::public_key const & pub_a, rai::raw_key const & prv_a) {
+		node.wallets.foreach_representative (transaction, [this, &hashes_l, &transaction](rai::public_key const & pub_a, rai::raw_extsk const & prv_a) {
 			auto vote (this->node.store.vote_generate (transaction, pub_a, prv_a, hashes_l));
 			this->node.vote_processor.vote (vote, this->node.network.endpoint ());
 		});

--- a/rai/node/wallet.hpp
+++ b/rai/node/wallet.hpp
@@ -66,11 +66,13 @@ public:
 	rai::account representative (rai::transaction const &);
 	void representative_set (rai::transaction const &, rai::account const &);
 	rai::public_key insert_adhoc (rai::transaction const &, rai::raw_key const &);
+	rai::public_key insert_scalar (rai::transaction const &, rai::raw_key const &);
 	void insert_watch (rai::transaction const &, rai::public_key const &);
 	void erase (rai::transaction const &, rai::public_key const &);
 	rai::wallet_value entry_get_raw (rai::transaction const &, rai::public_key const &);
 	void entry_put_raw (rai::transaction const &, rai::public_key const &, rai::wallet_value const &);
-	bool fetch (rai::transaction const &, rai::public_key const &, rai::raw_key &);
+	bool fetch_key (rai::transaction const &, rai::public_key const &, rai::raw_key &);
+	bool fetch (rai::transaction const &, rai::public_key const &, rai::raw_extsk &);
 	bool exists (rai::transaction const &, rai::public_key const &);
 	void destroy (rai::transaction const &);
 	rai::store_iterator<rai::uint256_union, rai::wallet_value> find (rai::transaction const &, rai::uint256_union const &);
@@ -130,6 +132,8 @@ public:
 	bool enter_password (rai::transaction const &, std::string const &);
 	rai::public_key insert_adhoc (rai::raw_key const &, bool = true);
 	rai::public_key insert_adhoc (rai::transaction const &, rai::raw_key const &, bool = true);
+	rai::public_key insert_scalar (rai::raw_key const &, bool = true);
+	rai::public_key insert_scalar (rai::transaction const &, rai::raw_key const &, bool = true);
 	void insert_watch (rai::transaction const &, rai::public_key const &);
 	rai::public_key deterministic_insert (rai::transaction const &, bool = true);
 	rai::public_key deterministic_insert (bool = true);
@@ -174,7 +178,7 @@ public:
 	void destroy (rai::uint256_union const &);
 	void do_wallet_actions ();
 	void queue_wallet_action (rai::uint128_t const &, std::shared_ptr<rai::wallet>, std::function<void(rai::wallet &)> const &);
-	void foreach_representative (rai::transaction const &, std::function<void(rai::public_key const &, rai::raw_key const &)> const &);
+	void foreach_representative (rai::transaction const &, std::function<void(rai::public_key const &, rai::raw_extsk const &)> const &);
 	bool exists (rai::transaction const &, rai::public_key const &);
 	void stop ();
 	void clear_send_ids (rai::transaction const &);

--- a/rai/secure/blockstore.hpp
+++ b/rai/secure/blockstore.hpp
@@ -239,8 +239,8 @@ public:
 	// Return latest vote for an account from store
 	virtual std::shared_ptr<rai::vote> vote_get (rai::transaction const &, rai::account const &) = 0;
 	// Populate vote with the next sequence number
-	virtual std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::shared_ptr<rai::block>) = 0;
-	virtual std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::raw_key const &, std::vector<rai::block_hash>) = 0;
+	virtual std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::extsk_source const &, std::shared_ptr<rai::block>) = 0;
+	virtual std::shared_ptr<rai::vote> vote_generate (rai::transaction const &, rai::account const &, rai::extsk_source const &, std::vector<rai::block_hash>) = 0;
 	// Return either vote or the stored vote with a higher sequence number
 	virtual std::shared_ptr<rai::vote> vote_max (rai::transaction const &, std::shared_ptr<rai::vote>) = 0;
 	// Return latest vote for an account considering the vote cache

--- a/rai/secure/common.hpp
+++ b/rai/secure/common.hpp
@@ -148,8 +148,8 @@ public:
 	vote (rai::vote const &);
 	vote (bool &, rai::stream &);
 	vote (bool &, rai::stream &, rai::block_type);
-	vote (rai::account const &, rai::raw_key const &, uint64_t, std::shared_ptr<rai::block>);
-	vote (rai::account const &, rai::raw_key const &, uint64_t, std::vector<rai::block_hash>);
+	vote (rai::account const &, rai::extsk_source const &, uint64_t, std::shared_ptr<rai::block>);
+	vote (rai::account const &, rai::extsk_source const &, uint64_t, std::vector<rai::block_hash>);
 	std::string hashes_string () const;
 	rai::uint256_union hash () const;
 	bool operator== (rai::vote const &) const;


### PR DESCRIPTION
This is a big change, it has merge conflicts, and may not be good in its current state, but I think some of the patterns here will be useful for adding better scalar support to wallets.

With this change, keys generated by tools like https://github.com/PlasmaPower/nano-bip32 can be used with rai_node. That said, this PR doesn't contain an RPC for the insert_scalar function, though one shouldn't be hard to make (it's the same as insert_adhoc).