### PR TITLE
RPC: option to render block as JSON

### DIFF
--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1072,9 +1072,8 @@ bool nano::state_block::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-void nano::state_block::serialize_json (std::string & string_a) const
+void nano::state_block::serialize_json (boost::property_tree::ptree & tree) const
 {
-	boost::property_tree::ptree tree;
 	tree.put ("type", "state");
 	tree.put ("account", hashables.account.to_account ());
 	tree.put ("previous", hashables.previous.to_string ());
@@ -1086,6 +1085,12 @@ void nano::state_block::serialize_json (std::string & string_a) const
 	signature.encode_hex (signature_l);
 	tree.put ("signature", signature_l);
 	tree.put ("work", nano::to_string_hex (work));
+}
+
+void nano::state_block::serialize_json (std::string & string_a) const
+{
+	boost::property_tree::ptree tree;
+	serialize_json (tree);
 	std::stringstream ostream;
 	boost::property_tree::write_json (ostream, tree);
 	string_a = ostream.str ();

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -240,6 +240,14 @@ bool nano::send_block::deserialize (nano::stream & stream_a)
 void nano::send_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
+	serialize_json (tree);
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, tree);
+	string_a = ostream.str ();
+}
+
+void nano::send_block::serialize_json (boost::property_tree::ptree & tree) const
+{
 	tree.put ("type", "send");
 	std::string previous;
 	hashables.previous.encode_hex (previous);
@@ -252,9 +260,6 @@ void nano::send_block::serialize_json (std::string & string_a) const
 	signature.encode_hex (signature_l);
 	tree.put ("work", nano::to_string_hex (work));
 	tree.put ("signature", signature_l);
-	std::stringstream ostream;
-	boost::property_tree::write_json (ostream, tree);
-	string_a = ostream.str ();
 }
 
 bool nano::send_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -555,6 +560,14 @@ bool nano::open_block::deserialize (nano::stream & stream_a)
 void nano::open_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
+	serialize_json (tree);
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, tree);
+	string_a = ostream.str ();
+}
+
+void nano::open_block::serialize_json (boost::property_tree::ptree & tree) const
+{
 	tree.put ("type", "open");
 	tree.put ("source", hashables.source.to_string ());
 	tree.put ("representative", representative ().to_account ());
@@ -563,9 +576,6 @@ void nano::open_block::serialize_json (std::string & string_a) const
 	signature.encode_hex (signature_l);
 	tree.put ("work", nano::to_string_hex (work));
 	tree.put ("signature", signature_l);
-	std::stringstream ostream;
-	boost::property_tree::write_json (ostream, tree);
-	string_a = ostream.str ();
 }
 
 bool nano::open_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -792,6 +802,14 @@ bool nano::change_block::deserialize (nano::stream & stream_a)
 void nano::change_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
+	serialize_json (tree);
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, tree);
+	string_a = ostream.str ();
+}
+
+void nano::change_block::serialize_json (boost::property_tree::ptree & tree) const
+{
 	tree.put ("type", "change");
 	tree.put ("previous", hashables.previous.to_string ());
 	tree.put ("representative", representative ().to_account ());
@@ -799,9 +817,6 @@ void nano::change_block::serialize_json (std::string & string_a) const
 	std::string signature_l;
 	signature.encode_hex (signature_l);
 	tree.put ("signature", signature_l);
-	std::stringstream ostream;
-	boost::property_tree::write_json (ostream, tree);
-	string_a = ostream.str ();
 }
 
 bool nano::change_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -1072,6 +1087,15 @@ bool nano::state_block::deserialize (nano::stream & stream_a)
 	return error;
 }
 
+void nano::state_block::serialize_json (std::string & string_a) const
+{
+	boost::property_tree::ptree tree;
+	serialize_json (tree);
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, tree);
+	string_a = ostream.str ();
+}
+
 void nano::state_block::serialize_json (boost::property_tree::ptree & tree) const
 {
 	tree.put ("type", "state");
@@ -1085,15 +1109,6 @@ void nano::state_block::serialize_json (boost::property_tree::ptree & tree) cons
 	signature.encode_hex (signature_l);
 	tree.put ("signature", signature_l);
 	tree.put ("work", nano::to_string_hex (work));
-}
-
-void nano::state_block::serialize_json (std::string & string_a) const
-{
-	boost::property_tree::ptree tree;
-	serialize_json (tree);
-	std::stringstream ostream;
-	boost::property_tree::write_json (ostream, tree);
-	string_a = ostream.str ();
 }
 
 bool nano::state_block::deserialize_json (boost::property_tree::ptree const & tree_a)
