### PR TITLE
Fix active_transactions/signature checker initialization order

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1027,14 +1027,13 @@ wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (init_a.wallets_st
 wallets_store (*wallets_store_impl),
 gap_cache (*this),
 ledger (store, stats, config.epoch_block_link, config.epoch_block_signer),
-active (*this),
+checker (config.signature_checker_threads),
 network (*this, config.peering_port),
 bootstrap_initiator (*this),
 bootstrap (io_ctx_a, config.peering_port, *this),
 application_path (application_path_a),
 wallets (init_a.wallet_init, *this),
 port_mapping (*this),
-checker (config.signature_checker_threads),
 vote_processor (*this),
 rep_crawler (*this),
 warmed_up (0),
@@ -1046,6 +1045,7 @@ block_processor_thread ([this]() {
 online_reps (*this, config.online_weight_minimum.number ()),
 stats (config.stat_config),
 vote_uniquer (block_uniquer),
+active (*this),
 startup_time (std::chrono::steady_clock::now ())
 {
 	wallets.observer = [this](bool active) {

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -488,7 +488,7 @@ public:
 	nano::wallets_store & wallets_store;
 	nano::gap_cache gap_cache;
 	nano::ledger ledger;
-	nano::active_transactions active;
+	nano::signature_checker checker;
 	nano::network network;
 	nano::bootstrap_initiator bootstrap_initiator;
 	nano::bootstrap_listener bootstrap;
@@ -496,7 +496,6 @@ public:
 	nano::node_observers observers;
 	nano::wallets wallets;
 	nano::port_mapping port_mapping;
-	nano::signature_checker checker;
 	nano::vote_processor vote_processor;
 	nano::rep_crawler rep_crawler;
 	unsigned warmed_up;
@@ -509,6 +508,7 @@ public:
 	nano::keypair node_id;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
+	nano::active_transactions active;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	static double constexpr price_max = 16.0;


### PR DESCRIPTION
Master currently crashes in active_transactions::confirm_frontiers from time to time.