### PR TITLE
[ASAN] replace junk data with 0 for peer_put ()

### DIFF
--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -896,8 +896,8 @@ void nano::mdb_store::delete_node_id (nano::transaction const & transaction_a)
 
 void nano::mdb_store::peer_put (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a)
 {
-	nano::mdb_val junk;
-	auto status (mdb_put (env.tx (transaction_a), peers, nano::mdb_val (endpoint_a), junk, 0));
+	nano::mdb_val zero (0);
+	auto status (mdb_put (env.tx (transaction_a), peers, nano::mdb_val (endpoint_a), zero, 0));
 	release_assert (status == 0);
 }
 


### PR DESCRIPTION
Clang 7.0.0, Ubuntu 18.10
```
[ RUN      ] block_store.peers
/root/nano_build/lmdb/libraries/liblmdb/mdb.c:7405:19: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:43:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /root/nano_build/lmdb/libraries/liblmdb/mdb.c:7405:19 in
[       OK ] block_store.peers (8 ms)
```
