### PR TITLE
Formatting fix, and add parens to lambda

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2510,7 +2510,7 @@ public:
 					auto callback_l (callback);
 					std::weak_ptr<nano::node> node_w (node);
 					auto next_backoff (std::min (backoff * 2, (unsigned int)60 * 5));
-					node->alarm.add (now + std::chrono::seconds (backoff), [ node_w, root_l, callback_l, next_backoff, difficulty = difficulty ] {
+					node->alarm.add (now + std::chrono::seconds (backoff), [node_w, root_l, callback_l, next_backoff, difficulty = difficulty]() {
 						if (auto node_l = node_w.lock ())
 						{
 							auto work_generation (std::make_shared<distributed_work> (next_backoff, node_l, root_l, callback_l, difficulty));


### PR DESCRIPTION
Added parens to lambda for consistency which hopefully also makes various versions of clang-format agree its formatting.