### PR TITLE
Convert deserializers to use exceptions

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1106,7 +1106,8 @@ TEST (network, ipv6)
 	ASSERT_EQ (0xff, bytes1[11]);
 	std::array<uint8_t, 16> bytes2;
 	nano::bufferstream stream (bytes1.data (), bytes1.size ());
-	nano::try_read (stream, bytes2);
+	auto error (nano::try_read (stream, bytes2));
+	ASSERT_FALSE (error);
 	nano::endpoint endpoint2 (boost::asio::ip::address_v6 (bytes2), 16384);
 	ASSERT_EQ (endpoint1, endpoint2);
 }

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1106,7 +1106,7 @@ TEST (network, ipv6)
 	ASSERT_EQ (0xff, bytes1[11]);
 	std::array<uint8_t, 16> bytes2;
 	nano::bufferstream stream (bytes1.data (), bytes1.size ());
-	nano::read (stream, bytes2);
+	nano::try_read (stream, bytes2);
 	nano::endpoint endpoint2 (boost::asio::ip::address_v6 (bytes2), 16384);
 	ASSERT_EQ (endpoint1, endpoint2);
 }

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -781,8 +781,9 @@ bool nano::change_block::deserialize (nano::stream & stream_a)
 		read (stream_a, signature);
 		read (stream_a, work);
 	}
-	catch (std::exception const &)
+	catch (nano::deserialization_error const & ex)
 	{
+		std::cerr << deserialization_error_message<change_block> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1423,7 +1423,7 @@ work (work_a)
 nano::receive_block::receive_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	if (error_a)
+	if (!error_a)
 	{
 		try
 		{

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1,6 +1,5 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
-#include <nano/lib/errors.hpp>
 
 #include <boost/endian/conversion.hpp>
 
@@ -170,9 +169,8 @@ nano::send_hashables::send_hashables (bool & error_a, nano::stream & stream_a)
 		nano::read (stream_a, destination.bytes);
 		nano::read (stream_a, balance.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<send_hashables> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -309,9 +307,8 @@ hashables (error_a, stream_a)
 		nano::read (stream_a, signature.bytes);
 		nano::read (stream_a, work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<send_block> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -407,9 +404,8 @@ nano::open_hashables::open_hashables (bool & error_a, nano::stream & stream_a)
 		nano::read (stream_a, representative.bytes);
 		nano::read (stream_a, account.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<open_hashables> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -469,9 +465,8 @@ hashables (error_a, stream_a)
 			nano::read (stream_a, signature);
 			nano::read (stream_a, work);
 		}
-		catch (nano::deserialization_error const & ex)
+		catch (std::runtime_error const &)
 		{
-			std::cerr << deserialization_error_message<open_block> (ex.get_type_str ()) << "\n";
 			error_a = true;
 		}
 	}
@@ -668,9 +663,8 @@ nano::change_hashables::change_hashables (bool & error_a, nano::stream & stream_
 		nano::read (stream_a, previous);
 		nano::read (stream_a, representative);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<change_hashables> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -714,9 +708,8 @@ hashables (error_a, stream_a)
 		nano::read (stream_a, signature);
 		nano::read (stream_a, work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<change_block> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -781,9 +774,8 @@ bool nano::change_block::deserialize (nano::stream & stream_a)
 		read (stream_a, signature);
 		read (stream_a, work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<change_block> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -913,9 +905,8 @@ nano::state_hashables::state_hashables (bool & error_a, nano::stream & stream_a)
 		nano::read (stream_a, balance);
 		nano::read (stream_a, link);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<state_hashables> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -978,9 +969,8 @@ hashables (error_a, stream_a)
 		nano::read (stream_a, work);
 		boost::endian::big_to_native_inplace (work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<state_block> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -1064,9 +1054,8 @@ bool nano::state_block::deserialize (nano::stream & stream_a)
 		read (stream_a, work);
 		boost::endian::big_to_native_inplace (work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<state_block> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -1357,9 +1346,8 @@ bool nano::receive_block::deserialize (nano::stream & stream_a)
 		read (stream_a, signature.bytes);
 		read (stream_a, work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<receive_block> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -1431,9 +1419,8 @@ hashables (error_a, stream_a)
 		nano::read (stream_a, signature);
 		nano::read (stream_a, work);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<receive_block> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }
@@ -1541,9 +1528,8 @@ nano::receive_hashables::receive_hashables (bool & error_a, nano::stream & strea
 		nano::read (stream_a, previous.bytes);
 		nano::read (stream_a, source.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<receive_hashables> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 }

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/errors.hpp>
 
 #include <boost/endian/conversion.hpp>
 
@@ -163,14 +164,16 @@ balance (balance_a)
 
 nano::send_hashables::send_hashables (bool & error_a, nano::stream & stream_a)
 {
-	error_a = nano::read (stream_a, previous.bytes);
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, destination.bytes);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, balance.bytes);
-		}
+		nano::read (stream_a, previous.bytes);
+		nano::read (stream_a, destination.bytes);
+		nano::read (stream_a, balance.bytes);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<send_hashables> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -216,6 +219,25 @@ void nano::send_block::serialize (nano::stream & stream_a) const
 	write (stream_a, work);
 }
 
+bool nano::send_block::deserialize (nano::stream & stream_a)
+{
+	auto error (false);
+	try
+	{
+		read (stream_a, hashables.previous.bytes);
+		read (stream_a, hashables.destination.bytes);
+		read (stream_a, hashables.balance.bytes);
+		read (stream_a, signature.bytes);
+		read (stream_a, work);
+	}
+	catch (std::exception const &)
+	{
+		error = true;
+	}
+
+	return error;
+}
+
 void nano::send_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
@@ -234,29 +256,6 @@ void nano::send_block::serialize_json (std::string & string_a) const
 	std::stringstream ostream;
 	boost::property_tree::write_json (ostream, tree);
 	string_a = ostream.str ();
-}
-
-bool nano::send_block::deserialize (nano::stream & stream_a)
-{
-	auto error (false);
-	error = read (stream_a, hashables.previous.bytes);
-	if (!error)
-	{
-		error = read (stream_a, hashables.destination.bytes);
-		if (!error)
-		{
-			error = read (stream_a, hashables.balance.bytes);
-			if (!error)
-			{
-				error = read (stream_a, signature.bytes);
-				if (!error)
-				{
-					error = read (stream_a, work);
-				}
-			}
-		}
-	}
-	return error;
 }
 
 bool nano::send_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -305,13 +304,15 @@ work (work_a)
 nano::send_block::send_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, signature.bytes);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, work);
-		}
+		nano::read (stream_a, signature.bytes);
+		nano::read (stream_a, work);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<send_block> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -400,14 +401,16 @@ account (account_a)
 
 nano::open_hashables::open_hashables (bool & error_a, nano::stream & stream_a)
 {
-	error_a = nano::read (stream_a, source.bytes);
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, representative.bytes);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, account.bytes);
-		}
+		nano::read (stream_a, source.bytes);
+		nano::read (stream_a, representative.bytes);
+		nano::read (stream_a, account.bytes);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<open_hashables> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -461,10 +464,15 @@ hashables (error_a, stream_a)
 {
 	if (!error_a)
 	{
-		error_a = nano::read (stream_a, signature);
-		if (!error_a)
+		try
 		{
-			error_a = nano::read (stream_a, work);
+			nano::read (stream_a, signature);
+			nano::read (stream_a, work);
+		}
+		catch (nano::deserialization_error const & ex)
+		{
+			std::cerr << deserialization_error_message<open_block> (ex.get_type_str ()) << "\n";
+			error_a = true;
 		}
 	}
 }
@@ -526,6 +534,25 @@ void nano::open_block::serialize (nano::stream & stream_a) const
 	write (stream_a, work);
 }
 
