### PR TITLE
Fix ASAN warning caused by global initialization order using CryptoPP functions

### DIFF
--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1212,7 +1212,7 @@ void nano::mdb_store::upgrade_v12_to_v13 (size_t const batch_size)
 	size_t cost (0);
 	nano::account account (0);
 	auto transaction (tx_begin_write ());
-	while (!stopped && account != nano::not_an_account)
+	while (!stopped && account != nano::not_an_account ())
 	{
 		nano::account first (0);
 		nano::account_info second;
@@ -1261,10 +1261,10 @@ void nano::mdb_store::upgrade_v12_to_v13 (size_t const batch_size)
 		}
 		else
 		{
-			account = nano::not_an_account;
+			account = nano::not_an_account ();
 		}
 	}
-	if (account == nano::not_an_account)
+	if (account == nano::not_an_account ())
 	{
 		BOOST_LOG (logging.log) << boost::str (boost::format ("Completed sideband upgrade"));
 		version_put (transaction, 13);

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1212,7 +1212,8 @@ void nano::mdb_store::upgrade_v12_to_v13 (size_t const batch_size)
 	size_t cost (0);
 	nano::account account (0);
 	auto transaction (tx_begin_write ());
-	while (!stopped && account != nano::not_an_account ())
+	auto const & not_an_account (nano::not_an_account ());
+	while (!stopped && account != not_an_account)
 	{
 		nano::account first (0);
 		nano::account_info second;
@@ -1261,10 +1262,10 @@ void nano::mdb_store::upgrade_v12_to_v13 (size_t const batch_size)
 		}
 		else
 		{
-			account = nano::not_an_account ();
+			account = not_an_account;
 		}
 	}
-	if (account == nano::not_an_account ())
+	if (account == not_an_account)
 	{
 		BOOST_LOG (logging.log) << boost::str (boost::format ("Completed sideband upgrade"));
 		version_put (transaction, 13);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -3817,10 +3817,10 @@ nano::inactive_node::~inactive_node ()
 
 nano::udp_buffer::udp_buffer (nano::stat & stats, size_t size, size_t count) :
 stats (stats),
-slab (size * count),
-entries (count),
 free (count),
 full (count),
+slab (size * count),
+entries (count),
 stopped (false)
 {
 	assert (count > 0);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -3021,7 +3021,7 @@ confirmed (false),
 stopped (false),
 announcements (0)
 {
-	last_votes.insert (std::make_pair (nano::not_an_account, nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () }));
+	last_votes.insert (std::make_pair (nano::not_an_account (), nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () }));
 	blocks.insert (std::make_pair (block_a->hash (), block_a));
 }
 
@@ -3817,10 +3817,10 @@ nano::inactive_node::~inactive_node ()
 
 nano::udp_buffer::udp_buffer (nano::stat & stats, size_t size, size_t count) :
 stats (stats),
-free (count),
-full (count),
 slab (size * count),
 entries (count),
+free (count),
+full (count),
 stopped (false)
 {
 	assert (count > 0);
@@ -3847,12 +3847,13 @@ nano::udp_data * nano::udp_buffer::allocate ()
 		result = free.front ();
 		free.pop_front ();
 	}
-	if (result == nullptr)
+	if (result == nullptr && !full.empty ())
 	{
 		result = full.front ();
 		full.pop_front ();
 		stats.inc (nano::stat::type::udp, nano::stat::detail::overflow, nano::stat::dir::in);
 	}
+	assert (result);
 	return result;
 }
 void nano::udp_buffer::enqueue (nano::udp_data * data_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -3847,13 +3847,12 @@ nano::udp_data * nano::udp_buffer::allocate ()
 		result = free.front ();
 		free.pop_front ();
 	}
-	if (result == nullptr && !full.empty ())
+	if (result == nullptr)
 	{
 		result = full.front ();
 		full.pop_front ();
 		stats.inc (nano::stat::type::udp, nano::stat::detail::overflow, nano::stat::dir::in);
 	}
-	assert (result);
 	return result;
 }
 void nano::udp_buffer::enqueue (nano::udp_data * data_a)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -314,10 +314,10 @@ private:
 	nano::stat & stats;
 	std::mutex mutex;
 	std::condition_variable condition;
-	boost::circular_buffer<nano::udp_data *> free;
-	boost::circular_buffer<nano::udp_data *> full;
 	std::vector<uint8_t> slab;
 	std::vector<nano::udp_data> entries;
