### PR TITLE
Websocket support

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable (core_test
 	versioning.cpp
 	wallet.cpp
 	wallets.cpp
+	websocket.cpp
 	work_pool.cpp)
 
 target_compile_definitions(core_test

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1,0 +1,109 @@
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <chrono>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <nano/core_test/testutil.hpp>
+#include <nano/node/testing.hpp>
+#include <nano/node/websocket.hpp>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+std::atomic<bool> ack_ready{ false };
+/** A simple blocking websocket client for testing */
+std::string websocket_test_call (boost::asio::io_context & ioc, std::string host, std::string port, std::string message_a, bool await_ack)
+{
+	boost::asio::ip::tcp::resolver resolver{ ioc };
+	boost::beast::websocket::stream<boost::asio::ip::tcp::socket> ws{ ioc };
+
+	auto const results = resolver.resolve (host, port);
+	boost::asio::connect (ws.next_layer (), results.begin (), results.end ());
+
+	ws.handshake (host, "/");
+	ws.text (true);
+	ws.write (boost::asio::buffer (message_a));
+
+	if (await_ack)
+	{
+		boost::beast::flat_buffer buffer;
+		ws.read (buffer);
+		ack_ready = true;
+	}
+
+	boost::beast::flat_buffer buffer;
+	ws.read (buffer);
+	std::ostringstream res;
+	res << boost::beast::buffers (buffer.data ());
+
+	ws.close (boost::beast::websocket::close_code::normal);
+	return res.str ();
+}
+}
+
+/** Subscribes to block confirmations, confirms a block and then awaits websocket notification */
+TEST (websocket, confirmation)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	nano::node_config config;
+	nano::node_flags node_flags;
+	config.websocket_config.enabled = true;
+	config.websocket_config.port = 24078;
+
+	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, nano::unique_path (), system.alarm, config, system.work, node_flags));
+	nano::uint256_union wallet;
+	nano::random_pool::generate_block (wallet.bytes.data (), wallet.bytes.size ());
+	node1->wallets.create (wallet);
+	node1->start ();
+	system.nodes.push_back (node1);
+
+	// Start websocket test-client in a separate thread
+	std::atomic<bool> confirmation_event_received{ false };
+	std::thread client_thread ([&system, &confirmation_event_received]() {
+		// This will expect two results: the acknowledgement of the subscription
+		// and then the block confirmation message
+		std::string response = websocket_test_call (system.io_ctx, "::1", "24078",
+		R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json", true);
+
+		boost::property_tree::ptree event;
+		std::stringstream stream;
+		stream << response;
+		boost::property_tree::read_json (stream, event);
+		ASSERT_EQ (event.get<std::string> ("topic"), "confirmation");
+		confirmation_event_received = true;
+	});
+	client_thread.detach ();
+
+	// Wait for the subscription to be acknowledged
+	system.deadline_set (5s);
+	while (!ack_ready)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	// Quick-confirm a block
+	nano::keypair key;
+	nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+	system.wallet (1)->insert_adhoc (key.prv);
+	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	auto send (std::make_shared<nano::send_block> (previous, key.pub, node1->config.online_weight_minimum.number () + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (previous)));
+	node1->process_active (send);
+
+	// Wait for the websocket client to receive the confirmation message
+	system.deadline_set (5s);
+	while (!confirmation_event_received)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	node1->stop ();
+}

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -65,6 +65,10 @@ add_library (node
 	voting.cpp
 	wallet.hpp
 	wallet.cpp
+	websocket.hpp
+	websocket.cpp
+	websocketconfig.hpp
+	websocketconfig.cpp
 	working.hpp
 	xorshift.hpp)
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1050,7 +1050,8 @@ startup_time (std::chrono::steady_clock::now ())
 {
 	if (config.websocket_config.enabled)
 	{
-		websocket_server = std::make_shared<nano::websocket::listener> (*this, nano::tcp_endpoint (boost::asio::ip::address_v6::any (), config.websocket_config.port));
+		auto endpoint_l (nano::tcp_endpoint (config.websocket_config.address, config.websocket_config.port));
+		websocket_server = std::make_shared<nano::websocket::listener> (*this, endpoint_l);
 		this->websocket_server->run ();
 	}
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -11,6 +11,7 @@
 #include <nano/node/stats.hpp>
 #include <nano/node/transport/udp.hpp>
 #include <nano/node/wallet.hpp>
+#include <nano/node/websocket.hpp>
 #include <nano/secure/ledger.hpp>
 
 #include <atomic>
@@ -478,6 +479,7 @@ public:
 	boost::asio::io_context & io_ctx;
 	nano::network_params network_params;
 	nano::node_config config;
+	std::shared_ptr<nano::websocket::listener> websocket_server;
 	nano::node_flags flags;
 	nano::alarm & alarm;
 	nano::work_pool & work;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -132,7 +132,9 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("unchecked_cutoff_time", unchecked_cutoff_time.count ());
 	json.put ("tcp_client_timeout", tcp_client_timeout.count ());
 	json.put ("tcp_server_timeout", tcp_server_timeout.count ());
-
+	nano::jsonconfig websocket_l;
+	websocket_config.serialize_json (websocket_l);
+	json.put_child ("websocket", websocket_l);
 	nano::jsonconfig ipc_l;
 	ipc_config.serialize_json (ipc_l);
 	json.put_child ("ipc", ipc_l);
@@ -257,6 +259,9 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 		}
 		case 16:
 		{
+			nano::jsonconfig websocket_l;
+			websocket_config.serialize_json (websocket_l);
+			json.put_child ("websocket", websocket_l);
 			json.put ("tcp_client_timeout", tcp_client_timeout.count ());
 			json.put ("tcp_server_timeout", tcp_server_timeout.count ());
 			upgraded = true;
@@ -372,7 +377,11 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			ipc_config.deserialize_json (ipc_config_l.get ());
 		}
