### PR TITLE
Add blocks_not_found in RPC blocks_info response rather than an error

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4423,7 +4423,7 @@ TEST (rpc, blocks_info)
 	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
-	auto check_blocks = [&](test_response & response) {
+	auto check_blocks = [&system](test_response & response) {
 		for (auto & blocks : response.json.get_child ("blocks"))
 		{
 			std::string hash_text (blocks.first);


### PR DESCRIPTION
Wiki markup:

**INCOMPLETE** - needs to be updated with latest changes

---

## Retrieve multiple blocks with additional info

Retrieves a json representations of **blocks** with block **account**, transaction **amount**, block **balance**, block **height** in account chain, block local modification **timstamp**, block **confirmation status** (since version 19.0), **subtype** (for state blocks since version 19.0).

Starting from version 19.0, **blocks_not_found** is an additional field in the response with the blocks that were not found locally. Before this version, an error would occur instead.

Request
```json
{
  "action": "blocks_info",
  "hashes": ["87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9", "0000000000000000000000000000000000000000000000000000000000000001"]
}
```
Response:
```json
{
  "blocks" : {
    "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": {
         "block_account": "xrb_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
         "amount": "30000000000000000000000000000000000",
         "balance": "5606157000000000000000000000000000000",
         "height": "58",
         "local_timestamp": "0",
         "confirmed": "false",
       "contents": "{\n
         \"type\": \"state\",\n
         \"account\": \"xrb_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n
         \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n
         \"representative\": \"xrb_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n
         \"balance\": \"5606157000000000000000000000000000000\",\n
         \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n
         \"link_as_account\": \"xrb_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n
         \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n
         \"work\": \"8a142e07a10996d5\"\n
      }\n",
      "subtype": "send"
     }
  },
  "blocks_not_found": [
    "0000000000000000000000000000000000000000000000000000000000000001"
  ]
}
```

(...)