### PR TITLE
Use RAII when stopping daemon to cleanup on SIGINT/SIGTERM

### DIFF
--- a/nano/nano_node/daemon.hpp
+++ b/nano/nano_node/daemon.hpp
@@ -2,13 +2,27 @@
 
 namespace nano
 {
+class node;
+class rpc;
 class node_flags;
+namespace ipc
+{
+	class ipc_server;
+}
 }
 namespace nano_daemon
 {
 class daemon
 {
 public:
-	void run (boost::filesystem::path const &, nano::node_flags const & flags);
+	daemon (boost::filesystem::path const & data_path, nano::node_flags const & flags);
+	~daemon ();
+	void run ();
+	void stop ();
+	boost::filesystem::path const & data_path;
+	nano::node_flags const & flags;
+	std::shared_ptr<nano::node> node;
+	std::shared_ptr<nano::rpc> rpc;
+	std::shared_ptr<nano::ipc::ipc_server> ipc;
 };
 }

--- a/nano/node/ipc.cpp
+++ b/nano/node/ipc.cpp
@@ -398,7 +398,7 @@ node (node_a), rpc (rpc_a)
 
 nano::ipc::ipc_server::~ipc_server ()
 {
-	node.logger.always_log ("IPC: server stopped");
+	stop ();
 }
 
 void nano::ipc::ipc_server::stop ()
@@ -407,6 +407,7 @@ void nano::ipc::ipc_server::stop ()
 	{
 		transport->stop ();
 	}
+	node.logger.always_log ("IPC: server stopped");
 }
 
 /** Socket agnostic IO interface */


### PR DESCRIPTION
This gracefully cleans up resources and frees ports using RAII and adding a signal handler to the daemon.

I expect a discussion around this, but I have yet to experience issues around ports being held on to after the process has died on macOS with this patch which previously has not been the case.