### PR TITLE
Reduce work.eco_pow intermittent failure rate

### DIFF
--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -178,10 +178,10 @@ TEST (work, eco_pow)
 	std::future<std::chrono::nanoseconds> future2 = promise2.get_future ();
 
 	std::thread thread1 (work_func, std::ref (promise1), std::chrono::nanoseconds (0));
-	std::thread thread2 (work_func, std::ref (promise2), std::chrono::nanoseconds (10000000));
+	std::thread thread2 (work_func, std::ref (promise2), std::chrono::milliseconds (10));
 
 	// Confirm that the eco pow rate limiter is working.
-	// It's possible under some unlucky circumstances that this fails to the random nature of valid work generation. 
+	// It's possible under some unlucky circumstances that this fails to the random nature of valid work generation.
 	ASSERT_LT (future1.get (), future2.get ());
 
 	thread1.join ();

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -178,10 +178,10 @@ TEST (work, eco_pow)
 	std::future<std::chrono::nanoseconds> future2 = promise2.get_future ();
 
 	std::thread thread1 (work_func, std::ref (promise1), std::chrono::nanoseconds (0));
-	std::thread thread2 (work_func, std::ref (promise2), std::chrono::nanoseconds (100000));
+	std::thread thread2 (work_func, std::ref (promise2), std::chrono::nanoseconds (10000000));
 
 	// Confirm that the eco pow rate limiter is working.
-	// It's possible under some unlucky circumstances that this fails.
+	// It's possible under some unlucky circumstances that this fails to the random nature of valid work generation. 
 	ASSERT_LT (future1.get (), future2.get ());
 
 	thread1.join ();


### PR DESCRIPTION
Due to the random nature of a successful proof when generating pow this test can fail when comparing the time taken for 2 threads to find a valid proof even when 1 thread has a delay. I have made this delay more pronounced, which does increase the time taken to complete the test (100ms on my machine), but it seems worthwhile to do this to cause it to fail even more infrequently (pretty much 0)