+	boost::circular_buffer<nano::udp_data *> free;
+	boost::circular_buffer<nano::udp_data *> full;
 	bool stopped;
 };
 class network

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -314,10 +314,10 @@ private:
 	nano::stat & stats;
 	std::mutex mutex;
 	std::condition_variable condition;
-	std::vector<uint8_t> slab;
-	std::vector<nano::udp_data> entries;
 	boost::circular_buffer<nano::udp_data *> free;
 	boost::circular_buffer<nano::udp_data *> full;
+	std::vector<uint8_t> slab;
+	std::vector<nano::udp_data> entries;
 	bool stopped;
 };
 class network

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -64,10 +64,6 @@ public:
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 	burn_account (0)
 	{
-		CryptoPP::AutoSeededRandomPool random_pool;
-		// Randomly generating these mean no two nodes will ever have the same sentinel values which protects against some insecure algorithms
-		random_pool.GenerateBlock (not_a_block.bytes.data (), not_a_block.bytes.size ());
-		random_pool.GenerateBlock (not_an_account.bytes.data (), not_an_account.bytes.size ());
 	}
 	nano::keypair zero_key;
 	nano::keypair test_genesis_key;
@@ -80,9 +76,24 @@ public:
 	nano::account genesis_account;
 	std::string genesis_block;
 	nano::uint128_t genesis_amount;
-	nano::block_hash not_a_block;
-	nano::account not_an_account;
 	nano::account burn_account;
+
+	nano::account const & not_an_account ()
+	{
+		static bool is_initialized = false;
+		static std::mutex mutex;
+		std::lock_guard<std::mutex> lk (mutex);
+		if (!is_initialized)
+		{
+			// Randomly generating these mean no two nodes will ever have the same sentinel values which protects against some insecure algorithms
+			nano::random_pool.GenerateBlock (not_an_account_m.bytes.data (), not_an_account_m.bytes.size ());
+			is_initialized = true;
+		}
+		return not_an_account_m;
+	}
+
+private:
+	nano::account not_an_account_m;
 };
 ledger_constants globals;
 }
@@ -105,10 +116,11 @@ std::string const & nano::nano_live_genesis (globals.nano_live_genesis);
 nano::account const & nano::genesis_account (globals.genesis_account);
 std::string const & nano::genesis_block (globals.genesis_block);
 nano::uint128_t const & nano::genesis_amount (globals.genesis_amount);
-nano::block_hash const & nano::not_a_block (globals.not_a_block);
-nano::block_hash const & nano::not_an_account (globals.not_an_account);
 nano::account const & nano::burn_account (globals.burn_account);
-
+nano::account const & nano::not_an_account ()
+{
+	return globals.not_an_account ();
+}
 // Create a new random keypair
 nano::keypair::keypair ()
 {

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -320,10 +320,8 @@ extern std::string const & genesis_block;
 extern nano::account const & genesis_account;
 extern nano::account const & burn_account;
 extern nano::uint128_t const & genesis_amount;
-// A block hash that compares inequal to any real block hash
-extern nano::block_hash const & not_a_block;
 // An account number that compares inequal to any real account number
-extern nano::block_hash const & not_an_account;
+extern nano::account const & not_an_account ();
 class genesis
 {
 public:


### PR DESCRIPTION
Fixes ASAN warning Mac/Clang:
```
[1m/Users/user/Library/raiblocks/crypto/cryptopp/randpool.cpp:46:4:[1m[31m runtime error: [1m[0m[1mreference binding to null pointer of type ‘const CryptoPP::NameValuePairs’[1m[0m
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/user/Library/raiblocks/crypto/cryptopp/randpool.cpp:46:4 in
[1m/Users/user/Library/raiblocks/crypto/cryptopp/cryptlib.cpp:61:64:[1m[31m runtime error: [1m[0m[1mreference binding to null pointer of type ‘const CryptoPP::NameValuePairs’[1m[0m
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/user/Library/raiblocks/crypto/cryptopp/cryptlib.cpp:61:64
```

This is because our `ledger_constants globals` variable is initialized with globals from CryptoPP which haven't been properly initialized yet. There is not specified order of global initialization within different translation units. The problem specifically comes from:

`random_pool.GenerateBlock (not_an_account.bytes.data (), not_an_account.bytes.size ());` in the `ledger_constants` constructor. This ultimately uses a default argument of `const NameValuePairs &params = g_nullNameValuePairs` but `g_nullNameValuePairs` has not been initialized yet.

I have modified it to use lazy initialization when the nano::not_an_account is used and made it thread safe as well.

not_a_block is not used so has been removed