### PR TITLE
Force drop lazy bootstrap connection for long chains

### DIFF
--- a/rai/node/bootstrap.cpp
+++ b/rai/node/bootstrap.cpp
@@ -1305,6 +1305,16 @@ bool rai::bootstrap_attempt::process_block (std::shared_ptr<rai::block> block_a)
 			{
 				// Disabled until server rewrite
 				// stop_pull = true;
+				auto account (node->ledger.account (transaction, hash));
+				rai::account_info info;
+				if (!node->store.account_get (transaction, account, info))
+				{
+					// Force drop lazy bootstrap connection for long chains to prevent high bandwidth usage
+					if (info.block_count > 256)
+					{
+						stop_pull = true;
+					}
+				}
 			}
 			//Search unknown state blocks balances
 			auto find_state (lazy_state_unknown.find (hash));


### PR DESCRIPTION
to prevent high bandwidth usage