### PR TITLE
Fix ASAN warning in wallet.history

### DIFF
--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -1722,7 +1722,7 @@ namespace
 class history_visitor : public nano::block_visitor
 {
 public:
-	history_visitor (nano::rpc_handler & handler_a, bool raw_a, nano::transaction & transaction_a, boost::property_tree::ptree & tree_a, nano::block_hash const & hash_a, std::vector<nano::public_key> const & accounts_filter_a = {}) :
+	history_visitor (nano::rpc_handler & handler_a, bool raw_a, nano::transaction & transaction_a, boost::property_tree::ptree & tree_a, nano::block_hash const & hash_a, std::vector<nano::public_key> const & accounts_filter_a) :
 	handler (handler_a),
 	raw (raw_a),
 	transaction (transaction_a),
@@ -3847,7 +3847,8 @@ void nano::rpc_handler::wallet_history ()
 					if (block != nullptr && timestamp >= modified_since)
 					{
 						boost::property_tree::ptree entry;
-						history_visitor visitor (*this, false, block_transaction, entry, hash);
+						std::vector<nano::public_key> no_filter;
+						history_visitor visitor (*this, false, block_transaction, entry, hash, no_filter);
 						block->visit (visitor);
 						if (!entry.empty ())
 						{


### PR DESCRIPTION
Mac/Clang ASAN warning
```
[ RUN      ] rpc.wallet_history
SUMMARY: AddressSanitizer: stack-use-after-scope vector:639 in (anonymous namespace)::history_visitor::should_ignore_account(nano::uint256_union const&)
```

A default argument which is a temporary bound to const reference was assigned to a member variable and accessed later in another method `should_ignore_account`. However from the standard:
> A temporary bound to a reference member in a constructor’s ctor-initializer (§12.6.2 [class.base.init]) persists until the constructor exits

I have removed the default argument and just pass an empty std::vector in the one place utilizing the default argument. 