### PR TITLE
[WIP] Endpoint abstraction

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable (core_test
 	gap_cache.cpp
 	ledger.cpp
 	network.cpp
+	network_generic.cpp
 	node.cpp
 	message.cpp
 	message_parser.cpp

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -722,10 +722,10 @@ TEST (votes, check_signature)
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
-	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (transaction, vote1, nano::endpoint (boost::asio::ip::address_v6 (), 0)));
+	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (transaction, vote1, nano::net::socket_addr (boost::asio::ip::address_v6 (), 0)));
 	vote1->signature.bytes[0] ^= 1;
-	ASSERT_EQ (nano::vote_code::vote, node1.vote_processor.vote_blocking (transaction, vote1, nano::endpoint (boost::asio::ip::address_v6 (), 0)));
-	ASSERT_EQ (nano::vote_code::replay, node1.vote_processor.vote_blocking (transaction, vote1, nano::endpoint (boost::asio::ip::address_v6 (), 0)));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_processor.vote_blocking (transaction, vote1, nano::net::socket_addr (boost::asio::ip::address_v6 (), 0)));
+	ASSERT_EQ (nano::vote_code::replay, node1.vote_processor.vote_blocking (transaction, vote1, nano::net::socket_addr (boost::asio::ip::address_v6 (), 0)));
 }
 
 TEST (votes, add_one)

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -22,7 +22,7 @@ TEST (message, keepalive_serialization)
 TEST (message, keepalive_deserialize)
 {
 	nano::keepalive message1;
-	message1.peers[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000);
+	message1.peers[0] = nano::net::socket_addr::make_udp (boost::asio::ip::address_v6::loopback (), 10000);
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);

