### PR TITLE
fix tests and update logic of work_watcher::run()

### DIFF
--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1403,7 +1403,11 @@ void nano::work_watcher::run ()
 			{
 				//and so we fall back to ledger confirmation
 				auto transaction (this->node.store.tx_begin_read ());
-				confirmed = this->node.ledger.block_confirmed (transaction, (i->second)->hash ());
+				auto block = this->node.store.block_get (transaction, (i->second)->hash ());
+				if (block)
+				{
+					confirmed = this->node.block_confirmed_or_being_confirmed (transaction, (i->second)->hash ());
+				}
 			}
 			lock.unlock ();
 


### PR DESCRIPTION
if a block doesn't exist in the ledger its definitely not confirmed
Don't bother checking confirmation as that will assert if the block doesn't exist
Update ledger check to block_confirmed_or_being_confirmed to check ledger and confirmation_height_processor