### PR TITLE
Remove deprecated bulk_pull_blocks

### DIFF
--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -13,7 +13,6 @@ public:
 	confirm_ack_count (0),
 	bulk_pull_count (0),
 	bulk_pull_account_count (0),
-	bulk_pull_blocks_count (0),
 	bulk_push_count (0),
 	frontier_req_count (0)
 	{
@@ -42,10 +41,6 @@ public:
 	{
 		++bulk_pull_account_count;
 	}
-	void bulk_pull_blocks (nano::bulk_pull_blocks const &) override
-	{
-		++bulk_pull_blocks_count;
-	}
 	void bulk_push (nano::bulk_push const &) override
 	{
 		++bulk_push_count;
@@ -64,7 +59,6 @@ public:
 	uint64_t confirm_ack_count;
 	uint64_t bulk_pull_count;
 	uint64_t bulk_pull_account_count;
-	uint64_t bulk_pull_blocks_count;
 	uint64_t bulk_push_count;
 	uint64_t frontier_req_count;
 	uint64_t node_id_handshake_count;

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -142,10 +142,8 @@ public:
 	void run ();
 	void receive_frontier ();
 	void received_frontier (boost::system::error_code const &, size_t);
-	void request_account (nano::account const &, nano::block_hash const &);
 	void unsynced (nano::block_hash const &, nano::block_hash const &);
 	void next (nano::transaction const &);
-	void insert_pull (nano::pull_info const &);
 	std::shared_ptr<nano::bootstrap_client> connection;
 	nano::account current;
 	nano::block_hash frontier;
@@ -271,9 +269,7 @@ public:
 	void receive_header_action (boost::system::error_code const &, size_t);
 	void receive_bulk_pull_action (boost::system::error_code const &, size_t, nano::message_header const &);
 	void receive_bulk_pull_account_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_bulk_pull_blocks_action (boost::system::error_code const &, size_t, nano::message_header const &);
 	void receive_frontier_req_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_bulk_push_action ();
 	void add_request (std::unique_ptr<nano::message>);
 	void finish_request ();
 	void run_next ();
@@ -323,26 +319,11 @@ public:
 	bool pending_include_address;
 	bool invalid_request;
 };
-class bulk_pull_blocks;
-class bulk_pull_blocks_server : public std::enable_shared_from_this<nano::bulk_pull_blocks_server>
-{
-public:
-	bulk_pull_blocks_server (std::shared_ptr<nano::bootstrap_server> const &, std::unique_ptr<nano::bulk_pull_blocks>);
-	void set_params ();
-	std::shared_ptr<nano::block> get_next ();
-	void send_next ();
-	void send_finished ();
-	void no_block_sent (boost::system::error_code const &, size_t);
-	std::shared_ptr<nano::bootstrap_server> connection;
-	std::unique_ptr<nano::bulk_pull_blocks> request;
-	std::shared_ptr<std::vector<uint8_t>> send_buffer;
-};
 class bulk_push_server : public std::enable_shared_from_this<nano::bulk_push_server>
 {
 public:
 	bulk_push_server (std::shared_ptr<nano::bootstrap_server> const &);
 	void receive ();
-	void receive_block ();
 	void received_type ();
 	void received_block (boost::system::error_code const &, size_t, nano::block_type);
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -713,53 +713,6 @@ void nano::bulk_pull_account::serialize (nano::stream & stream_a) const
 	write (stream_a, flags);
 }
 
-nano::bulk_pull_blocks::bulk_pull_blocks () :
-message (nano::message_type::bulk_pull_blocks)
-{
-}
-
-nano::bulk_pull_blocks::bulk_pull_blocks (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a)
-{
-	if (!error_a)
-	{
-		error_a = deserialize (stream_a);
-	}
-}
-
-void nano::bulk_pull_blocks::visit (nano::message_visitor & visitor_a) const
-{
-	visitor_a.bulk_pull_blocks (*this);
-}
-
-bool nano::bulk_pull_blocks::deserialize (nano::stream & stream_a)
-{
-	assert (header.type == nano::message_type::bulk_pull_blocks);
-	auto result (read (stream_a, min_hash));
-	if (!result)
-	{
-		result = read (stream_a, max_hash);
-		if (!result)
-		{
-			result = read (stream_a, mode);
-			if (!result)
-			{
-				result = read (stream_a, max_count);
-			}
-		}
-	}
-	return result;
-}
-
-void nano::bulk_pull_blocks::serialize (nano::stream & stream_a) const
-{
-	header.serialize (stream_a);
-	write (stream_a, min_hash);
-	write (stream_a, max_hash);
-	write (stream_a, mode);
-	write (stream_a, max_count);
-}
-
 nano::bulk_push::bulk_push () :
 message (nano::message_type::bulk_push)
 {

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -144,14 +144,9 @@ enum class message_type : uint8_t
 	bulk_pull = 0x6,
 	bulk_push = 0x7,
 	frontier_req = 0x8,
-	bulk_pull_blocks = 0x9,
+	/* deleted 0x9 */
 	node_id_handshake = 0x0a,
 	bulk_pull_account = 0x0b
-};
-enum class bulk_pull_blocks_mode : uint8_t
-{
-	list_blocks,
-	checksum_blocks
 };
 enum class bulk_pull_account_flags : uint8_t
 {
@@ -332,19 +327,6 @@ public:
 	nano::uint128_union minimum_amount;
 	bulk_pull_account_flags flags;
 };
-class bulk_pull_blocks : public message
-{
-public:
-	bulk_pull_blocks ();
-	bulk_pull_blocks (bool &, nano::stream &, nano::message_header const &);
-	bool deserialize (nano::stream &);
-	void serialize (nano::stream &) const override;
-	void visit (nano::message_visitor &) const override;
-	nano::block_hash min_hash;
-	nano::block_hash max_hash;
-	bulk_pull_blocks_mode mode;
-	uint32_t max_count;
-};
 class bulk_push : public message
 {
 public:
@@ -381,7 +363,6 @@ public:
 	virtual void confirm_ack (nano::confirm_ack const &) = 0;
 	virtual void bulk_pull (nano::bulk_pull const &) = 0;
 	virtual void bulk_pull_account (nano::bulk_pull_account const &) = 0;
-	virtual void bulk_pull_blocks (nano::bulk_pull_blocks const &) = 0;
 	virtual void bulk_push (nano::bulk_push const &) = 0;
 	virtual void frontier_req (nano::frontier_req const &) = 0;
 	virtual void node_id_handshake (nano::node_id_handshake const &) = 0;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -556,10 +556,6 @@ public:
 	{
 		assert (false);
 	}
-	void bulk_pull_blocks (nano::bulk_pull_blocks const &) override
-	{
-		assert (false);
-	}
 	void bulk_push (nano::bulk_push const &) override
 	{
 		assert (false);


### PR DESCRIPTION
This solves #1585
It removed anything which references bulk_pull_blocks, which was deprecated before and shouldn't be used anymore.

The only thing that is probably worth mentioning is the comment I've added to the removed `bulk_pull_blocks` enum value in common.hpp to indicate that the message was previously used and deleted, so as not to use it unintentionally, although maybe it's fine.