### PR TITLE
Find pthread in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# TODO check if any library requires these
-#find_package(Threads REQUIRED)
-#set (PLATFORM_LIBS ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+find_package(Threads REQUIRED)
 
 if (WIN32)
 	add_definitions(-D_WIN32_WINNT=0x0600

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-find_package(Threads REQUIRED)
+find_package(Threads)
 
 if (WIN32)
 	add_definitions(-D_WIN32_WINNT=0x0600


### PR DESCRIPTION
When using gcc 8.2 with Eclipse generated Makefiles on Linux I get unresolved pthread symbols. It appears to only be a gcc error where -lpthread is explicitly required. The recommendation is to use `find_package (Threads)`:
https://cmake.org/pipermail/cmake/2016-February/062729.html

Tested on Mac/clang, Fedora/gcc, and appveyor (Windows) seems to build it ok as well.