### PR TITLE
Memory stats in RPC

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -44,7 +44,7 @@ public:
 									boost::property_tree::read_json (body, json);
 									status = 200;
 								}
-								catch (std::exception & e)
+								catch (std::exception &)
 								{
 									status = 500;
 								}
@@ -4243,7 +4243,7 @@ TEST (rpc, wallet_history)
 	system.deadline_set (5s);
 	while (response.status == 0)
 	{
-		system.poll ();
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response.status);
 	std::vector<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>> history_l;
@@ -4344,4 +4344,32 @@ TEST (rpc, sign_block)
 	ASSERT_FALSE (nano::validate_message (key.pub, send.hash (), block->block_signature ()));
 	ASSERT_NE (block->block_signature (), send.block_signature ());
 	ASSERT_EQ (block->hash (), send.hash ());
+}
+
+TEST (rpc, memory_stats)
+{
+	nano::system system (24000, 1);
+	auto node = system.nodes.front ();
+	nano::rpc rpc (system.io_ctx, *node, nano::rpc_config (true));
+
+	// Preliminary test adding to the vote uniquer and checking json output is correct
+	nano::keypair key;
+	auto block (std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0));
+	std::vector<nano::block_hash> hashes;
+	hashes.push_back (block->hash ());
+	auto vote (std::make_shared<nano::vote> (key.pub, key.prv, 0, hashes));
+	node->vote_uniquer.unique (vote);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "stats");
+	request.put ("type", "objects");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+
+	ASSERT_EQ (response.json.get_child ("node").get_child ("vote_uniquer").get_child ("votes").get<std::string> ("count"), "1");
 }

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1607,3 +1607,15 @@ size_t nano::block_uniquer::size ()
 	std::lock_guard<std::mutex> lock (mutex);
 	return blocks.size ();
 }
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_uniquer & block_uniquer, const std::string & name)
+{
+	auto count = block_uniquer.size ();
+	auto sizeof_element = sizeof (block_uniquer::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", count, sizeof_element }));
+	return composite;
+}
+}

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/utility.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 #include <cassert>
@@ -322,14 +323,19 @@ public:
 class block_uniquer
 {
 public:
+	using value_type = std::pair<const nano::uint256_union, std::weak_ptr<nano::block>>;
+
 	std::shared_ptr<nano::block> unique (std::shared_ptr<nano::block>);
 	size_t size ();
 
 private:
 	std::mutex mutex;
-	std::unordered_map<nano::uint256_union, std::weak_ptr<nano::block>> blocks;
+	std::unordered_map<std::remove_const_t<value_type::first_type>, value_type::second_type> blocks;
 	static unsigned constexpr cleanup_count = 2;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_uniquer & block_uniquer, const std::string & name);