+bool nano::open_block::deserialize (nano::stream & stream_a)
+{
+	auto error (false);
+	try
+	{
+		read (stream_a, hashables.source);
+		read (stream_a, hashables.representative);
+		read (stream_a, hashables.account);
+		read (stream_a, signature);
+		read (stream_a, work);
+	}
+	catch (std::runtime_error const &)
+	{
+		error = true;
+	}
+
+	return error;
+}
+
 void nano::open_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
@@ -540,28 +567,6 @@ void nano::open_block::serialize_json (std::string & string_a) const
 	std::stringstream ostream;
 	boost::property_tree::write_json (ostream, tree);
 	string_a = ostream.str ();
-}
-
-bool nano::open_block::deserialize (nano::stream & stream_a)
-{
-	auto error (read (stream_a, hashables.source));
-	if (!error)
-	{
-		error = read (stream_a, hashables.representative);
-		if (!error)
-		{
-			error = read (stream_a, hashables.account);
-			if (!error)
-			{
-				error = read (stream_a, signature);
-				if (!error)
-				{
-					error = read (stream_a, work);
-				}
-			}
-		}
-	}
-	return error;
 }
 
 bool nano::open_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -658,10 +663,15 @@ representative (representative_a)
 
 nano::change_hashables::change_hashables (bool & error_a, nano::stream & stream_a)
 {
-	error_a = nano::read (stream_a, previous);
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, representative);
+		nano::read (stream_a, previous);
+		nano::read (stream_a, representative);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<change_hashables> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -699,13 +709,15 @@ work (work_a)
 nano::change_block::change_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, signature);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, work);
-		}
+		nano::read (stream_a, signature);
+		nano::read (stream_a, work);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<change_block> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -759,6 +771,24 @@ void nano::change_block::serialize (nano::stream & stream_a) const
 	write (stream_a, work);
 }
 
+bool nano::change_block::deserialize (nano::stream & stream_a)
+{
+	auto error (false);
+	try
+	{
+		read (stream_a, hashables.previous);
+		read (stream_a, hashables.representative);
+		read (stream_a, signature);
+		read (stream_a, work);
+	}
+	catch (std::exception const &)
+	{
+		error = true;
+	}
+
+	return error;
+}
+
 void nano::change_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
@@ -772,24 +802,6 @@ void nano::change_block::serialize_json (std::string & string_a) const
 	std::stringstream ostream;
 	boost::property_tree::write_json (ostream, tree);
 	string_a = ostream.str ();
-}
-
-bool nano::change_block::deserialize (nano::stream & stream_a)
-{
-	auto error (read (stream_a, hashables.previous));
-	if (!error)
-	{
-		error = read (stream_a, hashables.representative);
-		if (!error)
-		{
-			error = read (stream_a, signature);
-			if (!error)
-			{
-				error = read (stream_a, work);
-			}
-		}
-	}
-	return error;
 }
 
 bool nano::change_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -892,22 +904,18 @@ link (link_a)
 
 nano::state_hashables::state_hashables (bool & error_a, nano::stream & stream_a)
 {
-	error_a = nano::read (stream_a, account);
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, previous);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, representative);
-			if (!error_a)
-			{
-				error_a = nano::read (stream_a, balance);
-				if (!error_a)
-				{
-					error_a = nano::read (stream_a, link);
-				}
-			}
-		}
+		nano::read (stream_a, account);
+		nano::read (stream_a, previous);
+		nano::read (stream_a, representative);
+		nano::read (stream_a, balance);
+		nano::read (stream_a, link);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<state_hashables> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -963,14 +971,16 @@ work (work_a)
 nano::state_block::state_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, signature);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, work);
-			boost::endian::big_to_native_inplace (work);
-		}
+		nano::read (stream_a, signature);
+		nano::read (stream_a, work);
+		boost::endian::big_to_native_inplace (work);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<state_block> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -1039,6 +1049,29 @@ void nano::state_block::serialize (nano::stream & stream_a) const
 	write (stream_a, boost::endian::native_to_big (work));
 }
 
+bool nano::state_block::deserialize (nano::stream & stream_a)
+{
+	auto error (false);
+	try
+	{
+		read (stream_a, hashables.account);
+		read (stream_a, hashables.previous);
+		read (stream_a, hashables.representative);
+		read (stream_a, hashables.balance);
+		read (stream_a, hashables.link);
+		read (stream_a, signature);
+		read (stream_a, work);
+		boost::endian::big_to_native_inplace (work);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<state_block> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	return error;
+}
+
 void nano::state_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
@@ -1056,37 +1089,6 @@ void nano::state_block::serialize_json (std::string & string_a) const
 	std::stringstream ostream;
 	boost::property_tree::write_json (ostream, tree);
 	string_a = ostream.str ();
-}
-
-bool nano::state_block::deserialize (nano::stream & stream_a)
-{
-	auto error (read (stream_a, hashables.account));
-	if (!error)
-	{
-		error = read (stream_a, hashables.previous);
-		if (!error)
-		{
-			error = read (stream_a, hashables.representative);
-			if (!error)
-			{
-				error = read (stream_a, hashables.balance);
-				if (!error)
-				{
-					error = read (stream_a, hashables.link);
-					if (!error)
-					{
-						error = read (stream_a, signature);
-						if (!error)
-						{
-							error = read (stream_a, work);
-							boost::endian::big_to_native_inplace (work);
-						}
-					}
-				}
-			}
-		}
-	}
-	return error;
 }
 
 bool nano::state_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -1250,7 +1252,7 @@ std::shared_ptr<nano::block> nano::deserialize_block_json (boost::property_tree:
 std::shared_ptr<nano::block> nano::deserialize_block (nano::stream & stream_a, nano::block_uniquer * uniquer_a)
 {
 	nano::block_type type;
-	auto error (read (stream_a, type));
+	auto error (try_read (stream_a, type));
 	std::shared_ptr<nano::block> result;
 	if (!error)
 	{
@@ -1336,23 +1338,50 @@ bool nano::receive_block::operator== (nano::receive_block const & other_a) const
 	return result;
 }
 
+void nano::receive_block::serialize (nano::stream & stream_a) const
+{
+	write (stream_a, hashables.previous.bytes);
+	write (stream_a, hashables.source.bytes);
+	write (stream_a, signature.bytes);
+	write (stream_a, work);
+}
+
 bool nano::receive_block::deserialize (nano::stream & stream_a)
 {
 	auto error (false);
-	error = read (stream_a, hashables.previous.bytes);
-	if (!error)
+	try
 	{
-		error = read (stream_a, hashables.source.bytes);
-		if (!error)
-		{
-			error = read (stream_a, signature.bytes);
-			if (!error)
-			{
-				error = read (stream_a, work);
-			}
-		}
+		read (stream_a, hashables.previous.bytes);
+		read (stream_a, hashables.source.bytes);
+		read (stream_a, signature.bytes);
+		read (stream_a, work);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<receive_block> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
+}
+
+void nano::receive_block::serialize_json (std::string & string_a) const
+{
+	boost::property_tree::ptree tree;
+	tree.put ("type", "receive");
+	std::string previous;
+	hashables.previous.encode_hex (previous);
+	tree.put ("previous", previous);
+	std::string source;
+	hashables.source.encode_hex (source);
+	tree.put ("source", source);
+	std::string signature_l;
+	signature.encode_hex (signature_l);
+	tree.put ("work", nano::to_string_hex (work));
+	tree.put ("signature", signature_l);
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, tree);
+	string_a = ostream.str ();
 }
 
 bool nano::receive_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -1386,33 +1415,6 @@ bool nano::receive_block::deserialize_json (boost::property_tree::ptree const & 
 	return error;
 }
 
-void nano::receive_block::serialize (nano::stream & stream_a) const
-{
-	write (stream_a, hashables.previous.bytes);
-	write (stream_a, hashables.source.bytes);
-	write (stream_a, signature.bytes);
-	write (stream_a, work);
-}
-
-void nano::receive_block::serialize_json (std::string & string_a) const
-{
-	boost::property_tree::ptree tree;
-	tree.put ("type", "receive");
-	std::string previous;
-	hashables.previous.encode_hex (previous);
-	tree.put ("previous", previous);
-	std::string source;
-	hashables.source.encode_hex (source);
-	tree.put ("source", source);
-	std::string signature_l;
-	signature.encode_hex (signature_l);
-	tree.put ("work", nano::to_string_hex (work));
-	tree.put ("signature", signature_l);
-	std::stringstream ostream;
-	boost::property_tree::write_json (ostream, tree);
-	string_a = ostream.str ();
-}
-
 nano::receive_block::receive_block (nano::block_hash const & previous_a, nano::block_hash const & source_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :
 hashables (previous_a, source_a),
 signature (nano::sign_message (prv_a, pub_a, hash ())),
@@ -1423,13 +1425,15 @@ work (work_a)
 nano::receive_block::receive_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, signature);
-		if (!error_a)
-		{
-			error_a = nano::read (stream_a, work);
-		}
+		nano::read (stream_a, signature);
+		nano::read (stream_a, work);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<receive_block> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 
@@ -1531,10 +1535,15 @@ source (source_a)
 
 nano::receive_hashables::receive_hashables (bool & error_a, nano::stream & stream_a)
 {
-	error_a = nano::read (stream_a, previous.bytes);
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, source.bytes);
+		nano::read (stream_a, previous.bytes);
+		nano::read (stream_a, source.bytes);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<receive_hashables> (ex.get_type_str ()) << "\n";
+		error_a = true;
 	}
 }
 

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -302,14 +302,17 @@ work (work_a)
 nano::send_block::send_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	try
