### PR TITLE
Command to generate input to RNG test suites

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -48,6 +48,7 @@ int main (int argc, char * const * argv)
 		("debug_profile_sign", "Profile signature generation")
 		("debug_profile_process", "Profile active blocks processing (only for nano_test_network)")
 		("debug_profile_votes", "Profile votes processing (only for nano_test_network)")
+		("debug_random_feed", "Generates output to RNG test suites")
 		("debug_rpc", "Read an RPC command from stdin and invoke it. Network operations will have no effect.")
 		("debug_validate_blocks", "Check all blocks for correct hash, signature, work value")
 		("debug_peers", "Display peer IPv6:port connections")
@@ -639,6 +640,23 @@ int main (int argc, char * const * argv)
 			else
 			{
 				std::cerr << "For this test ACTIVE_NETWORK should be nano_test_network" << std::endl;
+			}
+		}
+		else if (vm.count ("debug_random_feed"))
+		{
+			/*
+			 * This command redirects an infinite stream of bytes from the random pool to standard out.
+			 * The result can be fed into various tools for testing RNGs and entropy pools.
+			 *
+			 * Example, running the entire dieharder test suite:
+			 *
+			 *   ./nano_node --debug_random_feed | dieharder -a -g 200
+			 */
+			nano::raw_key seed;
+			for (;;)
+			{
+				nano::random_pool::generate_block (seed.data.bytes.data (), seed.data.bytes.size ());
+				std::cout.write (reinterpret_cast<const char *> (seed.data.bytes.data ()), seed.data.bytes.size ());
 			}
 		}
 		else if (vm.count ("debug_rpc"))


### PR DESCRIPTION
Replaces #550 

`--debug_random_feed` makes it easy to feed output from the random generator used for keypair/seed generation into test suites, such as [dieharder](https://webhome.phy.duke.edu/~rgb/General/dieharder.php) (available at least for macOS and Linux)

Example:

```
brew install dieharder

./nano_node --debug_random_feed | dieharder -a -g 200

   rng_name    |rands/second|   Seed   |
stdin_input_raw|  7.24e+06  |3948269495|
#=============================================================================#
        test_name   |ntup| tsamples |psamples|  p-value |Assessment
#=============================================================================#
   diehard_birthdays|   0|       100|     100|0.55550323|  PASSED
      diehard_operm5|   0|   1000000|     100|0.35161023|  PASSED
  diehard_rank_32x32|   0|     40000|     100|0.76240519|  PASSED
    diehard_rank_6x8|   0|    100000|     100|0.62220366|  PASSED
   diehard_bitstream|   0|   2097152|     100|0.67553992|  PASSED
        diehard_opso|   0|   2097152|     100|0.64977517|  PASSED
        diehard_oqso|   0|   2097152|     100|0.12354025|  PASSED
 ... a lot more tests here ...
```

Running the entire suite takes a long time (for good reasons), though it's possible to pick just a few strong tests if we want this in CI in the future.