+
 std::shared_ptr<nano::block> deserialize_block (nano::stream &, nano::block_uniquer * = nullptr);
 std::shared_ptr<nano::block> deserialize_block (nano::stream &, nano::block_type, nano::block_uniquer * = nullptr);
 std::shared_ptr<nano::block> deserialize_block_json (boost::property_tree::ptree const &, nano::block_uniquer * = nullptr);

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -3,6 +3,44 @@
 
 namespace nano
 {
+seq_con_info_composite::seq_con_info_composite (const std::string & name) :
+name (name)
+{
+}
+
+bool seq_con_info_composite::is_composite () const
+{
+	return true;
+}
+
+void seq_con_info_composite::add_component (std::unique_ptr<seq_con_info_component> child)
+{
+	children.push_back (std::move (child));
+}
+
+const std::vector<std::unique_ptr<seq_con_info_component>> & seq_con_info_composite::get_children () const
+{
+	return children;
+}
+
+const std::string & seq_con_info_composite::get_name () const
+{
+	return name;
+}
+
+seq_con_info_leaf::seq_con_info_leaf (const seq_con_info & info) :
+info (info)
+{
+}
+bool seq_con_info_leaf::is_composite () const
+{
+	return false;
+}
+const seq_con_info & seq_con_info_leaf::get_info () const
+{
+	return info;
+}
+
 namespace thread_role
 {
 	/*

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -11,6 +11,49 @@
 
 namespace nano
 {
+/* These containers are used to collect information about sequence containers.
+ * It makes use of the composite design pattern to collect information
+ * from sequence containers and sequence containers inside member variables.
+ */
+struct seq_con_info
+{
+	std::string name;
+	size_t count;
+	size_t sizeof_element;
+};
+
+class seq_con_info_component
+{
+public:
+	virtual ~seq_con_info_component () = default;
+	virtual bool is_composite () const = 0;
+};
+
+class seq_con_info_composite : public seq_con_info_component
+{
+public:
+	seq_con_info_composite (const std::string & name);
+	bool is_composite () const override;
+	void add_component (std::unique_ptr<seq_con_info_component> child);
+	const std::vector<std::unique_ptr<seq_con_info_component>> & get_children () const;
+	const std::string & get_name () const;
+
+private:
+	std::string name;
+	std::vector<std::unique_ptr<seq_con_info_component>> children;
+};
+
+class seq_con_info_leaf : public seq_con_info_component
+{
+public:
+	seq_con_info_leaf (const seq_con_info & info);
+	bool is_composite () const override;
+	const seq_con_info & get_info () const;
+
+private:
+	seq_con_info info;
+};
+
 // Lower priority of calling work generating thread
 void work_thread_reprioritize ();
 
@@ -86,6 +129,22 @@ public:
 	std::mutex mutex;
 	std::vector<std::function<void(T...)>> observers;
 };
+
+template <typename... T>
+inline std::unique_ptr<seq_con_info_component> collect_seq_con_info (observer_set<T...> & observer_set, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> lock (observer_set.mutex);
+		count = observer_set.observers.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (observer_set.observers)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "observers", count }));
+	return composite;
+}
+
 }
 
 void release_assert_internal (bool check, const char * check_expr, const char * file, unsigned int line);

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -139,12 +139,11 @@ inline std::unique_ptr<seq_con_info_component> collect_seq_con_info (observer_se
 		count = observer_set.observers.size ();
 	}
 
-	auto sizeof_element = sizeof (decltype (observer_set.observers)::value_type);
+	auto sizeof_element = sizeof (typename decltype (observer_set.observers)::value_type);
 	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "observers", count }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "observers", count, sizeof_element }));
 	return composite;
 }
-
 }
 
 void release_assert_internal (bool check, const char * check_expr, const char * file, unsigned int line);

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -193,3 +193,21 @@ uint64_t nano::work_pool::generate (nano::uint256_union const & hash_a, uint64_t
 	auto result (work.get_future ().get ());
 	return result.value ();
 }
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (work_pool & work_pool, const std::string & name)
+{
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> (work_pool.mutex);
+		count = work_pool.pending.size ();
+	}
+	auto sizeof_element = sizeof (decltype (work_pool.pending)::value_type);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "pending", count, sizeof_element }));
+	composite->add_component (collect_seq_con_info (work_pool.work_observers, "work_observers"));
+	return composite;
+}
+}

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -48,4 +48,6 @@ public:
 	static uint64_t const publish_full_threshold = 0xffffffc000000000;
 	static uint64_t const publish_threshold = nano::nano_network == nano::nano_networks::nano_test_network ? publish_test_threshold : publish_full_threshold;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (work_pool & work_pool, const std::string & name);
 }

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1892,6 +1892,23 @@ void nano::bootstrap_initiator::notify_listeners (bool in_progress_a)
 	}
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiator & bootstrap_initiator, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> guard (bootstrap_initiator.mutex);
+		count = bootstrap_initiator.observers.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (bootstrap_initiator.observers)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "observers", count, sizeof_element }));
+	return composite;
+}
+}
+
 nano::bootstrap_listener::bootstrap_listener (boost::asio::io_context & io_ctx_a, uint16_t port_a, nano::node & node_a) :
 acceptor (io_ctx_a),
 defer_acceptor (io_ctx_a),
