### PR TITLE
Don't output useless log file entries

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -971,10 +971,6 @@ bool nano::bootstrap_attempt::request_frontier (std::unique_lock<std::mutex> & l
 			{
 				BOOST_LOG (node->log) << boost::str (boost::format ("Completed frontier request, %1% out of sync accounts according to %2%") % pulls.size () % connection_l->endpoint);
 			}
-			else
-			{
-				BOOST_LOG (node->log) << "frontier_req failed, reattempting";
-			}
 		}
 	}
 	return result;

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -971,6 +971,10 @@ bool nano::bootstrap_attempt::request_frontier (std::unique_lock<std::mutex> & l
 			{
 				BOOST_LOG (node->log) << boost::str (boost::format ("Completed frontier request, %1% out of sync accounts according to %2%") % pulls.size () % connection_l->endpoint);
 			}
+			else	
+			{	
+				node->stats.inc (nano::stat::type::error, nano::stat::detail::frontier_req, nano::stat::dir::out);
+			}
 		}
 	}
 	return result;

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -971,8 +971,8 @@ bool nano::bootstrap_attempt::request_frontier (std::unique_lock<std::mutex> & l
 			{
 				BOOST_LOG (node->log) << boost::str (boost::format ("Completed frontier request, %1% out of sync accounts according to %2%") % pulls.size () % connection_l->endpoint);
 			}
-			else	
-			{	
+			else
+			{
 				node->stats.inc (nano::stat::type::error, nano::stat::detail::frontier_req, nano::stat::dir::out);
 			}
 		}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -871,12 +871,6 @@ void nano::network::receive_action (nano::udp_data * data_a, nano::endpoint cons
 					/* Already checked, unreachable */
 					break;
 			}
-
-			auto ignore ((parser.status == nano::message_parser::parse_status::outdated_version) || (parser.status == nano::message_parser::parse_status::invalid_header));
-			if (node.config.logging.network_logging () && !ignore)
-			{
-				BOOST_LOG (node.log) << "Could not parse message.  Error: " << parser.status_string ();
-			}
 		}
 		else
 		{
@@ -1145,10 +1139,6 @@ void nano::vote_processor::vote (std::shared_ptr<nano::vote> vote_a, nano::endpo
 		else
 		{
 			node.stats.inc (nano::stat::type::vote, nano::stat::detail::vote_overflow);
-			if (node.config.logging.vote_logging ())
-			{
-				BOOST_LOG (node.log) << "Votes overflow";
-			}
 		}
 	}
 }
@@ -2975,10 +2965,6 @@ void nano::network::send_buffer (uint8_t const * data_a, size_t size_a, nano::en
 			if (ec == boost::system::errc::host_unreachable)
 			{
 				this->node.stats.inc (nano::stat::type::error, nano::stat::detail::unreachable_host, nano::stat::dir::out);
-			}
-			if (this->node.config.logging.network_packet_logging ())
-			{
-				BOOST_LOG (this->node.log) << "Packet send complete";
 			}
 		});
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -872,7 +872,8 @@ void nano::network::receive_action (nano::udp_data * data_a, nano::endpoint cons
 					break;
 			}
 
-			if (node.config.logging.network_logging () && parser.status != nano::message_parser::parse_status::outdated_version)
+			auto ignore ((parser.status == nano::message_parser::parse_status::outdated_version) || (parser.status == nano::message_parser::parse_status::invalid_header));
+			if (node.config.logging.network_logging () && !ignore)
 			{
 				BOOST_LOG (node.log) << "Could not parse message.  Error: " << parser.status_string ();
 			}


### PR DESCRIPTION
All receive_actions are already covered under stats, same with some other others where the log entry doesn't add anything extra, so log output has been removed. I have kept ones which give additional information as they can still be useful. Coupled with #1789 they should have a reduced impact on log file size.