### PR TITLE
Websockets - filtering options

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -33,7 +33,7 @@ boost::optional<std::string> websocket_test_call (boost::asio::io_context & ioc,
 	}
 
 	boost::asio::ip::tcp::resolver resolver{ ioc };
-	boost::beast::websocket::stream<boost::asio::ip::tcp::socket> ws (ioc);
+	boost::beast::websocket::stream<boost::asio::ip::tcp::socket> ws{ ioc };
 
 	auto const results = resolver.resolve (host, port);
 	boost::asio::connect (ws.next_layer (), results.begin (), results.end ());

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -22,6 +22,7 @@ using namespace std::chrono_literals;
 
 namespace
 {
+/** This variable must be set to false before setting up every thread that makes a websocket test call (and needs ack), to be safe */
 std::atomic<bool> ack_ready{ false };
 
 /** An optionally blocking websocket client for testing */
@@ -110,6 +111,7 @@ TEST (websocket, confirmation)
 	system.nodes.push_back (node1);
 
 	// Start websocket test-client in a separate thread
+	ack_ready = false;
 	std::atomic<bool> unsubscribe_ack_received{ false };
 	ASSERT_FALSE (node1->websocket_server->any_subscribers (nano::websocket::topic::confirmation));
 	std::thread client_thread ([&system, &unsubscribe_ack_received]() {
@@ -219,6 +221,7 @@ TEST (websocket, confirmation_options)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
+	ack_ready = false;
 	std::atomic<bool> client_thread_2_finished{ false };
 	std::thread client_thread_2 ([&system, &client_thread_2_finished]() {
 		// Re-subscribe with options for all local wallet accounts

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -21,32 +21,46 @@ using namespace std::chrono_literals;
 namespace
 {
 std::atomic<bool> ack_ready{ false };
-/** A simple blocking websocket client for testing */
-std::string websocket_test_call (boost::asio::io_context & ioc, std::string host, std::string port, std::string message_a, bool await_ack)
+
+/** A simple non-blocking websocket client for testing. Only blocks for ack if specified */
+std::unique_ptr<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>> websocket_test_call (boost::asio::io_context & ioc, std::string host, std::string port, std::string message_a, bool await_ack)
 {
+	if (await_ack)
+	{
+		ack_ready = false;
+	}
+
 	boost::asio::ip::tcp::resolver resolver{ ioc };
-	boost::beast::websocket::stream<boost::asio::ip::tcp::socket> ws{ ioc };
+	auto ws (std::make_unique<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>> (ioc));
 
 	auto const results = resolver.resolve (host, port);
-	boost::asio::connect (ws.next_layer (), results.begin (), results.end ());
+	boost::asio::connect (ws->next_layer (), results.begin (), results.end ());
 
-	ws.handshake (host, "/");
-	ws.text (true);
-	ws.write (boost::asio::buffer (message_a));
+	ws->handshake (host, "/");
+	ws->text (true);
+	ws->write (boost::asio::buffer (message_a));
 
 	if (await_ack)
 	{
 		boost::beast::flat_buffer buffer;
-		ws.read (buffer);
+		ws->read (buffer);
 		ack_ready = true;
 	}
 
+	return ws;
+}
+
+/** A blocking websocket client for testing, returns the response */
+std::string websocket_test_call_blocking (boost::asio::io_context & ioc, std::string host, std::string port, std::string message_a, bool await_ack)
+{
+	auto ws (websocket_test_call (ioc, host, port, message_a, await_ack));
+
 	boost::beast::flat_buffer buffer;
-	ws.read (buffer);
+	ws->read (buffer);
 	std::ostringstream res;
 	res << boost::beast::buffers (buffer.data ());
 
-	ws.close (boost::beast::websocket::close_code::normal);
+	ws->close (boost::beast::websocket::close_code::normal);
 	return res.str ();
 }
 }
@@ -74,7 +88,7 @@ TEST (websocket, confirmation)
 	std::thread client_thread ([&system, &confirmation_event_received]() {
 		// This will expect two results: the acknowledgement of the subscription
 		// and then the block confirmation message
-		std::string response = websocket_test_call (system.io_ctx, "::1", "24078",
+		std::string response = websocket_test_call_blocking (system.io_ctx, "::1", "24078",
 		R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json", true);
 
 		boost::property_tree::ptree event;
@@ -108,5 +122,93 @@ TEST (websocket, confirmation)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	node1->stop ();
+}
+
+/** Tests the filtering options of block confirmations */
+TEST (websocket, confirmation_options)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	nano::node_config config;
+	nano::node_flags node_flags;
+	config.websocket_config.enabled = true;
+	config.websocket_config.port = 24078;
+
+	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, nano::unique_path (), system.alarm, config, system.work, node_flags));
+	nano::uint256_union wallet;
+	nano::random_pool::generate_block (wallet.bytes.data (), wallet.bytes.size ());
+	node1->wallets.create (wallet);
+	node1->start ();
+	system.nodes.push_back (node1);
+
+	// Confirms a random block for an in-wallet account
+	auto confirm_block = [&node1, &system]() {
+		nano::keypair key;
+		nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+		system.wallet (1)->insert_adhoc (key.prv);
+		system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+		auto send (std::make_shared<nano::send_block> (previous, key.pub, node1->config.online_weight_minimum.number () + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (previous)));
+		node1->process_active (send);
+	};
+
+	// Start websocket test-client in a separate thread
+	std::atomic<bool> confirmation_event_received{ false };
+	std::thread client_thread ([&system, &confirmation_event_received]() {
+		// Subscribe initially with a specific invalid account
+		websocket_test_call (system.io_ctx, "::1", "24078",
+		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"accounts": ["xrb_invalid"]}})json", true);
+	});
+	client_thread.detach ();
+
+	system.deadline_set (5s);
+	while (!ack_ready)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	// Quick-confirm a block
+	confirm_block ();
+
+	// Wait up to 2 seconds, no confirmation message should be received with given filter
+	system.deadline_set (2s);
+	while (!confirmation_event_received)
+	{
+		if (!system.poll ())
+		{
+			break;
+		}
+	}
+	ASSERT_FALSE (confirmation_event_received);
+
+	std::atomic<bool> confirmation_event_received_2{ false };
+	std::thread client_thread_2 ([&system, &confirmation_event_received_2]() {
+		// Unsubscribe, wait for ack
+		websocket_test_call (system.io_ctx, "::1", "24078",
+		R"json({"action": "unsubscribe", "ack": "true", "topic": "confirmation"})json", true);
+
+		// Re-subscribe with options for all local wallet accounts
+		std::string response = websocket_test_call_blocking (system.io_ctx, "::1", "24078",
+		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"all_local_accounts": "true"}})json", true);
+
+		boost::property_tree::ptree event;
+		std::stringstream stream;
+		stream << response;
+		boost::property_tree::read_json (stream, event);
+		ASSERT_EQ (event.get<std::string> ("topic"), "confirmation");
+		confirmation_event_received_2 = true;
+	});
+	client_thread_2.detach ();
+
+	// Quick-confirm another block
+	confirm_block ();
+
+	// Wait for confirmation message
+	system.deadline_set (5s);
+	while (!confirmation_event_received_2)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_TRUE (confirmation_event_received_2);
 	node1->stop ();
 }

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -11,13 +11,13 @@ node (node_a)
 	auto accounts_l (options_a.get_child_optional ("accounts"));
 	if (accounts_l)
 	{
-		for (auto account : *accounts_l)
+		for (auto account_l : *accounts_l)
 		{
 			// Check if the account is valid, but no error handling if it's not, simply not added to the filter
-			nano::account result (0);
-			if (!result.decode_account (account.second.data ()))
+			nano::account result_l (0);
+			if (!result_l.decode_account (account_l.second.data ()))
 			{
-				accounts.insert (account.second.data ());
+				accounts.insert (account_l.second.data ());
 			}
 		}
 	}
@@ -25,30 +25,31 @@ node (node_a)
 
 bool nano::websocket::confirmation_options::should_filter (nano::websocket::message const & message_a) const
 {
-	auto source_text (message_a.contents.get<std::string> ("message.account"));
-	auto destination_opt (message_a.contents.get_optional<std::string> ("message.block.link_as_account"));
-	if (!destination_opt)
+	bool should_filter_l (true);
+	auto source_text_l (message_a.contents.get<std::string> ("message.account"));
+	auto destination_opt_l (message_a.contents.get_optional<std::string> ("message.block.link_as_account"));
+	if (!destination_opt_l)
 	{
-		destination_opt = message_a.contents.get_optional<std::string> ("message.block.destination");
+		destination_opt_l = message_a.contents.get_optional<std::string> ("message.block.destination");
 	}
-	assert (destination_opt);
-	auto destination_text (destination_opt.get ());
+	assert (destination_opt_l);
+	auto destination_text (destination_opt_l.get ());
 	if (all_local_accounts)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		nano::account source (0), destination (0);
-		assert (!source.decode_account (source_text));
-		assert (!destination.decode_account (destination_text));
-		if (node.wallets.exists (transaction, source) || node.wallets.exists (transaction, destination))
+		auto transaction_l (node.wallets.tx_begin_read ());
+		nano::account source_l (0), destination_l (0);
+		assert (!source_l.decode_account (source_text_l));
+		assert (!destination_l.decode_account (destination_text));
+		if (node.wallets.exists (transaction_l, source_l) || node.wallets.exists (transaction_l, destination_l))
 		{
-			return false;
+			should_filter_l = false;
 		}
 	}
-	if (accounts.find (source_text) != accounts.end () || accounts.find (destination_text) != accounts.end ())
+	if (accounts.find (source_text_l) != accounts.end () || accounts.find (destination_text) != accounts.end ())
 	{
-		return false;
+		should_filter_l = false;
 	}
-	return true;
+	return should_filter_l;
 }
 
 nano::websocket::session::session (nano::websocket::listener & listener_a, boost::asio::ip::tcp::socket socket_a) :

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -23,11 +23,11 @@ node (node_a)
 	}
 }
 
