### PR TITLE
Remove ip_address_hash from std namespace

### DIFF
--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -69,19 +69,6 @@ struct endpoint_hash<4>
 		return result;
 	}
 };
-}
-
-namespace std
-{
-template <>
-struct hash<::nano::endpoint>
-{
-	size_t operator() (::nano::endpoint const & endpoint_a) const
-	{
-		endpoint_hash<sizeof (size_t)> ehash;
-		return ehash (endpoint_a);
-	}
-};
 template <size_t size>
 struct ip_address_hash
 {
@@ -102,6 +89,19 @@ struct ip_address_hash<4>
 		uint64_t big (ip_address_hash_raw (ip_address_a));
 		uint32_t result (static_cast<uint32_t> (big) ^ static_cast<uint32_t> (big >> 32));
 		return result;
+	}
+};
+}
+
+namespace std
+{
+template <>
+struct hash<::nano::endpoint>
+{
+	size_t operator() (::nano::endpoint const & endpoint_a) const
+	{
+		endpoint_hash<sizeof (size_t)> ehash;
+		return ehash (endpoint_a);
 	}
 };
 template <>


### PR DESCRIPTION
In similar vein to #1460  the ip_address_hash struct and specializations have been removed from polluting the std namespace.