### PR TITLE
"update_existing_accounts" option for RPC wallet_representative_set

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -580,7 +580,7 @@ TEST (rpc, wallet_representative_set_force)
 	nano::keypair key;
 	request.put ("action", "wallet_representative_set");
 	request.put ("representative", key.pub.to_account ());
-	request.put ("force", true);
+	request.put ("update_existing_accounts", true);
 	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3493,7 +3493,7 @@ void nano::rpc_handler::wallet_representative_set ()
 			// Change representative for all wallet accounts
 			if (request.get<bool> ("update_existing_accounts", false))
 			{
-				std::deque<nano::account> accounts;
+				std::vector<nano::account> accounts;
 				{
 					auto transaction (node.store.tx_begin_read ());
 					for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3491,7 +3491,7 @@ void nano::rpc_handler::wallet_representative_set ()
 				wallet->store.representative_set (transaction, representative);
 			}
 			// Change representative for all wallet accounts
-			if (request.get<bool> ("force", false))
+			if (request.get<bool> ("update_existing_accounts", false))
 			{
 				std::deque<nano::account> accounts;
 				{


### PR DESCRIPTION
to change representative for existing accounts (https://github.com/nanocurrency/raiblocks/issues/1019, @renesq)