### PR TITLE
Limit nested bootstrap runs

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -769,7 +769,8 @@ account_count (0),
 total_blocks (0),
 stopped (false),
 lazy_mode (false),
-lazy_stopped (0)
+lazy_stopped (0),
+runs_count (0)
 {
 	BOOST_LOG (node->log) << "Starting bootstrap attempt";
 	node->bootstrap_initiator.notify_listeners (true);
@@ -939,8 +940,9 @@ void nano::bootstrap_attempt::run ()
 		BOOST_LOG (node->log) << "Completed pulls";
 		request_push (lock);
 		// Start lazy bootstrap if some lazy keys were inserted
-		if (!lazy_keys.empty () && !node->flags.disable_lazy_bootstrap)
+		if (runs_count < 2 && !lazy_keys.empty () && !node->flags.disable_lazy_bootstrap)
 		{
+			runs_count++;
 			lock.unlock ();
 			lazy_mode = true;
 			lazy_run ();
@@ -1310,8 +1312,9 @@ void nano::bootstrap_attempt::lazy_run ()
 		BOOST_LOG (node->log) << "Completed lazy pulls";
 		// Fallback to legacy bootstrap
 		std::unique_lock<std::mutex> lazy_lock (lazy_mutex);
-		if (!lazy_keys.empty () && !node->flags.disable_legacy_bootstrap)
+		if (runs_count < 2 && !lazy_keys.empty () && !node->flags.disable_legacy_bootstrap)
 		{
+			runs_count++;
 			pulls.clear ();
 			lock.unlock ();
 			lazy_blocks.clear ();

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -103,6 +103,7 @@ public:
 	std::shared_ptr<nano::node> node;
 	std::atomic<unsigned> account_count;
 	std::atomic<uint64_t> total_blocks;
+	std::atomic<unsigned> runs_count;
 	std::vector<std::pair<nano::block_hash, nano::block_hash>> bulk_push_targets;
 	bool stopped;
 	bool lazy_mode;

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -1391,6 +1391,7 @@ void nano::rpc_handler::bootstrap_status ()
 		response_l.put ("idle", std::to_string (attempt->idle.size ()));
 		response_l.put ("target_connections", std::to_string (attempt->target_connections (attempt->pulls.size ())));
 		response_l.put ("total_blocks", std::to_string (attempt->total_blocks));
+		response_l.put ("runs_count", std::to_string (attempt->runs_count));
 		response_l.put ("lazy_mode", attempt->lazy_mode);
 		response_l.put ("lazy_blocks", std::to_string (attempt->lazy_blocks.size ()));
 		response_l.put ("lazy_state_unknown", std::to_string (attempt->lazy_state_unknown.size ()));


### PR DESCRIPTION
Old behavior may cause issues for slow nodes, repeating bootstraps multiple times