### PR TITLE
Disable clang format where versions disagree

### DIFF
--- a/nano/lib/interface.h
+++ b/nano/lib/interface.h
@@ -9,7 +9,7 @@ typedef unsigned char * xrb_uint128; // 16byte array for public and private keys
 typedef unsigned char * xrb_uint256; // 32byte array for public and private keys
 typedef unsigned char * xrb_uint512; // 64byte array for signatures
 typedef void * xrb_transaction;
-
+// clang-format off
 // Convert amount bytes 'source' to a 40 byte null-terminated decimal string 'destination'
 [[deprecated]]
 void xrb_uint128_to_dec (const xrb_uint128 source, char * destination);
@@ -57,7 +57,7 @@ char * xrb_sign_transaction (const char * transaction, const xrb_uint256 private
 // Generate work for 'transaction'
 [[deprecated]]
 char * xrb_work_transaction (const char * transaction);
-
+// clang-format on
 #if __cplusplus
 } // extern "C"
 #endif

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2510,6 +2510,7 @@ public:
 					auto callback_l (callback);
 					std::weak_ptr<nano::node> node_w (node);
 					auto next_backoff (std::min (backoff * 2, (unsigned int)60 * 5));
+					// clang-format off
 					node->alarm.add (now + std::chrono::seconds (backoff), [ node_w, root_l, callback_l, next_backoff, difficulty = difficulty ] {
 						if (auto node_l = node_w.lock ())
 						{
@@ -2517,6 +2518,7 @@ public:
 							work_generation->start ();
 						}
 					});
+					// clang-format on
 				}
 			}
 		}


### PR DESCRIPTION
The current .clang-format file allows for three different results, depending on clang-format version. Proposing this PR to disable formatting where needed, until we have a better solution.