-
+		auto websocket_config_l (json.get_optional_child ("websocket"));
+		if (websocket_config_l)
+		{
+			websocket_config.deserialize_json (websocket_config_l.get ());
+		}
 		json.get<uint16_t> ("peering_port", peering_port);
 		json.get<unsigned> ("bootstrap_fraction_numerator", bootstrap_fraction_numerator);
 		json.get<unsigned> ("online_weight_quorum", online_weight_quorum);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -8,6 +8,7 @@
 #include <nano/node/ipcconfig.hpp>
 #include <nano/node/logging.hpp>
 #include <nano/node/stats.hpp>
+#include <nano/node/websocketconfig.hpp>
 #include <vector>
 
 namespace nano
@@ -43,6 +44,7 @@ public:
 	bool enable_voting;
 	unsigned bootstrap_connections;
 	unsigned bootstrap_connections_max;
+	nano::websocket::config websocket_config;
 	std::string callback_address;
 	uint16_t callback_port;
 	std::string callback_target;

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -1,0 +1,310 @@
+#include <algorithm>
+#include <boost/property_tree/json_parser.hpp>
+#include <chrono>
+#include <nano/node/node.hpp>
+#include <nano/node/websocket.hpp>
+
+nano::websocket::session::session (nano::websocket::listener & listener_a, boost::asio::ip::tcp::socket socket_a) :
+ws_listener (listener_a), ws (std::move (socket_a)), write_strand (ws.get_executor ())
+{
+	ws.text (true);
+}
+
+nano::websocket::session::~session ()
+{
+	ws_listener.get_node ().logger.try_log ("websocket session ended");
+}
+
+void nano::websocket::session::handshake ()
+{
+	std::lock_guard<std::mutex> lk (io_mutex);
+	ws.async_accept ([self_l = shared_from_this ()](boost::system::error_code const & ec) {
+		if (ec)
+		{
+			self_l->ws_listener.get_node ().logger.always_log ("websocket handshake failed: ", ec.message ());
+		}
+		else
+		{
+			// Start reading incoming messages
+			self_l->read ();
+		}
+	});
+}
+
+void nano::websocket::session::close ()
+{
+	std::lock_guard<std::mutex> lk (io_mutex);
+	boost::beast::websocket::close_reason reason;
+	reason.code = boost::beast::websocket::close_code::normal;
+	reason.reason = "Shutting down";
+	boost::system::error_code ec_ignore;
+	ws.close (reason, ec_ignore);
+}
+
+void nano::websocket::session::write (nano::websocket::message message_a)
+{
+	// clang-format off
+	std::lock_guard<std::mutex> lk (subscriptions_mutex);
+	if (message_a.topic == nano::websocket::topic::ack || subscriptions.find (message_a.topic) != subscriptions.end ())
+	{
+		subscriptions_mutex.unlock ();
+		boost::asio::post (write_strand,
+		[message_a, self_l = shared_from_this ()]() {
+			bool write_in_progress = !self_l->send_queue.empty ();
+			self_l->send_queue.emplace_back (message_a);
+			if (!write_in_progress)
+			{
+				self_l->write_queued_messages ();
+			}
+		});
+	}
+	// clang-format on
+}
+
+void nano::websocket::session::write_queued_messages ()
+{
+	// clang-format off
+	auto msg (send_queue.front ());
+	auto msg_str (msg.to_string ());
+
+	std::lock_guard<std::mutex> lk (io_mutex);
+	ws.async_write (boost::asio::buffer (msg_str.data (), msg_str.size ()),
+	boost::asio::bind_executor (write_strand,
+	[msg, self_l = shared_from_this ()](boost::system::error_code ec, std::size_t bytes_transferred) {
+		if (!ec)
+		{
+			self_l->send_queue.pop_front ();
+			if (!self_l->send_queue.empty ())
+			{
+				self_l->write_queued_messages ();
+			}
+		}
+	}));
+	// clang-format on
+}
+
+void nano::websocket::session::read ()
+{
+	std::lock_guard<std::mutex> lk (io_mutex);
+	ws.async_read (read_buffer,
+	[self_l = shared_from_this ()](boost::system::error_code ec, std::size_t bytes_transferred) {
+		if (!ec)
+		{
+			std::stringstream os;
+			os << boost::beast::buffers (self_l->read_buffer.data ());
+			std::string incoming_message = os.str ();
+
+			// Prepare next read by clearing the multibuffer
+			self_l->read_buffer.consume (self_l->read_buffer.size ());
+
+			boost::property_tree::ptree tree_msg;
+			try
+			{
+				boost::property_tree::read_json (os, tree_msg);
+				self_l->handle_message (tree_msg);
+				self_l->read ();
+			}
+			catch (boost::property_tree::json_parser::json_parser_error const & ex)
+			{
+				self_l->ws_listener.get_node ().logger.try_log ("websocket json parsing failed: ", ex.what ());
+			}
+		}
+		else
+		{
+			self_l->ws_listener.get_node ().logger.try_log ("websocket read failed: ", ec.message ());
+		}
+	});
+}
+
+namespace
+{
+nano::websocket::topic to_topic (std::string topic_a)
+{
+	nano::websocket::topic topic = nano::websocket::topic::invalid;
+	if (topic_a == "confirmation")
+	{
+		topic = nano::websocket::topic::confirmation;
+	}
+	else if (topic_a == "ack")
+	{
+		topic = nano::websocket::topic::ack;
+	}
+	return topic;
+}
+
+std::string from_topic (nano::websocket::topic topic_a)
+{
+	std::string topic = "invalid";
+	if (topic_a == nano::websocket::topic::confirmation)
+	{
+		topic = "confirmation";
+	}
+	else if (topic_a == nano::websocket::topic::ack)
+	{
+		topic = "ack";
+	}
+	return topic;
+}
+}
+
+void nano::websocket::session::send_ack (std::string action_a, std::string id_a)
+{
+	auto milli_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
+	nano::websocket::message msg (nano::websocket::topic::ack);
+	boost::property_tree::ptree & message_l = msg.contents;
+	message_l.add ("ack", action_a);
+	message_l.add ("time", std::to_string (milli_since_epoch));
+	if (!id_a.empty ())
+	{
+		message_l.add ("id", id_a);
+	}
+	write (msg);
+}
+
+void nano::websocket::session::handle_message (boost::property_tree::ptree const & message_a)
+{
+	std::string action (message_a.get<std::string> ("action", ""));
+	auto topic_l (to_topic (message_a.get<std::string> ("topic", "")));
+	auto ack_l (message_a.get<bool> ("ack", false));
+	auto id_l (message_a.get<std::string> ("id", ""));
+	auto subscribe_succeeded (false);
+	if (action == "subscribe" && topic_l != nano::websocket::topic::invalid)
+	{
+		std::lock_guard<std::mutex> lk (subscriptions_mutex);
+		subscriptions.insert (topic_l);
+		subscribe_succeeded = true;
+	}
+	else if (action == "unsubscribe" && topic_l != nano::websocket::topic::invalid)
+	{
+		std::lock_guard<std::mutex> lk (subscriptions_mutex);
+		subscriptions.erase (topic_l);
+		subscribe_succeeded = true;
+	}
+	if (ack_l && subscribe_succeeded)
+	{
+		send_ack (action, id_l);
+	}
+}
+
+void nano::websocket::listener::stop ()
+{
+	stopped = true;
+	acceptor.close ();
+
+	for (auto & weak_session : sessions)
+	{
+		auto session_ptr (weak_session.lock ());
+		if (session_ptr)
+		{
+			session_ptr->close ();
+		}
+	}
+}
+
+nano::websocket::listener::listener (nano::node & node_a, boost::asio::ip::tcp::endpoint endpoint_a) :
+node (node_a),
+acceptor (node_a.io_ctx),
+socket (node_a.io_ctx)
+{
+	try
+	{
+		acceptor.open (endpoint_a.protocol ());
+		acceptor.set_option (boost::asio::socket_base::reuse_address (true));
+		acceptor.bind (endpoint_a);
+		acceptor.listen (boost::asio::socket_base::max_listen_connections);
+	}
+	catch (std::exception const & ex)
+	{
+		node.logger.always_log ("websocket listen failed: ", ex.what ());
+	}
+}
+
+void nano::websocket::listener::run ()
+{
+	if (acceptor.is_open ())
+	{
+		accept ();
+	}
+}
+
+void nano::websocket::listener::accept ()
+{
+	acceptor.async_accept (socket,
+	[self_l = shared_from_this ()](boost::system::error_code const & ec) {
+		self_l->on_accept (ec);
+	});
+}
+
+void nano::websocket::listener::on_accept (boost::system::error_code ec)
+{
+	if (ec)
+	{
+		node.logger.always_log ("websocket accept failed: ", ec.message ());
+	}
+	else
+	{
+		// Create the session and initiate websocket handshake
+		auto session (std::make_shared<nano::websocket::session> (*this, std::move (socket)));
+		sessions_mutex.lock ();
+		sessions.push_back (session);
+		sessions_mutex.unlock ();
+		session->handshake ();
+	}
+
+	if (!stopped)
+	{
+		accept ();
+	}
+}
+
+void nano::websocket::listener::broadcast (nano::websocket::message message_a)
+{
+	std::lock_guard<std::mutex> lk (sessions_mutex);
+	for (auto & weak_session : sessions)
+	{
+		auto session_ptr (weak_session.lock ());
+		if (session_ptr)
+		{
+			session_ptr->write (message_a);
+		}
+	}
+
+	// Clean up expired sessions
+	sessions.erase (std::remove_if (sessions.begin (), sessions.end (), [](auto & elem) { return elem.expired (); }), sessions.end ());
+}
+
+nano::websocket::message nano::websocket::message_builder::block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype)
+{
+	nano::websocket::message msg (nano::websocket::topic::confirmation);
+	using namespace std::chrono;
+	auto milli_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
+
+	// Common message information
+	boost::property_tree::ptree & message_l = msg.contents;
+	message_l.add ("topic", from_topic (msg.topic));
+	message_l.add ("time", std::to_string (milli_since_epoch));
+
+	// Block confirmation properties
+	boost::property_tree::ptree message_node_l;
+	message_node_l.add ("account", account_a.to_account ());
+	message_node_l.add ("amount", amount_a.to_string_dec ());
+	message_node_l.add ("hash", block_a->hash ().to_string ());
+	boost::property_tree::ptree block_node_l;
+	block_a->serialize_json (block_node_l);
+	if (!subtype.empty ())
+	{
+		block_node_l.add ("subtype", subtype);
+	}
+	message_node_l.add_child ("block", block_node_l);
+	message_l.add_child ("message", message_node_l);
+
+	return msg;
+}
+
+std::string nano::websocket::message::to_string ()
+{
+	std::ostringstream ostream;
+	boost::property_tree::write_json (ostream, contents);
+	ostream.flush ();
+	return ostream.str ();
+}

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <algorithm>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <cstdlib>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+namespace nano
+{
+class node;
+namespace websocket
+{
+	class listener;
+
+	/** Supported topics */
+	enum class topic
+	{
+		invalid = 0,
+		/** Acknowledgement of prior incoming message */
+		ack,
+		/** A confirmation message */
+		confirmation
+	};
+
+	/** A message queued for broadcasting */
+	class message final
+	{
+	public:
+		message (nano::websocket::topic topic_a) :
+		topic (topic_a)
+		{
+		}
+		message (nano::websocket::topic topic_a, boost::property_tree::ptree & tree_a) :
+		topic (topic_a), contents (tree_a)
+		{
+		}
+
+		std::string to_string ();
+		nano::websocket::topic topic;
+		boost::property_tree::ptree contents;
+	};
+
+	/** Message builder. This is expanded with new builder functions are necessary. */
+	class message_builder final
+	{
+	public:
+		message block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype);
+	};
+
+	/** A websocket session managing its own lifetime */
+	class session final : public std::enable_shared_from_this<session>
+	{
+	public:
+		/** Constructor that takes ownership over \p socket_a */
+		explicit session (nano::websocket::listener & listener_a, boost::asio::ip::tcp::socket socket_a);
+		~session ();
+
+		/** Perform Websocket handshake and start reading messages */
+		void handshake ();
+
+		/** Close the websocket and end the session */
+		void close ();
+
+		/** Read the next message. This implicitely handles incoming websocket pings. */
+		void read ();
+
+		/** Enqueue \p message_a for writing to the websockets */
+		void write (nano::websocket::message message_a);
+
+	private:
+		/** The owning listener */
+		nano::websocket::listener & ws_listener;
+		/** Websocket */
+		boost::beast::websocket::stream<boost::asio::ip::tcp::socket> ws;
+		/** Buffer for received messages */
+		boost::beast::multi_buffer read_buffer;
+		/** All websocket writes and updates to send_queue must go through the write strand. */
+		boost::asio::strand<boost::asio::io_context::executor_type> write_strand;
+		/** Outgoing messages. The send queue is protected by accessing it only through the write strand */
+		std::deque<message> send_queue;
+		/** Serialize calls to websocket::stream initiating functions */
+		std::mutex io_mutex;
+
+		/** Hash functor for topic enums */
+		struct topic_hash
+		{
+			template <typename T>
+			std::size_t operator() (T t) const
+			{
+				return static_cast<std::size_t> (t);
+			}
+		};
+		/**
+		 * Set of subscriptions registered by this session. In the future, contextual information
+		 * can be added to subscription objects, such as which accounts to get confirmations for.
+		 */
+		std::unordered_set<topic, topic_hash> subscriptions;
+		std::mutex subscriptions_mutex;
+
+		/** Handle incoming message */
+		void handle_message (boost::property_tree::ptree const & message_a);
+		/** Acknowledge incoming message */
+		void send_ack (std::string action_a, std::string id_a);
+		/** Send all queued messages. This must be called from the write strand. */
+		void write_queued_messages ();
+	};
+
+	/** Creates a new session for each incoming connection */
+	class listener final : public std::enable_shared_from_this<listener>
+	{
+	public:
+		listener (nano::node & node_a, boost::asio::ip::tcp::endpoint endpoint_a);
+
+		/** Start accepting connections */
+		void run ();
+		void accept ();
+		void on_accept (boost::system::error_code ec_a);
+
+		/** Close all websocket sessions and stop listening for new connections */
+		void stop ();
+
+		/** Broadcast \p message to all session subscribing to the message topic. */
+		void broadcast (nano::websocket::message message_a);
+
+		nano::node & get_node () const
+		{
+			return node;
+		}
+
+	private:
+		nano::node & node;
+		boost::asio::ip::tcp::acceptor acceptor;
+		boost::asio::ip::tcp::socket socket;
+		std::mutex sessions_mutex;
+		std::vector<std::weak_ptr<session>> sessions;
+		std::atomic<bool> stopped{ false };
+	};
+}
+}

