### PR TITLE
MDB improvements

### DIFF
--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -25,7 +25,8 @@ nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, 
 			release_assert (status3 == 0);
 			// It seems if there's ever more threads than mdb_env_set_maxreaders has read slots available, we get failures on transaction creation unless MDB_NOTLS is specified
 			// This can happen if something like 256 io_threads are specified in the node config
-			auto status4 (mdb_env_open (environment, path_a.string ().c_str (), MDB_NOSUBDIR | MDB_NOTLS, 00600));
+			// MDB_NORDAHEAD will allow platforms that support it to load the DB in memory as needed.
+			auto status4 (mdb_env_open (environment, path_a.string ().c_str (), MDB_NOSUBDIR | MDB_NOTLS | MDB_NORDAHEAD, 00600));
 			release_assert (status4 == 0);
 			error_a = status4 != 0;
 		}


### PR DESCRIPTION
MDB_NOSYNC could provide improvements with disk usage by not calling fsync after commit
MDB_NORDAHEAD improves memory usage by not trying to read ahead in the DB, This has no effect on windows but other OSes should benefit. Windows does not read ahead so it is not affected