### PR TITLE
Use cpack to build zip for win

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,9 +36,9 @@ after_build:
 - cmd: >-
     cpack -C %CONFIGURATION% --verbose --config ./CPackConfig.cmake
 
-    7z a nano.zip %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.exe %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.com
+    cpack -G ZIP -C %CONFIGURATION% --verbose --config ./CPackConfig.cmake
 artifacts:
-- path: nano.zip
+- path: nano*.zip
   name: nano_release_%network%
 - path: Nano_Installer-*.exe
   name: Nano_Installer_%network%


### PR DESCRIPTION
fixes #45 replacing adhoc zip with proper portable packages, sample of build artifact virus total
https://www.virustotal.com/#/file/b6834a309c1b92c5ab999dcb32df16c9d5693826192446377b8765964d86965f/detection