### PR TITLE
Check that full is not empty and assert

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -3847,12 +3847,13 @@ nano::udp_data * nano::udp_buffer::allocate ()
 		result = free.front ();
 		free.pop_front ();
 	}
-	if (result == nullptr)
+	if (result == nullptr && !full.empty ())
 	{
 		result = full.front ();
 		full.pop_front ();
 		stats.inc (nano::stat::type::udp, nano::stat::detail::overflow, nano::stat::dir::in);
 	}
+	release_assert (result || stopped);
 	return result;
 }
 void nano::udp_buffer::enqueue (nano::udp_data * data_a)


### PR DESCRIPTION
`full` is not checked as to whether it has any elements in before popping off the container, which I guess can happen in some circumstances as the comment above the function declaration states `// Return nullptr if the container has stopped`. I have added an assert to check for this as well as a precaution.