### PR TITLE
Multi-thread the signature checker

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -634,9 +634,14 @@ TEST (node_config, v15_v16_upgrade)
 		auto upgraded (false);
 		nano::node_config config;
 		config.logging.init (path);
-		ASSERT_FALSE (tree.get_optional_child ("allow_local_peers")); // allow_local_peers should not be present now
+		// These config options should not be present at version 15
+		ASSERT_FALSE (tree.get_optional_child ("allow_local_peers"));
+		ASSERT_FALSE (tree.get_optional_child ("signature_checker_threads"));
 		config.deserialize_json (upgraded, tree);
-		ASSERT_TRUE (!!tree.get_optional_child ("allow_local_peers")); // allow_local_peers should be added after the update
+		// The config options should be added after the upgrade
+		ASSERT_TRUE (!!tree.get_optional_child ("allow_local_peers"));
+		ASSERT_TRUE (!!tree.get_optional_child ("signature_checker_threads"));
+
 		ASSERT_TRUE (upgraded);
 		auto version (tree.get<std::string> ("version"));
 
@@ -670,18 +675,22 @@ TEST (node_config, allow_local_peers)
 	nano::node_config config;
 	config.logging.init (path);
 
-	// Check config is correct when allow_local_peers is false
+	// Check config is correct
 	tree.put ("allow_local_peers", false);
+	tree.put ("signature_checker_threads", 1);
 	config.deserialize_json (upgraded, tree);
 	ASSERT_FALSE (upgraded);
 	ASSERT_FALSE (config.allow_local_peers);
+	ASSERT_EQ (config.signature_checker_threads, 1);
 
-	// Check config is correct when allow_local_peers is true
+	// Check config is correct with other values
 	tree.put ("allow_local_peers", true);
+	tree.put ("signature_checker_threads", 4);
 	upgraded = false;
 	config.deserialize_json (upgraded, tree);
 	ASSERT_FALSE (upgraded);
 	ASSERT_TRUE (config.allow_local_peers);
+	ASSERT_EQ (config.signature_checker_threads, 4);
 }
 
 // Regression test to ensure that deserializing includes changes node via get_required_child

--- a/nano/core_test/signing.cpp
+++ b/nano/core_test/signing.cpp
@@ -5,18 +5,18 @@
 
 TEST (signature_checker, empty)
 {
-	nano::signature_checker checker;
+	nano::signature_checker checker (1);
 	std::promise<void> promise;
 	nano::signature_check_set check = { 0, nullptr, nullptr, nullptr, nullptr, nullptr, &promise };
-	checker.add (check);
+	checker.verify (check);
 	promise.get_future ().wait ();
 }
 
-TEST (signature_checker, many)
+TEST (signature_checker, bulk_single_thread)
 {
 	nano::keypair key;
 	nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
-	nano::signature_checker checker;
+	nano::signature_checker checker (1);
 	std::promise<void> promise;
 	std::vector<nano::uint256_union> hashes;
 	size_t size (1000);
@@ -40,15 +40,80 @@ TEST (signature_checker, many)
 		signatures.push_back (block.signature.bytes.data ());
 	}
 	nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data (), &promise };
-	checker.add (check);
+	checker.verify (check);
 	promise.get_future ().wait ();
