### PR TITLE
Emit "nano_" prefixed addresses

### DIFF
--- a/nano/core_test/interface.cpp
+++ b/nano/core_test/interface.cpp
@@ -28,7 +28,19 @@ TEST (interface, xrb_uint256_to_address)
 	nano::uint256_union zero (0);
 	char text[66] = { 0 };
 	xrb_uint256_to_address (zero.bytes.data (), text);
-	ASSERT_STREQ ("xrb_1111111111111111111111111111111111111111111111111111hifc8npp", text);
+
+	/*
+	 * Handle both "xrb_" and "nano_" results, since it is not
+	 * specified which is returned
+	 */
+	if (text[0] == 'x')
+	{
+		ASSERT_STREQ ("xrb_1111111111111111111111111111111111111111111111111111hifc8npp", text);
+	}
+	else
+	{
+		ASSERT_STREQ ("nano_1111111111111111111111111111111111111111111111111111hifc8npp", text);
+	}
 }
 
 TEST (interface, xrb_uint512_to_string)
@@ -68,6 +80,9 @@ TEST (interface, xrb_valid_address)
 	ASSERT_EQ (0, xrb_valid_address ("xrb_1111111111111111111111111111111111111111111111111111hifc8npp"));
 	ASSERT_EQ (1, xrb_valid_address ("xrb_1111111111111111111111111111111111111111111111111111hifc8nppp"));
 	ASSERT_EQ (1, xrb_valid_address ("xrb_1111111211111111111111111111111111111111111111111111hifc8npp"));
+	ASSERT_EQ (0, xrb_valid_address ("nano_1111111111111111111111111111111111111111111111111111hifc8npp"));
+	ASSERT_EQ (1, xrb_valid_address ("nano_1111111111111111111111111111111111111111111111111111hifc8nppp"));
+	ASSERT_EQ (1, xrb_valid_address ("nano_1111111211111111111111111111111111111111111111111111hifc8npp"));
 }
 
 TEST (interface, xrb_seed_create)

--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -348,14 +348,28 @@ TEST (uint256_union, decode_account_variations)
 		nano::uint256_union pub;
 		xrb_key_account (key.data.bytes.data (), pub.bytes.data ());
 
+		unsigned offset;
 		char account[66] = { 0 };
 		xrb_uint256_to_address (pub.bytes.data (), account);
+
+		/*
+		 * Handle different offsets for the underscore separator
+		 * for "xrb_" prefixed and "nano_" prefixed accounts
+		 */
+		if (account[0] == 'x')
+		{
+			offset = 4;
+		}
+		else
+		{
+			offset = 5;
+		}
 
 		// Replace first digit after xrb_ with '0'..'9', make sure only one of them is valid
 		int errors = 0;
 		for (int variation = 0; variation < 10; variation++)
 		{
-			account[4] = static_cast<char> (variation + 48);
+			account[offset] = static_cast<char> (variation + 48);
 			errors += xrb_valid_address (account);
 		}
 
@@ -365,12 +379,26 @@ TEST (uint256_union, decode_account_variations)
 
 TEST (uint256_union, account_transcode)
 {
+	unsigned offset;
 	nano::uint256_union value;
 	auto text (nano::test_genesis_key.pub.to_account ());
 	ASSERT_FALSE (value.decode_account (text));
 	ASSERT_EQ (nano::test_genesis_key.pub, value);
-	ASSERT_EQ ('_', text[3]);
-	text[3] = '-';
+
+	/*
+	 * Handle different offsets for the underscore separator
+	 * for "xrb_" prefixed and "nano_" prefixed accounts
+	 */
+	if (text[0] == 'x')
+	{
+		offset = 3;
+	}
+	else
+	{
+		offset = 4;
+	}
+	ASSERT_EQ ('_', text[offset]);
+	text[offset] = '-';
 	nano::uint256_union value2;
 	ASSERT_FALSE (value2.decode_account (text));
 	ASSERT_EQ (value, value2);
@@ -381,9 +409,23 @@ TEST (uint256_union, account_encode_lex)
 	nano::uint256_union min ("0000000000000000000000000000000000000000000000000000000000000000");
 	nano::uint256_union max ("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 	auto min_text (min.to_account ());
-	ASSERT_EQ (64, min_text.size ());
 	auto max_text (max.to_account ());
-	ASSERT_EQ (64, max_text.size ());
+	unsigned length;
+
+	/*
+	 * Handle different lengths for "xrb_" prefixed and "nano_" prefixed accounts
+	 */
+	if (min_text[0] == 'x')
+	{
+		length = 64;
+	}
+	else
+	{
+		length = 65;
+	}
+	ASSERT_EQ (length, min_text.size ());
+	ASSERT_EQ (length, max_text.size ());
+
 	auto previous (min_text);
 	for (auto i (1); i != 1000; ++i)
 	{

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -314,7 +314,18 @@ TEST (account, encode_zero)
 	nano::uint256_union number0 (0);
 	std::string str0;
 	number0.encode_account (str0);
-	ASSERT_EQ (64, str0.size ());
+
+	/*
+	 * Handle different lengths for "xrb_" prefixed and "nano_" prefixed accounts
+	 */
+	if (str0[0] == 'x')
+	{
+		ASSERT_EQ (64, str0.size ());
+	}
+	else
+	{
+		ASSERT_EQ (65, str0.size ());
+	}
 	nano::uint256_union number1;
 	ASSERT_FALSE (number1.decode_account (str0));
 	ASSERT_EQ (number0, number1);
@@ -326,7 +337,19 @@ TEST (account, encode_all)
 	number0.decode_hex ("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 	std::string str0;
 	number0.encode_account (str0);
-	ASSERT_EQ (64, str0.size ());
+
+	/*
+	 * Handle different lengths for "xrb_" prefixed and "nano_" prefixed accounts
+	 */
+	if (str0[0] == 'x')
+	{
+		ASSERT_EQ (64, str0.size ());
+	}
+	else
+	{
+		ASSERT_EQ (65, str0.size ());
+	}
+
 	nano::uint256_union number1;
 	ASSERT_FALSE (number1.decode_account (str0));
 	ASSERT_EQ (number0, number1);

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -44,7 +44,7 @@ uint8_t account_decode (char value)
 void nano::uint256_union::encode_account (std::string & destination_a) const
 {
 	assert (destination_a.empty ());
-	destination_a.reserve (64);
+	destination_a.reserve (65);
 	uint64_t check (0);
 	blake2b_state hash;
 	blake2b_init (&hash, 5);
@@ -59,7 +59,7 @@ void nano::uint256_union::encode_account (std::string & destination_a) const
 		number_l >>= 5;
 		destination_a.push_back (account_encode (r));
 	}
-	destination_a.append ("_brx"); // xrb_
+	destination_a.append ("_onan"); // nano_
 	std::reverse (destination_a.begin (), destination_a.end ());
 }
 


### PR DESCRIPTION
This changeset changes the generated names to begin with "nano_" rather than "xrb_", as a follow-on to #1504 and the renaming of RaiBlocks to Nano.