### PR TITLE
RPC pending - sort by amount

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -1752,74 +1752,98 @@ TEST (rpc, pending)
 	request.put ("action", "pending");
 	request.put ("account", key1.pub.to_account ());
 	request.put ("count", "100");
-	test_response response (request, rpc, system.io_ctx);
-	system.deadline_set (5s);
-	while (response.status == 0)
 	{
-		ASSERT_NO_ERROR (system.poll ());
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		nano::block_hash hash (blocks_node.begin ()->second.get<std::string> (""));
+		ASSERT_EQ (block1->hash (), hash);
 	}
-	ASSERT_EQ (200, response.status);
-	auto & blocks_node (response.json.get_child ("blocks"));
-	ASSERT_EQ (1, blocks_node.size ());
-	nano::block_hash hash1 (blocks_node.begin ()->first);
-	ASSERT_EQ (block1->hash (), hash1);
+	request.put ("sorting", "true"); // Sorting test
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		nano::block_hash hash (blocks_node.begin ()->first);
+		ASSERT_EQ (block1->hash (), hash);
+		std::string amount (blocks_node.begin ()->second.get<std::string> (""));
+		ASSERT_EQ ("100", amount);
+	}
 	request.put ("threshold", "100"); // Threshold test
-	test_response response0 (request, rpc, system.io_ctx);
-	system.deadline_set (5s);
-	while (response0.status == 0)
 	{
-		ASSERT_NO_ERROR (system.poll ());
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		std::unordered_map<nano::block_hash, nano::uint128_union> blocks;
+		for (auto i (blocks_node.begin ()), j (blocks_node.end ()); i != j; ++i)
+		{
+			nano::block_hash hash;
+			hash.decode_hex (i->first);
+			nano::uint128_union amount;
+			amount.decode_dec (i->second.get<std::string> (""));
+			blocks[hash] = amount;
+			boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
+			ASSERT_FALSE (source.is_initialized ());
+			boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
+			ASSERT_FALSE (min_version.is_initialized ());
+		}
+		ASSERT_EQ (blocks[block1->hash ()], 100);
 	}
-	ASSERT_EQ (200, response0.status);
-	blocks_node = response0.json.get_child ("blocks");
-	ASSERT_EQ (1, blocks_node.size ());
-	std::unordered_map<nano::block_hash, nano::uint128_union> blocks;
-	for (auto i (blocks_node.begin ()), j (blocks_node.end ()); i != j; ++i)
-	{
-		nano::block_hash hash;
-		hash.decode_hex (i->first);
-		nano::uint128_union amount;
-		amount.decode_dec (i->second.get<std::string> (""));
-		blocks[hash] = amount;
-		boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
-		ASSERT_FALSE (source.is_initialized ());
-		boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
-		ASSERT_FALSE (min_version.is_initialized ());
-	}
-	ASSERT_EQ (blocks[block1->hash ()], 100);
 	request.put ("threshold", "101");
-	test_response response1 (request, rpc, system.io_ctx);
-	while (response1.status == 0)
 	{
-		ASSERT_NO_ERROR (system.poll ());
+		test_response response (request, rpc, system.io_ctx);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (0, blocks_node.size ());
 	}
-	ASSERT_EQ (200, response1.status);
-	blocks_node = response1.json.get_child ("blocks");
-	ASSERT_EQ (0, blocks_node.size ());
 	request.put ("threshold", "0");
 	request.put ("source", "true");
 	request.put ("min_version", "true");
-	test_response response2 (request, rpc, system.io_ctx);
-	system.deadline_set (5s);
-	while (response2.status == 0)
 	{
-		ASSERT_NO_ERROR (system.poll ());
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		std::unordered_map<nano::block_hash, nano::uint128_union> amounts;
+		std::unordered_map<nano::block_hash, nano::account> sources;
+		for (auto i (blocks_node.begin ()), j (blocks_node.end ()); i != j; ++i)
+		{
+			nano::block_hash hash;
+			hash.decode_hex (i->first);
+			amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
+			sources[hash].decode_account (i->second.get<std::string> ("source"));
+			ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
+		}
+		ASSERT_EQ (amounts[block1->hash ()], 100);
+		ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
 	}
-	ASSERT_EQ (200, response2.status);
-	blocks_node = response2.json.get_child ("blocks");
-	ASSERT_EQ (1, blocks_node.size ());
-	std::unordered_map<nano::block_hash, nano::uint128_union> amounts;
-	std::unordered_map<nano::block_hash, nano::account> sources;
-	for (auto i (blocks_node.begin ()), j (blocks_node.end ()); i != j; ++i)
-	{
-		nano::block_hash hash;
-		hash.decode_hex (i->first);
-		amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
-		sources[hash].decode_account (i->second.get<std::string> ("source"));
-		ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
-	}
-	ASSERT_EQ (amounts[block1->hash ()], 100);
-	ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
 }
 
 TEST (rpc_config, serialization)

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -1761,7 +1761,7 @@ TEST (rpc, pending)
 	ASSERT_EQ (200, response.status);
 	auto & blocks_node (response.json.get_child ("blocks"));
 	ASSERT_EQ (1, blocks_node.size ());
-	nano::block_hash hash1 (blocks_node.begin ()->second.get<std::string> (""));
+	nano::block_hash hash1 (blocks_node.begin ()->first);
 	ASSERT_EQ (block1->hash (), hash1);
 	request.put ("threshold", "100"); // Threshold test
 	test_response response0 (request, rpc, system.io_ctx);


### PR DESCRIPTION
Per request of @bbedward . This PR serves to add a `sorting` option to RPC "pending". It helps services which will now only need to get the first X blocks ordered by amount, to prioritize receiving the most important blocks instead of dust.

I decided to use `ptree::sort()` due to how cleaner it makes the code vs. having two branches as in `ledger ()`.

===== Wiki entry update =====

### Optional "sorting"

Boolean, false by default. Additionally sorts the blocks by their amounts in descending order.