@@ -1992,6 +2009,23 @@ void nano::bootstrap_listener::accept_action (boost::system::error_code const & 
 boost::asio::ip::tcp::endpoint nano::bootstrap_listener::endpoint ()
 {
 	return boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), local.port ());
+}
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_listener & bootstrap_listener, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> guard (bootstrap_listener.mutex);
+		count = bootstrap_listener.connections.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (bootstrap_listener.connections)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "connections", count, sizeof_element }));
+	return composite;
+}
 }
 
 nano::bootstrap_server::~bootstrap_server ()

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -242,7 +242,12 @@ private:
 	std::condition_variable condition;
 	std::vector<std::function<void(bool)>> observers;
 	boost::thread thread;
+
+	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiator & bootstrap_initiator, const std::string & name);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiator & bootstrap_initiator, const std::string & name);
+
 class bootstrap_server;
 class bootstrap_listener
 {
@@ -264,6 +269,9 @@ public:
 private:
 	boost::asio::steady_timer defer_acceptor;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_listener & bootstrap_listener, const std::string & name);
+
 class message;
 class bootstrap_server : public std::enable_shared_from_this<nano::bootstrap_server>
 {

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2317,6 +2317,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const
 	composite->add_component (collect_seq_con_info (node.block_processor, "block_processor"));
 	composite->add_component (collect_seq_con_info (node.block_arrival, "block_arrival"));
 	composite->add_component (collect_seq_con_info (node.online_reps, "online_reps"));
+	composite->add_component (collect_seq_con_info (node.votes_cache, "votes_cache"));
 	composite->add_component (collect_seq_con_info (node.block_uniquer, "block_uniquer"));
 	composite->add_component (collect_seq_con_info (node.vote_uniquer, "vote_uniquer"));
 	return composite;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1278,6 +1278,44 @@ void nano::vote_processor::calculate_weights ()
 	}
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (node_observers & node_observers, const std::string & name)
+{
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (collect_seq_con_info (node_observers.blocks, "blocks"));
+	composite->add_component (collect_seq_con_info (node_observers.wallet, "wallet"));
+	composite->add_component (collect_seq_con_info (node_observers.vote, "vote"));
+	composite->add_component (collect_seq_con_info (node_observers.account_balance, "account_balance"));
+	composite->add_component (collect_seq_con_info (node_observers.endpoint, "endpoint"));
+	composite->add_component (collect_seq_con_info (node_observers.disconnect, "disconnect"));
+	return composite;
+}
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & vote_processor, const std::string & name)
+{
+	size_t votes_count = 0;
+	size_t representatives_1_count = 0;
+	size_t representatives_2_count = 0;
+	size_t representatives_3_count = 0;
+
+	{
+		std::lock_guard<std::mutex> (vote_processor.mutex);
+		votes_count = vote_processor.votes.size ();
+		representatives_1_count = vote_processor.representatives_1.size ();
+		representatives_2_count = vote_processor.representatives_2.size ();
+		representatives_3_count = vote_processor.representatives_3.size ();
+	}
+
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "votes", votes_count, sizeof (decltype (vote_processor.votes)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "representatives_1", representatives_1_count, sizeof (decltype (vote_processor.representatives_1)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "representatives_2", representatives_2_count, sizeof (decltype (vote_processor.representatives_2)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "representatives_3", representatives_3_count, sizeof (decltype (vote_processor.representatives_3)::value_type) }));
+	return composite;
+}
+}
+
 void nano::rep_crawler::add (nano::block_hash const & hash_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
@@ -1296,6 +1334,22 @@ bool nano::rep_crawler::exists (nano::block_hash const & hash_a)
 	return active.count (hash_a) != 0;
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_crawler & rep_crawler, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> guard (rep_crawler.mutex);
+		count = rep_crawler.active.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (rep_crawler.active)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "active", count, sizeof_element }));
+	return composite;
+}
+}
 nano::signature_checker::signature_checker (unsigned num_threads) :
 thread_pool (num_threads),
 single_threaded (num_threads == 0),
