### PR TITLE
RPC 100-continue and max request size

### DIFF
--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -4368,58 +4368,108 @@ void nano::rpc_connection::write_result (std::string body, unsigned version, boo
 
 void nano::rpc_connection::read ()
 {
+	auto header_parser (std::make_shared<boost::beast::http::request_parser<boost::beast::http::empty_body>> ());
 	auto this_l (shared_from_this ());
-	boost::beast::http::async_read (socket, buffer, request, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+	std::promise<size_t> header_available_promise;
+	std::future<size_t> header_available = header_available_promise.get_future ();
+	header_parser->body_limit (rpc.config.max_request_size);
+	boost::system::error_code header_error;
+	boost::beast::http::async_read_header (socket, buffer, *header_parser, [this_l, header_parser, &header_available_promise, &header_error](boost::system::error_code const & ec, size_t bytes_transferred) {
+		size_t header_response_bytes_written = 0;
 		if (!ec)
 		{
-			this_l->node->background ([this_l]() {
-				auto start (std::chrono::steady_clock::now ());
-				auto version (this_l->request.version ());
-				std::string request_id (boost::str (boost::format ("%1%") % boost::io::group (std::hex, std::showbase, reinterpret_cast<uintptr_t> (this_l.get ()))));
-				auto response_handler ([this_l, version, start, request_id](boost::property_tree::ptree const & tree_a) {
-					std::stringstream ostream;
-					boost::property_tree::write_json (ostream, tree_a);
-					ostream.flush ();
-					auto body (ostream.str ());
-					this_l->write_result (body, version);
-					boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
-					});
-
-					if (this_l->node->config.logging.log_rpc ())
-					{
-						this_l->node->logger.always_log (boost::str (boost::format ("RPC request %2% completed in: %1% microseconds") % std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - start).count () % request_id));
-					}
-				});
-				auto method = this_l->request.method ();
-				switch (method)
-				{
-					case boost::beast::http::verb::post:
-					{
-						auto handler (std::make_shared<nano::rpc_handler> (*this_l->node, this_l->rpc, this_l->request.body (), request_id, response_handler));
-						handler->process_request ();
-						break;
-					}
-					case boost::beast::http::verb::options:
-					{
-						this_l->prepare_head (version);
-						this_l->res.prepare_payload ();
-						boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
-						});
-						break;
-					}
-					default:
-					{
-						error_response (response_handler, "Can only POST requests");
-						break;
-					}
-				}
-			});
+			if (boost::iequals (header_parser->get ()[boost::beast::http::field::expect], "100-continue"))
+			{
+				boost::beast::http::response<boost::beast::http::empty_body> continue_response;
+				continue_response.version (11);
+				continue_response.result (boost::beast::http::status::continue_);
+				continue_response.set (boost::beast::http::field::server, "nano");
+				auto response_size (boost::beast::http::async_write (this_l->socket, continue_response, boost::asio::use_future));
+				header_response_bytes_written = response_size.get ();
+			}
 		}
 		else
 		{
-			this_l->node->logger.always_log ("RPC read error: ", ec.message ());
+			header_error = ec;
+			this_l->node->logger.always_log ("RPC header error: ", ec.message ());
 		}
+
+		header_available_promise.set_value (header_response_bytes_written);
 	});
