### PR TITLE
Websockets - check for subscriptions before proceeding

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -70,7 +70,7 @@ TEST (websocket, confirmation)
 
 	// Start websocket test-client in a separate thread
 	std::atomic<bool> confirmation_event_received{ false };
-	ASSERT_FALSE (node1->websocket_server->any_subscription (nano::websocket::topic::confirmation));
+	ASSERT_FALSE (node1->websocket_server->any_subscribers (nano::websocket::topic::confirmation));
 	std::thread client_thread ([&system, &confirmation_event_received]() {
 		// This will expect two results: the acknowledgement of the subscription
 		// and then the block confirmation message
@@ -92,7 +92,7 @@ TEST (websocket, confirmation)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_TRUE (node1->websocket_server->any_subscription (nano::websocket::topic::confirmation));
+	ASSERT_TRUE (node1->websocket_server->any_subscribers (nano::websocket::topic::confirmation));
 
 	// Quick-confirm a block
 	nano::keypair key;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -70,6 +70,7 @@ TEST (websocket, confirmation)
 
 	// Start websocket test-client in a separate thread
 	std::atomic<bool> confirmation_event_received{ false };
+	ASSERT_FALSE (node1->websocket_server->any_subscription (nano::websocket::topic::confirmation));
 	std::thread client_thread ([&system, &confirmation_event_received]() {
 		// This will expect two results: the acknowledgement of the subscription
 		// and then the block confirmation message
@@ -91,6 +92,7 @@ TEST (websocket, confirmation)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	ASSERT_TRUE (node1->websocket_server->any_subscription (nano::websocket::topic::confirmation));
 
 	// Quick-confirm a block
 	nano::keypair key;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1124,7 +1124,7 @@ startup_time (std::chrono::steady_clock::now ())
 	if (websocket_server)
 	{
 		observers.blocks.add ([this](std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
-			if (this->websocket_server->any_subscription (nano::websocket::topic::confirmation))
+			if (this->websocket_server->any_subscribers (nano::websocket::topic::confirmation))
 			{
 				if (this->block_arrival.recent (block_a->hash ()))
 				{

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -13,9 +13,12 @@ ws_listener (listener_a), ws (std::move (socket_a)), write_strand (ws.get_execut
 
 nano::websocket::session::~session ()
 {
-	for (auto & subscription : subscriptions)
 	{
-		ws_listener.decrease_subscription_count (subscription);
+		std::unique_lock<std::mutex> lk (subscriptions_mutex);
+		for (auto & subscription : subscriptions)
+		{
+			ws_listener.decrease_subscription_count (subscription);
+		}
 	}
 
 	ws_listener.get_node ().logger.try_log ("websocket session ended");

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -288,31 +288,19 @@ void nano::websocket::listener::broadcast (nano::websocket::message message_a)
 
 bool nano::websocket::listener::any_subscribers (nano::websocket::topic const & topic_a)
 {
-	std::lock_guard<std::mutex> lk (counts_mutex);
-	auto existing (topic_subscription_count.find (topic_a));
-	return (existing != topic_subscription_count.end ()) ? existing->second > 0 : false;
+	return topic_subscription_count[static_cast<std::size_t> (topic_a)] > 0;
 }
 
 void nano::websocket::listener::increase_subscription_count (nano::websocket::topic const & topic_a)
 {
-	std::lock_guard<std::mutex> lk (counts_mutex);
-	auto existing (topic_subscription_count.find (topic_a));
-	if (existing == topic_subscription_count.end ())
-	{
-		topic_subscription_count.insert ({ topic_a, 1 });
-	}
-	else
-	{
-		existing->second += 1;
-	}
+	topic_subscription_count[static_cast<std::size_t> (topic_a)] += 1;
 }
 
 void nano::websocket::listener::decrease_subscription_count (nano::websocket::topic const & topic_a)
 {
-	std::lock_guard<std::mutex> lk (counts_mutex);
-	auto existing (topic_subscription_count.find (topic_a));
-	release_assert (existing != topic_subscription_count.end () && existing->second > 0);
-	existing->second -= 1;
+	auto & count (topic_subscription_count[static_cast<std::size_t> (topic_a)]);
+	release_assert (count > 0);
+	count -= 1;
 }
 
 nano::websocket::message nano::websocket::message_builder::block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype)

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -286,7 +286,7 @@ void nano::websocket::listener::broadcast (nano::websocket::message message_a)
 	sessions.erase (std::remove_if (sessions.begin (), sessions.end (), [](auto & elem) { return elem.expired (); }), sessions.end ());
 }
 
-bool nano::websocket::listener::any_subscription (nano::websocket::topic const & topic_a)
+bool nano::websocket::listener::any_subscribers (nano::websocket::topic const & topic_a)
 {
 	std::lock_guard<std::mutex> lk (counts_mutex);
 	auto existing (topic_subscription_count.find (topic_a));

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -144,7 +144,7 @@ namespace websocket
 		}
 
 		/** Per topic subscription check */
-		bool any_subscription (nano::websocket::topic const & topic_a);
+		bool any_subscribers (nano::websocket::topic const & topic_a);
 		/** Adds to subscription count of a specific topic*/
 		void increase_subscription_count (nano::websocket::topic const & topic_a);
 		/** Removes from subscription count of a specific topic*/

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -143,12 +143,20 @@ namespace websocket
 			return node;
 		}
 
+		/** Per topic subscription check */
+		bool any_subscription (nano::websocket::topic const & topic_a);
+		/** Adds to subscription count of a specific topic*/
+		void increase_subscription_count (nano::websocket::topic const & topic_a);
+		/** Removes from subscription count of a specific topic*/
+		void decrease_subscription_count (nano::websocket::topic const & topic_a);
+
 	private:
 		nano::node & node;
 		boost::asio::ip::tcp::acceptor acceptor;
 		boost::asio::ip::tcp::socket socket;
-		std::mutex sessions_mutex;
+		std::mutex sessions_mutex, counts_mutex;
 		std::vector<std::weak_ptr<session>> sessions;
+		std::unordered_map<topic, std::size_t> topic_subscription_count;
 		std::atomic<bool> stopped{ false };
 	};
 }


### PR DESCRIPTION
If the websocket server is active via config but there are no active subscriptions, currently the observer will still create and try to broadcast the block confirmation message.

A simple check would have been to go through all sessions and check if any topics are subscribed. However, since this would be done every time a new block arrives, I have added a map `topic -> subscription count` in the listener to do this lookup in constant time. I'm open to suggestions as I am not sure what the right pattern would be here.

Small test added for this as well.