### PR TITLE
Remove delay exiting node in request processor

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2775,16 +2775,8 @@ void nano::active_transactions::confirm_frontiers (nano::transaction const & tra
 	{
 		size_t max_elections (max_broadcast_queue / 4);
 		size_t elections_count (0);
-		for (auto i (node.store.latest_begin (transaction_a, next_frontier_account)), n (node.store.latest_end ()); i != n && elections_count < max_elections; ++i)
+		for (auto i (node.store.latest_begin (transaction_a, next_frontier_account)), n (node.store.latest_end ()); i != n && !stopped && elections_count < max_elections; ++i)
 		{
-			{
-				std::lock_guard<std::mutex> guard (mutex);
-				if (stopped)
-				{
-					break;
-				}
-			}
-
 			nano::account_info info (i->second);
 			if (info.block_count != info.confirmation_height)
 			{

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -158,7 +158,7 @@ private:
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
 	std::condition_variable condition;
 	bool started;
-	bool stopped;
+	std::atomic<bool> stopped;
 	boost::thread thread;
 };
 


### PR DESCRIPTION
I noticed this when running this CLI command `nano_node --network=live --debug_account_count` (Debug/Windows) but I'd imagine it will be caused by other commands depending on timing. It can take a while for the node to actually stop when it should be pretty instant. It was caused by the request loop, so I now check if `stopped` is true to break early out of some unnecessary processing.