+	if (!error_a)
 	{
-		nano::read (stream_a, signature.bytes);
-		nano::read (stream_a, work);
-	}
-	catch (std::runtime_error const &)
-	{
-		error_a = true;
+		try
+		{
+			nano::read (stream_a, signature.bytes);
+			nano::read (stream_a, work);
+		}
+		catch (std::runtime_error const &)
+		{
+			error_a = true;
+		}
 	}
 }
 
@@ -703,14 +706,17 @@ work (work_a)
 nano::change_block::change_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	try
+	if (!error_a)
 	{
-		nano::read (stream_a, signature);
-		nano::read (stream_a, work);
-	}
-	catch (std::runtime_error const &)
-	{
-		error_a = true;
+		try
+		{
+			nano::read (stream_a, signature);
+			nano::read (stream_a, work);
+		}
+		catch (std::runtime_error const &)
+		{
+			error_a = true;
+		}
 	}
 }
 
@@ -963,15 +969,18 @@ work (work_a)
 nano::state_block::state_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	try
+	if (!error_a)
 	{
-		nano::read (stream_a, signature);
-		nano::read (stream_a, work);
-		boost::endian::big_to_native_inplace (work);
-	}
-	catch (std::runtime_error const &)
-	{
-		error_a = true;
+		try
+		{
+			nano::read (stream_a, signature);
+			nano::read (stream_a, work);
+			boost::endian::big_to_native_inplace (work);
+		}
+		catch (std::runtime_error const &)
+		{
+			error_a = true;
+		}
 	}
 }
 
@@ -1414,14 +1423,17 @@ work (work_a)
 nano::receive_block::receive_block (bool & error_a, nano::stream & stream_a) :
 hashables (error_a, stream_a)
 {
-	try
+	if (error_a)
 	{
-		nano::read (stream_a, signature);
-		nano::read (stream_a, work);
-	}
-	catch (std::runtime_error const &)
-	{
-		error_a = true;
+		try
+		{
+			nano::read (stream_a, signature);
+			nano::read (stream_a, work);
+		}
+		catch (std::runtime_error const &)
+		{
+			error_a = true;
+		}
 	}
 }
 

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -112,8 +112,8 @@ public:
 	nano::block_hash previous () const override;
 	nano::block_hash root () const override;
 	void serialize (nano::stream &) const override;
-	void serialize_json (std::string &) const override;
 	bool deserialize (nano::stream &);
+	void serialize_json (std::string &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -155,8 +155,8 @@ public:
 	nano::block_hash source () const override;
 	nano::block_hash root () const override;
 	void serialize (nano::stream &) const override;
-	void serialize_json (std::string &) const override;
 	bool deserialize (nano::stream &);
+	void serialize_json (std::string &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -202,8 +202,8 @@ public:
 	nano::block_hash root () const override;
 	nano::account representative () const override;
 	void serialize (nano::stream &) const override;
-	void serialize_json (std::string &) const override;
 	bool deserialize (nano::stream &);
+	void serialize_json (std::string &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -245,8 +245,8 @@ public:
 	nano::block_hash root () const override;
 	nano::account representative () const override;
 	void serialize (nano::stream &) const override;
-	void serialize_json (std::string &) const override;
 	bool deserialize (nano::stream &);
+	void serialize_json (std::string &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -303,8 +303,8 @@ public:
 	nano::block_hash link () const override;
 	nano::account representative () const override;
 	void serialize (nano::stream &) const override;
-	void serialize_json (std::string &) const override;
 	bool deserialize (nano::stream &);
+	void serialize_json (std::string &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -25,12 +25,12 @@ bool try_read (nano::stream & stream_a, T & value)
 }
 // A wrapper of try_read which throws if there is an error
 template <typename T>
-void read (nano::stream & stream_a, T & value) throw (nano::deserialization_error)
+void read (nano::stream & stream_a, T & value) throw (std::runtime_error)
 {
 	auto error = try_read (stream_a, value);
 	if (error)
 	{
-		throw nano::deserialization_error ("Failed to read type", boost::typeindex::type_id<T> ().pretty_name ());
+		throw std::runtime_error ("Failed to read type");
 	}
 }
 

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <nano/lib/numbers.hpp>
 #include <nano/lib/errors.hpp>
+#include <nano/lib/numbers.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 #include <cassert>

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -128,8 +128,6 @@ enum class error_config
 	missing_value,
 };
 
-} // nano namespace
-
 /** Returns the error code if non-zero, otherwise the value */
 template <class T>
 auto either (T && value, std::error_code ec) -> expected<typename std::remove_reference_t<T>, std::error_code>
@@ -143,6 +141,30 @@ auto either (T && value, std::error_code ec) -> expected<typename std::remove_re
 		return std::move (value);
 	}
 }
