### PR TITLE
Fix lock ordering issue in udp_channels

### DIFF
--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -167,6 +167,7 @@ void nano::transport::udp_channels::store_all (nano::node & node_a)
 	std::vector<nano::endpoint> endpoints;
 	{
 		std::lock_guard<std::mutex> lock (mutex);
+		endpoints.reserve (channels.size ());
 		std::transform (channels.begin (), channels.end (),
 		std::back_inserter (endpoints), [](const auto & channel) { return channel.endpoint (); });
 	}

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -162,15 +162,21 @@ void nano::transport::udp_channels::random_fill (std::array<nano::endpoint, 8> &
 
 void nano::transport::udp_channels::store_all (nano::node & node_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
-	if (!channels.empty ())
+	// We can't hold the mutex while starting a write transaction, so
+	// we collect endpoints to be saved and then relase the lock.
+	std::vector<nano::endpoint> endpoints;
+	{
+		std::lock_guard<std::mutex> lock (mutex);
+		std::transform (channels.begin (), channels.end (),
+		std::back_inserter (endpoints), [](const auto & channel) { return channel.endpoint (); });
+	}
+	if (!endpoints.empty ())
 	{
 		// Clear all peers then refresh with the current list of peers
 		auto transaction (node_a.store.tx_begin_write ());
 		node_a.store.peer_clear (transaction);
-		for (auto channel : channels)
+		for (auto endpoint : endpoints)
 		{
-			auto endpoint (channel.endpoint ());
 			nano::endpoint_key endpoint_key (endpoint.address ().to_v6 ().to_bytes (), endpoint.port ());
 			node_a.store.peer_put (transaction, std::move (endpoint_key));
 		}


### PR DESCRIPTION
The load-tester exposed this lock ordering bug:

IO thread 1:
: rpc::process -> TX WRITE LOCK -> ... -> udp::channels::size -> MUTEX LOCK

IO thread 2:
: ongoing_peer_store -> MUTEX LOCK -> TX WRITE LOCK

(load-tester still occasionally times out with the tool's defaults; reducing node count or increasing timeout helps, but there's no longer a deadlock)