@@ -1372,6 +1387,14 @@ bool nano::receive_block::deserialize (nano::stream & stream_a)
 void nano::receive_block::serialize_json (std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
+	serialize_json (tree);
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, tree);
+	string_a = ostream.str ();
+}
+
+void nano::receive_block::serialize_json (boost::property_tree::ptree & tree) const
+{
 	tree.put ("type", "receive");
 	std::string previous;
 	hashables.previous.encode_hex (previous);
@@ -1383,9 +1406,6 @@ void nano::receive_block::serialize_json (std::string & string_a) const
 	signature.encode_hex (signature_l);
 	tree.put ("work", nano::to_string_hex (work));
 	tree.put ("signature", signature_l);
-	std::stringstream ostream;
-	boost::property_tree::write_json (ostream, tree);
-	string_a = ostream.str ();
 }
 
 bool nano::receive_block::deserialize_json (boost::property_tree::ptree const & tree_a)

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -306,6 +306,7 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void serialize_json (std::string &) const override;
+	void serialize_json (boost::property_tree::ptree &) const;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -76,6 +76,7 @@ public:
 	virtual nano::account representative () const;
 	virtual void serialize (nano::stream &) const = 0;
 	virtual void serialize_json (std::string &) const = 0;
+	virtual void serialize_json (boost::property_tree::ptree &) const = 0;
 	virtual void visit (nano::block_visitor &) const = 0;
 	virtual bool operator== (nano::block const &) const = 0;
 	virtual nano::block_type type () const = 0;