@@ -1889,6 +1943,36 @@ void nano::block_processor::queue_unchecked (nano::transaction const & transacti
 	node.gap_cache.blocks.get<1> ().erase (hash_a);
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name)
+{
+	size_t state_blocks_count = 0;
+	size_t blocks_count = 0;
+	size_t blocks_hashes_count = 0;
+	size_t forced_count = 0;
+	size_t rolled_back_count = 0;
+
+	{
+		std::lock_guard<std::mutex> guard (block_processor.mutex);
+		state_blocks_count = block_processor.state_blocks.size ();
+		blocks_count = block_processor.blocks.size ();
+		blocks_hashes_count = block_processor.blocks_hashes.size ();
+		forced_count = block_processor.forced.size ();
+		rolled_back_count = block_processor.rolled_back.size ();
+	}
+
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "state_blocks", state_blocks_count, sizeof (decltype (block_processor.state_blocks)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", blocks_count, sizeof (decltype (block_processor.blocks)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks_hashes", blocks_hashes_count, sizeof (decltype (block_processor.blocks_hashes)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "forced", forced_count, sizeof (decltype (block_processor.forced)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "rolled_back", rolled_back_count, sizeof (decltype (block_processor.rolled_back)::value_type) }));
+	composite->add_component (collect_seq_con_info (block_processor.generator, "generator"));
+	return composite;
+}
+}
+
 nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, uint16_t peering_port_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::logging const & logging_a, nano::work_pool & work_a) :
 node (init_a, io_ctx_a, application_path_a, alarm_a, nano::node_config (peering_port_a, logging_a), work_a)
 {
@@ -2214,6 +2298,31 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 	}
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name)
+{
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (collect_seq_con_info (node.work, "work"));
+	composite->add_component (collect_seq_con_info (node.gap_cache, "gap_cache"));
+	composite->add_component (collect_seq_con_info (node.ledger, "ledger"));
+	composite->add_component (collect_seq_con_info (node.active, "active"));
+	composite->add_component (collect_seq_con_info (node.bootstrap_initiator, "bootstrap_initiator"));
+	composite->add_component (collect_seq_con_info (node.bootstrap, "bootstrap"));
+	composite->add_component (collect_seq_con_info (node.peers, "peers"));
+	composite->add_component (collect_seq_con_info (node.observers, "observers"));
+	composite->add_component (collect_seq_con_info (node.wallets, "wallets"));
+	composite->add_component (collect_seq_con_info (node.vote_processor, "vote_processor"));
+	composite->add_component (collect_seq_con_info (node.rep_crawler, "rep_crawler"));
+	composite->add_component (collect_seq_con_info (node.block_processor, "block_processor"));
+	composite->add_component (collect_seq_con_info (node.block_arrival, "block_arrival"));
+	composite->add_component (collect_seq_con_info (node.online_reps, "online_reps"));
+	composite->add_component (collect_seq_con_info (node.block_uniquer, "block_uniquer"));
+	composite->add_component (collect_seq_con_info (node.vote_uniquer, "vote_uniquer"));
+	return composite;
+}
+}
+
 nano::gap_cache::gap_cache (nano::node & node_a) :
 node (node_a)
 {
@@ -2301,6 +2410,23 @@ nano::uint128_t nano::gap_cache::bootstrap_threshold (nano::transaction const & 
 {
 	auto result ((node.online_reps.online_stake () / 256) * node.config.bootstrap_fraction_numerator);
 	return result;
+}
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (gap_cache & gap_cache, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> (gap_cache.mutex);
+		count = gap_cache.blocks.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (gap_cache.blocks)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", count, sizeof_element }));
+	return composite;
+}
 }
 
 void nano::network::confirm_send (nano::confirm_ack const & confirm_a, std::shared_ptr<std::vector<uint8_t>> bytes_a, nano::endpoint const & endpoint_a)
@@ -3110,6 +3236,23 @@ bool nano::block_arrival::recent (nano::block_hash const & hash_a)
 	return arrival.get<1> ().find (hash_a) != arrival.get<1> ().end ();
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_arrival & block_arrival, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> guard (block_arrival.mutex);
+		count = block_arrival.arrival.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (block_arrival.arrival)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "arrival", count, sizeof_element }));
+	return composite;
+}
+}
+
 nano::online_reps::online_reps (nano::node & node) :
 node (node)
 {
@@ -3186,6 +3329,23 @@ std::vector<nano::account> nano::online_reps::list ()
 		result.push_back (i->representative);
 	}
 	return result;
