### PR TITLE
Fix vote::to_json()

### DIFF
--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -400,26 +400,33 @@ bool nano::vote::operator!= (nano::vote const & other_a) const
 	return !(*this == other_a);
 }
 
-std::string nano::vote::to_json () const
+void nano::vote::serialize_json (boost::property_tree::ptree & tree) const
 {
-	std::stringstream stream;
-	boost::property_tree::ptree tree;
 	tree.put ("account", account.to_account ());
 	tree.put ("signature", signature.number ());
 	tree.put ("sequence", std::to_string (sequence));
 	boost::property_tree::ptree blocks_tree;
 	for (auto block : blocks)
 	{
+		boost::property_tree::ptree entry;
 		if (block.which ())
 		{
-			blocks_tree.put ("", boost::get<nano::block_hash> (block).to_string ());
+			entry.put ("", boost::get<nano::block_hash> (block).to_string ());
 		}
 		else
 		{
-			blocks_tree.put ("", boost::get<std::shared_ptr<nano::block>> (block)->hash ().to_string ());
+			entry.put ("", boost::get<std::shared_ptr<nano::block>> (block)->hash ().to_string ());
 		}
+		blocks_tree.push_back (std::make_pair ("", entry));
 	}
 	tree.add_child ("blocks", blocks_tree);
+}
+
+std::string nano::vote::to_json () const
+{
+	std::stringstream stream;
+	boost::property_tree::ptree tree;
+	serialize_json (tree);
 	boost::property_tree::write_json (stream, tree);
 	return stream.str ();
 }

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -412,7 +412,7 @@ std::string nano::vote::to_json () const
 	{
 		if (block.which ())
 		{
-			blocks_tree.put ("", boost::get<std::shared_ptr<nano::block>> (block)->to_json ());
+			blocks_tree.put ("", boost::get<nano::block_hash> (block).to_string ());
 		}
 		else
 		{

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -227,6 +227,7 @@ public:
 	bool operator!= (nano::vote const &) const;
 	void serialize (nano::stream &, nano::block_type) const;
 	void serialize (nano::stream &) const;
+	void serialize_json (boost::property_tree::ptree & tree) const;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	bool validate () const;
 	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> begin () const;


### PR DESCRIPTION
2 bugs:

First, it would crash at a `block_hash` variant:
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::bad_get> >'
what():  boost::bad_get: failed value get using boost::get
Aborted (core dumped) 
```

Now, the `block_hash` variant is correctly handled.

Second, only one block would be serialized (overwritten on top of the last one). Now it serializes a list of all blocks. Tested with `--vote_dump`