### PR TITLE
Websockets - subscribe to votes

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -379,19 +379,123 @@ TEST (websocket, vote)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	ack_ready = false;
+
 	ASSERT_TRUE (node1->websocket_server->any_subscribers (nano::websocket::topic::vote));
 
 	// Quick-confirm a block
 	nano::keypair key;
-	nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
-	system.wallet (1)->insert_adhoc (key.prv);
 	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
 	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, nano::genesis_amount - (node1->config.online_weight_minimum.number () + 1), key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (previous)));
 	node1->process_active (send);
 
 	// Wait for the websocket client to receive the vote message
 	system.deadline_set (5s);
 	while (!client_thread_finished)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	node1->stop ();
+}
+
+/** Tests vote subscription options */
+TEST (websocket, vote_options)
+{
+	nano::system system (24000, 1);
+	nano::node_init init1;
+	nano::node_config config;
+	nano::node_flags node_flags;
+	config.websocket_config.enabled = true;
+	config.websocket_config.port = 24078;
+
+	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, nano::unique_path (), system.alarm, config, system.work, node_flags));
+	nano::uint256_union wallet;
+	nano::random_pool::generate_block (wallet.bytes.data (), wallet.bytes.size ());
+	node1->wallets.create (wallet);
+	node1->start ();
+	system.nodes.push_back (node1);
+
+	// Start websocket test-client in a separate thread
+	ack_ready = false;
+	std::atomic<bool> client_thread_finished{ false };
+	ASSERT_FALSE (node1->websocket_server->any_subscribers (nano::websocket::topic::vote));
+	std::thread client_thread ([&system, &client_thread_finished]() {
+		std::ostringstream data;
+		data << R"json({"action": "subscribe", "topic": "vote", "ack": true, "options": {"representatives": [")json"
+		     << nano::test_genesis_key.pub.to_account ()
+		     << R"json("]}})json";
+		auto response = websocket_test_call (system.io_ctx, "::1", "24078", data.str (), true, true);
+
+		ASSERT_TRUE (response);
+		boost::property_tree::ptree event;
+		std::stringstream stream;
+		stream << response;
+		boost::property_tree::read_json (stream, event);
+		ASSERT_EQ (event.get<std::string> ("topic"), "vote");
+		client_thread_finished = true;
+	});
+	client_thread.detach ();
+
+	// Wait for the subscription to be acknowledged
+	system.deadline_set (5s);
+	while (!ack_ready)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ack_ready = false;
+
+	ASSERT_TRUE (node1->websocket_server->any_subscribers (nano::websocket::topic::vote));
+
+	// Quick-confirm a block
+	nano::keypair key;
+	auto balance = nano::genesis_amount;
+	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	auto send_amount = node1->config.online_weight_minimum.number () + 1;
+	auto confirm_block = [&]() {
+		nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+		balance -= send_amount;
+		auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, balance, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (previous)));
+		node1->process_active (send);
+	};
+	confirm_block ();
+
+	// Wait for the websocket client to receive the vote message
+	system.deadline_set (5s);
+	while (!client_thread_finished)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	std::atomic<bool> client_thread_2_finished{ false };
+	ASSERT_FALSE (node1->websocket_server->any_subscribers (nano::websocket::topic::vote));
+	std::thread client_thread_2 ([&system, &client_thread_2_finished]() {
+		auto response = websocket_test_call (system.io_ctx, "::1", "24078",
+		R"json({"action": "subscribe", "topic": "vote", "ack": true, "options": {"representatives": ["xrb_invalid"]}})json", true, true, 1s);
+
+		// No response expected given the filter
+		ASSERT_FALSE (response);
+		client_thread_2_finished = true;
+	});
+	client_thread_2.detach ();
+
+	// Wait for the subscription to be acknowledged
+	system.deadline_set (5s);
+	while (!ack_ready)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ack_ready = false;
+
+	ASSERT_TRUE (node1->websocket_server->any_subscribers (nano::websocket::topic::vote));
+
+	// Confirm another block
+	confirm_block ();
+
+	// No response expected
+	system.deadline_set (5s);
+	while (!client_thread_2_finished)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1220,6 +1220,17 @@ startup_time (std::chrono::steady_clock::now ())
 			}
 		}
 	});
