### PR TITLE
RPC config versioning, remove unused options

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -1833,22 +1833,17 @@ TEST (rpc_config, serialization)
 	config1.address = boost::asio::ip::address_v6::any ();
 	config1.port = 10;
 	config1.enable_control = true;
-	config1.frontier_request_limit = 8192;
-	config1.chain_request_limit = 4096;
 	nano::jsonconfig tree;
 	config1.serialize_json (tree);
 	nano::rpc_config config2;
 	ASSERT_NE (config2.address, config1.address);
 	ASSERT_NE (config2.port, config1.port);
 	ASSERT_NE (config2.enable_control, config1.enable_control);
-	ASSERT_NE (config2.frontier_request_limit, config1.frontier_request_limit);
-	ASSERT_NE (config2.chain_request_limit, config1.chain_request_limit);
-	config2.deserialize_json (tree);
+	bool upgraded{ false };
+	config2.deserialize_json (upgraded, tree);
 	ASSERT_EQ (config2.address, config1.address);
 	ASSERT_EQ (config2.port, config1.port);
 	ASSERT_EQ (config2.enable_control, config1.enable_control);
-	ASSERT_EQ (config2.frontier_request_limit, config1.frontier_request_limit);
-	ASSERT_EQ (config2.chain_request_limit, config1.chain_request_limit);
 }
 
 TEST (rpc, search_pending)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -106,7 +106,7 @@ public:
 			}
 			if (!rpc_l.get_error ())
 			{
-				rpc.deserialize_json (rpc_l);
+				rpc.deserialize_json (upgraded_a, rpc_l);
 			}
 			if (!opencl_l.get_error ())
 			{

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -40,7 +40,7 @@ nano::error nano::daemon_config::deserialize_json (bool & upgraded_a, nano::json
 			json.get_optional<bool> ("rpc_enable", rpc_enable);
 			auto rpc_l (json.get_required_child ("rpc"));
 
-			if (!rpc.deserialize_json (rpc_l))
+			if (!rpc.deserialize_json (upgraded_a, rpc_l))
 			{
 				auto node_l (json.get_required_child ("node"));
 				if (!json.get_error ())

--- a/nano/node/rpcconfig.hpp
+++ b/nano/node/rpcconfig.hpp
@@ -37,14 +37,16 @@ class rpc_config
 public:
 	rpc_config (bool = false);
 	nano::error serialize_json (nano::jsonconfig &) const;
-	nano::error deserialize_json (nano::jsonconfig &);
+	nano::error deserialize_json (bool & upgraded_a, nano::jsonconfig &);
 	boost::asio::ip::address_v6 address;
 	uint16_t port;
 	bool enable_control;
-	uint64_t frontier_request_limit;
-	uint64_t chain_request_limit;
 	rpc_secure_config secure;
 	uint8_t max_json_depth;
 	bool enable_sign_hash;
+	static int json_version ()
+	{
+		return 1;
+	}
 };
 }


### PR DESCRIPTION
frontier_request_limit and chain_request_limit are not used. Introduces a version field for the rpc json child.