### PR TITLE
Remove fork() warning from gtest output for some builds

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -577,8 +577,9 @@ TEST (block_builder, state_equality)
 	ASSERT_EQ (block1.work, block2->work);
 }
 
-TEST (block_builder, state_errors)
+TEST (block_builderDeathTest, state_errors)
 {
+	::testing::FLAGS_gtest_death_test_style = "threadsafe";
 	std::error_code ec;
 	nano::block_builder builder;
 


### PR DESCRIPTION
When running the core_tests `block_builder.state_errors` has output (in travis Linux and on my mac):
> [WARNING] /workspace/gtest/src/gtest-death-test.cc:825:: Death tests use fork(), which is unsafe particularly in a threaded context

According to https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-test-naming:

> IMPORTANT: We strongly recommend you to follow the convention of naming your test suite (not test) *DeathTest when it contains a death test.

This doesn't help with the warning message, it just makes it run at the start of the test run which is supposed to help raise awareness of threading issues apparently.

From https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads:

> The "threadsafe" death test style was introduced in order to help mitigate the risks of testing in a possibly multithreaded environment. It trades increased test execution time (potentially dramatically so) for improved thread safety.

This is referring to the `testing::FLAGS_gtest_death_test_style="threadsafe"` option. Using this now suppresses the original warning because if we were using it in a thread unsafe manner it should sprout a different error.