### PR TITLE
Fix TSAN warning with node.rep_self_vote

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1462,8 +1462,8 @@ TEST (node, rep_self_vote)
 	// Wait until representatives are activated & make vote
 	while (election->last_votes_size () != 3)
 	{
-		lock.lock ();
 		auto transaction (node0->store.tx_begin ());
+		lock.lock ();
 		election->compute_rep_votes (transaction);
 		lock.unlock ();
 		node0->vote_processor.flush ();


### PR DESCRIPTION
There was a TSAN warning about a potential lock-ordering deadlock. Moved the lock to after getting the transaction.