+}
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (online_reps & online_reps, const std::string & name)
+{
+	size_t count = 0;
+	{
+		std::lock_guard<std::mutex> guard (online_reps.mutex);
+		count = online_reps.reps.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (online_reps.reps)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "arrival", count, sizeof_element }));
+	return composite;
+}
 }
 
 namespace
@@ -4023,6 +4183,28 @@ bool nano::active_transactions::publish (std::shared_ptr<nano::block> block_a)
 	return result;
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transactions & active_transactions, const std::string & name)
+{
+	size_t roots_count = 0;
+	size_t blocks_count = 0;
+	size_t confirmed_count = 0;
+
+	{
+		std::lock_guard<std::mutex> guard (active_transactions.mutex);
+		roots_count = active_transactions.roots.size ();
+		blocks_count = active_transactions.blocks.size ();
+		confirmed_count = active_transactions.confirmed.size ();
+	}
+
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "roots", roots_count, sizeof (decltype (active_transactions.roots)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", blocks_count, sizeof (decltype (active_transactions.blocks)::value_type) }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "confirmed", confirmed_count, sizeof (decltype (active_transactions.confirmed)::value_type) }));
+	return composite;
+}
+}
 int nano::node::store_version ()
 {
 	auto transaction (store.tx_begin_read ());

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -148,6 +148,9 @@ private:
 	bool stopped;
 	boost::thread thread;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transactions & active_transactions, const std::string & name);
+
 class operation
 {
 public:
@@ -192,6 +195,9 @@ public:
 	std::mutex mutex;
 	nano::node & node;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (gap_cache & gap_cache, const std::string & name);
+
 class work_pool;
 class send_info
 {
@@ -225,6 +231,9 @@ public:
 	static size_t constexpr arrival_size_min = 8 * 1024;
 	static std::chrono::seconds constexpr arrival_time_min = std::chrono::seconds (300);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_arrival & block_arrival, const std::string & name);
+
 class rep_last_heard_info
 {
 public:
@@ -240,6 +249,8 @@ public:
 	nano::uint128_t online_stake ();
 	nano::uint128_t online_stake_total;
 	std::vector<nano::account> list ();
+
+private:
 	boost::multi_index_container<
 	nano::rep_last_heard_info,
 	boost::multi_index::indexed_by<
@@ -247,10 +258,14 @@ public:
 	boost::multi_index::hashed_unique<boost::multi_index::member<nano::rep_last_heard_info, nano::account, &nano::rep_last_heard_info::representative>>>>
 	reps;
 
-private:
 	std::mutex mutex;
 	nano::node & node;
+
+	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (online_reps & online_reps, const std::string & name);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (online_reps & online_reps, const std::string & name);
+
 class udp_data
 {
 public:
@@ -359,6 +374,9 @@ public:
 	nano::observer_set<nano::endpoint const &> endpoint;
 	nano::observer_set<> disconnect;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (node_observers & node_observers, const std::string & name);
+
 class vote_processor
 {
 public:
@@ -385,7 +403,12 @@ private:
 	bool stopped;
 	bool active;
 	boost::thread thread;
+
+	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & vote_processor, const std::string & name);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & vote_processor, const std::string & name);
+
 // The network is crawled for representatives by occasionally sending a unicast confirm_req for a specific block and watching to see if it's acknowledged with a vote.
 class rep_crawler
 {
@@ -396,6 +419,9 @@ public:
 	std::mutex mutex;
 	std::unordered_set<nano::block_hash> active;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_crawler & rep_crawler, const std::string & name);
+
 class block_processor;
 class signature_check_set final
 {
@@ -494,7 +520,12 @@ private:
 	std::condition_variable condition;
 	nano::node & node;
 	std::mutex mutex;
+
+	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name);
+
 class node : public std::enable_shared_from_this<nano::node>
 {
 public:
@@ -588,6 +619,9 @@ public:
 	static std::chrono::seconds constexpr search_pending_interval = (nano::nano_network == nano::nano_networks::nano_test_network) ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
 	static std::chrono::seconds constexpr peer_interval = search_pending_interval;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name);
+
 class thread_runner
 {
 public:

--- a/nano/node/peers.hpp
+++ b/nano/node/peers.hpp
@@ -137,4 +137,6 @@ public:
 	// Maximum number of peers per IP
 	static size_t constexpr max_peers_per_ip = 10;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (peer_container & peer_container, const std::string & name);
 }

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -156,4 +156,19 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & v
 	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "state_blocks", hashes_count, sizeof_element }));
 	return composite;
 }
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name)
+{
+	size_t cache_count = 0;
+
+	{
+		std::lock_guard<std::mutex> guard (votes_cache.cache_mutex);
+		cache_count = votes_cache.cache.size ();
+	}
+	auto sizeof_element = sizeof (decltype (votes_cache.cache)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	/* This does not currently loop over each element inside the cache to get the sizes of the votes inside cached_votes */
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "cache", cache_count, sizeof_element }));
+	return composite;
+}
 }

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -140,3 +140,20 @@ std::vector<std::shared_ptr<nano::vote>> nano::votes_cache::find (nano::block_ha
 	}
 	return result;
 }
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name)
+{
+	size_t hashes_count = 0;
+
+	{
+		std::lock_guard<std::mutex> guard (vote_generator.mutex);
+		hashes_count = vote_generator.hashes.size ();
+	}
+	auto sizeof_element = sizeof (decltype (vote_generator.hashes)::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "state_blocks", hashes_count, sizeof_element }));
+	return composite;
+}
+}

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/utility.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
@@ -35,7 +36,11 @@ private:
 	bool stopped;
 	bool started;
 	boost::thread thread;
