### PR TITLE
Fix rpc.wallet_create_seed test

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -726,18 +726,18 @@ TEST (rpc, wallet_create_seed)
 	std::string wallet_text (response.json.get<std::string> ("wallet"));
 	nano::uint256_union wallet_id;
 	ASSERT_FALSE (wallet_id.decode_hex (wallet_text));
-	auto wallet (system.nodes[0]->wallets.items.find (wallet_id));
-	ASSERT_NE (system.nodes[0]->wallets.items.end (), wallet);
+	auto existing (system.nodes[0]->wallets.items.find (wallet_id));
+	ASSERT_NE (system.nodes[0]->wallets.items.end (), existing);
 	{
 		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 		nano::raw_key seed0;
-		wallet->second->store.seed (seed0, transaction);
+		existing->second->store.seed (seed0, transaction);
 		ASSERT_EQ (seed.pub, seed0.data);
 	}
 	auto account_text (response.json.get<std::string> ("account"));
 	nano::uint256_union account;
 	ASSERT_FALSE (account.decode_account (account_text));
-	ASSERT_TRUE (system.wallet (0)->exists (account));
+	ASSERT_TRUE (existing->second->exists (account));
 }
 
 TEST (rpc, wallet_export)

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<nano::wallet> nano::system::wallet (size_t index_a)
 {
 	assert (nodes.size () > index_a);
 	auto size (nodes[index_a]->wallets.items.size ());
-	assert (size >= 1);
+	assert (size == 1);
 	return nodes[index_a]->wallets.items.begin ()->second;
 }
 


### PR DESCRIPTION
Test failing occasionally only with Windows core_test.exe build. Wasn't able to reprocude failures on Linux machine.

`system.wallet (0)` returning `nodes[0]->wallets.items.begin ()->second` while wallets.items is unordered_map. According to http://www.cplusplus.com/reference/unordered_map/unordered_map/begin/ an unordered_map object makes no guarantees on which specific element is considered its first element. In test there are 2 wallets in unordered_map: 1st default, 2nd created with RPC.