### PR TITLE
Support release_assert failures in tests

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library (nano_lib
 	work.cpp)
 
 target_link_libraries (nano_lib
+	gtest
 	xxhash
 	blake2
 	${CRYPTOPP_LIBRARY}

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library (nano_lib
 	work.hpp
 	work.cpp)
 
+target_include_directories(nano_lib PRIVATE ${CMAKE_SOURCE_DIR}/gtest/googletest/include)
 target_link_libraries (nano_lib
 	gtest
 	xxhash

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -1,4 +1,6 @@
+#include <gtest/gtest.h>
 #include <iostream>
+#include <nano/lib/config.hpp>
 #include <nano/lib/utility.hpp>
 
 namespace nano
@@ -143,6 +145,14 @@ void release_assert_internal (bool check, const char * check_expr, const char * 
 		return;
 	}
 
-	std::cerr << "Assertion (" << check_expr << ") failed " << file << ":" << line << std::endl;
-	abort ();
+	nano::network_params params;
+	if (!params.is_test_network ())
+	{
+		std::cerr << "Assertion (" << check_expr << ") failed " << file << ":" << line << std::endl;
+		abort ();
+	}
+	else
+	{
+		FAIL () << "Assertion (" << check_expr << ") failed at " << file << ":" << line;
+	}
 }


### PR DESCRIPTION
Replacement of https://github.com/nanocurrency/nano-node/pull/1117 which works with `network_params``

Not convinced the added dependency on gtest is worth it (release asserts should be very rare and easy to spot in tests), but putting it up for discussion.