### PR TITLE
Add wallet_seed RPC

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -2413,6 +2413,32 @@ TEST (rpc, representatives)
 	ASSERT_EQ (nano::genesis_account, representatives[0]);
 }
 
+TEST (rpc, wallet_seed)
+{
+	nano::system system (24000, 1);
+	nano::raw_key seed;
+	{
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
+		system.wallet (0)->store.seed (seed, transaction);
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_seed");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	{
+		std::string seed_text (response.json.get<std::string> ("seed"));
+		ASSERT_EQ (seed.data.to_string (), seed_text);
+	}
+}
+
 TEST (rpc, wallet_change_seed)
 {
 	nano::system system0 (24000, 1);

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3932,6 +3932,27 @@ void nano::rpc_handler::wallet_republish ()
 	response_errors ();
 }
 
+void nano::rpc_handler::wallet_seed ()
+{
+	rpc_control_impl ();
+	auto wallet (wallet_impl ());
+	if (!ec)
+	{
+		auto transaction (node.wallets.tx_begin_read ());
+		if (wallet->store.valid_password (transaction))
+		{
+			nano::raw_key seed;
+			wallet->store.seed (seed, transaction);
+			response_l.put ("seed", seed.data.to_string ());
+		}
+		else
+		{
+			ec = nano::error_common::wallet_locked;
+		}
+	}
+	response_errors ();
+}
+
 void nano::rpc_handler::wallet_work_get ()
 {
 	rpc_control_impl ();
@@ -4635,6 +4656,10 @@ void nano::rpc_handler::process_request ()
 			else if (action == "wallet_balances")
 			{
 				wallet_balances ();
+			}
+			else if (action == "wallet_seed")
+			{
+				wallet_seed ();
 			}
 			else if (action == "wallet_change_seed")
 			{

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -227,6 +227,7 @@ public:
 	void wallet_representative ();
 	void wallet_representative_set ();
 	void wallet_republish ();
+	void wallet_seed ();
 	void wallet_work_get ();
 	void work_generate ();
 	void work_cancel ();


### PR DESCRIPTION
An alternative to https://github.com/nanocurrency/nano-node/pull/949 by @SergiySW.

This only adds a `wallet_seed` action and includes a test.

My rationale can be found here: https://github.com/nanocurrency/nano-node/pull/949#issuecomment-462010711