### PR TITLE
Add missing beta/live network helper constants

### DIFF
--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -201,7 +201,7 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 		nano::message_header header (error, stream);
 		if (!error)
 		{
-			if (nano::nano_network == nano::nano_networks::nano_beta_network && header.version_using < nano::protocol_version_reasonable_min)
+			if (nano::is_beta_network && header.version_using < nano::protocol_version_reasonable_min)
 			{
 				status = parse_status::outdated_version;
 			}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2218,7 +2218,7 @@ startup_time (std::chrono::steady_clock::now ())
 		BOOST_LOG (log) << "Node ID: " << node_id.pub.to_account ();
 	}
 	peers.online_weight_minimum = config.online_weight_minimum.number ();
-	if (nano::nano_network == nano::nano_networks::nano_live_network || nano::nano_network == nano::nano_networks::nano_beta_network)
+	if (nano::is_live_network || nano::is_beta_network)
 	{
 		nano::bufferstream weight_stream ((const uint8_t *)nano_bootstrap_weights, nano_bootstrap_weights_size);
 		nano::uint128_union block_height;
@@ -3582,7 +3582,7 @@ bool nano::reserved_address (nano::endpoint const & endpoint_a, bool blacklist_l
 	{
 		result = true;
 	}
-	else if (nano::nano_network == nano::nano_networks::nano_live_network)
+	else if (nano::is_live_network)
 	{
 		if (bytes >= rfc1918_1_min && bytes <= rfc1918_1_max)
 		{
@@ -4113,7 +4113,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 		node.network.republish_block_batch (rebroadcast_bundle);
 	}
 	// Batch confirmation request
-	if (nano::nano_network != nano::nano_networks::nano_live_network && !requests_bundle.empty ())
+	if (!nano::is_live_network && !requests_bundle.empty ())
 	{
 		node.network.broadcast_confirm_req_batch (requests_bundle, 50);
 	}

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -248,7 +248,7 @@ public:
 	std::vector<nano::account> list ();
 	static uint64_t constexpr weight_period = 5 * 60; // 5 minutes
 	// The maximum amount of samples for a 2 week period on live or 3 days on beta
-	static uint64_t constexpr weight_samples = (nano::nano_network == nano::nano_networks::nano_live_network) ? 4032 : 864;
+	static uint64_t constexpr weight_samples = nano::is_live_network ? 4032 : 864;
 
 private:
 	nano::uint128_t trend (nano::transaction &);
@@ -348,7 +348,7 @@ public:
 	std::vector<boost::thread> packet_processing_threads;
 	nano::node & node;
 	std::atomic<bool> on;
-	static uint16_t const node_port = nano::nano_network == nano::nano_networks::nano_live_network ? 7075 : 54000;
+	static uint16_t const node_port = nano::is_live_network ? 7075 : 54000;
 	static size_t const buffer_size = 512;
 	static size_t const confirm_req_hashes_max = 6;
 };

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -87,7 +87,7 @@ public:
 	nano::rpc_config config;
 	nano::node & node;
 	bool on;
-	static uint16_t const rpc_port = nano::nano_network == nano::nano_networks::nano_live_network ? 7076 : 55000;
+	static uint16_t const rpc_port = nano::is_live_network ? 7076 : 55000;
 };
 class rpc_connection : public std::enable_shared_from_this<nano::rpc_connection>
 {


### PR DESCRIPTION
Seems #1680 only searched for the test network and changed those (and any near them). Add missing ones for beta/live.