@@ -115,6 +116,7 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void serialize_json (std::string &) const override;
+	void serialize_json (boost::property_tree::ptree &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -158,6 +160,7 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void serialize_json (std::string &) const override;
+	void serialize_json (boost::property_tree::ptree &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -205,6 +208,7 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void serialize_json (std::string &) const override;
+	void serialize_json (boost::property_tree::ptree &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -248,6 +252,7 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void serialize_json (std::string &) const override;
+	void serialize_json (boost::property_tree::ptree &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;
@@ -306,7 +311,7 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void serialize_json (std::string &) const override;
-	void serialize_json (boost::property_tree::ptree &) const;
+	void serialize_json (boost::property_tree::ptree &) const override;
 	bool deserialize_json (boost::property_tree::ptree const &);
 	void visit (nano::block_visitor &) const override;
 	nano::block_type type () const override;

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -891,9 +891,20 @@ void nano::rpc_handler::block_info ()
 			response_l.put ("balance", balance.convert_to<std::string> ());
 			response_l.put ("height", std::to_string (sideband.height));
 			response_l.put ("local_timestamp", std::to_string (sideband.timestamp));
-			std::string contents;
-			block->serialize_json (contents);
-			response_l.put ("contents", contents);
+
+			bool json_block_l = request.get<bool> ("json_block", false);
+			if (json_block_l)
+			{
+				boost::property_tree::ptree block_node_l;
+				block->serialize_json (block_node_l);
+				response_l.add_child ("contents", block_node_l);
+			}
+			else
+			{
+				std::string contents;
+				block->serialize_json (contents);
+				response_l.put ("contents", contents);
+			}
 		}
 		else
 		{

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -1235,9 +1235,19 @@ void nano::rpc_handler::block_create ()
 					}
 					nano::state_block state (pub, previous, representative, balance, link, prv, pub, work);
 					response_l.put ("hash", state.hash ().to_string ());
-					std::string contents;
-					state.serialize_json (contents);
-					response_l.put ("block", contents);
+					bool block_only = request.get<bool> ("json_block", false);
+					if (block_only)
+					{
+						boost::property_tree::ptree block_node_l;
+						state.serialize_json (block_node_l);
+						response_l.add_child ("block", block_node_l);
+					}
+					else
+					{
+						std::string contents;
+						state.serialize_json (contents);
+						response_l.put ("block", contents);
+					}
 				}
 				else
 				{

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -1235,8 +1235,8 @@ void nano::rpc_handler::block_create ()
 					}
 					nano::state_block state (pub, previous, representative, balance, link, prv, pub, work);
 					response_l.put ("hash", state.hash ().to_string ());
-					bool block_only = request.get<bool> ("json_block", false);
-					if (block_only)
+					bool json_block_l = request.get<bool> ("json_block", false);
+					if (json_block_l)
 					{
 						boost::property_tree::ptree block_node_l;
 						state.serialize_json (block_node_l);

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -973,6 +973,8 @@ void nano::rpc_handler::blocks_info ()
 {
 	const bool pending = request.get<bool> ("pending", false);
 	const bool source = request.get<bool> ("source", false);
+	const bool json_block_l = request.get<bool> ("json_block", false);
+
 	std::vector<std::string> hashes;
 	boost::property_tree::ptree blocks;
 	auto transaction (node.store.tx_begin_read ());
@@ -997,9 +999,20 @@ void nano::rpc_handler::blocks_info ()
 					entry.put ("balance", balance.convert_to<std::string> ());
 					entry.put ("height", std::to_string (sideband.height));
 					entry.put ("local_timestamp", std::to_string (sideband.timestamp));
-					std::string contents;
-					block->serialize_json (contents);
-					entry.put ("contents", contents);
+
+					if (json_block_l)
+					{
+						boost::property_tree::ptree block_node_l;
+						block->serialize_json (block_node_l);
+						entry.add_child ("contents", block_node_l);
+					}
+					else
+					{
+						std::string contents;
+						block->serialize_json (contents);
+						entry.put ("contents", contents);
+					}
+
 					if (pending)
 					{
 						bool exists (false);
@@ -1569,6 +1582,7 @@ void nano::rpc_handler::confirmation_info ()
 {
 	const bool representatives = request.get<bool> ("representatives", false);
 	const bool contents = request.get<bool> ("contents", true);
+	const bool json_block_l = request.get<bool> ("json_block", false);
 	std::string root_text (request.get<std::string> ("root"));
 	nano::uint512_union root;
 	if (!root.decode_hex (root_text))
@@ -1592,9 +1606,18 @@ void nano::rpc_handler::confirmation_info ()
 				total += tally;
 				if (contents)
 				{
-					std::string contents;
-					i->second->serialize_json (contents);
-					entry.put ("contents", contents);
+					if (json_block_l)
+					{
+						boost::property_tree::ptree block_node_l;
+						i->second->serialize_json (block_node_l);
+						entry.add_child ("contents", block_node_l);
+					}
+					else
+					{
+						std::string contents;
+						i->second->serialize_json (contents);
+						entry.put ("contents", contents);
+					}
 				}
 				if (representatives)
 				{
@@ -3277,6 +3300,7 @@ void nano::rpc_handler::unchecked_clear ()
 
 void nano::rpc_handler::unchecked_get ()
 {
+	const bool json_block_l = request.get<bool> ("json_block", false);
 	auto hash (hash_impl ());
 	if (!ec)
 	{
@@ -3288,9 +3312,19 @@ void nano::rpc_handler::unchecked_get ()
 			{
 				nano::unchecked_info info (i->second);
 				response_l.put ("modified_timestamp", std::to_string (info.modified));
-				std::string contents;
-				info.block->serialize_json (contents);
-				response_l.put ("contents", contents);
+
+				if (json_block_l)
+				{
+					boost::property_tree::ptree block_node_l;
+					info.block->serialize_json (block_node_l);
+					response_l.add_child ("contents", block_node_l);
+				}
+				else
+				{
+					std::string contents;
+					info.block->serialize_json (contents);
+					response_l.put ("contents", contents);
+				}
 				break;
 			}
 		}
@@ -3304,6 +3338,7 @@ void nano::rpc_handler::unchecked_get ()
 
 void nano::rpc_handler::unchecked_keys ()
 {
+	const bool json_block_l = request.get<bool> ("json_block", false);
 	auto count (count_optional_impl ());
 	nano::uint256_union key (0);
 	boost::optional<std::string> hash_text (request.get_optional<std::string> ("key"));
@@ -3322,12 +3357,21 @@ void nano::rpc_handler::unchecked_keys ()
 		{
 			boost::property_tree::ptree entry;
 			nano::unchecked_info info (i->second);
-			std::string contents;
-			info.block->serialize_json (contents);
 			entry.put ("key", nano::block_hash (i->first.key ()).to_string ());
 			entry.put ("hash", info.block->hash ().to_string ());
 			entry.put ("modified_timestamp", std::to_string (info.modified));
-			entry.put ("contents", contents);
+			if (json_block_l)
+			{
+				boost::property_tree::ptree block_node_l;
+				info.block->serialize_json (block_node_l);
+				entry.add_child ("contents", block_node_l);
+			}
+			else
+			{
+				std::string contents;
+				info.block->serialize_json (contents);
+				entry.put ("contents", contents);
+			}
 			unchecked.push_back (std::make_pair ("", entry));
 		}
 		response_l.add_child ("unchecked", unchecked);

--- a/nano/node/rpc_secure.cpp
+++ b/nano/node/rpc_secure.cpp
@@ -191,14 +191,12 @@ void nano::rpc_connection_secure::read ()
 						this_l->res.set (boost::beast::http::field::allow, "POST, OPTIONS");
 						this_l->res.prepare_payload ();
 						boost::beast::http::async_write (this_l->stream, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
-
 							// Perform the SSL shutdown
 							this_l->stream.async_shutdown (
 							std::bind (
 							&nano::rpc_connection_secure::on_shutdown,
 							this_l,
 							std::placeholders::_1));
-
 						});
 						break;
 					}


### PR DESCRIPTION
A new option `json_block` (bool) is added to `create_block` and a few other RPCs stringifying blocks. 

Default is "false" (the old behavior)

If set to "true", the returned block will be proper JSON instead of being stringified with embedded escapes of newlines and quotes. This makes it easier to move offline-signed blocks for processing via the Qt wallet or websites with process functionality.

(A future PR could make `process` support non-stringified blocks.)