### PR TITLE
Deserializer changes in unchecked_info

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1399,9 +1399,9 @@ node (init_a, io_ctx_a, application_path_a, alarm_a, nano::node_config (peering_
 nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a) :
 io_ctx (io_ctx_a),
 config (config_a),
+flags (flags_a),
 alarm (alarm_a),
 work (work_a),
-flags (flags_a),
 store_impl (std::make_unique<nano::mdb_store> (init_a.block_store_init, config.logging, application_path_a / "data.ldb", config_a.lmdb_max_dbs, !flags.disable_unchecked_drop, flags.sideband_batch_size)),
 store (*store_impl),
 wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (init_a.wallets_store_init, application_path_a / "wallets.ldb", config_a.lmdb_max_dbs)),

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -342,14 +342,15 @@ bool nano::unchecked_info::deserialize (nano::stream & stream_a)
 	bool error (block == nullptr);
 	if (!error)
 	{
-		error = nano::read (stream_a, account.bytes);
-		if (!error)
+		try
 		{
-			error = nano::read (stream_a, modified);
-			if (!error)
-			{
-				error = nano::read (stream_a, verified);
-			}
+			nano::read (stream_a, account.bytes);
+			nano::read (stream_a, modified);
+			nano::read (stream_a, verified);
+		}
+		catch (std::runtime_error const &)
+		{
+			error = true;
 		}
 	}
 	return error;


### PR DESCRIPTION
nano::read no longer returns a bool.

Also noticed a build warning about member variable initialization in node.cpp which seems to have crept in, fixed that as well.