+	bool all_valid = std::all_of (verifications.cbegin (), verifications.cend (), [](auto verification) { return verification == 1; });
+	ASSERT_TRUE (all_valid);
+}
+
+TEST (signature_checker, many_multi_threaded)
+{
+	nano::signature_checker checker (8);
+
+	auto signature_checker_work_func = [&checker]() {
+		nano::keypair key;
+		nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
+		auto block_hash = block.hash ();
+
+		constexpr auto num_check_sizes = 18;
+		constexpr std::array<size_t, num_check_sizes> check_sizes{ 2048, 256, 1024, 1,
+			4096, 512, 2050, 1024, 8092, 513, 17, 1024, 2047, 255, 513, 2049, 1025, 1023 };
+
+		std::array<std::promise<void>, num_check_sizes> promises;
+		std::vector<nano::signature_check_set> signature_checker_sets;
+		signature_checker_sets.reserve (num_check_sizes);
+
+		// Create containers so everything is kept in scope while the threads work on the signature checks
+		std::array<std::vector<unsigned char const *>, num_check_sizes> messages;
+		std::array<std::vector<size_t>, num_check_sizes> lengths;
+		std::array<std::vector<unsigned char const *>, num_check_sizes> pub_keys;
+		std::array<std::vector<unsigned char const *>, num_check_sizes> signatures;
+		std::array<std::vector<int>, num_check_sizes> verifications;
+
+		// Populate all the signature check sets
+		for (int i = 0; i < num_check_sizes; ++i)
+		{
+			auto check_size = check_sizes[i];
+
+			messages[i].resize (check_size);
+			std::fill (messages[i].begin (), messages[i].end (), block_hash.bytes.data ());
+
+			lengths[i].resize (check_size);
+			std::fill (lengths[i].begin (), lengths[i].end (), sizeof (decltype (block_hash)));
+
+			pub_keys[i].resize (check_size);
+			std::fill (pub_keys[i].begin (), pub_keys[i].end (), block.hashables.account.bytes.data ());
+
+			signatures[i].resize (check_size);
+			std::fill (signatures[i].begin (), signatures[i].end (), block.signature.bytes.data ());
+
+			verifications[i].resize (check_size);
+
+			signature_checker_sets.emplace_back (check_size, messages[i].data (), lengths[i].data (), pub_keys[i].data (), signatures[i].data (), verifications[i].data (), &promises[i]);
+			checker.verify (signature_checker_sets[i]);
+		}
+
+		// Wait for all signature checks to be finished
+		for (int i = 0; i < num_check_sizes; ++i)
+		{
+			promises[i].get_future ().wait ();
+			bool all_valid = std::all_of (verifications[i].cbegin (), verifications[i].cend (), [](auto verification) { return verification == 1; });
+			ASSERT_TRUE (all_valid);
+		}
+	};
+
+	std::thread signature_checker_thread1 (signature_checker_work_func);
+	std::thread signature_checker_thread2 (signature_checker_work_func);
+
+	signature_checker_thread1.join ();
+	signature_checker_thread2.join ();
 }
 
 TEST (signature_checker, one)
 {
 	nano::keypair key;
 	nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
-	nano::signature_checker checker;
+	nano::signature_checker checker (1);
 	std::promise<void> promise;
 	std::vector<nano::uint256_union> hashes;
 	std::vector<unsigned char const *> messages;
@@ -67,6 +132,7 @@ TEST (signature_checker, one)
 		signatures.push_back (block.signature.bytes.data ());
 	}
 	nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data (), &promise };
-	checker.add (check);
+	checker.verify (check);
 	promise.get_future ().wait ();
+	ASSERT_EQ (verifications.front (), 1);
 }

--- a/nano/core_test/signing.cpp
+++ b/nano/core_test/signing.cpp
@@ -48,7 +48,7 @@ TEST (signature_checker, bulk_single_thread)
 
 TEST (signature_checker, many_multi_threaded)
 {
-	nano::signature_checker checker (8);
+	nano::signature_checker checker (4);
 
 	auto signature_checker_work_func = [&checker]() {
 		nano::keypair key;

--- a/nano/core_test/signing.cpp
+++ b/nano/core_test/signing.cpp
@@ -1,23 +1,19 @@
 #include <gtest/gtest.h>
 
-#include <future>
 #include <nano/node/node.hpp>
 
 TEST (signature_checker, empty)
 {
-	nano::signature_checker checker (1);
-	std::promise<void> promise;
-	nano::signature_check_set check = { 0, nullptr, nullptr, nullptr, nullptr, nullptr, &promise };
+	nano::signature_checker checker (0);
+	nano::signature_check_set check = { 0, nullptr, nullptr, nullptr, nullptr, nullptr };
 	checker.verify (check);
-	promise.get_future ().wait ();
 }
 
 TEST (signature_checker, bulk_single_thread)
 {
 	nano::keypair key;
 	nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
-	nano::signature_checker checker (1);
-	std::promise<void> promise;
+	nano::signature_checker checker (0);
 	std::vector<nano::uint256_union> hashes;
 	size_t size (1000);
 	hashes.reserve (size);
@@ -39,9 +35,8 @@ TEST (signature_checker, bulk_single_thread)
 		pub_keys.push_back (block.hashables.account.bytes.data ());
 		signatures.push_back (block.signature.bytes.data ());
 	}
-	nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data (), &promise };
+	nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data () };
 	checker.verify (check);
