### PR TITLE
Improve lazy_start function

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1151,8 +1151,8 @@ void rai::bootstrap_attempt::add_bulk_push_target (rai::block_hash const & head,
 void rai::bootstrap_attempt::lazy_start (rai::block_hash const & hash_a)
 {
 	std::unique_lock<std::mutex> lock (lazy_mutex);
-	// Add start blocks
-	if (lazy_keys.find (hash_a) == lazy_keys.end () && lazy_blocks.find (hash_a) == lazy_blocks.end ())
+	// Add start blocks, limit 1024
+	if (lazy_keys.size () < 1024 && lazy_keys.find (hash_a) == lazy_keys.end () && lazy_blocks.find (hash_a) == lazy_blocks.end ())
 	{
 		lazy_keys.insert (hash_a);
 		lazy_pulls.push_back (hash_a);


### PR DESCRIPTION
Prevent multiple lazy_pulls with same key
Limit max lazy_keys size to 1024