### PR TITLE
Add required stake to confirmation_quorum

### DIFF
--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -1674,7 +1674,7 @@ void nano::rpc_handler::confirmation_quorum ()
 	response_l.put ("online_weight_minimum", node.config.online_weight_minimum.to_string_dec ());
 	response_l.put ("online_stake_total", node.online_reps.online_stake ().convert_to<std::string> ());
 	response_l.put ("peers_stake_total", node.rep_crawler.total_weight ().convert_to<std::string> ());
-	response_l.put ("peers_stake_required", std::max (node.config.online_weight_minimum.number (), node.delta ()));
+	response_l.put ("peers_stake_required", std::max (node.config.online_weight_minimum.number (), node.delta ()).convert_to<std::string> ());
 	if (request.get<bool> ("peer_details", false))
 	{
 		boost::property_tree::ptree peers;

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -1674,6 +1674,7 @@ void nano::rpc_handler::confirmation_quorum ()
 	response_l.put ("online_weight_minimum", node.config.online_weight_minimum.to_string_dec ());
 	response_l.put ("online_stake_total", node.online_reps.online_stake ().convert_to<std::string> ());
 	response_l.put ("peers_stake_total", node.rep_crawler.total_weight ().convert_to<std::string> ());
+	response_l.put ("peers_stake_required", std::max (node.config.online_weight_minimum.number (), node.delta ()));
 	if (request.get<bool> ("peer_details", false))
 	{
 		boost::property_tree::ptree peers;


### PR DESCRIPTION
The rules for effective stake required for quorum may change and isn't obvious from the output of confirmation_quorum (it's the largest of online_weight_minimum and quorum_delta)

Adding `peers_stake_required` to make this obvious and allow for future changes to the rules without breaking clients.