### PR TITLE
Cache resolved dependent elections to save a read in confirmation height processor later

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2335,7 +2335,7 @@ TEST (node, block_processor_reject_rolled_back)
 	ASSERT_TRUE (node.active.empty ());
 }
 
-TEST (node, confirm_back)
+TEST (node, confirm_dependent_elections)
 {
 	nano::system system (24000, 1);
 	nano::keypair key;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -607,14 +607,22 @@ bool nano::active_transactions::publish (std::shared_ptr<nano::block> block_a)
 	return result;
 }
 
-void nano::active_transactions::confirm_block (nano::block_hash const & hash_a)
+/** Returns whether this block confirmed an active election */
+bool nano::active_transactions::finalize_election (nano::block_hash const & hash_a)
 {
+	bool election_confirmed = false;
 	std::lock_guard<std::mutex> lock (mutex);
 	auto existing (blocks.find (hash_a));
 	if (existing != blocks.end () && !existing->second->confirmed && !existing->second->stopped && existing->second->status.winner->hash () == hash_a)
 	{
 		existing->second->confirm_once ();
+		election_confirmed = true;
 	}
+	else
+	{
+		election_confirmed = false;
+	}
+	return election_confirmed;
 }
 
 namespace nano

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -72,7 +72,7 @@ public:
 	size_t size ();
 	void stop ();
 	bool publish (std::shared_ptr<nano::block> block_a);
-	void confirm_block (nano::block_hash const &);
+	bool finalize_election (nano::block_hash const &);
 	boost::multi_index_container<
 	nano::conflict_info,
 	boost::multi_index::indexed_by<

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -21,12 +21,16 @@ public:
 	size_t size ();
 	bool is_processing_block (nano::block_hash const &);
 	nano::block_hash current ();
+	size_t dependent_active_elections_confirmed_size ();
 
 private:
 	std::mutex mutex;
 	std::unordered_set<nano::block_hash> pending;
 	/** This is the last block popped off the confirmation height pending collection */
 	nano::block_hash current_hash{ 0 };
+
+	/** These are blocks which had active elections being confirmed by a higher up block */
+	std::unordered_set<nano::block_hash> dependent_active_elections_confirmed;
 	friend class confirmation_height_processor;
 };
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5356,7 +5356,6 @@ TEST (rpc, online_reps)
 // If this test fails, try increasing the num_blocks size.
 TEST (rpc, confirmation_height_currently_processing)
 {
-	// The chains should be longer than the	batch_write_size to test the amount of blocks confirmed is correct.
 	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	auto node = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);


### PR DESCRIPTION
Currently `active.confirm_block` (now renamed to `finalize_election` proposed by @cryptocode) will add the hash to the confirmation height processor pending queue if it confirmed an active election. This results in a read when it is popped off to compare if the block height is greater than the confirmation height which will never succeed. Probably not a big deal but it was an area I saw could be improved.

However if a block underneath a block which is being confirmed and has already been iterated over any future active elections will not have any performance improvement and still require voting. This can be alleviated by storing every single block that is traversed and comparing against this. However the collection alone could hold many millions of hashes if it hits long chains (so could reach many 100s of MBs of memory usage) when first upgrading not sure if this is worth it.

(Unrelated) Removed an erroneous comment in the `rpc.confirmation_height_currently_processing` test which was copied from another test.