### PR TITLE
Create and use new network helper constants

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -21,6 +21,10 @@ enum class nano_networks
 	nano_live_network = 2,
 	rai_live_network = 2,
 };
-nano::nano_networks const nano_network = nano_networks::ACTIVE_NETWORK;
+nano::nano_networks constexpr nano_network = nano_networks::ACTIVE_NETWORK;
+bool constexpr is_live_network = nano_network == nano_networks::nano_live_network;
+bool constexpr is_beta_network = nano_network == nano_networks::nano_beta_network;
+bool constexpr is_test_network = nano_network == nano_networks::nano_test_network;
+
 std::chrono::milliseconds const transaction_timeout = std::chrono::milliseconds (1000);
 }

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -39,7 +39,7 @@ opencl (opencl_a)
 	static_assert (ATOMIC_INT_LOCK_FREE == 2, "Atomic int needed");
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
-	auto count (nano::nano_network == nano::nano_networks::nano_test_network ? 1 : std::min (max_threads_a, std::max (1u, boost::thread::hardware_concurrency ())));
+	auto count (nano::is_test_network ? 1 : std::min (max_threads_a, std::max (1u, boost::thread::hardware_concurrency ())));
 	for (auto i (0); i < count; ++i)
 	{
 		auto thread (boost::thread (attrs, [this, i]() {

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -46,7 +46,7 @@ public:
 	// Local work threshold for rate-limiting publishing blocks. ~5 seconds of work.
 	static uint64_t const publish_test_threshold = 0xff00000000000000;
 	static uint64_t const publish_full_threshold = 0xffffffc000000000;
-	static uint64_t const publish_threshold = nano::nano_network == nano::nano_networks::nano_test_network ? publish_test_threshold : publish_full_threshold;
+	static uint64_t const publish_threshold = nano::is_test_network ? publish_test_threshold : publish_full_threshold;
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (work_pool & work_pool, const std::string & name);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -388,7 +388,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_process"))
 		{
-			if (nano::nano_network == nano::nano_networks::nano_test_network)
+			if (nano::is_test_network)
 			{
 				nano::block_builder builder;
 				size_t num_accounts (100000);
@@ -505,7 +505,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_votes"))
 		{
-			if (nano::nano_network == nano::nano_networks::nano_test_network)
+			if (nano::is_test_network)
 			{
 				nano::block_builder builder;
 				size_t num_elections (40000);

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -129,7 +129,7 @@ public:
 	std::unordered_set<nano::block_hash> lazy_keys;
 	std::deque<nano::block_hash> lazy_pulls;
 	std::atomic<uint64_t> lazy_stopped;
-	uint64_t lazy_max_pull_blocks = (nano::nano_network == nano::nano_networks::nano_test_network) ? 2 : 512;
+	uint64_t lazy_max_pull_blocks = nano::is_test_network ? 2 : 512;
 	uint64_t lazy_max_stopped = 256;
 	std::mutex lazy_mutex;
 	// Wallet lazy bootstrap

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -195,7 +195,7 @@ public:
 	bool deserialize (nano::stream &);
 	nano::block_type block_type () const;
 	void block_type_set (nano::block_type);
-	static std::array<uint8_t, 2> constexpr magic_number = nano::nano_network == nano::nano_networks::nano_test_network ? std::array<uint8_t, 2>{ { 'R', 'A' } } : nano::nano_network == nano::nano_networks::nano_beta_network ? std::array<uint8_t, 2>{ { 'R', 'B' } } : std::array<uint8_t, 2>{ { 'R', 'C' } };
+	static std::array<uint8_t, 2> constexpr magic_number = nano::is_test_network ? std::array<uint8_t, 2>{ { 'R', 'A' } } : nano::is_beta_network ? std::array<uint8_t, 2>{ { 'R', 'B' } } : std::array<uint8_t, 2>{ { 'R', 'C' } };
 	uint8_t version_max;
 	uint8_t version_using;
 	uint8_t version_min;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1090,7 +1090,7 @@ void nano::vote_processor::vote (std::shared_ptr<nano::vote> vote_a, nano::endpo
 		/* Random early delection levels
 		Always process votes for test network (process = true)
 		Stop processing with max 144 * 1024 votes */
-		if (nano::nano_network != nano::nano_networks::nano_test_network)
+		if (!nano::is_test_network)
 		{
 			// Level 0 (< 0.1%)
 			if (votes.size () < 96 * 1024)
@@ -1525,7 +1525,7 @@ stopped (false),
 active (false),
 next_log (std::chrono::steady_clock::now ()),
 node (node_a),
-generator (node_a, nano::nano_network == nano::nano_networks::nano_test_network ? std::chrono::milliseconds (10) : std::chrono::milliseconds (500))
+generator (node_a, nano::is_test_network ? std::chrono::milliseconds (10) : std::chrono::milliseconds (500))
 {
 }
 
@@ -2459,7 +2459,7 @@ void nano::gap_cache::vote (std::shared_ptr<nano::vote> vote_a)
 				{
 					auto node_l (node.shared ());
 					auto now (std::chrono::steady_clock::now ());
-					node.alarm.add (nano::nano_network == nano::nano_networks::nano_test_network ? now + std::chrono::milliseconds (5) : now + std::chrono::seconds (5), [node_l, hash]() {
+					node.alarm.add (nano::is_test_network ? now + std::chrono::milliseconds (5) : now + std::chrono::seconds (5), [node_l, hash]() {
 						auto transaction (node_l->store.tx_begin_read ());
 						if (!node_l->store.block_exists (transaction, hash))
 						{
@@ -3790,7 +3790,7 @@ nano::election_vote_result nano::election::vote (nano::account rep, uint64_t seq
 	auto supply (node.online_reps.online_stake ());
 	auto weight (node.ledger.weight (transaction, rep));
 	auto should_process (false);
-	if (nano::nano_network == nano::nano_networks::nano_test_network || weight > supply / 1000) // 0.1% or above
+	if (nano::is_test_network || weight > supply / 1000) // 0.1% or above
 	{
 		unsigned int cooldown;
 		if (weight < supply / 100) // 0.1% to 1%
@@ -3956,7 +3956,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				/* Escalation for long unconfirmed elections
 				Start new elections for previous block & source
 				if there are less than 100 active elections */
-				if (i->election->announcements % announcement_long == 1 && roots_size < 100 && nano::nano_network != nano::nano_networks::nano_test_network)
+				if (i->election->announcements % announcement_long == 1 && roots_size < 100 && !nano::is_test_network)
 				{
 					std::shared_ptr<nano::block> previous;
 					auto previous_hash (election_l->status.winner->previous ());
@@ -4041,7 +4041,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				if ((!reps->empty () && total_weight > node.config.online_weight_minimum.number ()) || roots_size > 5)
 				{
 					// broadcast_confirm_req_base modifies reps, so we clone it once to avoid aliasing
-					if (nano::nano_network != nano::nano_networks::nano_test_network)
+					if (!nano::is_test_network)
 					{
 						if (confirm_req_bundle.size () < max_broadcast_queue)
 						{
@@ -4072,7 +4072,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				}
 				else
 				{
-					if (nano::nano_network != nano::nano_networks::nano_test_network)
+					if (!nano::is_test_network)
 					{
 						confirm_req_bundle.push_back (std::make_pair (i->election->status.winner, std::make_shared<std::vector<nano::peer_information>> (node.peers.list_vector (100))));
 					}

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -134,7 +134,7 @@ public:
 	static unsigned constexpr announcement_min = 2;
 	// Threshold to start logging blocks haven't yet been confirmed
 	static unsigned constexpr announcement_long = 20;
-	static unsigned constexpr request_interval_ms = (nano::nano_network == nano::nano_networks::nano_test_network) ? 10 : 16000;
+	static unsigned constexpr request_interval_ms = nano::is_test_network ? 10 : 16000;
 	static size_t constexpr election_history_size = 2048;
 	static size_t constexpr max_broadcast_queue = 1000;
 
@@ -611,15 +611,15 @@ public:
 	const std::chrono::steady_clock::time_point startup_time;
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
-	static std::chrono::seconds constexpr period = (nano::nano_network == nano::nano_networks::nano_test_network) ? std::chrono::seconds (1) : std::chrono::seconds (60);
+	static std::chrono::seconds constexpr period = nano::is_test_network ? std::chrono::seconds (1) : std::chrono::seconds (60);
 	static std::chrono::seconds constexpr cutoff = period * 5;
 	static std::chrono::seconds constexpr syn_cookie_cutoff = std::chrono::seconds (5);
 	static std::chrono::minutes constexpr backup_interval = std::chrono::minutes (5);
-	static std::chrono::seconds constexpr search_pending_interval = (nano::nano_network == nano::nano_networks::nano_test_network) ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
+	static std::chrono::seconds constexpr search_pending_interval = nano::is_test_network ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
 	static std::chrono::seconds constexpr peer_interval = search_pending_interval;
 	static std::chrono::hours constexpr unchecked_cleaning_interval = std::chrono::hours (2);
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
-	static std::chrono::milliseconds constexpr process_confirmed_interval = (nano::nano_network == nano::nano_networks::nano_test_network) ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
+	static std::chrono::milliseconds constexpr process_confirmed_interval = nano::is_test_network ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name);

--- a/nano/node/peers.cpp
+++ b/nano/node/peers.cpp
@@ -453,7 +453,7 @@ bool nano::peer_container::insert (nano::endpoint const & endpoint_a, unsigned v
 			else
 			{
 				unknown = true;
-				if (!result && nano_network != nano_networks::nano_test_network)
+				if (!result && !nano::is_test_network)
 				{
 					auto ip_peers (peers.get<nano::peer_by_ip_addr> ().count (endpoint_a.address ()));
 					if (ip_peers >= max_peers_per_ip)

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -20,7 +20,7 @@ void nano::port_mapping::start ()
 
 void nano::port_mapping::refresh_devices ()
 {
-	if (nano::nano_network != nano::nano_networks::nano_test_network)
+	if (!nano::is_test_network)
 	{
 		std::lock_guard<std::mutex> lock (mutex);
 		int discover_error = 0;
@@ -50,7 +50,7 @@ void nano::port_mapping::refresh_devices ()
 
 void nano::port_mapping::refresh_mapping ()
 {
-	if (nano::nano_network != nano::nano_networks::nano_test_network)
+	if (!nano::is_test_network)
 	{
 		std::lock_guard<std::mutex> lock (mutex);
 		auto node_port (std::to_string (node.network.endpoint ().port ()));
@@ -80,7 +80,7 @@ void nano::port_mapping::refresh_mapping ()
 int nano::port_mapping::check_mapping ()
 {
 	int result (3600);
-	if (nano::nano_network != nano::nano_networks::nano_test_network)
+	if (!nano::is_test_network)
 	{
 		// Long discovery time and fast setup/teardown make this impractical for testing
 		std::lock_guard<std::mutex> lock (mutex);

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -44,8 +44,8 @@ private:
 	/** UPnP state */
 	IGDdatas data;
 	/** Timeouts are primes so they infrequently happen at the same time */
-	static int constexpr mapping_timeout = nano::nano_network == nano::nano_networks::nano_test_network ? 53 : 3593;
-	static int constexpr check_timeout = nano::nano_network == nano::nano_networks::nano_test_network ? 17 : 53;
+	static int constexpr mapping_timeout = nano::is_test_network ? 53 : 3593;
+	static int constexpr check_timeout = nano::is_test_network ? 17 : 53;
 	boost::asio::ip::address_v4 address;
 	std::array<mapping_protocol, 2> protocols;
 	uint64_t check_count;

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -62,7 +62,7 @@ private:
 	boost::multi_index::ordered_non_unique<boost::multi_index::member<nano::cached_votes, std::chrono::steady_clock::time_point, &nano::cached_votes::time>>,
 	boost::multi_index::hashed_unique<boost::multi_index::member<nano::cached_votes, nano::block_hash, &nano::cached_votes::hash>>>>
 	cache;
-	static size_t constexpr max_cache = (nano::nano_network == nano::nano_networks::nano_test_network) ? 2 : 1000;
+	static size_t constexpr max_cache = (nano::is_test_network) ? 2 : 1000;
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name);
 };

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1628,7 +1628,7 @@ void nano::wallets::ongoing_compute_reps ()
 {
 	compute_reps ();
 	auto & node_l (node);
-	auto compute_delay (nano::nano_network == nano::nano_networks::nano_test_network ? std::chrono::milliseconds (10) : std::chrono::milliseconds (15 * 60 * 1000)); // Representation drifts quickly on the test network but very slowly on the live network
+	auto compute_delay (nano::is_test_network ? std::chrono::milliseconds (10) : std::chrono::milliseconds (15 * 60 * 1000)); // Representation drifts quickly on the test network but very slowly on the live network
 	node.alarm.add (std::chrono::steady_clock::now () + compute_delay, [&node_l]() {
 		node_l.wallets.ongoing_compute_reps ();
 	});

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -106,7 +106,7 @@ public:
 	static int const special_count;
 	static unsigned const kdf_full_work = 64 * 1024;
 	static unsigned const kdf_test_work = 8;
-	static unsigned const kdf_work = nano::nano_network == nano::nano_networks::nano_test_network ? kdf_test_work : kdf_full_work;
+	static unsigned const kdf_work = nano::is_test_network ? kdf_test_work : kdf_full_work;
 	nano::kdf & kdf;
 	MDB_dbi handle;
 	std::recursive_mutex mutex;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -73,11 +73,11 @@ wallet (wallet_a)
 {
 	your_account_label->setStyleSheet ("font-weight: bold;");
 	std::string network = "Live";
-	if (nano::nano_network == nano::nano_networks::nano_beta_network)
+	if (nano::is_beta_network)
 	{
 		network = "Beta";
 	}
-	else if (nano::nano_network == nano::nano_networks::nano_test_network)
+	else if (nano::is_test_network)
 	{
 		network = "Test";
 	}

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -59,8 +59,8 @@ public:
 	nano_test_genesis (test_genesis_data),
 	nano_beta_genesis (beta_genesis_data),
 	nano_live_genesis (live_genesis_data),
-	genesis_account (nano::nano_network == nano::nano_networks::nano_test_network ? nano_test_account : nano::nano_network == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_account),
-	genesis_block (nano::nano_network == nano::nano_networks::nano_test_network ? nano_test_genesis : nano::nano_network == nano::nano_networks::nano_beta_network ? nano_beta_genesis : nano_live_genesis),
+	genesis_account (nano::is_test_network ? nano_test_account : nano::is_beta_network ? nano_beta_account : nano_live_account),
+	genesis_block (nano::is_test_network ? nano_test_genesis : nano::is_beta_network ? nano_beta_genesis : nano_live_genesis),
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 	burn_account (0)
 	{


### PR DESCRIPTION
We do a lot of conditional checking like `nano::nano_network == nano::nano_networks::nano_test_network` I have created some helper constexpr variables which can be used instead e.g `nano::is_test_network`.

It especially helps in situations like this:
`(nano::nano_network == nano::nano_networks::nano_test_network ? nano_test_account : nano::nano_network == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_account)`

Which becomes:
`(nano::is_test_network ? nano_test_account : nano::is_beta_network ? nano_beta_account : nano_live_account)`