### PR TITLE
Confirmation height enhancement

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -3519,7 +3519,7 @@ TEST (rpc, blocks_info)
 		ASSERT_FALSE (source.is_initialized ());
 		std::string balance_text (blocks.second.get<std::string> ("balance"));
 		ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), balance_text);
-		ASSERT_FALSE (response.json.get<bool> ("confirmed"));
+		ASSERT_FALSE (blocks.second.get<bool> ("confirmed"));
 	}
 	// Test for optional values
 	request.put ("source", "true");

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -840,6 +840,7 @@ TEST (rpc, block)
 	ASSERT_EQ (200, response.status);
 	auto contents (response.json.get<std::string> ("contents"));
 	ASSERT_FALSE (contents.empty ());
+	ASSERT_FALSE (response.json.get<bool> ("confirmed"));
 }
 
 TEST (rpc, block_account)
@@ -3518,6 +3519,7 @@ TEST (rpc, blocks_info)
 		ASSERT_FALSE (source.is_initialized ());
 		std::string balance_text (blocks.second.get<std::string> ("balance"));
 		ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), balance_text);
+		ASSERT_FALSE (response.json.get<bool> ("confirmed"));
 	}
 	// Test for optional values
 	request.put ("source", "true");
@@ -4792,7 +4794,7 @@ TEST (rpc, block_confirmed)
 	nano::rpc rpc (system.io_ctx, *node, nano::rpc_config (true));
 	rpc.start ();
 	boost::property_tree::ptree request;
