### PR TITLE
recalculate work for long unconfirmed local blocks

### DIFF
--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -36,7 +36,7 @@ public:
 	void flush ();
 	bool full ();
 	void add (nano::unchecked_info const &);
-	void add (std::shared_ptr<nano::block>, uint64_t = 0);
+	void add (std::shared_ptr<nano::block>, uint64_t = 0, bool = false);
 	void force (std::shared_ptr<nano::block>);
 	bool should_log (bool);
 	bool have_blocks ();
@@ -51,7 +51,7 @@ private:
 	void queue_unchecked (nano::transaction const &, nano::block_hash const &);
 	void verify_state_blocks (nano::transaction const & transaction_a, std::unique_lock<std::mutex> &, size_t = std::numeric_limits<size_t>::max ());
 	void process_batch (std::unique_lock<std::mutex> &);
-	void process_live (nano::block_hash const &, std::shared_ptr<nano::block>);
+	void process_live (nano::block_hash const &, std::shared_ptr<nano::block>, bool = false);
 	bool stopped;
 	bool active;
 	std::chrono::steady_clock::time_point next_log;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2925,8 +2925,8 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 								election_l->ongoing_work_update = false;
 							}
 						};
-					node.work_generate (block_l->root (), callback, difficulty);
-					election_l->ongoing_work_update = true;
+						node.work_generate (block_l->root (), callback, difficulty);
+						election_l->ongoing_work_update = true;
 					}
 				}
 			}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2915,6 +2915,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 					nano::work_validate (*block_l, &difficulty);
 					if (difficulty < active_difficulty)
 					{
+						election_l->ongoing_work_update = true;
 						auto node_l (node.shared ());
 						auto callback = [node_l, block_l, election_l](boost::optional<uint64_t> const & work_a) {
 							if (work_a && !nano::work_validate (block_l->root (), work_a.get ()))
@@ -2926,7 +2927,6 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 							}
 						};
 						node.work_generate (block_l->root (), callback, difficulty);
-						election_l->ongoing_work_update = true;
 					}
 				}
 			}

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -60,7 +60,7 @@ class election final : public std::enable_shared_from_this<nano::election>
 	std::function<void(std::shared_ptr<nano::block>)> confirmation_action;
 
 public:
-	election (nano::node &, std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const &);
+	election (nano::node &, std::shared_ptr<nano::block>, bool, std::function<void(std::shared_ptr<nano::block>)> const &);
 	nano::election_vote_result vote (nano::account, uint64_t, nano::block_hash);
 	nano::tally_t tally (nano::transaction const &);
 	// Check if we have vote quorum
@@ -85,6 +85,8 @@ public:
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 	unsigned announcements;
 	std::unordered_set<nano::block_hash> dependent_blocks;
+	bool local_block;
+	std::atomic<bool> ongoing_work_update{ false };
 };
 class conflict_info final
 {
@@ -104,7 +106,7 @@ public:
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
 	// clang-format off
-	bool start (std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
+	bool start (std::shared_ptr<nano::block>, bool = false, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
@@ -149,7 +151,7 @@ public:
 private:
 	// Call action with confirmed block, may be different than what we started with
 	// clang-format off
-	bool add (std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
+	bool add (std::shared_ptr<nano::block>, bool = false, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	void request_loop ();
 	void request_confirm (std::unique_lock<std::mutex> &);
@@ -436,7 +438,7 @@ public:
 	void receive_confirmed (nano::transaction const &, std::shared_ptr<nano::block>, nano::block_hash const &);
 	void process_confirmed (std::shared_ptr<nano::block>, uint8_t = 0);
 	void process_message (nano::message const &, std::shared_ptr<nano::transport::channel>);
-	void process_active (std::shared_ptr<nano::block>);
+	void process_active (std::shared_ptr<nano::block>, bool = false);
 	nano::process_return process (nano::block const &);
 	void keepalive_preconfigured (std::vector<std::string> const &);
 	nano::block_hash latest (nano::account const &);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -978,7 +978,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block const & s
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block->hash ().to_string () % account.to_account ()));
 			wallets.node.work_generate_blocking (*block);
 		}
-		wallets.node.process_active (block);
+		wallets.node.process_active (block, true);
 		wallets.node.block_processor.flush ();
 		if (generate_work_a)
 		{
@@ -1020,7 +1020,7 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block->hash ().to_string () % source_a.to_account ()));
 			wallets.node.work_generate_blocking (*block);
 		}
-		wallets.node.process_active (block);
+		wallets.node.process_active (block, true);
 		wallets.node.block_processor.flush ();
 		if (generate_work_a)
 		{
@@ -1106,7 +1106,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block->hash ().to_string () % account_a.to_account ()));
 			wallets.node.work_generate_blocking (*block);
 		}
-		wallets.node.process_active (block);
+		wallets.node.process_active (block, true);
 		wallets.node.block_processor.flush ();
 		if (generate_work_a)
 		{

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -302,11 +302,12 @@ nano::block_hash nano::pending_key::key () const
 	return account;
 }
 
-nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> block_a, nano::account const & account_a, uint64_t modified_a, nano::signature_verification verified_a) :
+nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> block_a, nano::account const & account_a, uint64_t modified_a, nano::signature_verification verified_a, bool local_block_a) :
 block (block_a),
 account (account_a),
 modified (modified_a),
-verified (verified_a)
+verified (verified_a),
+local_block (local_block_a)
 {
 }
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -175,7 +175,7 @@ class unchecked_info final
 {
 public:
 	unchecked_info () = default;
-	unchecked_info (std::shared_ptr<nano::block>, nano::account const &, uint64_t, nano::signature_verification = nano::signature_verification::unknown);
+	unchecked_info (std::shared_ptr<nano::block>, nano::account const &, uint64_t, nano::signature_verification = nano::signature_verification::unknown, bool = false);
 	void serialize (nano::stream &) const;
 	bool deserialize (nano::stream &);
 	std::shared_ptr<nano::block> block;
@@ -183,6 +183,8 @@ public:
 	/** Seconds since posix epoch */
 	uint64_t modified{ 0 };
 	nano::signature_verification verified{ nano::signature_verification::unknown };
+	// Local block flag is not used in serialization/deserialization
+	bool local_block{ false };
 };
 
 class block_info final


### PR DESCRIPTION
using a difficulty threshold of the long unconfirmed block
#1858 allows for recalculating with a threshold of active_difficulty instead
part of #1336 