-	promise.get_future ().wait ();
 	bool all_valid = std::all_of (verifications.cbegin (), verifications.cend (), [](auto verification) { return verification == 1; });
 	ASSERT_TRUE (all_valid);
 }
@@ -55,11 +50,14 @@ TEST (signature_checker, many_multi_threaded)
 		nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
 		auto block_hash = block.hash ();
 
+		nano::state_block invalid_block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
+		invalid_block.signature.bytes[31] ^= 0x1;
+		auto invalid_block_hash = block.hash ();
+
 		constexpr auto num_check_sizes = 18;
 		constexpr std::array<size_t, num_check_sizes> check_sizes{ 2048, 256, 1024, 1,
 			4096, 512, 2050, 1024, 8092, 513, 17, 1024, 2047, 255, 513, 2049, 1025, 1023 };
 
-		std::array<std::promise<void>, num_check_sizes> promises;
 		std::vector<nano::signature_check_set> signature_checker_sets;
 		signature_checker_sets.reserve (num_check_sizes);
 
@@ -70,35 +68,37 @@ TEST (signature_checker, many_multi_threaded)
 		std::array<std::vector<unsigned char const *>, num_check_sizes> signatures;
 		std::array<std::vector<int>, num_check_sizes> verifications;
 
-		// Populate all the signature check sets
+		// Populate all the signature check sets. The last one in each set is given an incorrect block signature.
 		for (int i = 0; i < num_check_sizes; ++i)
 		{
 			auto check_size = check_sizes[i];
+			assert (check_size > 0);
+			auto last_signature_index = check_size - 1;
 
 			messages[i].resize (check_size);
 			std::fill (messages[i].begin (), messages[i].end (), block_hash.bytes.data ());
+			messages[i][last_signature_index] = invalid_block_hash.bytes.data ();
 
 			lengths[i].resize (check_size);
 			std::fill (lengths[i].begin (), lengths[i].end (), sizeof (decltype (block_hash)));
 
 			pub_keys[i].resize (check_size);
 			std::fill (pub_keys[i].begin (), pub_keys[i].end (), block.hashables.account.bytes.data ());
+			pub_keys[i][last_signature_index] = invalid_block.hashables.account.bytes.data ();
 
 			signatures[i].resize (check_size);
 			std::fill (signatures[i].begin (), signatures[i].end (), block.signature.bytes.data ());
+			signatures[i][last_signature_index] = invalid_block.signature.bytes.data ();
 
 			verifications[i].resize (check_size);
 
-			signature_checker_sets.emplace_back (check_size, messages[i].data (), lengths[i].data (), pub_keys[i].data (), signatures[i].data (), verifications[i].data (), &promises[i]);
+			signature_checker_sets.emplace_back (check_size, messages[i].data (), lengths[i].data (), pub_keys[i].data (), signatures[i].data (), verifications[i].data ());
 			checker.verify (signature_checker_sets[i]);
-		}
 
-		// Wait for all signature checks to be finished
-		for (int i = 0; i < num_check_sizes; ++i)
-		{
-			promises[i].get_future ().wait ();
-			bool all_valid = std::all_of (verifications[i].cbegin (), verifications[i].cend (), [](auto verification) { return verification == 1; });
+			// Confirm all but last are valid
+			auto all_valid = std::all_of (verifications[i].cbegin (), verifications[i].cend () - 1, [](auto verification) { return verification == 1; });
 			ASSERT_TRUE (all_valid);
+			ASSERT_EQ (verifications[i][last_signature_index], 0);
 		}
 	};
 