+	if (this->websocket_server)
+	{
+		observers.vote.add ([this](nano::transaction const & transaction, std::shared_ptr<nano::vote> vote_a, std::shared_ptr<nano::transport::channel> channel_a) {
+			if (this->websocket_server->any_subscribers (nano::websocket::topic::vote))
+			{
+				nano::websocket::message_builder builder;
+				auto msg (builder.vote_received (vote_a));
+				this->websocket_server->broadcast (msg);
+			}
+		});
+	}
 	if (NANO_VERSION_PATCH == 0)
 	{
 		logger.always_log ("Node starting, version: ", NANO_MAJOR_MINOR_VERSION);

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -26,7 +26,7 @@ node (node_a)
 		}
 	}
 	// Warn the user if the options resulted in an empty filter
-	if (accounts.empty ())
+	if (!all_local_accounts && accounts.empty ())
 	{
 		node.logger.always_log ("Websocket: provided options resulted in an empty block confirmation filter");
 	}

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -37,6 +37,8 @@ namespace websocket
 		ack,
 		/** A confirmation message */
 		confirmation,
+		/** A vote message **/
+		vote,
 		/** Auxiliary length, not a valid topic, must be the last enum */
 		_length
 	};
@@ -65,6 +67,11 @@ namespace websocket
 	{
 	public:
 		message block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype);
+		message vote_received (std::shared_ptr<nano::vote> vote_a);
+
+	private:
+		/** Set the common fields for messages: timestamp and topic. */
+		void set_common_fields (message & message_a);
 	};
 
 	/** Filtering options for subscriptions */

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -96,7 +96,6 @@ namespace websocket
 	 * * "all_local_accounts" (bool) - will only not filter blocks that have local wallet accounts as source/destination
 	 * * "accounts" (array of std::strings) - will only not filter blocks that have these accounts as source/destination
 	 * @remark Both options can be given, the resulting filter is an intersection of individual filters
-	 * @remark No error is shown if any given account is invalid, the entry is simply ignored
 	 * @warn Legacy blocks are always filtered (not broadcasted)
 	 */
 	class confirmation_options final : public options
@@ -122,13 +121,12 @@ namespace websocket
 	 * Filtering options for vote subscriptions
 	 * Possible filtering options:
 	 * * "representatives" (array of std::strings) - will only broadcast votes from these representatives
-	 * @remark No error is shown if any given representative is invalid, the entry is simply ignored
 	 */
 	class vote_options final : public options
 	{
 	public:
 		vote_options ();
-		vote_options (boost::property_tree::ptree const & options_a);
+		vote_options (boost::property_tree::ptree const & options_a, nano::node & node_a);
 
 		/**
 		 * Checks if a message should be filtered for given vote received options.
@@ -138,6 +136,7 @@ namespace websocket
 		bool should_filter (message const & message_a) const override;
 
 	private:
+		nano::node & node;
 		std::unordered_set<std::string> representatives;
 	};
 

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -118,6 +118,29 @@ namespace websocket
 		std::unordered_set<std::string> accounts;
 	};
 
+	/**
+	 * Filtering options for vote subscriptions
+	 * Possible filtering options:
+	 * * "representatives" (array of std::strings) - will only broadcast votes from these representatives
+	 * @remark No error is shown if any given representative is invalid, the entry is simply ignored
+	 */
+	class vote_options final : public options
+	{
+	public:
+		vote_options ();
+		vote_options (boost::property_tree::ptree const & options_a);
+
+		/**
+		 * Checks if a message should be filtered for given vote received options.
+		 * @param message_a the message to be checked
+		 * @return false if the message should be broadcasted, true if it should be filtered
+		 */
+		bool should_filter (message const & message_a) const override;
+
+	private:
+		std::unordered_set<std::string> representatives;
+	};
+
 	/** A websocket session managing its own lifetime */
 	class session final : public std::enable_shared_from_this<session>
 	{


### PR DESCRIPTION
Related: #1901 .

```json
{
  "topic": "vote",
  "time": "1554995525343",
  "message": {
    "account": "xrb_1n5aisgwmq1oibg8c7aerrubboccp3mfcjgm8jaas1fwhxmcndaf4jrt75fy",
    "signature": "1950700796914893705657789944906107642480343124305202910152471520450456881722545967829502369630995363643731706156278026749554294222131169148120786048025353",
    "sequence": "855471574",
    "blocks": [
      "6FB9DE5D7908DEB8A2EA391AEA95041587CBF3420EF8A606F1489FECEE75C869"
    ]
  }
}
```

Added the ability to filter by representative as well, very similarly to the other filtering options. I think this one has no performance penalties, just a O(1) search in an unordered_set.

A good filter would also be `rebroadcasting_only` or a minimum weight. What do you think?