--- a/nano/node/websocketconfig.cpp
+++ b/nano/node/websocketconfig.cpp
@@ -1,0 +1,16 @@
+#include <nano/lib/jsonconfig.hpp>
+#include <nano/node/websocketconfig.hpp>
+
+nano::error nano::websocket::config::serialize_json (nano::jsonconfig & json) const
+{
+	json.put ("enable", enabled);
+	json.put ("port", port);
+	return json.get_error ();
+}
+
+nano::error nano::websocket::config::deserialize_json (nano::jsonconfig & json)
+{
+	json.get<bool> ("enable", enabled);
+	json.get<uint16_t> ("port", port);
+	return json.get_error ();
+}

--- a/nano/node/websocketconfig.cpp
+++ b/nano/node/websocketconfig.cpp
@@ -4,6 +4,7 @@
 nano::error nano::websocket::config::serialize_json (nano::jsonconfig & json) const
 {
 	json.put ("enable", enabled);
+	json.put ("address", address.to_string ());
 	json.put ("port", port);
 	return json.get_error ();
 }
@@ -11,6 +12,7 @@ nano::error nano::websocket::config::serialize_json (nano::jsonconfig & json) co
 nano::error nano::websocket::config::deserialize_json (nano::jsonconfig & json)
 {
 	json.get<bool> ("enable", enabled);
+	json.get_required<boost::asio::ip::address_v6> ("address", address);
 	json.get<uint16_t> ("port", port);
 	return json.get_error ();
 }

