### PR TITLE
RPC: Support json literals as block input

### DIFF
--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -212,6 +212,7 @@ public:
 	nano::account account_impl (std::string = "");
 	nano::amount amount_impl ();
 	std::shared_ptr<nano::block> block_impl (bool = true);
+	std::shared_ptr<nano::block> block_json_impl (bool = true);
 	nano::block_hash hash_impl (std::string = "hash");
 	nano::amount threshold_optional_impl ();
 	uint64_t work_optional_impl ();


### PR DESCRIPTION
Followup to https://github.com/nanocurrency/nano-node/pull/1740 which optionally returned json block literals instead of strings. This does the same for input blocks. In total, this should make working with blocks in RPC's a bit more ergonomic.