+
+	// Avait header
+	header_available.get ();
+
+	if (!header_error)
+	{
+		auto body_parser (std::make_shared<boost::beast::http::request_parser<boost::beast::http::string_body>> (std::move (*header_parser)));
+		boost::beast::http::async_read (socket, buffer, *body_parser, [this_l, body_parser](boost::system::error_code const & ec, size_t bytes_transferred) {
+			if (!ec)
+			{
+				this_l->node->background ([this_l, body_parser]() {
+					auto & req (body_parser->get ());
+					auto start (std::chrono::steady_clock::now ());
+					auto version (req.version ());
+					std::string request_id (boost::str (boost::format ("%1%") % boost::io::group (std::hex, std::showbase, reinterpret_cast<uintptr_t> (this_l.get ()))));
+					auto response_handler ([this_l, version, start, request_id](boost::property_tree::ptree const & tree_a) {
+						std::stringstream ostream;
+						boost::property_tree::write_json (ostream, tree_a);
+						ostream.flush ();
+						auto body (ostream.str ());
+						this_l->write_result (body, version);
+						boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+						});
+
+						if (this_l->node->config.logging.log_rpc ())
+						{
+							this_l->node->logger.always_log (boost::str (boost::format ("RPC request %2% completed in: %1% microseconds") % std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - start).count () % request_id));
+						}
+					});
+					auto method = req.method ();
+					switch (method)
+					{
+						case boost::beast::http::verb::post:
+						{
+							auto handler (std::make_shared<nano::rpc_handler> (*this_l->node, this_l->rpc, req.body (), request_id, response_handler));
+							handler->process_request ();
+							break;
+						}
+						case boost::beast::http::verb::options:
+						{
+							this_l->prepare_head (version);
+							this_l->res.prepare_payload ();
+							boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+							});
+							break;
+						}
+						default:
+						{
+							error_response (response_handler, "Can only POST requests");
+							break;
+						}
+					}
+				});
+			}
+			else
+			{
+				this_l->node->logger.always_log ("RPC read error: ", ec.message ());
+			}
+		});
+	}
+	else
+	{
+		// Respond with the reason for the invalid header
+		auto response_handler ([this_l](boost::property_tree::ptree const & tree_a) {
+			std::stringstream ostream;
+			boost::property_tree::write_json (ostream, tree_a);
+			ostream.flush ();
+			auto body (ostream.str ());
+			this_l->write_result (body, 11);
+			boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+			});
+		});
+		error_response (response_handler, std::string ("Invalid header: ") + header_error.message ());
+	}
 }
 
 namespace

--- a/nano/node/rpc.hpp
+++ b/nano/node/rpc.hpp
@@ -65,7 +65,6 @@ public:
 	nano::rpc & rpc;
 	boost::asio::ip::tcp::socket socket;
 	boost::beast::flat_buffer buffer;
-	boost::beast::http::request<boost::beast::http::string_body> request;
 	boost::beast::http::response<boost::beast::http::string_body> res;
 	std::atomic_flag responded;
 };

--- a/nano/node/rpcconfig.cpp
+++ b/nano/node/rpcconfig.cpp
@@ -37,7 +37,8 @@ address (boost::asio::ip::address_v6::loopback ()),
 port (network_params.default_rpc_port),
 enable_control (enable_control_a),
 max_json_depth (20),
-enable_sign_hash (false)
+enable_sign_hash (false),
+max_request_size (32 * 1024 * 1024)
 {
 }
 
@@ -49,6 +50,7 @@ nano::error nano::rpc_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("enable_control", enable_control);
 	json.put ("max_json_depth", max_json_depth);
 	json.put ("enable_sign_hash", enable_sign_hash);
+	json.put ("max_request_size", max_request_size);
 	return json.get_error ();
 }
 
@@ -59,8 +61,10 @@ nano::error nano::rpc_config::deserialize_json (bool & upgraded_a, nano::jsoncon
 	{
 		version_l = 1;
 		json.put ("version", *version_l);
+		json.put ("max_request_size", max_request_size);
 		json.erase ("frontier_request_limit");
 		json.erase ("chain_request_limit");
+
 		upgraded_a = true;
 	}
 
@@ -75,5 +79,6 @@ nano::error nano::rpc_config::deserialize_json (bool & upgraded_a, nano::jsoncon
 	json.get_optional<bool> ("enable_control", enable_control);
 	json.get_optional<uint8_t> ("max_json_depth", max_json_depth);
 	json.get_optional<bool> ("enable_sign_hash", enable_sign_hash);
+	json.get_optional<uint64_t> ("max_request_size", max_request_size);
 	return json.get_error ();
 }

--- a/nano/node/rpcconfig.hpp
+++ b/nano/node/rpcconfig.hpp
@@ -45,6 +45,7 @@ public:
 	rpc_secure_config secure;
 	uint8_t max_json_depth;
 	bool enable_sign_hash;
+	uint64_t max_request_size;
 	static int json_version ()
 	{
 		return 1;


### PR DESCRIPTION
Closes https://github.com/nanocurrency/nano-node/issues/1671

We've had reports of RPC requests sometimes taking 1 second before being handled. Some clients, such as curl (and Python wrappers), sends an `Expect: 100-continue` header for large requests (per rfc7231). These clients typically wait one second for the header response before sending the body (a workaround in curl is to use -H Expect:)

The PR also adds the ability to restrict request body sizes via `config.json`. The proposed default limit is 32MB (this must be large enough for services - opinions welcome)