### PR TITLE
Better handling of TCP accept overflow

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1949,7 +1949,6 @@ void nano::bootstrap_listener::accept_connection ()
 				 * get an error from the I/O context, something is probably
 				 * wrong.
 				 */
-				assert (!ec);
 				if (!ec)
 				{
 					accept_connection ();

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1942,7 +1942,7 @@ void nano::bootstrap_listener::accept_connection ()
 		{
 			BOOST_LOG (node.log) << boost::str (boost::format ("Unable to accept new TCP network sockets (have %1% concurrent connections, limit of %2%), will try to accept again in 1s") % connections.size () % node.config.bootstrap_connections_max);
 			defer_acceptor.expires_after (std::chrono::seconds (1));
-			defer_acceptor.async_wait([this](const boost::system::error_code & ec) {
+			defer_acceptor.async_wait ([this](const boost::system::error_code & ec) {
 				/*
 				 * There should be no other call points that can invoke
 				 * accept_connect() after starting the listener, so if we
@@ -1950,7 +1950,8 @@ void nano::bootstrap_listener::accept_connection ()
 				 * wrong.
 				 */
 				assert (!ec);
-				if (!ec) {
+				if (!ec)
+				{
 					accept_connection ();
 				}
 			});

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -259,6 +259,7 @@ public:
 	boost::asio::io_context & io_ctx;
 	nano::node & node;
 	bool on;
+
 private:
 	boost::asio::steady_timer defer_acceptor;
 };

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -259,6 +259,8 @@ public:
 	boost::asio::io_context & io_ctx;
 	nano::node & node;
 	bool on;
+private:
+	boost::asio::steady_timer defer_acceptor;
 };
 class message;
 class bootstrap_server : public std::enable_shared_from_this<nano::bootstrap_server>


### PR DESCRIPTION
Currently when we overflow the number of concurrent TCP sockets
we wish to service we accept them then immediately disconnect.
This change causes us to defer accepting new connections until we
are ready for them, relying instead on the OS socket backlog to
queue TCP handshakes until full, then stop processing new
connections when the backlog is full.

We use the I/O threads for scheduling all but one accept, so this
keeps the same thread affinity.