-bool nano::websocket::confirmation_options::should_filter (boost::property_tree::ptree const & message_a) const
+bool nano::websocket::confirmation_options::should_filter (nano::websocket::message const & message_a) const
 {
 	// If this fails, the message builder has been changed
-	auto source_text (message_a.get<std::string> ("message.account"));
-	auto destination_text (message_a.get<std::string> ("message.block.link_as_account"));
+	auto source_text (message_a.contents.get<std::string> ("message.account"));
+	auto destination_text (message_a.contents.get_optional<std::string> ("message.block.link_as_account"));
 	if (all_local_accounts)
 	{
 		auto transaction (node.wallets.tx_begin_read ());
@@ -97,7 +97,7 @@ void nano::websocket::session::write (nano::websocket::message message_a)
 	// clang-format off
 	std::unique_lock<std::mutex> lk (subscriptions_mutex);
 	auto subscription (subscriptions.find (message_a.topic));
-	if (message_a.topic == nano::websocket::topic::ack || (subscription != subscriptions.end () && !subscription->second->should_filter (message_a.contents)))
+	if (message_a.topic == nano::websocket::topic::ack || (subscription != subscriptions.end () && !subscription->second->should_filter (message_a)))
 	{
 		lk.unlock ();
 		boost::asio::post (write_strand,
@@ -382,7 +382,7 @@ nano::websocket::message nano::websocket::message_builder::block_confirmed (std:
 	return msg;
 }
 
-std::string nano::websocket::message::to_string ()
+std::string nano::websocket::message::to_string () const
 {
 	std::ostringstream ostream;
 	boost::property_tree::write_json (ostream, contents);

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -23,7 +23,7 @@ node (node_a)
 	}
 }
 
-bool nano::websocket::confirmation_options::filter (boost::property_tree::ptree const & message_a) const
+bool nano::websocket::confirmation_options::should_filter (boost::property_tree::ptree const & message_a) const
 {
 	// If this fails, the message builder has been changed
 	auto source_text (message_a.get<std::string> ("message.account"));
@@ -97,7 +97,7 @@ void nano::websocket::session::write (nano::websocket::message message_a)
 	// clang-format off
 	std::unique_lock<std::mutex> lk (subscriptions_mutex);
 	auto subscription (subscriptions.find (message_a.topic));
-	if (message_a.topic == nano::websocket::topic::ack || (subscription != subscriptions.end () && !subscription->second->filter (message_a.contents)))
+	if (message_a.topic == nano::websocket::topic::ack || (subscription != subscriptions.end () && !subscription->second->should_filter (message_a.contents)))
 	{
 		lk.unlock ();
 		boost::asio::post (write_strand,

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -26,18 +26,20 @@ node (node_a)
 bool nano::websocket::confirmation_options::filter (boost::property_tree::ptree const & message_a) const
 {
 	// If this fails, the message builder has been changed
-	auto account_text (message_a.get<std::string> ("message.account"));
+	auto source_text (message_a.get<std::string> ("message.account"));
+	auto destination_text (message_a.get<std::string> ("message.block.link_as_account"));
 	if (all_local_accounts)
 	{
 		auto transaction (node.wallets.tx_begin_read ());
-		nano::account account (0);
-		assert (!account.decode_account (account_text));
-		if (node.wallets.exists (transaction, account))
+		nano::account source (0), destination (0);
+		assert (!source.decode_account (source_text));
+		assert (!destination.decode_account (destination_text));
+		if (node.wallets.exists (transaction, source) || node.wallets.exists (transaction, destination))
 		{
 			return false;
 		}
 	}
-	if (accounts.find (account_text) != accounts.end ())
+	if (accounts.find (source_text) != accounts.end () || accounts.find (destination_text) != accounts.end ())
 	{
 		return false;
 	}

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -38,8 +38,8 @@ bool nano::websocket::confirmation_options::should_filter (nano::websocket::mess
 	{
 		auto transaction_l (node.wallets.tx_begin_read ());
 		nano::account source_l (0), destination_l (0);
-		assert (!source_l.decode_account (source_text_l));
-		assert (!destination_l.decode_account (destination_text));
+		release_assert (!source_l.decode_account (source_text_l));
+		release_assert (!destination_l.decode_account (destination_text));
 		if (node.wallets.exists (transaction_l, source_l) || node.wallets.exists (transaction_l, destination_l))
 		{
 			should_filter_l = false;

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -25,9 +25,14 @@ node (node_a)
 
 bool nano::websocket::confirmation_options::should_filter (nano::websocket::message const & message_a) const
 {
-	// If this fails, the message builder has been changed
 	auto source_text (message_a.contents.get<std::string> ("message.account"));
-	auto destination_text (message_a.contents.get_optional<std::string> ("message.block.link_as_account"));
+	auto destination_opt (message_a.contents.get_optional<std::string> ("message.block.link_as_account"));
+	if (!destination_opt)
+	{
+		destination_opt = message_a.contents.get_optional<std::string> ("message.block.destination");
+	}
+	assert (destination_opt);
+	auto destination_text (destination_opt.get ());
 	if (all_local_accounts)
 	{
 		auto transaction (node.wallets.tx_begin_read ());

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -212,7 +212,6 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		std::lock_guard<std::mutex> lk (subscriptions_mutex);
 		if (topic_l == nano::websocket::topic::confirmation)
 		{
-			;
 			subscriptions.insert (std::make_pair (topic_l, options_l ? std::make_unique<nano::websocket::confirmation_options> (options_l.get ()) : std::make_unique<nano::websocket::options> ()));
 		}
 		else

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -30,7 +30,7 @@ bool nano::websocket::confirmation_options::filter (boost::property_tree::ptree 
 	{
 		auto transaction (node_a.wallets.tx_begin_read ());
 		nano::account account (0);
-		assert (account.decode_account (account_text));
+		assert (!account.decode_account (account_text));
 		if (node_a.wallets.exists (transaction, account))
 		{
 			return false;

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -70,7 +70,6 @@ namespace websocket
 	public:
 		virtual bool filter (boost::property_tree::ptree const & message_a, nano::node & node_a) const
 		{
-			std::cout << "vanilla" << std::endl;
 			return false;
 		}
 	};

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -90,6 +90,7 @@ namespace websocket
 	 * * "accounts" (array of std::strings) - will only not filter blocks that have these accounts as source/destination
 	 * @remark Both options can be given, the resulting filter is an intersection of individual filters
 	 * @remark No error is shown if any given account is invalid, the entry is simply ignored
+	 * @warn Legacy blocks are always filtered (not broadcasted)
 	 */
 	class confirmation_options final : public options
 	{

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -85,8 +85,8 @@ namespace websocket
 	/**
 	 * Filtering options for block confirmation subscriptions
 	 * Possible filtering options:
-	 * * "all_local_accounts" (bool) - will filter (not send) blocks that are not from local wallet accounts
-	 * * "accounts" (array of std::strings) - will only send blocks for these accounts
+	 * * "all_local_accounts" (bool) - will only send (not filter) blocks that have local wallet accounts as source/destination
+	 * * "accounts" (array of std::strings) - will only send (not filter) blocks that have these accounts as source/destination
 	 * @remark Both options can be given, the resulting filter is an intersection of individual filters
 	 * @remark No error is shown if any given account is invalid, the entry is simply ignored
 	 */

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -71,18 +71,35 @@ namespace websocket
 	class options
 	{
 	public:
+		/**
+		 * Checks if a message should be filtered (not sent) for default options (no options given).
+		 * @return false
+		 */
 		virtual bool filter (boost::property_tree::ptree const & message_a, nano::node & node_a) const
 		{
 			return false;
 		}
 	};
 
+	/**
+	 * Filtering options for block confirmation subscriptions
+	 * Possible filtering options:
+	 * * "all_local_accounts" (bool) - will filter (not send) blocks that are not from local wallet accounts
+	 * * "accounts" (array of std::strings) - will only send blocks for these accounts
+	 * @remark Both options can be given, the resulting filter is an intersection of individual filters
+	 * @remark No error is shown if any given account is invalid, the entry is simply ignored
+	 */
 	class confirmation_options final : public options
 	{
 	public:
 		confirmation_options ();
 		confirmation_options (boost::property_tree::ptree const & options_a);
-		virtual bool filter (boost::property_tree::ptree const & message_a, nano::node & node_a) const;
+
+		/**
+		 * Checks if a message should be filtered (not sent) for given block confirmation options.
+		 * @return false if the message should be sent (not filtered), true otherwise
+		 */
+		bool filter (boost::property_tree::ptree const & message_a, nano::node & node_a) const;
 
 	private:
 		bool all_local_accounts{ false };
@@ -167,8 +184,8 @@ namespace websocket
 		}
 
 		/**
-		 *  Per-topic subscribers check. Relies on all sessions correctly increasing and
-		 *  decreasing the subscriber counts themselves.
+		 * Per-topic subscribers check. Relies on all sessions correctly increasing and
+		 * decreasing the subscriber counts themselves.
 		 */
 		bool any_subscribers (nano::websocket::topic const & topic_a);
 		/** Adds to subscription count of a specific topic*/

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -73,9 +73,10 @@ namespace websocket
 	public:
 		/**
 		 * Checks if a message should be filtered (not sent) for default options (no options given).
+		 * @param message_a the message contents
 		 * @return false
 		 */
-		virtual bool filter (boost::property_tree::ptree const & message_a, nano::node & node_a) const
+		virtual bool filter (boost::property_tree::ptree const & message_a) const
 		{
 			return false;
 		}
@@ -93,15 +94,17 @@ namespace websocket
 	{
 	public:
 		confirmation_options ();
-		confirmation_options (boost::property_tree::ptree const & options_a);
+		confirmation_options (boost::property_tree::ptree const & options_a, nano::node & node_a);
 
 		/**
 		 * Checks if a message should be filtered (not sent) for given block confirmation options.
+		 * @param message_a the message contents		 
 		 * @return false if the message should be sent (not filtered), true otherwise
 		 */
-		bool filter (boost::property_tree::ptree const & message_a, nano::node & node_a) const;
+		bool filter (boost::property_tree::ptree const & message_a) const;
 
 	private:
+		nano::node & node;
 		bool all_local_accounts{ false };
 		std::unordered_set<std::string> accounts;
 	};
@@ -124,7 +127,7 @@ namespace websocket
 		void read ();
 
 		/** Enqueue \p message_a for writing to the websockets */
-		void write (nano::websocket::message message_a, nano::node & node_a);
+		void write (nano::websocket::message message_a);
 
 	private:
 		/** The owning listener */

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -72,11 +72,11 @@ namespace websocket
 	{
 	public:
 		/**
-		 * Checks if a message should be filtered (not sent) for default options (no options given).
+		 * Checks if a message should be filtered for default options (no options given).
 		 * @param message_a the message contents
-		 * @return false
+		 * @return false - the message should always be broadcasted
 		 */
-		virtual bool filter (boost::property_tree::ptree const & message_a) const
+		virtual bool should_filter (boost::property_tree::ptree const & message_a) const
 		{
 			return false;
 		}
@@ -85,8 +85,8 @@ namespace websocket
 	/**
 	 * Filtering options for block confirmation subscriptions
 	 * Possible filtering options:
-	 * * "all_local_accounts" (bool) - will only send (not filter) blocks that have local wallet accounts as source/destination
-	 * * "accounts" (array of std::strings) - will only send (not filter) blocks that have these accounts as source/destination
+	 * * "all_local_accounts" (bool) - will only not filter blocks that have local wallet accounts as source/destination
+	 * * "accounts" (array of std::strings) - will only not filter blocks that have these accounts as source/destination
 	 * @remark Both options can be given, the resulting filter is an intersection of individual filters
 	 * @remark No error is shown if any given account is invalid, the entry is simply ignored
 	 */
@@ -97,11 +97,11 @@ namespace websocket
 		confirmation_options (boost::property_tree::ptree const & options_a, nano::node & node_a);
 
 		/**
-		 * Checks if a message should be filtered (not sent) for given block confirmation options.
+		 * Checks if a message should be filtered for given block confirmation options.
 		 * @param message_a the message contents		 
-		 * @return false if the message should be sent (not filtered), true otherwise
+		 * @return false if the message should be broadcasted, true if it should be filtered
 		 */
-		bool filter (boost::property_tree::ptree const & message_a) const;
+		bool should_filter (boost::property_tree::ptree const & message_a) const;
 
 	private:
 		nano::node & node;

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -83,7 +83,7 @@ namespace websocket
 
 	private:
 		bool all_local_accounts{ false };
-		std::unordered_set<nano::account> accounts;
+		std::unordered_set<std::string> accounts;
 	};
 
 	/** A websocket session managing its own lifetime */
@@ -129,9 +129,7 @@ namespace websocket
 				return static_cast<std::size_t> (t);
 			}
 		};
-		/**
-		 * Map of subscriptions -> options registered by this session.
-		 */
+		/** Map of subscriptions -> options registered by this session. */
 		std::unordered_map<topic, std::unique_ptr<options>, topic_hash> subscriptions;
 		std::mutex subscriptions_mutex;
 

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -80,6 +80,7 @@ namespace websocket
 		{
 			return false;
 		}
+		virtual ~options () = default;
 	};
 
 	/**
@@ -101,7 +102,7 @@ namespace websocket
 		 * @param message_a the message to be checked
 		 * @return false if the message should be broadcasted, true if it should be filtered
 		 */
-		bool should_filter (message const & message_a) const;
+		bool should_filter (message const & message_a) const override;
 
 	private:
 		nano::node & node;

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -55,7 +55,7 @@ namespace websocket
 		{
 		}
 
-		std::string to_string ();
+		std::string to_string () const;
 		nano::websocket::topic topic;
 		boost::property_tree::ptree contents;
 	};
@@ -73,10 +73,10 @@ namespace websocket
 	public:
 		/**
 		 * Checks if a message should be filtered for default options (no options given).
-		 * @param message_a the message contents
+		 * @param message_a the message to be checked
 		 * @return false - the message should always be broadcasted
 		 */
-		virtual bool should_filter (boost::property_tree::ptree const & message_a) const
+		virtual bool should_filter (message const & message_a) const
 		{
 			return false;
 		}
@@ -98,10 +98,10 @@ namespace websocket
 
 		/**
 		 * Checks if a message should be filtered for given block confirmation options.
-		 * @param message_a the message contents		 
+		 * @param message_a the message to be checked
 		 * @return false if the message should be broadcasted, true if it should be filtered
 		 */
-		bool should_filter (boost::property_tree::ptree const & message_a) const;
+		bool should_filter (message const & message_a) const;
 
 	private:
 		nano::node & node;


### PR DESCRIPTION
This adds per-subscription filtering options via an extra field in a subscribe action:

```json
{
  "action": "subscribe",
  "topic": "confirmation",
  "options": {
    "all_local_accounts": "true",
    "accounts": [ "xrb_123...", "..." ]
  }
}
```

Filtering happens after the message is built and is sent for broadcasting, with a bunch of O(1) checks for existance of accounts. We would have to change the dynamics of the websocket server quite a bit to handle it differently. Open to suggestions as usually or just pickup from this PR and improve!

Can add something to `core_test` if this seems ok.

Related: #1901 