### PR TITLE
RPC to clear stats

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4152,6 +4152,8 @@ TEST (rpc, stats_clear)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	std::string success (response.json.get<std::string> ("success"));
+	ASSERT_TRUE (success.empty ());
 	ASSERT_EQ (0, system.nodes[0]->stats.count (nano::stat::type::ledger, nano::stat::dir::in));
 	ASSERT_LE (system.nodes[0]->stats.last_reset ().count (), 5);
 }

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4136,6 +4136,26 @@ TEST (rpc, node_id_delete)
 	ASSERT_NE (node_id.pub.to_string (), system.nodes[0]->node_id.pub.to_string ());
 }
 
+TEST (rpc, stats_clear)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.nodes[0]->stats.inc (nano::stat::type::ledger, nano::stat::dir::in);
+	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::ledger, nano::stat::dir::in));
+	boost::property_tree::ptree request;
+	request.put ("action", "stats_clear");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (0, system.nodes[0]->stats.count (nano::stat::type::ledger, nano::stat::dir::in));
+	ASSERT_LE (system.nodes[0]->stats.last_reset ().count (), 5);
+}
+
 TEST (rpc, uptime)
 {
 	nano::system system (24000, 1);

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -2972,12 +2972,21 @@ void nano::rpc_handler::stats ()
 	}
 	if (!ec)
 	{
-		response (*static_cast<boost::property_tree::ptree *> (sink->to_object ()));
+		auto stat_tree_l (*static_cast<boost::property_tree::ptree *> (sink->to_object ()));
+		stat_tree_l.put ("stat_duration_seconds", node.stats.last_reset ().count ());
+		response (stat_tree_l);
 	}
 	else
 	{
 		response_errors ();
 	}
+}
+
+void nano::rpc_handler::stats_clear ()
+{
+	node.stats.clear ();
+	response_l.put ("success", "");
+	response (response_l);
 }
 
 void nano::rpc_handler::stop ()
@@ -4258,6 +4267,10 @@ void nano::rpc_handler::process_request ()
 			else if (action == "stats")
 			{
 				stats ();
+			}
+			else if (action == "stats_clear")
+			{
+				stats_clear ();
 			}
 			else if (action == "stop")
 			{

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -190,6 +190,7 @@ public:
 	void search_pending_all ();
 	void send ();
 	void stats ();
+	void stats_clear ();
 	void stop ();
 	void unchecked ();
 	void unchecked_clear ();

--- a/nano/node/stats.cpp
+++ b/nano/node/stats.cpp
@@ -310,6 +310,20 @@ void nano::stat::update (uint32_t key_a, uint64_t value)
 	}
 }
 
+std::chrono::seconds nano::stat::last_reset ()
+{
+	std::unique_lock<std::mutex> lock (stat_mutex);
+	auto now (std::chrono::steady_clock::now ());
+	return std::chrono::duration_cast<std::chrono::seconds> (now - timestamp);
+}
+
+void nano::stat::clear ()
+{
+	std::unique_lock<std::mutex> lock (stat_mutex);
+	entries.clear ();
+	timestamp = std::chrono::steady_clock::now ();
+}
+
 std::string nano::stat::type_to_string (uint32_t key)
 {
 	auto type = static_cast<stat::type> (key >> 16 & 0x000000ff);

--- a/nano/node/stats.hpp
+++ b/nano/node/stats.hpp
@@ -381,6 +381,12 @@ public:
 		return get_entry (key_of (type, detail, dir))->counter.value;
 	}
 
+	/** Returns the number of seconds since clear() was last called, or node startup if it's never called. */
+	std::chrono::seconds last_reset ();
+
+	/** Clear all stats */
+	void clear ();
+
 	/** Log counters to the given log link */
 	void log_counters (stat_log_sink & sink);
 
@@ -425,6 +431,9 @@ private:
 
 	/** Unlocked implementation of log_samples() to avoid using recursive locking */
 	void log_samples_impl (stat_log_sink & sink);
+
+	/** Time of last clear() call */
+	std::chrono::steady_clock::time_point timestamp{ std::chrono::steady_clock::now () };
 
 	/** Configuration deserialized from config.json */
 	nano::stat_config config;


### PR DESCRIPTION
Closes #1620 

`stats_clear` clears all existing stats, and `stats` is  updated to include seconds since last clear (or node startup if never cleared)