### PR TITLE
Get rid of nounset flag when running the Boost bootstrap subscript

### DIFF
--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -104,15 +104,15 @@ else
 	keepArchive='true'
 fi
 
-if [ -n  "${buildCArgs[*]}" ]; then
+if [ -n "${buildCArgs[*]}" ]; then
 	buildArgs+=(cflags="${buildCArgs[*]}")
 fi
 
-if [ -n  "${buildCXXArgs[*]}" ]; then
+if [ -n "${buildCXXArgs[*]}" ]; then
 	buildArgs+=(cxxflags="${buildCXXArgs[*]}")
 fi
 
-if [ -n  "${buildLDArgs[*]}" ]; then
+if [ -n "${buildLDArgs[*]}" ]; then
 	buildArgs+=(linkflags="${buildLDArgs[*]}")
 fi
 

--- a/util/build_prep/update-common
+++ b/util/build_prep/update-common
@@ -31,6 +31,7 @@ for file in */prep.sh.in; do
 			# Print out the bootstrap_boost
 			print "function bootstrap_boost () {"
 			print "\t("
+			print "\t\tset +u"
 			print "\t\tmkdir -p \"${KEEP_AROUND_DIRECTORY}\" || exit 1"
 			print "\t\tcd \"${KEEP_AROUND_DIRECTORY}\" || exit 1"
 			while (getline <"bootstrap_boost.sh") {


### PR DESCRIPTION
Due to bugs in bash empty arrays are treated as unset, but we use empty
arrays in some conditions in the boost bootstrap script.  When calling
that script from the build prep script by inclusion, remove the nounset
flag so that empty arrays can be used as empty arrays.