### PR TITLE
Fix scope issue when setting thread names in the multi-threaded signature checker

### DIFF
--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -464,7 +464,7 @@ private:
 	static constexpr size_t batch_size = 256;
 	const bool single_threaded;
 	unsigned num_threads;
-	std::mutex stopped_mutex;
+	std::mutex mutex;
 	bool stopped{ false };
 };
 


### PR DESCRIPTION
There are some intermittent test failures (I could only reproduce them on a MAC), caused by a SIGABRT in the ~std::unique_ptr destructor. It seems that the mutex is going out of scope before the thread pool has fully finished. When the last promise.set_value () is called it notifies the main thread that the thread work is finished, and then exits the function (set_thread_names), but the threads haven't fully finished (i.e they still need to call destructors). I'm now (re)using the class member mutex so that it stays in the scope during this cleanup. 