+
+class deserialization_error : public std::runtime_error
+{
+public:
+	deserialization_error (const char * what, const std::string & type_str_a) :
+	std::runtime_error (what), type_str (type_str_a)
+	{
+	}
+
+	const std::string get_type_str () const
+	{
+		return type_str;
+	}
+
+private:
+	std::string type_str;
+};
+
+template <typename Type>
+std::string deserialization_error_message (const std::string & member)
+{
+	return boost::str (boost::format ("Error deserializing member %1% of %2%") % member % boost::typeindex::type_id<Type> ().pretty_name ());
+}
+} // nano namespace
 
 // Convenience macro to implement the standard boilerplate for using std::error_code with enums
 // Use this at the end of any header defining one or more error code enums.

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -145,8 +145,8 @@ auto either (T && value, std::error_code ec) -> expected<typename std::remove_re
 class deserialization_error : public std::runtime_error
 {
 public:
-	deserialization_error (const char * what, const std::string & type_str_a) :
-	std::runtime_error (what), type_str (type_str_a)
+	deserialization_error (const char * what, std::string && type_str_a) :
+	std::runtime_error (what), type_str (std::move(type_str_a))
 	{
 	}
 
@@ -160,9 +160,9 @@ private:
 };
 
 template <typename Type>
-std::string deserialization_error_message (const std::string & member)
+std::string deserialization_error_message (const std::string & member_type)
 {
-	return boost::str (boost::format ("Error deserializing member %1% of %2%") % member % boost::typeindex::type_id<Type> ().pretty_name ());
+	return boost::str (boost::format ("Error deserializing member type %1% of %2%") % member_type % boost::typeindex::type_id<Type> ().pretty_name ());
 }
 } // nano namespace
 

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <system_error>
 #include <type_traits>
-#include <boost/type_index.hpp>
 
 using tl::expected;
 using tl::make_unexpected;
@@ -147,7 +146,7 @@ class deserialization_error : public std::runtime_error
 {
 public:
 	deserialization_error (const char * what, std::string && type_str_a) :
-	std::runtime_error (what), type_str (std::move(type_str_a))
+	std::runtime_error (what), type_str (std::move (type_str_a))
 	{
 	}
 

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -141,29 +141,6 @@ auto either (T && value, std::error_code ec) -> expected<typename std::remove_re
 		return std::move (value);
 	}
 }
-
-class deserialization_error : public std::runtime_error
-{
-public:
-	deserialization_error (const char * what, std::string && type_str_a) :
-	std::runtime_error (what), type_str (std::move (type_str_a))
-	{
-	}
-
-	const std::string get_type_str () const
-	{
-		return type_str;
-	}
-
-private:
-	std::string type_str;
-};
-
-template <typename Type>
-std::string deserialization_error_message (const std::string & member_type)
-{
-	return boost::str (boost::format ("Error deserializing member type %1% of %2%") % member_type % boost::typeindex::type_id<Type> ().pretty_name ());
-}
 } // nano namespace
 
 // Convenience macro to implement the standard boilerplate for using std::error_code with enums

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <system_error>
 #include <type_traits>
+#include <boost/type_index.hpp>
 
 using tl::expected;
 using tl::make_unexpected;

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -281,11 +281,11 @@ void nano::frontier_req_client::received_frontier (boost::system::error_code con
 		assert (size_a == nano::frontier_req_client::size_frontier);
 		nano::account account;
 		nano::bufferstream account_stream (connection->receive_buffer->data (), sizeof (account));
-		auto error1 (nano::read (account_stream, account));
+		auto error1 (nano::try_read (account_stream, account));
 		assert (!error1);
 		nano::block_hash latest;
 		nano::bufferstream latest_stream (connection->receive_buffer->data () + sizeof (account), sizeof (latest));
-		auto error2 (nano::read (latest_stream, latest));
+		auto error2 (nano::try_read (latest_stream, latest));
 		assert (!error2);
 		if (count == 0)
 		{
@@ -824,11 +824,11 @@ void nano::bulk_pull_account_client::receive_pending ()
 			{
 				nano::block_hash pending;
 				nano::bufferstream frontier_stream (this_l->connection->receive_buffer->data (), sizeof (nano::uint256_union));
-				auto error1 (nano::read (frontier_stream, pending));
+				auto error1 (nano::try_read (frontier_stream, pending));
 				assert (!error1);
 				nano::amount balance;
 				nano::bufferstream balance_stream (this_l->connection->receive_buffer->data () + sizeof (nano::uint256_union), sizeof (nano::uint128_union));
-				auto error2 (nano::read (balance_stream, balance));
+				auto error2 (nano::try_read (balance_stream, balance));
 				assert (!error2);
 				if (this_l->total_blocks == 0 || !pending.is_zero ())
 				{

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -45,7 +45,7 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 		read (stream_a, magic_number_l);
 		if (magic_number_l != magic_number)
 		{
-			throw nano::deserialization_error ("Magic numbers do not match", boost::typeindex::type_id<decltype (magic_number)> ().pretty_name ());
+			throw std::runtime_error ("Magic numbers do not match");
 		}
 
 		nano::read (stream_a, version_max);
@@ -55,9 +55,8 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, extensions_l);
 		extensions = extensions_l;
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<message_header> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -689,9 +688,8 @@ bool nano::frontier_req::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, age);
 		nano::read (stream_a, count);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<frontier_req> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -788,9 +786,8 @@ bool nano::bulk_pull::deserialize (nano::stream & stream_a)
 			count = 0;
 		}
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<bulk_pull> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -844,9 +841,8 @@ bool nano::bulk_pull_account::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, minimum_amount);
 		nano::read (stream_a, flags);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<bulk_pull_account> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -941,9 +937,8 @@ bool nano::node_id_handshake::deserialize (nano::stream & stream_a)
 			response = std::make_pair (response_account, response_signature);
 		}
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<message_header> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -39,18 +39,29 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 {
 	uint16_t extensions_l;
 	std::array<uint8_t, 2> magic_number_l;
-	auto result (nano::read (stream_a, magic_number_l));
-	result = result || magic_number_l != magic_number;
-	result = result || nano::read (stream_a, version_max);
-	result = result || nano::read (stream_a, version_using);
-	result = result || nano::read (stream_a, version_min);
-	result = result || nano::read (stream_a, type);
-	result = result || nano::read (stream_a, extensions_l);
-	if (!result)
+	auto error (false);
+	try
 	{
+		read (stream_a, magic_number_l);
+		if (magic_number_l != magic_number)
+		{
+			throw nano::deserialization_error ("Magic numbers do not match", boost::typeindex::type_id<decltype (magic_number)> ().pretty_name ());
+		}
+
+		nano::read (stream_a, version_max);
+		nano::read (stream_a, version_using);
+		nano::read (stream_a, version_min);
+		nano::read (stream_a, type);
+		nano::read (stream_a, extensions_l);
 		extensions = extensions_l;
 	}
-	return result;
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<message_header> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	return error;
 }
 
 nano::message::message (nano::message_type type_a) :
