### PR TITLE
 Improve node::process_confirmed ()

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -3172,7 +3172,7 @@ void nano::node::process_confirmed (std::shared_ptr<nano::block> block_a, uint8_
 	{
 		iteration++;
 		std::weak_ptr<nano::node> node_w (shared ());
-		alarm.add (now + std::chrono::seconds (1), [node_w, block_a, iteration]() {
+		alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (1), [node_w, block_a, iteration]() {
 			if (auto node_l = node_w.lock ())
 			{
 				node_l->process_confirmed (block_a, iteration);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -23,6 +23,7 @@ std::chrono::minutes constexpr nano::node::backup_interval;
 std::chrono::seconds constexpr nano::node::search_pending_interval;
 std::chrono::seconds constexpr nano::node::peer_interval;
 std::chrono::hours constexpr nano::node::unchecked_cleaning_interval;
+std::chrono::milliseconds constexpr nano::node::process_confirmed_interval;
 
 int constexpr nano::port_mapping::mapping_timeout;
 int constexpr nano::port_mapping::check_timeout;
@@ -3168,11 +3169,12 @@ void nano::node::process_confirmed (std::shared_ptr<nano::block> block_a, uint8_
 			}
 		}
 	}
-	else if (iteration < 10)
+	// Limit to 0.5 * 20 = 10 seconds (more than max block_processor::process_batch finish time)
+	else if (iteration < 20)
 	{
 		iteration++;
 		std::weak_ptr<nano::node> node_w (shared ());
-		alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (1), [node_w, block_a, iteration]() {
+		alarm.add (std::chrono::steady_clock::now () + process_confirmed_interval, [node_w, block_a, iteration]() {
 			if (auto node_l = node_w.lock ())
 			{
 				node_l->process_confirmed (block_a, iteration);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -592,6 +592,7 @@ public:
 	static std::chrono::seconds constexpr peer_interval = search_pending_interval;
 	static std::chrono::hours constexpr unchecked_cleaning_interval = std::chrono::hours (2);
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
+	static std::chrono::milliseconds constexpr process_confirmed_interval = (nano::nano_network == nano::nano_networks::nano_test_network) ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
 };
 class thread_runner
 {

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -515,7 +515,7 @@ public:
 	void stop ();
 	std::shared_ptr<nano::node> shared ();
 	int store_version ();
-	void process_confirmed (std::shared_ptr<nano::block>);
+	void process_confirmed (std::shared_ptr<nano::block>, uint8_t = 0);
 	void process_message (nano::message &, nano::endpoint const &);
 	void process_active (std::shared_ptr<nano::block>);
 	nano::process_return process (nano::block const &);


### PR DESCRIPTION
Fixing rare node.vote_republish test failures (process_confirmed () can be called before block_processor transaction commit to roll back fork)