--- a/nano/node/websocketconfig.hpp
+++ b/nano/node/websocketconfig.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/asio.hpp>
 #include <nano/lib/errors.hpp>
 #include <string>
 
@@ -16,6 +17,7 @@ namespace websocket
 		nano::error serialize_json (nano::jsonconfig & json) const;
 		bool enabled{ false };
 		uint16_t port{ 7078 };
+		boost::asio::ip::address_v6 address{ boost::asio::ip::address_v6::loopback () };
 	};
 }
 }

--- a/nano/node/websocketconfig.hpp
+++ b/nano/node/websocketconfig.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <nano/lib/errors.hpp>
+#include <string>
+
+namespace nano
+{
+class jsonconfig;
+namespace websocket
+{
+	/** websocket configuration */
+	class config
+	{
+	public:
+		nano::error deserialize_json (nano::jsonconfig & json_a);
+		nano::error serialize_json (nano::jsonconfig & json) const;
+		bool enabled{ false };
+		uint16_t port{ 7078 };
+	};
+}
+}


### PR DESCRIPTION
Adds support for notifications via Websockets. This offers a more efficient callback mechanism for block confirmations, and allows for multiple listeners. As it's topic-based, filtering and additional events can be added in the future. Proper JSON is returned (the http callback returns stringified blocks). Comments on message formatting are most welcome. Note that the http callback is still supported.

Preliminary docs: https://github.com/cryptocode/notes/wiki/Websocket-support
Sample nodejs client: https://github.com/cryptocode/nano-websocket-sample-nodejs