### PR TITLE
Set outdated-version status on livenet as well

### DIFF
--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -174,6 +174,10 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 			{
 				status = parse_status::outdated_version;
 			}
+			else if (header.version_using < nano::protocol_version_min)
+			{
+				status = parse_status::outdated_version;
+			}
 			else if (!header.valid_magic ())
 			{
 				status = parse_status::invalid_magic;


### PR DESCRIPTION
As a result, the network visitor never deals with messages from outdated peers. There's an outdated-version stat counter though.