### PR TITLE
Fix ASAN warning in rpc.account_history

### DIFF
--- a/nano/core_test/rpc.cpp
+++ b/nano/core_test/rpc.cpp
@@ -1220,7 +1220,7 @@ TEST (rpc, account_history)
 	auto account2 (system.wallet (0)->deterministic_insert ());
 	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, account2, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send2);
-	auto receive2 (system.wallet (0)->receive_action (static_cast<nano::send_block &> (*send2), account2, system.nodes[0]->config.receive_minimum.number ()));
+	auto receive2 (system.wallet (0)->receive_action (*send2, account2, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive2);
 	{
 		boost::property_tree::ptree request;


### PR DESCRIPTION
```
[ RUN      ] rpc.account_history
[1m/Users/user/Library/raiblocks/nano/core_test/rpc.cpp:1223:52:[1m[31m runtime error: [1m[0m[1mdowncast of address 0x611000050a40 which does not point to an object of type ‘nano::send_block’[1m[0m
[1m0x611000050a40:[1m[30m note: [1m[0mobject is of type ‘nano::state_block’[1m[0m
39 00 80 3c  b0 6a 2d 09 01 00 00 00  b0 31 1e a5 57 08 d6 a5  3c 75 cd bf 88 30 02 59  c6 d0 18 52
[1m[32m              ^~~~~~~~~~~~~~~~~~~~~~~[1m[0m
             vptr for ‘nano::state_block’
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
```

Just pass the block directly like all other tests do instead of trying to cast it.