+
+	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);
 class cached_votes
 {
 public:

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -63,5 +63,10 @@ private:
 	boost::multi_index::hashed_unique<boost::multi_index::member<nano::cached_votes, nano::block_hash, &nano::cached_votes::hash>>>>
 	cache;
 	static size_t constexpr max_cache = (nano::nano_network == nano::nano_networks::nano_test_network) ? 2 : 1000;
+
+	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name);
+
 }

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -68,5 +68,4 @@ private:
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name);
-
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1680,3 +1680,24 @@ MDB_txn * nano::wallet_store::tx (nano::transaction const & transaction_a) const
 	auto result (boost::polymorphic_downcast<nano::mdb_txn *> (transaction_a.impl.get ()));
 	return *result;
 }
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (wallets & wallets, const std::string & name)
+{
+	size_t items_count = 0;
+	size_t actions_count = 0;
+	{
+		std::lock_guard<std::mutex> guard (wallets.mutex);
+		items_count = wallets.items.size ();
+		actions_count = wallets.actions.size ();
+	}
+
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	auto sizeof_item_element = sizeof (decltype (wallets.items)::value_type);
+	auto sizeof_actions_element = sizeof (decltype (wallets.actions)::value_type);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "items", items_count, sizeof_item_element }));
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "actions_count", actions_count, sizeof_actions_element }));
+	return composite;
+}
+}

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -209,6 +209,9 @@ public:
 	 */
 	nano::transaction tx_begin (bool write = false);
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (wallets & wallets, const std::string & name);
+
 class wallets_store
 {
 public:

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -725,6 +725,18 @@ size_t nano::vote_uniquer::size ()
 	return votes.size ();
 }
 
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_uniquer & vote_uniquer, const std::string & name)
+{
+	auto count = vote_uniquer.size ();
+	auto sizeof_element = sizeof (vote_uniquer::value_type);
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "votes", count, sizeof_element }));
+	return composite;
+}
+}
+
 nano::genesis::genesis ()
 {
 	boost::property_tree::ptree tree;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/blockbuilders.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/lib/utility.hpp>
 #include <nano/secure/utility.hpp>
 
 #include <boost/iterator/transform_iterator.hpp>
@@ -225,6 +226,8 @@ public:
 class vote_uniquer
 {
 public:
+	using value_type = std::pair<const nano::uint256_union, std::weak_ptr<nano::vote>>;
+
 	vote_uniquer (nano::block_uniquer &);
 	std::shared_ptr<nano::vote> unique (std::shared_ptr<nano::vote>);
 	size_t size ();
@@ -232,9 +235,12 @@ public:
 private:
 	nano::block_uniquer & uniquer;
 	std::mutex mutex;
-	std::unordered_map<nano::uint256_union, std::weak_ptr<nano::vote>> votes;
+	std::unordered_map<std::remove_const_t<value_type::first_type>, value_type::second_type> votes;
 	static unsigned constexpr cleanup_count = 2;
 };
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_uniquer & vote_uniquer, const std::string & name);
+
 enum class vote_code
 {
 	invalid, // Vote is not signed correctly

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -968,3 +968,15 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 	}
 	return result;
 }
