### PR TITLE
Periodically wake up the block processor

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1275,7 +1275,7 @@ void nano::block_processor::process_blocks ()
 			condition.notify_all ();
 			lock.lock ();
 
-			condition.wait (lock);
+			condition.wait_for (lock, std::chrono::milliseconds (1000));
 		}
 	}
 }


### PR DESCRIPTION
Periodically wake up the block processor even if it has not been notified.
This can occur if a notify is missing, or if a notify was sent out while we were not waiting for it because there is a lot of lock/unlock activity in process_receive_many