### PR TITLE
Unsafe encoding in IPC

### DIFF
--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -58,7 +58,9 @@ namespace ipc
 		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
 		 * Response is 32-bit BE payload length followed by payload bytes.
 		 */
-		json_legacy = 1
+		json_legacy = 0x1,
+		/** Request/response is same as json_legacy and exposes unsafe RPC's */
+		json_unsafe = 0x2
 	};
 
 	/** IPC transport interface */

--- a/nano/node/ipcconfig.cpp
+++ b/nano/node/ipcconfig.cpp
@@ -20,6 +20,7 @@ nano::error nano::ipc::ipc_config::serialize_json (nano::jsonconfig & json) cons
 		domain_l.put ("io_threads", transport_domain.io_threads);
 	}
 	domain_l.put ("enable", transport_domain.enabled);
+	domain_l.put ("allow_unsafe", transport_domain.allow_unsafe);
 	domain_l.put ("path", transport_domain.path);
 	domain_l.put ("io_timeout", transport_domain.io_timeout);
 	json.put_child ("local", domain_l);
@@ -32,6 +33,7 @@ nano::error nano::ipc::ipc_config::deserialize_json (nano::jsonconfig & json)
 	if (tcp_l)
 	{
 		tcp_l->get_optional<long> ("io_threads", transport_tcp.io_threads, -1);
+		tcp_l->get_optional<bool> ("allow_unsafe", transport_tcp.allow_unsafe);
 		tcp_l->get<bool> ("enable", transport_tcp.enabled);
 		tcp_l->get<uint16_t> ("port", transport_tcp.port);
 		tcp_l->get<size_t> ("io_timeout", transport_tcp.io_timeout);
@@ -41,6 +43,7 @@ nano::error nano::ipc::ipc_config::deserialize_json (nano::jsonconfig & json)
 	if (domain_l)
 	{
 		domain_l->get_optional<long> ("io_threads", transport_domain.io_threads, -1);
+		domain_l->get_optional<bool> ("allow_unsafe", transport_domain.allow_unsafe);
 		domain_l->get<bool> ("enable", transport_domain.enabled);
 		domain_l->get<std::string> ("path", transport_domain.path);
 		domain_l->get<size_t> ("io_timeout", transport_domain.io_timeout);

--- a/nano/node/ipcconfig.hpp
+++ b/nano/node/ipcconfig.hpp
@@ -16,6 +16,7 @@ namespace ipc
 	public:
 		virtual ~ipc_config_transport () = default;
 		bool enabled{ false };
+		bool allow_unsafe{ false };
 		size_t io_timeout{ 15 };
 		long io_threads{ -1 };
 	};

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -4138,6 +4138,27 @@ void nano::rpc_handler::wallet_republish ()
 	response_errors ();
 }
 
+void nano::rpc_handler::wallet_seed ()
+{
+	rpc_control_impl ();
+	auto wallet (wallet_impl ());
+	if (!ec)
+	{
+		auto transaction (node.wallets.tx_begin_read ());
+		if (wallet->store.valid_password (transaction))
+		{
+			nano::raw_key seed;
+			wallet->store.seed (seed, transaction);
+			response_l.put ("seed", seed.data.to_string ());
+		}
+		else
+		{
+			ec = nano::error_common::wallet_locked;
+		}
+	}
+	response_errors ();
+}
+
 void nano::rpc_handler::wallet_work_get ()
 {
 	rpc_control_impl ();
@@ -4369,7 +4390,7 @@ std::string filter_request (boost::property_tree::ptree tree_a)
 }
 }
 
-void nano::rpc_handler::process_request ()
+void nano::rpc_handler::process_request (bool unsafe_a)
 {
 	try
 	{
@@ -4410,7 +4431,18 @@ void nano::rpc_handler::process_request ()
 			else
 			{
 				// Try the rest of the options
-				if (action == "chain")
+				if (action == "wallet_seed")
+				{
+					if (unsafe_a || rpc.node.network_params.network.is_test_network ())
+					{
+						wallet_seed ();
+					}
+					else
+					{
+						error_response (response, "Unsafe RPC not allowed");
+					}
+				}
+				else if (action == "chain")
 				{
 					chain ();
 				}

--- a/nano/rpc/rpc_handler.hpp
+++ b/nano/rpc/rpc_handler.hpp
@@ -16,7 +16,12 @@ class rpc_handler : public std::enable_shared_from_this<nano::rpc_handler>
 {
 public:
 	rpc_handler (nano::node &, nano::rpc &, std::string const &, std::string const &, std::function<void(boost::property_tree::ptree const &)> const &);
-	void process_request ();
+
+	/**
+	 * Process http request
+	 * @param unsafe If true, the caller requests an unsafe action. This will be granted only if the config allows it.
+	 */
+	void process_request (bool unsafe = false);
 	void account_balance ();
 	void account_block_count ();
 	void account_count ();
@@ -117,6 +122,7 @@ public:
 	void wallet_representative ();
 	void wallet_representative_set ();
 	void wallet_republish ();
+	void wallet_seed ();
 	void wallet_work_get ();
 	void work_generate ();
 	void work_cancel ();


### PR DESCRIPTION
Enables wallet_seed over a new IPC encoding. In addition to clients using the new encoding, a config flag must be set on each transport the client wants to use for this.

Based on #949 (only wallet_seed is used for now) and #1716