### PR TITLE
Refactor preparation for moving RPC out of process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@
 *.DS_Store
 core_test
 !core_test/
+rpc_test
+!rpc_test/
 qt_test
 nano_node
 nano_wallet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ add_subdirectory(nano/crypto_lib)
 add_subdirectory(nano/secure)
 add_subdirectory(nano/lib)
 add_subdirectory(nano/node)
+add_subdirectory(nano/rpc)
 add_subdirectory(nano/nano_node)
 
 if (NANO_TEST OR RAIBLOCKS_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ if (NANO_TEST OR RAIBLOCKS_TEST)
 		"${CMAKE_SOURCE_DIR}/gtest/googletest/include")
 
 	add_subdirectory(nano/core_test)
+	add_subdirectory(nano/rpc_test)
 	add_subdirectory(nano/slow_test)
 endif ()
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -65,6 +65,9 @@ run_tests() {
         fi
     done
 
+    xvfb_run_ ./rpc_test
+    rpc_test_res=${?}
+    
     xvfb_run_ ./qt_test
     qt_test_res=${?}
 
@@ -72,6 +75,7 @@ run_tests() {
     load_test_res=${?}
 
     echo "Core Test return code: ${core_test_res}"
+    echo "RPC  Test return code: ${rpc_test_res}"
     echo "QT Test return code: ${qt_test_res}"
     echo "Load Test return code: ${load_test_res}"
     return ${core_test_res}

--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -8,8 +8,8 @@
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/common.hpp>
-#include <nano/node/rpc.hpp>
 #include <nano/node/testing.hpp>
+#include <nano/rpc/rpc.hpp>
 
 using namespace std::chrono_literals;
 

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -15,20 +15,27 @@ add_library (nano_lib
 	errors.hpp
 	errors.cpp
 	expected.hpp
-	blockbuilders.cpp
 	blockbuilders.hpp
-	blocks.cpp
+	blockbuilders.cpp
 	blocks.hpp
+	blocks.cpp
 	config.hpp
 	config.cpp
-	interface.cpp
 	interface.h
+	interface.cpp
+	ipc.hpp
+	ipc.cpp
+	ipc_client.hpp
+	ipc_client.cpp
 	jsonconfig.hpp
-	numbers.cpp
+	logger_mt.hpp
+	rpcconfig.hpp
+	rpcconfig.cpp
 	numbers.hpp
+	numbers.cpp
 	timer.hpp
-	utility.cpp
 	utility.hpp
+	utility.cpp
 	work.hpp
 	work.cpp)
 

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -7,6 +7,15 @@
 #include <nano/lib/numbers.hpp>
 #include <string>
 
+#define xstr(a) ver_str (a)
+#define ver_str(a) #a
+
+/**
+* Returns build version information
+*/
+static const char * NANO_MAJOR_MINOR_VERSION = xstr (NANO_VERSION_MAJOR) "." xstr (NANO_VERSION_MINOR);
+static const char * NANO_MAJOR_MINOR_RC_VERSION = xstr (NANO_VERSION_MAJOR) "." xstr (NANO_VERSION_MINOR) "RC" xstr (NANO_VERSION_PATCH);
+
 namespace nano
 {
 /**

--- a/nano/lib/ipc.cpp
+++ b/nano/lib/ipc.cpp
@@ -1,0 +1,43 @@
+#include <nano/lib/ipc.hpp>
+
+nano::ipc::socket_base::socket_base (boost::asio::io_context & io_ctx_a) :
+io_timer (io_ctx_a)
+{
+}
+
+void nano::ipc::socket_base::timer_start (std::chrono::seconds timeout_a)
+{
+	if (timeout_a < std::chrono::seconds::max ())
+	{
+		io_timer.expires_from_now (boost::posix_time::seconds (static_cast<long> (timeout_a.count ())));
+		io_timer.async_wait ([this](const boost::system::error_code & ec) {
+			if (!ec)
+			{
+				this->timer_expired ();
+			}
+		});
+	}
+}
+
+void nano::ipc::socket_base::timer_expired ()
+{
+	close ();
+}
+
+void nano::ipc::socket_base::timer_cancel ()
+{
+	boost::system::error_code ec;
+	io_timer.cancel (ec);
+	assert (!ec);
+}
+
+nano::ipc::dsock_file_remover::dsock_file_remover (std::string const & file_a) :
+filename (file_a)
+{
+	std::remove (filename.c_str ());
+}
+
+nano::ipc::dsock_file_remover::~dsock_file_remover ()
+{
+	std::remove (filename.c_str ());
+}

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <string>
+
+namespace nano
+{
+namespace ipc
+{
+	/**
+	 * The IPC framing format is simple: preamble followed by an encoding specific payload.
+	 * Preamble is uint8_t {'N', encoding_type, reserved, reserved}. Reserved bytes MUST be zero.
+	 * @note This is intentionally not an enum class as the values are only used as vector indices.
+	 */
+	enum preamble_offset
+	{
+		/** Always 'N' */
+		lead = 0,
+		/** One of the payload_encoding values */
+		encoding = 1,
+		/** Always zero */
+		reserved_1 = 2,
+		/** Always zero */
+		reserved_2 = 3,
+	};
+
+	/** Abstract base type for sockets, implementing timer logic and a close operation */
+	class socket_base
+	{
+	public:
+		socket_base (boost::asio::io_context & io_ctx_a);
+		virtual ~socket_base () = default;
+
+		/** Close socket */
+		virtual void close () = 0;
+
+		/**
+		 * Start IO timer.
+		 * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
+		 */
+		void timer_start (std::chrono::seconds timeout_a);
+		void timer_expired ();
+		void timer_cancel ();
+
+	private:
+		/** IO operation timer */
+		boost::asio::deadline_timer io_timer;
+	};
+
+	/**
+	 * Payload encodings; add protobuf, flatbuffers and so on as needed.
+	 */
+	enum class payload_encoding : uint8_t
+	{
+		/**
+		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
+		 * Response is 32-bit BE payload length followed by payload bytes.
+		 */
+		json_legacy = 1
+	};
+
+	/** IPC transport interface */
+	class transport
+	{
+	public:
+		virtual void stop () = 0;
+		virtual ~transport () = default;
+	};
+
+	/** The domain socket file is attempted to be removed at both startup and shutdown. */
+	class dsock_file_remover final
+	{
+	public:
+		dsock_file_remover (std::string const & file_a);
+		~dsock_file_remover ();
+
+	private:
+		std::string filename;
+	};
+}
+}

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -1,0 +1,227 @@
+#include <boost/endian/conversion.hpp>
+#include <boost/polymorphic_cast.hpp>
+#include <nano/lib/ipc.hpp>
+#include <nano/lib/ipc_client.hpp>
+
+namespace
+{
+/** Socket agnostic IO interface */
+class channel
+{
+public:
+	virtual void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) = 0;
+	virtual void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) = 0;
+};
+
+/** Domain and TCP client socket */
+template <typename SOCKET_TYPE, typename ENDPOINT_TYPE>
+class socket_client : public nano::ipc::socket_base, public channel
+{
+public:
+	socket_client (boost::asio::io_context & io_ctx_a, ENDPOINT_TYPE endpoint_a) :
+	socket_base (io_ctx_a), endpoint (endpoint_a), socket (io_ctx_a), resolver (io_ctx_a)
+	{
+	}
+
+	void async_resolve (std::string const & host_a, uint16_t port_a, std::function<void(boost::system::error_code const &, boost::asio::ip::tcp::endpoint)> callback_a)
+	{
+		this->timer_start (io_timeout);
+		resolver.async_resolve (boost::asio::ip::tcp::resolver::query (host_a, std::to_string (port_a)), [this, callback_a](boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator endpoint_iterator_a) {
+			this->timer_cancel ();
+			boost::asio::ip::tcp::resolver::iterator end;
+			if (!ec && endpoint_iterator_a != end)
+			{
+				endpoint = *endpoint_iterator_a;
+				callback_a (ec, *endpoint_iterator_a);
+			}
+			else
+			{
+				callback_a (ec, *end);
+			}
+		});
+	}
+
+	void async_connect (std::function<void(boost::system::error_code const &)> callback_a)
+	{
+		this->timer_start (io_timeout);
+		socket.async_connect (endpoint, [this, callback_a](boost::system::error_code const & ec) {
+			this->timer_cancel ();
+			callback_a (ec);
+		});
+	}
+
+	void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) override
+	{
+		this->timer_start (io_timeout);
+		buffer_a->resize (size_a);
+		boost::asio::async_read (socket, boost::asio::buffer (buffer_a->data (), size_a), [this, callback_a](boost::system::error_code const & ec, size_t size_a) {
+			this->timer_cancel ();
+			callback_a (ec, size_a);
+		});
+	}
+
+	void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) override
+	{
+		this->timer_start (io_timeout);
+		boost::asio::async_write (socket, boost::asio::buffer (buffer_a->data (), buffer_a->size ()), [this, callback_a, buffer_a](boost::system::error_code const & ec, size_t size_a) {
+			this->timer_cancel ();
+			callback_a (ec, size_a);
+		});
+	}
+
+	/** Shut down and close socket */
+	void close () override
+	{
+		socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both);
+		socket.close ();
+	}
+
+private:
+	ENDPOINT_TYPE endpoint;
+	SOCKET_TYPE socket;
+	boost::asio::ip::tcp::resolver resolver;
+	std::chrono::seconds io_timeout{ 60 };
+};
+
+/**
+ * PIMPL class for ipc_client. This ensures that socket_client and boost details can
+ * stay out of the header file.
+ */
+class client_impl : public nano::ipc::ipc_client_impl
+{
+public:
+	client_impl (boost::asio::io_context & io_ctx_a) :
+	io_ctx (io_ctx_a)
+	{
+	}
+
+	void connect (std::string const & host_a, uint16_t port_a, std::function<void(nano::error)> callback_a)
+	{
+		tcp_client = std::make_shared<socket_client<boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>> (io_ctx, boost::asio::ip::tcp::endpoint (boost::asio::ip::tcp::v6 (), port_a));
+
+		tcp_client->async_resolve (host_a, port_a, [this, callback_a](boost::system::error_code const & ec_resolve_a, boost::asio::ip::tcp::endpoint endpoint_a) {
+			if (!ec_resolve_a)
+			{
+				this->tcp_client->async_connect ([callback_a](const boost::system::error_code & ec_connect_a) {
+					callback_a (nano::error (ec_connect_a));
+				});
+			}
+			else
+			{
+				callback_a (nano::error (ec_resolve_a));
+			}
+		});
+	}
+
+	nano::error connect (std::string const & path_a)
+	{
+		nano::error err;
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+		domain_client = std::make_shared<socket_client<boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> (io_ctx, boost::asio::local::stream_protocol::endpoint (path_a));
+#else
+		err = nano::error ("Domain sockets are not supported by this platform");
+#endif
+		return err;
+	}
+
+	channel & get_channel ()
+	{
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+		return tcp_client ? static_cast<channel &> (*tcp_client) : static_cast<channel &> (*domain_client);
+#else
+		return static_cast<channel &> (*tcp_client);
+#endif
+	}
+
+private:
+	boost::asio::io_context & io_ctx;
+	std::shared_ptr<socket_client<boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>> tcp_client;
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+	std::shared_ptr<socket_client<boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> domain_client;
+#endif
+};
+}
+
+nano::ipc::ipc_client::ipc_client (boost::asio::io_context & io_ctx_a) :
+io_ctx (io_ctx_a)
+{
+}
+
+nano::error nano::ipc::ipc_client::connect (std::string const & path_a)
+{
+	impl = std::make_unique<client_impl> (io_ctx);
+	return boost::polymorphic_downcast<client_impl *> (impl.get ())->connect (path_a);
+}
+
+void nano::ipc::ipc_client::async_connect (std::string const & host_a, uint16_t port_a, std::function<void(nano::error)> callback_a)
+{
+	impl = std::make_unique<client_impl> (io_ctx);
+	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
+	client->connect (host_a, port_a, callback_a);
+}
+
+nano::error nano::ipc::ipc_client::connect (std::string const & host, uint16_t port)
+{
+	std::promise<nano::error> result_l;
+	async_connect (host, port, [&result_l](nano::error err_a) {
+		result_l.set_value (err_a);
+	});
+	return result_l.get_future ().get ();
+}
+
+void nano::ipc::ipc_client::async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(nano::error, size_t)> callback_a)
+{
+	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
+	client->get_channel ().async_write (buffer_a, [callback_a](const boost::system::error_code & ec_a, size_t bytes_written_a) {
+		callback_a (nano::error (ec_a), bytes_written_a);
+	});
+}
+
+void nano::ipc::ipc_client::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(nano::error, size_t)> callback_a)
+{
+	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
+	client->get_channel ().async_read (buffer_a, size_a, [callback_a](const boost::system::error_code & ec_a, size_t bytes_read_a) {
+		callback_a (nano::error (ec_a), bytes_read_a);
+	});
+}
+
+std::shared_ptr<std::vector<uint8_t>> nano::ipc::prepare_request (nano::ipc::payload_encoding encoding_a, std::string const & payload_a)
+{
+	auto buffer_l (std::make_shared<std::vector<uint8_t>> ());
+	if (encoding_a == nano::ipc::payload_encoding::json_legacy)
+	{
+		buffer_l->push_back ('N');
+		buffer_l->push_back (static_cast<uint8_t> (encoding_a));
+		buffer_l->push_back (0);
+		buffer_l->push_back (0);
+
+		auto payload_length = static_cast<uint32_t> (payload_a.size ());
+		uint32_t be = boost::endian::native_to_big (payload_length);
+		char * chars = reinterpret_cast<char *> (&be);
+		buffer_l->insert (buffer_l->end (), chars, chars + sizeof (uint32_t));
+		buffer_l->insert (buffer_l->end (), payload_a.begin (), payload_a.end ());
+	}
+	return buffer_l;
+}
+
+std::string nano::ipc::request (nano::ipc::ipc_client & ipc_client, std::string const & rpc_action_a)
+{
+	auto req (prepare_request (nano::ipc::payload_encoding::json_legacy, rpc_action_a));
+	auto res (std::make_shared<std::vector<uint8_t>> ());
+
+	std::promise<std::string> result_l;
+	// clang-format off
+	ipc_client.async_write (req, [&ipc_client, &res, &result_l](nano::error err_a, size_t size_a) {
+		// Read length
+		ipc_client.async_read (res, sizeof (uint32_t), [&ipc_client, &res, &result_l](nano::error err_read_a, size_t size_read_a) {
+			uint32_t payload_size_l = boost::endian::big_to_native (*reinterpret_cast<uint32_t *> (res->data ()));
+			// Read json payload
+			ipc_client.async_read (res, payload_size_l, [&res, &result_l](nano::error err_read_a, size_t size_read_a) {
+				result_l.set_value (std::string (res->begin (), res->end ()));
+			});
+		});
+	});
+	// clang-format on
+
+	return result_l.get_future ().get ();
+}

--- a/nano/lib/ipc_client.hpp
+++ b/nano/lib/ipc_client.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <nano/lib/errors.hpp>
+#include <nano/lib/ipc.hpp>
+#include <string>
+#include <vector>
+
+namespace nano
+{
+namespace ipc
+{
+	class ipc_client_impl
+	{
+	public:
+		virtual ~ipc_client_impl () = default;
+	};
+
+	/** IPC client */
+	class ipc_client
+	{
+	public:
+		ipc_client (boost::asio::io_context & io_ctx_a);
+		ipc_client (ipc_client && ipc_client) = default;
+		virtual ~ipc_client () = default;
+
+		/** Connect to a domain socket */
+		nano::error connect (std::string const & path);
+
+		/** Connect to a tcp socket synchronously */
+		nano::error connect (std::string const & host, uint16_t port);
+
+		/** Connect to a tcp socket asynchronously */
+		void async_connect (std::string const & host, uint16_t port, std::function<void(nano::error)> callback);
+
+		/** Write buffer asynchronously */
+		void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(nano::error, size_t)> callback_a);
+
+		/** Read \p size_a bytes asynchronously */
+		void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(nano::error, size_t)> callback_a);
+
+	private:
+		boost::asio::io_context & io_ctx;
+
+		// PIMPL pattern to hide implementation details
+		std::unique_ptr<ipc_client_impl> impl;
+	};
+
+	/** Convenience function for making synchronous IPC calls. The client must be connected */
+	std::string request (nano::ipc::ipc_client & ipc_client, std::string const & rpc_action_a);
+
+	/**
+  	 * Returns a buffer with an IPC preamble for the given \p encoding_a followed by the payload. Depending on encoding,
+	 * the buffer may contain a payload length or end sentinel.
+	 */
+	std::shared_ptr<std::vector<uint8_t>> prepare_request (nano::ipc::payload_encoding encoding_a, std::string const & payload_a);
+}
+}

--- a/nano/lib/logger_mt.hpp
+++ b/nano/lib/logger_mt.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <boost/log/sources/logger.hpp>
+#include <boost/log/trivial.hpp>
+#include <chrono>
+
+namespace nano
+{
+// A wrapper around a boost logger object to allow minimum
+// time spaced output to prevent logging happening too quickly.
+class logger_mt
+{
+private:
+	void add_to_stream (boost::log::record_ostream & stream)
+	{
+	}
+
+ 	template <typename LogItem, typename... LogItems>
+	void add_to_stream (boost::log::record_ostream & stream, const LogItem & first_log_item, LogItems &&... remainder_log_items)
+	{
+		stream << first_log_item;
+		add_to_stream (stream, remainder_log_items...);
+	}
+
+ 	template <typename... LogItems>
+	void output (LogItems &&... log_items)
+	{
+		boost::log::record rec = boost_logger_mt.open_record ();
+		if (rec)
+		{
+			boost::log::record_ostream strm (rec);
+			add_to_stream (strm, std::forward<LogItems> (log_items)...);
+			strm.flush ();
+			boost_logger_mt.push_record (std::move (rec));
+		}
+	}
+
+ public:
+	/**
+	 * @param min_log_delta_a The minimum time between successive output
+	 */
+	explicit logger_mt (std::chrono::milliseconds const & min_log_delta_a) :
+	min_log_delta (min_log_delta_a)
+	{
+	}
+
+ 	/*
+	 * @param log_items A collection of objects with overloaded operator<< to be output to the log file
+	 */
+	template <typename... LogItems>
+	void always_log (LogItems &&... log_items)
+	{
+		output (std::forward<LogItems> (log_items)...);
+	}
+
+ 	/*
+	 * @param log_items Output to the log file if the last write was over min_log_delta time ago.
+	 * @return true if the log was successful
+	 */
+	template <typename... LogItems>
+	bool try_log (LogItems &&... log_items)
+	{
+		auto error (true);
+		auto time_now = std::chrono::steady_clock::now ();
+		if (((time_now - last_log_time) > min_log_delta) || last_log_time == std::chrono::steady_clock::time_point{})
+		{
+			output (std::forward<LogItems> (log_items)...);
+			last_log_time = time_now;
+			error = false;
+		}
+		return error;
+	}
+
+ 	std::chrono::milliseconds min_log_delta;
+
+ private:
+	std::chrono::steady_clock::time_point last_log_time;
+	boost::log::sources::logger_mt boost_logger_mt;
+};
+}

--- a/nano/lib/logger_mt.hpp
+++ b/nano/lib/logger_mt.hpp
@@ -15,14 +15,14 @@ private:
 	{
 	}
 
- 	template <typename LogItem, typename... LogItems>
+	template <typename LogItem, typename... LogItems>
 	void add_to_stream (boost::log::record_ostream & stream, const LogItem & first_log_item, LogItems &&... remainder_log_items)
 	{
 		stream << first_log_item;
 		add_to_stream (stream, remainder_log_items...);
 	}
 
- 	template <typename... LogItems>
+	template <typename... LogItems>
 	void output (LogItems &&... log_items)
 	{
 		boost::log::record rec = boost_logger_mt.open_record ();
@@ -35,7 +35,7 @@ private:
 		}
 	}
 
- public:
+public:
 	/**
 	 * @param min_log_delta_a The minimum time between successive output
 	 */
@@ -44,7 +44,7 @@ private:
 	{
 	}
 
- 	/*
+	/*
 	 * @param log_items A collection of objects with overloaded operator<< to be output to the log file
 	 */
 	template <typename... LogItems>
@@ -53,7 +53,7 @@ private:
 		output (std::forward<LogItems> (log_items)...);
 	}
 
- 	/*
+	/*
 	 * @param log_items Output to the log file if the last write was over min_log_delta time ago.
 	 * @return true if the log was successful
 	 */
@@ -71,9 +71,9 @@ private:
 		return error;
 	}
 
- 	std::chrono::milliseconds min_log_delta;
+	std::chrono::milliseconds min_log_delta;
 
- private:
+private:
 	std::chrono::steady_clock::time_point last_log_time;
 	boost::log::sources::logger_mt boost_logger_mt;
 };

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -1,12 +1,6 @@
 #include <nano/lib/config.hpp>
 #include <nano/lib/jsonconfig.hpp>
