### PR TITLE
Accept seed in RPC wallet_create

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -733,6 +733,10 @@ TEST (rpc, wallet_create_seed)
 		wallet->second->store.seed (seed0, transaction);
 		ASSERT_EQ (seed.pub, seed0.data);
 	}
+	auto account_text (response.json.get<std::string> ("account"));
+	nano::uint256_union account;
+	ASSERT_FALSE (account.decode_account (account_text));
+	ASSERT_TRUE (system.wallet (0)->exists (account));
 }
 
 TEST (rpc, wallet_export)

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3282,7 +3282,7 @@ void nano::rpc_handler::wallet_create ()
 			{
 				auto transaction_w (node.store.tx_begin_write ());
 				nano::public_key account (wallet->change_seed (transaction_w, seed));
-				response_l.put ("account", account.to_string ());
+				response_l.put ("account", account.to_account ());
 			}
 		}
 	}

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3258,17 +3258,32 @@ void nano::rpc_handler::wallet_create ()
 	rpc_control_impl ();
 	if (!ec)
 	{
-		nano::keypair wallet_id;
-		node.wallets.create (wallet_id.pub);
-		auto transaction (node.store.tx_begin_read ());
-		auto existing (node.wallets.items.find (wallet_id.pub));
-		if (existing != node.wallets.items.end ())
+		nano::raw_key seed;
+		auto seed_text (request.get_optional<std::string> ("seed"));
+		if (seed_text.is_initialized () && seed.data.decode_hex (*seed_text))
 		{
-			response_l.put ("wallet", wallet_id.pub.to_string ());
+			ec = nano::error_common::bad_seed;
 		}
-		else
+		if (!ec)
 		{
-			ec = nano::error_common::wallet_lmdb_max_dbs;
+			nano::keypair wallet_id;
+			auto wallet (node.wallets.create (wallet_id.pub));
+			auto transaction (node.store.tx_begin_read ());
+			auto existing (node.wallets.items.find (wallet_id.pub));
+			if (existing != node.wallets.items.end ())
+			{
+				response_l.put ("wallet", wallet_id.pub.to_string ());
+			}
+			else
+			{
+				ec = nano::error_common::wallet_lmdb_max_dbs;
+			}
+			if (!ec && seed_text.is_initialized ())
+			{
+				auto transaction_w (node.store.tx_begin_write ());
+				nano::public_key account (wallet->change_seed (transaction_w, seed));
+				response_l.put ("account", account.to_string ());
+			}
 		}
 	}
 	response_errors ();


### PR DESCRIPTION
Fixes #1341 

Since wallet::change_seed() inserts and returns the first key, it is also included in the response. If seed is not provided, the first account is not generated.

One could argue this is inconsistent behavior, and that doing the same when the seed is not provided would not break anything for users/services, so we could add that too.
