### PR TITLE
RPC unopened

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4405,6 +4405,24 @@ TEST (rpc, unopened_burn)
 	ASSERT_EQ (0, accounts.size ());
 }
 
+TEST (rpc, unopened_no_accounts)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "unopened");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & accounts (response.json.get_child ("accounts"));
+	ASSERT_EQ (0, accounts.size ());
+}
+
 TEST (rpc, uptime)
 {
 	nano::system system (24000, 1);

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4357,6 +4357,29 @@ TEST (rpc, stats_clear)
 	ASSERT_LE (system.nodes[0]->stats.last_reset ().count (), 5);
 }
 
+TEST (rpc, unopened)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	ASSERT_NE (nullptr, send);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "unopened");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("1", response.json.get<std::string> (key.pub.to_account ()));
+}
+
 TEST (rpc, uptime)
 {
 	nano::system system (24000, 1);

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -4377,7 +4377,9 @@ TEST (rpc, unopened)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response.status);
-	ASSERT_EQ ("1", response.json.get<std::string> (key.pub.to_account ()));
+	auto & accounts (response.json.get_child ("accounts"));
+	ASSERT_EQ (1, accounts.size ());
+	ASSERT_EQ ("1", accounts.get<std::string> (key.pub.to_account ()));
 }
 
 TEST (rpc, unopened_burn)
@@ -4399,7 +4401,8 @@ TEST (rpc, unopened_burn)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response.status);
-	ASSERT_EQ (response.json.not_found (), response.json.find (nano::burn_account.to_account ()));
+	auto & accounts (response.json.get_child ("accounts"));
+	ASSERT_EQ (0, accounts.size ());
 }
 
 TEST (rpc, uptime)

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3340,15 +3340,22 @@ void nano::rpc_handler::unopened ()
 		{
 			if (account != current_account)
 			{
-				accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+				if (current_account_sum > 0)
+				{
+					accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+					current_account_sum = 0;
+				}
 				current_account = account;
-				current_account_sum = 0;
 			}
 			current_account_sum += info.amount.number ();
 			++iterator;
 		}
 	}
-	accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ()); // last one
+	// last one after iterator reaches end
+	if (current_account_sum > 0)
+	{
+		accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+	}
 	response_l.add_child ("accounts", accounts);
 	response_errors ();
 }

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3321,6 +3321,7 @@ void nano::rpc_handler::unopened ()
 	auto end (node.store.pending_end ());
 	nano::account current_account;
 	nano::uint128_t current_account_sum{ 0 };
+	boost::property_tree::ptree accounts;
 	while (iterator != end)
 	{
 		nano::pending_key key (iterator->first);
@@ -3339,7 +3340,7 @@ void nano::rpc_handler::unopened ()
 		{
 			if (account != current_account)
 			{
-				response_l.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+				accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
 				current_account = account;
 				current_account_sum = 0;
 			}
@@ -3347,7 +3348,8 @@ void nano::rpc_handler::unopened ()
 			++iterator;
 		}
 	}
-	response_l.put (current_account.to_account (), current_account_sum.convert_to<std::string> ()); // last one
+	accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ()); // last one
+	response_l.add_child ("accounts", accounts);
 	response_errors ();
 }
 

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3319,47 +3319,60 @@ void nano::rpc_handler::unopened ()
 	rpc_control_impl ();
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
-		auto iterator (node.store.pending_begin (transaction, nano::pending_key (1, 0))); // exclude burn account
-		auto end (node.store.pending_end ());
-		nano::account current_account;
-		nano::uint128_t current_account_sum{ 0 };
-		boost::property_tree::ptree accounts;
-		while (iterator != end)
+		auto count (count_optional_impl ());
+		nano::account start (1); // exclude burn account by default
+		boost::optional<std::string> account_text (request.get_optional<std::string> ("account"));
+		if (account_text.is_initialized ())
 		{
-			nano::pending_key key (iterator->first);
-			nano::account account (key.account);
-			nano::pending_info info (iterator->second);
-			if (node.store.account_exists (transaction, account))
+			if (start.decode_account (account_text.get ()))
 			{
-				if (account.number () == std::numeric_limits<nano::uint256_t>::max ())
-				{
-					break;
-				}
-				// Skip existing accounts
-				iterator = node.store.pending_begin (transaction, nano::pending_key (account.number () + 1, 0));
+				ec = nano::error_common::bad_account_number;
 			}
-			else
+		}
+		if (!ec)
+		{
+			auto transaction (node.store.tx_begin_read ());
+			auto iterator (node.store.pending_begin (transaction, nano::pending_key (start, 0)));
+			auto end (node.store.pending_end ());
+			nano::account current_account (start);
+			nano::uint128_t current_account_sum{ 0 };
+			boost::property_tree::ptree accounts;
+			while (iterator != end && accounts.size () < count)
 			{
-				if (account != current_account)
+				nano::pending_key key (iterator->first);
+				nano::account account (key.account);
+				nano::pending_info info (iterator->second);
+				if (node.store.account_exists (transaction, account))
 				{
-					if (current_account_sum > 0)
+					if (account.number () == std::numeric_limits<nano::uint256_t>::max ())
 					{
-						accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
-						current_account_sum = 0;
+						break;
 					}
-					current_account = account;
+					// Skip existing accounts
+					iterator = node.store.pending_begin (transaction, nano::pending_key (account.number () + 1, 0));
 				}
-				current_account_sum += info.amount.number ();
-				++iterator;
+				else
+				{
+					if (account != current_account)
+					{
+						if (current_account_sum > 0)
+						{
+							accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+							current_account_sum = 0;
+						}
+						current_account = account;
+					}
+					current_account_sum += info.amount.number ();
+					++iterator;
+				}
 			}
+			// last one after iterator reaches end
+			if (current_account_sum > 0 && accounts.size () < count)
+			{
+				accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+			}
+			response_l.add_child ("accounts", accounts);
 		}
