### PR TITLE
Port config cleanup, allow running tests alongside beta node

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -51,9 +51,10 @@ public:
 		uint64_t constexpr publish_full_threshold = 0xffffffc000000000;
 		publish_threshold = is_test_network () ? publish_test_threshold : publish_full_threshold;
 
-		default_node_port = is_live_network () ? 7075 : 54000;
-		default_rpc_port = is_live_network () ? 7076 : 55000;
-		default_ipc_port = is_live_network () ? 7077 : 24077;
+		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : 44000;
+		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : 45000;
+		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : 46000;
+		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : 47000;
 		request_interval_ms = is_test_network () ? 10 : 16000;
 	}
 
@@ -63,6 +64,7 @@ public:
 	uint16_t default_node_port;
 	uint16_t default_rpc_port;
 	uint16_t default_ipc_port;
+	uint16_t default_websocket_port;
 	unsigned request_interval_ms;
 
 	/** Returns the network this object contains values for */

--- a/nano/node/ipcconfig.hpp
+++ b/nano/node/ipcconfig.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>
 #include <string>
 
@@ -34,8 +35,13 @@ namespace ipc
 	class ipc_config_tcp_socket : public ipc_config_transport
 	{
 	public:
+		ipc_config_tcp_socket () :
+		port (network_constants.default_ipc_port)
+		{
+		}
+		nano::network_constants network_constants;
 		/** Listening port */
-		uint16_t port{ 7077 };
+		uint16_t port;
 	};
 
 	/** IPC configuration */

--- a/nano/node/websocketconfig.cpp
+++ b/nano/node/websocketconfig.cpp
@@ -1,6 +1,11 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/websocketconfig.hpp>
 
+nano::websocket::config::config () :
+port (network_constants.default_websocket_port)
+{
+}
+
 nano::error nano::websocket::config::serialize_json (nano::jsonconfig & json) const
 {
 	json.put ("enable", enabled);

--- a/nano/node/websocketconfig.hpp
+++ b/nano/node/websocketconfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
+#include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>
 
 namespace nano
@@ -12,10 +13,12 @@ namespace websocket
 	class config final
 	{
 	public:
+		config ();
 		nano::error deserialize_json (nano::jsonconfig & json_a);
 		nano::error serialize_json (nano::jsonconfig & json) const;
+		nano::network_constants network_constants;
 		bool enabled{ false };
-		uint16_t port{ 7078 };
+		uint16_t port;
 		boost::asio::ip::address_v6 address{ boost::asio::ip::address_v6::loopback () };
 	};
 }


### PR DESCRIPTION
beta and test nets currently share default port numbers, which makes rpc and other tests fail if a beta node or wallet is running. Also makes use of network_constants for ipc and websockets.