### PR TITLE
Data race when upgrading sideband information

### DIFF
--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -408,7 +408,7 @@ private:
 	boost::optional<MDB_val> block_raw_get_by_type (nano::transaction const &, nano::block_hash const &, nano::block_type &);
 	void block_raw_put (nano::transaction const &, MDB_dbi, nano::block_hash const &, MDB_val);
 	void clear (MDB_dbi);
-	bool stopped{ false };
+	std::atomic<bool> stopped{ false };
 	std::thread upgrades;
 };
 class wallet_value


### PR DESCRIPTION
`stopped` is accessed from different threads and is flagged up by TSAN as a data race.