### PR TITLE
Remove vote generator delay

### DIFF
--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -67,35 +67,15 @@ void nano::vote_generator::run ()
 	lock.unlock ();
 	condition.notify_all ();
 	lock.lock ();
-	auto min (std::numeric_limits<std::chrono::steady_clock::time_point>::min ());
-	auto cutoff (min);
 	while (!stopped)
 	{
-		auto now (std::chrono::steady_clock::now ());
-		if (hashes.size () >= 12)
+		if (!hashes.empty ())
 		{
 			send (lock);
 		}
-		else if (cutoff == min) // && hashes.size () < 12
+		else
 		{
-			cutoff = now + network_params.voting.generator_delay;
-			condition.wait_until (lock, cutoff);
-		}
-		else if (now < cutoff) // && hashes.size () < 12
-		{
-			condition.wait_until (lock, cutoff);
-		}
-		else // now >= cutoff && hashes.size () < 12
-		{
-			cutoff = min;
-			if (!hashes.empty ())
-			{
-				send (lock);
-			}
-			else
-			{
-				condition.wait (lock);
-			}
+			condition.wait (lock);
 		}
 	}
 }

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -124,7 +124,6 @@ nano::node_constants::node_constants (nano::network_constants & network_constant
 nano::voting_constants::voting_constants (nano::network_constants & network_constants)
 {
 	max_cache = network_constants.is_test_network () ? 2 : 1000;
-	generator_delay = network_constants.is_test_network () ? std::chrono::milliseconds (10) : std::chrono::milliseconds (500);
 }
 
 nano::portmapping_constants::portmapping_constants (nano::network_constants & network_constants)

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -361,7 +361,6 @@ class voting_constants
 public:
 	voting_constants (nano::network_constants & network_constants);
 	size_t max_cache;
-	std::chrono::milliseconds generator_delay;
 };
 
 /** Port-mapping related constants whose value depends on the active network */


### PR DESCRIPTION
Colin realized we could remove the vote generator delay. Multiple hashes still got packed when I tested this on beta (with high tps it should still stuff 12 hashes into a v-b-h message)

Some confirmation height tests will fail intermittently until PR #1877 is merged.