### PR TITLE
Improve block_exists table lookup order

### DIFF
--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1709,13 +1709,14 @@ bool nano::mdb_store::block_exists (nano::transaction const & transaction_a, nan
 
 bool nano::mdb_store::block_exists (nano::transaction const & tx_a, nano::block_hash const & hash_a)
 {
+	// Table lookups are ordered by match probability
 	// clang-format off
 	return
+		block_exists (tx_a, nano::block_type::state, hash_a) ||
 		block_exists (tx_a, nano::block_type::send, hash_a) ||
 		block_exists (tx_a, nano::block_type::receive, hash_a) ||
 		block_exists (tx_a, nano::block_type::open, hash_a) ||
-		block_exists (tx_a, nano::block_type::change, hash_a) ||
-		block_exists (tx_a, nano::block_type::state, hash_a);
+		block_exists (tx_a, nano::block_type::change, hash_a);
 	// clang-format on
 }
 


### PR DESCRIPTION
Same as was done for block_raw_get, i.e order table lookups according to match probability.