### PR TITLE
Make new random_constants class for not_an_account

### DIFF
--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1160,7 +1160,7 @@ void nano::mdb_store::upgrade_v12_to_v13 (nano::transaction const & transaction_
 {
 	size_t cost (0);
 	nano::account account (0);
-	auto const & not_an_account (network_params.ledger.not_an_account ());
+	auto const & not_an_account (network_params.random.not_an_account);
 	while (account != not_an_account)
 	{
 		nano::account first (0);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2549,7 +2549,7 @@ confirmed (false),
 stopped (false),
 announcements (0)
 {
-	last_votes.insert (std::make_pair (node.network_params.ledger.not_an_account (), nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () }));
+	last_votes.insert (std::make_pair (node.network_params.random.not_an_account, nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () }));
 	blocks.insert (std::make_pair (block_a->hash (), block_a));
 	update_dependent ();
 }

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -92,19 +92,13 @@ nano_live_genesis (live_genesis_data),
 genesis_account (network_a == nano::nano_networks::nano_test_network ? nano_test_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_account),
 genesis_block (network_a == nano::nano_networks::nano_test_network ? nano_test_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : nano_live_genesis),
 genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
-burn_account (0),
-not_an_account_m (0)
+burn_account (0)
 {
 }
 
-nano::account const & nano::ledger_constants::not_an_account ()
+nano::random_constants::random_constants ()
 {
-	if (not_an_account_m.is_zero ())
-	{
-		// Randomly generating these mean no two nodes will ever have the same sentinel values which protects against some insecure algorithms
-		nano::random_pool::generate_block (not_an_account_m.bytes.data (), not_an_account_m.bytes.size ());
-	}
-	return not_an_account_m;
+	nano::random_pool::generate_block (not_an_account.bytes.data (), not_an_account.bytes.size ());
 }
 
 nano::node_constants::node_constants (nano::network_constants & network_constants)

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -330,11 +330,15 @@ public:
 	nano::account genesis_account;
 	std::string genesis_block;
 	nano::uint128_t genesis_amount;
-	nano::account const & not_an_account ();
 	nano::account burn_account;
+};
 
-private:
-	nano::account not_an_account_m;
+/** Constants which depend on random values (this class should never be used globally due to CryptoPP globals potentially not being initialized) */
+class random_constants
+{
+public:
+	random_constants ();
+	nano::account not_an_account;
 };
 
 /** Node related constants whose value depends on the active network */
@@ -396,6 +400,7 @@ public:
 	unsigned kdf_work;
 	network_constants network;
 	ledger_constants ledger;
+	random_constants random;
 	voting_constants voting;
 	node_constants node;
 	portmapping_constants portmapping;


### PR DESCRIPTION
`not_an_account ()` is not thread-safe now, it cannot be called in the constructor of `ledger_constants` because there are global objects of it (and it will trigger an ASAN warning with CryptoPP globals not initialized yet). However it can just be moved out into a separate class and set in the constructor because there are relatively few users of it and they don't touch any globals. Ran ASAN on both core tests + daemon and no CryptoPP warnings.