### PR TITLE
qualified_root type alias

### DIFF
--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -17,7 +17,7 @@ TEST (conflicts, start_stop)
 	auto root1 (send1->root ());
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing1 (node1.active.roots.find (nano::uint512_union (send1->previous (), root1)));
+		auto existing1 (node1.active.roots.find (nano::qualified_root (send1->previous (), root1)));
 		ASSERT_NE (node1.active.roots.end (), existing1);
 		auto votes1 (existing1->election);
 		ASSERT_NE (nullptr, votes1);
@@ -44,7 +44,7 @@ TEST (conflicts, add_existing)
 	ASSERT_EQ (1, node1.active.size ());
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto votes1 (node1.active.roots.find (nano::uint512_union (send2->previous (), send2->root ()))->election);
+		auto votes1 (node1.active.roots.find (nano::qualified_root (send2->previous (), send2->root ()))->election);
 		ASSERT_NE (nullptr, votes1);
 		ASSERT_EQ (2, votes1->last_votes.size ());
 		ASSERT_NE (votes1->last_votes.end (), votes1->last_votes.find (key2.pub));
@@ -171,7 +171,7 @@ TEST (conflicts, reprioritize)
 	node1.block_processor.flush ();
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ())));
+		auto existing1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ())));
 		ASSERT_NE (node1.active.roots.end (), existing1);
 		ASSERT_EQ (difficulty1, existing1->difficulty);
 	}
@@ -182,7 +182,7 @@ TEST (conflicts, reprioritize)
 	node1.block_processor.flush ();
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing2 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ())));
+		auto existing2 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ())));
 		ASSERT_NE (node1.active.roots.end (), existing2);
 		ASSERT_EQ (difficulty2, existing2->difficulty);
 	}
@@ -204,7 +204,7 @@ TEST (conflicts, dependency)
 	// Check dependecy for genesis block
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing1 (node1.active.roots.find (nano::uint512_union (genesis.open->previous (), genesis.open->root ())));
+		auto existing1 (node1.active.roots.find (nano::qualified_root (genesis.open->previous (), genesis.open->root ())));
 		ASSERT_NE (node1.active.roots.end (), existing1);
 		auto election1 (existing1->election);
 		ASSERT_NE (nullptr, election1);

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -14,10 +14,9 @@ TEST (conflicts, start_stop)
 	ASSERT_EQ (0, node1.active.size ());
 	node1.active.start (send1);
 	ASSERT_EQ (1, node1.active.size ());
-	auto root1 (send1->root ());
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing1 (node1.active.roots.find (nano::qualified_root (send1->previous (), root1)));
+		auto existing1 (node1.active.roots.find (send1->qualified_root ()));
 		ASSERT_NE (node1.active.roots.end (), existing1);
 		auto votes1 (existing1->election);
 		ASSERT_NE (nullptr, votes1);
@@ -44,7 +43,7 @@ TEST (conflicts, add_existing)
 	ASSERT_EQ (1, node1.active.size ());
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto votes1 (node1.active.roots.find (nano::qualified_root (send2->previous (), send2->root ()))->election);
+		auto votes1 (node1.active.roots.find (send2->qualified_root ())->election);
 		ASSERT_NE (nullptr, votes1);
 		ASSERT_EQ (2, votes1->last_votes.size ());
 		ASSERT_NE (votes1->last_votes.end (), votes1->last_votes.find (key2.pub));
@@ -171,7 +170,7 @@ TEST (conflicts, reprioritize)
 	node1.block_processor.flush ();
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ())));
+		auto existing1 (node1.active.roots.find (send1->qualified_root ()));
 		ASSERT_NE (node1.active.roots.end (), existing1);
 		ASSERT_EQ (difficulty1, existing1->difficulty);
 	}
@@ -182,7 +181,7 @@ TEST (conflicts, reprioritize)
 	node1.block_processor.flush ();
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing2 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ())));
+		auto existing2 (node1.active.roots.find (send1->qualified_root ()));
 		ASSERT_NE (node1.active.roots.end (), existing2);
 		ASSERT_EQ (difficulty2, existing2->difficulty);
 	}