-#include <nano/node/rpcconfig.hpp>
-
-nano::rpc_secure_config::rpc_secure_config () :
-enable (false),
-verbose_logging (false)
-{
-}
+#include <nano/lib/rpcconfig.hpp>
 
 nano::error nano::rpc_secure_config::serialize_json (nano::jsonconfig & json) const
 {

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -10,17 +10,16 @@ namespace nano
 class jsonconfig;
 
 /** Configuration options for RPC TLS */
-class rpc_secure_config
+class rpc_secure_config final
 {
 public:
-	rpc_secure_config ();
 	nano::error serialize_json (nano::jsonconfig &) const;
 	nano::error deserialize_json (nano::jsonconfig &);
 
 	/** If true, enable TLS */
-	bool enable;
+	bool enable{ false };
 	/** If true, log certificate verification details */
-	bool verbose_logging;
+	bool verbose_logging{ false };
 	/** Must be set if the private key PEM is password protected */
 	std::string server_key_passphrase;
 	/** Path to certificate- or chain file. Must be PEM formatted. */
@@ -33,10 +32,10 @@ public:
 	std::string client_certs_path;
 };
 
-class rpc_config
+class rpc_config final
 {
 public:
-	rpc_config (bool = false);
+	explicit rpc_config (bool = false);
 	nano::error serialize_json (nano::jsonconfig &) const;
 	nano::error deserialize_json (bool & upgraded_a, nano::jsonconfig &);
 	nano::network_constants network_constants;

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -130,6 +130,49 @@ void nano::thread_attributes::set (boost::thread::attributes & attrs)
 	attrs_l->set_stack_size (8000000); //8MB
 }
 
+nano::thread_runner::thread_runner (boost::asio::io_context & io_ctx_a, unsigned service_threads_a)
+{
+	boost::thread::attributes attrs;
+	nano::thread_attributes::set (attrs);
+	for (auto i (0u); i < service_threads_a; ++i)
+	{
+		threads.push_back (boost::thread (attrs, [&io_ctx_a]() {
+			nano::thread_role::set (nano::thread_role::name::io);
+			try
+			{
+				io_ctx_a.run ();
+			}
+			catch (...)
+			{
+#ifndef NDEBUG
+				/*
+				 * In a release build, catch and swallow the
+				 * io_context exception, in debug mode pass it
+				 * on
+				 */
+				throw;
+#endif
+			}
+		}));
+	}
+}
+
+nano::thread_runner::~thread_runner ()
+{
+	join ();
+}
+
+void nano::thread_runner::join ()
+{
+	for (auto & i : threads)
+	{
+		if (i.joinable ())
+		{
+			i.join ();
+		}
+	}
+}
+
 /*
  * Backing code for "release_assert", which is itself a macro
  */

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread/thread.hpp>
@@ -107,6 +108,15 @@ namespace thread_attributes
 {
 	void set (boost::thread::attributes &);
 }
+
+class thread_runner final
+{
+public:
+	thread_runner (boost::asio::io_context &, unsigned);
+	~thread_runner ();
+	void join ();
+	std::vector<boost::thread> threads;
+};
 
 template <typename... T>
 class observer_set final

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -3,8 +3,9 @@
 #include <nano/nano_node/daemon.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/node.hpp>
-#include <nano/node/rpc.hpp>
 #include <nano/node/testing.hpp>
+#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_handler.hpp>
 #include <sstream>
 
 #include <argon2.h>

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -5,9 +5,9 @@
 #include <nano/nano_wallet/icon.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/ipc.hpp>
-#include <nano/node/rpc.hpp>
 #include <nano/node/working.hpp>
 #include <nano/qt/qt.hpp>
+#include <nano/rpc/rpc.hpp>
 
 #include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>

--- a/nano/nano_wallet/entry_com.cpp
+++ b/nano/nano_wallet/entry_com.cpp
@@ -1,8 +1,8 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/cli.hpp>
-#include <nano/node/rpc.hpp>
 #include <nano/node/working.hpp>
+#include <nano/rpc/rpc.hpp>
 
 #include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (NANO_SECURE_RPC OR RAIBLOCKS_SECURE_RPC)
-	set (secure_rpc_sources rpc_secure.cpp rpc_secure.hpp)
-endif ()
-
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	# No opencl
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -45,10 +41,6 @@ add_library (node
 	portmapping.cpp
 	repcrawler.hpp
 	repcrawler.cpp
-	rpc.hpp
-	rpc.cpp
-	rpcconfig.hpp
-	rpcconfig.cpp
 	testing.hpp
 	testing.cpp
 	transport/tcp.cpp
@@ -75,6 +67,7 @@ add_library (node
 target_link_libraries (node
 	secure
 	nano_lib
+	rpc
 	libminiupnpc-static
 	argon2
 	lmdb

--- a/nano/node/daemonconfig.hpp
+++ b/nano/node/daemonconfig.hpp
@@ -2,7 +2,7 @@
 
 #include <nano/lib/errors.hpp>
 #include <nano/node/node.hpp>
-#include <nano/node/rpc.hpp>
+#include <nano/rpc/rpc.hpp>
 
 namespace nano
 {

--- a/nano/node/ipc.cpp
+++ b/nano/node/ipc.cpp
@@ -11,87 +11,25 @@
 #include <fstream>
 #include <future>
 #include <iostream>
+#include <nano/lib/config.hpp>
+#include <nano/lib/ipc.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/ipc.hpp>
 #include <nano/node/node.hpp>
-#include <nano/node/rpc.hpp>
+#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_handler.hpp>
 #include <thread>
 
 using namespace boost::log;
+
 namespace
 {
-/**
- * The IPC framing format is simple: preamble followed by an encoding specific payload.
- * Preamble is uint8_t {'N', encoding_type, reserved, reserved}. Reserved bytes MUST be zero.
- * @note This is intentionally not an enum class as the values are only used as vector indices.
- */
-enum preamble_offset
-{
-	/** Always 'N' */
-	lead = 0,
-	/** One of the payload_encoding values */
-	encoding = 1,
-	/** Always zero */
-	reserved_1 = 2,
-	/** Always zero */
-	reserved_2 = 3,
-};
-}
-
-/** Abstract base type for sockets, implementing timer logic and a close operation */
-class socket_base
-{
-public:
-	socket_base (boost::asio::io_context & io_ctx_a) :
-	io_timer (io_ctx_a)
-	{
-	}
-	virtual ~socket_base () = default;
-
-	/** Close socket */
-	virtual void close () = 0;
-
-	/**
-	 * Start IO timer.
-	 * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
-	 */
-	void timer_start (std::chrono::seconds timeout_a)
-	{
-		if (timeout_a < std::chrono::seconds::max ())
-		{
-			io_timer.expires_from_now (boost::posix_time::seconds (static_cast<long> (timeout_a.count ())));
-			io_timer.async_wait ([this](const boost::system::error_code & ec) {
-				if (!ec)
-				{
-					this->timer_expired ();
-				}
-			});
-		}
-	}
-
-	void timer_expired ()
-	{
-		close ();
-	}
-
-	void timer_cancel ()
-	{
-		boost::system::error_code ec;
-		io_timer.cancel (ec);
-		assert (!ec);
-	}
-
-private:
-	/** IO operation timer */
-	boost::asio::deadline_timer io_timer;
-};
-
 /**
  * A session represents an inbound connection over which multiple requests/reponses are transmitted.
  */
 template <typename SOCKET_TYPE>
-class session : public socket_base, public std::enable_shared_from_this<session<SOCKET_TYPE>>
+class session : public nano::ipc::socket_base, public std::enable_shared_from_this<session<SOCKET_TYPE>>
 {
 public:
 	session (nano::ipc::ipc_server & server_a, boost::asio::io_context & io_ctx_a, nano::ipc::ipc_config_transport & config_transport_a) :
@@ -202,14 +140,14 @@ public:
 		// Await next request indefinitely
 		buffer.resize (sizeof (buffer_size));
 		async_read_exactly (buffer.data (), buffer.size (), std::chrono::seconds::max (), [this_l]() {
-			if (this_l->buffer[preamble_offset::lead] != 'N' || this_l->buffer[preamble_offset::reserved_1] != 0 || this_l->buffer[preamble_offset::reserved_2] != 0)
+			if (this_l->buffer[nano::ipc::preamble_offset::lead] != 'N' || this_l->buffer[nano::ipc::preamble_offset::reserved_1] != 0 || this_l->buffer[nano::ipc::preamble_offset::reserved_2] != 0)
 			{
 				if (this_l->node.config.logging.log_ipc ())
 				{
 					this_l->node.logger.always_log ("IPC: Invalid preamble");
 				}
 			}
-			else if (this_l->buffer[preamble_offset::encoding] == static_cast<uint8_t> (nano::ipc::payload_encoding::json_legacy))
+			else if (this_l->buffer[nano::ipc::preamble_offset::encoding] == static_cast<uint8_t> (nano::ipc::payload_encoding::json_legacy))
 			{
 				// Length of payload
 				this_l->async_read_exactly (&this_l->buffer_size, sizeof (this_l->buffer_size), [this_l]() {
@@ -349,22 +287,7 @@ private:
 	std::unique_ptr<boost::asio::io_context> io_ctx;
 	std::unique_ptr<ACCEPTOR_TYPE> acceptor;
 };
-
-/** The domain socket file is attempted removed at both startup and shutdown. */
-class nano::ipc::dsock_file_remover final
-{
-public:
-	dsock_file_remover (std::string const & file_a) :
-	filename (file_a)
-	{
-		std::remove (filename.c_str ());
-	}
-	~dsock_file_remover ()
-	{
-		std::remove (filename.c_str ());
-	}
-	std::string filename;
-};
+}
 
 nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::rpc & rpc_a) :
 node (node_a), rpc (rpc_a)
@@ -408,222 +331,4 @@ void nano::ipc::ipc_server::stop ()
 	{
 		transport->stop ();
 	}
-}
-
-/** Socket agnostic IO interface */
-class channel
-{
-public:
-	virtual void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) = 0;
-	virtual void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) = 0;
-};
-
-/** Domain and TCP client socket */
-template <typename SOCKET_TYPE, typename ENDPOINT_TYPE>
-class socket_client : public socket_base, public channel
-{
-public:
-	socket_client (boost::asio::io_context & io_ctx_a, ENDPOINT_TYPE endpoint_a) :
-	socket_base (io_ctx_a), endpoint (endpoint_a), socket (io_ctx_a), resolver (io_ctx_a)
-	{
-	}
-
-	void async_resolve (std::string const & host_a, uint16_t port_a, std::function<void(boost::system::error_code const &, boost::asio::ip::tcp::endpoint)> callback_a)
-	{
-		this->timer_start (io_timeout);
-		resolver.async_resolve (boost::asio::ip::tcp::resolver::query (host_a, std::to_string (port_a)), [this, callback_a](boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator endpoint_iterator_a) {
-			this->timer_cancel ();
-			boost::asio::ip::tcp::resolver::iterator end;
-			if (!ec && endpoint_iterator_a != end)
-			{
-				endpoint = *endpoint_iterator_a;
-				callback_a (ec, *endpoint_iterator_a);
-			}
-			else
-			{
-				callback_a (ec, *end);
-			}
-		});
-	}
-
-	void async_connect (std::function<void(boost::system::error_code const &)> callback_a)
-	{
-		this->timer_start (io_timeout);
-		socket.async_connect (endpoint, [this, callback_a](boost::system::error_code const & ec) {
-			this->timer_cancel ();
-			callback_a (ec);
-		});
-	}
-
-	void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) override
-	{
-		this->timer_start (io_timeout);
-		buffer_a->resize (size_a);
-		boost::asio::async_read (socket, boost::asio::buffer (buffer_a->data (), size_a), [this, callback_a](boost::system::error_code const & ec, size_t size_a) {
-			this->timer_cancel ();
-			callback_a (ec, size_a);
-		});
-	}
-
-	void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) override
-	{
-		this->timer_start (io_timeout);
-		boost::asio::async_write (socket, boost::asio::buffer (buffer_a->data (), buffer_a->size ()), [this, callback_a, buffer_a](boost::system::error_code const & ec, size_t size_a) {
-			this->timer_cancel ();
-			callback_a (ec, size_a);
-		});
-	}
-
-	/** Shut down and close socket */
-	void close () override
-	{
-		socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both);
-		socket.close ();
-	}
-
-private:
-	ENDPOINT_TYPE endpoint;
-	SOCKET_TYPE socket;
-	boost::asio::ip::tcp::resolver resolver;
-	std::chrono::seconds io_timeout{ 60 };
-};
-
-/**
- * PIMPL class for ipc_client. This ensures that socket_client and boost details can
- * stay out of the header file.
- */
-class client_impl : public nano::ipc::ipc_client_impl
-{
-public:
-	client_impl (boost::asio::io_context & io_ctx_a) :
-	io_ctx (io_ctx_a)
-	{
-	}
-
-	void connect (std::string const & host_a, uint16_t port_a, std::function<void(nano::error)> callback_a)
-	{
-		tcp_client = std::make_shared<socket_client<boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>> (io_ctx, boost::asio::ip::tcp::endpoint (boost::asio::ip::tcp::v6 (), port_a));
-
-		tcp_client->async_resolve (host_a, port_a, [this, callback_a](boost::system::error_code const & ec_resolve_a, boost::asio::ip::tcp::endpoint endpoint_a) {
-			if (!ec_resolve_a)
-			{
-				this->tcp_client->async_connect ([callback_a](const boost::system::error_code & ec_connect_a) {
-					callback_a (nano::error (ec_connect_a));
-				});
-			}
-			else
-			{
-				callback_a (nano::error (ec_resolve_a));
-			}
-		});
-	}
-
-	nano::error connect (std::string const & path_a)
-	{
-		nano::error err;
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
-		domain_client = std::make_shared<socket_client<boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> (io_ctx, boost::asio::local::stream_protocol::endpoint (path_a));
-#else
-		err = nano::error ("Domain sockets are not supported by this platform");
-#endif
-		return err;
-	}
-
-	channel & get_channel ()
-	{
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
-		return tcp_client ? static_cast<channel &> (*tcp_client) : static_cast<channel &> (*domain_client);
-#else
-		return static_cast<channel &> (*tcp_client);
-#endif
-	}
-
-private:
-	boost::asio::io_context & io_ctx;
-	std::shared_ptr<socket_client<boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>> tcp_client;
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
-	std::shared_ptr<socket_client<boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> domain_client;
-#endif
-};
-
-nano::ipc::ipc_client::ipc_client (boost::asio::io_context & io_ctx_a) :
-io_ctx (io_ctx_a)
-{
-}
-
-nano::error nano::ipc::ipc_client::connect (std::string const & path_a)
-{
-	impl = std::make_unique<client_impl> (io_ctx);
-	return boost::polymorphic_downcast<client_impl *> (impl.get ())->connect (path_a);
-}
-
-void nano::ipc::ipc_client::async_connect (std::string const & host_a, uint16_t port_a, std::function<void(nano::error)> callback_a)
-{
-	impl = std::make_unique<client_impl> (io_ctx);
-	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
-	client->connect (host_a, port_a, callback_a);
-}
-
-nano::error nano::ipc::ipc_client::connect (std::string const & host, uint16_t port)
-{
-	std::promise<nano::error> result_l;
-	async_connect (host, port, [&result_l](nano::error err_a) {
-		result_l.set_value (err_a);
-	});
-	return result_l.get_future ().get ();
-}
-
-void nano::ipc::ipc_client::async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(nano::error, size_t)> callback_a)
-{
-	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
-	client->get_channel ().async_write (buffer_a, [callback_a](const boost::system::error_code & ec_a, size_t bytes_written_a) {
-		callback_a (nano::error (ec_a), bytes_written_a);
-	});
-}
-
-void nano::ipc::ipc_client::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(nano::error, size_t)> callback_a)
-{
-	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
-	client->get_channel ().async_read (buffer_a, size_a, [callback_a](const boost::system::error_code & ec_a, size_t bytes_read_a) {
-		callback_a (nano::error (ec_a), bytes_read_a);
-	});
-}
-
-std::shared_ptr<std::vector<uint8_t>> nano::ipc::ipc_client::prepare_request (nano::ipc::payload_encoding encoding_a, std::string const & payload_a)
-{
-	auto buffer_l (std::make_shared<std::vector<uint8_t>> ());
-	if (encoding_a == nano::ipc::payload_encoding::json_legacy)
-	{
-		buffer_l->push_back ('N');
-		buffer_l->push_back (static_cast<uint8_t> (encoding_a));
-		buffer_l->push_back (0);
-		buffer_l->push_back (0);
-
-		auto payload_length = static_cast<uint32_t> (payload_a.size ());
-		uint32_t be = boost::endian::native_to_big (payload_length);
-		char * chars = reinterpret_cast<char *> (&be);
-		buffer_l->insert (buffer_l->end (), chars, chars + sizeof (uint32_t));
-		buffer_l->insert (buffer_l->end (), payload_a.begin (), payload_a.end ());
-	}
-	return buffer_l;
-}
-
-std::string nano::ipc::rpc_ipc_client::request (std::string const & rpc_action_a)
-{
-	auto req (prepare_request (nano::ipc::payload_encoding::json_legacy, rpc_action_a));
-	auto res (std::make_shared<std::vector<uint8_t>> ());
-
-	std::promise<std::string> result_l;
-	async_write (req, [this, &res, &result_l](nano::error err_a, size_t size_a) {
-		// Read length
-		this->async_read (res, sizeof (uint32_t), [this, &res, &result_l](nano::error err_read_a, size_t size_read_a) {
-			uint32_t payload_size_l = boost::endian::big_to_native (*reinterpret_cast<uint32_t *> (res->data ()));
-			// Read json payload
-			this->async_read (res, payload_size_l, [&res, &result_l](nano::error err_read_a, size_t size_read_a) {
-				result_l.set_value (std::string (res->begin (), res->end ()));
-			});
-		});
-	});
-
-	return result_l.get_future ().get ();
 }

--- a/nano/node/ipc.hpp
+++ b/nano/node/ipc.hpp
@@ -1,46 +1,17 @@
 #pragma once
 
 #include <atomic>
-#include <boost/asio.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <nano/lib/errors.hpp>
+#include <nano/lib/ipc.hpp>
 #include <nano/lib/jsonconfig.hpp>
-#include <string>
 #include <vector>
 
 namespace nano
 {
 class node;
 class rpc;
-}
 
-namespace nano
-{
 namespace ipc
 {
-	/**
-	 * Payload encodings; add protobuf, flatbuffers and so on as needed.
-	 */
-	enum class payload_encoding : uint8_t
-	{
-		/**
-		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
-		 * Response is 32-bit BE payload length followed by payload bytes.
-		 */
-		json_legacy = 1
-	};
-
-	/** Removes domain socket files on startup and shutdown */
-	class dsock_file_remover;
-
-	/** IPC transport interface */
-	class transport
-	{
-	public:
-		virtual void stop () = 0;
-		virtual ~transport () = default;
-	};
-
 	/** The IPC server accepts connections on one or more configured transports */
 	class ipc_server
 	{
@@ -58,59 +29,6 @@ namespace ipc
 	private:
 		std::unique_ptr<dsock_file_remover> file_remover;
 		std::vector<std::shared_ptr<nano::ipc::transport>> transports;
-	};
-
-	class ipc_client_impl
-	{
-	public:
-		virtual ~ipc_client_impl () = default;
-	};
-
-	/** IPC client */
-	class ipc_client
-	{
-	public:
-		ipc_client (boost::asio::io_context & io_ctx_a);
-		virtual ~ipc_client () = default;
-
-		/** Connect to a domain socket */
-		nano::error connect (std::string const & path);
-
-		/** Connect to a tcp socket synchronously */
-		nano::error connect (std::string const & host, uint16_t port);
-
-		/** Connect to a tcp socket asynchronously */
-		void async_connect (std::string const & host, uint16_t port, std::function<void(nano::error)> callback);
-
-		/** Write buffer asynchronously */
-		void async_write (std::shared_ptr<std::vector<uint8_t>> buffer_a, std::function<void(nano::error, size_t)> callback_a);
-
-		/** Read \p size_a bytes asynchronously */
-		void async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, size_t size_a, std::function<void(nano::error, size_t)> callback_a);
-
-		/**
-		 * Returns a buffer with an IPC preamble for the given \p encoding_a followed by the payload. Depending on encoding,
-		 * the buffer may contain a payload length or end sentinel.
-		 */
-		std::shared_ptr<std::vector<uint8_t>> prepare_request (nano::ipc::payload_encoding encoding_a, std::string const & payload_a);
-
-	private:
-		boost::asio::io_context & io_ctx;
-
-		// PIMPL pattern to hide implementation details
-		std::unique_ptr<ipc_client_impl> impl;
-	};
-
-	/** Convenience wrapper for making synchronous RPC calls via IPC */
-	class rpc_ipc_client : public ipc_client
-	{
-	public:
-		rpc_ipc_client (boost::asio::io_context & io_ctx_a) :
-		ipc_client (io_ctx_a)
-		{
-		}
-		/** Calls the RPC server via IPC and waits for the result. The client must be connected. */
-		std::string request (std::string const & rpc_action_a);
 	};
 }
 }

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/lib/logger_mt.hpp>
 
 #define FATAL_LOG_PREFIX "FATAL ERROR: "
 
@@ -13,79 +14,6 @@ using namespace std::chrono;
 
 namespace nano
 {
-// A wrapper around a boost logger object to allow
-// minimum time spaced output to prevent logging happening
-// too quickly.
-class logger_mt
-{
-private:
-	void add_to_stream (boost::log::record_ostream & stream)
-	{
-	}
-
-	template <typename LogItem, typename... LogItems>
-	void add_to_stream (boost::log::record_ostream & stream, const LogItem & first_log_item, LogItems &&... remainder_log_items)
-	{
-		stream << first_log_item;
-		add_to_stream (stream, remainder_log_items...);
-	}
-
-	template <typename... LogItems>
-	void output (LogItems &&... log_items)
-	{
-		boost::log::record rec = boost_logger_mt.open_record ();
-		if (rec)
-		{
-			boost::log::record_ostream strm (rec);
-			add_to_stream (strm, std::forward<LogItems> (log_items)...);
-			strm.flush ();
-			boost_logger_mt.push_record (std::move (rec));
-		}
-	}
-
-public:
-	/**
-	 * @param min_log_delta_a The minimum time between successive output
-	 */
-	explicit logger_mt (std::chrono::milliseconds const & min_log_delta_a) :
-	min_log_delta (min_log_delta_a)
-	{
-	}
-
-	/*
-	 * @param log_items A collection of objects with overloaded operator<< to be output to the log file
-	 */
-	template <typename... LogItems>
-	void always_log (LogItems &&... log_items)
-	{
-		output (std::forward<LogItems> (log_items)...);
-	}
-
-	/*
-	 * @param log_items Output to the log file if the last write was over min_log_delta time ago.
-	 * @return true if the log was successful
-	 */
-	template <typename... LogItems>
-	bool try_log (LogItems &&... log_items)
-	{
-		auto error (true);
-		auto time_now = std::chrono::steady_clock::now ();
-		if (((time_now - last_log_time) > min_log_delta) || last_log_time == std::chrono::steady_clock::time_point{})
-		{
-			output (std::forward<LogItems> (log_items)...);
-			last_log_time = time_now;
-			error = false;
-		}
-		return error;
-	}
-
-	std::chrono::milliseconds min_log_delta;
-
-private:
-	std::chrono::steady_clock::time_point last_log_time;
-	boost::log::sources::logger_mt boost_logger_mt;
-};
-
 class logging
 {
 public:

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -5,7 +5,7 @@
 #include <nano/lib/timer.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/common.hpp>
-#include <nano/node/rpc.hpp>
+#include <nano/rpc/rpc.hpp>
 
 #include <algorithm>
 #include <cstdlib>
@@ -3463,49 +3463,6 @@ int nano::node::store_version ()
 {
 	auto transaction (store.tx_begin_read ());
 	return store.version_get (transaction);
-}
-
-nano::thread_runner::thread_runner (boost::asio::io_context & io_ctx_a, unsigned service_threads_a)
-{
-	boost::thread::attributes attrs;
-	nano::thread_attributes::set (attrs);
-	for (auto i (0u); i < service_threads_a; ++i)
-	{
-		threads.push_back (boost::thread (attrs, [&io_ctx_a]() {
-			nano::thread_role::set (nano::thread_role::name::io);
-			try
-			{
-				io_ctx_a.run ();
-			}
-			catch (...)
-			{
-#ifndef NDEBUG
-				/*
-				 * In a release build, catch and swallow the
-				 * io_context exception, in debug mode pass it
-				 * on
-				 */
-				throw;
-#endif
-			}
-		}));
-	}
-}
-
-nano::thread_runner::~thread_runner ()
-{
-	join ();
-}
-
-void nano::thread_runner::join ()
-{
-	for (auto & i : threads)
-	{
-		if (i.joinable ())
-		{
-			i.join ();
-		}
-	}
 }
 
 nano::inactive_node::inactive_node (boost::filesystem::path const & path_a, uint16_t peering_port_a) :

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -28,15 +28,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/thread/thread.hpp>
 
-#define xstr(a) ver_str (a)
-#define ver_str(a) #a
-
-/**
-* Returns build version information
-*/
-static const char * NANO_MAJOR_MINOR_VERSION = xstr (NANO_VERSION_MAJOR) "." xstr (NANO_VERSION_MINOR);
-static const char * NANO_MAJOR_MINOR_RC_VERSION = xstr (NANO_VERSION_MAJOR) "." xstr (NANO_VERSION_MINOR) "RC" xstr (NANO_VERSION_PATCH);
-
 namespace nano
 {
 class channel;
@@ -521,14 +512,6 @@ private:
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name);
 
-class thread_runner final
-{
-public:
-	thread_runner (boost::asio::io_context &, unsigned);
-	~thread_runner ();
-	void join ();
-	std::vector<boost::thread> threads;
-};
 class inactive_node final
 {
 public:

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -1,0 +1,24 @@
+if (NANO_SECURE_RPC OR RAIBLOCKS_SECURE_RPC)
+	set (secure_rpc_sources rpc_secure.hpp rpc_secure.cpp rpc_connection_secure.hpp rpc_connection_secure.cpp)
+endif ()
+
+add_library (rpc
+	${secure_rpc_sources}
+	rpc.hpp
+	rpc.cpp
+	rpc_connection.hpp
+	rpc_connection.cpp
+	rpc_handler.hpp
+	rpc_handler.cpp)
+
+target_link_libraries (rpc
+	node
+	nano_lib
+	${OPENSSL_LIBRARIES}
+	Boost::boost)
+
+target_compile_definitions(rpc
+	PRIVATE
+	-DNANO_VERSION_MAJOR=${CPACK_PACKAGE_VERSION_MAJOR}
+	-DNANO_VERSION_MINOR=${CPACK_PACKAGE_VERSION_MINOR}
+	-DNANO_VERSION_PATCH=${CPACK_PACKAGE_VERSION_PATCH})

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -1,0 +1,184 @@
+#include <boost/algorithm/string.hpp>
+#include <nano/lib/config.hpp>
+#include <nano/lib/interface.h>
+#include <nano/node/node.hpp>
+
+#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_connection.hpp>
+#include <nano/rpc/rpc_handler.hpp>
+
+#ifdef NANO_SECURE_RPC
+#include <nano/rpc/rpc_secure.hpp>
+#endif
+
+#include <nano/lib/errors.hpp>
+
+nano::rpc::rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a) :
+acceptor (io_ctx_a),
+config (config_a),
+node (node_a)
+{
+}
+
+void nano::rpc::add_block_observer ()
+{
+	node.observers.blocks.add ([this](std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::uint128_t const &, bool) {
+		observer_action (account_a);
+	});
+}
+
+void nano::rpc::start (bool rpc_enabled_a)
+{
+	if (rpc_enabled_a)
+	{
+		auto endpoint (nano::tcp_endpoint (config.address, config.port));
+		acceptor.open (endpoint.protocol ());
+		acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
+
+		boost::system::error_code ec;
+		acceptor.bind (endpoint, ec);
+		if (ec)
+		{
+			node.logger.always_log (boost::str (boost::format ("Error while binding for RPC on port %1%: %2%") % endpoint.port () % ec.message ()));
+			throw std::runtime_error (ec.message ());
+		}
+
+		acceptor.listen ();
+	}
+
+	add_block_observer ();
+
+	if (rpc_enabled_a)
+	{
+		accept ();
+	}
+}
+
+void nano::rpc::accept ()
+{
+	auto connection (std::make_shared<nano::rpc_connection> (node, *this));
+	acceptor.async_accept (connection->socket, [this, connection](boost::system::error_code const & ec) {
+		if (ec != boost::asio::error::operation_aborted && acceptor.is_open ())
+		{
+			accept ();
+		}
+		if (!ec)
+		{
+			connection->parse_connection ();
+		}
+		else
+		{
+			this->node.logger.always_log (boost::str (boost::format ("Error accepting RPC connections: %1% (%2%)") % ec.message () % ec.value ()));
+		}
+	});
+}
+
+void nano::rpc::stop ()
+{
+	acceptor.close ();
+}
+
+void nano::rpc::observer_action (nano::account const & account_a)
+{
+	std::shared_ptr<nano::payment_observer> observer;
+	{
+		std::lock_guard<std::mutex> lock (mutex);
+		auto existing (payment_observers.find (account_a));
+		if (existing != payment_observers.end ())
+		{
+			observer = existing->second;
+		}
+	}
+	if (observer != nullptr)
+	{
+		observer->observe ();
+	}
+}
+
+nano::payment_observer::payment_observer (std::function<void(boost::property_tree::ptree const &)> const & response_a, nano::rpc & rpc_a, nano::account const & account_a, nano::amount const & amount_a) :
+rpc (rpc_a),
+account (account_a),
+amount (amount_a),
+response (response_a)
+{
+	completed.clear ();
+}
+
+void nano::payment_observer::start (uint64_t timeout)
+{
+	auto this_l (shared_from_this ());
+	rpc.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (timeout), [this_l]() {
+		this_l->complete (nano::payment_status::nothing);
+	});
+}
+
+nano::payment_observer::~payment_observer ()
+{
+}
+
+void nano::payment_observer::observe ()
+{
+	if (rpc.node.balance (account) >= amount.number ())
+	{
+		complete (nano::payment_status::success);
+	}
+}
+
+void nano::payment_observer::complete (nano::payment_status status)
+{
+	auto already (completed.test_and_set ());
+	if (!already)
+	{
+		if (rpc.node.config.logging.log_rpc ())
+		{
+			rpc.node.logger.always_log (boost::str (boost::format ("Exiting payment_observer for account %1% status %2%") % account.to_account () % static_cast<unsigned> (status)));
+		}
+		switch (status)
+		{
+			case nano::payment_status::nothing:
+			{
+				boost::property_tree::ptree response_l;
+				response_l.put ("deprecated", "1");
+				response_l.put ("status", "nothing");
+				response (response_l);
+				break;
+			}
+			case nano::payment_status::success:
+			{
+				boost::property_tree::ptree response_l;
+				response_l.put ("deprecated", "1");
+				response_l.put ("status", "success");
+				response (response_l);
+				break;
+			}
+			default:
+			{
+				error_response (response, "Internal payment error");
+				break;
+			}
+		}
+		std::lock_guard<std::mutex> lock (rpc.mutex);
+		assert (rpc.payment_observers.find (account) != rpc.payment_observers.end ());
+		rpc.payment_observers.erase (account);
+	}
+}
+
+std::unique_ptr<nano::rpc> nano::get_rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a)
+{
+	std::unique_ptr<rpc> impl;
+
+	if (config_a.secure.enable)
+	{
+#ifdef NANO_SECURE_RPC
+		impl.reset (new rpc_secure (io_ctx_a, node_a, config_a));
+#else
+		std::cerr << "RPC configured for TLS, but the node is not compiled with TLS support" << std::endl;
+#endif
+	}
+	else
+	{
+		impl.reset (new rpc (io_ctx_a, node_a, config_a));
+	}
+
+	return impl;
+}

