### PR TITLE
Restore old default response for RPC "peers"

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -1539,7 +1539,6 @@ TEST (rpc, peers)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
-	request.put ("deprecated", true);
 	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)
@@ -1565,6 +1564,7 @@ TEST (rpc, peers_node_id)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
+	request.put ("peer_details", true);
 	test_response response (request, rpc, system.io_ctx);
 	system.deadline_set (5s);
 	while (response.status == 0)

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -2224,14 +2224,14 @@ void nano::rpc_handler::password_valid (bool wallet_locked)
 void nano::rpc_handler::peers ()
 {
 	boost::property_tree::ptree peers_l;
-	const bool deprecated = request.get<bool> ("deprecated", false);
+	const bool peer_details = request.get<bool> ("peer_details", false);
 	auto peers_list (node.peers.list_vector (std::numeric_limits<size_t>::max ()));
 	std::sort (peers_list.begin (), peers_list.end ());
 	for (auto i (peers_list.begin ()), n (peers_list.end ()); i != n; ++i)
 	{
 		std::stringstream text;
 		text << i->endpoint;
-		if (!deprecated)
+		if (peer_details)
 		{
 			boost::property_tree::ptree pending_tree;
 			pending_tree.put ("protocol_version", std::to_string (i->network_version));


### PR DESCRIPTION
Using optional "peer_details" for more info (node_id etc.)

Change for compatibility with existing nano rpc libraries (RPC "peers" is widely used for explorers & node monitoring)