### PR TITLE
Split wallet from ledger

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -593,7 +593,7 @@ TEST (system, DISABLED_generate_send_existing)
 	auto send_block (system.wallet (0)->send_action (nano::genesis_account, stake_preserver.pub, nano::genesis_amount / 3 * 2, true));
 	nano::account_info info1;
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin ());
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info1));
 	}
 	std::vector<nano::account> accounts;
@@ -609,7 +609,7 @@ TEST (system, DISABLED_generate_send_existing)
 	ASSERT_GT (system.nodes[0]->balance (stake_preserver.pub), system.nodes[0]->balance (nano::genesis_account));
 	nano::account_info info2;
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin ());
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info2));
 	}
 	ASSERT_NE (info1.head, info2.head);
@@ -617,13 +617,13 @@ TEST (system, DISABLED_generate_send_existing)
 	while (info2.block_count < info1.block_count + 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin ());
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info2));
 	}
 	ASSERT_EQ (info1.block_count + 2, info2.block_count);
 	ASSERT_EQ (info2.balance, nano::genesis_amount / 3);
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin ());
 		ASSERT_NE (system.nodes[0]->ledger.amount (transaction, info2.head), 0);
 	}
 	system.stop ();
@@ -656,7 +656,7 @@ TEST (system, generate_send_new)
 	system.generate_send_new (*system.nodes[0], accounts);
 	nano::account new_account (0);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		auto iterator2 (system.wallet (0)->store.begin (transaction));
 		if (nano::uint256_union (iterator2->first) != nano::test_genesis_key.pub)
 		{

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -363,7 +363,7 @@ TEST (network, receive_weight_change)
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
 	{
-		auto transaction (system.nodes[1]->store.tx_begin (true));
+		auto transaction (system.nodes[1]->wallets.tx_begin (true));
 		system.wallet (1)->store.representative_set (transaction, key2.pub);
 	}
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -608,7 +608,7 @@ TEST (wallet, work)
 	system.deadline_set (10s);
 	while (!done)
 	{
-		nano::transaction transaction (system.nodes[0]->store.tx_begin ());
+		nano::transaction transaction (system.wallet (0)->wallets.tx_begin ());
 		uint64_t work (0);
 		if (!wallet->store.work_get (transaction, nano::test_genesis_key.pub, work))
 		{
@@ -627,7 +627,7 @@ TEST (wallet, work_generate)
 	wallet->insert_adhoc (nano::test_genesis_key.prv);
 	nano::account account1;
 	{
-		nano::transaction transaction (system.nodes[0]->store.tx_begin ());
+		nano::transaction transaction (system.nodes[0]->wallets.tx_begin ());
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
@@ -643,8 +643,9 @@ TEST (wallet, work_generate)
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto transaction (system.nodes[0]->store.tx_begin ());
-		again = wallet->store.work_get (transaction, account1, work1) || nano::work_validate (system.nodes[0]->ledger.latest_root (transaction, account1), work1);
+		auto block_transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		again = wallet->store.work_get (transaction, account1, work1) || nano::work_validate (system.nodes[0]->ledger.latest_root (block_transaction, account1), work1);
 	}
 }
 
@@ -859,7 +860,7 @@ TEST (wallet, no_work)
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
 	ASSERT_FALSE (nano::work_validate (block->root (), block->block_work ()));
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.wallet (0)->wallets.tx_begin ());
 	uint64_t cached_work (0);
 	system.wallet (0)->store.work_get (transaction, nano::test_genesis_key.pub, cached_work);
 	ASSERT_EQ (0, cached_work);

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -8,7 +8,7 @@
 
 #include <queue>
 
-nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, int max_dbs)
+nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, int max_dbs, size_t map_size_a)
 {
 	boost::system::error_code error_mkdir, error_chmod;
 	if (path_a.has_parent_path ())
@@ -21,7 +21,7 @@ nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, 
 			release_assert (status1 == 0);
 			auto status2 (mdb_env_set_maxdbs (environment, max_dbs));
 			release_assert (status2 == 0);
-			auto status3 (mdb_env_set_mapsize (environment, 1ULL * 1024 * 1024 * 1024 * 128)); // 128 Gigabyte
+			auto status3 (mdb_env_set_mapsize (environment, map_size_a));
 			release_assert (status3 == 0);
 			// It seems if there's ever more threads than mdb_env_set_maxreaders has read slots available, we get failures on transaction creation unless MDB_NOTLS is specified
 			// This can happen if something like 256 io_threads are specified in the node config

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -30,7 +30,7 @@ public:
 class mdb_env
 {
 public:
-	mdb_env (bool &, boost::filesystem::path const &, int max_dbs = 128);
+	mdb_env (bool &, boost::filesystem::path const &, int max_dbs = 128, size_t map_size = 128ULL * 1024 * 1024 * 1024);
 	~mdb_env ();
 	operator MDB_env * () const;
 	nano::transaction tx_begin (bool = false) const;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -329,6 +329,7 @@ public:
 	node_init ();
 	bool error ();
 	bool block_store_init;
+	bool wallets_store_init;
 	bool wallet_init;
 };
 class node_observers
@@ -510,6 +511,8 @@ public:
 	boost::log::sources::logger_mt log;
 	std::unique_ptr<nano::block_store> store_impl;
 	nano::block_store & store;
+	std::unique_ptr<nano::wallets_store> wallets_store_impl;
+	nano::wallets_store & wallets_store;
 	nano::gap_cache gap_cache;
 	nano::ledger ledger;
 	nano::active_transactions active;
@@ -519,6 +522,7 @@ public:
 	nano::peer_container peers;
 	boost::filesystem::path application_path;
 	nano::node_observers observers;
+	nano::wallets wallets_old;
 	nano::wallets wallets;
 	nano::port_mapping port_mapping;
 	nano::signature_checker checker;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
 #include <boost/thread/thread.hpp>
-#include <nano/node/common.hpp>
 #include <nano/node/lmdb.hpp>
 #include <nano/node/openclwork.hpp>
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/common.hpp>
 
 #include <mutex>
-#include <queue>
-#include <thread>
 #include <unordered_set>
 
 namespace nano
@@ -90,13 +87,15 @@ public:
 	void upgrade_v1_v2 (nano::transaction const &);
 	void upgrade_v2_v3 (nano::transaction const &);
 	void upgrade_v3_v4 (nano::transaction const &);
+	void upgrade_v4_v5 (nano::transaction const &);
 	nano::fan password;
 	nano::fan wallet_key_mem;
 	static unsigned const version_1 = 1;
 	static unsigned const version_2 = 2;
 	static unsigned const version_3 = 3;
 	static unsigned const version_4 = 4;
-	unsigned const version_current = version_4;
+	static unsigned const version_5 = 5;
+	unsigned const version_current = version_5;
 	static nano::uint256_union const version_special;
 	static nano::uint256_union const wallet_key_special;
 	static nano::uint256_union const salt_special;
@@ -168,6 +167,7 @@ class wallets
 {
 public:
 	wallets (bool &, nano::node &);
+	wallets (bool &, nano::node &, nano::mdb_env &);
 	~wallets ();
 	std::shared_ptr<nano::wallet> open (nano::uint256_union const &);
 	std::shared_ptr<nano::wallet> create (nano::uint256_union const &);
@@ -206,5 +206,16 @@ public:
 	 * @param write If true, start a read-write transaction
 	 */
 	nano::transaction tx_begin (bool write = false);
+};
+class wallets_store
+{
+public:
+	virtual ~wallets_store () = default;
+};
+class mdb_wallets_store : public wallets_store
+{
+public:
+	mdb_wallets_store (bool &, boost::filesystem::path const &, int lmdb_max_dbs = 128);
+	nano::mdb_env environment;
 };
 }

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -253,13 +253,14 @@ wallet (wallet_a)
 void nano_qt::accounts::refresh_wallet_balance ()
 {
 	auto transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
+	auto block_transaction (this->wallet.node.store.tx_begin_read ());
 	nano::uint128_t balance (0);
 	nano::uint128_t pending (0);
 	for (auto i (this->wallet.wallet_m->store.begin (transaction)), j (this->wallet.wallet_m->store.end ()); i != j; ++i)
 	{
 		nano::public_key key (i->first);
-		balance = balance + (this->wallet.node.ledger.account_balance (transaction, key));
-		pending = pending + (this->wallet.node.ledger.account_pending (transaction, key));
+		balance = balance + (this->wallet.node.ledger.account_balance (block_transaction, key));
+		pending = pending + (this->wallet.node.ledger.account_pending (block_transaction, key));
 	}
 	auto final_text (std::string ("Balance: ") + wallet.format_balance (balance));
 	if (!pending.is_zero ())
@@ -278,11 +279,12 @@ void nano_qt::accounts::refresh ()
 {
 	model->removeRows (0, model->rowCount ());
 	auto transaction (wallet.wallet_m->wallets.tx_begin_read ());
+	auto block_transaction (this->wallet.node.store.tx_begin_read ());
 	QBrush brush;
 	for (auto i (wallet.wallet_m->store.begin (transaction)), j (wallet.wallet_m->store.end ()); i != j; ++i)
 	{
 		nano::public_key key (i->first);
-		auto balance_amount (wallet.node.ledger.account_balance (transaction, key));
+		auto balance_amount (wallet.node.ledger.account_balance (block_transaction, key));
 		bool display (true);
 		switch (wallet.wallet_m->store.key_type (i->second))
 		{
@@ -1666,7 +1668,8 @@ void nano_qt::settings::refresh_representative ()
 	}
 	else
 	{
-		current_representative->setText (this->wallet.wallet_m->store.representative (transaction).to_account ().c_str ());
+		auto wallet_transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
+		current_representative->setText (this->wallet.wallet_m->store.representative (wallet_transaction).to_account ().c_str ());
 	}
 }
 
@@ -2182,17 +2185,18 @@ void nano_qt::block_creation::create_send ()
 			error = destination_l.decode_account (destination->text ().toStdString ());
 			if (!error)
 			{
-				auto transaction (wallet.node.store.tx_begin_read ());
+				auto transaction (wallet.node.wallets.tx_begin_read ());
+				auto block_transaction (wallet.node.store.tx_begin_read ());
 				nano::raw_key key;
 				if (!wallet.wallet_m->store.fetch (transaction, account_l, key))
 				{
-					auto balance (wallet.node.ledger.account_balance (transaction, account_l));
+					auto balance (wallet.node.ledger.account_balance (block_transaction, account_l));
 					if (amount_l.number () <= balance)
 					{
 						nano::account_info info;
-						auto error (wallet.node.store.account_get (transaction, account_l, info));
+						auto error (wallet.node.store.account_get (block_transaction, account_l, info));
 						assert (!error);
-						auto rep_block (wallet.node.store.block_get (transaction, info.rep_block));
+						auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
 						assert (rep_block != nullptr);
 						nano::state_block send (account_l, info.head, rep_block->representative (), balance - amount_l.number (), destination_l, key, account_l, 0);
 						wallet.node.work_generate_blocking (send);
@@ -2239,26 +2243,27 @@ void nano_qt::block_creation::create_receive ()
 	auto error (source_l.decode_hex (source->text ().toStdString ()));
 	if (!error)
 	{
-		auto transaction (wallet.node.store.tx_begin_read ());
-		auto block_l (wallet.node.store.block_get (transaction, source_l));
+		auto transaction (wallet.node.wallets.tx_begin_read ());
+		auto block_transaction (wallet.node.store.tx_begin_read ());
+		auto block_l (wallet.node.store.block_get (block_transaction, source_l));
 		if (block_l != nullptr)
 		{
-			auto destination (wallet.node.ledger.block_destination (transaction, *block_l));
+			auto destination (wallet.node.ledger.block_destination (block_transaction, *block_l));
 			if (!destination.is_zero ())
 			{
 				nano::pending_key pending_key (destination, source_l);
 				nano::pending_info pending;
-				if (!wallet.node.store.pending_get (transaction, pending_key, pending))
+				if (!wallet.node.store.pending_get (block_transaction, pending_key, pending))
 				{
 					nano::account_info info;
-					auto error (wallet.node.store.account_get (transaction, pending_key.account, info));
+					auto error (wallet.node.store.account_get (block_transaction, pending_key.account, info));
 					if (!error)
 					{
 						nano::raw_key key;
 						auto error (wallet.wallet_m->store.fetch (transaction, pending_key.account, key));
 						if (!error)
 						{
-							auto rep_block (wallet.node.store.block_get (transaction, info.rep_block));
+							auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
 							assert (rep_block != nullptr);
 							nano::state_block receive (pending_key.account, info.head, rep_block->representative (), info.balance.number () + pending.amount.number (), source_l, key, pending_key.account, 0);
 							wallet.node.work_generate_blocking (receive);
@@ -2315,9 +2320,10 @@ void nano_qt::block_creation::create_change ()
 		error = representative_l.decode_account (representative->text ().toStdString ());
 		if (!error)
 		{
-			auto transaction (wallet.node.store.tx_begin_read ());
+			auto transaction (wallet.node.wallets.tx_begin_read ());
+			auto block_transaction (wallet.node.store.tx_begin_read ());
 			nano::account_info info;
-			auto error (wallet.node.store.account_get (transaction, account_l, info));
+			auto error (wallet.node.store.account_get (block_transaction, account_l, info));
 			if (!error)
 			{
 				nano::raw_key key;
@@ -2367,19 +2373,20 @@ void nano_qt::block_creation::create_open ()
 		error = representative_l.decode_account (representative->text ().toStdString ());
 		if (!error)
 		{
-			auto transaction (wallet.node.store.tx_begin_read ());
-			auto block_l (wallet.node.store.block_get (transaction, source_l));
+			auto transaction (wallet.node.wallets.tx_begin_read ());
+			auto block_transaction (wallet.node.store.tx_begin_read ());
+			auto block_l (wallet.node.store.block_get (block_transaction, source_l));
 			if (block_l != nullptr)
 			{
-				auto destination (wallet.node.ledger.block_destination (transaction, *block_l));
+				auto destination (wallet.node.ledger.block_destination (block_transaction, *block_l));
 				if (!destination.is_zero ())
 				{
 					nano::pending_key pending_key (destination, source_l);
 					nano::pending_info pending;
-					if (!wallet.node.store.pending_get (transaction, pending_key, pending))
+					if (!wallet.node.store.pending_get (block_transaction, pending_key, pending))
 					{
 						nano::account_info info;
-						auto error (wallet.node.store.account_get (transaction, pending_key.account, info));
+						auto error (wallet.node.store.account_get (block_transaction, pending_key.account, info));
 						if (error)
 						{
 							nano::raw_key key;

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -87,10 +87,10 @@ TEST (wallet, select_account)
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	wallet->accounts.view->selectionModel ()->setCurrentIndex (wallet->accounts.model->index (0, 0), QItemSelectionModel::SelectionFlag::Select);
-	QTest::mouseClick (wallet->accounts.use_account, Qt::LeftButton);
+	wallet->accounts.use_account->click ();
 	auto key3 (wallet->account);
 	wallet->accounts.view->selectionModel ()->setCurrentIndex (wallet->accounts.model->index (1, 0), QItemSelectionModel::SelectionFlag::Select);
-	QTest::mouseClick (wallet->accounts.use_account, Qt::LeftButton);
+	wallet->accounts.use_account->click ();
 	auto key4 (wallet->account);
 	ASSERT_NE (key3, key4);
 	ASSERT_EQ (key2, key4);
@@ -134,14 +134,14 @@ TEST (wallet, password_change)
 	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		nano::raw_key password1;
 		nano::raw_key password2;
 		system.wallet (0)->store.derive_key (password1, transaction, "1");
@@ -152,7 +152,7 @@ TEST (wallet, password_change)
 	QTest::keyClicks (wallet->settings.retype_password, "1");
 	QTest::mouseClick (wallet->settings.change, Qt::LeftButton);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		nano::raw_key password1;
 		nano::raw_key password2;
 		system.wallet (0)->store.derive_key (password1, transaction, "1");
@@ -170,7 +170,7 @@ TEST (client, password_nochange)
 	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -185,7 +185,7 @@ TEST (client, password_nochange)
 		system.wallet (0)->store.password.value (password);
 	}
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		nano::raw_key password1;
 		system.wallet (0)->store.derive_key (password1, transaction, "");
 		nano::raw_key password2;
@@ -196,7 +196,7 @@ TEST (client, password_nochange)
 	QTest::keyClicks (wallet->settings.retype_password, "2");
 	QTest::mouseClick (wallet->settings.change, Qt::LeftButton);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		nano::raw_key password1;
 		system.wallet (0)->store.derive_key (password1, transaction, "");
 		nano::raw_key password2;
@@ -214,7 +214,7 @@ TEST (wallet, enter_password)
 	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -229,7 +229,7 @@ TEST (wallet, enter_password)
 	test_application->processEvents ();
 	ASSERT_EQ ("Status: Wallet password empty, Blocks: 1", wallet->status->text ().toStdString ());
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->wallets.tx_begin (true));
 		ASSERT_FALSE (system.wallet (0)->store.rekey (transaction, "abc"));
 	}
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
@@ -309,7 +309,7 @@ TEST (wallet, process_block)
 	nano::block_hash latest (system.nodes[0]->latest (nano::genesis_account));
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -409,7 +409,7 @@ TEST (wallet, create_open_receive)
 	ASSERT_EQ (nano::process_result::old, system.nodes[0]->process (open).code);
 	wallet->block_creation.block->clear ();
 	wallet->block_creation.source->clear ();
-	QTest::mouseClick (wallet->block_creation.receive, Qt::LeftButton);
+	wallet->block_creation.receive->click ();
 	QTest::keyClicks (wallet->block_creation.source, latest2.to_string ().c_str ());
 	QTest::mouseClick (wallet->block_creation.create, Qt::LeftButton);
 	std::string json2 (wallet->block_creation.block->toPlainText ().toStdString ());
@@ -436,7 +436,7 @@ TEST (wallet, create_change)
 	wallet->client_window->show ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	QTest::mouseClick (wallet->advanced.create_block, Qt::LeftButton);
-	QTest::mouseClick (wallet->block_creation.change, Qt::LeftButton);
+	wallet->block_creation.change->click ();
 	QTest::keyClicks (wallet->block_creation.account, nano::test_genesis_key.pub.to_account ().c_str ());
 	QTest::keyClicks (wallet->block_creation.representative, key.pub.to_account ().c_str ());
 	QTest::mouseClick (wallet->block_creation.create, Qt::LeftButton);
@@ -461,7 +461,7 @@ TEST (history, short_text)
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -493,7 +493,7 @@ TEST (wallet, startup_work)
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -501,7 +501,7 @@ TEST (wallet, startup_work)
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	uint64_t work1;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		ASSERT_TRUE (wallet->wallet_m->store.work_get (transaction, nano::test_genesis_key.pub, work1));
 	}
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
@@ -512,7 +512,7 @@ TEST (wallet, startup_work)
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		again = wallet->wallet_m->store.work_get (transaction, nano::test_genesis_key.pub, work1);
 	}
 }
@@ -525,7 +525,7 @@ TEST (wallet, block_viewer)
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -551,7 +551,7 @@ TEST (wallet, import)
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (key1.prv);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
 		system.wallet (0)->store.serialize_json (transaction, json);
 	}
 	system.wallet (1)->insert_adhoc (key2.prv);
@@ -718,7 +718,7 @@ TEST (wallet, seed_work_generation)
 		system.wallet (0)->store.work_get (transaction, key1, work);
 		ASSERT_NO_ERROR (ec);
 	}
-	auto transaction (system.wallet (0)->wallets.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin ());
 	ASSERT_FALSE (nano::work_validate (system.nodes[0]->ledger.latest_root (transaction, key1), work));
 }
 


### PR DESCRIPTION
Splits existing wallet away from the ledger into a separate wallets.ldb closes #210 
Things currently remaining
- [ ]  Locked wallets will not unlock until nano_node/wallet is restarted after migration
- [ ]  provide automated/rpc/cli based removal of wallet databases in the ledger db