--- a/nano/rpc/rpc.hpp
+++ b/nano/rpc/rpc.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/config.hpp>
+#include <nano/lib/errors.hpp>
+#include <nano/lib/jsonconfig.hpp>
+#include <nano/lib/rpcconfig.hpp>
+#include <nano/secure/blockstore.hpp>
+#include <nano/secure/utility.hpp>
+#include <unordered_map>
+
+namespace nano
+{
+class node;
+enum class payment_status
+{
+	not_a_status,
+	unknown,
+	nothing, // Timeout and nothing was received
+	//insufficient, // Timeout and not enough was received
+	//over, // More than requested received
+	//success_fork, // Amount received but it involved a fork
+	success // Amount received
+};
+class wallet;
+class payment_observer;
+class rpc
+{
+public:
+	rpc (boost::asio::io_context &, nano::node &, nano::rpc_config const &);
+	virtual ~rpc () = default;
+
+	/**
+	 * Start serving RPC requests if \p rpc_enabled_a, otherwise this will only
+	 * add a block observer since requests may still arrive via IPC.
+	 */
+	void start (bool rpc_enabled_a = true);
+	void add_block_observer ();
+	virtual void accept ();
+	void stop ();
+	void observer_action (nano::account const &);
+	boost::asio::ip::tcp::acceptor acceptor;
+	std::mutex mutex;
+	std::unordered_map<nano::account, std::shared_ptr<nano::payment_observer>> payment_observers;
+	nano::rpc_config config;
+	nano::node & node;
+	bool on;
+};
+
+class payment_observer : public std::enable_shared_from_this<nano::payment_observer>
+{
+public:
+	payment_observer (std::function<void(boost::property_tree::ptree const &)> const &, nano::rpc &, nano::account const &, nano::amount const &);
+	~payment_observer ();
+	void start (uint64_t);
+	void observe ();
+	void complete (nano::payment_status);
+	std::mutex mutex;
+	std::condition_variable condition;
+	nano::rpc & rpc;
+	nano::account account;
+	nano::amount amount;
+	std::function<void(boost::property_tree::ptree const &)> response;
+	std::atomic_flag completed;
+};
+
+/** Returns the correct RPC implementation based on TLS configuration */
+std::unique_ptr<nano::rpc> get_rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a);
+}

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -1,0 +1,163 @@
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/format.hpp>
+#include <nano/lib/config.hpp>
+#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_connection.hpp>
+#include <nano/rpc/rpc_handler.hpp>
+
+nano::rpc_connection::rpc_connection (nano::node & node_a, nano::rpc & rpc_a) :
+node (node_a.shared ()),
+rpc (rpc_a),
+socket (node_a.io_ctx)
+{
+	responded.clear ();
+}
+
+void nano::rpc_connection::parse_connection ()
+{
+	read ();
+}
+
+void nano::rpc_connection::prepare_head (unsigned version, boost::beast::http::status status)
+{
+	res.version (version);
+	res.result (status);
+	res.set (boost::beast::http::field::allow, "POST, OPTIONS");
+	res.set (boost::beast::http::field::content_type, "application/json");
+	res.set (boost::beast::http::field::access_control_allow_origin, "*");
+	res.set (boost::beast::http::field::access_control_allow_methods, "POST, OPTIONS");
+	res.set (boost::beast::http::field::access_control_allow_headers, "Accept, Accept-Language, Content-Language, Content-Type");
+	res.set (boost::beast::http::field::connection, "close");
+}
+
+void nano::rpc_connection::write_result (std::string body, unsigned version, boost::beast::http::status status)
+{
+	if (!responded.test_and_set ())
+	{
+		prepare_head (version, status);
+		res.body () = body;
+		res.prepare_payload ();
+	}
+	else
+	{
+		assert (false && "RPC already responded and should only respond once");
+		// Guards `res' from being clobbered while async_write is being serviced
+	}
+}
+
+void nano::rpc_connection::read ()
+{
+	auto this_l (shared_from_this ());
+	boost::system::error_code header_error;
+	auto header_parser (std::make_shared<boost::beast::http::request_parser<boost::beast::http::empty_body>> ());
+	std::promise<size_t> header_available_promise;
+	std::future<size_t> header_available = header_available_promise.get_future ();
+	header_parser->body_limit (rpc.config.max_request_size);
+	if (!node->network_params.network.is_test_network ())
+	{
+		boost::beast::http::async_read_header (socket, buffer, *header_parser, [this_l, header_parser, &header_available_promise, &header_error](boost::system::error_code const & ec, size_t bytes_transferred) {
+			size_t header_response_bytes_written = 0;
+			if (!ec)
+			{
+				if (boost::iequals (header_parser->get ()[boost::beast::http::field::expect], "100-continue"))
+				{
+					boost::beast::http::response<boost::beast::http::empty_body> continue_response;
+					continue_response.version (11);
+					continue_response.result (boost::beast::http::status::continue_);
+					continue_response.set (boost::beast::http::field::server, "nano");
+					auto response_size (boost::beast::http::async_write (this_l->socket, continue_response, boost::asio::use_future));
+					header_response_bytes_written = response_size.get ();
+				}
+			}
+			else
+			{
+				header_error = ec;
+				this_l->node->logger.always_log ("RPC header error: ", ec.message ());
+			}
+
+			header_available_promise.set_value (header_response_bytes_written);
+		});
+
+		// Avait header
+		header_available.get ();
+	}
+
+	if (!header_error)
+	{
+		auto body_parser (std::make_shared<boost::beast::http::request_parser<boost::beast::http::string_body>> (std::move (*header_parser)));
+		boost::beast::http::async_read (socket, buffer, *body_parser, [this_l, body_parser](boost::system::error_code const & ec, size_t bytes_transferred) {
+			if (!ec)
+			{
+				this_l->node->background ([this_l, body_parser]() {
+					auto & req (body_parser->get ());
+					auto start (std::chrono::steady_clock::now ());
+					auto version (req.version ());
+					std::string request_id (boost::str (boost::format ("%1%") % boost::io::group (std::hex, std::showbase, reinterpret_cast<uintptr_t> (this_l.get ()))));
+					auto response_handler ([this_l, version, start, request_id](boost::property_tree::ptree const & tree_a) {
+						std::stringstream ostream;
+						boost::property_tree::write_json (ostream, tree_a);
+						ostream.flush ();
+						auto body (ostream.str ());
+						this_l->write_result (body, version);
+						boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+							this_l->write_completion_handler (this_l);
+						});
+
+						if (this_l->node->config.logging.log_rpc ())
+						{
+							this_l->node->logger.always_log (boost::str (boost::format ("RPC request %2% completed in: %1% microseconds") % std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - start).count () % request_id));
+						}
+					});
+					auto method = req.method ();
+					switch (method)
+					{
+						case boost::beast::http::verb::post:
+						{
+							auto handler (std::make_shared<nano::rpc_handler> (*this_l->node, this_l->rpc, req.body (), request_id, response_handler));
+							handler->process_request ();
+							break;
+						}
+						case boost::beast::http::verb::options:
+						{
+							this_l->prepare_head (version);
+							this_l->res.prepare_payload ();
+							boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+								this_l->write_completion_handler (this_l);
+							});
+							break;
+						}
+						default:
+						{
+							error_response (response_handler, "Can only POST requests");
+							break;
+						}
+					}
+				});
+			}
+			else
+			{
+				this_l->node->logger.always_log ("RPC read error: ", ec.message ());
+			}
+		});
+	}
+	else
+	{
+		// Respond with the reason for the invalid header
+		auto response_handler ([this_l](boost::property_tree::ptree const & tree_a) {
+			std::stringstream ostream;
+			boost::property_tree::write_json (ostream, tree_a);
+			ostream.flush ();
+			auto body (ostream.str ());
+			this_l->write_result (body, 11);
+			boost::beast::http::async_write (this_l->socket, this_l->res, [this_l](boost::system::error_code const & ec, size_t bytes_transferred) {
+				this_l->write_completion_handler (this_l);
+			});
+		});
+		error_response (response_handler, std::string ("Invalid header: ") + header_error.message ());
+	}
+}
+
+void nano::rpc_connection::write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc_connection)
+{
+	// Intentional no-op
+}

--- a/nano/rpc/rpc_connection.hpp
+++ b/nano/rpc/rpc_connection.hpp
@@ -10,7 +10,7 @@ class rpc;
 class rpc_connection : public std::enable_shared_from_this<nano::rpc_connection>
 {
 public:
-	rpc_connection (nano::node &, nano::rpc&);
+	rpc_connection (nano::node &, nano::rpc &);
 	virtual ~rpc_connection () = default;
 	virtual void parse_connection ();
 	virtual void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc_connection);

--- a/nano/rpc/rpc_connection.hpp
+++ b/nano/rpc/rpc_connection.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <atomic>
+#include <boost/beast.hpp>
+#include <nano/node/node.hpp>
+
+namespace nano
+{
+class rpc;
+class rpc_connection : public std::enable_shared_from_this<nano::rpc_connection>
+{
+public:
+	rpc_connection (nano::node &, nano::rpc&);
+	virtual ~rpc_connection () = default;
+	virtual void parse_connection ();
+	virtual void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc_connection);
+	virtual void prepare_head (unsigned version, boost::beast::http::status status = boost::beast::http::status::ok);
+	virtual void write_result (std::string body, unsigned version, boost::beast::http::status status = boost::beast::http::status::ok);
+	void read ();
+	std::shared_ptr<nano::node> node;
+	nano::rpc & rpc;
+	boost::asio::ip::tcp::socket socket;
+	boost::beast::flat_buffer buffer;
+	boost::beast::http::response<boost::beast::http::string_body> res;
+	std::atomic_flag responded;
+};
+}

--- a/nano/rpc/rpc_connection_secure.cpp
+++ b/nano/rpc/rpc_connection_secure.cpp
@@ -1,0 +1,46 @@
+#include <nano/rpc/rpc_connection_secure.hpp>
+#include <nano/rpc/rpc_secure.hpp>
+
+#include <boost/polymorphic_pointer_cast.hpp>
+
+nano::rpc_connection_secure::rpc_connection_secure (nano::node & node_a, nano::rpc_secure & rpc_a) :
+nano::rpc_connection (node_a, rpc_a),
+stream (socket, rpc_a.ssl_context)
+{
+}
+
+void nano::rpc_connection_secure::parse_connection ()
+{
+	// Perform the SSL handshake
+	auto this_l = std::static_pointer_cast<nano::rpc_connection_secure> (shared_from_this ());
+	stream.async_handshake (boost::asio::ssl::stream_base::server,
+	[this_l](auto & ec) {
+		this_l->handle_handshake (ec);
+	});
+}
+
+void nano::rpc_connection_secure::on_shutdown (const boost::system::error_code & error)
+{
+	// No-op. We initiate the shutdown (since the RPC server kills the connection after each request)
+	// and we'll thus get an expected EOF error. If the client disconnects, a short-read error will be expected.
+}
+
+void nano::rpc_connection_secure::handle_handshake (const boost::system::error_code & error)
+{
+	if (!error)
+	{
+		read ();
+	}
+	else
+	{
+		node->logger.always_log ("TLS: Handshake error: ", error.message ());
+	}
+}
+
+void nano::rpc_connection_secure::write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc)
+{
+	auto rpc_connection_secure = boost::polymorphic_pointer_downcast<nano::rpc_connection_secure> (rpc);
+	rpc_connection_secure->stream.async_shutdown ([rpc_connection_secure](auto const & ec_shutdown) {
+		rpc_connection_secure->on_shutdown (ec_shutdown);
+	});
+}

--- a/nano/rpc/rpc_connection_secure.hpp
+++ b/nano/rpc/rpc_connection_secure.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <boost/asio/ssl/stream.hpp>
+#include <nano/rpc/rpc_connection.hpp>
+
+namespace nano
+{
+class rpc_secure;
+/**
+ * Specialization of nano::rpc_connection for establishing TLS connections.
+ * Handshakes with client certificates are supported.
+ */
+class rpc_connection_secure : public rpc_connection
+{
+public:
+	rpc_connection_secure (nano::node &, nano::rpc_secure &);
+	void parse_connection () override;
+	void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc) override;
+	/** The TLS handshake callback */
+	void handle_handshake (const boost::system::error_code & error);
+	/** The TLS async shutdown callback */
+	void on_shutdown (const boost::system::error_code & error);
+
+private:
+	boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> stream;
+};
+}

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -1,14 +1,12 @@
-#include <boost/algorithm/string.hpp>
-#include <nano/lib/config.hpp>
-#include <nano/lib/interface.h>
-#include <nano/node/node.hpp>
-#include <nano/node/rpc.hpp>
-
-#ifdef NANO_SECURE_RPC
-#include <nano/node/rpc_secure.hpp>
-#endif
-
+#include <boost/endian/conversion.hpp>
+#include <boost/property_tree/json_parser.hpp>
 #include <nano/lib/errors.hpp>
+#include <nano/lib/ipc_client.hpp>
+#include <nano/lib/rpcconfig.hpp>
+#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_handler.hpp>
+#include <nano/node/node.hpp>
+#include <unordered_set>
 
 namespace
 {
@@ -16,95 +14,6 @@ void construct_json (nano::seq_con_info_component * component, boost::property_t
 using rpc_handler_no_arg_func_map = std::unordered_map<std::string, std::function<void(nano::rpc_handler *)>>;
 rpc_handler_no_arg_func_map create_rpc_handler_no_arg_func_map ();
 auto rpc_handler_no_arg_funcs = create_rpc_handler_no_arg_func_map ();
-}
-
-nano::rpc::rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a) :
-acceptor (io_ctx_a),
-config (config_a),
-node (node_a)
-{
-}
-
-void nano::rpc::add_block_observer ()
-{
-	node.observers.blocks.add ([this](std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::uint128_t const &, bool) {
-		observer_action (account_a);
-	});
-}
-
-void nano::rpc::start (bool rpc_enabled_a)
-{
-	if (rpc_enabled_a)
-	{
-		auto endpoint (nano::tcp_endpoint (config.address, config.port));
-		acceptor.open (endpoint.protocol ());
-		acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
-
-		boost::system::error_code ec;
-		acceptor.bind (endpoint, ec);
-		if (ec)
-		{
-			node.logger.always_log (boost::str (boost::format ("Error while binding for RPC on port %1%: %2%") % endpoint.port () % ec.message ()));
-			throw std::runtime_error (ec.message ());
-		}
-
-		acceptor.listen ();
-	}
-
-	add_block_observer ();
-
-	if (rpc_enabled_a)
-	{
-		accept ();
-	}
-}
-
-void nano::rpc::accept ()
-{
-	auto connection (std::make_shared<nano::rpc_connection> (node, *this));
-	acceptor.async_accept (connection->socket, [this, connection](boost::system::error_code const & ec) {
-		if (ec != boost::asio::error::operation_aborted && acceptor.is_open ())
-		{
-			accept ();
-		}
-		if (!ec)
-		{
-			connection->parse_connection ();
-		}
-		else
-		{
-			this->node.logger.always_log (boost::str (boost::format ("Error accepting RPC connections: %1% (%2%)") % ec.message () % ec.value ()));
-		}
-	});
-}
-
-void nano::rpc::stop ()
-{
-	acceptor.close ();
-}
-
-void nano::rpc::observer_action (nano::account const & account_a)
-{
-	std::shared_ptr<nano::payment_observer> observer;
-	{
-		std::lock_guard<std::mutex> lock (mutex);
-		auto existing (payment_observers.find (account_a));
-		if (existing != payment_observers.end ())
-		{
-			observer = existing->second;
-		}
-	}
-	if (observer != nullptr)
-	{
-		observer->observe ();
-	}
-}
-
-void nano::error_response (std::function<void(boost::property_tree::ptree const &)> response_a, std::string const & message_a)
-{
-	boost::property_tree::ptree response_l;
-	response_l.put ("error", message_a);
-	response_a (response_l);
 }
 
 nano::rpc_handler::rpc_handler (nano::node & node_a, nano::rpc & rpc_a, std::string const & body_a, std::string const & request_id_a, std::function<void(boost::property_tree::ptree const &)> const & response_a) :
@@ -4562,120 +4471,15 @@ void nano::rpc_handler::process_request ()
 	}
 }
 
-nano::payment_observer::payment_observer (std::function<void(boost::property_tree::ptree const &)> const & response_a, nano::rpc & rpc_a, nano::account const & account_a, nano::amount const & amount_a) :
-rpc (rpc_a),
-account (account_a),
-amount (amount_a),
-response (response_a)
+void nano::error_response (std::function<void(boost::property_tree::ptree const &)> response_a, std::string const & message_a)
 {
-	completed.clear ();
-}
-
-void nano::payment_observer::start (uint64_t timeout)
-{
-	auto this_l (shared_from_this ());
-	rpc.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (timeout), [this_l]() {
-		this_l->complete (nano::payment_status::nothing);
-	});
-}
-
-nano::payment_observer::~payment_observer ()
-{
-}
-
-void nano::payment_observer::observe ()
-{
-	if (rpc.node.balance (account) >= amount.number ())
-	{
-		complete (nano::payment_status::success);
-	}
-}
-
-void nano::payment_observer::complete (nano::payment_status status)
-{
-	auto already (completed.test_and_set ());
-	if (!already)
-	{
-		if (rpc.node.config.logging.log_rpc ())
-		{
-			rpc.node.logger.always_log (boost::str (boost::format ("Exiting payment_observer for account %1% status %2%") % account.to_account () % static_cast<unsigned> (status)));
-		}
-		switch (status)
-		{
-			case nano::payment_status::nothing:
-			{
-				boost::property_tree::ptree response_l;
-				response_l.put ("deprecated", "1");
-				response_l.put ("status", "nothing");
-				response (response_l);
-				break;
-			}
-			case nano::payment_status::success:
-			{
-				boost::property_tree::ptree response_l;
-				response_l.put ("deprecated", "1");
-				response_l.put ("status", "success");
-				response (response_l);
-				break;
-			}
-			default:
-			{
-				error_response (response, "Internal payment error");
-				break;
-			}
-		}
-		std::lock_guard<std::mutex> lock (rpc.mutex);
-		assert (rpc.payment_observers.find (account) != rpc.payment_observers.end ());
-		rpc.payment_observers.erase (account);
-	}
-}
-
-std::unique_ptr<nano::rpc> nano::get_rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a)
-{
-	std::unique_ptr<rpc> impl;
-
-	if (config_a.secure.enable)
-	{
-#ifdef NANO_SECURE_RPC
-		impl.reset (new rpc_secure (io_ctx_a, node_a, config_a));
-#else
-		std::cerr << "RPC configured for TLS, but the node is not compiled with TLS support" << std::endl;
-#endif
-	}
-	else
-	{
-		impl.reset (new rpc (io_ctx_a, node_a, config_a));
-	}
-
-	return impl;
+	boost::property_tree::ptree response_l;
+	response_l.put ("error", message_a);
+	response_a (response_l);
 }
 
 namespace
 {
-void construct_json (nano::seq_con_info_component * component, boost::property_tree::ptree & parent)
-{
-	// We are a leaf node, print name and exit
-	if (!component->is_composite ())
-	{
-		auto & leaf_info = static_cast<nano::seq_con_info_leaf *> (component)->get_info ();
-		boost::property_tree::ptree child;
-		child.put ("count", leaf_info.count);
-		child.put ("size", leaf_info.count * leaf_info.sizeof_element);
-		parent.add_child (leaf_info.name, child);
-		return;
-	}
-
-	auto composite = static_cast<nano::seq_con_info_composite *> (component);
-
-	boost::property_tree::ptree current;
-	for (auto & child : composite->get_children ())
-	{
-		construct_json (child.get (), current);
-	}
-
-	parent.add_child (composite->get_name (), current);
-}
-
 rpc_handler_no_arg_func_map create_rpc_handler_no_arg_func_map ()
 {
 	rpc_handler_no_arg_func_map no_arg_funcs;
@@ -4788,5 +4592,29 @@ rpc_handler_no_arg_func_map create_rpc_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("work_peers", &nano::rpc_handler::work_peers);
 	no_arg_funcs.emplace ("work_peers_clear", &nano::rpc_handler::work_peers_clear);
 	return no_arg_funcs;
+}
+
+void construct_json (nano::seq_con_info_component * component, boost::property_tree::ptree & parent)
+{
+	// We are a leaf node, print name and exit
+	if (!component->is_composite ())
+	{
+		auto & leaf_info = static_cast<nano::seq_con_info_leaf *> (component)->get_info ();
+		boost::property_tree::ptree child;
+		child.put ("count", leaf_info.count);
+		child.put ("size", leaf_info.count * leaf_info.sizeof_element);
+		parent.add_child (leaf_info.name, child);
+		return;
+	}
+
+	auto composite = static_cast<nano::seq_con_info_composite *> (component);
+
+	boost::property_tree::ptree current;
+	for (auto & child : composite->get_children ())
+	{
+		construct_json (child.get (), current);
+	}
+
+	parent.add_child (composite->get_name (), current);
 }
 }

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -3,9 +3,9 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/ipc_client.hpp>
 #include <nano/lib/rpcconfig.hpp>
