### PR TITLE
tsan: Fix race in repcrawler and remove redundant weight computation

### DIFF
--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -122,17 +122,14 @@ private:
 	/** Called continuously to crawl for representatives */
 	void ongoing_crawl ();
 
-	/** Returns a list of endpoints to crawl */
-	std::vector<std::shared_ptr<nano::transport::channel>> get_crawl_targets ();
+	/** Returns a list of endpoints to crawl. The total weight is passed in to avoid computing it twice. */
+	std::vector<std::shared_ptr<nano::transport::channel>> get_crawl_targets (nano::uint128_t total_weight_a);
 
 	/** When a rep request is made, this is called to update the last-request timestamp. */
 	void on_rep_request (std::shared_ptr<nano::transport::channel> channel_a);
 
 	/** Protects the probable_reps container */
 	std::mutex probable_reps_mutex;
-
-	/** Get total available weight from representatives (must be called with a lock on probable_reps_mutex) */
-	nano::uint128_t total_weight_internal ();
 
 	/** Probable representatives */
 	probably_rep_t probable_reps;


### PR DESCRIPTION
The unlocked version of total_weight() was called where a lock is needed. Weight was also computed twice, now it's passed as an argument. 