@@ -204,7 +203,7 @@ TEST (conflicts, dependency)
 	// Check dependecy for genesis block
 	{
 		std::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto existing1 (node1.active.roots.find (nano::qualified_root (genesis.open->previous (), genesis.open->root ())));
+		auto existing1 (node1.active.roots.find (genesis.open->qualified_root ()));
 		ASSERT_NE (node1.active.roots.end (), existing1);
 		auto election1 (existing1->election);
 		ASSERT_NE (nullptr, election1);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -720,7 +720,7 @@ TEST (votes, check_signature)
 	auto node_l (system.nodes[0]);
 	node1.active.start (send1);
 	std::lock_guard<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
@@ -742,7 +742,7 @@ TEST (votes, add_one)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	lock.unlock ();
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
@@ -778,7 +778,7 @@ TEST (votes, add_two)
 	ASSERT_FALSE (node1.active.vote (vote2));
 	{
 		std::lock_guard<std::mutex> lock (node1.active.mutex);
-		auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+		auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 		ASSERT_EQ (3, votes1->last_votes.size ());
 		ASSERT_NE (votes1->last_votes.end (), votes1->last_votes.find (nano::test_genesis_key.pub));
 		ASSERT_EQ (send1->hash (), votes1->last_votes[nano::test_genesis_key.pub].hash);
@@ -805,7 +805,7 @@ TEST (votes, add_existing)
 	ASSERT_FALSE (node1.active.vote (vote1));
 	ASSERT_FALSE (node1.active.publish (send1));
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 	ASSERT_EQ (1, votes1->last_votes[nano::test_genesis_key.pub].sequence);
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
@@ -844,7 +844,7 @@ TEST (votes, add_old)
 	node1.active.start (send1);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
 	std::lock_guard<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
 	nano::keypair key2;
@@ -876,8 +876,8 @@ TEST (votes, add_old_different_account)
 	node1.active.start (send1);
 	node1.active.start (send2);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
-	auto votes2 (node1.active.roots.find (nano::qualified_root (send2->previous (), send2->root ()))->election);
+	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
+	auto votes2 (node1.active.roots.find (send2->qualified_root ())->election);
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	ASSERT_EQ (1, votes2->last_votes.size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
@@ -914,7 +914,7 @@ TEST (votes, add_cooldown)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
@@ -940,7 +940,7 @@ TEST (ledger, successor)
 	auto transaction (system.nodes[0]->store.tx_begin (true));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, send1).code);
 	ASSERT_EQ (send1, *system.nodes[0]->ledger.successor (transaction, nano::qualified_root (genesis.hash (), 0)));
-	ASSERT_EQ (*genesis.open, *system.nodes[0]->ledger.successor (transaction, nano::qualified_root (genesis.open->previous (), genesis.open->root ())));
+	ASSERT_EQ (*genesis.open, *system.nodes[0]->ledger.successor (transaction, genesis.open->qualified_root ()));
 	ASSERT_EQ (nullptr, system.nodes[0]->ledger.successor (transaction, nano::qualified_root (0)));
 }
 

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -720,7 +720,7 @@ TEST (votes, check_signature)
 	auto node_l (system.nodes[0]);
 	node1.active.start (send1);
 	std::lock_guard<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
@@ -742,7 +742,7 @@ TEST (votes, add_one)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	lock.unlock ();
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
@@ -778,7 +778,7 @@ TEST (votes, add_two)
 	ASSERT_FALSE (node1.active.vote (vote2));
 	{
 		std::lock_guard<std::mutex> lock (node1.active.mutex);
-		auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
+		auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
 		ASSERT_EQ (3, votes1->last_votes.size ());
 		ASSERT_NE (votes1->last_votes.end (), votes1->last_votes.find (nano::test_genesis_key.pub));
 		ASSERT_EQ (send1->hash (), votes1->last_votes[nano::test_genesis_key.pub].hash);
@@ -805,7 +805,7 @@ TEST (votes, add_existing)
 	ASSERT_FALSE (node1.active.vote (vote1));
 	ASSERT_FALSE (node1.active.publish (send1));
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
 	ASSERT_EQ (1, votes1->last_votes[nano::test_genesis_key.pub].sequence);
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
@@ -844,7 +844,7 @@ TEST (votes, add_old)
 	node1.active.start (send1);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
 	std::lock_guard<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
 	nano::keypair key2;
@@ -876,8 +876,8 @@ TEST (votes, add_old_different_account)
 	node1.active.start (send1);
 	node1.active.start (send2);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
-	auto votes2 (node1.active.roots.find (nano::uint512_union (send2->previous (), send2->root ()))->election);
+	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
+	auto votes2 (node1.active.roots.find (nano::qualified_root (send2->previous (), send2->root ()))->election);
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	ASSERT_EQ (1, votes2->last_votes.size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
@@ -914,7 +914,7 @@ TEST (votes, add_cooldown)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ()))->election);
+	auto votes1 (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ()))->election);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
@@ -939,9 +939,9 @@ TEST (ledger, successor)
 	nano::send_block send1 (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	auto transaction (system.nodes[0]->store.tx_begin (true));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, send1).code);
