### PR TITLE
Set current time for block in RPC process

### DIFF
--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -2491,7 +2491,9 @@ void nano::rpc_handler::process ()
 			nano::process_return result;
 			{
 				auto transaction (node.store.tx_begin_write ());
-				result = node.block_processor.process_one (transaction, block);
+				// Set current time to trigger automatic rebroadcast and election
+				nano::unchecked_info info (block, block->account (), nano::seconds_since_epoch (), nano::signature_verification::unknown);
+				result = node.block_processor.process_one (transaction, info);
 			}
 			switch (result.code)
 			{


### PR DESCRIPTION
to trigger automatic rebroadcast and election after https://github.com/nanocurrency/nano-node/commit/e6ab82f5e6ccce2f0de6b529f25a3aef8ee5c204
Credits for finding bug to **Barnabas Liu**