### PR TITLE
Websocket tests: Use error_code when closing

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -68,7 +68,8 @@ boost::optional<std::string> websocket_test_call (std::string host, std::string 
 	}
 	if (ws.is_open ())
 	{
-		ws.close (boost::beast::websocket::close_code::normal);
+		boost::beast::error_code ec_ignored;
+		ws.close (boost::beast::websocket::close_code::normal, ec_ignored);
 	}
 	return ret;
 }


### PR DESCRIPTION
Closing may throw on Windows; any close error can be ignored in the tests.