@@ -363,7 +374,7 @@ void nano::message_parser::deserialize_node_id_handshake (nano::stream & stream_
 bool nano::message_parser::at_end (nano::stream & stream_a)
 {
 	uint8_t junk;
-	auto end (nano::read (stream_a, junk));
+	auto end (nano::try_read (stream_a, junk));
 	return end;
 }
 
@@ -411,7 +422,7 @@ bool nano::keepalive::deserialize (nano::stream & stream_a)
 	{
 		std::array<uint8_t, 16> address;
 		uint16_t port;
-		if (!read (stream_a, address) && !read (stream_a, port))
+		if (!try_read (stream_a, address) && !try_read (stream_a, port))
 		{
 			*i = nano::endpoint (boost::asio::ip::address_v6 (address), port);
 		}
@@ -501,41 +512,6 @@ roots_hashes (std::vector<std::pair<nano::block_hash, nano::block_hash>> (1, std
 	header.block_type_set (nano::block_type::not_a_block);
 }
 
-bool nano::confirm_req::deserialize (nano::stream & stream_a, nano::block_uniquer * uniquer_a)
-{
-	bool result (true);
-	assert (header.type == nano::message_type::confirm_req);
-	if (header.block_type () == nano::block_type::not_a_block)
-	{
-		uint8_t count (0);
-		result = read (stream_a, count);
-		for (auto i (0); i != count && !result; ++i)
-		{
-			nano::block_hash block_hash (0);
-			nano::block_hash root (0);
-			result = read (stream_a, block_hash);
-			if (!result && !block_hash.is_zero ())
-			{
-				result = read (stream_a, root);
-				if (!result && !root.is_zero ())
-				{
-					roots_hashes.push_back (std::make_pair (block_hash, root));
-				}
-			}
-		}
-		if (!result)
-		{
-			result = roots_hashes.empty () || (roots_hashes.size () != count);
-		}
-	}
-	else
-	{
-		block = nano::deserialize_block (stream_a, header.block_type (), uniquer_a);
-		result = block == nullptr;
-	}
-	return result;
-}
-
 void nano::confirm_req::visit (nano::message_visitor & visitor_a) const
 {
 	visitor_a.confirm_req (*this);
@@ -563,6 +539,41 @@ void nano::confirm_req::serialize (nano::stream & stream_a) const
 		assert (block != nullptr);
 		block->serialize (stream_a);
 	}
+}
+
+bool nano::confirm_req::deserialize (nano::stream & stream_a, nano::block_uniquer * uniquer_a)
+{
+	bool result (true);
+	assert (header.type == nano::message_type::confirm_req);
+	if (header.block_type () == nano::block_type::not_a_block)
+	{
+		uint8_t count (0);
+		result = try_read (stream_a, count);
+		for (auto i (0); i != count && !result; ++i)
+		{
+			nano::block_hash block_hash (0);
+			nano::block_hash root (0);
+			result = try_read (stream_a, block_hash);
+			if (!result && !block_hash.is_zero ())
+			{
+				result = try_read (stream_a, root);
+				if (!result && !root.is_zero ())
+				{
+					roots_hashes.push_back (std::make_pair (block_hash, root));
+				}
+			}
+		}
+		if (!result)
+		{
+			result = roots_hashes.empty () || (roots_hashes.size () != count);
+		}
+	}
+	else
+	{
+		block = nano::deserialize_block (stream_a, header.block_type (), uniquer_a);
+		result = block == nullptr;
+	}
+	return result;
 }
 
 bool nano::confirm_req::operator== (nano::confirm_req const & other_a) const
@@ -660,27 +671,31 @@ message (header_a)
 	}
 }
 
-bool nano::frontier_req::deserialize (nano::stream & stream_a)
-{
-	assert (header.type == nano::message_type::frontier_req);
-	auto result (read (stream_a, start.bytes));
-	if (!result)
-	{
-		result = read (stream_a, age);
-		if (!result)
-		{
-			result = read (stream_a, count);
-		}
-	}
-	return result;
-}
-
 void nano::frontier_req::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, start.bytes);
 	write (stream_a, age);
 	write (stream_a, count);
+}
+
+bool nano::frontier_req::deserialize (nano::stream & stream_a)
+{
+	assert (header.type == nano::message_type::frontier_req);
+	auto error (false);
+	try
+	{
+		nano::read (stream_a, start.bytes);
+		nano::read (stream_a, age);
+		nano::read (stream_a, count);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<frontier_req> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	return error;
 }
 
 void nano::frontier_req::visit (nano::message_visitor & visitor_a) const
@@ -714,41 +729,6 @@ void nano::bulk_pull::visit (nano::message_visitor & visitor_a) const
 	visitor_a.bulk_pull (*this);
 }
 
