### PR TITLE
Include all representatives with delegated weight in online representatives list

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2774,7 +2774,7 @@ minimum (minimum_a)
 void nano::online_reps::observe (nano::account const & rep_a)
 {
 	auto transaction (ledger.store.tx_begin_read ());
-	if (ledger.weight (transaction, rep_a) > nano::Gxrb_ratio)
+	if (ledger.weight (transaction, rep_a) > 0)
 	{
 		std::lock_guard<std::mutex> lock (mutex);
 		reps.insert (rep_a);


### PR DESCRIPTION
Previously representatives had to have 1000 Nano voting weight to be included in online_reps and this reduces the amount to any representatives that have at least 1 raw delegated to them.