@@ -111,28 +111,38 @@ TEST (signature_checker, many_multi_threaded)
 
 TEST (signature_checker, one)
 {
+	nano::signature_checker checker (0);
+
+	auto verify_block = [&checker](auto & block, auto result) {
+		std::vector<nano::uint256_union> hashes;
+		std::vector<unsigned char const *> messages;
+		std::vector<size_t> lengths;
+		std::vector<unsigned char const *> pub_keys;
+		std::vector<unsigned char const *> signatures;
+		std::vector<int> verifications;
+		size_t size (1);
+		verifications.resize (size);
+		for (auto i (0); i < size; ++i)
+		{
+			hashes.push_back (block.hash ());
+			messages.push_back (hashes.back ().bytes.data ());
+			lengths.push_back (sizeof (decltype (hashes)::value_type));
+			pub_keys.push_back (block.hashables.account.bytes.data ());
+			signatures.push_back (block.signature.bytes.data ());
+		}
+		nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data () };
+		checker.verify (check);
+		ASSERT_EQ (verifications.front (), result);
+	};
+
 	nano::keypair key;
 	nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
-	nano::signature_checker checker (1);
-	std::promise<void> promise;
-	std::vector<nano::uint256_union> hashes;
-	std::vector<unsigned char const *> messages;
-	std::vector<size_t> lengths;
-	std::vector<unsigned char const *> pub_keys;
-	std::vector<unsigned char const *> signatures;
-	std::vector<int> verifications;
-	size_t size (1);
-	verifications.resize (size);
-	for (auto i (0); i < size; ++i)
-	{
-		hashes.push_back (block.hash ());
-		messages.push_back (hashes.back ().bytes.data ());
-		lengths.push_back (sizeof (decltype (hashes)::value_type));
-		pub_keys.push_back (block.hashables.account.bytes.data ());
-		signatures.push_back (block.signature.bytes.data ());
-	}
-	nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data (), &promise };
-	checker.verify (check);
-	promise.get_future ().wait ();
-	ASSERT_EQ (verifications.front (), 1);
+
+	// Make signaure invalid and check result is incorrect
+	block.signature.bytes[31] ^= 0x1;
+	verify_block (block, 0);
+
+	// Make it valid and check for succcess
+	block.signature.bytes[31] ^= 0x1;
+	verify_block (block, 1);
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1403,7 +1403,7 @@ void nano::signature_checker::set_thread_names (unsigned num_threads)
 	{
 		future.wait ();
 	}
