### PR TITLE
Use asio strands in udp channels

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2317,7 +2317,7 @@ void nano::node::process_message (nano::message const & message_a, std::shared_p
 
 nano::endpoint nano::network::endpoint ()
 {
-	return udp_channels.local_endpoint ();
+	return udp_channels.get_local_endpoint ();
 }
 
 void nano::network::cleanup (std::chrono::steady_clock::time_point const & cutoff_a)

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -54,7 +54,7 @@ namespace transport
 		void start ();
 		void stop ();
 		void send (boost::asio::const_buffer buffer_a, nano::endpoint endpoint_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a);
-		nano::endpoint local_endpoint () const;
+		nano::endpoint get_local_endpoint () const;
 		void receive_action (nano::message_buffer *);
 		void process_packets ();
 		std::shared_ptr<nano::transport::channel> create (nano::endpoint const &);
@@ -82,7 +82,6 @@ namespace transport
 		static std::chrono::seconds constexpr syn_cookie_cutoff = std::chrono::seconds (5);
 
 	private:
-		bool is_socket_open ();
 		void ongoing_syn_cookie_cleanup ();
 		class endpoint_tag
 		{
@@ -151,8 +150,11 @@ namespace transport
 		std::unordered_map<nano::endpoint, syn_cookie_info> syn_cookies;
 		std::unordered_map<boost::asio::ip::address, unsigned> syn_cookies_per_ip;
 		nano::node & node;
+		boost::asio::strand<boost::asio::io_context::executor_type> strand;
 		boost::asio::ip::udp::socket socket;
+		nano::endpoint local_endpoint;
 		nano::network_params network_params;
+		std::atomic<bool> stopped{ false };
 	};
 } // namespace transport
 } // namespace nano


### PR DESCRIPTION
#1873 and #1876 fixed some issues in udp_channels (lock ordering causing load-tester to fail + tsan race reports), but they introduced another race.

Sockets are not thread safe and the recommended solution is to use strands.

Changes: Any access to the udp `socket` has to go through the strand, and bind_executor is used to also put the completion handler in the strand. This makes it safe to access the socket from the handler. 

Using strands means no more calling `socket.local_endpoint/is_open/close` or async initiating functions directly - `asio::post` is used for this. This makes it a bit awkward to do calls like socket.local_endpoint(..)  - as the caller would need a completion callback - so the local endpoint is put in a field in the constructor. The `stop` function then invalidates it (this keeps the `endpoint_bad_fd` test happy - previously it depended on socket being closed synchronously)