-		// last one after iterator reaches end
-		if (current_account_sum > 0)
-		{
-			accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
-		}
-		response_l.add_child ("accounts", accounts);
 	}
 	response_errors ();
 }

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3328,6 +3328,10 @@ void nano::rpc_handler::unopened ()
 		nano::pending_info info (iterator->second);
 		if (node.store.account_exists (transaction, account))
 		{
+			if (account.number () == std::numeric_limits<nano::uint256_t>::max ())
+			{
+				break;
+			}
 			// Skip existing accounts
 			iterator = node.store.pending_begin (transaction, nano::pending_key (account.number () + 1, 0));
 		}

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -3316,6 +3316,7 @@ void nano::rpc_handler::unchecked_keys ()
 
 void nano::rpc_handler::unopened ()
 {
+	rpc_control_impl ();
 	auto transaction (node.store.tx_begin_read ());
 	auto iterator (node.store.pending_begin (transaction, nano::pending_key (1, 0))); // exclude burn account
 	auto end (node.store.pending_end ());

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -206,6 +206,7 @@ public:
 	void unchecked_clear ();
 	void unchecked_get ();
 	void unchecked_keys ();
+	void unopened ();
 	void uptime ();
 	void validate_account_number ();
 	void version ();

--- a/nano/node/rpc_secure.cpp
+++ b/nano/node/rpc_secure.cpp
@@ -191,14 +191,12 @@ void nano::rpc_connection_secure::read ()
 						this_l->res.set (boost::beast::http::field::allow, "POST, OPTIONS");
 						this_l->res.prepare_payload ();
 						boost::beast::http::async_write (this_l->stream, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
-
 							// Perform the SSL shutdown
 							this_l->stream.async_shutdown (
 							std::bind (
 							&nano::rpc_connection_secure::on_shutdown,
 							this_l,
 							std::placeholders::_1));
-
 						});
 						break;
 					}

--- a/nano/node/rpc_secure.cpp
+++ b/nano/node/rpc_secure.cpp
@@ -191,12 +191,14 @@ void nano::rpc_connection_secure::read ()
 						this_l->res.set (boost::beast::http::field::allow, "POST, OPTIONS");
 						this_l->res.prepare_payload ();
 						boost::beast::http::async_write (this_l->stream, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+
 							// Perform the SSL shutdown
 							this_l->stream.async_shutdown (
 							std::bind (
 							&nano::rpc_connection_secure::on_shutdown,
 							this_l,
 							std::placeholders::_1));
+
 						});
 						break;
 					}


### PR DESCRIPTION
Fixes #1166 .

Wiki update:

## Unopened

_enable_control required, version 19.0+_

Returns the total pending balance for unopened accounts in the local database, starting at **account** (optional) up to **count** (optional), sorted by account number. _**Notes:**_ By default excludes the burn account.

Request:
  ```
  {  
    "action": "unopened",  
    "account": "xrb_1111111111111111111111111111111111111111111111111111hifc8npp",   
    "count": "1"
  }
  ```

Response:
  ```
  {
    "accounts": {
      "xrb_1111111111111111111111111111111111111111111111111111hifc8npp": "207034077034226183413773082289554618448"
    }
  }
  ```