-bool nano::bulk_pull::deserialize (nano::stream & stream_a)
-{
-	assert (header.type == nano::message_type::bulk_pull);
-	auto result (read (stream_a, start));
-	if (!result)
-	{
-		result = read (stream_a, end);
-
-		if (!result)
-		{
-			if (is_count_present ())
-			{
-				std::array<uint8_t, extended_parameters_size> extended_parameters_buffers;
-				static_assert (sizeof (count) < (extended_parameters_buffers.size () - 1), "count must fit within buffer");
-
-				result = read (stream_a, extended_parameters_buffers);
-				if (extended_parameters_buffers[0] != 0)
-				{
-					result = true;
-				}
-				else
-				{
-					memcpy (&count, extended_parameters_buffers.data () + 1, sizeof (count));
-					boost::endian::little_to_native_inplace (count);
-				}
-			}
-			else
-			{
-				count = 0;
-			}
-		}
-	}
-	return result;
-}
-
 void nano::bulk_pull::serialize (nano::stream & stream_a) const
 {
 	/*
@@ -776,6 +756,45 @@ void nano::bulk_pull::serialize (nano::stream & stream_a) const
 
 		write (stream_a, count_buffer);
 	}
+}
+
+bool nano::bulk_pull::deserialize (nano::stream & stream_a)
+{
+	assert (header.type == nano::message_type::bulk_pull);
+	auto error (false);
+	try
+	{
+		nano::read (stream_a, start);
+		nano::read (stream_a, end);
+
+		if (is_count_present ())
+		{
+			std::array<uint8_t, extended_parameters_size> extended_parameters_buffers;
+			static_assert (sizeof (count) < (extended_parameters_buffers.size () - 1), "count must fit within buffer");
+
+			nano::read (stream_a, extended_parameters_buffers);
+			if (extended_parameters_buffers.front () != 0)
+			{
+				error = true;
+			}
+			else
+			{
+				memcpy (&count, extended_parameters_buffers.data () + 1, sizeof (count));
+				boost::endian::little_to_native_inplace (count);
+			}
+		}
+		else
+		{
+			count = 0;
+		}
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<bulk_pull> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	return error;
 }
 
 bool nano::bulk_pull::is_count_present () const
@@ -807,27 +826,31 @@ void nano::bulk_pull_account::visit (nano::message_visitor & visitor_a) const
 	visitor_a.bulk_pull_account (*this);
 }
 
-bool nano::bulk_pull_account::deserialize (nano::stream & stream_a)
-{
-	assert (header.type == nano::message_type::bulk_pull_account);
-	auto result (read (stream_a, account));
-	if (!result)
-	{
-		result = read (stream_a, minimum_amount);
-		if (!result)
-		{
-			result = read (stream_a, flags);
-		}
-	}
-	return result;
-}
-
 void nano::bulk_pull_account::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, account);
 	write (stream_a, minimum_amount);
 	write (stream_a, flags);
+}
+
+bool nano::bulk_pull_account::deserialize (nano::stream & stream_a)
+{
+	assert (header.type == nano::message_type::bulk_pull_account);
+	auto error (false);
+	try
+	{
+		nano::read (stream_a, account);
+		nano::read (stream_a, minimum_amount);
+		nano::read (stream_a, flags);
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<bulk_pull_account> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	return error;
 }
 
 nano::bulk_push::bulk_push () :
@@ -882,36 +905,6 @@ response (response)
 	}
 }
 
-bool nano::node_id_handshake::deserialize (nano::stream & stream_a)
-{
-	auto result (false);
-	assert (header.type == nano::message_type::node_id_handshake);
-	if (!result && is_query_flag ())
-	{
-		nano::uint256_union query_hash;
-		result = read (stream_a, query_hash);
-		if (!result)
-		{
-			query = query_hash;
-		}
-	}
-	if (!result && is_response_flag ())
-	{
-		nano::account response_account;
-		result = read (stream_a, response_account);
-		if (!result)
-		{
-			nano::signature response_signature;
-			result = read (stream_a, response_signature);
-			if (!result)
-			{
-				response = std::make_pair (response_account, response_signature);
-			}
-		}
-	}
-	return result;
-}
-
 void nano::node_id_handshake::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
@@ -924,6 +917,37 @@ void nano::node_id_handshake::serialize (nano::stream & stream_a) const
 		write (stream_a, response->first);
 		write (stream_a, response->second);
 	}
+}
+
+bool nano::node_id_handshake::deserialize (nano::stream & stream_a)
+{
+	assert (header.type == nano::message_type::node_id_handshake);
+	auto error (false);
+	try
+	{
+		if (is_query_flag ())
+		{
+			nano::uint256_union query_hash;
+			read (stream_a, query_hash);
+			query = query_hash;
+		}
+
+		if (is_response_flag ())
+		{
+			nano::account response_account;
+			read (stream_a, response_account);
+			nano::signature response_signature;
+			read (stream_a, response_signature);
+			response = std::make_pair (response_account, response_signature);
+		}
+	}
+	catch (std::exception const & ex)
+	{
+		std::cerr << ex.what () << "\n";
+		error = true;
+	}
+
+	return error;
 }
 
 bool nano::node_id_handshake::operator== (nano::node_id_handshake const & other_a) const

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -276,8 +276,8 @@ public:
 	keepalive (bool &, nano::stream &, nano::message_header const &);
 	keepalive ();
 	void visit (nano::message_visitor &) const override;
-	bool deserialize (nano::stream &);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &);
 	bool operator== (nano::keepalive const &) const;
 	std::array<nano::endpoint, 8> peers;
 };
@@ -287,8 +287,8 @@ public:
 	publish (bool &, nano::stream &, nano::message_header const &, nano::block_uniquer * = nullptr);
 	publish (std::shared_ptr<nano::block>);
 	void visit (nano::message_visitor &) const override;
-	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	bool operator== (nano::publish const &) const;
 	std::shared_ptr<nano::block> block;
 };
@@ -299,8 +299,8 @@ public:
 	confirm_req (std::shared_ptr<nano::block>);
 	confirm_req (std::vector<std::pair<nano::block_hash, nano::block_hash>> const &);
 	confirm_req (nano::block_hash const &, nano::block_hash const &);
-	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_req const &) const;
 	std::shared_ptr<nano::block> block;
@@ -312,8 +312,8 @@ class confirm_ack : public message
 public:
 	confirm_ack (bool &, nano::stream &, nano::message_header const &, nano::vote_uniquer * = nullptr);
 	confirm_ack (std::shared_ptr<nano::vote>);
-	bool deserialize (nano::stream &, nano::vote_uniquer * = nullptr);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &, nano::vote_uniquer * = nullptr);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_ack const &) const;
 	std::shared_ptr<nano::vote> vote;
@@ -323,8 +323,8 @@ class frontier_req : public message
 public:
 	frontier_req ();
 	frontier_req (bool &, nano::stream &, nano::message_header const &);
-	bool deserialize (nano::stream &);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::frontier_req const &) const;
 	nano::account start;
@@ -338,8 +338,8 @@ public:
 	typedef uint32_t count_t;
 	bulk_pull ();
 	bulk_pull (bool &, nano::stream &, nano::message_header const &);
-	bool deserialize (nano::stream &);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	nano::uint256_union start;
 	nano::block_hash end;
@@ -355,8 +355,8 @@ class bulk_pull_account : public message
 public:
 	bulk_pull_account ();
 	bulk_pull_account (bool &, nano::stream &, nano::message_header const &);
-	bool deserialize (nano::stream &);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	nano::uint256_union account;
 	nano::uint128_union minimum_amount;
@@ -368,8 +368,8 @@ class bulk_push : public message
 public:
 	bulk_push ();
 	bulk_push (nano::message_header const &);
-	bool deserialize (nano::stream &);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 };
 class node_id_handshake : public message
@@ -377,8 +377,8 @@ class node_id_handshake : public message
 public:
 	node_id_handshake (bool &, nano::stream &, nano::message_header const &);
 	node_id_handshake (boost::optional<nano::block_hash>, boost::optional<std::pair<nano::account, nano::signature>>);
-	bool deserialize (nano::stream &);
 	void serialize (nano::stream &) const override;
+	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::node_id_handshake const &) const;
 	bool is_query_flag () const;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1921,7 +1921,7 @@ startup_time (std::chrono::steady_clock::now ())
 	{
 		nano::bufferstream weight_stream ((const uint8_t *)nano_bootstrap_weights, nano_bootstrap_weights_size);
 		nano::uint128_union block_height;
-		if (!nano::read (weight_stream, block_height))
+		if (!nano::try_read (weight_stream, block_height))
 		{
 			auto max_blocks = (uint64_t)block_height.number ();
 			auto transaction (store.tx_begin_read ());
@@ -1931,12 +1931,12 @@ startup_time (std::chrono::steady_clock::now ())
 				while (true)
 				{
 					nano::account account;
-					if (nano::read (weight_stream, account.bytes))
+					if (nano::try_read (weight_stream, account.bytes))
 					{
 						break;
 					}
 					nano::amount weight;
-					if (nano::read (weight_stream, weight.bytes))
+					if (nano::try_read (weight_stream, weight.bytes))
 					{
 						break;
 					}

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -56,8 +56,8 @@ public:
 	nano::account destination;
 	uint64_t start;
 	uint64_t last;
-	bool deserialize (std::istream &);
 	void serialize (std::ostream &) const;
+	bool deserialize (std::istream &);
 	bool operator== (nano::landing_store const &) const;
 };
 class landing

--- a/nano/secure/blockstore.cpp
+++ b/nano/secure/blockstore.cpp
@@ -57,26 +57,34 @@ void nano::block_sideband::serialize (nano::stream & stream_a) const
 bool nano::block_sideband::deserialize (nano::stream & stream_a)
 {
 	bool result (false);
-	result |= nano::read (stream_a, successor.bytes);
-	if (type != nano::block_type::state && type != nano::block_type::open)
+	try
 	{
-		result |= nano::read (stream_a, account.bytes);
+		nano::read (stream_a, successor.bytes);
+		if (type != nano::block_type::state && type != nano::block_type::open)
+		{
+			nano::read (stream_a, account.bytes);
+		}
+		if (type != nano::block_type::open)
+		{
+			nano::read (stream_a, height);
+			boost::endian::big_to_native_inplace (height);
+		}
+		else
+		{
+			height = 0;
+		}
+		if (type == nano::block_type::receive || type == nano::block_type::change || type == nano::block_type::open)
+		{
+			nano::read (stream_a, balance.bytes);
+		}
+		nano::read (stream_a, timestamp);
+		boost::endian::big_to_native_inplace (timestamp);
 	}
-	if (type != nano::block_type::open)
+	catch (std::runtime_error &)
 	{
-		result |= nano::read (stream_a, height);
-		boost::endian::big_to_native_inplace (height);
+		result = true;
 	}
-	else
-	{
-		height = 0;
-	}
-	if (type == nano::block_type::receive || type == nano::block_type::change || type == nano::block_type::open)
-	{
-		nano::read (stream_a, balance.bytes);
-	}
-	result |= nano::read (stream_a, timestamp);
-	boost::endian::big_to_native_inplace (timestamp);
+
 	return result;
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -171,27 +171,22 @@ void nano::account_info::serialize (nano::stream & stream_a) const
 
 bool nano::account_info::deserialize (nano::stream & stream_a)
 {
-	auto error (read (stream_a, head.bytes));
-	if (!error)
+	auto error (false);
+	try
 	{
-		error = read (stream_a, rep_block.bytes);
-		if (!error)
-		{
-			error = read (stream_a, open_block.bytes);
-			if (!error)
-			{
-				error = read (stream_a, balance.bytes);
-				if (!error)
-				{
-					error = read (stream_a, modified);
-					if (!error)
-					{
-						error = read (stream_a, block_count);
-					}
-				}
-			}
-		}
+		nano::read (stream_a, head.bytes);
+		nano::read (stream_a, rep_block.bytes);
+		nano::read (stream_a, open_block.bytes);
+		nano::read (stream_a, balance.bytes);
+		nano::read (stream_a, modified);
+		nano::read (stream_a, block_count);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<account_info> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
 }
 
@@ -253,12 +248,19 @@ void nano::pending_info::serialize (nano::stream & stream_a) const
 
 bool nano::pending_info::deserialize (nano::stream & stream_a)
 {
-	auto result (nano::read (stream_a, source.bytes));
-	if (!result)
+	auto error (false);
+	try
 	{
-		result = nano::read (stream_a, amount.bytes);
+		nano::read (stream_a, source.bytes);
+		nano::read (stream_a, amount.bytes);
 	}
-	return result;
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<pending_info> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	return error;
 }
 
 bool nano::pending_info::operator== (nano::pending_info const & other_a) const
@@ -286,11 +288,18 @@ void nano::pending_key::serialize (nano::stream & stream_a) const
 
 bool nano::pending_key::deserialize (nano::stream & stream_a)
 {
-	auto error (nano::read (stream_a, account.bytes));
-	if (!error)
+	auto error (false);
+	try
 	{
-		error = nano::read (stream_a, hash.bytes);
+		nano::read (stream_a, account.bytes);
+		nano::read (stream_a, hash.bytes);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<pending_key> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
 }
 
@@ -324,11 +333,18 @@ void nano::block_info::serialize (nano::stream & stream_a) const
 
 bool nano::block_info::deserialize (nano::stream & stream_a)
 {
-	auto error (nano::read (stream_a, account.bytes));
-	if (!error)
+	auto error (false);
+	try
 	{
-		error = nano::read (stream_a, balance.bytes);
+		nano::read (stream_a, account.bytes);
+		nano::read (stream_a, balance.bytes);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<block_info> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
 }
 
@@ -417,45 +433,40 @@ nano::vote::vote (bool & error_a, nano::stream & stream_a, nano::block_uniquer *
 
 nano::vote::vote (bool & error_a, nano::stream & stream_a, nano::block_type type_a, nano::block_uniquer * uniquer_a)
 {
-	if (!error_a)
+	try
 	{
-		error_a = nano::read (stream_a, account.bytes);
-		if (!error_a)
+		nano::read (stream_a, account.bytes);
+		nano::read (stream_a, signature.bytes);
+		nano::read (stream_a, sequence);
+
+		while (stream_a.in_avail () > 0)
 		{
-			error_a = nano::read (stream_a, signature.bytes);
-			if (!error_a)
+			if (type_a == nano::block_type::not_a_block)
 			{
-				error_a = nano::read (stream_a, sequence);
-				if (!error_a)
+				nano::block_hash block_hash;
+				nano::read (stream_a, block_hash);
+				blocks.push_back (block_hash);
+			}
+			else
+			{
+				std::shared_ptr<nano::block> block (nano::deserialize_block (stream_a, type_a, uniquer_a));
+				if (block == nullptr)
 				{
-					while (!error_a && stream_a.in_avail () > 0)
-					{
-						if (type_a == nano::block_type::not_a_block)
-						{
-							nano::block_hash block_hash;
-							error_a = nano::read (stream_a, block_hash);
-							if (!error_a)
-							{
-								blocks.push_back (block_hash);
-							}
-						}
-						else
-						{
-							std::shared_ptr<nano::block> block (nano::deserialize_block (stream_a, type_a, uniquer_a));
-							error_a = block == nullptr;
-							if (!error_a)
-							{
-								blocks.push_back (block);
-							}
-						}
-					}
-					if (blocks.empty ())
-					{
-						error_a = true;
-					}
+					throw nano::deserialization_error ("Block is null", "nano::block");
 				}
+				blocks.push_back (block);
 			}
 		}
+	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<vote> (ex.get_type_str ()) << "\n";
+		error_a = true;
+	}
+
+	if (blocks.empty ())
+	{
+		error_a = true;
 	}
 }
 
@@ -576,52 +587,53 @@ void nano::vote::serialize (nano::stream & stream_a)
 
 bool nano::vote::deserialize (nano::stream & stream_a, nano::block_uniquer * uniquer_a)
 {
-	auto result (read (stream_a, account));
-	if (!result)
+	auto error (false);
+	try
 	{
-		result = read (stream_a, signature);
-		if (!result)
+		nano::read (stream_a, account);
+		nano::read (stream_a, signature);
+		nano::read (stream_a, sequence);
+
+		nano::block_type type;
+
+		while (true)
 		{
-			result = read (stream_a, sequence);
-			if (!result)
+			if (nano::try_read (stream_a, type))
 			{
-				nano::block_type type;
-				while (!result)
+				// Reached the end of the stream
+				break;
+			}
+
+			if (type == nano::block_type::not_a_block)
+			{
+				nano::block_hash block_hash;
+				nano::read (stream_a, block_hash);
+				blocks.push_back (block_hash);
+			}
+			else
+			{
+				std::shared_ptr<nano::block> block (nano::deserialize_block (stream_a, type, uniquer_a));
+				if (block == nullptr)
 				{
-					if (nano::read (stream_a, type))
-					{
-						if (blocks.empty ())
-						{
-							result = true;
-						}
-						break;
-					}
-					if (!result)
-					{
-						if (type == nano::block_type::not_a_block)
-						{
-							nano::block_hash block_hash;
-							result = nano::read (stream_a, block_hash);
-							if (!result)
-							{
-								blocks.push_back (block_hash);
-							}
-						}
-						else
-						{
-							std::shared_ptr<nano::block> block (nano::deserialize_block (stream_a, type, uniquer_a));
-							result = block == nullptr;
-							if (!result)
-							{
-								blocks.push_back (block);
-							}
-						}
-					}
+					throw nano::deserialization_error ("Block is empty", "nano::block");
 				}
+
+				blocks.push_back (block);
 			}
 		}
 	}
-	return result;
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<vote> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
+	if (blocks.empty ())
+	{
+		error = true;
+	}
+
+	return error;
 }
 
 bool nano::vote::validate ()

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -181,9 +181,8 @@ bool nano::account_info::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, modified);
 		nano::read (stream_a, block_count);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<account_info> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -254,9 +253,8 @@ bool nano::pending_info::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, source.bytes);
 		nano::read (stream_a, amount.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<pending_info> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -294,9 +292,8 @@ bool nano::pending_key::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, account.bytes);
 		nano::read (stream_a, hash.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<pending_key> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -339,9 +336,8 @@ bool nano::block_info::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, account.bytes);
 		nano::read (stream_a, balance.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<block_info> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -452,15 +448,14 @@ nano::vote::vote (bool & error_a, nano::stream & stream_a, nano::block_type type
 				std::shared_ptr<nano::block> block (nano::deserialize_block (stream_a, type_a, uniquer_a));
 				if (block == nullptr)
 				{
-					throw nano::deserialization_error ("Block is null", "nano::block");
+					throw std::runtime_error ("Block is null");
 				}
 				blocks.push_back (block);
 			}
 		}
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<vote> (ex.get_type_str ()) << "\n";
 		error_a = true;
 	}
 
@@ -615,16 +610,15 @@ bool nano::vote::deserialize (nano::stream & stream_a, nano::block_uniquer * uni
 				std::shared_ptr<nano::block> block (nano::deserialize_block (stream_a, type, uniquer_a));
 				if (block == nullptr)
 				{
-					throw nano::deserialization_error ("Block is empty", "nano::block");
+					throw std::runtime_error ("Block is empty");
 				}
 
 				blocks.push_back (block);
 			}
 		}
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<vote> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -33,19 +33,20 @@ void nano::account_info_v1::serialize (nano::stream & stream_a) const
 
 bool nano::account_info_v1::deserialize (nano::stream & stream_a)
 {
-	auto error (read (stream_a, head.bytes));
-	if (!error)
+	auto error (false);
+	try
 	{
-		error = read (stream_a, rep_block.bytes);
-		if (!error)
-		{
-			error = read (stream_a, balance.bytes);
-			if (!error)
-			{
-				error = read (stream_a, modified);
-			}
-		}
+		read (stream_a, head.bytes);
+		read (stream_a, rep_block.bytes);
+		read (stream_a, balance.bytes);
+		read (stream_a, modified);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<account_info_v1> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
 }
 
@@ -84,15 +85,19 @@ void nano::pending_info_v3::serialize (nano::stream & stream_a) const
 
 bool nano::pending_info_v3::deserialize (nano::stream & stream_a)
 {
-	auto error (nano::read (stream_a, source.bytes));
-	if (!error)
+	auto error (false);
+	try
 	{
-		error = nano::read (stream_a, amount.bytes);
-		if (!error)
-		{
-			error = nano::read (stream_a, destination.bytes);
-		}
+		read (stream_a, source.bytes);
+		read (stream_a, amount.bytes);
+		read (stream_a, destination.bytes);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<pending_info_v3> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
 }
 
@@ -142,23 +147,21 @@ void nano::account_info_v5::serialize (nano::stream & stream_a) const
 
 bool nano::account_info_v5::deserialize (nano::stream & stream_a)
 {
-	auto error (read (stream_a, head.bytes));
-	if (!error)
+	auto error (false);
+	try
 	{
-		error = read (stream_a, rep_block.bytes);
-		if (!error)
-		{
-			error = read (stream_a, open_block.bytes);
-			if (!error)
-			{
-				error = read (stream_a, balance.bytes);
-				if (!error)
-				{
-					error = read (stream_a, modified);
-				}
-			}
-		}
+		read (stream_a, head.bytes);
+		read (stream_a, rep_block.bytes);
+		read (stream_a, open_block.bytes);
+		read (stream_a, balance.bytes);
+		read (stream_a, modified);
 	}
+	catch (nano::deserialization_error const & ex)
+	{
+		std::cerr << deserialization_error_message<account_info_v5> (ex.get_type_str ()) << "\n";
+		error = true;
+	}
+
 	return error;
 }
 

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -41,9 +41,8 @@ bool nano::account_info_v1::deserialize (nano::stream & stream_a)
 		read (stream_a, balance.bytes);
 		read (stream_a, modified);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<account_info_v1> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -92,9 +91,8 @@ bool nano::pending_info_v3::deserialize (nano::stream & stream_a)
 		read (stream_a, amount.bytes);
 		read (stream_a, destination.bytes);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<pending_info_v3> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 
@@ -156,9 +154,8 @@ bool nano::account_info_v5::deserialize (nano::stream & stream_a)
 		read (stream_a, balance.bytes);
 		read (stream_a, modified);
 	}
-	catch (nano::deserialization_error const & ex)
+	catch (std::runtime_error const &)
 	{
-		std::cerr << deserialization_error_message<account_info_v5> (ex.get_type_str ()) << "\n";
 		error = true;
 	}
 


### PR DESCRIPTION
While working on Issue #1374 I have to (de)serialize a new object type which had a few member variables. While looking at the existing serialization functions to the data store I thought it would be more readable to use exceptions. It turns something like this:

```
auto error (read (stream_a, min_hash));
if (!error)	
{	
	error= read (stream_a, max_hash);	
	if (!error)
	{	
		error= read (stream_a, mode);	
                if (!error)
                {
                    error = read (stream_a, max_count);
                }
	}	
}	
return error;
```

Into:
```
auto error (false);
try
{
	nano::read (stream_a, min_hash);
	nano::read (stream_a, max_hash);
	nano::read (stream_a, mode);
	nano::read (stream_a, max_count);
}
catch (std::runtime_error const &)
{
	error = true;
}

return error;
```

The previous (existing) form doesn't scale well, some places have 6 members and it's not unfeasible to expect some to have many more in the future. It is in my opinion much more readable and looks more like the serializing functions:

```
nano::write (stream_a, min_hash);
nano::write (stream_a, max_hash);
nano::write (stream_a, mode);
nano::write (stream_a, max_count);
```

So it is much easier to spot mistakes. In an ideal world the exceptions wouldn't be handled as low level here and instead much higher up the stack, so it could look even cleaner however as deserializer functions return a boolean and there are many of them which would need changing I have left this for now to reduce the risk of regression. 

A few things were done:
- The innards of nano::read have been put into a new function called nano::try_read. This follows a convention in .NET which uses try_* prefixes which return a boolean indicating success/failure and the normal function throws an exception as we still need both and it was a nice way to differentiate them. Boost also has `try_lexical_convert` which returns a boolean while `lexical_cast` throws.  In a previous commit I created my own exception type (`deserialization_error`) and also std::cerr'ed any exceptions. However this is too low level, so gets output in tests for instance so I am just keeping it has it currently is.
- All serialize functions now proceed deserialize in both header and source files, to keep things consistent.
- If there are json equivalents these are now kept together
- In lmdb.cpp `nano::mdb_val::operator std::array<char, 64> () const` demonstrates that returning errors can be happily ignored, something that doesn't happen with exceptions. In c++17 there is the [[no_discard]] attribute however but this cannot be used yet. core/test/network.cpp also checks the returned error condition now.