--- a/nano/core_test/network_generic.cpp
+++ b/nano/core_test/network_generic.cpp
@@ -1,0 +1,68 @@
+#include <boost/thread.hpp>
+#include <gtest/gtest.h>
+#include <map>
+#include <nano/core_test/testutil.hpp>
+#include <nano/node/network_generic.hpp>
+#include <nano/node/testing.hpp>
+#include <set>
+#include <unordered_map>
+
+using namespace std::chrono_literals;
+
+TEST (net, remote_protocol_predicates)
+{
+	bool error;
+
+	auto tcp1 (nano::net::socket_addr::make_tcp ("::1:24000", error));
+	ASSERT_TRUE (tcp1.is_tcp ());
+	ASSERT_FALSE (tcp1.is_udp ());
+
+	auto udp1 (nano::net::socket_addr::make_udp ("::1:24000", error));
+	ASSERT_TRUE (udp1.is_udp ());
+	ASSERT_FALSE (udp1.is_tcp ());
+}
+
+TEST (net, remote_parse_relational)
+{
+	bool error;
+	auto tcp1 (nano::net::socket_addr::make_tcp ("::1:24000", error));
+	auto tcp2 (nano::net::socket_addr::make_tcp ("::1:24000", error));
+	auto tcp3 (nano::net::socket_addr::make_tcp ("::1:25000", error));
+	auto udp1 (nano::net::socket_addr::make_udp ("::1:24000", error));
+	ASSERT_EQ (tcp1, tcp2);
+	ASSERT_NE (tcp1, tcp3);
+	ASSERT_LT (tcp1, tcp3);
+	ASSERT_GT (tcp3, tcp2);
+	// TCP sorts before UDP
+	ASSERT_LT (tcp1, udp1);
+}
+
+TEST (net, remote_container)
+{
+	bool error;
+	// Make sure duplicate addresses are treated as such and that
+	// the same address for udp and tcp are treated as different.
+	std::set<nano::net::socket_addr> remotes;
+	remotes.insert (nano::net::socket_addr::make_tcp ("::1:24000", error));
+	remotes.insert (nano::net::socket_addr::make_tcp ("::1:24000", error));
+	remotes.insert (nano::net::socket_addr::make_udp ("::ffff:192.168.40.2:24000", error));
+	remotes.insert (nano::net::socket_addr::make_udp ("::ffff:192.168.40.1:24000", error));
+	remotes.insert (nano::net::socket_addr::make_tcp ("::ffff:192.168.40.1:24000", error));
+	remotes.insert (nano::net::socket_addr::make_udp ("::ffff:192.168.40.1:25000", error));
+	ASSERT_EQ (remotes.size (), 5);
+
+	// Add same socket address twice for different types, make sure tcp is sorted first
+	remotes.clear ();
+	remotes.insert (nano::net::socket_addr::make_udp ("::ffff:192.168.40.1:24000", error));
+	remotes.insert (nano::net::socket_addr::make_tcp ("::ffff:192.168.40.1:24000", error));
+	ASSERT_TRUE (remotes.begin ()->is_tcp ());
+	ASSERT_TRUE (remotes.rbegin ()->is_udp ());
+
+	// Test the hash
+	std::unordered_map<nano::net::socket_addr, std::string> map;
+	map[nano::net::socket_addr::make_tcp ("::1:24000", error)] = "a";
+	map[nano::net::socket_addr::make_tcp ("::1:24001", error)] = "b";
+	map[nano::net::socket_addr::make_tcp ("::1:24002", error)] = "c";
+	map[nano::net::socket_addr::make_tcp ("::ffff:192.168.40.1:25000", error)] = "d";
+	map[nano::net::socket_addr::make_tcp ("::ffff:192.168.40.2:25000", error)] = "e";
+}

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -21,7 +21,7 @@ public:
 	sock (io_ctx),
 	status (0)
 	{
-		sock.async_connect (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), rpc_a.config.port), [this](boost::system::error_code const & ec) {
+		sock.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), rpc_a.config.port), [this](boost::system::error_code const & ec) {
 			if (!ec)
 			{
 				std::stringstream ostream;
@@ -1686,7 +1686,7 @@ TEST (rpc, payment_wait)
 TEST (rpc, peers)
 {
 	nano::system system (24000, 2);
-	nano::endpoint endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
+	nano::net::socket_addr endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
 	system.nodes[0]->peers.insert (endpoint, nano::protocol_version);
 	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
 	rpc.start ();
@@ -1711,7 +1711,7 @@ TEST (rpc, peers)
 TEST (rpc, peers_node_id)
 {
 	nano::system system (24000, 2);
-	nano::endpoint endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
+	nano::net::socket_addr endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
 	system.nodes[0]->peers.insert (endpoint, nano::protocol_version);
 	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
 	rpc.start ();

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -835,7 +835,7 @@ int main (int argc, char * const * argv)
 
 			for (auto i (node.node->store.peers_begin (transaction)), n (node.node->store.peers_end ()); i != n; ++i)
 			{
-				std::cout << boost::str (boost::format ("%1%\n") % nano::endpoint (boost::asio::ip::address_v6 (i->first.address_bytes ()), i->first.port ()));
+				std::cout << boost::str (boost::format ("%1%\n") % nano::net::socket_addr::make_udp (boost::asio::ip::address_v6 (i->first.address_bytes ()), i->first.port ()));
 			}
 		}
 		else if (vm.count ("version"))

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library (node
 	lmdb.hpp
 	logging.cpp
 	logging.hpp
+	network_generic.hpp
+	network_generic.cpp
 	nodeconfig.hpp
 	nodeconfig.cpp
 	node.hpp

--- a/nano/node/network_generic.cpp
+++ b/nano/node/network_generic.cpp
@@ -1,0 +1,252 @@
+#include <cassert>
+#include <nano/node/common.hpp>
+#include <nano/node/network_generic.hpp>
+#include <nano/node/node.hpp>
+
+nano::net::socket_addr nano::net::socket_addr::make_tcp (std::string address_a, bool & error_a)
+{
+	nano::net::socket_addr endpoint;
+	error_a = nano::parse_tcp_endpoint (address_a, endpoint);
+	return endpoint;
+}
+
+nano::net::socket_addr nano::net::socket_addr::make_udp (std::string address_a, bool & error_a)
+{
+	nano::net::socket_addr endpoint;
+	error_a = nano::parse_udp_endpoint (address_a, endpoint);
+	return endpoint;
+}
+
+nano::net::socket_addr nano::net::socket_addr::tcp_map_to_v6 (nano::net::socket_addr const & endpoint_a)
+{
+	auto endpoint_l (endpoint_a);
+	if (endpoint_l.address ().is_v4 ())
+	{
+		endpoint_l = boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::v4_mapped (endpoint_l.address ().to_v4 ()), endpoint_l.port ());
+	}
+	assert (endpoint_l.address ().is_v6 ());
+	return endpoint_l;
+}
+
+nano::net::socket_addr nano::net::socket_addr::udp_map_to_v6 (nano::net::socket_addr const & endpoint_a)
+{
+	auto endpoint_l (endpoint_a);
+	if (endpoint_l.address ().is_v4 ())
+	{
+		endpoint_l = boost::asio::ip::udp::endpoint (boost::asio::ip::address_v6::v4_mapped (endpoint_l.address ().to_v4 ()), endpoint_l.port ());
+	}
+	assert (endpoint_l.address ().is_v6 ());
+	return endpoint_l;
+}
+
+nano::net::socket_addr nano::net::socket_addr::map_to_v6 () const
+{
+	if (is_udp ())
+	{
+		return nano::net::socket_addr::udp_map_to_v6 (*this);
+	}
+	else if (is_tcp ())
+	{
+		return nano::net::socket_addr::tcp_map_to_v6 (*this);
+	}
+	else
+	{
+		assert (false);
+		return nano::net::socket_addr ();
+	}
+}
+
+nano::net::socket_addr nano::net::socket_addr::make_tcp (const boost::asio::ip::address & address_a, unsigned short port_a)
+{
+	return boost::asio::ip::tcp::endpoint (address_a, port_a);
+}
+
+nano::net::socket_addr nano::net::socket_addr::make_udp (const boost::asio::ip::address & address_a, unsigned short port_a)
+{
+	return boost::asio::ip::udp::endpoint (address_a, port_a);
+}
+
+nano::net::socket_addr nano::net::socket_addr::make_default_tcp ()
+{
+	return boost::asio::ip::tcp::endpoint{};
+}
+
+nano::net::socket_addr nano::net::socket_addr::make_default_udp ()
+{
+	return boost::asio::ip::udp::endpoint{};
+}
+
+nano::net::tcp_client::tcp_client (nano::node & node_a) :
+cutoff (std::numeric_limits<uint64_t>::max ()),
+node (node_a),
+socket_m (node_a.io_ctx)
+{
+}
+
+void nano::net::tcp_client::async_connect (nano::net::socket_addr const & endpoint_a, std::function<void(boost::system::error_code const &)> callback_a)
+{
+	assert (endpoint_a.is_tcp ());
+	checkup ();
+	auto this_l (shared_from_this ());
+	start ();
+	socket_m.async_connect (endpoint_a.tcp (), [this_l, callback_a](boost::system::error_code const & ec) {
+		this_l->stop ();
+		callback_a (ec);
+	});
+}
+
+void nano::net::tcp_client::async_read (uint8_t * buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)> callback_a)
+{
+	auto this_l (shared_from_this ());
+	if (socket_m.is_open ())
+	{
+		start ();
+		boost::asio::async_read (socket_m, boost::asio::buffer (buffer_a, size_a), [this_l, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
+			this_l->stop ();
+			callback_a (ec, size_a, this_l->socket_m.remote_endpoint ());
+		});
+	}
+}
+
+void nano::net::tcp_client::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)> callback_a)
+{
+	assert (size_a <= buffer_a->size ());
+	auto this_l (shared_from_this ());
+	if (socket_m.is_open ())
+	{
+		start ();
+		boost::asio::async_read (socket_m, boost::asio::buffer (buffer_a->data (), size_a), [this_l, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
+			this_l->stop ();
+			boost::system::error_code ec_remote;
+			auto remote (this_l->socket_m.remote_endpoint (ec_remote));
+			callback_a (ec, size_a, remote);
+		});
+	}
+}
+
+void nano::net::tcp_client::async_write (uint8_t const * buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t)> callback_a)
+{
+	auto this_l (shared_from_this ());
+	if (socket_m.is_open ())
+	{
+		start ();
+		boost::asio::async_write (socket_m, boost::asio::buffer (buffer_a, size_a), [this_l, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
+			this_l->stop ();
+			callback_a (ec, size_a);
+		});
+	}
+}
+
+void nano::net::tcp_client::async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a)
+{
+	auto this_l (shared_from_this ());
+	if (socket_m.is_open ())
+	{
+		start ();
+		boost::asio::async_write (socket_m, boost::asio::buffer (buffer_a->data (), buffer_a->size ()), [this_l, callback_a, buffer_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
+			this_l->stop ();
+			callback_a (ec, size_a);
+		});
+	}
+}
+
+void nano::net::tcp_client::start (std::chrono::steady_clock::time_point timeout_a)
+{
+	cutoff = timeout_a.time_since_epoch ().count ();
+}
+
+void nano::net::tcp_client::stop ()
+{
+	cutoff = std::numeric_limits<uint64_t>::max ();
+}
+
+void nano::net::tcp_client::checkup ()
+{
+	std::weak_ptr<nano::net::tcp_client> this_w (shared_from_this ());
+	node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (10), [this_w]() {
+		if (auto this_l = this_w.lock ())
+		{
+			if (this_l->cutoff != std::numeric_limits<uint64_t>::max () && this_l->cutoff < static_cast<uint64_t> (std::chrono::steady_clock::now ().time_since_epoch ().count ()))
+			{
+				if (this_l->node.config.logging.bulk_pull_logging ())
+				{
+					boost::system::error_code ec;
+					BOOST_LOG (this_l->node.log) << boost::str (boost::format ("Disconnecting from %1% due to timeout") % this_l->remote_endpoint (ec));
+				}
+				this_l->close ();
+			}
+			else
+			{
+				this_l->checkup ();
+			}
+		}
+	});
+}
+
+nano::net::udp_client::udp_client (nano::node & node_a, nano::net::socket_addr local_endpoint_a) :
+node (node_a),
+socket (node_a.io_ctx, local_endpoint_a.udp ())
+{
+}
+
+void nano::net::udp_client::async_connect (nano::net::socket_addr const & endpoint_a, std::function<void(boost::system::error_code const &)> callback_a)
+{
+	boost::system::error_code ec;
+	remote_endpoint_m = endpoint_a.udp ();
+	callback_a (ec);
+}
+
+void nano::net::udp_client::async_read (uint8_t * buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)> callback_a)
+{
+	auto this_l (shared_from_this ());
+	if (socket.is_open ())
+	{
+		auto remote_a (std::make_shared<boost::asio::ip::udp::endpoint> ());
+		socket.async_receive_from (boost::asio::buffer (buffer_a, size_a), *remote_a, [this_l, remote_a, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic, nano::stat::dir::in, size_a);
+			callback_a (ec, size_a, *remote_a);
+		});
+	}
+}
+
+void nano::net::udp_client::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)> callback_a)
+{
+	assert (size_a <= buffer_a->size ());
+	auto this_l (shared_from_this ());
+	if (socket.is_open ())
+	{
+		auto remote_a (std::make_shared<boost::asio::ip::udp::endpoint> ());
+		socket.async_receive_from (boost::asio::buffer (buffer_a->data (), size_a), *remote_a, [this_l, remote_a, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic, nano::stat::dir::in, size_a);
+			callback_a (ec, size_a, *remote_a);
+		});
+	}
+}
+
+void nano::net::udp_client::async_write (uint8_t const * buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t)> callback_a)
+{
+	auto this_l (shared_from_this ());
+	if (socket.is_open ())
+	{
+		socket.async_send_to (boost::asio::buffer (buffer_a, size_a), remote_endpoint_m, [this_l, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic, nano::stat::dir::out, size_a);
+			callback_a (ec, size_a);
+		});
+	}
+}
+
+void nano::net::udp_client::async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a)
+{
+	auto this_l (shared_from_this ());
+	if (socket.is_open ())
+	{
+		socket.async_send_to (boost::asio::buffer (buffer_a->data (), buffer_a->size ()), remote_endpoint_m, [this_l, callback_a, buffer_a](boost::system::error_code const & ec, size_t size_a) {
+			this_l->node.stats.add (nano::stat::type::traffic, nano::stat::dir::out, size_a);
+			callback_a (ec, size_a);
+		});
+	}
+}