-	ASSERT_EQ (send1, *system.nodes[0]->ledger.successor (transaction, nano::uint512_union (genesis.hash (), 0)));
-	ASSERT_EQ (*genesis.open, *system.nodes[0]->ledger.successor (transaction, nano::uint512_union (genesis.open->previous (), genesis.open->root ())));
-	ASSERT_EQ (nullptr, system.nodes[0]->ledger.successor (transaction, nano::uint512_union (0)));
+	ASSERT_EQ (send1, *system.nodes[0]->ledger.successor (transaction, nano::qualified_root (genesis.hash (), 0)));
+	ASSERT_EQ (*genesis.open, *system.nodes[0]->ledger.successor (transaction, nano::qualified_root (genesis.open->previous (), genesis.open->root ())));
+	ASSERT_EQ (nullptr, system.nodes[0]->ledger.successor (transaction, nano::qualified_root (0)));
 }
 
 TEST (ledger, fail_change_old)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -202,7 +202,7 @@ TEST (node, node_receive_quorum)
 	{
 		{
 			std::lock_guard<std::mutex> guard (system.nodes[0]->active.mutex);
-			auto info (system.nodes[0]->active.roots.find (nano::uint512_union (previous, previous)));
+			auto info (system.nodes[0]->active.roots.find (nano::qualified_root (previous, previous)));
 			ASSERT_NE (system.nodes[0]->active.roots.end (), info);
 			done = info->election->announcements > nano::active_transactions::announcement_min;
 		}
@@ -863,7 +863,7 @@ TEST (node, fork_publish)
 		node1.block_processor.flush ();
 		ASSERT_EQ (1, node1.active.size ());
 		std::unique_lock<std::mutex> lock (node1.active.mutex);
-		auto existing (node1.active.roots.find (nano::uint512_union (send1->previous (), send1->root ())));
+		auto existing (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ())));
 		ASSERT_NE (node1.active.roots.end (), existing);
 		auto election (existing->election);
 		lock.unlock ();
@@ -913,7 +913,7 @@ TEST (node, fork_keep)
 	node2.process_active (send2);
 	node2.block_processor.flush ();
 	std::unique_lock<std::mutex> lock (node2.active.mutex);
-	auto conflict (node2.active.roots.find (nano::uint512_union (genesis.hash (), genesis.hash ())));
+	auto conflict (node2.active.roots.find (nano::qualified_root (genesis.hash (), genesis.hash ())));
 	ASSERT_NE (node2.active.roots.end (), conflict);
 	auto votes1 (conflict->election);
 	ASSERT_NE (nullptr, votes1);
@@ -969,7 +969,7 @@ TEST (node, fork_flip)
 	node2.process_message (publish1, channel2);
 	node2.block_processor.flush ();
 	std::unique_lock<std::mutex> lock (node2.active.mutex);
-	auto conflict (node2.active.roots.find (nano::uint512_union (genesis.hash (), genesis.hash ())));
+	auto conflict (node2.active.roots.find (nano::qualified_root (genesis.hash (), genesis.hash ())));
 	ASSERT_NE (node2.active.roots.end (), conflict);
 	auto votes1 (conflict->election);
 	ASSERT_NE (nullptr, votes1);
