### PR TITLE
Remove expect_death test

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -582,13 +582,6 @@ TEST (block_builder, state_errors)
 	std::error_code ec;
 	nano::block_builder builder;
 
-	// Make sure we assert when building a block without an std::error_code
-	EXPECT_DEATH (builder
-	              .state ()
-	              .account_hex ("xyz")
-	              .build (),
-	".*");
-
 	// Ensure the proper error is generated
 	builder.state ().account_hex ("xrb_bad").build (ec);
 	ASSERT_EQ (ec, nano::error_common::bad_account_number);


### PR DESCRIPTION
Not supported on all platforms. It was an experiment to try and catch asserts, but there seems to be a few issues with the implementation in gtest.