--- a/nano/node/network_generic.hpp
+++ b/nano/node/network_generic.hpp
@@ -1,0 +1,678 @@
+#pragma once
+
+#include <boost/asio.hpp>
+#include <boost/variant.hpp>
+#include <chrono>
+#include <crypto/xxhash/xxhash.h>
+#include <memory>
+#include <mutex>
+#include <nano/lib/numbers.hpp>
+
+namespace nano
+{
+class node;
+class message;
+namespace net
+{
+	/** Supported protocols. These have explicit values as they may be serialized. */
+	enum class protocol : uint8_t
+	{
+		unknown = 0,
+		udp = 1,
+		tcp = 2
+	};
+
+	/**
+	 * Encapsulates an ip address, port and protocol with conversion to and from Boost endpoint types.
+	 * The socket_addr can be converted between protocol types using as_<type> ()
+	 * @todo The static factory functions are for convenience in tests, but we might want to replace them with additional constructors.
+	 */
+	class socket_addr
+	{
+	public:
+		static socket_addr tcp_map_to_v6 (nano::net::socket_addr const & endpoint_a);
+		static socket_addr udp_map_to_v6 (nano::net::socket_addr const & endpoint_a);
+		/** Create a tcp endpoint from ip address and port number */
+		static socket_addr make_tcp (const boost::asio::ip::address & address_a, unsigned short port_a);
+		/** Create a udp endpoint from ip address and port number */
+		static socket_addr make_udp (const boost::asio::ip::address & address_a, unsigned short port_a);
+		/** Parse ip address and port into a tcp endpoint */
+		static socket_addr make_tcp (std::string address_a, bool & parse_error_a);
+		/** Parse ip address and port into a udp endpoint */
+		static socket_addr make_udp (std::string address_a, bool & parse_error_a);
+		/** Creates an endpoint equivalent to a default-constructed boost::asio::ip::tcp::endpoint */
+		static socket_addr make_default_tcp ();
+		/** Creates an endpoint equivalent to a default-constructed boost::asio::ip::udp::endpoint */
+		static socket_addr make_default_udp ();
+
+		socket_addr () = default;
+
+		/** Construct based on IP address and port number */
+		socket_addr (const boost::asio::ip::address & addr, unsigned short port_a, nano::net::protocol protocol_a = nano::net::protocol::udp)
+		{
+			if (protocol_a == nano::net::protocol::udp)
+			{
+				*this = make_udp (addr, port_a);
+			}
+			else if (protocol_a == nano::net::protocol::tcp)
+			{
+				*this = make_tcp (addr, port_a);
+			}
+			else
+			{
+				assert (false);
+			}
+		}
+
+		/** Returns an ipv6 mapped copy */
+		socket_addr map_to_v6 () const;
+
+		/** Convert this endpoint to another protocol type. This is a no-op if the protocol type is already used. */
+		void convert_to (nano::net::protocol protocol_a)
+		{
+			if (protocol_a == nano::net::protocol::tcp && endpoint.which () != type_tcp)
+			{
+				*this = make_tcp (address (), port ());
+			}
+			else if (protocol_a == nano::net::protocol::udp && endpoint.which () != type_udp)
+			{
+				*this = make_udp (address (), port ());
+			}
+		}
+
+		/** Get a copy, enforcing tcp protocol */
+		socket_addr as_tcp () const
+		{
+			auto result (*this);
+			result.convert_to (nano::net::protocol::tcp);
+			return result;
+		}
+
+		/** Get a copy, enforcing udp protocol */
+		socket_addr as_udp () const
+		{
+			auto result (*this);
+			result.convert_to (nano::net::protocol::udp);
+			return result;
+		}
+		socket_addr (socket_addr const & other_a)
+		{
+			endpoint = other_a.endpoint;
+		}
+		socket_addr (boost::asio::ip::udp::endpoint const & udp)
+		{
+			endpoint = udp;
+		}
+		socket_addr (boost::asio::ip::udp::endpoint && udp)
+		{
+			endpoint = std::move (udp);
+		}
+		socket_addr (boost::asio::ip::tcp::endpoint const & tcp)
+		{
+			endpoint = tcp;
+		}
+		socket_addr (boost::asio::ip::tcp::endpoint && tcp)
+		{
+			endpoint = std::move (tcp);
+		}
+		explicit operator boost::asio::ip::tcp::endpoint () const
+		{
+			return tcp ();
+		}
+		explicit operator boost::asio::ip::udp::endpoint () const
+		{
+			return udp ();
+		}
+		socket_addr & operator= (const socket_addr & other)
+		{
+			endpoint = other.endpoint;
+			return *this;
+		}
+		socket_addr & operator= (socket_addr && other)
+		{
+			endpoint = other.endpoint;
+			return *this;
+		}
+		socket_addr & operator= (const boost::asio::ip::udp::endpoint & other)
+		{
+			endpoint = other;
+			return *this;
+		}
+		socket_addr & operator= (boost::asio::ip::udp::endpoint && other)
+		{
+			endpoint = other;
+			return *this;
+		}
+		socket_addr & operator= (const boost::asio::ip::tcp::endpoint & other)
+		{
+			endpoint = other;
+			return *this;
+		}
+		socket_addr & operator= (boost::asio::ip::tcp::endpoint && other)
+		{
+			endpoint = other;
+			return *this;
+		}
+		/** Compare two endpoints for equality. */
+		friend bool operator== (const socket_addr & e1,
+		const socket_addr & e2)
+		{
+			if (e1.is_udp () && e2.is_udp ())
+			{
+				return e1.udp () == e2.udp ();
+			}
+			else if (e1.is_tcp () && e2.is_tcp ())
+			{
+				return e1.tcp () == e2.tcp ();
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		/** Compare two endpoints for inequality. */
+		friend bool operator!= (const socket_addr & e1,
+		const socket_addr & e2)
+		{
+			if (e1.is_udp () && e2.is_udp ())
+			{
+				return !(e1.udp () == e2.udp ());
+			}
+			else if (e1.is_tcp () && e2.is_tcp ())
+			{
+				return !(e1.tcp () == e2.tcp ());
+			}
+			else
+			{
+				return true;
+			}
+		}
+
+		/** Compare endpoints for ordering. If endpoints are of different types, the tcp endpoint is deemed smaller. */
+		friend bool operator< (const socket_addr & e1,
+		const socket_addr & e2)
+		{
+			if (e1.is_udp () && e2.is_udp ())
+			{
+				return e1.udp () < e2.udp ();
+			}
+			else if (e1.is_tcp () && e2.is_tcp ())
+			{
+				return e1.tcp () < e2.tcp ();
+			}
+			else
+			{
+				return e1.is_tcp ();
+			}
+		}
+
+		/** Compare endpoints for ordering. */
+		friend bool operator> (const socket_addr & e1,
+		const socket_addr & e2)
+		{
+			return e2 < e1;
+		}
+
+		/** Compare endpoints for ordering. */
+		friend bool operator<= (const socket_addr & e1,
+		const socket_addr & e2)
+		{
+			return !(e2 < e1);
+		}
+
+		/** Compare endpoints for ordering. */
+		friend bool operator>= (const socket_addr & e1,
+		const socket_addr & e2)
+		{
+			return !(e1 < e2);
+		}
+		bool is_udp () const
+		{
+			return endpoint.which () == type_udp;
+		}
+		bool is_tcp () const
+		{
+			return endpoint.which () == type_tcp;
+		}
+
+		void set (boost::asio::ip::udp::endpoint endpoint_a)
+		{
+			endpoint = endpoint_a;
+		}
+
+		void set (boost::asio::ip::tcp::endpoint endpoint_a)
+		{
+			endpoint = endpoint_a;
+		}
+
+		/** Returns the socket address as a UDP endpoint, converting from other endpoint types if necessary */
+		boost::asio::ip::udp::endpoint udp () const
+		{
+			if (is_udp ())
+			{
+				return boost::get<boost::asio::ip::udp::endpoint> (endpoint);
+			}
+			else
+			{
+				return as_udp ().udp ();
+			}
+		}
+
+		/** Returns the socket address as a TCP endpoint, converting from other endpoint types if necessary */
+		boost::asio::ip::tcp::endpoint tcp () const
+		{
+			if (is_tcp ())
+			{
+				return boost::get<boost::asio::ip::tcp::endpoint> (endpoint);
+			}
+			else
+			{
+				return as_tcp ().tcp ();
+			}
+		}
+
+		/** Get the port associated with the endpoint. The port number is always in the host's byte order. If the endpoint is invalid, 0 is returnd. */
+		unsigned short port () const
+		{
+			if (is_udp ())
+			{
+				return udp ().port ();
+			}
+			else if (is_tcp ())
+			{
+				return tcp ().port ();
+			}
+			else
+			{
+				return 0;
+			}
+		}
+
+		/** Set the port associated with the endpoint. The port number is always in the host's byte order. */
+		void port (unsigned short port_num)
+		{
+			if (is_udp ())
+			{
+				auto ep (udp ());
+				ep.port (port_num);
+				set (ep);
+			}
+			else if (is_tcp ())
+			{
+				auto ep (tcp ());
+				ep.port (port_num);
+				set (ep);
+			}
+			else
+			{
+				assert (false);
+			}
+		}
+
+		/** Get the IP address associated with the endpoint. If the endpoint is invalid, the default address is returned. */
+		boost::asio::ip::address address () const
+		{
+			boost::asio::ip::address addr;
+			if (is_udp ())
+			{
+				return udp ().address ();
+			}
+			else if (is_tcp ())
+			{
+				return tcp ().address ();
+			}
+			else
+			{
+				return boost::asio::ip::address ();
+			}
+		}
+
+		/** Set the IP address associated with the endpoint. */
+		void address (const boost::asio::ip::address & addr)
+		{
+			if (is_udp ())
+			{
+				auto ep (udp ());
+				ep.address (addr);
+				set (ep);
+			}
+			else if (is_tcp ())
+			{
+				auto ep (tcp ());
+				ep.address (addr);
+				set (ep);
+			}
+			else
+			{
+				assert (false);
+			}
+		}
+
+		boost::asio::ip::udp protocol_udp () const
+		{
+			assert (is_udp ());
+			return udp ().protocol ();
+		}
+
+		boost::asio::ip::tcp protocol_tcp () const
+		{
+			assert (is_tcp ());
+			return tcp ().protocol ();
+		}
+
+		/** True if the socket address contains a valid value */
+		bool valid () const
+		{
+			return endpoint.which () != type_invalid;
+		}
+
+		/** Invalidates the socket address */
+		void invalidate ()
+		{
+			endpoint = false;
+		}
+
+	private:
+		boost::variant<bool, boost::asio::ip::udp::endpoint, boost::asio::ip::tcp::endpoint> endpoint;
+		static constexpr auto type_invalid = static_cast<int> (nano::net::protocol::unknown);
+		static constexpr auto type_udp = static_cast<int> (nano::net::protocol::udp);
+		static constexpr auto type_tcp = static_cast<int> (nano::net::protocol::tcp);
+	};
+
+	/** Enable socket_addr to be used as arguments to ostreams, such as boost log */
+	template <typename Elem, typename Traits>
+	std::basic_ostream<Elem, Traits> & operator<< (std::basic_ostream<Elem, Traits> & os, const socket_addr & endpoint)
+	{
+		if (endpoint.is_udp ())
+		{
+			os << endpoint.udp ();
+		}
+		else
+		{
+			os << endpoint.tcp ();
+		}
+		return os;
+	}
+
+	/** Protocol-agnostic connection interface */
+	class client
+	{
+	public:
+		virtual void async_connect (nano::net::socket_addr const &, std::function<void(boost::system::error_code const &)>) = 0;
+		virtual void async_read (uint8_t * buffer_a, size_t size, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)> callback_a) = 0;
+		virtual void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)> callback_a) = 0;
+		virtual void async_write (uint8_t const * buffer_a, size_t size, std::function<void(boost::system::error_code const &, size_t)> callback_a) = 0;
+		virtual void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) = 0;
+		virtual void close () = 0;
+		virtual nano::net::socket_addr local_endpoint (boost::system::error_code & ec) = 0;
+		virtual nano::net::socket_addr remote_endpoint (boost::system::error_code & ec) = 0;
+		virtual nano::net::socket_addr local_endpoint ()
+		{
+			boost::system::error_code ec;
+			return local_endpoint (ec);
+		}
+		virtual nano::net::socket_addr remote_endpoint ()
+		{
+			boost::system::error_code ec;
+			return remote_endpoint (ec);
+		}
+		virtual ~client () = default;
+	};
+
+	/** Utilities shared between socket types */
+	template <typename SOCKET_BASE>
+	class socket_common
+	{
+	public:
+		socket_common ()
+		{
+		}
+		virtual typename SOCKET_BASE::socket & raw_socket () = 0;
+		typename SOCKET_BASE::endpoint remote_endpoint (boost::system::error_code & ec)
+		{
+			typename SOCKET_BASE::endpoint endpoint;
+
+			if (raw_socket ().is_open ())
+			{
+				endpoint = raw_socket ().remote_endpoint (ec);
+			}
+
+			return endpoint;
+		}
+		typename SOCKET_BASE::endpoint local_endpoint (boost::system::error_code & ec)
+		{
+			typename SOCKET_BASE::endpoint endpoint;
+
+			if (raw_socket ().is_open ())
+			{
+				endpoint = raw_socket ().local_endpoint (ec);
+			}
+
+			return endpoint;
+		}
+		void close ()
+		{
+			if (raw_socket ().is_open ())
+			{
+				try
+				{
+					raw_socket ().shutdown (SOCKET_BASE::socket::shutdown_both);
+				}
+				catch (...)
+				{
+					/* Ignore spurious exceptions; shutdown is best effort. */
+				}
+				raw_socket ().close ();
+			}
+		}
+
+	protected:
+		std::chrono::steady_clock::time_point last_contact;
+	};
+
+	/** Client socket for TCP */
+	class tcp_client : public socket_common<boost::asio::ip::tcp>, public client, public std::enable_shared_from_this<nano::net::tcp_client>
+	{
+	public:
+		tcp_client (nano::node & node);
+		void async_connect (nano::net::socket_addr const &, std::function<void(boost::system::error_code const &)>) override;
+		void async_read (uint8_t * buffer_a, size_t size, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)>) override;
+		void async_read (std::shared_ptr<std::vector<uint8_t>>, size_t, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)>) override;
+		void async_write (uint8_t const * buffer_a, size_t size, std::function<void(boost::system::error_code const &, size_t)> callback_a) override;
+		void async_write (std::shared_ptr<std::vector<uint8_t>>, std::function<void(boost::system::error_code const &, size_t)>) override;
+		nano::net::socket_addr local_endpoint (boost::system::error_code & ec) override
+		{
+			return socket_common<boost::asio::ip::tcp>::local_endpoint (ec);
+		}
+		nano::net::socket_addr remote_endpoint (boost::system::error_code & ec) override
+		{
+			return socket_common<boost::asio::ip::tcp>::remote_endpoint (ec);
+		}
+		void close () override
+		{
+			socket_common<boost::asio::ip::tcp>::close ();
+		}
+		boost::asio::ip::tcp::socket & raw_socket () override
+		{
+			return socket_m;
+		}
+
+	private:
+		void start (std::chrono::steady_clock::time_point = std::chrono::steady_clock::now () + std::chrono::seconds (5));
+		void stop ();
+		void checkup ();
+
+		std::atomic<uint64_t> cutoff;
+		nano::node & node;
+		boost::asio::ip::tcp::socket socket_m;
+	};
+
+	/** Client socket for UDP */
+	class udp_client : public socket_common<boost::asio::ip::udp>, public client, public std::enable_shared_from_this<nano::net::udp_client>
+	{
+	public:
+		/**
+		 * @param local_endpoint Endpoint to send from, typically udp::endpoint (boost::asio::ip::address_v6::any (), port)
+		 */
+		udp_client (nano::node & node, nano::net::socket_addr local_endpoint);
+
+		/** UDP is connectionless; set remote endpoint (for writes) and invoke the callback synchronously. */
+		void async_connect (nano::net::socket_addr const &, std::function<void(boost::system::error_code const &)>) override;
+		void async_read (uint8_t * buffer_a, size_t size, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)>) override;
+		void async_read (std::shared_ptr<std::vector<uint8_t>>, size_t, std::function<void(boost::system::error_code const &, size_t, nano::net::socket_addr const &)>) override;
+		void async_write (uint8_t const * buffer_a, size_t size, std::function<void(boost::system::error_code const &, size_t)> callback_a) override;
+		void async_write (std::shared_ptr<std::vector<uint8_t>>, std::function<void(boost::system::error_code const &, size_t)>) override;
+		nano::net::socket_addr local_endpoint (boost::system::error_code & ec) override
+		{
+			return socket_common<boost::asio::ip::udp>::local_endpoint (ec);
+		}
+		nano::net::socket_addr remote_endpoint (boost::system::error_code & ec) override
+		{
+			return remote_endpoint_m;
+		}
+		void close () override
+		{
+			socket_common<boost::asio::ip::udp>::close ();
+		}
+		boost::asio::ip::udp::socket & raw_socket () override
+		{
+			return socket;
+		}
+
+	private:
+		nano::node & node;
+		boost::asio::ip::udp::socket socket;
+		/** Endpoint we're sending to */
+		boost::asio::ip::udp::endpoint remote_endpoint_m;
+	};
+
+	/*
+	 	Everything below here is work in progress / exploring ideas
+	*/
+
+	/** Interface for receiving inbound messages */
+	class message_processor
+	{
+	private:
+		virtual void on_message (nano::message const & message) = 0;
+	};
+
+	class session_pool;
+
+	/**
+	 * A session is a high level interface for sending messages over any transport. A session maintains a connection
+	 * along with metadata such as when there was last communication with the peer.
+	 * @todo Pass session to tcp_client/udp_client so they can update last_activity, etc?
+	 */
+	class session
+	{
+	public:
+		session (session_pool & pool_a);
+
+		/** Send message to the peer */
+		std::error_code send_message (nano::message const & message);
+
+		/** Close the session and the underlying connection. */
+		std::error_code close ();
+
+	private:
+		session_pool & pool;
+		std::shared_ptr<nano::net::client> connection;
+		std::chrono::steady_clock::time_point last_activity;
+	};
+
+	/** Manages a set of peer sessions */
+	class session_pool
+	{
+	public:
+		/** Get a session by address, create a new one if necessary */
+		std::shared_ptr<session> get_session (nano::net::socket_addr & addr)
+		{
+			// todo: look up by address. do a bit of cleanup.
+			return nullptr;
+		}
+
+		/** If a session is inactive for longer than the limit, it's eligble for removal. Future attempts will cause a reconnection. */
+		static constexpr std::chrono::minutes inactivity_limit{ 5 };
+		// TODO: a multi-index container with last-activity index, etc
+	};
+
+	/** Abstract interface for servers */
+	class server
+	{
+	public:
+		virtual void start () = 0;
+		virtual void stop () = 0;
+	};
+
+	class tcp_server : public server
+	{
+	public:
+		tcp_server (std::shared_ptr<nano::node> port, uint16_t listening_port);
+		void start () override;
+		void stop () override;
+
+	protected:
+		/** This is implemented by subclasses to handle new connections. */
+		void accept_action (boost::system::error_code const & ec, std::shared_ptr<nano::net::client> socket_a);
+
+	private:
+		void accept ();
+	};
+
+	class udp_server : public server
+	{
+	public:
+		void start () override;
+		void stop () override;
+	};
+}
+}
+
+namespace
+{
+struct remote_hash
+{
+	std::size_t operator() (::nano::net::socket_addr const & endpoint_a) const noexcept
+	{
+		assert (endpoint_a.address ().is_v6 ());
+		nano::uint128_union address;
+		address.bytes = endpoint_a.address ().to_v6 ().to_bytes ();
+		XXH64_state_t * const state = XXH64_createState ();
+		XXH64_reset (state, 0);
+		XXH64_update (state, address.bytes.data (), address.bytes.size ());
+		auto port (endpoint_a.port ());
+		XXH64_update (state, &port, sizeof (port));
+		auto result (XXH64_digest (state));
+		XXH64_freeState (state);
+		return static_cast<std::size_t> (result);
+	}
+};
+}
+namespace std
+{
+template <>
+struct hash<::nano::net::socket_addr>
+{
+	std::size_t operator() (::nano::net::socket_addr const & endpoint_a) const
+	{
+		::remote_hash rhash;
+		return rhash (endpoint_a);
+	}
+};
+}
+
+/** Inject hash into the boost namespace for the multi_index container */
+namespace boost
+{
+template <>
+struct hash<::nano::net::socket_addr>
+{
+	size_t operator() (::nano::net::socket_addr const & endpoint_a) const
+	{
+		std::hash<::nano::net::socket_addr> hash;
+		return hash (endpoint_a);
+	}
+};
+}

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -103,7 +103,7 @@ void nano::rpc::start (bool rpc_enabled_a)
 {
 	if (rpc_enabled_a)
 	{
-		auto endpoint (nano::tcp_endpoint (config.address, config.port));
+		auto endpoint (boost::asio::ip::tcp::endpoint (config.address, config.port));
 		acceptor.open (endpoint.protocol ());
 		acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
 
@@ -1361,7 +1361,7 @@ void nano::rpc_handler::bootstrap ()
 		uint16_t port;
 		if (!nano::parse_port (port_text, port))
 		{
-			node.bootstrap_initiator.bootstrap (nano::endpoint (address, port));
+			node.bootstrap_initiator.bootstrap (nano::net::socket_addr::make_tcp (address, port));
 			response_l.put ("success", "");
 		}
 		else

--- a/nano/node/rpc_secure.cpp
+++ b/nano/node/rpc_secure.cpp
@@ -191,14 +191,12 @@ void nano::rpc_connection_secure::read ()
 						this_l->res.set (boost::beast::http::field::allow, "POST, OPTIONS");
 						this_l->res.prepare_payload ();
 						boost::beast::http::async_write (this_l->stream, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
-
 							// Perform the SSL shutdown
 							this_l->stream.async_shutdown (
 							std::bind (
 							&rai::rpc_connection_secure::on_shutdown,
 							this_l,
 							std::placeholders::_1));
-
 						});
 						break;
 					}

