### PR TITLE
RPC uptime

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4000,3 +4000,24 @@ TEST (rpc, node_id_delete)
 	nano::keypair node_id (system.nodes[0]->store.get_node_id (transaction));
 	ASSERT_NE (node_id.pub.to_string (), system.nodes[0]->node_id.pub.to_string ());
 }
+
+TEST (rpc, uptime)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "uptime");
+	std::this_thread::sleep_for (std::chrono::seconds (1));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("0", response.json.get<std::string> ("days"));
+	ASSERT_EQ ("0", response.json.get<std::string> ("hours"));
+	ASSERT_EQ ("0", response.json.get<std::string> ("minutes"));
+	ASSERT_LE (1, response.json.get<int> ("seconds"));
+}

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4016,8 +4016,5 @@ TEST (rpc, uptime)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response.status);
-	ASSERT_EQ ("0", response.json.get<std::string> ("days"));
-	ASSERT_EQ ("0", response.json.get<std::string> ("hours"));
-	ASSERT_EQ ("0", response.json.get<std::string> ("minutes"));
 	ASSERT_LE (1, response.json.get<int> ("seconds"));
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1622,6 +1622,7 @@ node (init_a, io_ctx_a, application_path_a, alarm_a, nano::node_config (peering_
 }
 
 nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::node_config const & config_a, nano::work_pool & work_a) :
+startup_time (std::chrono::system_clock::now ()),
 io_ctx (io_ctx_a),
 config (config_a),
 alarm (alarm_a),

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1622,7 +1622,6 @@ node (init_a, io_ctx_a, application_path_a, alarm_a, nano::node_config (peering_
 }
 
 nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::node_config const & config_a, nano::work_pool & work_a) :
-startup_time (std::chrono::system_clock::now ()),
 io_ctx (io_ctx_a),
 config (config_a),
 alarm (alarm_a),
@@ -1648,7 +1647,8 @@ block_processor_thread ([this]() {
 }),
 online_reps (*this),
 stats (config.stat_config),
-vote_uniquer (block_uniquer)
+vote_uniquer (block_uniquer),
+startup_time (std::chrono::steady_clock::now ())
 {
 	wallets.observer = [this](bool active) {
 		observers.wallet.notify (active);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -534,6 +534,7 @@ public:
 	nano::keypair node_id;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
+	const std::chrono::system_clock::time_point startup_time;
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
 	static std::chrono::seconds constexpr period = std::chrono::seconds (60);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -534,7 +534,7 @@ public:
 	nano::keypair node_id;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
-	const std::chrono::system_clock::time_point startup_time;
+	const std::chrono::steady_clock::time_point startup_time;
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
 	static std::chrono::seconds constexpr period = std::chrono::seconds (60);

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3057,7 +3057,7 @@ void nano::rpc_handler::unchecked_keys ()
 
 void nano::rpc_handler::uptime ()
 {
-	response_l.put ("seconds", std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now () - node.startup_time).count ());
+	response_l.put ("seconds", std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - node.startup_time).count ());
 	response_errors ();
 }
 

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3055,6 +3055,27 @@ void nano::rpc_handler::unchecked_keys ()
 	response_errors ();
 }
 
+void nano::rpc_handler::uptime ()
+{
+	using namespace std::chrono;
+	typedef duration<int, std::ratio<86400>> days; // 60*60*24
+
+	auto uptime_duration (system_clock::now () - node.startup_time);
+	auto d (duration_cast<days> (uptime_duration));
+	uptime_duration -= d;
+	auto h (duration_cast<hours> (uptime_duration));
+	uptime_duration -= h;
+	auto m (duration_cast<minutes> (uptime_duration));
+	uptime_duration -= m;
+	auto s (duration_cast<seconds> (uptime_duration));
+
+	response_l.put ("days", d.count ());
+	response_l.put ("hours", h.count ());
+	response_l.put ("minutes", m.count ());
+	response_l.put ("seconds", s.count ());
+	response_errors ();
+}
+
 void nano::rpc_handler::version ()
 {
 	response_l.put ("rpc_version", "1");
@@ -4222,6 +4243,10 @@ void nano::rpc_handler::process_request ()
 			else if (action == "unchecked_keys")
 			{
 				unchecked_keys ();
+			}
+			else if (action == "uptime")
+			{
+				uptime ();
 			}
 			else if (action == "validate_account_number")
 			{

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3057,22 +3057,7 @@ void nano::rpc_handler::unchecked_keys ()
 
 void nano::rpc_handler::uptime ()
 {
-	using namespace std::chrono;
-	typedef duration<int, std::ratio<86400>> days; // 60*60*24
-
-	auto uptime_duration (system_clock::now () - node.startup_time);
-	auto d (duration_cast<days> (uptime_duration));
-	uptime_duration -= d;
-	auto h (duration_cast<hours> (uptime_duration));
-	uptime_duration -= h;
-	auto m (duration_cast<minutes> (uptime_duration));
-	uptime_duration -= m;
-	auto s (duration_cast<seconds> (uptime_duration));
-
-	response_l.put ("days", d.count ());
-	response_l.put ("hours", h.count ());
-	response_l.put ("minutes", m.count ());
-	response_l.put ("seconds", s.count ());
+	response_l.put ("seconds", std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now () - node.startup_time).count ());
 	response_errors ();
 }
 

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -195,6 +195,7 @@ public:
 	void unchecked_clear ();
 	void unchecked_get ();
 	void unchecked_keys ();
+	void uptime ();
 	void validate_account_number ();
 	void version ();
 	void wallet_add ();


### PR DESCRIPTION
Tracks the node uptime in seconds.

Sample

```json
{"action": "uptime"}

{"seconds": "73"}
```