### PR TITLE
Remove checksum table

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -342,25 +342,6 @@ TEST (unchecked, multiple_get)
 	ASSERT_EQ (unchecked5.size (), 0);
 }
 
-TEST (checksum, simple)
-{
-	nano::logging logging;
-	bool init (false);
-	nano::mdb_store store (init, logging, nano::unique_path ());
-	ASSERT_TRUE (!init);
-	nano::block_hash hash0 (0);
-	auto transaction (store.tx_begin (true));
-	ASSERT_TRUE (store.checksum_get (transaction, 0x100, 0x10, hash0));
-	nano::block_hash hash1 (0);
-	store.checksum_put (transaction, 0x100, 0x10, hash1);
-	nano::block_hash hash2;
-	ASSERT_FALSE (store.checksum_get (transaction, 0x100, 0x10, hash2));
-	ASSERT_EQ (hash1, hash2);
-	store.checksum_del (transaction, 0x100, 0x10);
-	nano::block_hash hash3;
-	ASSERT_TRUE (store.checksum_get (transaction, 0x100, 0x10, hash3));
-}
-
 TEST (block_store, empty_accounts)
 {
 	nano::logging logging;

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -94,7 +94,6 @@ using account = uint256_union;
 using public_key = uint256_union;
 using private_key = uint256_union;
 using secret_key = uint256_union;
-using checksum = uint256_union;
 class raw_key
 {
 public:

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1072,6 +1072,9 @@ void nano::mdb_store::upgrade_v11_to_v12 (nano::transaction const & transaction_
 	version_put (transaction_a, 12);
 	mdb_drop (env.tx (transaction_a), unchecked, 1);
 	mdb_dbi_open (env.tx (transaction_a), "unchecked", MDB_CREATE, &unchecked);
+	MDB_dbi checksum;
+	mdb_dbi_open (env.tx (transaction_a), "checksum", MDB_CREATE, &checksum);
+	mdb_drop (env.tx (transaction_a), checksum, 1);
 }
 
 void nano::mdb_store::clear (MDB_dbi db_a)

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -226,10 +226,6 @@ public:
 	nano::store_iterator<nano::unchecked_key, std::shared_ptr<nano::block>> unchecked_end () override;
 	size_t unchecked_count (nano::transaction const &) override;
 
-	void checksum_put (nano::transaction const &, uint64_t, uint8_t, nano::checksum const &) override;
-	bool checksum_get (nano::transaction const &, uint64_t, uint8_t, nano::checksum &) override;
-	void checksum_del (nano::transaction const &, uint64_t, uint8_t) override;
-
 	// Return latest vote for an account from store
 	std::shared_ptr<nano::vote> vote_get (nano::transaction const &, nano::account const &) override;
 	// Populate vote with the next sequence number
@@ -354,12 +350,6 @@ public:
 	 * nano::block_hash -> nano::block
 	 */
 	MDB_dbi unchecked;
-
-	/**
-	 * Mapping of region to checksum.
-	 * (uint56_t, uint8_t) -> nano::block_hash
-	 */
-	MDB_dbi checksum;
 
 	/**
 	 * Highest vote observed for account.

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -265,10 +265,6 @@ public:
 	virtual nano::store_iterator<nano::unchecked_key, std::shared_ptr<nano::block>> unchecked_end () = 0;
 	virtual size_t unchecked_count (nano::transaction const &) = 0;
 
-	virtual void checksum_put (nano::transaction const &, uint64_t, uint8_t, nano::checksum const &) = 0;
-	virtual bool checksum_get (nano::transaction const &, uint64_t, uint8_t, nano::checksum &) = 0;
-	virtual void checksum_del (nano::transaction const &, uint64_t, uint8_t) = 0;
-
 	// Return latest vote for an account from store
 	virtual std::shared_ptr<nano::vote> vote_get (nano::transaction const &, nano::account const &) = 0;
 	// Populate vote with the next sequence number

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -40,8 +40,6 @@ public:
 	nano::process_return process (nano::transaction const &, nano::block const &, bool = false);
 	void rollback (nano::transaction const &, nano::block_hash const &);
 	void change_latest (nano::transaction const &, nano::account const &, nano::block_hash const &, nano::account const &, nano::uint128_union const &, uint64_t, bool = false, nano::epoch = nano::epoch::epoch_0);
-	void checksum_update (nano::transaction const &, nano::block_hash const &);
-	nano::checksum checksum (nano::transaction const &, nano::account const &, nano::account const &);
 	void dump_account_chain (nano::account const &);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool is_epoch_link (nano::uint256_union const &);


### PR DESCRIPTION
Proposing to remove checksum as it isn't used beyond tests, to save some IO in `ledger::update_latest` and remove some code.

- [x] delete table in upgrade path (it's just one entry though)