### PR TITLE
Upgrade preconfigured peers in config.json file to use nano url instead of rai

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -9,6 +9,11 @@
 
 using namespace std::chrono_literals;
 
+namespace
+{
+void add_required_children_node_config_tree (nano::jsonconfig & tree);
+}
+
 TEST (node, stop)
 {
 	nano::system system (24000, 1);
@@ -547,21 +552,6 @@ TEST (node_config, serialization)
 	ASSERT_EQ (config2.lmdb_max_dbs, config1.lmdb_max_dbs);
 }
 
-void add_barebones_node_config_tree (nano::jsonconfig & tree)
-{
-	nano::logging logging1;
-	nano::jsonconfig logging_l;
-	logging1.serialize_json (logging_l);
-	tree.put_child ("logging", logging_l);
-	nano::jsonconfig preconfigured_peers_l;
-	tree.put_child ("preconfigured_peers", preconfigured_peers_l);
-	nano::jsonconfig preconfigured_representatives_l;
-	tree.put_child ("preconfigured_representatives", preconfigured_representatives_l);
-	nano::jsonconfig work_peers_l;
-	tree.put_child ("work_peers", work_peers_l);
-	tree.put ("version", std::to_string (nano::node_config::json_version ()));
-}
-
 TEST (node_config, v1_v2_upgrade)
 {
 	auto path (nano::unique_path ());
@@ -593,7 +583,7 @@ TEST (node_config, v1_v2_upgrade)
 TEST (node_config, v2_v3_upgrade)
 {
 	nano::jsonconfig tree;
-	add_barebones_node_config_tree (tree);
+	add_required_children_node_config_tree (tree);
 	tree.put ("peering_port", std::to_string (0));
 	tree.put ("packet_delay_microseconds", std::to_string (0));
 	tree.put ("bootstrap_fraction_numerator", std::to_string (0));
@@ -628,7 +618,7 @@ TEST (node_config, v15_v16_upgrade)
 	auto test_upgrade = [](auto old_preconfigured_peers_url, auto new_preconfigured_peers_url) {
 		auto path (nano::unique_path ());
 		nano::jsonconfig tree;
-		add_barebones_node_config_tree (tree);
+		add_required_children_node_config_tree (tree);
 		tree.put ("version", "15");
 
 		const char * dummy_peer = "127.5.2.1";
@@ -669,7 +659,7 @@ TEST (node_config, v15_v16_upgrade)
 TEST (node_config, allow_local_peers)
 {
 	nano::jsonconfig tree;
-	add_barebones_node_config_tree (tree);
+	add_required_children_node_config_tree (tree);
 
 	auto path (nano::unique_path ());
 	auto upgraded (false);
@@ -2123,4 +2113,22 @@ TEST (node, confirm_back)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+}
+
+namespace
+{
+void add_required_children_node_config_tree (nano::jsonconfig & tree)
+{
+	nano::logging logging1;
+	nano::jsonconfig logging_l;
+	logging1.serialize_json (logging_l);
+	tree.put_child ("logging", logging_l);
+	nano::jsonconfig preconfigured_peers_l;
+	tree.put_child ("preconfigured_peers", preconfigured_peers_l);
+	nano::jsonconfig preconfigured_representatives_l;
+	tree.put_child ("preconfigured_representatives", preconfigured_representatives_l);
+	nano::jsonconfig work_peers_l;
+	tree.put_child ("work_peers", work_peers_l);
+	tree.put ("version", std::to_string (nano::node_config::json_version ()));
+}
 }

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -172,8 +172,8 @@ public:
 
 	jsonconfig & replace_child (std::string const & key_a, nano::jsonconfig & conf_a)
 	{
-		conf_a.erase (key_a);
-		conf_a.put_child (key_a, conf_a);
+		tree.erase (key_a);
+		put_child (key_a, conf_a);
 		return *this;
 	}
 
@@ -332,7 +332,7 @@ protected:
 				conditionally_set_error<T> (nano::error_config::invalid_value, optional, key);
 			}
 		}
-		catch (boost::property_tree::ptree_bad_path const & ex)
+		catch (boost::property_tree::ptree_bad_path const &)
 		{
 			if (!optional)
 			{
@@ -407,7 +407,7 @@ protected:
 			auto val (tree.get<std::string> (key));
 			bool_conv (val);
 		}
-		catch (boost::property_tree::ptree_bad_path const & ex)
+		catch (boost::property_tree::ptree_bad_path const &)
 		{
 			if (!optional)
 			{

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -367,7 +367,7 @@ protected:
 				target = static_cast<uint8_t> (tmp);
 			}
 		}
-		catch (boost::property_tree::ptree_bad_path const & ex)
+		catch (boost::property_tree::ptree_bad_path const &)
 		{
 			if (!optional)
 			{
@@ -438,7 +438,7 @@ protected:
 				conditionally_set_error<T> (nano::error_config::invalid_value, optional, key);
 			}
 		}
-		catch (boost::property_tree::ptree_bad_path const & ex)
+		catch (boost::property_tree::ptree_bad_path const &)
 		{
 			if (!optional)
 			{

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -202,14 +202,13 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
 			upgraded = true;
 		case 15:
-			json.put ("allow_local_peers", allow_local_peers);
-			upgraded = true;
-		case 16:
 		{
+			json.put ("allow_local_peers", allow_local_peers);
+
 			// Update to the new preconfigured_peers url for rebrand if it is found (rai -> nano)
-			auto reps_l (json.get_required_child (preconfigured_peers_key));
+			auto peers_l (json.get_required_child (preconfigured_peers_key));
 			nano::jsonconfig peers;
-			reps_l.array_entries<std::string> ([&peers](std::string entry) {
+			peers_l.array_entries<std::string> ([&peers](std::string entry) {
 				if (entry == "rai-beta.raiblocks.net")
 				{
 					entry = default_beta_peer_network;
@@ -225,7 +224,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.replace_child (preconfigured_peers_key, peers);
 			upgraded = true;
 		}
-		case 17:
+		case 16:
 			break;
 		default:
 			throw std::runtime_error ("Unknown node_config version");
@@ -330,6 +329,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<std::string> ("callback_target", callback_target);
 		json.get<int> ("lmdb_max_dbs", lmdb_max_dbs);
 		json.get<bool> ("enable_voting", enable_voting);
+		json.get<bool> ("allow_local_peers", allow_local_peers);
 
 		// Validate ranges
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -50,9 +50,9 @@ public:
 	static std::chrono::seconds constexpr keepalive_period = std::chrono::seconds (60);
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
-	int json_version () const
+	static int json_version ()
 	{
-		return 17;
+		return 16;
 	}
 };
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -50,9 +50,9 @@ public:
 	static std::chrono::seconds constexpr keepalive_period = std::chrono::seconds (60);
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
-	inline int json_version () const
+	int json_version () const
 	{
-		return 16;
+		return 17;
 	}
 };
 


### PR DESCRIPTION
This solves #1575 and also 2 other config bugs (`jsonconfig::replace_child ()` not working as expected, and `allow_local_peers` is not being read from the config file).

**nodeconfig.cpp** - Add upgraded section from 16 to 17 which updates `rai.raiblocks.net` -> `peering.nano.org` and `rai-beta.raiblocks.net` -> `peering-beta.nano.org`.  To reduce some duplication of the hardcoded strings, I've made some internal linkage variables. Also using `emplace_back` so that nano::accounts can be created inside the vector directly.
**jsonconfig.hpp** - There were some warnings generated for unused `ex` variables so I've now removed them.

Added a new test which checks that both live/beta preconfigured peer urls are successfully changed and one for allow_local_peers.