### PR TITLE
Improve wallet_history consistency with other RPC

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4186,7 +4186,7 @@ TEST (rpc, wallet_history)
 	auto & history_node (response.json.get_child ("history"));
 	for (auto i (history_node.begin ()), n (history_node.end ()); i != n; ++i)
 	{
-		history_l.push_back (std::make_tuple (i->second.get<std::string> ("type"), i->second.get<std::string> ("account"), i->second.get<std::string> ("amount"), i->second.get<std::string> ("hash"), i->second.get<std::string> ("wallet_account"), i->second.get<std::string> ("local_timestamp")));
+		history_l.push_back (std::make_tuple (i->second.get<std::string> ("type"), i->second.get<std::string> ("account"), i->second.get<std::string> ("amount"), i->second.get<std::string> ("hash"), i->second.get<std::string> ("block_account"), i->second.get<std::string> ("local_timestamp")));
 	}
 	ASSERT_EQ (4, history_l.size ());
 	ASSERT_EQ ("send", std::get<0> (history_l[0]));

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3417,12 +3417,15 @@ void nano::rpc_handler::wallet_history ()
 					if (block != nullptr && timestamp >= modified_since && timestamp != std::numeric_limits<uint64_t>::max ())
 					{
 						boost::property_tree::ptree entry;
-						entry.put ("wallet_account", account.to_account ());
-						entry.put ("hash", hash.to_string ());
 						history_visitor visitor (*this, false, block_transaction, entry, hash);
 						block->visit (visitor);
-						entry.put ("local_timestamp", std::to_string (timestamp));
-						entries.insert (std::make_pair (timestamp, entry));
+						if (!entry.empty ())
+						{
+							entry.put ("block_account", account.to_account ());
+							entry.put ("hash", hash.to_string ());
+							entry.put ("local_timestamp", std::to_string (timestamp));
+							entries.insert (std::make_pair (timestamp, entry));
+						}
 						hash = block->previous ();
 					}
 					else


### PR DESCRIPTION
wallet_account --> block_account
And prevent history for change blocks (like in RPC account_history)