### PR TITLE
Add support for getting the current thread's name as a string

### DIFF
--- a/nano/lib/plat/darwin/thread_role.cpp
+++ b/nano/lib/plat/darwin/thread_role.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/utility.hpp>
 #include <pthread.h>
 
-void nano::thread_role::set_name (std::string thread_name)
+void nano::thread_role::set_os_name (std::string thread_name)
 {
 	pthread_setname_np (thread_name.c_str ());
 }

--- a/nano/lib/plat/freebsd/thread_role.cpp
+++ b/nano/lib/plat/freebsd/thread_role.cpp
@@ -2,7 +2,7 @@
 #include <pthread.h>
 #include <pthread_np.h>
 
-void nano::thread_role::set_name (std::string thread_name)
+void nano::thread_role::set_os_name (std::string thread_name)
 {
 	pthread_set_name_np (pthread_self (), thread_name.c_str ());
 }

--- a/nano/lib/plat/linux/thread_role.cpp
+++ b/nano/lib/plat/linux/thread_role.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/utility.hpp>
 #include <pthread.h>
 
-void nano::thread_role::set_name (std::string thread_name)
+void nano::thread_role::set_os_name (std::string thread_name)
 {
 	pthread_setname_np (pthread_self (), thread_name.c_str ());
 }

--- a/nano/lib/plat/windows/thread_role.cpp
+++ b/nano/lib/plat/windows/thread_role.cpp
@@ -5,7 +5,7 @@
 
 typedef HRESULT (*SetThreadDescription_t) (HANDLE, PCWSTR);
 
-void nano::thread_role::set_name (std::string thread_name)
+void nano::thread_role::set_os_name (std::string thread_name)
 {
 	SetThreadDescription_t SetThreadDescription_local;
 

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -11,12 +11,12 @@ namespace thread_role
 	 * Manage thread role
 	 */
 	static thread_local nano::thread_role::name current_thread_role = nano::thread_role::name::unknown;
-	nano::thread_role::name get (void)
+	nano::thread_role::name get ()
 	{
 		return current_thread_role;
 	}
-
-	void set (nano::thread_role::name role)
+	
+	static std::string get_string (nano::thread_role::name role)
 	{
 		std::string thread_role_name_string;
 
@@ -67,6 +67,17 @@ namespace thread_role
 		 * (specifically, Linux)
 		 */
 		assert (thread_role_name_string.size () < 16);
+		return (thread_role_name_string);
+	}
+	
+	std::string get_string ()
+	{
+		return get_string (current_thread_role);
+	}
+
+	void set (nano::thread_role::name role)
+	{
+		auto thread_role_name_string (get_string (role));
 
 		nano::thread_role::set_os_name (thread_role_name_string);
 

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -69,7 +69,7 @@ namespace thread_role
 		assert (thread_role_name_string.size () < 16);
 		return (thread_role_name_string);
 	}
-	
+
 	std::string get_string ()
 	{
 		return get_string (current_thread_role);

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -68,7 +68,7 @@ namespace thread_role
 		 */
 		assert (thread_role_name_string.size () < 16);
 
-		nano::thread_role::set_name (thread_role_name_string);
+		nano::thread_role::set_os_name (thread_role_name_string);
 
 		nano::thread_role::current_thread_role = role;
 	}

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -15,7 +15,7 @@ namespace thread_role
 	{
 		return current_thread_role;
 	}
-	
+
 	static std::string get_string (nano::thread_role::name role)
 	{
 		std::string thread_role_name_string;

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -43,9 +43,21 @@ namespace thread_role
 		voting,
 		signature_checking,
 	};
-	nano::thread_role::name get (void);
+	/*
+	 * Get/Set the identifier for the current thread
+	 */
+	nano::thread_role::name get ();
 	void set (nano::thread_role::name);
-	void set_name (std::string);
+
+	/*
+	 * Get the current thread's role as a string
+	 */
+	std::string get_string ();
+
+	/*
+	 * Internal only, should not be called directly
+	 */
+	void set_os_name (std::string);
 }
 
 namespace thread_attributes


### PR DESCRIPTION
Add support for getting the current thread's name as a string, which can be useful for logging.

Includes a bit of cleanup as well.