+
+namespace nano
+{
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (ledger & ledger, const std::string & name)
+{
+	auto composite = std::make_unique<seq_con_info_composite> (name);
+	auto count = ledger.bootstrap_weights.size ();
+	auto sizeof_element = sizeof (decltype (ledger.bootstrap_weights)::value_type);
+	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "bootstrap_weights", count, sizeof_element }));
+	return composite;
+}
+}

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -52,4 +52,6 @@ public:
 	nano::uint256_union epoch_link;
 	nano::account epoch_signer;
 };
-};
+
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (ledger & ledger, const std::string & name);
+}


### PR DESCRIPTION
This provides an alternate implementation for #1439. The idea is to scan a `node` and all nested variables for sequence containers (`std::vector`, `std::list` etc..) and outputs the number of elements and the size in bytes of the container in a JSON-RPC call when requesting:

Request:
```
{
    "action":"stats",
    "type":"objects"
}
```
Response:
```
{
    "node": {
        "ledger": {
            "bootstrap_weights": {
                "count": "125",
                "size": "7000"
            }
        }
        "peers": {
            "peers": {
                "count": "38",
                "size": "7296"
            },
            "attempts": {
                "count": "95",
                "size": "3800"
            },
        },
        .
        .
        ...
    }
}
```
Ideally the members could be scanned recursively until something which has the methods `.size ()` & `operator[]` and the `value_type` alias is found and then use this. However C++ currently lacks reflection (even in c++17) without some very nasty template tricks which will have problems with edge cases and not feasible to create with current time constraints. There is Boost.Hana (among others) which offer ways to add meta-data to classes and then be able to parse, but Boost.Hana has known problems with MSVC even recent 2017 versions https://blogs.msdn.microsoft.com/vcblog/2018/08/30/use-the-official-boost-hana-with-msvc-2017-update-8-compiler/. I gave it a go but ran into a few issues and it started to feel like an over-engineered solution anyway.

What I have instead done instead is implement the composite design pattern where leaf nodes are the sequence containers and composites are member variables containing sequence containers. This could have probably gone into it's own file, but I've added it to `nano/lib/utility.hpp`. All classes which should be processed should have a corresponding `collect_seq_con_info` function definition. I have not tried looking for sequence containers more than 2 levels deep, so it's possible I may have missed some, but these can be easily added.

There is only have a basic test. Full test coverage would probably require a couple dozen tests which would take a while to write, which is currently limited before the RC, and I wanted to first check if this would be accepted without spending more time on it. This should be quite self-contained and only affect the new RPC call and not have regression consequences for anything else.

I didn't want to change the interface of the existing data structures if I could help it. If I needed access to private mutexes for instance, the new function was added as a friend so that it could access it. A lot of the classes had public access specifier for the needed member variables so the majority did not need changing.

vote_uniquer/block_uniquer both had a size() method, so they somewhat act on the outside at least as a sequence container, so I have added value_type which other std containers have (although mainly because they are templates)

I noticed there was no mutex in the `ledger`, I don't know if that is by design.

I couple warnings about unused variables have been removed.