### PR TITLE
WIP: Config RPC

### DIFF
--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -122,7 +122,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 			{
 				node->flags = flags;
 				node->start ();
-				std::unique_ptr<nano::rpc> rpc = get_rpc (io_ctx, *node, config.rpc);
+				std::unique_ptr<nano::rpc> rpc = get_rpc (io_ctx, *node, config.rpc, config);
 				if (rpc && config.rpc_enable)
 				{
 					rpc->start ();

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -8,6 +8,10 @@
 #include <nano/secure/utility.hpp>
 #include <unordered_map>
 
+namespace nano_daemon
+{
+	class daemon_config;
+}
 namespace nano
 {
 void error_response (std::function<void(boost::property_tree::ptree const &)> response_a, std::string const & message_a);
@@ -65,7 +69,7 @@ class payment_observer;
 class rpc
 {
 public:
-	rpc (boost::asio::io_context &, nano::node &, nano::rpc_config const &);
+	rpc (boost::asio::io_context &, nano::node &, nano::rpc_config const &, nano_daemon::daemon_config &);
 	virtual ~rpc () = default;
 	void start ();
 	virtual void accept ();
@@ -74,6 +78,7 @@ public:
 	boost::asio::ip::tcp::acceptor acceptor;
 	std::mutex mutex;
 	std::unordered_map<nano::account, std::shared_ptr<nano::payment_observer>> payment_observers;
+	nano_daemon::daemon_config & config_daemon;
 	nano::rpc_config config;
 	nano::node & node;
 	bool on;
@@ -150,6 +155,7 @@ public:
 	void bootstrap_lazy ();
 	void bootstrap_status ();
 	void chain (bool = false);
+	void config ();
 	void confirmation_active ();
 	void confirmation_history ();
 	void confirmation_info ();
@@ -241,5 +247,5 @@ public:
 	bool rpc_control_impl ();
 };
 /** Returns the correct RPC implementation based on TLS configuration */
-std::unique_ptr<nano::rpc> get_rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a);
+std::unique_ptr<nano::rpc> get_rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a, nano_daemon::daemon_config & daemon_a);
 }

--- a/nano/node/rpc_secure.cpp
+++ b/nano/node/rpc_secure.cpp
@@ -88,8 +88,8 @@ void nano::rpc_secure::load_certs (boost::asio::ssl::context & context_a)
 	}
 }
 
-nano::rpc_secure::rpc_secure (boost::asio::io_service & service_a, nano::node & node_a, nano::rpc_config const & config_a) :
-rpc (service_a, node_a, config_a),
+nano::rpc_secure::rpc_secure (boost::asio::io_service & service_a, nano::node & node_a, nano::rpc_config const & config_a, nano_daemon::daemon_config & daemon_config_a) :
+rpc (service_a, node_a, config_a, daemon_config_a),
 ssl_context (boost::asio::ssl::context::tlsv12_server)
 {
 	load_certs (ssl_context);

--- a/nano/node/rpc_secure.hpp
+++ b/nano/node/rpc_secure.hpp
@@ -11,7 +11,7 @@ namespace nano
 class rpc_secure : public rpc
 {
 public:
-	rpc_secure (boost::asio::io_service & service_a, nano::node & node_a, nano::rpc_config const & config_a);
+	rpc_secure (boost::asio::io_service & service_a, nano::node & node_a, nano::rpc_config const & config_a, nano_daemon::daemon_config const & daemon_a);
 
 	/** Starts accepting connections */
 	void accept () override;


### PR DESCRIPTION
RPC `{"action": "config"}`

Unfortunately exposes `daemon_config` to `rpc` to be able to get the full config.