### PR TITLE
fixing bootstrap_max being overwritten

### DIFF
--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -135,7 +135,7 @@ public:
 		json.put ("account", account.to_account ());
 		nano::jsonconfig node_l;
 		node.enable_voting = false;
-		node.bootstrap_connections_max = 4;
+		json.put ("bootstrap_connections_max", node.bootstrap_connections_max);
 		node.serialize_json (node_l);
 		json.put_child ("node", node_l);
 		nano::jsonconfig rpc_l;


### PR DESCRIPTION
It would appear that bootstrap_connections_max is being overwritten to 4 when run from the wallet regardless of the existing config settings, looks to have been part of
https://github.com/nanocurrency/nano-node/commit/e5c2b66959168da2140a22c146fa965a88c225a8

@SergiySW was this intentional or a side effect of something else