+#include <nano/node/node.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_handler.hpp>
-#include <nano/node/node.hpp>
 #include <unordered_set>
 
 namespace

--- a/nano/rpc/rpc_handler.hpp
+++ b/nano/rpc/rpc_handler.hpp
@@ -1,90 +1,17 @@
 #pragma once
 
-#include <atomic>
-#include <boost/asio.hpp>
-#include <boost/beast.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <functional>
 #include <nano/lib/blocks.hpp>
-#include <nano/lib/config.hpp>
-#include <nano/lib/errors.hpp>
-#include <nano/lib/jsonconfig.hpp>
-#include <nano/node/rpcconfig.hpp>
-#include <nano/secure/blockstore.hpp>
-#include <nano/secure/utility.hpp>
-#include <unordered_map>
+#include <nano/node/wallet.hpp>
+#include <string>
 
 namespace nano
 {
-void error_response (std::function<void(boost::property_tree::ptree const &)> response_a, std::string const & message_a);
 class node;
-enum class payment_status
-{
-	not_a_status,
-	unknown,
-	nothing, // Timeout and nothing was received
-	//insufficient, // Timeout and not enough was received
-	//over, // More than requested received
-	//success_fork, // Amount received but it involved a fork
-	success // Amount received
-};
-class wallet;
-class payment_observer;
-class rpc
-{
-public:
-	rpc (boost::asio::io_context &, nano::node &, nano::rpc_config const &);
-	virtual ~rpc () = default;
+class rpc;
+void error_response (std::function<void(boost::property_tree::ptree const &)> response_a, std::string const & message_a);
 
-	/**
-	 * Start serving RPC requests if \p rpc_enabled_a, otherwise this will only
-	 * add a block observer since requests may still arrive via IPC.
-	 */
-	void start (bool rpc_enabled_a = true);
-	void add_block_observer ();
-	virtual void accept ();
-	void stop ();
-	void observer_action (nano::account const &);
-	boost::asio::ip::tcp::acceptor acceptor;
-	std::mutex mutex;
-	std::unordered_map<nano::account, std::shared_ptr<nano::payment_observer>> payment_observers;
-	nano::rpc_config config;
-	nano::node & node;
-	bool on;
-};
-class rpc_connection : public std::enable_shared_from_this<nano::rpc_connection>
-{
-public:
-	rpc_connection (nano::node &, nano::rpc &);
-	virtual ~rpc_connection () = default;
-	virtual void parse_connection ();
-	virtual void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc_connection);
-	virtual void prepare_head (unsigned version, boost::beast::http::status status = boost::beast::http::status::ok);
-	virtual void write_result (std::string body, unsigned version, boost::beast::http::status status = boost::beast::http::status::ok);
-	void read ();
-	std::shared_ptr<nano::node> node;
-	nano::rpc & rpc;
-	boost::asio::ip::tcp::socket socket;
-	boost::beast::flat_buffer buffer;
-	boost::beast::http::response<boost::beast::http::string_body> res;
-	std::atomic_flag responded;
-};
-class payment_observer : public std::enable_shared_from_this<nano::payment_observer>
-{
-public:
-	payment_observer (std::function<void(boost::property_tree::ptree const &)> const &, nano::rpc &, nano::account const &, nano::amount const &);
-	~payment_observer ();
-	void start (uint64_t);
-	void observe ();
-	void complete (nano::payment_status);
-	std::mutex mutex;
-	std::condition_variable condition;
-	nano::rpc & rpc;
-	nano::account account;
-	nano::amount amount;
-	std::function<void(boost::property_tree::ptree const &)> response;
-	std::atomic_flag completed;
-};
 class rpc_handler : public std::enable_shared_from_this<nano::rpc_handler>
 {
 public:
@@ -222,6 +149,4 @@ public:
 	uint64_t offset_optional_impl (uint64_t = 0);
 	bool rpc_control_impl ();
 };
-/** Returns the correct RPC implementation based on TLS configuration */
-std::unique_ptr<nano::rpc> get_rpc (boost::asio::io_context & io_ctx_a, nano::node & node_a, nano::rpc_config const & config_a);
 }

--- a/nano/rpc/rpc_secure.hpp
+++ b/nano/rpc/rpc_secure.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/stream.hpp>
-#include <nano/node/rpc.hpp>
+#include <nano/rpc/rpc.hpp>
 
 namespace nano
 {
@@ -27,24 +27,5 @@ public:
 
 	/** The context needs to be shared between sessions to make resumption work */
 	boost::asio::ssl::context ssl_context;
-};
-
-/**
- * Specialization of nano::rpc_connection for establishing TLS connections.
- * Handshakes with client certificates are supported.
- */
-class rpc_connection_secure : public rpc_connection
-{
-public:
-	rpc_connection_secure (nano::node &, nano::rpc_secure &);
-	void parse_connection () override;
-	void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc) override;
-	/** The TLS handshake callback */
-	void handle_handshake (const boost::system::error_code & error);
-	/** The TLS async shutdown callback */
-	void on_shutdown (const boost::system::error_code & error);
-
-private:
-	boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> stream;
 };
 }

--- a/nano/rpc_test/CMakeLists.txt
+++ b/nano/rpc_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable (rpc_test
+	entry.cpp
+	rpc.cpp)
+
+target_link_libraries(rpc_test gtest gtest_main rpc)
+
+target_compile_definitions(rpc_test
+	PUBLIC
+		-DACTIVE_NETWORK=${ACTIVE_NETWORK}
+	PRIVATE
+		-DNANO_VERSION_MAJOR=${CPACK_PACKAGE_VERSION_MAJOR}
+		-DNANO_VERSION_MINOR=${CPACK_PACKAGE_VERSION_MINOR}
+		-DNANO_VERSION_PATCH=${CPACK_PACKAGE_VERSION_PATCH})

