### PR TITLE
Fix TSAN warning with work.eco_pow

### DIFF
--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -180,10 +180,10 @@ TEST (work, eco_pow)
 	std::thread thread1 (work_func, std::ref (promise1), std::chrono::nanoseconds (0));
 	std::thread thread2 (work_func, std::ref (promise2), std::chrono::milliseconds (10));
 
+	thread1.join ();
+	thread2.join ();
+
 	// Confirm that the eco pow rate limiter is working.
 	// It's possible under some unlucky circumstances that this fails to the random nature of valid work generation.
 	ASSERT_LT (future1.get (), future2.get ());
-
-	thread1.join ();
-	thread2.join ();
 }


### PR DESCRIPTION
This is a test I wrote, and wanted to try use `set_value_at_thread_exit` as I hadn't used it before. However it raised a TSAN warning when calling future.get (). I tried various things, but it seems that the thread needs to be finished before get () is called on the future, despite the example not doing this https://en.cppreference.com/w/cpp/thread/promise/set_value_at_thread_exit. I could simply just use set_value, but that's no fun :), and it at least shows an example of the apparent correct usage should someone require it in the future.