@@ -1030,7 +1030,7 @@ TEST (node, fork_multi_flip)
 	node2.process_message (publish1, node2.network.udp_channels.create (node2.network.endpoint ()));
 	node2.block_processor.flush ();
 	std::unique_lock<std::mutex> lock (node2.active.mutex);
-	auto conflict (node2.active.roots.find (nano::uint512_union (genesis.hash (), genesis.hash ())));
+	auto conflict (node2.active.roots.find (nano::qualified_root (genesis.hash (), genesis.hash ())));
 	ASSERT_NE (node2.active.roots.end (), conflict);
 	auto votes1 (conflict->election);
 	ASSERT_NE (nullptr, votes1);
@@ -1163,7 +1163,7 @@ TEST (node, fork_open_flip)
 	node2.process_active (open1);
 	node2.block_processor.flush ();
 	std::unique_lock<std::mutex> lock (node2.active.mutex);
-	auto conflict (node2.active.roots.find (nano::uint512_union (open1->previous (), open1->root ())));
+	auto conflict (node2.active.roots.find (nano::qualified_root (open1->previous (), open1->root ())));
 	ASSERT_NE (node2.active.roots.end (), conflict);
 	auto votes1 (conflict->election);
 	ASSERT_NE (nullptr, votes1);
@@ -1447,7 +1447,7 @@ TEST (node, rep_self_vote)
 	auto & active (node0->active);
 	active.start (block0);
 	std::unique_lock<std::mutex> lock (active.mutex);
-	auto existing (active.roots.find (nano::uint512_union (block0->previous (), block0->root ())));
+	auto existing (active.roots.find (nano::qualified_root (block0->previous (), block0->root ())));
 	ASSERT_NE (active.roots.end (), existing);
 	auto election (existing->election);
 	lock.unlock ();
@@ -1967,7 +1967,7 @@ TEST (node, confirm_quorum)
 		ASSERT_FALSE (system.nodes[0]->active.empty ());
 		{
 			std::lock_guard<std::mutex> guard (system.nodes[0]->active.mutex);
-			auto info (system.nodes[0]->active.roots.find (nano::uint512_union (send1->hash (), send1->hash ())));
+			auto info (system.nodes[0]->active.roots.find (nano::qualified_root (send1->hash (), send1->hash ())));
 			ASSERT_NE (system.nodes[0]->active.roots.end (), info);
 			done = info->election->announcements > nano::active_transactions::announcement_min;
 		}

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -863,7 +863,7 @@ TEST (node, fork_publish)
 		node1.block_processor.flush ();
 		ASSERT_EQ (1, node1.active.size ());
 		std::unique_lock<std::mutex> lock (node1.active.mutex);
-		auto existing (node1.active.roots.find (nano::qualified_root (send1->previous (), send1->root ())));
+		auto existing (node1.active.roots.find (send1->qualified_root ()));
 		ASSERT_NE (node1.active.roots.end (), existing);
 		auto election (existing->election);
 		lock.unlock ();
@@ -1163,7 +1163,7 @@ TEST (node, fork_open_flip)
 	node2.process_active (open1);
 	node2.block_processor.flush ();
 	std::unique_lock<std::mutex> lock (node2.active.mutex);
-	auto conflict (node2.active.roots.find (nano::qualified_root (open1->previous (), open1->root ())));
+	auto conflict (node2.active.roots.find (open1->qualified_root ()));
 	ASSERT_NE (node2.active.roots.end (), conflict);
 	auto votes1 (conflict->election);
 	ASSERT_NE (nullptr, votes1);
@@ -1447,7 +1447,7 @@ TEST (node, rep_self_vote)
 	auto & active (node0->active);
 	active.start (block0);
 	std::unique_lock<std::mutex> lock (active.mutex);
-	auto existing (active.roots.find (nano::qualified_root (block0->previous (), block0->root ())));
+	auto existing (active.roots.find (block0->qualified_root ()));
 	ASSERT_NE (active.roots.end (), existing);
 	auto election (existing->election);
 	lock.unlock ();

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -135,6 +135,11 @@ nano::account nano::block::account () const
 	return 0;
 }
 