--- a/nano/rpc_test/entry.cpp
+++ b/nano/rpc_test/entry.cpp
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+
+namespace nano
+{
+void force_nano_test_network ();
+}
+
+int main (int argc, char ** argv)
+{
+	nano::force_nano_test_network ();
+	testing::InitGoogleTest (&argc, argv);
+	return RUN_ALL_TESTS ();
+}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1,0 +1,5123 @@
+#include <gtest/gtest.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/beast.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/thread.hpp>
+#include <nano/core_test/testutil.hpp>
+#include <nano/lib/jsonconfig.hpp>
+#include <nano/node/common.hpp>
+#include <nano/node/testing.hpp>
+#include <nano/rpc/rpc.hpp>
+
+using namespace std::chrono_literals;
+
+class test_response
+{
+public:
+	test_response (boost::property_tree::ptree const & request_a, nano::rpc & rpc_a, boost::asio::io_context & io_ctx) :
+	request (request_a),
+	sock (io_ctx),
+	status (0)
+	{
+		sock.async_connect (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), rpc_a.config.port), [this](boost::system::error_code const & ec) {
+			if (!ec)
+			{
+				std::stringstream ostream;
+				boost::property_tree::write_json (ostream, request);
+				req.method (boost::beast::http::verb::post);
+				req.target ("/");
+				req.version (11);
+				ostream.flush ();
+				req.body () = ostream.str ();
+				req.prepare_payload ();
+				boost::beast::http::async_write (sock, req, [this](boost::system::error_code const & ec, size_t bytes_transferred) {
+					if (!ec)
+					{
+						boost::beast::http::async_read (sock, sb, resp, [this](boost::system::error_code const & ec, size_t bytes_transferred) {
+							if (!ec)
+							{
+								std::stringstream body (resp.body ());
+								try
+								{
+									boost::property_tree::read_json (body, json);
+									status = 200;
+								}
+								catch (std::exception &)
+								{
+									status = 500;
+								}
+							}
+							else
+							{
+								status = 400;
+							};
+						});
+					}
+					else
+					{
+						status = 600;
+					}
+				});
+			}
+			else
+			{
+				status = 400;
+			}
+		});
+	}
+	boost::property_tree::ptree const & request;
+	boost::asio::ip::tcp::socket sock;
+	boost::property_tree::ptree json;
+	boost::beast::flat_buffer sb;
+	boost::beast::http::request<boost::beast::http::string_body> req;
+	boost::beast::http::response<boost::beast::http::string_body> resp;
+	int status;
+};
+
+TEST (rpc, account_balance)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "account_balance");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string balance_text (response.json.get<std::string> ("balance"));
+	ASSERT_EQ ("340282366920938463463374607431768211455", balance_text);
+	std::string pending_text (response.json.get<std::string> ("pending"));
+	ASSERT_EQ ("0", pending_text);
+}
+
+TEST (rpc, account_block_count)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "account_block_count");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string block_count_text (response.json.get<std::string> ("block_count"));
+	ASSERT_EQ ("1", block_count_text);
+}
+
+TEST (rpc, account_create)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "account_create");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response0 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response0.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response0.status);
+	auto account_text0 (response0.json.get<std::string> ("account"));
+	nano::uint256_union account0;
+	ASSERT_FALSE (account0.decode_account (account_text0));
+	ASSERT_TRUE (system.wallet (0)->exists (account0));
+	uint64_t max_index (std::numeric_limits<uint32_t>::max ());
+	request.put ("index", max_index);
+	test_response response1 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto account_text1 (response1.json.get<std::string> ("account"));
+	nano::uint256_union account1;
+	ASSERT_FALSE (account1.decode_account (account_text1));
+	ASSERT_TRUE (system.wallet (0)->exists (account1));
+	request.put ("index", max_index + 1);
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ (response2.json.get<std::string> ("error"), "Invalid index");
+}
+
+TEST (rpc, account_weight)
+{
+	nano::keypair key;
+	nano::system system (24000, 1);
+	nano::block_hash latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::change_block block (latest, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	ASSERT_EQ (nano::process_result::progress, node1.process (block).code);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "account_weight");
+	request.put ("account", key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string balance_text (response.json.get<std::string> ("weight"));
+	ASSERT_EQ ("340282366920938463463374607431768211455", balance_text);
+}
+
+TEST (rpc, wallet_contains)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_contains");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string exists_text (response.json.get<std::string> ("exists"));
+	ASSERT_EQ ("1", exists_text);
+}
+
+TEST (rpc, wallet_doesnt_contain)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_contains");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string exists_text (response.json.get<std::string> ("exists"));
+	ASSERT_EQ ("0", exists_text);
+}
+
+TEST (rpc, validate_account_number)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	request.put ("action", "validate_account_number");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	std::string exists_text (response.json.get<std::string> ("valid"));
+	ASSERT_EQ ("1", exists_text);
+}
+
+TEST (rpc, validate_account_invalid)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	std::string account;
+	nano::test_genesis_key.pub.encode_account (account);
+	account[0] ^= 0x1;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	request.put ("action", "validate_account_number");
+	request.put ("account", account);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string exists_text (response.json.get<std::string> ("valid"));
+	ASSERT_EQ ("0", exists_text);
+}
+
+TEST (rpc, send)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "send");
+	request.put ("source", nano::test_genesis_key.pub.to_account ());
+	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("amount", "100");
+	system.deadline_set (10s);
+	boost::thread thread2 ([&system]() {
+		while (system.nodes[0]->balance (nano::test_genesis_key.pub) == nano::genesis_amount)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+	});
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string block_text (response.json.get<std::string> ("block"));
+	nano::block_hash block;
+	ASSERT_FALSE (block.decode_hex (block_text));
+	ASSERT_TRUE (system.nodes[0]->ledger.block_exists (block));
+	ASSERT_EQ (system.nodes[0]->latest (nano::test_genesis_key.pub), block);
+	thread2.join ();
+}
+
+TEST (rpc, send_fail)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "send");
+	request.put ("source", nano::test_genesis_key.pub.to_account ());
+	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("amount", "100");
+	std::atomic<bool> done (false);
+	system.deadline_set (10s);
+	boost::thread thread2 ([&system, &done]() {
+		while (!done)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+	});
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	done = true;
+	ASSERT_EQ (response.json.get<std::string> ("error"), "Account not found in wallet");
+	thread2.join ();
+}
+
+TEST (rpc, send_work)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "send");
+	request.put ("source", nano::test_genesis_key.pub.to_account ());
+	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("amount", "100");
+	request.put ("work", "1");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (10s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (response.json.get<std::string> ("error"), "Invalid work");
+	request.erase ("work");
+	request.put ("work", nano::to_string_hex (system.nodes[0]->work_generate_blocking (system.nodes[0]->latest (nano::test_genesis_key.pub))));
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (10s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	std::string block_text (response2.json.get<std::string> ("block"));
+	nano::block_hash block;
+	ASSERT_FALSE (block.decode_hex (block_text));
+	ASSERT_TRUE (system.nodes[0]->ledger.block_exists (block));
+	ASSERT_EQ (system.nodes[0]->latest (nano::test_genesis_key.pub), block);
+}
+
+TEST (rpc, send_idempotent)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "send");
+	request.put ("source", nano::test_genesis_key.pub.to_account ());
+	request.put ("destination", nano::account (0).to_account ());
+	request.put ("amount", (nano::genesis_amount - (nano::genesis_amount / 4)).convert_to<std::string> ());
+	request.put ("id", "123abc");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string block_text (response.json.get<std::string> ("block"));
+	nano::block_hash block;
+	ASSERT_FALSE (block.decode_hex (block_text));
+	ASSERT_TRUE (system.nodes[0]->ledger.block_exists (block));
+	ASSERT_EQ (system.nodes[0]->balance (nano::test_genesis_key.pub), nano::genesis_amount / 4);
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ ("", response2.json.get<std::string> ("error", ""));
+	ASSERT_EQ (block_text, response2.json.get<std::string> ("block"));
+	ASSERT_EQ (system.nodes[0]->balance (nano::test_genesis_key.pub), nano::genesis_amount / 4);
+	request.erase ("id");
+	request.put ("id", "456def");
+	test_response response3 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	ASSERT_EQ (response3.json.get<std::string> ("error"), "Insufficient balance");
+}
+
+TEST (rpc, stop)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "stop");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	};
+}
+
+TEST (rpc, wallet_add)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	nano::keypair key1;
+	std::string key_text;
+	key1.prv.data.encode_hex (key_text);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_add");
+	request.put ("key", key_text);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("account"));
+	ASSERT_EQ (account_text1, key1.pub.to_account ());
+	ASSERT_TRUE (system.wallet (0)->exists (key1.pub));
+}
+
+TEST (rpc, wallet_password_valid)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "password_valid");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("valid"));
+	ASSERT_EQ (account_text1, "1");
+}
+
+TEST (rpc, wallet_password_change)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "password_change");
+	request.put ("password", "test");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("changed"));
+	ASSERT_EQ (account_text1, "1");
+	auto transaction (system.wallet (0)->wallets.tx_begin (true));
+	ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
+	ASSERT_TRUE (system.wallet (0)->enter_password (transaction, ""));
+	ASSERT_FALSE (system.wallet (0)->store.valid_password (transaction));
+	ASSERT_FALSE (system.wallet (0)->enter_password (transaction, "test"));
+	ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
+}
+
+TEST (rpc, wallet_password_enter)
+{
+	nano::system system (24000, 1);
+	nano::raw_key password_l;
+	password_l.data.clear ();
+	system.deadline_set (10s);
+	while (password_l.data == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+		system.wallet (0)->store.password.value (password_l);
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "password_enter");
+	request.put ("password", "");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("valid"));
+	ASSERT_EQ (account_text1, "1");
+}
+
+TEST (rpc, wallet_representative)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_representative");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("representative"));
+	ASSERT_EQ (account_text1, nano::genesis_account.to_account ());
+}
+
+TEST (rpc, wallet_representative_set)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	nano::keypair key;
+	request.put ("action", "wallet_representative_set");
+	request.put ("representative", key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	ASSERT_EQ (key.pub, system.nodes[0]->wallets.items.begin ()->second->store.representative (transaction));
+}
+
+TEST (rpc, wallet_representative_set_force)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	nano::keypair key;
+	request.put ("action", "wallet_representative_set");
+	request.put ("representative", key.pub.to_account ());
+	request.put ("update_existing_accounts", true);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	{
+		auto transaction (system.nodes[0]->wallets.tx_begin ());
+		ASSERT_EQ (key.pub, system.nodes[0]->wallets.items.begin ()->second->store.representative (transaction));
+	}
+	nano::account representative (0);
+	while (representative != key.pub)
+	{
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
+		nano::account_info info;
+		if (!system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info))
+		{
+			auto block (system.nodes[0]->store.block_get (transaction, info.rep_block));
+			assert (block != nullptr);
+			representative = block->representative ();
+		}
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, account_list)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	nano::keypair key2;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key2.prv);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "account_list");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & accounts_node (response.json.get_child ("accounts"));
+	std::vector<nano::uint256_union> accounts;
+	for (auto i (accounts_node.begin ()), j (accounts_node.end ()); i != j; ++i)
+	{
+		auto account (i->second.get<std::string> (""));
+		nano::uint256_union number;
+		ASSERT_FALSE (number.decode_account (account));
+		accounts.push_back (number);
+	}
+	ASSERT_EQ (2, accounts.size ());
+	for (auto i (accounts.begin ()), j (accounts.end ()); i != j; ++i)
+	{
+		ASSERT_TRUE (system.wallet (0)->exists (*i));
+	}
+}
+
+TEST (rpc, wallet_key_valid)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_key_valid");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string exists_text (response.json.get<std::string> ("valid"));
+	ASSERT_EQ ("1", exists_text);
+}
+
+TEST (rpc, wallet_create)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_create");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string wallet_text (response.json.get<std::string> ("wallet"));
+	nano::uint256_union wallet_id;
+	ASSERT_FALSE (wallet_id.decode_hex (wallet_text));
+	ASSERT_NE (system.nodes[0]->wallets.items.end (), system.nodes[0]->wallets.items.find (wallet_id));
+}
+
+TEST (rpc, wallet_create_seed)
+{
+	nano::system system (24000, 1);
+	nano::keypair seed;
+	nano::raw_key prv;
+	nano::deterministic_key (seed.pub, 0, prv.data);
+	auto pub (nano::pub_key (prv.data));
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_create");
+	request.put ("seed", seed.pub.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	std::string wallet_text (response.json.get<std::string> ("wallet"));
+	nano::uint256_union wallet_id;
+	ASSERT_FALSE (wallet_id.decode_hex (wallet_text));
+	auto existing (system.nodes[0]->wallets.items.find (wallet_id));
+	ASSERT_NE (system.nodes[0]->wallets.items.end (), existing);
+	{
+		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
+		nano::raw_key seed0;
+		existing->second->store.seed (seed0, transaction);
+		ASSERT_EQ (seed.pub, seed0.data);
+	}
+	auto account_text (response.json.get<std::string> ("last_restored_account"));
+	nano::uint256_union account;
+	ASSERT_FALSE (account.decode_account (account_text));
+	ASSERT_TRUE (existing->second->exists (account));
+	ASSERT_EQ (pub, account);
+	ASSERT_EQ ("1", response.json.get<std::string> ("restored_count"));
+}
+
+TEST (rpc, wallet_export)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_export");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string wallet_json (response.json.get<std::string> ("json"));
+	bool error (false);
+	auto transaction (system.nodes[0]->wallets.tx_begin (true));
+	nano::kdf kdf;
+	nano::wallet_store store (error, kdf, transaction, nano::genesis_account, 1, "0", wallet_json);
+	ASSERT_FALSE (error);
+	ASSERT_TRUE (store.exists (transaction, nano::test_genesis_key.pub));
+}
+
+TEST (rpc, wallet_destroy)
+{
+	nano::system system (24000, 1);
+	auto wallet_id (system.nodes[0]->wallets.items.begin ()->first);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_destroy");
+	request.put ("wallet", wallet_id.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ (system.nodes[0]->wallets.items.end (), system.nodes[0]->wallets.items.find (wallet_id));
+}
+
+TEST (rpc, account_move)
+{
+	nano::system system (24000, 1);
+	auto wallet_id (system.nodes[0]->wallets.items.begin ()->first);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	auto destination (system.wallet (0));
+	nano::keypair key;
+	destination->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair source_id;
+	auto source (system.nodes[0]->wallets.create (source_id.pub));
+	source->insert_adhoc (key.prv);
+	boost::property_tree::ptree request;
+	request.put ("action", "account_move");
+	request.put ("wallet", wallet_id.to_string ());
+	request.put ("source", source_id.pub.to_string ());
+	boost::property_tree::ptree keys;
+	boost::property_tree::ptree entry;
+	entry.put ("", key.pub.to_account ());
+	keys.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", keys);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("1", response.json.get<std::string> ("moved"));
+	ASSERT_TRUE (destination->exists (key.pub));
+	ASSERT_TRUE (destination->exists (nano::test_genesis_key.pub));
+	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	ASSERT_EQ (source->store.end (), source->store.begin (transaction));
+}
+
+TEST (rpc, block)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block");
+	request.put ("hash", system.nodes[0]->latest (nano::genesis_account).to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto contents (response.json.get<std::string> ("contents"));
+	ASSERT_FALSE (contents.empty ());
+	ASSERT_TRUE (response.json.get<bool> ("confirmed")); // Genesis block is confirmed by default
+}
+
+TEST (rpc, block_account)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	nano::genesis genesis;
+	boost::property_tree::ptree request;
+	request.put ("action", "block_account");
+	request.put ("hash", genesis.hash ().to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text (response.json.get<std::string> ("account"));
+	nano::account account;
+	ASSERT_FALSE (account.decode_account (account_text));
+}
+
+TEST (rpc, chain)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	ASSERT_NE (nullptr, block);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "chain");
+	request.put ("block", block->hash ().to_string ());
+	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & blocks_node (response.json.get_child ("blocks"));
+	std::vector<nano::block_hash> blocks;
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (2, blocks.size ());
+	ASSERT_EQ (block->hash (), blocks[0]);
+	ASSERT_EQ (genesis, blocks[1]);
+}
+
+TEST (rpc, chain_limit)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	ASSERT_NE (nullptr, block);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "chain");
+	request.put ("block", block->hash ().to_string ());
+	request.put ("count", 1);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & blocks_node (response.json.get_child ("blocks"));
+	std::vector<nano::block_hash> blocks;
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (1, blocks.size ());
+	ASSERT_EQ (block->hash (), blocks[0]);
+}
+
+TEST (rpc, chain_offset)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	ASSERT_NE (nullptr, block);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "chain");
+	request.put ("block", block->hash ().to_string ());
+	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
+	request.put ("offset", 1);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & blocks_node (response.json.get_child ("blocks"));
+	std::vector<nano::block_hash> blocks;
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (1, blocks.size ());
+	ASSERT_EQ (genesis, blocks[0]);
+}
+
+TEST (rpc, frontier)
+{
+	nano::system system (24000, 1);
+	std::unordered_map<nano::account, nano::block_hash> source;
+	{
+		auto transaction (system.nodes[0]->store.tx_begin (true));
+		for (auto i (0); i < 1000; ++i)
+		{
+			nano::keypair key;
+			source[key.pub] = key.prv.data;
+			system.nodes[0]->store.account_put (transaction, key.pub, nano::account_info (key.prv.data, 0, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
+		}
+	}
+	nano::keypair key;
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "frontiers");
+	request.put ("account", nano::account (0).to_account ());
+	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & frontiers_node (response.json.get_child ("frontiers"));
+	std::unordered_map<nano::account, nano::block_hash> frontiers;
+	for (auto i (frontiers_node.begin ()), j (frontiers_node.end ()); i != j; ++i)
+	{
+		nano::account account;
+		account.decode_account (i->first);
+		nano::block_hash frontier;
+		frontier.decode_hex (i->second.get<std::string> (""));
+		frontiers[account] = frontier;
+	}
+	ASSERT_EQ (1, frontiers.erase (nano::test_genesis_key.pub));
+	ASSERT_EQ (source, frontiers);
+}
+
+TEST (rpc, frontier_limited)
+{
+	nano::system system (24000, 1);
+	std::unordered_map<nano::account, nano::block_hash> source;
+	{
+		auto transaction (system.nodes[0]->store.tx_begin (true));
+		for (auto i (0); i < 1000; ++i)
+		{
+			nano::keypair key;
+			source[key.pub] = key.prv.data;
+			system.nodes[0]->store.account_put (transaction, key.pub, nano::account_info (key.prv.data, 0, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
+		}
+	}
+	nano::keypair key;
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "frontiers");
+	request.put ("account", nano::account (0).to_account ());
+	request.put ("count", std::to_string (100));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & frontiers_node (response.json.get_child ("frontiers"));
+	ASSERT_EQ (100, frontiers_node.size ());
+}
+
+TEST (rpc, frontier_startpoint)
+{
+	nano::system system (24000, 1);
+	std::unordered_map<nano::account, nano::block_hash> source;
+	{
+		auto transaction (system.nodes[0]->store.tx_begin (true));
+		for (auto i (0); i < 1000; ++i)
+		{
+			nano::keypair key;
+			source[key.pub] = key.prv.data;
+			system.nodes[0]->store.account_put (transaction, key.pub, nano::account_info (key.prv.data, 0, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
+		}
+	}
+	nano::keypair key;
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "frontiers");
+	request.put ("account", source.begin ()->first.to_account ());
+	request.put ("count", std::to_string (1));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & frontiers_node (response.json.get_child ("frontiers"));
+	ASSERT_EQ (1, frontiers_node.size ());
+	ASSERT_EQ (source.begin ()->first.to_account (), frontiers_node.begin ()->first);
+}
+
+TEST (rpc, history)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, change);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send);
+	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive);
+	auto node0 (system.nodes[0]);
+	nano::genesis genesis;
+	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	{
+		auto transaction (node0->store.tx_begin (true));
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, ureceive).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, uchange).code);
+	}
+	nano::rpc rpc (system.io_ctx, *node0, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "history");
+	request.put ("hash", uchange.hash ().to_string ());
+	request.put ("count", 100);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::vector<std::tuple<std::string, std::string, std::string, std::string>> history_l;
+	auto & history_node (response.json.get_child ("history"));
+	for (auto i (history_node.begin ()), n (history_node.end ()); i != n; ++i)
+	{
+		history_l.push_back (std::make_tuple (i->second.get<std::string> ("type"), i->second.get<std::string> ("account"), i->second.get<std::string> ("amount"), i->second.get<std::string> ("hash")));
+	}
+	ASSERT_EQ (5, history_l.size ());
+	ASSERT_EQ ("receive", std::get<0> (history_l[0]));
+	ASSERT_EQ (ureceive.hash ().to_string (), std::get<3> (history_l[0]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[0]));
+	ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[0]));
+	ASSERT_EQ (5, history_l.size ());
+	ASSERT_EQ ("send", std::get<0> (history_l[1]));
+	ASSERT_EQ (usend.hash ().to_string (), std::get<3> (history_l[1]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
+	ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[1]));
+	ASSERT_EQ ("receive", std::get<0> (history_l[2]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
+	ASSERT_EQ (system.nodes[0]->config.receive_minimum.to_string_dec (), std::get<2> (history_l[2]));
+	ASSERT_EQ (receive->hash ().to_string (), std::get<3> (history_l[2]));
+	ASSERT_EQ ("send", std::get<0> (history_l[3]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
+	ASSERT_EQ (system.nodes[0]->config.receive_minimum.to_string_dec (), std::get<2> (history_l[3]));
+	ASSERT_EQ (send->hash ().to_string (), std::get<3> (history_l[3]));
+	ASSERT_EQ ("receive", std::get<0> (history_l[4]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[4]));
+	ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), std::get<2> (history_l[4]));
+	ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[4]));
+}
+
+TEST (rpc, account_history)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, change);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send);
+	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive);
+	auto node0 (system.nodes[0]);
+	nano::genesis genesis;
+	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	{
+		auto transaction (node0->store.tx_begin_write ());
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, ureceive).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, uchange).code);
+	}
+	nano::rpc rpc (system.io_ctx, *node0, nano::rpc_config (true));
+	rpc.start ();
+	{
+		boost::property_tree::ptree request;
+		request.put ("action", "account_history");
+		request.put ("account", nano::genesis_account.to_account ());
+		request.put ("count", 100);
+		test_response response (request, rpc, system.io_ctx);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		std::vector<std::tuple<std::string, std::string, std::string, std::string, std::string>> history_l;
+		auto & history_node (response.json.get_child ("history"));
+		for (auto i (history_node.begin ()), n (history_node.end ()); i != n; ++i)
+		{
+			history_l.push_back (std::make_tuple (i->second.get<std::string> ("type"), i->second.get<std::string> ("account"), i->second.get<std::string> ("amount"), i->second.get<std::string> ("hash"), i->second.get<std::string> ("height")));
+		}
+
+		ASSERT_EQ (5, history_l.size ());
+		ASSERT_EQ ("receive", std::get<0> (history_l[0]));
+		ASSERT_EQ (ureceive.hash ().to_string (), std::get<3> (history_l[0]));
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[0]));
+		ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[0]));
+		ASSERT_EQ ("6", std::get<4> (history_l[0])); // change block (height 7) is skipped by account_history since "raw" is not set
+		ASSERT_EQ ("send", std::get<0> (history_l[1]));
+		ASSERT_EQ (usend.hash ().to_string (), std::get<3> (history_l[1]));
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
+		ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[1]));
+		ASSERT_EQ ("5", std::get<4> (history_l[1]));
+		ASSERT_EQ ("receive", std::get<0> (history_l[2]));
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
+		ASSERT_EQ (system.nodes[0]->config.receive_minimum.to_string_dec (), std::get<2> (history_l[2]));
+		ASSERT_EQ (receive->hash ().to_string (), std::get<3> (history_l[2]));
+		ASSERT_EQ ("4", std::get<4> (history_l[2]));
+		ASSERT_EQ ("send", std::get<0> (history_l[3]));
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
+		ASSERT_EQ (system.nodes[0]->config.receive_minimum.to_string_dec (), std::get<2> (history_l[3]));
+		ASSERT_EQ (send->hash ().to_string (), std::get<3> (history_l[3]));
+		ASSERT_EQ ("3", std::get<4> (history_l[3]));
+		ASSERT_EQ ("receive", std::get<0> (history_l[4]));
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[4]));
+		ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), std::get<2> (history_l[4]));
+		ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[4]));
+		ASSERT_EQ ("1", std::get<4> (history_l[4])); // change block (height 2) is skipped
+	}
+	// Test count and reverse
+	{
+		boost::property_tree::ptree request;
+		request.put ("action", "account_history");
+		request.put ("account", nano::genesis_account.to_account ());
+		request.put ("reverse", true);
+		request.put ("count", 1);
+		test_response response (request, rpc, system.io_ctx);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & history_node (response.json.get_child ("history"));
+		ASSERT_EQ (1, history_node.size ());
+		ASSERT_EQ ("1", history_node.begin ()->second.get<std::string> ("height"));
+		ASSERT_EQ (change->hash ().to_string (), response.json.get<std::string> ("next"));
+	}
+
+	// Test filtering
+	auto account2 (system.wallet (0)->deterministic_insert ());
+	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, account2, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send2);
+	auto receive2 (system.wallet (0)->receive_action (static_cast<nano::send_block &> (*send2), account2, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive2);
+	{
+		boost::property_tree::ptree request;
+		request.put ("action", "account_history");
+		request.put ("account", nano::test_genesis_key.pub.to_account ());
+		boost::property_tree::ptree other_account;
+		other_account.put ("", account2.to_account ());
+		boost::property_tree::ptree filtered_accounts;
+		filtered_accounts.push_back (std::make_pair ("", other_account));
+		request.add_child ("account_filter", filtered_accounts);
+		request.put ("count", 100);
+		test_response response (request, rpc, system.io_ctx);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		auto history_node (response.json.get_child ("history"));
+		ASSERT_EQ (history_node.size (), 1);
+	}
+}
+
+TEST (rpc, history_count)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, change);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send);
+	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "history");
+	request.put ("hash", receive->hash ().to_string ());
+	request.put ("count", 1);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & history_node (response.json.get_child ("history"));
+	ASSERT_EQ (1, history_node.size ());
+}
+
+TEST (rpc, process_block)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	system.deadline_set (10s);
+	while (system.nodes[0]->latest (nano::test_genesis_key.pub) != send.hash ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	std::string send_hash (response.json.get<std::string> ("hash"));
+	ASSERT_EQ (send.hash ().to_string (), send_hash);
+}
+
+TEST (rpc, process_block_no_work)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	send.block_work_set (0);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_FALSE (response.json.get<std::string> ("error", "").empty ());
+}
+
+TEST (rpc, process_republish)
+{
+	nano::system system (24000, 2);
+	nano::keypair key;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	system.deadline_set (10s);
+	while (system.nodes[1]->latest (nano::test_genesis_key.pub) != send.hash ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, process_subtype_send)
+{
+	nano::system system (24000, 2);
+	nano::keypair key;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	request.put ("subtype", "receive");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::error_code ec (nano::error_rpc::invalid_subtype_balance);
+	ASSERT_EQ (response.json.get<std::string> ("error"), ec.message ());
+	request.put ("subtype", "change");
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ (response2.json.get<std::string> ("error"), ec.message ());
+	request.put ("subtype", "send");
+	test_response response3 (request, rpc, system.io_ctx);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	ASSERT_EQ (send.hash ().to_string (), response3.json.get<std::string> ("hash"));
+	system.deadline_set (10s);
+	while (system.nodes[1]->latest (nano::test_genesis_key.pub) != send.hash ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, process_subtype_open)
+{
+	nano::system system (24000, 2);
+	nano::keypair key;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	{
+		auto transaction (node1.store.tx_begin_write ());
+		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send).code);
+	}
+	node1.active.start (std::make_shared<nano::state_block> (send));
+	nano::state_block open (key.pub, 0, key.pub, nano::Gxrb_ratio, send.hash (), key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	std::string json;
+	open.serialize_json (json);
+	request.put ("block", json);
+	request.put ("subtype", "send");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::error_code ec (nano::error_rpc::invalid_subtype_balance);
+	ASSERT_EQ (response.json.get<std::string> ("error"), ec.message ());
+	request.put ("subtype", "epoch");
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ (response2.json.get<std::string> ("error"), ec.message ());
+	request.put ("subtype", "open");
+	test_response response3 (request, rpc, system.io_ctx);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	ASSERT_EQ (open.hash ().to_string (), response3.json.get<std::string> ("hash"));
+	system.deadline_set (10s);
+	while (system.nodes[1]->latest (key.pub) != open.hash ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, process_subtype_receive)
+{
+	nano::system system (24000, 2);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	{
+		auto transaction (node1.store.tx_begin_write ());
+		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send).code);
+	}
+	node1.active.start (std::make_shared<nano::state_block> (send));
+	nano::state_block receive (nano::test_genesis_key.pub, send.hash (), nano::test_genesis_key.pub, nano::genesis_amount, send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (send.hash ()));
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	std::string json;
+	receive.serialize_json (json);
+	request.put ("block", json);
+	request.put ("subtype", "send");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::error_code ec (nano::error_rpc::invalid_subtype_balance);
+	ASSERT_EQ (response.json.get<std::string> ("error"), ec.message ());
+	request.put ("subtype", "open");
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ec = nano::error_rpc::invalid_subtype_previous;
+	ASSERT_EQ (response2.json.get<std::string> ("error"), ec.message ());
+	request.put ("subtype", "receive");
+	test_response response3 (request, rpc, system.io_ctx);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	ASSERT_EQ (receive.hash ().to_string (), response3.json.get<std::string> ("hash"));
+	system.deadline_set (10s);
+	while (system.nodes[1]->latest (nano::test_genesis_key.pub) != receive.hash ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, keepalive)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
+	node1->start ();
+	system.nodes.push_back (node1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "keepalive");
+	auto address (boost::str (boost::format ("%1%") % node1->network.endpoint ().address ()));
+	auto port (boost::str (boost::format ("%1%") % node1->network.endpoint ().port ()));
+	request.put ("address", address);
+	request.put ("port", port);
+	ASSERT_EQ (nullptr, system.nodes[0]->network.udp_channels.channel (node1->network.endpoint ()));
+	ASSERT_EQ (0, system.nodes[0]->network.size ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	system.deadline_set (10s);
+	while (system.nodes[0]->network.udp_channels.channel (node1->network.endpoint ()) == nullptr)
+	{
+		ASSERT_EQ (0, system.nodes[0]->network.size ());
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	node1->stop ();
+}
+
+TEST (rpc, payment_init)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair wallet_id;
+	auto wallet (node1->wallets.create (wallet_id.pub));
+	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "payment_init");
+	request.put ("wallet", wallet_id.pub.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("Ready", response.json.get<std::string> ("status"));
+}
+
+TEST (rpc, payment_begin_end)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair wallet_id;
+	auto wallet (node1->wallets.create (wallet_id.pub));
+	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "payment_begin");
+	request1.put ("wallet", wallet_id.pub.to_string ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto account_text (response1.json.get<std::string> ("account"));
+	nano::uint256_union account;
+	ASSERT_FALSE (account.decode_account (account_text));
+	ASSERT_TRUE (wallet->exists (account));
+	nano::block_hash root1;
+	{
+		auto transaction (node1->store.tx_begin ());
+		root1 = node1->ledger.latest_root (transaction, account);
+	}
+	uint64_t work (0);
+	while (!nano::work_validate (root1, work))
+	{
+		++work;
+		ASSERT_LT (work, 50);
+	}
+	system.deadline_set (10s);
+	while (nano::work_validate (root1, work))
+	{
+		auto ec = system.poll ();
+		auto transaction (wallet->wallets.tx_begin ());
+		ASSERT_FALSE (wallet->store.work_get (transaction, account, work));
+		ASSERT_NO_ERROR (ec);
+	}
+	ASSERT_EQ (wallet->free_accounts.end (), wallet->free_accounts.find (account));
+	boost::property_tree::ptree request2;
+	request2.put ("action", "payment_end");
+	request2.put ("wallet", wallet_id.pub.to_string ());
+	request2.put ("account", account.to_account ());
+	test_response response2 (request2, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_TRUE (wallet->exists (account));
+	ASSERT_NE (wallet->free_accounts.end (), wallet->free_accounts.find (account));
+	rpc.stop ();
+	system.stop ();
+}
+
+TEST (rpc, payment_end_nonempty)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto transaction (node1->wallets.tx_begin ());
+	system.wallet (0)->init_free_accounts (transaction);
+	auto wallet_id (node1->wallets.items.begin ()->first);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "payment_end");
+	request1.put ("wallet", wallet_id.to_string ());
+	request1.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_FALSE (response1.json.get<std::string> ("error", "").empty ());
+}
+
+TEST (rpc, payment_zero_balance)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto transaction (node1->wallets.tx_begin ());
+	system.wallet (0)->init_free_accounts (transaction);
+	auto wallet_id (node1->wallets.items.begin ()->first);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "payment_begin");
+	request1.put ("wallet", wallet_id.to_string ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto account_text (response1.json.get<std::string> ("account"));
+	nano::uint256_union account;
+	ASSERT_FALSE (account.decode_account (account_text));
+	ASSERT_NE (nano::test_genesis_key.pub, account);
+}
+
+TEST (rpc, payment_begin_reuse)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair wallet_id;
+	auto wallet (node1->wallets.create (wallet_id.pub));
+	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "payment_begin");
+	request1.put ("wallet", wallet_id.pub.to_string ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto account_text (response1.json.get<std::string> ("account"));
+	nano::uint256_union account;
+	ASSERT_FALSE (account.decode_account (account_text));
+	ASSERT_TRUE (wallet->exists (account));
+	ASSERT_EQ (wallet->free_accounts.end (), wallet->free_accounts.find (account));
+	boost::property_tree::ptree request2;
+	request2.put ("action", "payment_end");
+	request2.put ("wallet", wallet_id.pub.to_string ());
+	request2.put ("account", account.to_account ());
+	test_response response2 (request2, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_TRUE (wallet->exists (account));
+	ASSERT_NE (wallet->free_accounts.end (), wallet->free_accounts.find (account));
+	test_response response3 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	auto account2_text (response1.json.get<std::string> ("account"));
+	nano::uint256_union account2;
+	ASSERT_FALSE (account2.decode_account (account2_text));
+	ASSERT_EQ (account, account2);
+}
+
+TEST (rpc, payment_begin_locked)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair wallet_id;
+	auto wallet (node1->wallets.create (wallet_id.pub));
+	{
+		auto transaction (wallet->wallets.tx_begin (true));
+		wallet->store.rekey (transaction, "1");
+		ASSERT_TRUE (wallet->store.attempt_password (transaction, ""));
+	}
+	ASSERT_TRUE (node1->wallets.items.find (wallet_id.pub) != node1->wallets.items.end ());
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "payment_begin");
+	request1.put ("wallet", wallet_id.pub.to_string ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_FALSE (response1.json.get<std::string> ("error", "").empty ());
+}
+
+TEST (rpc, payment_wait)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "payment_wait");
+	request1.put ("account", key.pub.to_account ());
+	request1.put ("amount", nano::amount (nano::Mxrb_ratio).to_string_dec ());
+	request1.put ("timeout", "100");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("nothing", response1.json.get<std::string> ("status"));
+	request1.put ("timeout", "100000");
+	system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Mxrb_ratio);
+	system.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (500), [&]() {
+		system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Mxrb_ratio);
+	});
+	test_response response2 (request1, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ ("success", response2.json.get<std::string> ("status"));
+	request1.put ("amount", nano::amount (nano::Mxrb_ratio * 2).to_string_dec ());
+	test_response response3 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	ASSERT_EQ ("success", response2.json.get<std::string> ("status"));
+}
+
+TEST (rpc, peers)
+{
+	nano::system system (24000, 2);
+	nano::endpoint endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
+	system.nodes[0]->network.udp_channels.insert (endpoint, nano::protocol_version);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "peers");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & peers_node (response.json.get_child ("peers"));
+	ASSERT_EQ (2, peers_node.size ());
+	ASSERT_EQ (std::to_string (nano::protocol_version), peers_node.get<std::string> ("UDP: [::1]:24001"));
+	// Previously "[::ffff:80.80.80.80]:4000", but IPv4 address cause "No such node thrown in the test body" issue with peers_node.get
+	std::stringstream endpoint_text;
+	endpoint_text << endpoint;
+	ASSERT_EQ (std::to_string (nano::protocol_version), peers_node.get<std::string> ("UDP: " + endpoint_text.str ()));
+}
+
+TEST (rpc, peers_node_id)
+{
+	nano::system system (24000, 2);
+	nano::endpoint endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
+	system.nodes[0]->network.udp_channels.insert (endpoint, nano::protocol_version);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "peers");
+	request.put ("peer_details", true);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & peers_node (response.json.get_child ("peers"));
+	ASSERT_EQ (2, peers_node.size ());
+	auto tree1 (peers_node.get_child ("UDP: [::1]:24001"));
+	ASSERT_EQ (std::to_string (nano::protocol_version), tree1.get<std::string> ("protocol_version"));
+	ASSERT_EQ (system.nodes[1]->node_id.pub.to_account (), tree1.get<std::string> ("node_id"));
+	std::stringstream endpoint_text;
+	endpoint_text << endpoint;
+	auto tree2 (peers_node.get_child ("UDP: " + endpoint_text.str ()));
+	ASSERT_EQ (std::to_string (nano::protocol_version), tree2.get<std::string> ("protocol_version"));
+	ASSERT_EQ ("", tree2.get<std::string> ("node_id"));
+}
+
+TEST (rpc, pending)
+{
+	nano::system system (24000, 1);
+	nano::keypair key1;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	system.deadline_set (5s);
+	while (system.nodes[0]->active.active (*block1))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "pending");
+	request.put ("account", key1.pub.to_account ());
+	request.put ("count", "100");
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		nano::block_hash hash (blocks_node.begin ()->second.get<std::string> (""));
+		ASSERT_EQ (block1->hash (), hash);
+	}
+	request.put ("sorting", "true"); // Sorting test
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		nano::block_hash hash (blocks_node.begin ()->first);
+		ASSERT_EQ (block1->hash (), hash);
+		std::string amount (blocks_node.begin ()->second.get<std::string> (""));
+		ASSERT_EQ ("100", amount);
+	}
+	request.put ("threshold", "100"); // Threshold test
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		std::unordered_map<nano::block_hash, nano::uint128_union> blocks;
+		for (auto i (blocks_node.begin ()), j (blocks_node.end ()); i != j; ++i)
+		{
+			nano::block_hash hash;
+			hash.decode_hex (i->first);
+			nano::uint128_union amount;
+			amount.decode_dec (i->second.get<std::string> (""));
+			blocks[hash] = amount;
+			boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
+			ASSERT_FALSE (source.is_initialized ());
+			boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
+			ASSERT_FALSE (min_version.is_initialized ());
+		}
+		ASSERT_EQ (blocks[block1->hash ()], 100);
+	}
+	request.put ("threshold", "101");
+	{
+		test_response response (request, rpc, system.io_ctx);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (0, blocks_node.size ());
+	}
+	request.put ("threshold", "0");
+	request.put ("source", "true");
+	request.put ("min_version", "true");
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blocks_node (response.json.get_child ("blocks"));
+		ASSERT_EQ (1, blocks_node.size ());
+		std::unordered_map<nano::block_hash, nano::uint128_union> amounts;
+		std::unordered_map<nano::block_hash, nano::account> sources;
+		for (auto i (blocks_node.begin ()), j (blocks_node.end ()); i != j; ++i)
+		{
+			nano::block_hash hash;
+			hash.decode_hex (i->first);
+			amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
+			sources[hash].decode_account (i->second.get<std::string> ("source"));
+			ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
+		}
+		ASSERT_EQ (amounts[block1->hash ()], 100);
+		ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
+	}
+}
+
+TEST (rpc_config, serialization)
+{
+	nano::rpc_config config1;
+	config1.address = boost::asio::ip::address_v6::any ();
+	config1.port = 10;
+	config1.enable_control = true;
+	nano::jsonconfig tree;
+	config1.serialize_json (tree);
+	nano::rpc_config config2;
+	ASSERT_NE (config2.address, config1.address);
+	ASSERT_NE (config2.port, config1.port);
+	ASSERT_NE (config2.enable_control, config1.enable_control);
+	bool upgraded{ false };
+	config2.deserialize_json (upgraded, tree);
+	ASSERT_EQ (config2.address, config1.address);
+	ASSERT_EQ (config2.port, config1.port);
+	ASSERT_EQ (config2.enable_control, config1.enable_control);
+}
+
+TEST (rpc, search_pending)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto wallet (system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (latest));
+	{
+		auto transaction (system.nodes[0]->store.tx_begin (true));
+		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "search_pending");
+	request.put ("wallet", wallet);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	system.deadline_set (10s);
+	while (system.nodes[0]->balance (nano::test_genesis_key.pub) != nano::genesis_amount)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, version)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "version");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("rpc_version"));
+	ASSERT_EQ (200, response1.status);
+	{
+		auto transaction (system.nodes[0]->store.tx_begin ());
+		ASSERT_EQ (std::to_string (node1->store.version_get (transaction)), response1.json.get<std::string> ("store_version"));
+	}
+	ASSERT_EQ (std::to_string (nano::protocol_version), response1.json.get<std::string> ("protocol_version"));
+	if (NANO_VERSION_PATCH == 0)
+	{
+		ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_MAJOR_MINOR_VERSION), response1.json.get<std::string> ("node_vendor"));
+	}
+	else
+	{
+		ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_MAJOR_MINOR_RC_VERSION), response1.json.get<std::string> ("node_vendor"));
+	}
+	auto headers (response1.resp.base ());
+	auto allow (headers.at ("Allow"));
+	auto content_type (headers.at ("Content-Type"));
+	auto access_control_allow_origin (headers.at ("Access-Control-Allow-Origin"));
+	auto access_control_allow_methods (headers.at ("Access-Control-Allow-Methods"));
+	auto access_control_allow_headers (headers.at ("Access-Control-Allow-Headers"));
+	auto connection (headers.at ("Connection"));
+	ASSERT_EQ ("POST, OPTIONS", allow);
+	ASSERT_EQ ("application/json", content_type);
+	ASSERT_EQ ("*", access_control_allow_origin);
+	ASSERT_EQ (allow, access_control_allow_methods);
+	ASSERT_EQ ("Accept, Accept-Language, Content-Language, Content-Type", access_control_allow_headers);
+	ASSERT_EQ ("close", connection);
+}
+
+TEST (rpc, work_generate)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	nano::block_hash hash1 (1);
+	boost::property_tree::ptree request1;
+	request1.put ("action", "work_generate");
+	request1.put ("hash", hash1.to_string ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto work1 (response1.json.get<std::string> ("work"));
+	uint64_t work2;
+	ASSERT_FALSE (nano::from_string_hex (work1, work2));
+	ASSERT_FALSE (nano::work_validate (hash1, work2));
+}
+
+TEST (rpc, work_generate_difficulty)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto node1 (system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	nano::block_hash hash1 (1);
+	uint64_t difficulty1 (0xfff0000000000000);
+	boost::property_tree::ptree request1;
+	request1.put ("action", "work_generate");
+	request1.put ("hash", hash1.to_string ());
+	request1.put ("difficulty", nano::to_string_hex (difficulty1));
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (10s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto work_text1 (response1.json.get<std::string> ("work"));
+	uint64_t work1;
+	ASSERT_FALSE (nano::from_string_hex (work_text1, work1));
+	uint64_t result_difficulty1;
+	ASSERT_FALSE (nano::work_validate (hash1, work1, &result_difficulty1));
+	ASSERT_GE (result_difficulty1, difficulty1);
+	uint64_t difficulty2 (0xffff000000000000);
+	request1.put ("difficulty", nano::to_string_hex (difficulty2));
+	test_response response2 (request1, rpc, system.io_ctx);
+	system.deadline_set (20s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	auto work_text2 (response2.json.get<std::string> ("work"));
+	uint64_t work2;
+	ASSERT_FALSE (nano::from_string_hex (work_text2, work2));
+	uint64_t result_difficulty2;
+	ASSERT_FALSE (nano::work_validate (hash1, work2, &result_difficulty2));
+	ASSERT_GE (result_difficulty2, difficulty2);
+	uint64_t difficulty3 (rpc.config.max_work_generate_difficulty + 1);
+	request1.put ("difficulty", nano::to_string_hex (difficulty3));
+	test_response response3 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	std::error_code ec (nano::error_rpc::difficulty_limit);
+	ASSERT_EQ (response3.json.get<std::string> ("error"), ec.message ());
+}
+
+TEST (rpc, work_cancel)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	nano::block_hash hash1 (1);
+	boost::property_tree::ptree request1;
+	request1.put ("action", "work_cancel");
+	request1.put ("hash", hash1.to_string ());
+	std::atomic<bool> done (false);
+	system.deadline_set (10s);
+	while (!done)
+	{
+		system.work.generate (hash1, [&done](boost::optional<uint64_t> work_a) {
+			done = !work_a;
+		});
+		test_response response1 (request1, rpc, system.io_ctx);
+		std::error_code ec;
+		while (response1.status == 0)
+		{
+			ec = system.poll ();
+		}
+		ASSERT_EQ (200, response1.status);
+		ASSERT_NO_ERROR (ec);
+	}
+}
+
+TEST (rpc, work_peer_bad)
+{
+	nano::system system (24000, 2);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	auto & node2 (*system.nodes[1]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	node2.config.work_peers.push_back (std::make_pair (boost::asio::ip::address_v6::any ().to_string (), 0));
+	nano::block_hash hash1 (1);
+	std::atomic<uint64_t> work (0);
+	node2.work_generate (hash1, [&work](uint64_t work_a) {
+		work = work_a;
+	});
+	system.deadline_set (5s);
+	while (nano::work_validate (hash1, work))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, work_peer_one)
+{
+	nano::system system (24000, 2);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	auto & node2 (*system.nodes[1]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	node2.config.work_peers.push_back (std::make_pair (node1.network.endpoint ().address ().to_string (), rpc.config.port));
+	nano::keypair key1;
+	uint64_t work (0);
+	node2.work_generate (key1.pub, [&work](uint64_t work_a) {
+		work = work_a;
+	});
+	system.deadline_set (5s);
+	while (nano::work_validate (key1.pub, work))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, work_peer_many)
+{
+	nano::system system1 (24000, 1);
+	nano::system system2 (24001, 1);
+	nano::system system3 (24002, 1);
+	nano::system system4 (24003, 1);
+	nano::node_init init1;
+	auto & node1 (*system1.nodes[0]);
+	auto & node2 (*system2.nodes[0]);
+	auto & node3 (*system3.nodes[0]);
+	auto & node4 (*system4.nodes[0]);
+	nano::keypair key;
+	nano::rpc_config config2 (true);
+	config2.port += 0;
+	nano::rpc rpc2 (system2.io_ctx, node2, config2);
+	rpc2.start ();
+	nano::rpc_config config3 (true);
+	config3.port += 1;
+	nano::rpc rpc3 (system3.io_ctx, node3, config3);
+	rpc3.start ();
+	nano::rpc_config config4 (true);
+	config4.port += 2;
+	nano::rpc rpc4 (system4.io_ctx, node4, config4);
+	rpc4.start ();
+	node1.config.work_peers.push_back (std::make_pair (node2.network.endpoint ().address ().to_string (), rpc2.config.port));
+	node1.config.work_peers.push_back (std::make_pair (node3.network.endpoint ().address ().to_string (), rpc3.config.port));
+	node1.config.work_peers.push_back (std::make_pair (node4.network.endpoint ().address ().to_string (), rpc4.config.port));
+	for (auto i (0); i < 10; ++i)
+	{
+		nano::keypair key1;
+		uint64_t work (0);
+		node1.work_generate (key1.pub, [&work](uint64_t work_a) {
+			work = work_a;
+		});
+		while (nano::work_validate (key1.pub, work))
+		{
+			system1.poll ();
+			system2.poll ();
+			system3.poll ();
+			system4.poll ();
+		}
+	}
+}
+
+TEST (rpc, block_count)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "block_count");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
+	ASSERT_EQ ("0", response1.json.get<std::string> ("unchecked"));
+}
+
+TEST (rpc, frontier_count)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "frontier_count");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
+}
+
+TEST (rpc, account_count)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "account_count");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
+}
+
+TEST (rpc, available_supply)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "available_supply");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("0", response1.json.get<std::string> ("available"));
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	test_response response2 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ ("1", response2.json.get<std::string> ("available"));
+	auto block2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, 0, 100)); // Sending to burning 0 account
+	test_response response3 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	ASSERT_EQ ("1", response3.json.get<std::string> ("available"));
+}
+
+TEST (rpc, mrai_to_raw)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "mrai_to_raw");
+	request1.put ("amount", "1");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ (nano::Mxrb_ratio.convert_to<std::string> (), response1.json.get<std::string> ("amount"));
+}
+
+TEST (rpc, mrai_from_raw)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "mrai_from_raw");
+	request1.put ("amount", nano::Mxrb_ratio.convert_to<std::string> ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("amount"));
+}
+
+TEST (rpc, krai_to_raw)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "krai_to_raw");
+	request1.put ("amount", "1");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ (nano::kxrb_ratio.convert_to<std::string> (), response1.json.get<std::string> ("amount"));
+}
+
+TEST (rpc, krai_from_raw)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "krai_from_raw");
+	request1.put ("amount", nano::kxrb_ratio.convert_to<std::string> ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("amount"));
+}
+
+TEST (rpc, nano_to_raw)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "nano_to_raw");
+	request1.put ("amount", "1");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ (nano::xrb_ratio.convert_to<std::string> (), response1.json.get<std::string> ("amount"));
+}
+
+TEST (rpc, nano_from_raw)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request1;
+	request1.put ("action", "nano_from_raw");
+	request1.put ("amount", nano::xrb_ratio.convert_to<std::string> ());
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("1", response1.json.get<std::string> ("amount"));
+}
+
+TEST (rpc, account_representative)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	request.put ("account", nano::genesis_account.to_account ());
+	request.put ("action", "account_representative");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("representative"));
+	ASSERT_EQ (account_text1, nano::genesis_account.to_account ());
+}
+
+TEST (rpc, account_representative_set)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	nano::keypair rep;
+	request.put ("account", nano::genesis_account.to_account ());
+	request.put ("representative", rep.pub.to_account ());
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("action", "account_representative_set");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string block_text1 (response.json.get<std::string> ("block"));
+	nano::block_hash hash;
+	ASSERT_FALSE (hash.decode_hex (block_text1));
+	ASSERT_FALSE (hash.is_zero ());
+	auto transaction (system.nodes[0]->store.tx_begin ());
+	ASSERT_TRUE (system.nodes[0]->store.block_exists (transaction, hash));
+	ASSERT_EQ (rep.pub, system.nodes[0]->store.block_get (transaction, hash)->representative ());
+}
+
+TEST (rpc, bootstrap)
+{
+	nano::system system0 (24000, 1);
+	nano::system system1 (24001, 1);
+	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system1.nodes[0]->work_generate_blocking (latest));
+	{
+		auto transaction (system1.nodes[0]->store.tx_begin (true));
+		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
+	}
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "bootstrap");
+	request.put ("address", "::ffff:127.0.0.1");
+	request.put ("port", system1.nodes[0]->network.endpoint ().port ());
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	system1.deadline_set (10s);
+	while (system0.nodes[0]->latest (nano::genesis_account) != system1.nodes[0]->latest (nano::genesis_account))
+	{
+		ASSERT_NO_ERROR (system0.poll ());
+		ASSERT_NO_ERROR (system1.poll ());
+	}
+}
+
+TEST (rpc, account_remove)
+{
+	nano::system system0 (24000, 1);
+	auto key1 (system0.wallet (0)->deterministic_insert ());
+	ASSERT_TRUE (system0.wallet (0)->exists (key1));
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "account_remove");
+	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("account", key1.to_account ());
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_FALSE (system0.wallet (0)->exists (key1));
+}
+
+TEST (rpc, representatives)
+{
+	nano::system system0 (24000, 1);
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives");
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	auto & representatives_node (response.json.get_child ("representatives"));
+	std::vector<nano::account> representatives;
+	for (auto i (representatives_node.begin ()), n (representatives_node.end ()); i != n; ++i)
+	{
+		nano::account account;
+		ASSERT_FALSE (account.decode_account (i->first));
+		representatives.push_back (account);
+	}
+	ASSERT_EQ (1, representatives.size ());
+	ASSERT_EQ (nano::genesis_account, representatives[0]);
+}
+
+TEST (rpc, wallet_change_seed)
+{
+	nano::system system0 (24000, 1);
+	nano::keypair seed;
+	{
+		auto transaction (system0.nodes[0]->wallets.tx_begin ());
+		nano::raw_key seed0;
+		system0.wallet (0)->store.seed (seed0, transaction);
+		ASSERT_NE (seed.pub, seed0.data);
+	}
+	nano::raw_key prv;
+	nano::deterministic_key (seed.pub, 0, prv.data);
+	auto pub (nano::pub_key (prv.data));
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_change_seed");
+	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("seed", seed.pub.to_string ());
+	test_response response (request, rpc, system0.io_ctx);
+	system0.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system0.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	{
+		auto transaction (system0.nodes[0]->wallets.tx_begin ());
+		nano::raw_key seed0;
+		system0.wallet (0)->store.seed (seed0, transaction);
+		ASSERT_EQ (seed.pub, seed0.data);
+	}
+	auto account_text (response.json.get<std::string> ("last_restored_account"));
+	nano::uint256_union account;
+	ASSERT_FALSE (account.decode_account (account_text));
+	ASSERT_TRUE (system0.wallet (0)->exists (account));
+	ASSERT_EQ (pub, account);
+	ASSERT_EQ ("1", response.json.get<std::string> ("restored_count"));
+}
+
+TEST (rpc, wallet_frontiers)
+{
+	nano::system system0 (24000, 1);
+	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_frontiers");
+	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	auto & frontiers_node (response.json.get_child ("frontiers"));
+	std::vector<nano::account> frontiers;
+	for (auto i (frontiers_node.begin ()), n (frontiers_node.end ()); i != n; ++i)
+	{
+		frontiers.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (1, frontiers.size ());
+	ASSERT_EQ (system0.nodes[0]->latest (nano::genesis_account), frontiers[0]);
+}
+
+TEST (rpc, work_validate)
+{
+	nano::network_constants constants;
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	nano::block_hash hash (1);
+	uint64_t work1 (node1.work_generate_blocking (hash));
+	boost::property_tree::ptree request;
+	request.put ("action", "work_validate");
+	request.put ("hash", hash.to_string ());
+	request.put ("work", nano::to_string_hex (work1));
+	test_response response1 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	std::string validate_text1 (response1.json.get<std::string> ("valid"));
+	ASSERT_EQ ("1", validate_text1);
+	uint64_t work2 (0);
+	request.put ("work", nano::to_string_hex (work2));
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	std::string validate_text2 (response2.json.get<std::string> ("valid"));
+	ASSERT_EQ ("0", validate_text2);
+	uint64_t result_difficulty;
+	ASSERT_FALSE (nano::work_validate (hash, work1, &result_difficulty));
+	ASSERT_GE (result_difficulty, constants.publish_threshold);
+	request.put ("work", nano::to_string_hex (work1));
+	request.put ("difficulty", nano::to_string_hex (result_difficulty));
+	test_response response3 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	bool validate3 (response3.json.get<bool> ("valid"));
+	ASSERT_TRUE (validate3);
+	uint64_t difficulty4 (0xfff0000000000000);
+	request.put ("work", nano::to_string_hex (work1));
+	request.put ("difficulty", nano::to_string_hex (difficulty4));
+	test_response response4 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response4.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response4.status);
+	bool validate4 (response4.json.get<bool> ("valid"));
+	ASSERT_EQ (result_difficulty >= difficulty4, validate4);
+	uint64_t work3 (node1.work_generate_blocking (hash, difficulty4));
+	request.put ("work", nano::to_string_hex (work3));
+	test_response response5 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response5.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response5.status);
+	bool validate5 (response5.json.get<bool> ("valid"));
+	ASSERT_TRUE (validate5);
+}
+
+TEST (rpc, successors)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	ASSERT_NE (nullptr, block);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "successors");
+	request.put ("block", genesis.to_string ());
+	request.put ("count", std::to_string (std::numeric_limits<uint64_t>::max ()));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & blocks_node (response.json.get_child ("blocks"));
+	std::vector<nano::block_hash> blocks;
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (2, blocks.size ());
+	ASSERT_EQ (genesis, blocks[0]);
+	ASSERT_EQ (block->hash (), blocks[1]);
+	// RPC chain "reverse" option
+	request.put ("action", "chain");
+	request.put ("reverse", "true");
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	ASSERT_EQ (response.json, response2.json);
+}
+
+TEST (rpc, bootstrap_any)
+{
+	nano::system system0 (24000, 1);
+	nano::system system1 (24001, 1);
+	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system1.nodes[0]->work_generate_blocking (latest));
+	{
+		auto transaction (system1.nodes[0]->store.tx_begin (true));
+		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
+	}
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "bootstrap_any");
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	std::string success (response.json.get<std::string> ("success"));
+	ASSERT_TRUE (success.empty ());
+}
+
+TEST (rpc, republish)
+{
+	nano::system system (24000, 2);
+	nano::keypair key;
+	nano::genesis genesis;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "republish");
+	request.put ("hash", send.hash ().to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	system.deadline_set (10s);
+	while (system.nodes[1]->balance (nano::test_genesis_key.pub) == nano::genesis_amount)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto & blocks_node (response.json.get_child ("blocks"));
+	std::vector<nano::block_hash> blocks;
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (1, blocks.size ());
+	ASSERT_EQ (send.hash (), blocks[0]);
+
+	request.put ("hash", genesis.hash ().to_string ());
+	request.put ("count", 1);
+	test_response response1 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	blocks_node = response1.json.get_child ("blocks");
+	blocks.clear ();
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (1, blocks.size ());
+	ASSERT_EQ (genesis.hash (), blocks[0]);
+
+	request.put ("hash", open.hash ().to_string ());
+	request.put ("sources", 2);
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	blocks_node = response2.json.get_child ("blocks");
+	blocks.clear ();
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (3, blocks.size ());
+	ASSERT_EQ (genesis.hash (), blocks[0]);
+	ASSERT_EQ (send.hash (), blocks[1]);
+	ASSERT_EQ (open.hash (), blocks[2]);
+}
+
+TEST (rpc, deterministic_key)
+{
+	nano::system system0 (24000, 1);
+	nano::raw_key seed;
+	{
+		auto transaction (system0.nodes[0]->wallets.tx_begin ());
+		system0.wallet (0)->store.seed (seed, transaction);
+	}
+	nano::account account0 (system0.wallet (0)->deterministic_insert ());
+	nano::account account1 (system0.wallet (0)->deterministic_insert ());
+	nano::account account2 (system0.wallet (0)->deterministic_insert ());
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "deterministic_key");
+	request.put ("seed", seed.data.to_string ());
+	request.put ("index", "0");
+	test_response response0 (request, rpc, system0.io_ctx);
+	while (response0.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response0.status);
+	std::string validate_text (response0.json.get<std::string> ("account"));
+	ASSERT_EQ (account0.to_account (), validate_text);
+	request.put ("index", "2");
+	test_response response1 (request, rpc, system0.io_ctx);
+	while (response1.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response1.status);
+	validate_text = response1.json.get<std::string> ("account");
+	ASSERT_NE (account1.to_account (), validate_text);
+	ASSERT_EQ (account2.to_account (), validate_text);
+}
+
+TEST (rpc, accounts_balances)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "accounts_balances");
+	boost::property_tree::ptree entry;
+	boost::property_tree::ptree peers_l;
+	entry.put ("", nano::test_genesis_key.pub.to_account ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", peers_l);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	for (auto & balances : response.json.get_child ("balances"))
+	{
+		std::string account_text (balances.first);
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		std::string balance_text (balances.second.get<std::string> ("balance"));
+		ASSERT_EQ ("340282366920938463463374607431768211455", balance_text);
+		std::string pending_text (balances.second.get<std::string> ("pending"));
+		ASSERT_EQ ("0", pending_text);
+	}
+}
+
+TEST (rpc, accounts_frontiers)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "accounts_frontiers");
+	boost::property_tree::ptree entry;
+	boost::property_tree::ptree peers_l;
+	entry.put ("", nano::test_genesis_key.pub.to_account ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", peers_l);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	for (auto & frontiers : response.json.get_child ("frontiers"))
+	{
+		std::string account_text (frontiers.first);
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		std::string frontier_text (frontiers.second.get<std::string> (""));
+		ASSERT_EQ (system.nodes[0]->latest (nano::genesis_account), frontier_text);
+	}
+}
+
+TEST (rpc, accounts_pending)
+{
+	nano::system system (24000, 1);
+	nano::keypair key1;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	system.deadline_set (5s);
+	while (system.nodes[0]->active.active (*block1))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "accounts_pending");
+	boost::property_tree::ptree entry;
+	boost::property_tree::ptree peers_l;
+	entry.put ("", key1.pub.to_account ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", peers_l);
+	request.put ("count", "100");
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		for (auto & blocks : response.json.get_child ("blocks"))
+		{
+			std::string account_text (blocks.first);
+			ASSERT_EQ (key1.pub.to_account (), account_text);
+			nano::block_hash hash1 (blocks.second.begin ()->second.get<std::string> (""));
+			ASSERT_EQ (block1->hash (), hash1);
+		}
+	}
+	request.put ("sorting", "true"); // Sorting test
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		for (auto & blocks : response.json.get_child ("blocks"))
+		{
+			std::string account_text (blocks.first);
+			ASSERT_EQ (key1.pub.to_account (), account_text);
+			nano::block_hash hash1 (blocks.second.begin ()->first);
+			ASSERT_EQ (block1->hash (), hash1);
+			std::string amount (blocks.second.begin ()->second.get<std::string> (""));
+			ASSERT_EQ ("100", amount);
+		}
+	}
+	request.put ("threshold", "100"); // Threshold test
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		std::unordered_map<nano::block_hash, nano::uint128_union> blocks;
+		for (auto & pending : response.json.get_child ("blocks"))
+		{
+			std::string account_text (pending.first);
+			ASSERT_EQ (key1.pub.to_account (), account_text);
+			for (auto i (pending.second.begin ()), j (pending.second.end ()); i != j; ++i)
+			{
+				nano::block_hash hash;
+				hash.decode_hex (i->first);
+				nano::uint128_union amount;
+				amount.decode_dec (i->second.get<std::string> (""));
+				blocks[hash] = amount;
+				boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
+				ASSERT_FALSE (source.is_initialized ());
+			}
+		}
+		ASSERT_EQ (blocks[block1->hash ()], 100);
+	}
+	request.put ("source", "true");
+	{
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		std::unordered_map<nano::block_hash, nano::uint128_union> amounts;
+		std::unordered_map<nano::block_hash, nano::account> sources;
+		for (auto & pending : response.json.get_child ("blocks"))
+		{
+			std::string account_text (pending.first);
+			ASSERT_EQ (key1.pub.to_account (), account_text);
+			for (auto i (pending.second.begin ()), j (pending.second.end ()); i != j; ++i)
+			{
+				nano::block_hash hash;
+				hash.decode_hex (i->first);
+				amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
+				sources[hash].decode_account (i->second.get<std::string> ("source"));
+			}
+		}
+		ASSERT_EQ (amounts[block1->hash ()], 100);
+		ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
+	}
+}
+
+TEST (rpc, blocks)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "blocks");
+	boost::property_tree::ptree entry;
+	boost::property_tree::ptree peers_l;
+	entry.put ("", system.nodes[0]->latest (nano::genesis_account).to_string ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("hashes", peers_l);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	for (auto & blocks : response.json.get_child ("blocks"))
+	{
+		std::string hash_text (blocks.first);
+		ASSERT_EQ (system.nodes[0]->latest (nano::genesis_account).to_string (), hash_text);
+		std::string blocks_text (blocks.second.get<std::string> (""));
+		ASSERT_FALSE (blocks_text.empty ());
+	}
+}
+
+TEST (rpc, wallet_info)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	nano::account account (system.wallet (0)->deterministic_insert ());
+	{
+		auto transaction (system.nodes[0]->wallets.tx_begin (true));
+		system.wallet (0)->store.erase (transaction, account);
+	}
+	account = system.wallet (0)->deterministic_insert ();
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_info");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string balance_text (response.json.get<std::string> ("balance"));
+	ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
+	std::string pending_text (response.json.get<std::string> ("pending"));
+	ASSERT_EQ ("1", pending_text);
+	std::string count_text (response.json.get<std::string> ("accounts_count"));
+	ASSERT_EQ ("3", count_text);
+	std::string adhoc_count (response.json.get<std::string> ("adhoc_count"));
+	ASSERT_EQ ("2", adhoc_count);
+	std::string deterministic_count (response.json.get<std::string> ("deterministic_count"));
+	ASSERT_EQ ("1", deterministic_count);
+	std::string index_text (response.json.get<std::string> ("deterministic_index"));
+	ASSERT_EQ ("2", index_text);
+}
+
+TEST (rpc, wallet_balances)
+{
+	nano::system system0 (24000, 1);
+	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_balances");
+	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	for (auto & balances : response.json.get_child ("balances"))
+	{
+		std::string account_text (balances.first);
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		std::string balance_text (balances.second.get<std::string> ("balance"));
+		ASSERT_EQ ("340282366920938463463374607431768211455", balance_text);
+		std::string pending_text (balances.second.get<std::string> ("pending"));
+		ASSERT_EQ ("0", pending_text);
+	}
+	nano::keypair key;
+	system0.wallet (0)->insert_adhoc (key.prv);
+	auto send (system0.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	request.put ("threshold", "2");
+	test_response response1 (request, rpc, system0.io_ctx);
+	while (response1.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response1.status);
+	for (auto & balances : response1.json.get_child ("balances"))
+	{
+		std::string account_text (balances.first);
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		std::string balance_text (balances.second.get<std::string> ("balance"));
+		ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
+		std::string pending_text (balances.second.get<std::string> ("pending"));
+		ASSERT_EQ ("0", pending_text);
+	}
+}
+
+TEST (rpc, pending_exists)
+{
+	nano::system system (24000, 1);
+	nano::keypair key1;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto hash0 (system.nodes[0]->latest (nano::genesis_account));
+	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	system.deadline_set (5s);
+	while (system.nodes[0]->active.active (*block1))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "pending_exists");
+	request.put ("hash", hash0.to_string ());
+	test_response response0 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response0.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response0.status);
+	std::string exists_text (response0.json.get<std::string> ("exists"));
+	ASSERT_EQ ("0", exists_text);
+	request.put ("hash", block1->hash ().to_string ());
+	test_response response1 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	std::string exists_text1 (response1.json.get<std::string> ("exists"));
+	ASSERT_EQ ("1", exists_text1);
+}
+
+TEST (rpc, wallet_pending)
+{
+	nano::system system0 (24000, 1);
+	nano::keypair key1;
+	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system0.wallet (0)->insert_adhoc (key1.prv);
+	auto block1 (system0.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	auto iterations (0);
+	while (system0.nodes[0]->active.active (*block1))
+	{
+		system0.poll ();
+		++iterations;
+		ASSERT_LT (iterations, 200);
+	}
+	nano::rpc rpc (system0.io_ctx, *system0.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_pending");
+	request.put ("wallet", system0.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("count", "100");
+	test_response response (request, rpc, system0.io_ctx);
+	while (response.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ (1, response.json.get_child ("blocks").size ());
+	for (auto & pending : response.json.get_child ("blocks"))
+	{
+		std::string account_text (pending.first);
+		ASSERT_EQ (key1.pub.to_account (), account_text);
+		nano::block_hash hash1 (pending.second.begin ()->second.get<std::string> (""));
+		ASSERT_EQ (block1->hash (), hash1);
+	}
+	request.put ("threshold", "100"); // Threshold test
+	test_response response0 (request, rpc, system0.io_ctx);
+	while (response0.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response0.status);
+	std::unordered_map<nano::block_hash, nano::uint128_union> blocks;
+	ASSERT_EQ (1, response0.json.get_child ("blocks").size ());
+	for (auto & pending : response0.json.get_child ("blocks"))
+	{
+		std::string account_text (pending.first);
+		ASSERT_EQ (key1.pub.to_account (), account_text);
+		for (auto i (pending.second.begin ()), j (pending.second.end ()); i != j; ++i)
+		{
+			nano::block_hash hash;
+			hash.decode_hex (i->first);
+			nano::uint128_union amount;
+			amount.decode_dec (i->second.get<std::string> (""));
+			blocks[hash] = amount;
+			boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
+			ASSERT_FALSE (source.is_initialized ());
+			boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
+			ASSERT_FALSE (min_version.is_initialized ());
+		}
+	}
+	ASSERT_EQ (blocks[block1->hash ()], 100);
+	request.put ("threshold", "101");
+	test_response response1 (request, rpc, system0.io_ctx);
+	while (response1.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response1.status);
+	auto & pending1 (response1.json.get_child ("blocks"));
+	ASSERT_EQ (0, pending1.size ());
+	request.put ("threshold", "0");
+	request.put ("source", "true");
+	request.put ("min_version", "true");
+	test_response response2 (request, rpc, system0.io_ctx);
+	while (response2.status == 0)
+	{
+		system0.poll ();
+	}
+	ASSERT_EQ (200, response2.status);
+	std::unordered_map<nano::block_hash, nano::uint128_union> amounts;
+	std::unordered_map<nano::block_hash, nano::account> sources;
+	ASSERT_EQ (1, response0.json.get_child ("blocks").size ());
+	for (auto & pending : response2.json.get_child ("blocks"))
+	{
+		std::string account_text (pending.first);
+		ASSERT_EQ (key1.pub.to_account (), account_text);
+		for (auto i (pending.second.begin ()), j (pending.second.end ()); i != j; ++i)
+		{
+			nano::block_hash hash;
+			hash.decode_hex (i->first);
+			amounts[hash].decode_dec (i->second.get<std::string> ("amount"));
+			sources[hash].decode_account (i->second.get<std::string> ("source"));
+			ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
+		}
+	}
+	ASSERT_EQ (amounts[block1->hash ()], 100);
+	ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
+}
+
+TEST (rpc, receive_minimum)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "receive_minimum");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string amount (response.json.get<std::string> ("amount"));
+	ASSERT_EQ (system.nodes[0]->config.receive_minimum.to_string_dec (), amount);
+}
+
+TEST (rpc, receive_minimum_set)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "receive_minimum_set");
+	request.put ("amount", "100");
+	ASSERT_NE (system.nodes[0]->config.receive_minimum.to_string_dec (), "100");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string success (response.json.get<std::string> ("success"));
+	ASSERT_TRUE (success.empty ());
+	ASSERT_EQ (system.nodes[0]->config.receive_minimum.to_string_dec (), "100");
+}
+
+TEST (rpc, work_get)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->work_cache_blocking (nano::test_genesis_key.pub, system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "work_get");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string work_text (response.json.get<std::string> ("work"));
+	uint64_t work (1);
+	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	system.nodes[0]->wallets.items.begin ()->second->store.work_get (transaction, nano::genesis_account, work);
+	ASSERT_EQ (nano::to_string_hex (work), work_text);
+}
+
+TEST (rpc, wallet_work_get)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->work_cache_blocking (nano::test_genesis_key.pub, system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_work_get");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	for (auto & works : response.json.get_child ("works"))
+	{
+		std::string account_text (works.first);
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		std::string work_text (works.second.get<std::string> (""));
+		uint64_t work (1);
+		system.nodes[0]->wallets.items.begin ()->second->store.work_get (transaction, nano::genesis_account, work);
+		ASSERT_EQ (nano::to_string_hex (work), work_text);
+	}
+}
+
+TEST (rpc, work_set)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	uint64_t work0 (100);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "work_set");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("work", nano::to_string_hex (work0));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string success (response.json.get<std::string> ("success"));
+	ASSERT_TRUE (success.empty ());
+	uint64_t work1 (1);
+	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	system.nodes[0]->wallets.items.begin ()->second->store.work_get (transaction, nano::genesis_account, work1);
+	ASSERT_EQ (work1, work0);
+}
+
+TEST (rpc, search_pending_all)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (latest));
+	{
+		auto transaction (system.nodes[0]->store.tx_begin (true));
+		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "search_pending_all");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	system.deadline_set (10s);
+	while (system.nodes[0]->balance (nano::test_genesis_key.pub) != nano::genesis_amount)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (rpc, wallet_republish)
+{
+	nano::system system (24000, 1);
+	nano::genesis genesis;
+	nano::keypair key;
+	while (key.pub < nano::test_genesis_key.pub)
+	{
+		nano::keypair key1;
+		key.pub = key1.pub;
+		key.prv.data = key1.prv.data;
+	}
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_republish");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("count", 1);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & blocks_node (response.json.get_child ("blocks"));
+	std::vector<nano::block_hash> blocks;
+	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
+	{
+		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (2, blocks.size ());
+	ASSERT_EQ (send.hash (), blocks[0]);
+	ASSERT_EQ (open.hash (), blocks[1]);
+}
+
+TEST (rpc, delegators)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "delegators");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & delegators_node (response.json.get_child ("delegators"));
+	boost::property_tree::ptree delegators;
+	for (auto i (delegators_node.begin ()), n (delegators_node.end ()); i != n; ++i)
+	{
+		delegators.put ((i->first), (i->second.get<std::string> ("")));
+	}
+	ASSERT_EQ (2, delegators.size ());
+	ASSERT_EQ ("100", delegators.get<std::string> (nano::test_genesis_key.pub.to_account ()));
+	ASSERT_EQ ("340282366920938463463374607431768211355", delegators.get<std::string> (key.pub.to_account ()));
+}
+
+TEST (rpc, delegators_count)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "delegators_count");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string count (response.json.get<std::string> ("count"));
+	ASSERT_EQ ("2", count);
+}
+
+TEST (rpc, account_info)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	auto time (nano::seconds_since_epoch ());
+
+	{
+		auto transaction = system.nodes[0]->store.tx_begin_write ();
+		nano::account_info account_info;
+		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
+		account_info.confirmation_height = 1;
+		system.nodes[0]->store.account_put (transaction, nano::test_genesis_key.pub, account_info);
+	}
+
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "account_info");
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string frontier (response.json.get<std::string> ("frontier"));
+	ASSERT_EQ (send.hash ().to_string (), frontier);
+	std::string open_block (response.json.get<std::string> ("open_block"));
+	ASSERT_EQ (genesis.hash ().to_string (), open_block);
+	std::string representative_block (response.json.get<std::string> ("representative_block"));
+	ASSERT_EQ (genesis.hash ().to_string (), representative_block);
+	std::string balance (response.json.get<std::string> ("balance"));
+	ASSERT_EQ ("100", balance);
+	std::string modified_timestamp (response.json.get<std::string> ("modified_timestamp"));
+	ASSERT_LT (std::abs ((long)time - stol (modified_timestamp)), 5);
+	std::string block_count (response.json.get<std::string> ("block_count"));
+	ASSERT_EQ ("2", block_count);
+	std::string confirmation_height (response.json.get<std::string> ("confirmation_height"));
+	ASSERT_EQ ("1", confirmation_height);
+	ASSERT_EQ (0, response.json.get<uint8_t> ("account_version"));
+	boost::optional<std::string> weight (response.json.get_optional<std::string> ("weight"));
+	ASSERT_FALSE (weight.is_initialized ());
+	boost::optional<std::string> pending (response.json.get_optional<std::string> ("pending"));
+	ASSERT_FALSE (pending.is_initialized ());
+	boost::optional<std::string> representative (response.json.get_optional<std::string> ("representative"));
+	ASSERT_FALSE (representative.is_initialized ());
+	// Test for optional values
+	request.put ("weight", "true");
+	request.put ("pending", "1");
+	request.put ("representative", "1");
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	std::string weight2 (response2.json.get<std::string> ("weight"));
+	ASSERT_EQ ("100", weight2);
+	std::string pending2 (response2.json.get<std::string> ("pending"));
+	ASSERT_EQ ("0", pending2);
+	std::string representative2 (response2.json.get<std::string> ("representative"));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), representative2);
+}
+
+/** Make sure we can use json block literals instead of string as input */
+TEST (rpc, json_block_input)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	auto & node1 (*system.nodes[0]);
+	nano::state_block send (nano::genesis_account, node1.latest (nano::test_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "sign");
+	request.put ("json_block", "true");
+	system.wallet (0)->insert_adhoc (key.prv);
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("account", key.pub.to_account ());
+	boost::property_tree::ptree json;
+	send.serialize_json (json);
+	request.add_child ("block", json);
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+
+	bool json_error{ false };
+	nano::state_block block (json_error, response.json.get_child ("block"));
+	ASSERT_FALSE (json_error);
+
+	ASSERT_FALSE (nano::validate_message (key.pub, send.hash (), block.block_signature ()));
+	ASSERT_NE (block.block_signature (), send.block_signature ());
+	ASSERT_EQ (block.hash (), send.hash ());
+}
+
+/** Make sure we can receive json block literals instead of string as output */
+TEST (rpc, json_block_output)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_info");
+	request.put ("json_block", "true");
+	request.put ("hash", send.hash ().to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+
+	// Make sure contents contains a valid JSON subtree instread of stringified json
+	bool json_error{ false };
+	nano::send_block send_from_json (json_error, response.json.get_child ("contents"));
+	ASSERT_FALSE (json_error);
+}
+
+TEST (rpc, blocks_info)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "blocks_info");
+	boost::property_tree::ptree entry;
+	boost::property_tree::ptree peers_l;
+	entry.put ("", system.nodes[0]->latest (nano::genesis_account).to_string ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("hashes", peers_l);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	for (auto & blocks : response.json.get_child ("blocks"))
+	{
+		std::string hash_text (blocks.first);
+		ASSERT_EQ (system.nodes[0]->latest (nano::genesis_account).to_string (), hash_text);
+		std::string account_text (blocks.second.get<std::string> ("block_account"));
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		std::string amount_text (blocks.second.get<std::string> ("amount"));
+		ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), amount_text);
+		std::string blocks_text (blocks.second.get<std::string> ("contents"));
+		ASSERT_FALSE (blocks_text.empty ());
+		boost::optional<std::string> pending (blocks.second.get_optional<std::string> ("pending"));
+		ASSERT_FALSE (pending.is_initialized ());
+		boost::optional<std::string> source (blocks.second.get_optional<std::string> ("source_account"));
+		ASSERT_FALSE (source.is_initialized ());
+		std::string balance_text (blocks.second.get<std::string> ("balance"));
+		ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), balance_text);
+		ASSERT_TRUE (blocks.second.get<bool> ("confirmed")); // Genesis block is confirmed by default
+	}
+	// Test for optional values
+	request.put ("source", "true");
+	request.put ("pending", "1");
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	for (auto & blocks : response2.json.get_child ("blocks"))
+	{
+		std::string source (blocks.second.get<std::string> ("source_account"));
+		ASSERT_EQ ("0", source);
+		std::string pending (blocks.second.get<std::string> ("pending"));
+		ASSERT_EQ ("0", pending);
+	}
+}
+
+TEST (rpc, blocks_info_subtype)
+{
+	nano::system system (24000, 1);
+	auto & node1 (*system.nodes[0]);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, nano::Gxrb_ratio));
+	ASSERT_NE (nullptr, send);
+	auto receive (system.wallet (0)->receive_action (*send, key.pub, nano::Gxrb_ratio));
+	ASSERT_NE (nullptr, receive);
+	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, key.pub));
+	ASSERT_NE (nullptr, change);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "blocks_info");
+	boost::property_tree::ptree peers_l;
+	boost::property_tree::ptree entry;
+	entry.put ("", send->hash ().to_string ());
+	peers_l.push_back (std::make_pair ("", entry));
+	entry.put ("", receive->hash ().to_string ());
+	peers_l.push_back (std::make_pair ("", entry));
+	entry.put ("", change->hash ().to_string ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("hashes", peers_l);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto & blocks (response.json.get_child ("blocks"));
+	ASSERT_EQ (3, blocks.size ());
+	auto send_subtype (blocks.get_child (send->hash ().to_string ()).get<std::string> ("subtype"));
+	ASSERT_EQ (send_subtype, "send");
+	auto receive_subtype (blocks.get_child (receive->hash ().to_string ()).get<std::string> ("subtype"));
+	ASSERT_EQ (receive_subtype, "receive");
+	auto change_subtype (blocks.get_child (change->hash ().to_string ()).get<std::string> ("subtype"));
+	ASSERT_EQ (change_subtype, "change");
+}
+
+TEST (rpc, work_peers_all)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	auto & node1 (*system.nodes[0]);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "work_peer_add");
+	request.put ("address", "::1");
+	request.put ("port", "0");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string success (response.json.get<std::string> ("success", ""));
+	ASSERT_TRUE (success.empty ());
+	boost::property_tree::ptree request1;
+	request1.put ("action", "work_peers");
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	auto & peers_node (response1.json.get_child ("work_peers"));
+	std::vector<std::string> peers;
+	for (auto i (peers_node.begin ()), n (peers_node.end ()); i != n; ++i)
+	{
+		peers.push_back (i->second.get<std::string> (""));
+	}
+	ASSERT_EQ (1, peers.size ());
+	ASSERT_EQ ("::1:0", peers[0]);
+	boost::property_tree::ptree request2;
+	request2.put ("action", "work_peers_clear");
+	test_response response2 (request2, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	success = response2.json.get<std::string> ("success", "");
+	ASSERT_TRUE (success.empty ());
+	test_response response3 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response3.status);
+	peers_node = response3.json.get_child ("work_peers");
+	ASSERT_EQ (0, peers_node.size ());
+}
+
+TEST (rpc, block_count_type)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send);
+	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_count_type");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string send_count (response.json.get<std::string> ("send"));
+	ASSERT_EQ ("0", send_count);
+	std::string receive_count (response.json.get<std::string> ("receive"));
+	ASSERT_EQ ("0", receive_count);
+	std::string open_count (response.json.get<std::string> ("open"));
+	ASSERT_EQ ("1", open_count);
+	std::string change_count (response.json.get<std::string> ("change"));
+	ASSERT_EQ ("0", change_count);
+	std::string state_count (response.json.get<std::string> ("state"));
+	ASSERT_EQ ("2", state_count);
+}
+
+TEST (rpc, ledger)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	auto time (nano::seconds_since_epoch ());
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "ledger");
+	request.put ("sorting", "1");
+	request.put ("count", "1");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	for (auto & accounts : response.json.get_child ("accounts"))
+	{
+		std::string account_text (accounts.first);
+		ASSERT_EQ (key.pub.to_account (), account_text);
+		std::string frontier (accounts.second.get<std::string> ("frontier"));
+		ASSERT_EQ (open.hash ().to_string (), frontier);
+		std::string open_block (accounts.second.get<std::string> ("open_block"));
+		ASSERT_EQ (open.hash ().to_string (), open_block);
+		std::string representative_block (accounts.second.get<std::string> ("representative_block"));
+		ASSERT_EQ (open.hash ().to_string (), representative_block);
+		std::string balance_text (accounts.second.get<std::string> ("balance"));
+		ASSERT_EQ ("340282366920938463463374607431768211355", balance_text);
+		std::string modified_timestamp (accounts.second.get<std::string> ("modified_timestamp"));
+		ASSERT_LT (std::abs ((long)time - stol (modified_timestamp)), 5);
+		std::string block_count (accounts.second.get<std::string> ("block_count"));
+		ASSERT_EQ ("1", block_count);
+		boost::optional<std::string> weight (accounts.second.get_optional<std::string> ("weight"));
+		ASSERT_FALSE (weight.is_initialized ());
+		boost::optional<std::string> pending (accounts.second.get_optional<std::string> ("pending"));
+		ASSERT_FALSE (pending.is_initialized ());
+		boost::optional<std::string> representative (accounts.second.get_optional<std::string> ("representative"));
+		ASSERT_FALSE (representative.is_initialized ());
+	}
+	// Test for optional values
+	request.put ("weight", "1");
+	request.put ("pending", "1");
+	request.put ("representative", "true");
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	for (auto & accounts : response2.json.get_child ("accounts"))
+	{
+		boost::optional<std::string> weight (accounts.second.get_optional<std::string> ("weight"));
+		ASSERT_TRUE (weight.is_initialized ());
+		ASSERT_EQ ("0", weight.get ());
+		boost::optional<std::string> pending (accounts.second.get_optional<std::string> ("pending"));
+		ASSERT_TRUE (pending.is_initialized ());
+		ASSERT_EQ ("0", pending.get ());
+		boost::optional<std::string> representative (accounts.second.get_optional<std::string> ("representative"));
+		ASSERT_TRUE (representative.is_initialized ());
+		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), representative.get ());
+	}
+}
+
+TEST (rpc, accounts_create)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "accounts_create");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("count", "8");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & accounts (response.json.get_child ("accounts"));
+	for (auto i (accounts.begin ()), n (accounts.end ()); i != n; ++i)
+	{
+		std::string account_text (i->second.get<std::string> (""));
+		nano::uint256_union account;
+		ASSERT_FALSE (account.decode_account (account_text));
+		ASSERT_TRUE (system.wallet (0)->exists (account));
+	}
+	ASSERT_EQ (8, accounts.size ());
+}
+
+TEST (rpc, block_create)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto send_work = node1.work_generate_blocking (latest);
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, send_work);
+	auto open_work = node1.work_generate_blocking (key.pub);
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, open_work);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_create");
+	request.put ("type", "send");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("previous", latest.to_string ());
+	request.put ("amount", "340282366920938463463374607431768211355");
+	request.put ("destination", key.pub.to_account ());
+	request.put ("work", nano::to_string_hex (send_work));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string send_hash (response.json.get<std::string> ("hash"));
+	ASSERT_EQ (send.hash ().to_string (), send_hash);
+	auto send_text (response.json.get<std::string> ("block"));
+	boost::property_tree::ptree block_l;
+	std::stringstream block_stream (send_text);
+	boost::property_tree::read_json (block_stream, block_l);
+	auto send_block (nano::deserialize_block_json (block_l));
+	ASSERT_EQ (send.hash (), send_block->hash ());
+	system.nodes[0]->process (send);
+	boost::property_tree::ptree request1;
+	request1.put ("action", "block_create");
+	request1.put ("type", "open");
+	std::string key_text;
+	key.prv.data.encode_hex (key_text);
+	request1.put ("key", key_text);
+	request1.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request1.put ("source", send.hash ().to_string ());
+	request1.put ("work", nano::to_string_hex (open_work));
+	test_response response1 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response1.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response1.status);
+	std::string open_hash (response1.json.get<std::string> ("hash"));
+	ASSERT_EQ (open.hash ().to_string (), open_hash);
+	auto open_text (response1.json.get<std::string> ("block"));
+	std::stringstream block_stream1 (open_text);
+	boost::property_tree::read_json (block_stream1, block_l);
+	auto open_block (nano::deserialize_block_json (block_l));
+	ASSERT_EQ (open.hash (), open_block->hash ());
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	request1.put ("representative", key.pub.to_account ());
+	test_response response2 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response2.status);
+	std::string open2_hash (response2.json.get<std::string> ("hash"));
+	ASSERT_NE (open.hash ().to_string (), open2_hash); // different blocks with wrong representative
+	auto change_work = node1.work_generate_blocking (open.hash ());
+	nano::change_block change (open.hash (), key.pub, key.prv, key.pub, change_work);
+	request1.put ("type", "change");
+	request1.put ("work", nano::to_string_hex (change_work));
+	test_response response4 (request1, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response4.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response4.status);
+	std::string change_hash (response4.json.get<std::string> ("hash"));
+	ASSERT_EQ (change.hash ().to_string (), change_hash);
+	auto change_text (response4.json.get<std::string> ("block"));
+	std::stringstream block_stream4 (change_text);
+	boost::property_tree::read_json (block_stream4, block_l);
+	auto change_block (nano::deserialize_block_json (block_l));
+	ASSERT_EQ (change.hash (), change_block->hash ());
+	ASSERT_EQ (nano::process_result::progress, node1.process (change).code);
+	nano::send_block send2 (send.hash (), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (send.hash ()));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (send2).code);
+	boost::property_tree::ptree request2;
+	request2.put ("action", "block_create");
+	request2.put ("type", "receive");
+	request2.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request2.put ("account", key.pub.to_account ());
+	request2.put ("source", send2.hash ().to_string ());
+	request2.put ("previous", change.hash ().to_string ());
+	request2.put ("work", nano::to_string_hex (node1.work_generate_blocking (change.hash ())));
+	test_response response5 (request2, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response5.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response5.status);
+	std::string receive_hash (response4.json.get<std::string> ("hash"));
+	auto receive_text (response5.json.get<std::string> ("block"));
+	std::stringstream block_stream5 (change_text);
+	boost::property_tree::read_json (block_stream5, block_l);
+	auto receive_block (nano::deserialize_block_json (block_l));
+	ASSERT_EQ (receive_hash, receive_block->hash ().to_string ());
+	system.nodes[0]->process_active (std::move (receive_block));
+	latest = system.nodes[0]->latest (key.pub);
+	ASSERT_EQ (receive_hash, latest.to_string ());
+}
+
+TEST (rpc, block_create_state)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	boost::property_tree::ptree request;
+	request.put ("action", "block_create");
+	request.put ("type", "state");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("previous", genesis.hash ().to_string ());
+	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("balance", (nano::genesis_amount - nano::Gxrb_ratio).convert_to<std::string> ());
+	request.put ("link", key.pub.to_account ());
+	request.put ("work", nano::to_string_hex (system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string state_hash (response.json.get<std::string> ("hash"));
+	auto state_text (response.json.get<std::string> ("block"));
+	std::stringstream block_stream (state_text);
+	boost::property_tree::ptree block_l;
+	boost::property_tree::read_json (block_stream, block_l);
+	auto state_block (nano::deserialize_block_json (block_l));
+	ASSERT_NE (nullptr, state_block);
+	ASSERT_EQ (nano::block_type::state, state_block->type ());
+	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
+	auto process_result (system.nodes[0]->process (*state_block));
+	ASSERT_EQ (nano::process_result::progress, process_result.code);
+}
+
+TEST (rpc, block_create_state_open)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	ASSERT_NE (nullptr, send_block);
+	boost::property_tree::ptree request;
+	request.put ("action", "block_create");
+	request.put ("type", "state");
+	request.put ("key", key.prv.data.to_string ());
+	request.put ("account", key.pub.to_account ());
+	request.put ("previous", 0);
+	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("balance", nano::Gxrb_ratio.convert_to<std::string> ());
+	request.put ("link", send_block->hash ().to_string ());
+	request.put ("work", nano::to_string_hex (system.nodes[0]->work_generate_blocking (send_block->hash ())));
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string state_hash (response.json.get<std::string> ("hash"));
+	auto state_text (response.json.get<std::string> ("block"));
+	std::stringstream block_stream (state_text);
+	boost::property_tree::ptree block_l;
+	boost::property_tree::read_json (block_stream, block_l);
+	auto state_block (nano::deserialize_block_json (block_l));
+	ASSERT_NE (nullptr, state_block);
+	ASSERT_EQ (nano::block_type::state, state_block->type ());
+	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
+	ASSERT_TRUE (system.nodes[0]->latest (key.pub).is_zero ());
+	auto process_result (system.nodes[0]->process (*state_block));
+	ASSERT_EQ (nano::process_result::progress, process_result.code);
+	ASSERT_FALSE (system.nodes[0]->latest (key.pub).is_zero ());
+}
+
+// Missing "work" parameter should cause work to be generated for us.
+TEST (rpc, block_create_state_request_work)
+{
+	nano::genesis genesis;
+
+	// Test work generation for state blocks both with and without previous (in the latter
+	// case, the account will be used for work generation)
+	std::vector<std::string> previous_test_input{ genesis.hash ().to_string (), std::string ("0") };
+	for (auto previous : previous_test_input)
+	{
+		nano::system system (24000, 1);
+		nano::keypair key;
+		nano::genesis genesis;
+		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		boost::property_tree::ptree request;
+		request.put ("action", "block_create");
+		request.put ("type", "state");
+		request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+		request.put ("account", nano::test_genesis_key.pub.to_account ());
+		request.put ("representative", nano::test_genesis_key.pub.to_account ());
+		request.put ("balance", (nano::genesis_amount - nano::Gxrb_ratio).convert_to<std::string> ());
+		request.put ("link", key.pub.to_account ());
+		request.put ("previous", previous);
+		nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+		rpc.start ();
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		boost::property_tree::ptree block_l;
+		std::stringstream block_stream (response.json.get<std::string> ("block"));
+		boost::property_tree::read_json (block_stream, block_l);
+		auto block (nano::deserialize_block_json (block_l));
+		ASSERT_NE (nullptr, block);
+		ASSERT_FALSE (nano::work_validate (*block));
+	}
+}
+
+TEST (rpc, block_hash)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node1 (*system.nodes[0]);
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_hash");
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string send_hash (response.json.get<std::string> ("hash"));
+	ASSERT_EQ (send.hash ().to_string (), send_hash);
+}
+
+TEST (rpc, wallet_lock)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	{
+		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
+	}
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_lock");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("locked"));
+	ASSERT_EQ (account_text1, "1");
+	auto transaction (system.wallet (0)->wallets.tx_begin ());
+	ASSERT_FALSE (system.wallet (0)->store.valid_password (transaction));
+}
+
+TEST (rpc, wallet_locked)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_locked");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string account_text1 (response.json.get<std::string> ("locked"));
+	ASSERT_EQ (account_text1, "0");
+}
+
+TEST (rpc, wallet_create_fail)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	auto node = system.nodes[0];
+	// lmdb_max_dbs should be removed once the wallet store is refactored to support more wallets.
+	for (int i = 0; i < 127; i++)
+	{
+		nano::keypair key;
+		node->wallets.create (key.pub);
+	}
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_create");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ ("Failed to create wallet. Increase lmdb_max_dbs in node config", response.json.get<std::string> ("error"));
+}
+
+TEST (rpc, wallet_ledger)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (key.prv);
+	auto & node1 (*system.nodes[0]);
+	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	system.nodes[0]->process (send);
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
+	auto time (nano::seconds_since_epoch ());
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_ledger");
+	request.put ("wallet", system.nodes[0]->wallets.items.begin ()->first.to_string ());
+	request.put ("sorting", "1");
+	request.put ("count", "1");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	for (auto & accounts : response.json.get_child ("accounts"))
+	{
+		std::string account_text (accounts.first);
+		ASSERT_EQ (key.pub.to_account (), account_text);
+		std::string frontier (accounts.second.get<std::string> ("frontier"));
+		ASSERT_EQ (open.hash ().to_string (), frontier);
+		std::string open_block (accounts.second.get<std::string> ("open_block"));
+		ASSERT_EQ (open.hash ().to_string (), open_block);
+		std::string representative_block (accounts.second.get<std::string> ("representative_block"));
+		ASSERT_EQ (open.hash ().to_string (), representative_block);
+		std::string balance_text (accounts.second.get<std::string> ("balance"));
+		ASSERT_EQ ("340282366920938463463374607431768211355", balance_text);
+		std::string modified_timestamp (accounts.second.get<std::string> ("modified_timestamp"));
+		ASSERT_LT (std::abs ((long)time - stol (modified_timestamp)), 5);
+		std::string block_count (accounts.second.get<std::string> ("block_count"));
+		ASSERT_EQ ("1", block_count);
+		boost::optional<std::string> weight (accounts.second.get_optional<std::string> ("weight"));
+		ASSERT_FALSE (weight.is_initialized ());
+		boost::optional<std::string> pending (accounts.second.get_optional<std::string> ("pending"));
+		ASSERT_FALSE (pending.is_initialized ());
+		boost::optional<std::string> representative (accounts.second.get_optional<std::string> ("representative"));
+		ASSERT_FALSE (representative.is_initialized ());
+	}
+	// Test for optional values
+	request.put ("weight", "true");
+	request.put ("pending", "1");
+	request.put ("representative", "false");
+	test_response response2 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	for (auto & accounts : response2.json.get_child ("accounts"))
+	{
+		boost::optional<std::string> weight (accounts.second.get_optional<std::string> ("weight"));
+		ASSERT_TRUE (weight.is_initialized ());
+		ASSERT_EQ ("0", weight.get ());
+		boost::optional<std::string> pending (accounts.second.get_optional<std::string> ("pending"));
+		ASSERT_TRUE (pending.is_initialized ());
+		ASSERT_EQ ("0", pending.get ());
+		boost::optional<std::string> representative (accounts.second.get_optional<std::string> ("representative"));
+		ASSERT_FALSE (representative.is_initialized ());
+	}
+}
+
+TEST (rpc, wallet_add_watch)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("action", "wallet_add_watch");
+	boost::property_tree::ptree entry;
+	boost::property_tree::ptree peers_l;
+	entry.put ("", nano::test_genesis_key.pub.to_account ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", peers_l);
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::string success (response.json.get<std::string> ("success"));
+	ASSERT_TRUE (success.empty ());
+	ASSERT_TRUE (system.wallet (0)->exists (nano::test_genesis_key.pub));
+}
+
+TEST (rpc, online_reps)
+{
+	nano::system system (24000, 2);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	ASSERT_TRUE (system.nodes[1]->online_reps.online_stake () == system.nodes[1]->config.online_weight_minimum.number ());
+	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	ASSERT_NE (nullptr, send_block);
+	system.deadline_set (10s);
+	while (system.nodes[1]->online_reps.list ().empty ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[1], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives_online");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto representatives (response.json.get_child ("representatives"));
+	auto item (representatives.begin ());
+	ASSERT_NE (representatives.end (), item);
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), item->second.get<std::string> (""));
+	boost::optional<std::string> weight (item->second.get_optional<std::string> ("weight"));
+	ASSERT_FALSE (weight.is_initialized ());
+	while (system.nodes[1]->block (send_block->hash ()) == nullptr)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	//Test weight option
+	request.put ("weight", "true");
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto representatives2 (response2.json.get_child ("representatives"));
+	auto item2 (representatives2.begin ());
+	ASSERT_NE (representatives2.end (), item2);
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), item2->first);
+	auto weight2 (item2->second.get<std::string> ("weight"));
+	ASSERT_EQ (system.nodes[1]->weight (nano::test_genesis_key.pub).convert_to<std::string> (), weight2);
+	//Test accounts filter
+	auto new_rep (system.wallet (1)->deterministic_insert ());
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, new_rep, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send);
+	while (system.nodes[1]->block (send->hash ()) == nullptr)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto receive (system.wallet (1)->receive_action (*send, new_rep, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive);
+	while (system.nodes[1]->block (receive->hash ()) == nullptr)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, new_rep));
+	ASSERT_NE (nullptr, change);
+	while (system.nodes[1]->block (change->hash ()) == nullptr)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	system.deadline_set (5s);
+	while (system.nodes[1]->online_reps.list ().size () != 2)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	boost::property_tree::ptree child_rep;
+	child_rep.put ("", new_rep.to_account ());
+	boost::property_tree::ptree filtered_accounts;
+	filtered_accounts.push_back (std::make_pair ("", child_rep));
+	request.add_child ("accounts", filtered_accounts);
+	test_response response3 (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response3.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto representatives3 (response3.json.get_child ("representatives"));
+	auto item3 (representatives3.begin ());
+	ASSERT_NE (representatives3.end (), item3);
+	ASSERT_EQ (new_rep.to_account (), item3->first);
+	ASSERT_EQ (representatives3.size (), 1);
+	system.nodes[1]->stop ();
+}
+
+TEST (rpc, confirmation_history)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	ASSERT_TRUE (system.nodes[0]->active.list_confirmed ().empty ());
+	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	system.deadline_set (10s);
+	while (system.nodes[0]->active.list_confirmed ().empty ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "confirmation_history");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto representatives (response.json.get_child ("confirmations"));
+	auto item (representatives.begin ());
+	ASSERT_NE (representatives.end (), item);
+	auto hash (item->second.get<std::string> ("hash"));
+	auto tally (item->second.get<std::string> ("tally"));
+	ASSERT_FALSE (item->second.get<std::string> ("duration", "").empty ());
+	ASSERT_FALSE (item->second.get<std::string> ("time", "").empty ());
+	ASSERT_EQ (block->hash ().to_string (), hash);
+	nano::amount tally_num;
+	tally_num.decode_dec (tally);
+	assert (tally_num == nano::genesis_amount || tally_num == (nano::genesis_amount - nano::Gxrb_ratio));
+	system.stop ();
+}
+
+TEST (rpc, confirmation_history_hash)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	ASSERT_TRUE (system.nodes[0]->active.list_confirmed ().empty ());
+	auto send1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send3 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	system.deadline_set (10s);
+	while (system.nodes[0]->active.list_confirmed ().size () != 3)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "confirmation_history");
+	request.put ("hash", send2->hash ().to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto representatives (response.json.get_child ("confirmations"));
+	ASSERT_EQ (representatives.size (), 1);
+	auto item (representatives.begin ());
+	ASSERT_NE (representatives.end (), item);
+	auto hash (item->second.get<std::string> ("hash"));
+	auto tally (item->second.get<std::string> ("tally"));
+	ASSERT_FALSE (item->second.get<std::string> ("duration", "").empty ());
+	ASSERT_FALSE (item->second.get<std::string> ("time", "").empty ());
+	ASSERT_EQ (send2->hash ().to_string (), hash);
+	nano::amount tally_num;
+	tally_num.decode_dec (tally);
+	assert (tally_num == nano::genesis_amount || tally_num == (nano::genesis_amount - nano::Gxrb_ratio) || tally_num == (nano::genesis_amount - 2 * nano::Gxrb_ratio) || tally_num == (nano::genesis_amount - 3 * nano::Gxrb_ratio));
+	system.stop ();
+}
+
+TEST (rpc, block_confirm)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	{
+		auto transaction (system.nodes[0]->store.tx_begin (true));
+		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send1).code);
+	}
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_confirm");
+	request.put ("hash", send1->hash ().to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("1", response.json.get<std::string> ("started"));
+}
+
+TEST (rpc, block_confirm_absent)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_confirm");
+	request.put ("hash", "0");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("Block not found", response.json.get<std::string> ("error"));
+}
+
+TEST (rpc, node_id)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "node_id");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
+	nano::keypair node_id (system.nodes[0]->store.get_node_id (transaction));
+	ASSERT_EQ (node_id.prv.data.to_string (), response.json.get<std::string> ("private"));
+	ASSERT_EQ (node_id.pub.to_account (), response.json.get<std::string> ("as_account"));
+}
+
+TEST (rpc, node_id_delete)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	{
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
+		nano::keypair node_id (system.nodes[0]->store.get_node_id (transaction));
+		ASSERT_EQ (node_id.pub.to_string (), system.nodes[0]->node_id.pub.to_string ());
+	}
+	boost::property_tree::ptree request;
+	request.put ("action", "node_id_delete");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("1", response.json.get<std::string> ("deleted"));
+	auto transaction (system.nodes[0]->store.tx_begin_write ());
+	nano::keypair node_id (system.nodes[0]->store.get_node_id (transaction));
+	ASSERT_NE (node_id.pub.to_string (), system.nodes[0]->node_id.pub.to_string ());
+}
+
+TEST (rpc, stats_clear)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	system.nodes[0]->stats.inc (nano::stat::type::ledger, nano::stat::dir::in);
+	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::ledger, nano::stat::dir::in));
+	boost::property_tree::ptree request;
+	request.put ("action", "stats_clear");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	std::string success (response.json.get<std::string> ("success"));
+	ASSERT_TRUE (success.empty ());
+	ASSERT_EQ (0, system.nodes[0]->stats.count (nano::stat::type::ledger, nano::stat::dir::in));
+	ASSERT_LE (system.nodes[0]->stats.last_reset ().count (), 5);
+}
+
+TEST (rpc, unopened)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::account account1 (1), account2 (account1.number () + 1);
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, account1, 1));
+	ASSERT_NE (nullptr, send);
+	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, account2, 2));
+	ASSERT_NE (nullptr, send2);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	{
+		boost::property_tree::ptree request;
+		request.put ("action", "unopened");
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & accounts (response.json.get_child ("accounts"));
+		ASSERT_EQ (2, accounts.size ());
+		ASSERT_EQ ("1", accounts.get<std::string> (account1.to_account ()));
+		ASSERT_EQ ("2", accounts.get<std::string> (account2.to_account ()));
+	}
+	{
+		// starting at second account should get a single result
+		boost::property_tree::ptree request;
+		request.put ("action", "unopened");
+		request.put ("account", account2.to_account ());
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & accounts (response.json.get_child ("accounts"));
+		ASSERT_EQ (1, accounts.size ());
+		ASSERT_EQ ("2", accounts.get<std::string> (account2.to_account ()));
+	}
+	{
+		// starting at third account should get no results
+		boost::property_tree::ptree request;
+		request.put ("action", "unopened");
+		request.put ("account", nano::account (account2.number () + 1).to_account ());
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & accounts (response.json.get_child ("accounts"));
+		ASSERT_EQ (0, accounts.size ());
+	}
+	{
+		// using count=1 should get a single result
+		boost::property_tree::ptree request;
+		request.put ("action", "unopened");
+		request.put ("count", "1");
+		test_response response (request, rpc, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & accounts (response.json.get_child ("accounts"));
+		ASSERT_EQ (1, accounts.size ());
+		ASSERT_EQ ("1", accounts.get<std::string> (account1.to_account ()));
+	}
+}
+
+TEST (rpc, unopened_burn)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto genesis (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	ASSERT_FALSE (genesis.is_zero ());
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::burn_account, 1));
+	ASSERT_NE (nullptr, send);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "unopened");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & accounts (response.json.get_child ("accounts"));
+	ASSERT_EQ (0, accounts.size ());
+}
+
+TEST (rpc, unopened_no_accounts)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "unopened");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	auto & accounts (response.json.get_child ("accounts"));
+	ASSERT_EQ (0, accounts.size ());
+}
+
+TEST (rpc, uptime)
+{
+	nano::system system (24000, 1);
+	nano::rpc rpc (system.io_ctx, *system.nodes[0], nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "uptime");
+	std::this_thread::sleep_for (std::chrono::seconds (1));
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_LE (1, response.json.get<int> ("seconds"));
+}
+
+TEST (rpc, wallet_history)
+{
+	nano::system system (24000, 1);
+	auto node0 (system.nodes[0]);
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto timestamp1 (nano::seconds_since_epoch ());
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, node0->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send);
+	std::this_thread::sleep_for (std::chrono::milliseconds (1000));
+	auto timestamp2 (nano::seconds_since_epoch ());
+	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, node0->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, receive);
+	nano::keypair key;
+	std::this_thread::sleep_for (std::chrono::milliseconds (1000));
+	auto timestamp3 (nano::seconds_since_epoch ());
+	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, node0->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send2);
+	system.deadline_set (10s);
+	nano::rpc rpc (system.io_ctx, *node0, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_history");
+	request.put ("wallet", node0->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+	std::vector<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>> history_l;
+	auto & history_node (response.json.get_child ("history"));
+	for (auto i (history_node.begin ()), n (history_node.end ()); i != n; ++i)
+	{
+		history_l.push_back (std::make_tuple (i->second.get<std::string> ("type"), i->second.get<std::string> ("account"), i->second.get<std::string> ("amount"), i->second.get<std::string> ("hash"), i->second.get<std::string> ("block_account"), i->second.get<std::string> ("local_timestamp")));
+	}
+	ASSERT_EQ (4, history_l.size ());
+	ASSERT_EQ ("send", std::get<0> (history_l[0]));
+	ASSERT_EQ (key.pub.to_account (), std::get<1> (history_l[0]));
+	ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[0]));
+	ASSERT_EQ (send2->hash ().to_string (), std::get<3> (history_l[0]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[0]));
+	ASSERT_EQ (std::to_string (timestamp3), std::get<5> (history_l[0]));
+	ASSERT_EQ ("receive", std::get<0> (history_l[1]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
+	ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[1]));
+	ASSERT_EQ (receive->hash ().to_string (), std::get<3> (history_l[1]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[1]));
+	ASSERT_EQ (std::to_string (timestamp2), std::get<5> (history_l[1]));
+	ASSERT_EQ ("send", std::get<0> (history_l[2]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
+	ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[2]));
+	ASSERT_EQ (send->hash ().to_string (), std::get<3> (history_l[2]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[2]));
+	ASSERT_EQ (std::to_string (timestamp1), std::get<5> (history_l[2]));
+	// Genesis block
+	ASSERT_EQ ("receive", std::get<0> (history_l[3]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
+	ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), std::get<2> (history_l[3]));
+	ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[3]));
+	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[3]));
+}
+
+TEST (rpc, sign_hash)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	auto & node1 (*system.nodes[0]);
+	nano::state_block send (nano::genesis_account, node1.latest (nano::test_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "sign");
+	request.put ("hash", send.hash ().to_string ());
+	request.put ("key", key.prv.data.to_string ());
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	std::error_code ec (nano::error_rpc::sign_hash_disabled);
+	ASSERT_EQ (response.json.get<std::string> ("error"), ec.message ());
+	rpc.config.enable_sign_hash = true;
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response2.status);
+	nano::signature signature;
+	std::string signature_text (response2.json.get<std::string> ("signature"));
+	ASSERT_FALSE (signature.decode_hex (signature_text));
+	ASSERT_FALSE (nano::validate_message (key.pub, send.hash (), signature));
+}
+
+TEST (rpc, sign_block)
+{
+	nano::system system (24000, 1);
+	nano::keypair key;
+	auto & node1 (*system.nodes[0]);
+	nano::state_block send (nano::genesis_account, node1.latest (nano::test_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::rpc rpc (system.io_ctx, node1, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "sign");
+	system.wallet (0)->insert_adhoc (key.prv);
+	std::string wallet;
+	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
+	request.put ("wallet", wallet);
+	request.put ("account", key.pub.to_account ());
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	auto contents (response.json.get<std::string> ("block"));
+	boost::property_tree::ptree block_l;
+	std::stringstream block_stream (contents);
+	boost::property_tree::read_json (block_stream, block_l);
+	auto block (nano::deserialize_block_json (block_l));
+	ASSERT_FALSE (nano::validate_message (key.pub, send.hash (), block->block_signature ()));
+	ASSERT_NE (block->block_signature (), send.block_signature ());
+	ASSERT_EQ (block->hash (), send.hash ());
+}
+
+TEST (rpc, memory_stats)
+{
+	nano::system system (24000, 1);
+	auto node = system.nodes.front ();
+	nano::rpc rpc (system.io_ctx, *node, nano::rpc_config (true));
+
+	// Preliminary test adding to the vote uniquer and checking json output is correct
+	nano::keypair key;
+	auto block (std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0));
+	std::vector<nano::block_hash> hashes;
+	hashes.push_back (block->hash ());
+	auto vote (std::make_shared<nano::vote> (key.pub, key.prv, 0, hashes));
+	node->vote_uniquer.unique (vote);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "stats");
+	request.put ("type", "objects");
+	test_response response (request, rpc, system.io_ctx);
+	system.deadline_set (5s);
+	while (response.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response.status);
+
+	ASSERT_EQ (response.json.get_child ("node").get_child ("vote_uniquer").get_child ("votes").get<std::string> ("count"), "1");
+}
+
+TEST (rpc, block_confirmed)
+{
+	nano::system system (24000, 1);
+	auto node = system.nodes.front ();
+	nano::rpc rpc (system.io_ctx, *node, nano::rpc_config (true));
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "block_info");
+	request.put ("hash", "bad_hash1337");
+	test_response response (request, rpc, system.io_ctx);
+	while (response.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response.status);
+	ASSERT_EQ ("Invalid block hash", response.json.get<std::string> ("error"));
+
+	request.put ("hash", "0");
+	test_response response1 (request, rpc, system.io_ctx);
+	while (response1.status == 0)
+	{
+		system.poll ();
+	}
+	ASSERT_EQ (200, response1.status);
+	ASSERT_EQ ("Block not found", response1.json.get<std::string> ("error"));
+
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	system.wallet (0)->insert_adhoc (key.prv);
+
+	// Open an account directly in the ledger
+	{
+		auto transaction = node->store.tx_begin_write ();
+		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::send_block send1 (latest, key.pub, 300, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (latest));
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
+
+		nano::open_block open1 (send1.hash (), nano::genesis_account, key.pub, key.prv, key.pub, system.work.generate (key.pub));
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open1).code);
+	}
+
+	// This should not be confirmed
+	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+	request.put ("hash", latest.to_string ());
+	test_response response2 (request, rpc, system.io_ctx);
+	while (response2.status == 0)
+	{
+		system.poll ();
+	}
+
+	ASSERT_EQ (200, response2.status);
+	ASSERT_FALSE (response2.json.get<bool> ("confirmed"));
+
+	// Create and process a new send block
+	auto send = std::make_shared<nano::send_block> (latest, key.pub, 10, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (latest));
+	node->process_active (send);
+	node->block_processor.flush ();
+
+	// Wait until it has been confirmed by the network
+	system.deadline_set (10s);
+	while (true)
+	{
+		auto transaction = node->store.tx_begin_read ();
+		if (node->ledger.block_confirmed (transaction, send->hash ()))
+		{
+			break;
+		}
+
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	// Requesting confirmation for this should now succeed
+	request.put ("hash", send->hash ().to_string ());
+	test_response response3 (request, rpc, system.io_ctx);
+	while (response3.status == 0)
+	{
+		system.poll ();
+	}
+
+	ASSERT_EQ (200, response3.status);
+	ASSERT_TRUE (response3.json.get<bool> ("confirmed"));
+}


### PR DESCRIPTION
Move RPC classes to a new subfolder nano/rpc and also create a few different files to hold the related clases in. It currently depends on the `node` library (and vice versa) but this dependency will be removed in the main RPC task. Also moved the rpc tests to their own executable.
Extracted a few other things like thread_runner, logging, ipc_client/transport etc.. to the lib library to make them accessible to other libraries which won't have access to the `node` library (e.g the new RPC server process).