-	release_assert (pending == 0);
+	assert (pending == 0);
 }
 
 nano::block_processor::block_processor (nano::node & node_a) :

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1379,7 +1379,7 @@ void nano::signature_checker::set_thread_names (unsigned num_threads)
 
 	for (auto i = 0u; i < num_threads; ++i)
 	{
-		boost::asio::post (thread_pool, [&cv, &ready, &pending, &mutex_l, &promise = promises[i]]() {
+		boost::asio::post (thread_pool, [&cv, &ready, &pending, &mutex_l, &promise = promises[i] ]() {
 			std::unique_lock<std::mutex> lk (mutex_l);
 			nano::thread_role::set (nano::thread_role::name::signature_checking);
 			if (--pending == 0)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1359,7 +1359,7 @@ void nano::signature_checker::set_name_threads (unsigned num_threads)
 
 	for (auto i = 0u; i < num_threads; ++i)
 	{
-		boost::asio::post (thread_pool, [&cv, &ready, &pending, &mutex_l, &promise = promises[i]]() {
+		boost::asio::post (thread_pool, [&cv, &ready, &pending, &mutex_l, &promise = promises[i] ]() {
 			std::unique_lock<std::mutex> lk (mutex_l);
 			nano::thread_role::set (nano::thread_role::name::signature_checking);
 			if (--pending == 0)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1600,7 +1600,7 @@ void nano::block_processor::process_batch (std::unique_lock<std::mutex> & lock_a
 		auto transaction (node.store.tx_begin_read ());
 		while (!state_blocks.empty () && timer_l.before_deadline (std::chrono::seconds (2)))
 		{
-			verify_state_blocks (transaction, lock_a, 2048 * node.config.signature_checker_threads);
+			verify_state_blocks (transaction, lock_a, 2048 * (node.config.signature_checker_threads + 1));
 		}
 	}
 	lock_a.unlock ();
@@ -1685,7 +1685,7 @@ void nano::block_processor::process_batch (std::unique_lock<std::mutex> & lock_a
 		Because verification is long process, avoid large deque verification inside of write transaction */
 		if (blocks.empty () && !state_blocks.empty ())
 		{
-			verify_state_blocks (transaction, lock_a, 256 * node.config.signature_checker_threads);
+			verify_state_blocks (transaction, lock_a, 256 * (node.config.signature_checker_threads + 1));
 		}
 	}
 	lock_a.unlock ();

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -420,8 +420,7 @@ private:
 		{
 		}
 		nano::signature_check_set & check;
-		std::mutex pending_mutex;
-		int pending;
+		std::atomic<int> pending;
 	};
 
 	bool verify_batch (const nano::signature_check_set & check_a, unsigned index, unsigned size);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -419,6 +419,10 @@ private:
 		check (check), pending (pending)
 		{
 		}
+		~Task ()
+		{
+			release_assert (pending == 0);
+		}
 		nano::signature_check_set & check;
 		std::atomic<int> pending;
 	};

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -427,12 +427,12 @@ private:
 		std::atomic<int> pending;
 	};
 
-	bool verify_batch (const nano::signature_check_set & check_a, unsigned index, unsigned size);
+	bool verify_batch (const nano::signature_check_set & check_a, size_t index, size_t size);
 	void verify_threaded (nano::signature_check_set & check_a);
 	void set_name_threads (unsigned num_threads);
 	boost::asio::thread_pool thread_pool;
 	std::atomic<int> tasks_remaining{ 0 };
-	static constexpr unsigned multithreaded_cutoff = 513; // minimum signature_check_set size eligible to be multithreaded
+	static constexpr size_t multithreaded_cutoff = 513; // minimum signature_check_set size eligible to be multithreaded
 	const bool single_threaded;
 	std::mutex mutex;
 	bool stopped{ false };

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -432,7 +432,7 @@ private:
 	static constexpr unsigned multithreaded_cutoff = 513; // minimum signature_check_set size eligible to be multithreaded
 	const bool single_threaded;
 	std::mutex mutex;
-	bool stopped {false};
+	bool stopped{ false };
 };
 
 class rolled_hash

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -390,8 +390,8 @@ class block_processor;
 class signature_check_set final
 {
 public:
-	signature_check_set (size_t size, unsigned char const ** messages, size_t * message_lengths, unsigned char const ** pub_keys, unsigned char const ** signatures, int * verifications, std::promise<void> * promise) :
-	size (size), messages (messages), message_lengths (message_lengths), pub_keys (pub_keys), signatures (signatures), verifications (verifications), promise (promise)
+	signature_check_set (size_t size, unsigned char const ** messages, size_t * message_lengths, unsigned char const ** pub_keys, unsigned char const ** signatures, int * verifications) :
+	size (size), messages (messages), message_lengths (message_lengths), pub_keys (pub_keys), signatures (signatures), verifications (verifications)
 	{
 	}
 
@@ -401,7 +401,6 @@ public:
 	unsigned char const ** pub_keys;
 	unsigned char const ** signatures;
 	int * verifications;
-	std::promise<void> * promise;
 };
 class signature_checker final
 {
@@ -428,13 +427,15 @@ private:
 	};
 
 	bool verify_batch (const nano::signature_check_set & check_a, size_t index, size_t size);
-	void verify_threaded (nano::signature_check_set & check_a);
-	void set_name_threads (unsigned num_threads);
+	void verify_async (nano::signature_check_set & check_a, size_t num_batches, std::promise<void> & promise);
+	void set_thread_names (unsigned num_threads);
 	boost::asio::thread_pool thread_pool;
 	std::atomic<int> tasks_remaining{ 0 };
 	static constexpr size_t multithreaded_cutoff = 513; // minimum signature_check_set size eligible to be multithreaded
+	static constexpr size_t batch_size = 256;
 	const bool single_threaded;
-	std::mutex mutex;
+	unsigned num_threads;
+	std::mutex stopped_mutex;
 	bool stopped{ false };
 };
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -28,7 +28,7 @@ password_fanout (1024),
 io_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 network_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 work_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
-signature_checker_threads (boost::thread::hardware_concurrency () - 1), /* The calling thread does checks as well so remove it from the number of threads needed */
+signature_checker_threads ((boost::thread::hardware_concurrency () != 0) ? boost::thread::hardware_concurrency () - 1 : 0), /* The calling thread does checks as well so remove it from the number of threads used */
 enable_voting (false),
 bootstrap_connections (4),
 bootstrap_connections_max (64),

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -7,6 +7,7 @@
 namespace
 {
 const char * preconfigured_peers_key = "preconfigured_peers";
+const char * signature_checker_threads_key = "signature_checker_threads";
 const char * default_beta_peer_network = "peering-beta.nano.org";
 const char * default_live_peer_network = "peering.nano.org";
 }
@@ -27,6 +28,7 @@ password_fanout (1024),
 io_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 network_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 work_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
+signature_checker_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 enable_voting (false),
 bootstrap_connections (4),
 bootstrap_connections_max (64),
@@ -106,6 +108,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("io_threads", io_threads);
 	json.put ("network_threads", network_threads);
 	json.put ("work_threads", work_threads);
+	json.put (signature_checker_threads_key, signature_checker_threads);
 	json.put ("enable_voting", enable_voting);
 	json.put ("bootstrap_connections", bootstrap_connections);
 	json.put ("bootstrap_connections_max", bootstrap_connections_max);
@@ -231,6 +234,9 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			nano::jsonconfig ipc_l;
 			ipc_config.serialize_json (ipc_l);
 			json.put_child ("ipc", ipc_l);
+
+			json.put (signature_checker_threads_key, signature_checker_threads);
+
 			upgraded = true;
 		}
 		case 16:
@@ -345,6 +351,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<int> ("lmdb_max_dbs", lmdb_max_dbs);
 		json.get<bool> ("enable_voting", enable_voting);
 		json.get<bool> ("allow_local_peers", allow_local_peers);
+		json.get<unsigned> (signature_checker_threads_key, signature_checker_threads);
 
 		// Validate ranges
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -28,7 +28,7 @@ password_fanout (1024),
 io_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 network_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
 work_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
-signature_checker_threads (std::max<unsigned> (4, boost::thread::hardware_concurrency ())),
+signature_checker_threads (boost::thread::hardware_concurrency () - 1), /* The calling thread does checks as well so remove it from the number of threads needed */
 enable_voting (false),
 bootstrap_connections (4),
 bootstrap_connections_max (64),

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -36,6 +36,7 @@ public:
 	unsigned io_threads;
 	unsigned network_threads;
 	unsigned work_threads;
+	unsigned signature_checker_threads;
 	bool enable_voting;
 	unsigned bootstrap_connections;
 	unsigned bootstrap_connections_max;


### PR DESCRIPTION
This solves #1606 and provides a finished implementation of #1614 which which was created from the work of @termoose @guilhermelawless so thanks a lot!

Currently the vote and block processors add checks to the `signature checker` which runs on a separate thread and sets the value of a promise which the calling threads are blocked on until it is set. Having it in a separate thread doesn't really do much because the calling threads are blocked straight away so the caller might as well do the work themselves. I have removed that thread and added a thread pool which can be user assigned on the config.json file and is called if the batch size of the signatures to check are > 512. This value was heuristically chosen as the largest size seemed to be 2048 (hardcoded) and 256 size chunks were found to be optimal in terms of memory size and speed benchmarked by Colin in 57d819b which is what each thread on a thread pool works on.

A new test was added which runs over multiple threads and the promises are checked after all signature checks are added to the thread pool rather than waiting for each one to finish (which checks overloading the boost thread pool). Using this test and changing the cores I got the following results:
1 core - 5.9s
2 cores - 5.4s
4 cores - 3.4s
8 cores - 2.5s

This is by no means a benchmark test as it needs to run quickly on any number of cores. A more biased test which has more messages of a larger size greatly favours the higher amount of cores used. 

I ran TSAN for a few hours on the live network and it showed no new errors.