### PR TITLE
Separating the concepts of:

### DIFF
--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -213,14 +213,6 @@ public:
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (gap_cache & gap_cache, const std::string & name);
 
 class work_pool;
-class send_info
-{
-public:
-	uint8_t const * data;
-	size_t size;
-	nano::endpoint endpoint;
-	std::function<void(boost::system::error_code const &, size_t)> callback;
-};
 class block_arrival_info
 {
 public:
@@ -351,12 +343,15 @@ public:
 	bool send_votes_cache (nano::block_hash const &, nano::endpoint const &);
 	void send_buffer (std::shared_ptr<std::vector<uint8_t>>, nano::endpoint const &, std::function<void(boost::system::error_code const &, size_t)>);
 	nano::endpoint endpoint ();
+	void cleanup (std::chrono::steady_clock::time_point const &);
+	void ongoing_cleanup ();
 	nano::message_buffer_manager buffer_container;
 	boost::asio::ip::udp::socket socket;
 	std::mutex socket_mutex;
 	boost::asio::ip::udp::resolver resolver;
 	std::vector<boost::thread> packet_processing_threads;
 	nano::node & node;
+	std::function<void()> disconnect_observer;
 	static size_t const buffer_size = 512;
 	static size_t const confirm_req_hashes_max = 6;
 	static unsigned const broadcast_interval_ms = 10;

--- a/nano/node/peers.hpp
+++ b/nano/node/peers.hpp
@@ -82,8 +82,8 @@ public:
 	std::vector<peer_information> list_probable_rep_weights ();
 	// Get the next peer for attempting bootstrap
 	nano::endpoint bootstrap_peer ();
-	// Purge any peer where last_contact < time_point and return what was left
-	std::vector<nano::peer_information> purge_list (std::chrono::steady_clock::time_point const &);
+	// Purge any peer where last_contact < time_point
+	void purge (std::chrono::steady_clock::time_point const &);
 	void purge_syn_cookies (std::chrono::steady_clock::time_point const &);
 	// Should we reach out to this endpoint with a keepalive message
 	bool reachout (nano::endpoint const &, bool = false);
@@ -120,7 +120,6 @@ public:
 	std::unordered_map<boost::asio::ip::address, unsigned> syn_cookies_per_ip;
 	// Called when a new peer is observed
 	std::function<void(nano::endpoint const &)> peer_observer;
-	std::function<void()> disconnect_observer;
 	// Number of peers to crawl for being a rep every period
 	static size_t constexpr peers_per_crawl = 8;
 	// Maximum number of peers per IP

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -54,7 +54,7 @@ TEST (wallet, status)
 		test_application->processEvents ();
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	system.nodes[0]->peers.purge_list (std::chrono::steady_clock::now () + std::chrono::seconds (5));
+	system.nodes[0]->peers.purge (std::chrono::steady_clock::now () + std::chrono::seconds (5));
 	while (wallet_has (nano_qt::status_types::synchronizing))
 	{
 		test_application->processEvents ();


### PR DESCRIPTION
- Purging the peer_container
- Sending keepalives to nodes we haven't heard from
- Signaling the disconnect observer

This makes the logic around each easier to reason around and movable to different portions of the code.