--- a/nano/node/stats.cpp
+++ b/nano/node/stats.cpp
@@ -360,7 +360,7 @@ std::string nano::stat::type_to_string (uint32_t key)
 		case nano::stat::type::traffic:
 			res = "traffic";
 			break;
-		case nano::stat::type::traffic_bootstrap:
+		case nano::stat::type::traffic_tcp:
 			res = "traffic_bootstrap";
 			break;
 		case nano::stat::type::vote:

--- a/nano/node/stats.hpp
+++ b/nano/node/stats.hpp
@@ -217,7 +217,7 @@ public:
 	enum class type : uint8_t
 	{
 		traffic,
-		traffic_bootstrap,
+		traffic_tcp,
 		error,
 		message,
 		block,

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1,10 +1,10 @@
-#include <nano/qt/qt.hpp>
-
 #include <boost/foreach.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <iomanip>
+#include <nano/node/network_generic.hpp>
+#include <nano/qt/qt.hpp>
 #include <sstream>
 
 namespace
@@ -1331,7 +1331,7 @@ void nano_qt::wallet::start ()
 			}));
 		}
 	});
-	node.observers.endpoint.add ([this_w](nano::endpoint const &) {
+	node.observers.endpoint.add ([this_w](nano::net::socket_addr const &) {
 		if (auto this_l = this_w.lock ())
 		{
 			this_l->application.postEvent (&this_l->processor, new eventloop_event ([this_w]() {
@@ -1881,8 +1881,8 @@ wallet (wallet_a)
 		this->wallet.pop_main_stack ();
 	});
 	QObject::connect (peers_bootstrap, &QPushButton::released, [this]() {
-		nano::endpoint endpoint;
-		auto error (nano::parse_endpoint (bootstrap_line->text ().toStdString (), endpoint));
+		bool error;
+		auto endpoint (nano::net::socket_addr::make_tcp (bootstrap_line->text ().toStdString (), error));
 		if (!error)
 		{
 			show_line_ok (*bootstrap_line);

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <nano/core_test/testutil.hpp>
+#include <nano/node/network_generic.hpp>
 #include <nano/node/testing.hpp>
 
 #include <nano/qt/qt.hpp>
@@ -44,7 +45,7 @@ TEST (wallet, status)
 		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
 	};
 	ASSERT_EQ ("Status: Disconnected, Blocks: 1", wallet->status->text ().toStdString ());
-	system.nodes[0]->peers.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000), 0);
+	system.nodes[0]->peers.insert (nano::net::socket_addr (boost::asio::ip::address_v6::loopback (), 10000), 0);
 	// Because of the wallet "vulnerable" message, this won't be the message displayed.
 	// However, it will still be part of the status set.
 	ASSERT_FALSE (wallet_has (nano_qt::status_types::synchronizing));

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -124,6 +124,7 @@ public:
 	nano::block_hash key () const;
 };
 
+// TODO: expand with supported protocols?
 class endpoint_key
 {
 public:

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -354,10 +354,10 @@ TEST (broadcast, sqrt_broadcast_simulate)
 TEST (peer_container, random_set)
 {
 	auto loopback (boost::asio::ip::address_v6::loopback ());
-	nano::peer_container container (nano::endpoint (loopback, 24000));
+	nano::peer_container container (boost::asio::ip::udp::endpoint (loopback, 24000));
 	for (auto i (0); i < 200; ++i)
 	{
-		container.contacted (nano::endpoint (loopback, 24001 + i), 0);
+		container.contacted (boost::asio::ip::udp::endpoint (loopback, 24001 + i), 0);
 	}
 	auto old (std::chrono::steady_clock::now ());
 	for (auto i (0); i < 10000; ++i)


### PR DESCRIPTION
In prep for tcp support, this PR provides an abstraction for the asio endpoint types, and a uniform socket api. 

As the nano namespace is getting overloaded, a `nano::net` namespace is introduced for core networking. The `nano::net::socket_addr` type replaces all uses of asio's udp and tcp specific endpoints (our internal aliases are removed as well). The hashing and ordering behavior should be retained. The  `nano::net::client` and subtypes replaces the socket type previously in bootstrap.

A few ideas are explored at the bottom half of network_generic.cpp.

Tests are passing locally and the node is syncing.