+nano::qualified_root nano::block::qualified_root () const
+{
+	return nano::qualified_root (previous (), root ());
+}
+
 void nano::send_block::visit (nano::block_visitor & visitor_a) const
 {
 	visitor_a.send_block (*this);

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -71,6 +71,8 @@ public:
 	virtual nano::block_hash source () const;
 	// Previous block or account number for open blocks
 	virtual nano::block_hash root () const = 0;
+	// Qualified root value based on previous() and root()
+	virtual nano::qualified_root qualified_root () const;
 	// Link field for state blocks, zero otherwise.
 	virtual nano::block_hash link () const;
 	virtual nano::account representative () const;

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -145,8 +145,8 @@ union uint512_union
 	nano::uint512_t number () const;
 	std::string to_string () const;
 };
-// Only signatures are 512 bit.
 using signature = uint512_union;
+using qualified_root = uint512_union;
 
 nano::uint512_union sign_message (nano::raw_key const &, nano::public_key const &, nano::uint256_union const &);
 bool validate_message (nano::public_key const &, nano::uint256_union const &, nano::uint512_union const &);

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -288,7 +288,7 @@ void nano::block_processor::process_batch (std::unique_lock<std::mutex> & lock_a
 		auto hash (info.block->hash ());
 		if (force)
 		{
-			auto successor (node.ledger.successor (transaction, nano::uint512_union (info.block->previous (), info.block->root ())));
+			auto successor (node.ledger.successor (transaction, nano::qualified_root (info.block->previous (), info.block->root ())));
 			if (successor != nullptr && successor->hash () != hash)
 			{
 				// Replace our block with the winner and roll back any dependent blocks

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -288,7 +288,7 @@ void nano::block_processor::process_batch (std::unique_lock<std::mutex> & lock_a
 		auto hash (info.block->hash ());
 		if (force)
 		{
-			auto successor (node.ledger.successor (transaction, nano::qualified_root (info.block->previous (), info.block->root ())));
+			auto successor (node.ledger.successor (transaction, info.block->qualified_root ()));
 			if (successor != nullptr && successor->hash () != hash)
 			{
 				// Replace our block with the winner and roll back any dependent blocks

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -434,7 +434,7 @@ public:
 				if (!node.network.send_votes_cache (*channel, hash))
 				{
 					auto transaction (node.store.tx_begin_read ());
-					auto successor (node.ledger.successor (transaction, nano::qualified_root (message_a.block->previous (), message_a.block->root ())));
+					auto successor (node.ledger.successor (transaction, message_a.block->qualified_root ()));
 					if (successor != nullptr)
 					{
 						auto same_block (successor->hash () == hash);
@@ -3113,7 +3113,7 @@ bool nano::active_transactions::add (std::shared_ptr<nano::block> block_a, std::
 	auto error (true);
 	if (!stopped)
 	{
-		auto root (nano::qualified_root (block_a->previous (), block_a->root ()));
+		auto root (block_a->qualified_root ());
 		auto existing (roots.find (root));
 		if (existing == roots.end ())
 		{
@@ -3157,7 +3157,7 @@ bool nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool s
 			else
 			{
 				auto block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-				auto existing (roots.find (nano::qualified_root (block->previous (), block->root ())));
+				auto existing (roots.find (block->qualified_root ()));
 				if (existing != roots.end ())
 				{
 					result = existing->election->vote (vote_a->account, vote_a->sequence, block->hash ());
@@ -3177,13 +3177,13 @@ bool nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool s
 bool nano::active_transactions::active (nano::block const & block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	return roots.find (nano::qualified_root (block_a.previous (), block_a.root ())) != roots.end ();
+	return roots.find (block_a.qualified_root ()) != roots.end ();
 }
 
 void nano::active_transactions::update_difficulty (nano::block const & block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	auto existing (roots.find (nano::qualified_root (block_a.previous (), block_a.root ())));
+	auto existing (roots.find (block_a.qualified_root ()));
 	if (existing != roots.end ())
 	{
 		uint64_t difficulty;
@@ -3305,9 +3305,9 @@ std::deque<nano::election_status> nano::active_transactions::list_confirmed ()
 void nano::active_transactions::erase (nano::block const & block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	if (roots.find (nano::qualified_root (block_a.previous (), block_a.root ())) != roots.end ())
+	if (roots.find (block_a.qualified_root ()) != roots.end ())
 	{
-		roots.erase (nano::qualified_root (block_a.previous (), block_a.root ()));
+		roots.erase (block_a.qualified_root ());
 		node.logger.try_log (boost::str (boost::format ("Election erased for block block %1% root %2%") % block_a.hash ().to_string () % block_a.root ().to_string ()));
 	}
 }
@@ -3348,7 +3348,7 @@ nano::active_transactions::~active_transactions ()
 bool nano::active_transactions::publish (std::shared_ptr<nano::block> block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	auto existing (roots.find (nano::qualified_root (block_a->previous (), block_a->root ())));
+	auto existing (roots.find (block_a->qualified_root ()));
 	auto result (true);
 	if (existing != roots.end ())
 	{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -434,7 +434,7 @@ public:
 				if (!node.network.send_votes_cache (*channel, hash))
 				{
 					auto transaction (node.store.tx_begin_read ());
-					auto successor (node.ledger.successor (transaction, nano::uint512_union (message_a.block->previous (), message_a.block->root ())));
+					auto successor (node.ledger.successor (transaction, nano::qualified_root (message_a.block->previous (), message_a.block->root ())));
 					if (successor != nullptr)
 					{
 						auto same_block (successor->hash () == hash);
@@ -2848,7 +2848,7 @@ void nano::election::update_dependent ()
 
 void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & lock_a)
 {
-	std::unordered_set<nano::uint512_union> inactive;
+	std::unordered_set<nano::qualified_root> inactive;
 	auto transaction (node.store.tx_begin_read ());
 	unsigned unconfirmed_count (0);
 	unsigned unconfirmed_announcements (0);
@@ -3113,7 +3113,7 @@ bool nano::active_transactions::add (std::shared_ptr<nano::block> block_a, std::
 	auto error (true);
 	if (!stopped)
 	{
-		auto root (nano::uint512_union (block_a->previous (), block_a->root ()));
+		auto root (nano::qualified_root (block_a->previous (), block_a->root ()));
 		auto existing (roots.find (root));
 		if (existing == roots.end ())
 		{
@@ -3157,7 +3157,7 @@ bool nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool s
 			else
 			{
 				auto block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-				auto existing (roots.find (nano::uint512_union (block->previous (), block->root ())));
+				auto existing (roots.find (nano::qualified_root (block->previous (), block->root ())));
 				if (existing != roots.end ())
 				{
 					result = existing->election->vote (vote_a->account, vote_a->sequence, block->hash ());
@@ -3177,13 +3177,13 @@ bool nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool s
 bool nano::active_transactions::active (nano::block const & block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	return roots.find (nano::uint512_union (block_a.previous (), block_a.root ())) != roots.end ();
+	return roots.find (nano::qualified_root (block_a.previous (), block_a.root ())) != roots.end ();
 }
 
 void nano::active_transactions::update_difficulty (nano::block const & block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	auto existing (roots.find (nano::uint512_union (block_a.previous (), block_a.root ())));
+	auto existing (roots.find (nano::qualified_root (block_a.previous (), block_a.root ())));
 	if (existing != roots.end ())
 	{
 		uint64_t difficulty;
@@ -3205,7 +3205,7 @@ void nano::active_transactions::adjust_difficulty (nano::block_hash const & hash
 	std::deque<std::pair<nano::block_hash, int64_t>> remaining_blocks;
 	remaining_blocks.emplace_back (hash_a, 0);
 	std::unordered_set<nano::block_hash> processed_blocks;
-	std::vector<std::pair<nano::uint512_union, int64_t>> elections_list;
+	std::vector<std::pair<nano::qualified_root, int64_t>> elections_list;
 	uint128_t sum (0);
 	while (!remaining_blocks.empty ())
 	{
@@ -3237,7 +3237,7 @@ void nano::active_transactions::adjust_difficulty (nano::block_hash const & hash
 					remaining_blocks.emplace_back (dependent_block, level - 1);
 				}
 				processed_blocks.insert (hash);
-				nano::uint512_union root (previous, existing->second->status.winner->root ());
+				nano::qualified_root root (previous, existing->second->status.winner->root ());
 				auto existing_root (roots.find (root));
 				if (existing_root != roots.end ())
 				{
@@ -3305,9 +3305,9 @@ std::deque<nano::election_status> nano::active_transactions::list_confirmed ()
 void nano::active_transactions::erase (nano::block const & block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	if (roots.find (nano::uint512_union (block_a.previous (), block_a.root ())) != roots.end ())
+	if (roots.find (nano::qualified_root (block_a.previous (), block_a.root ())) != roots.end ())
 	{
-		roots.erase (nano::uint512_union (block_a.previous (), block_a.root ()));
+		roots.erase (nano::qualified_root (block_a.previous (), block_a.root ()));
 		node.logger.try_log (boost::str (boost::format ("Election erased for block block %1% root %2%") % block_a.hash ().to_string () % block_a.root ().to_string ()));
 	}
 }
@@ -3348,7 +3348,7 @@ nano::active_transactions::~active_transactions ()
 bool nano::active_transactions::publish (std::shared_ptr<nano::block> block_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
-	auto existing (roots.find (nano::uint512_union (block_a->previous (), block_a->root ())));
+	auto existing (roots.find (nano::qualified_root (block_a->previous (), block_a->root ())));
 	auto result (true);
 	if (existing != roots.end ())
 	{

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -98,7 +98,7 @@ public:
 class conflict_info
 {
 public:
-	nano::uint512_union root;
+	nano::qualified_root root;
 	uint64_t difficulty;
 	uint64_t adjusted_difficulty;
 	std::shared_ptr<nano::election> election;
@@ -133,7 +133,7 @@ public:
 	nano::conflict_info,
 	boost::multi_index::indexed_by<
 	boost::multi_index::hashed_unique<
-	boost::multi_index::member<nano::conflict_info, nano::uint512_union, &nano::conflict_info::root>>,
+	boost::multi_index::member<nano::conflict_info, nano::qualified_root, &nano::conflict_info::root>>,
 	boost::multi_index::ordered_non_unique<
 	boost::multi_index::member<nano::conflict_info, uint64_t, &nano::conflict_info::adjusted_difficulty>,
 	std::greater<uint64_t>>>>

--- a/nano/node/rpc.cpp
+++ b/nano/node/rpc.cpp
@@ -1613,7 +1613,7 @@ void nano::rpc_handler::confirmation_info ()
 	const bool contents = request.get<bool> ("contents", true);
 	const bool json_block_l = request.get<bool> ("json_block", false);
 	std::string root_text (request.get<std::string> ("root"));
-	nano::uint512_union root;
+	nano::qualified_root root;
 	if (!root.decode_hex (root_text))
 	{
 		std::lock_guard<std::mutex> lock (node.active.mutex);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1006,7 +1006,7 @@ void nano::ledger::change_latest (nano::transaction const & transaction_a, nano:
 	}
 }
 
-std::shared_ptr<nano::block> nano::ledger::successor (nano::transaction const & transaction_a, nano::uint512_union const & root_a)
+std::shared_ptr<nano::block> nano::ledger::successor (nano::transaction const & transaction_a, nano::qualified_root const & root_a)
 {
 	nano::block_hash successor (0);
 	if (root_a.uint256s[0].is_zero () && store.account_exists (transaction_a, root_a.uint256s[1]))

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -25,7 +25,7 @@ public:
 	nano::uint128_t account_balance (nano::transaction const &, nano::account const &);
 	nano::uint128_t account_pending (nano::transaction const &, nano::account const &);
 	nano::uint128_t weight (nano::transaction const &, nano::account const &);
-	std::shared_ptr<nano::block> successor (nano::transaction const &, nano::uint512_union const &);
+	std::shared_ptr<nano::block> successor (nano::transaction const &, nano::qualified_root const &);
 	std::shared_ptr<nano::block> forked_block (nano::transaction const &, nano::block const &);
 	bool block_confirmed (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 	nano::block_hash latest (nano::transaction const &, nano::account const &);


### PR DESCRIPTION
A type alias in the same vein as nano::signature to improve readability and a new qualified_root 
 function in `block` to construct the value.