### PR TITLE
Only build essential boost libraries in docker

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -9,16 +9,8 @@ RUN apt-get update -qq && apt-get install -yqq \
     g++ \
     wget
 
-WORKDIR "/tmp"
-
-RUN wget -qO ${BOOST_BASENAME}.tar.gz ${BOOST_URL} && \
-    tar xzf ${BOOST_BASENAME}.tar.gz && \
-    cd ${BOOST_BASENAME} && \
-    ./bootstrap.sh --with-libraries=thread,log,filesystem,program_options && \
-    ./b2 -d0 link=static install && \
-    rm -rf ${BOOST_BASENAME} && \
-    rm -f ${BOOST_BASENAME}.tar.gz && \
-    cd ..
+ADD util/build_prep/bootstrap_boost.sh bootstrap_boost.sh
+RUN ./bootstrap_boost.sh -m
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -28,4 +20,3 @@ RUN apt-get update -qq && apt-get install -yqq \
     xorg xvfb xauth xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic \
     cargo
 
-RUN rm -rf /tmp/*

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,8 +20,6 @@ RUN wget -qO ${BOOST_BASENAME}.tar.gz ${BOOST_URL} && \
     rm -f ${BOOST_BASENAME}.tar.gz && \
     cd ..
 
-RUN apt-get remove wget
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && apt-get install -yqq \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -qq && apt-get install -yqq \
     build-essential \
     cmake \
@@ -11,8 +13,6 @@ ENV BOOST_ROOT=/usr/local
 ADD util/build_prep/bootstrap_boost.sh bootstrap_boost.sh
 RUN ./bootstrap_boost.sh -m -B 1.66
 RUN rm bootstrap_boost.sh
-
-ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && apt-get install -yqq \
     qt5-default \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -14,16 +14,17 @@ WORKDIR "/tmp"
 RUN wget -qO ${BOOST_BASENAME}.tar.gz ${BOOST_URL} && \
     tar xzf ${BOOST_BASENAME}.tar.gz && \
     cd ${BOOST_BASENAME} && \
-    ./bootstrap.sh && \
+    ./bootstrap.sh --with-libraries=thread,log,filesystem,program_options && \
     ./b2 -d0 link=static install && \
     rm -rf ${BOOST_BASENAME} && \
     rm -f ${BOOST_BASENAME}.tar.gz && \
     cd ..
 
+RUN apt-get remove wget
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get install -yq \
+RUN apt-get update -qq && apt-get install -yqq \
     qt5-default \
     valgrind \
     xorg xvfb xauth xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:16.04
 
-ENV BOOST_BASENAME=boost_1_66_0 \
-    BOOST_URL=https://netix.dl.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz
-
 RUN apt-get update -qq && apt-get install -yqq \
     build-essential \
     cmake \
     g++ \
-    wget
+    wget \
+    python
 
+ENV BOOST_ROOT=/usr/local
 ADD util/build_prep/bootstrap_boost.sh bootstrap_boost.sh
-RUN ./bootstrap_boost.sh -m
+RUN ./bootstrap_boost.sh -m -B 1.66
+RUN rm bootstrap_boost.sh
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
In the Dockerfile used for continuous integration all the boost libraries are built; however we only need 4: thread, log, filesystem & program_options. Now this isn't a big issue as we use the option "--cache-from nanocurrency/nano-ci:latest", which picks up the boost files from the intermediate cache layer. But it would be a bit quicker getting the cache and also result in a smaller docker image.

I've made another adjustment as per the docker best practices ["Always combine RUN apt-get update with apt-get install in the same RUN statement"](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get). This is because, if we only changed the second RUN then we would not be getting the latest repositories from apt even though apt-get update is called in the first one, because it is taken from the cache.

It is also recommend to clear the apt cache with rm -rf /var/lib/apt/lists/* after calling apt-get install, however this caused problems getting ccache from travis-ci, so I have left this as is.