-	request.put ("action", "block_confirmed");
+	request.put ("action", "block_info");
 	request.put ("hash", "bad_hash1337");
 	test_response response (request, rpc, system.io_ctx);
 	while (response.status == 0)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -3757,17 +3757,6 @@ void nano::node::add_confirmation_heights (nano::block_hash const & hash)
 		{
 			current = open_receive_blocks.top ();
 			open_receive_blocks.pop ();
-
-			auto block (store.block_get (transaction, current));
-			if (block != nullptr)
-			{
-				nano::block_hash source_hash = block->source ();
-				auto source_block (store.block_get (transaction, source_hash));
-				if (source_block != nullptr)
-				{
-					current = source_block->hash ();
-				}
-			}
 		}
 
 		auto hash (current);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1701,7 +1701,7 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 	if (!store.block_exists (transaction_a, block_a->type (), block_a->hash ()) && store.root_exists (transaction_a, block_a->root ()))
 	{
 		std::shared_ptr<nano::block> ledger_block (ledger.forked_block (transaction_a, *block_a));
-		if (ledger_block)
+		if (ledger_block && !ledger.block_confirmed (transaction_a, ledger_block->hash ()))
 		{
 			std::weak_ptr<nano::node> this_w (shared_from_this ());
 			if (!active.start (ledger_block, [this_w, root](std::shared_ptr<nano::block>) {

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2669,10 +2669,7 @@ void nano::node::process_confirmed (std::shared_ptr<nano::block> block_a, uint8_
 	auto hash (block_a->hash ());
 	if (ledger.block_exists (block_a->type (), hash))
 	{
-		{
-			auto transaction (store.tx_begin_write ());
-			add_confirmation_heights (transaction, hash);
-		}
+		add_confirmation_heights (hash);
 
 		auto transaction (store.tx_begin_read ());
 		confirmed_visitor visitor (transaction, *this, block_a, hash);
@@ -3747,8 +3744,9 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transaction
  * For all the blocks below this height which have been implicitly confirmed check if they
  * are open/receive blocks, and if so follow the source blocks and iteratively repeat to genesis.
  */
-void nano::node::add_confirmation_heights (nano::transaction const & transaction, nano::block_hash const & hash)
+void nano::node::add_confirmation_heights (nano::block_hash const & hash)
 {
+	auto transaction (store.tx_begin_write ());
 	std::stack<nano::block_hash, std::vector<nano::block_hash>> open_receive_blocks;
 	auto current = hash;
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -64,8 +64,6 @@ public:
 class election : public std::enable_shared_from_this<nano::election>
 {
 	std::function<void(std::shared_ptr<nano::block>)> confirmation_action;
-	void confirm_once (nano::transaction const &, bool = false);
-	void confirm_back (nano::transaction const &);
 
 public:
 	election (nano::node &, std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const &);
@@ -75,6 +73,7 @@ public:
 	bool have_quorum (nano::tally_t const &, nano::uint128_t);
 	// Change our winner to agree with the network
 	void compute_rep_votes (nano::transaction const &);
+	void confirm_once ();
 	// Confirm this block if quorum is met
 	void confirm_if_quorum (nano::transaction const &);
 	void log_votes (nano::tally_t const &);
@@ -122,6 +121,7 @@ public:
 	size_t size ();
 	void stop ();
 	bool publish (std::shared_ptr<nano::block> block_a);
+	void confirm_block (nano::block_hash const &);
 	boost::multi_index_container<
 	nano::conflict_info,
 	boost::multi_index::indexed_by<

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -449,6 +449,7 @@ public:
 	void stop ();
 	std::shared_ptr<nano::node> shared ();
 	int store_version ();
+	void receive_confirmed (nano::transaction const &, std::shared_ptr<nano::block>, nano::block_hash const &);
 	void process_confirmed (std::shared_ptr<nano::block>, uint8_t = 0);
 	void process_message (nano::message &, nano::endpoint const &);
 	void process_active (std::shared_ptr<nano::block>);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -531,7 +531,7 @@ public:
 	static std::chrono::milliseconds constexpr process_confirmed_interval = nano::is_test_network ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
 
 private:
-	void add_confirmation_heights (nano::transaction const & transaction, nano::block_hash const & hash);
+	void add_confirmation_heights (nano::block_hash const & hash);
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name);

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -4657,7 +4657,6 @@ rpc_handler_no_arg_func_map create_rpc_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("blocks", &nano::rpc_handler::blocks);
 	no_arg_funcs.emplace ("blocks_info", &nano::rpc_handler::blocks_info);
 	no_arg_funcs.emplace ("block_account", &nano::rpc_handler::block_account);
-	no_arg_funcs.emplace ("block_confirmed", &nano::rpc_handler::block_confirmed);
 	no_arg_funcs.emplace ("block_count", &nano::rpc_handler::block_count);
 	no_arg_funcs.emplace ("block_count_type", &nano::rpc_handler::block_count_type);
 	no_arg_funcs.emplace ("block_create", &nano::rpc_handler::block_create);

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -782,8 +782,7 @@ void nano::rpc_handler::accounts_pending ()
 			for (auto i (node.store.pending_begin (transaction, nano::pending_key (account, 0))); nano::pending_key (i->first).account == account && peers_l.size () < count; ++i)
 			{
 				nano::pending_key key (i->first);
-				std::shared_ptr<nano::block> block (include_active ? nullptr : node.store.block_get (transaction, key.hash));
-				if (include_active || (block && !node.active.active (*block)))
+				if (include_active || node.ledger.block_confirmed (transaction, key.hash))
 				{
 					if (threshold.is_zero () && !source)
 					{
@@ -2342,8 +2341,7 @@ void nano::rpc_handler::pending ()
 		for (auto i (node.store.pending_begin (transaction, nano::pending_key (account, 0))); nano::pending_key (i->first).account == account && peers_l.size () < count; ++i)
 		{
 			nano::pending_key key (i->first);
-			std::shared_ptr<nano::block> block (include_active ? nullptr : node.store.block_get (transaction, key.hash));
-			if (include_active || (block && !node.active.active (*block)))
+			if (include_active || node.ledger.block_confirmed (transaction, key.hash))
 			{
 				if (threshold.is_zero () && !source && !min_version)
 				{
@@ -2399,7 +2397,7 @@ void nano::rpc_handler::pending_exists ()
 			{
 				exists = node.store.pending_exists (transaction, nano::pending_key (destination, hash));
 			}
-			exists = exists && (include_active || !node.active.active (*block));
+			exists = exists && (include_active || node.ledger.block_confirmed (transaction, hash));
 			response_l.put ("exists", exists ? "1" : "0");
 		}
 		else
@@ -3970,8 +3968,7 @@ void nano::rpc_handler::wallet_pending ()
 			for (auto ii (node.store.pending_begin (block_transaction, nano::pending_key (account, 0))); nano::pending_key (ii->first).account == account && peers_l.size () < count; ++ii)
 			{
 				nano::pending_key key (ii->first);
-				std::shared_ptr<nano::block> block (include_active ? nullptr : node.store.block_get (block_transaction, key.hash));
-				if (include_active || (block && !node.active.active (*block)))
+				if (include_active || node.ledger.block_confirmed (block_transaction, key.hash))
 				{
 					if (threshold.is_zero () && !source)
 					{

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -871,6 +871,8 @@ void nano::rpc_handler::block_info ()
 			response_l.put ("balance", balance.convert_to<std::string> ());
 			response_l.put ("height", std::to_string (sideband.height));
 			response_l.put ("local_timestamp", std::to_string (sideband.timestamp));
+			auto confirmed (node.ledger.block_confirmed (transaction, hash));
+			response_l.put ("confirmed", confirmed);
 
 			bool json_block_l = request.get<bool> ("json_block", false);
 			if (json_block_l)
@@ -993,6 +995,8 @@ void nano::rpc_handler::blocks_info ()
 					entry.put ("balance", balance.convert_to<std::string> ());
 					entry.put ("height", std::to_string (sideband.height));
 					entry.put ("local_timestamp", std::to_string (sideband.timestamp));
+					auto confirmed (node.ledger.block_confirmed (transaction, hash));
+					entry.put ("confirmed", confirmed);
 
 					if (json_block_l)
 					{
@@ -1061,25 +1065,6 @@ void nano::rpc_handler::block_account ()
 		{
 			auto account (node.ledger.account (transaction, hash));
 			response_l.put ("account", account.to_account ());
-		}
-		else
-		{
-			ec = nano::error_blocks::not_found;
-		}
-	}
-	response_errors ();
-}
-
-void nano::rpc_handler::block_confirmed ()
-{
-	auto hash (hash_impl ());
-	if (!ec)
-	{
-		auto transaction (node.store.tx_begin_read ());
-		if (node.store.block_exists (transaction, hash))
-		{
-			auto confirmed (node.ledger.block_confirmed (transaction, hash));
-			response_l.put ("confirmed", confirmed);
 		}
 		else
 		{

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -113,7 +113,6 @@ public:
 	void blocks ();
 	void blocks_info ();
 	void block_account ();
-	void block_confirmed ();
 	void block_count ();
 	void block_count_type ();
 	void block_create ();


### PR DESCRIPTION
* improve add_confirmation_heights ()
* disable process_fork () for confirmed blocks
* replace active blocks check with confirmation status in RPCs pending*
* replace election::confirm_back () with add_confirmation_heights ()
* simplify search_pending for confirmed blocks
* merge RPC block_confirmed into block_info & blocks_info