### PR TITLE
Allow long running read transactions to be broken up

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -57,7 +57,7 @@ TEST (block_store, add_item)
 	ASSERT_TRUE (!init);
 	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
 	nano::uint256_union hash1 (block.hash ());
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto latest1 (store.block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
 	ASSERT_FALSE (store.block_exists (transaction, hash1));
@@ -80,7 +80,7 @@ TEST (block_store, clear_successor)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
 	store.block_put (transaction, block1.hash (), block1, sideband);
 	nano::open_block block2 (0, 2, 0, nano::keypair ().prv, 0, 0);
@@ -106,7 +106,7 @@ TEST (block_store, add_nonempty_block)
 	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
 	nano::uint256_union hash1 (block.hash ());
 	block.signature = nano::sign_message (key1.prv, key1.pub, hash1);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto latest1 (store.block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
 	nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
@@ -126,7 +126,7 @@ TEST (block_store, add_two_items)
 	nano::open_block block (0, 1, 1, nano::keypair ().prv, 0, 0);
 	nano::uint256_union hash1 (block.hash ());
 	block.signature = nano::sign_message (key1.prv, key1.pub, hash1);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto latest1 (store.block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
 	nano::open_block block2 (0, 1, 3, nano::keypair ().prv, 0, 0);
@@ -157,7 +157,7 @@ TEST (block_store, add_receive)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::block_sideband sideband1 (nano::block_type::open, 0, 0, 0, 0, 0);
 	store.block_put (transaction, block1.hash (), block1, sideband1);
 	nano::receive_block block (block1.hash (), 1, nano::keypair ().prv, 2, 3);
@@ -180,7 +180,7 @@ TEST (block_store, add_pending)
 	nano::keypair key1;
 	nano::pending_key key2 (0, 0);
 	nano::pending_info pending1;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_TRUE (store.pending_get (transaction, key2, pending1));
 	store.pending_put (transaction, key2, pending1);
 	nano::pending_info pending2;
@@ -196,7 +196,7 @@ TEST (block_store, pending_iterator)
 	bool init (false);
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (store.pending_end (), store.pending_begin (transaction));
 	store.pending_put (transaction, nano::pending_key (1, 2), { 2, 3, nano::epoch::epoch_1 });
 	auto current (store.pending_begin (transaction));
@@ -223,7 +223,7 @@ TEST (block_store, pending_iterator_comparison)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	nano::stat stats;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	// Populate pending
 	store.pending_put (transaction, nano::pending_key (nano::account (3), nano::block_hash (1)), nano::pending_info (nano::account (10), nano::amount (1), nano::epoch::epoch_0));
 	store.pending_put (transaction, nano::pending_key (nano::account (3), nano::block_hash (4)), nano::pending_info (nano::account (10), nano::amount (0), nano::epoch::epoch_0));
@@ -268,7 +268,7 @@ TEST (block_store, genesis)
 	ASSERT_TRUE (!init);
 	nano::genesis genesis;
 	auto hash (genesis.hash ());
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info;
 	ASSERT_FALSE (store.account_get (transaction, nano::genesis_account, info));
@@ -294,7 +294,7 @@ TEST (representation, changes)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	nano::keypair key1;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, store.representation_get (transaction, key1.pub));
 	store.representation_put (transaction, key1.pub, 1);
 	ASSERT_EQ (1, store.representation_get (transaction, key1.pub));
@@ -309,7 +309,7 @@ TEST (bootstrap, simple)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto block2 (store.unchecked_get (transaction, block1->previous ()));
 	ASSERT_TRUE (block2.empty ());
 	store.unchecked_put (transaction, block1->previous (), block1);
@@ -328,7 +328,7 @@ TEST (unchecked, multiple)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto block2 (store.unchecked_get (transaction, block1->previous ()));
 	ASSERT_TRUE (block2.empty ());
 	store.unchecked_put (transaction, block1->previous (), block1);
@@ -346,7 +346,7 @@ TEST (unchecked, double_put)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto block2 (store.unchecked_get (transaction, block1->previous ()));
 	ASSERT_TRUE (block2.empty ());
 	store.unchecked_put (transaction, block1->previous (), block1);
@@ -365,7 +365,7 @@ TEST (unchecked, multiple_get)
 	auto block2 (std::make_shared<nano::send_block> (3, 1, 2, nano::keypair ().prv, 4, 5));
 	auto block3 (std::make_shared<nano::send_block> (5, 1, 2, nano::keypair ().prv, 4, 5));
 	{
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.unchecked_put (transaction, block1->previous (), block1); // unchecked1
 		store.unchecked_put (transaction, block1->hash (), block1); // unchecked2
 		store.unchecked_put (transaction, block2->previous (), block2); // unchecked3
@@ -375,7 +375,7 @@ TEST (unchecked, multiple_get)
 		store.unchecked_put (transaction, block3->hash (), block3); // unchecked4
 		store.unchecked_put (transaction, block1->previous (), block3); // unchecked1
 	}
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	auto unchecked_count (store.unchecked_count (transaction));
 	ASSERT_EQ (unchecked_count, 8);
 	std::vector<nano::block_hash> unchecked1;
@@ -413,7 +413,7 @@ TEST (block_store, empty_accounts)
 	bool init (false);
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	auto begin (store.latest_begin (transaction));
 	auto end (store.latest_end ());
 	ASSERT_EQ (end, begin);
@@ -426,7 +426,7 @@ TEST (block_store, one_block)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
 	store.block_put (transaction, block1.hash (), block1, sideband);
 	ASSERT_TRUE (store.block_exists (transaction, block1.hash ()));
@@ -438,7 +438,7 @@ TEST (block_store, empty_bootstrap)
 	bool init (false);
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	auto begin (store.unchecked_begin (transaction));
 	auto end (store.unchecked_end ());
 	ASSERT_EQ (end, begin);
@@ -451,7 +451,7 @@ TEST (block_store, one_bootstrap)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.unchecked_put (transaction, block1->hash (), block1);
 	store.flush (transaction);
 	auto begin (store.unchecked_begin (transaction));
@@ -486,7 +486,7 @@ TEST (block_store, frontier_retrieval)
 	ASSERT_TRUE (!init);
 	nano::account account1 (0);
 	nano::account_info info1 (0, 0, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.account_put (transaction, account1, info1);
 	nano::account_info info2;
 	store.account_get (transaction, account1, info2);
@@ -501,7 +501,7 @@ TEST (block_store, one_account)
 	ASSERT_TRUE (!init);
 	nano::account account (0);
 	nano::block_hash hash (0);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.account_put (transaction, account, { hash, account, hash, 42, 100, 200, 20, nano::epoch::epoch_0 });
 	auto begin (store.latest_begin (transaction));
 	auto end (store.latest_end ());
@@ -529,7 +529,7 @@ TEST (block_store, two_block)
 	std::vector<nano::open_block> blocks;
 	hashes.push_back (block1.hash ());
 	blocks.push_back (block1);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::block_sideband sideband1 (nano::block_type::open, 0, 0, 0, 0, 0);
 	store.block_put (transaction, hashes[0], block1, sideband1);
 	nano::open_block block2 (0, 1, 2, nano::keypair ().prv, 0, 0);
@@ -551,7 +551,7 @@ TEST (block_store, two_account)
 	nano::block_hash hash1 (2);
 	nano::account account2 (3);
 	nano::block_hash hash2 (4);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.account_put (transaction, account1, { hash1, account1, hash1, 42, 100, 300, 20, nano::epoch::epoch_0 });
 	store.account_put (transaction, account2, { hash2, account2, hash2, 84, 200, 400, 30, nano::epoch::epoch_0 });
 	auto begin (store.latest_begin (transaction));
@@ -587,7 +587,7 @@ TEST (block_store, latest_find)
 	nano::block_hash hash1 (2);
 	nano::account account2 (3);
 	nano::block_hash hash2 (4);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.account_put (transaction, account1, { hash1, account1, hash1, 100, 0, 300, 0, nano::epoch::epoch_0 });
 	store.account_put (transaction, account2, { hash2, account2, hash2, 200, 0, 400, 0, nano::epoch::epoch_0 });
 	auto first (store.latest_begin (transaction));
@@ -647,7 +647,7 @@ TEST (block_store, pending_exists)
 	ASSERT_TRUE (!init);
 	nano::pending_key two (2, 0);
 	nano::pending_info pending;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.pending_put (transaction, two, pending);
 	nano::pending_key one (1, 0);
 	ASSERT_FALSE (store.pending_exists (transaction, one));
@@ -661,7 +661,7 @@ TEST (block_store, latest_exists)
 	ASSERT_TRUE (!init);
 	nano::block_hash two (2);
 	nano::account_info info;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.account_put (transaction, two, info);
 	nano::block_hash one (1);
 	ASSERT_FALSE (store.account_exists (transaction, one));
@@ -676,7 +676,7 @@ TEST (block_store, large_iteration)
 	std::unordered_set<nano::account> accounts1;
 	for (auto i (0); i < 1000; ++i)
 	{
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::account account;
 		nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
 		accounts1.insert (account);
@@ -684,7 +684,7 @@ TEST (block_store, large_iteration)
 	}
 	std::unordered_set<nano::account> accounts2;
 	nano::account previous (0);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	for (auto i (store.latest_begin (transaction, 0)), n (store.latest_end ()); i != n; ++i)
 	{
 		nano::account current (i->first);
@@ -701,7 +701,7 @@ TEST (block_store, frontier)
 	bool init (false);
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::block_hash hash (100);
 	nano::account account (200);
 	ASSERT_TRUE (store.frontier_get (transaction, hash).is_zero ());
@@ -719,7 +719,7 @@ TEST (block_store, block_replace)
 	ASSERT_TRUE (!init);
 	nano::send_block send1 (0, 0, 0, nano::keypair ().prv, 0, 1);
 	nano::send_block send2 (0, 0, 0, nano::keypair ().prv, 0, 2);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::block_sideband sideband1 (nano::block_type::send, 0, 0, 0, 0, 0);
 	store.block_put (transaction, 0, send1, sideband1);
 	nano::block_sideband sideband2 (nano::block_type::send, 0, 0, 0, 0, 0);
@@ -735,7 +735,7 @@ TEST (block_store, block_count)
 	bool init (false);
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, store.block_count (transaction).sum ());
 	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
 	nano::uint256_union hash1 (block.hash ());
@@ -750,7 +750,7 @@ TEST (block_store, account_count)
 	bool init (false);
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, store.account_count (transaction));
 	nano::account account (200);
 	store.account_put (transaction, account, nano::account_info ());
@@ -766,7 +766,7 @@ TEST (block_store, sequence_increment)
 	nano::keypair key1;
 	nano::keypair key2;
 	auto block1 (std::make_shared<nano::open_block> (0, 1, 0, nano::keypair ().prv, 0, 0));
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto vote1 (store.vote_generate (transaction, key1.pub, key1.prv, block1));
 	ASSERT_EQ (1, vote1->sequence);
 	auto vote2 (store.vote_generate (transaction, key1.pub, key1.prv, block1));
@@ -798,7 +798,7 @@ TEST (block_store, upgrade_v2_v3)
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
 		ASSERT_TRUE (!init);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::genesis genesis;
 		auto hash (genesis.hash ());
 		store.initialize (transaction, genesis);
@@ -827,7 +827,7 @@ TEST (block_store, upgrade_v2_v3)
 	nano::mdb_store store (init, logger, path);
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_TRUE (!init);
 	ASSERT_LT (2, store.version_get (transaction));
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (transaction, key1.pub));
@@ -848,7 +848,7 @@ TEST (block_store, upgrade_v3_v4)
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
 		ASSERT_FALSE (init);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.version_put (transaction, 3);
 		nano::pending_info_v3 info (key1.pub, 100, key2.pub);
 		auto status (mdb_put (store.env.tx (transaction), store.pending_v0, nano::mdb_val (key3.pub), info.val (), 0));
@@ -859,7 +859,7 @@ TEST (block_store, upgrade_v3_v4)
 	nano::mdb_store store (init, logger, path);
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_FALSE (init);
 	ASSERT_LT (3, store.version_get (transaction));
 	nano::pending_key key (key2.pub, key3.pub);
@@ -881,7 +881,7 @@ TEST (block_store, upgrade_v4_v5)
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
 		ASSERT_FALSE (init);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::genesis genesis;
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
@@ -903,7 +903,7 @@ TEST (block_store, upgrade_v4_v5)
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
 	ASSERT_FALSE (init);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	ASSERT_EQ (hash, store.block_successor (transaction, genesis_hash));
 }
 
@@ -914,7 +914,7 @@ TEST (block_store, block_random)
 	nano::mdb_store store (init, logger, nano::unique_path ());
 	ASSERT_TRUE (!init);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	auto block (store.block_random (transaction));
 	ASSERT_NE (nullptr, block);
@@ -929,7 +929,7 @@ TEST (block_store, upgrade_v5_v6)
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
 		ASSERT_FALSE (init);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::genesis genesis;
 		store.initialize (transaction, genesis);
 		store.version_put (transaction, 5);
@@ -939,7 +939,7 @@ TEST (block_store, upgrade_v5_v6)
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
 	ASSERT_FALSE (init);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	nano::account_info info;
 	store.account_get (transaction, nano::test_genesis_key.pub, info);
 	ASSERT_EQ (1, info.block_count);
@@ -953,7 +953,7 @@ TEST (block_store, upgrade_v6_v7)
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
 		ASSERT_FALSE (init);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::genesis genesis;
 		store.initialize (transaction, genesis);
 		store.version_put (transaction, 6);
@@ -967,7 +967,7 @@ TEST (block_store, upgrade_v6_v7)
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
 	ASSERT_FALSE (init);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	ASSERT_EQ (store.unchecked_end (), store.unchecked_begin (transaction));
 }
 
@@ -978,7 +978,7 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 	nano::logger_mt logger;
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked, 1));
 	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked));
 	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
@@ -1024,7 +1024,7 @@ TEST (block_store, upgrade_v7_v8)
 		nano::logger_mt logger;
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked, 1));
 		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked));
 		store.version_put (transaction, 7);
@@ -1033,7 +1033,7 @@ TEST (block_store, upgrade_v7_v8)
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
 	ASSERT_FALSE (init);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	auto send2 (std::make_shared<nano::send_block> (1, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	store.unchecked_put (transaction, send1->hash (), send1);
@@ -1055,7 +1055,7 @@ TEST (block_store, sequence_flush)
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
 	ASSERT_FALSE (init);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	auto vote1 (store.vote_generate (transaction, key1.pub, key1.prv, send1));
@@ -1096,7 +1096,7 @@ TEST (block_store, upgrade_v8_v9)
 		nano::logger_mt logger;
 		bool init (false);
 		nano::mdb_store store (init, logger, path);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.vote, 1));
 		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "sequence", MDB_CREATE, &store.vote));
 		uint64_t sequence (10);
@@ -1107,7 +1107,7 @@ TEST (block_store, upgrade_v8_v9)
 	bool init (false);
 	nano::mdb_store store (init, logger, path);
 	ASSERT_FALSE (init);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	ASSERT_LT (8, store.version_get (transaction));
 	auto vote (store.vote_get (transaction, key.pub));
 	ASSERT_NE (nullptr, vote);
@@ -1121,7 +1121,7 @@ TEST (block_store, state_block)
 	nano::mdb_store store (error, logger, nano::unique_path ());
 	ASSERT_FALSE (error);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::state_block block1 (1, genesis.hash (), 3, 4, 6, key1.prv, key1.pub, 7);
@@ -1172,7 +1172,7 @@ TEST (block_store, upgrade_sideband_genesis)
 		nano::logger_mt logger;
 		nano::mdb_store store (error, logger, path);
 		ASSERT_FALSE (error);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.version_put (transaction, 11);
 		store.initialize (transaction, genesis);
 		modify_account_info_to_v13 (store, transaction, nano::genesis_account);
@@ -1208,7 +1208,7 @@ TEST (block_store, upgrade_sideband_two_blocks)
 		ASSERT_FALSE (error);
 		nano::stat stat;
 		nano::ledger ledger (store, stat);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.version_put (transaction, 11);
 		store.initialize (transaction, genesis);
 		nano::state_block block (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1247,7 +1247,7 @@ TEST (block_store, upgrade_sideband_two_accounts)
 		ASSERT_FALSE (error);
 		nano::stat stat;
 		nano::ledger ledger (store, stat);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.version_put (transaction, 11);
 		store.initialize (transaction, genesis);
 		nano::state_block block1 (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1290,7 +1290,7 @@ TEST (block_store, insert_after_legacy)
 	ASSERT_FALSE (error);
 	nano::stat stat;
 	nano::ledger ledger (store, stat);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.version_put (transaction, 11);
 	store.initialize (transaction, genesis);
 	write_legacy_sideband (store, transaction, *genesis.open, 0, store.open_blocks);
@@ -1308,7 +1308,7 @@ TEST (block_store, legacy_account_computed)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	store.version_put (transaction, 11);
 	write_legacy_sideband (store, transaction, *genesis.open, 0, store.open_blocks);
@@ -1327,7 +1327,7 @@ TEST (block_store, upgrade_sideband_epoch)
 		ASSERT_FALSE (error);
 		nano::stat stat;
 		nano::ledger ledger (store, stat, 42, nano::test_genesis_key.pub);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.version_put (transaction, 11);
 		store.initialize (transaction, genesis);
 		nano::state_block block1 (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount, 42, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1368,7 +1368,7 @@ TEST (block_store, sideband_height)
 	nano::stat stat;
 	nano::ledger ledger (store, stat);
 	ledger.epoch_signer = epoch_key.pub;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::send_block send (genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
@@ -1509,7 +1509,7 @@ TEST (block_store, online_weight)
 	bool error (false);
 	nano::mdb_store store (error, logger, nano::unique_path ());
 	ASSERT_FALSE (error);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, store.online_weight_count (transaction));
 	ASSERT_EQ (store.online_weight_end (), store.online_weight_begin (transaction));
 	store.online_weight_put (transaction, 1, 2);
@@ -1532,7 +1532,7 @@ TEST (block_store, upgrade_v13_v14)
 		nano::genesis genesis;
 		auto error (false);
 		nano::mdb_store store (error, logger, path);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, genesis);
 		nano::account_info account_info;
 		ASSERT_FALSE (store.account_get (transaction, nano::genesis_account, account_info));
@@ -1550,7 +1550,7 @@ TEST (block_store, upgrade_v13_v14)
 	auto error (false);
 	nano::mdb_store store (error, logger, path);
 	ASSERT_FALSE (error);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 
 	// This should now work and have confirmation height of 0
 	nano::account_info account_info;
@@ -1572,7 +1572,7 @@ TEST (block_store, confirmation_height)
 	nano::logger_mt logger;
 	auto error (false);
 	nano::mdb_store store (error, logger, path);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 
 	nano::account account1 (0);
 	nano::account_info info1 (0, 0, 0, 0, 0, 0, 500, nano::epoch::epoch_0);
@@ -1622,7 +1622,7 @@ TEST (block_store, upgrade_confirmation_height_many)
 		nano::logger_mt logger;
 		nano::mdb_store store (error, logger, path);
 		ASSERT_FALSE (error);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.version_put (transaction, 13);
 		store.initialize (transaction, genesis);
 		modify_account_info_to_v13 (store, transaction, nano::genesis_account);
@@ -1643,7 +1643,7 @@ TEST (block_store, upgrade_confirmation_height_many)
 	// Loop over them all and confirm all have a confirmation height of 0
 	nano::logger_mt logger;
 	nano::mdb_store store (error, logger, path);
-	auto transaction (store.tx_begin (false));
+	auto transaction (store.tx_begin_read ());
 	ASSERT_EQ (store.account_count (transaction), total_num_accounts);
 
 	for (auto i (store.latest_begin (transaction)), n (store.latest_end ()); i != n; ++i)

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -9,7 +9,7 @@ TEST (gap_cache, add_new)
 	nano::system system (24000, 1);
 	nano::gap_cache cache (*system.nodes[0]);
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (system.nodes[0]->store.tx_begin (true));
+	auto transaction (system.nodes[0]->store.tx_begin_write ());
 	cache.add (transaction, block1->hash ());
 }
 
@@ -18,7 +18,7 @@ TEST (gap_cache, add_existing)
 	nano::system system (24000, 1);
 	nano::gap_cache cache (*system.nodes[0]);
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (system.nodes[0]->store.tx_begin (true));
+	auto transaction (system.nodes[0]->store.tx_begin_write ());
 	cache.add (transaction, block1->hash ());
 	std::unique_lock<std::mutex> lock (cache.mutex);
 	auto existing1 (cache.blocks.get<1> ().find (block1->hash ()));
@@ -43,7 +43,7 @@ TEST (gap_cache, comparison)
 	nano::system system (24000, 1);
 	nano::gap_cache cache (*system.nodes[0]);
 	auto block1 (std::make_shared<nano::send_block> (1, 0, 2, nano::keypair ().prv, 4, 5));
-	auto transaction (system.nodes[0]->store.tx_begin (true));
+	auto transaction (system.nodes[0]->store.tx_begin_write ());
 	cache.add (transaction, block1->hash ());
 	std::unique_lock<std::mutex> lock (cache.mutex);
 	auto existing1 (cache.blocks.get<1> ().find (block1->hash ()));
@@ -72,7 +72,7 @@ TEST (gap_cache, gap_bootstrap)
 	nano::keypair key;
 	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (latest)));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->block_processor.process_one (transaction, send).code);
 	}
 	ASSERT_EQ (nano::genesis_amount - 100, system.nodes[0]->balance (nano::genesis_account));
@@ -87,7 +87,7 @@ TEST (gap_cache, gap_bootstrap)
 	{
 		// The separate publish and vote system doesn't work very well here because it's instantly confirmed.
 		// We help it get the block and vote out here.
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		system.nodes[0]->network.flood_block (latest_block);
 	}
 	while (system.nodes[1]->balance (nano::genesis_account) != nano::genesis_amount - 200)
@@ -114,7 +114,7 @@ TEST (gap_cache, two_dependencies)
 	system.nodes[0]->block_processor.add (send1, nano::seconds_since_epoch ());
 	system.nodes[0]->block_processor.flush ();
 	ASSERT_EQ (0, system.nodes[0]->gap_cache.size ());
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	ASSERT_TRUE (system.nodes[0]->store.block_exists (transaction, send1->hash ()));
 	ASSERT_TRUE (system.nodes[0]->store.block_exists (transaction, send2->hash ()));
 	ASSERT_TRUE (system.nodes[0]->store.block_exists (transaction, open->hash ()));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -28,7 +28,7 @@ TEST (ledger, empty)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::account account;
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	auto balance (ledger.account_balance (transaction, account));
 	ASSERT_TRUE (balance.is_zero ());
 }
@@ -43,7 +43,7 @@ TEST (ledger, genesis_balance)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	auto balance (ledger.account_balance (transaction, nano::genesis_account));
 	ASSERT_EQ (nano::genesis_amount, balance);
@@ -64,7 +64,7 @@ TEST (system, system_genesis)
 	nano::system system (24000, 2);
 	for (auto & i : system.nodes)
 	{
-		auto transaction (i->store.tx_begin ());
+		auto transaction (i->store.tx_begin_read ());
 		ASSERT_EQ (nano::genesis_amount, i->ledger.account_balance (transaction, nano::genesis_account));
 	}
 }
@@ -78,7 +78,7 @@ TEST (ledger, process_send)
 	ASSERT_TRUE (!init);
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::genesis genesis;
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
@@ -173,7 +173,7 @@ TEST (ledger, process_receive)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -231,7 +231,7 @@ TEST (ledger, rollback_receiver)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -270,7 +270,7 @@ TEST (ledger, rollback_representation)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key5;
 	nano::change_block change1 (genesis.hash (), key5.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -324,7 +324,7 @@ TEST (ledger, receive_rollback)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::send_block send (genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
@@ -342,7 +342,7 @@ TEST (ledger, process_duplicate)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -365,7 +365,7 @@ TEST (ledger, representative_genesis)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	auto latest (ledger.latest (transaction, nano::test_genesis_key.pub));
 	ASSERT_FALSE (latest.is_zero ());
@@ -381,7 +381,7 @@ TEST (ledger, weight)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (transaction, nano::genesis_account));
 }
@@ -396,7 +396,7 @@ TEST (ledger, representative_change)
 	nano::ledger ledger (store, stats);
 	nano::keypair key2;
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (transaction, nano::test_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (transaction, key2.pub));
@@ -436,7 +436,7 @@ TEST (ledger, send_fork)
 	nano::keypair key2;
 	nano::keypair key3;
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -457,7 +457,7 @@ TEST (ledger, receive_fork)
 	nano::keypair key2;
 	nano::keypair key3;
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -484,7 +484,7 @@ TEST (ledger, open_fork)
 	nano::keypair key2;
 	nano::keypair key3;
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -505,7 +505,7 @@ TEST (system, DISABLED_generate_send_existing)
 	auto send_block (system.wallet (0)->send_action (nano::genesis_account, stake_preserver.pub, nano::genesis_amount / 3 * 2, true));
 	nano::account_info info1;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info1));
 	}
 	std::vector<nano::account> accounts;
@@ -513,7 +513,7 @@ TEST (system, DISABLED_generate_send_existing)
 	system.generate_send_existing (*system.nodes[0], accounts);
 	// Have stake_preserver receive funds after generate_send_existing so it isn't chosen as the destination
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		auto open_block (std::make_shared<nano::open_block> (send_block->hash (), nano::genesis_account, stake_preserver.pub, stake_preserver.prv, stake_preserver.pub, 0));
 		system.nodes[0]->work_generate_blocking (*open_block);
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *open_block).code);
@@ -521,7 +521,7 @@ TEST (system, DISABLED_generate_send_existing)
 	ASSERT_GT (system.nodes[0]->balance (stake_preserver.pub), system.nodes[0]->balance (nano::genesis_account));
 	nano::account_info info2;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info2));
 	}
 	ASSERT_NE (info1.head, info2.head);
@@ -529,13 +529,13 @@ TEST (system, DISABLED_generate_send_existing)
 	while (info2.block_count < info1.block_count + 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info2));
 	}
 	ASSERT_EQ (info1.block_count + 2, info2.block_count);
 	ASSERT_EQ (info2.balance, nano::genesis_amount / 3);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_NE (system.nodes[0]->ledger.amount (transaction, info2.head), 0);
 	}
 	system.stop ();
@@ -548,7 +548,7 @@ TEST (system, generate_send_new)
 	nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		auto iterator1 (system.nodes[0]->store.latest_begin (transaction));
 		ASSERT_NE (system.nodes[0]->store.latest_end (), iterator1);
 		++iterator1;
@@ -557,7 +557,7 @@ TEST (system, generate_send_new)
 	nano::keypair stake_preserver;
 	auto send_block (system.wallet (0)->send_action (nano::genesis_account, stake_preserver.pub, nano::genesis_amount / 3 * 2, true));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		auto open_block (std::make_shared<nano::open_block> (send_block->hash (), nano::genesis_account, stake_preserver.pub, stake_preserver.prv, stake_preserver.pub, 0));
 		system.nodes[0]->work_generate_blocking (*open_block);
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *open_block).code);
@@ -568,7 +568,7 @@ TEST (system, generate_send_new)
 	system.generate_send_new (*system.nodes[0], accounts);
 	nano::account new_account (0);
 	{
-		auto transaction (system.nodes[0]->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 		auto iterator2 (system.wallet (0)->store.begin (transaction));
 		if (nano::uint256_union (iterator2->first) != nano::test_genesis_key.pub)
 		{
@@ -602,7 +602,7 @@ TEST (ledger, representation)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	ASSERT_EQ (nano::genesis_amount, store.representation_get (transaction, nano::test_genesis_key.pub));
 	nano::keypair key2;
@@ -676,7 +676,7 @@ TEST (ledger, double_open)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key2;
 	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -696,7 +696,7 @@ TEST (ledger, double_receive)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key2;
 	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -715,7 +715,7 @@ TEST (votes, check_signature)
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	auto node_l (system.nodes[0]);
 	node1.active.start (send1);
@@ -738,7 +738,7 @@ TEST (votes, add_one)
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
@@ -767,7 +767,7 @@ TEST (votes, add_two)
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
@@ -798,7 +798,7 @@ TEST (votes, add_existing)
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
@@ -839,7 +839,7 @@ TEST (votes, add_old)
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
@@ -870,7 +870,7 @@ TEST (votes, add_old_different_account)
 	node1.work_generate_blocking (*send1);
 	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send2).code);
 	node1.active.start (send1);
@@ -910,7 +910,7 @@ TEST (votes, add_cooldown)
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin (true));
+	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
@@ -937,7 +937,7 @@ TEST (ledger, successor)
 	nano::keypair key1;
 	nano::genesis genesis;
 	nano::send_block send1 (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-	auto transaction (system.nodes[0]->store.tx_begin (true));
+	auto transaction (system.nodes[0]->store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, send1).code);
 	ASSERT_EQ (send1, *system.nodes[0]->ledger.successor (transaction, nano::qualified_root (genesis.hash (), 0)));
 	ASSERT_EQ (*genesis.open, *system.nodes[0]->ledger.successor (transaction, genesis.open->qualified_root ()));
@@ -953,7 +953,7 @@ TEST (ledger, fail_change_old)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::change_block block (genesis.hash (), key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -972,7 +972,7 @@ TEST (ledger, fail_change_gap_previous)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::change_block block (1, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -989,7 +989,7 @@ TEST (ledger, fail_change_bad_signature)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::change_block block (genesis.hash (), key1.pub, nano::keypair ().prv, 0, 0);
@@ -1006,7 +1006,7 @@ TEST (ledger, fail_change_fork)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::change_block block1 (genesis.hash (), key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1027,7 +1027,7 @@ TEST (ledger, fail_send_old)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1046,7 +1046,7 @@ TEST (ledger, fail_send_gap_previous)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block (1, key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1063,7 +1063,7 @@ TEST (ledger, fail_send_bad_signature)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block (genesis.hash (), key1.pub, 1, nano::keypair ().prv, 0, 0);
@@ -1080,7 +1080,7 @@ TEST (ledger, fail_send_negative_spend)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1099,7 +1099,7 @@ TEST (ledger, fail_send_fork)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1118,7 +1118,7 @@ TEST (ledger, fail_open_old)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1137,7 +1137,7 @@ TEST (ledger, fail_open_gap_source)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::open_block block2 (1, 1, key1.pub, key1.prv, key1.pub, 0);
@@ -1154,7 +1154,7 @@ TEST (ledger, fail_open_bad_signature)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1173,7 +1173,7 @@ TEST (ledger, fail_open_fork_previous)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1195,7 +1195,7 @@ TEST (ledger, fail_open_account_mismatch)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1214,7 +1214,7 @@ TEST (ledger, fail_receive_old)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1237,7 +1237,7 @@ TEST (ledger, fail_receive_gap_source)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1263,7 +1263,7 @@ TEST (ledger, fail_receive_overreceive)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1286,7 +1286,7 @@ TEST (ledger, fail_receive_bad_signature)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1312,7 +1312,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1338,7 +1338,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1361,7 +1361,7 @@ TEST (ledger, fail_receive_fork_previous)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1391,7 +1391,7 @@ TEST (ledger, fail_receive_received_source)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1427,7 +1427,7 @@ TEST (ledger, latest_empty)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::keypair key;
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	auto latest (ledger.latest (transaction, key.pub));
 	ASSERT_TRUE (latest.is_zero ());
 }
@@ -1441,7 +1441,7 @@ TEST (ledger, latest_root)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub));
@@ -1460,7 +1460,7 @@ TEST (ledger, change_representative_move_representation)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::keypair key1;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::genesis genesis;
 	store.initialize (transaction, genesis);
 	auto hash1 (genesis.hash ());
@@ -1485,7 +1485,7 @@ TEST (ledger, send_open_receive_rollback)
 	ASSERT_TRUE (!init);
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::genesis genesis;
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
@@ -1548,26 +1548,26 @@ TEST (ledger, bootstrap_rep_weight)
 	nano::keypair key2;
 	nano::genesis genesis;
 	{
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, genesis);
 		ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
 		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 		ledger.process (transaction, send);
 	}
 	{
-		auto transaction (store.tx_begin ());
+		auto transaction (store.tx_begin_read ());
 		ledger.bootstrap_weight_max_blocks = 3;
 		ledger.bootstrap_weights[key2.pub] = 1000;
 		ASSERT_EQ (1000, ledger.weight (transaction, key2.pub));
 	}
 	{
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
 		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 		ledger.process (transaction, send);
 	}
 	{
-		auto transaction (store.tx_begin ());
+		auto transaction (store.tx_begin_read ());
 		ASSERT_EQ (0, ledger.weight (transaction, key2.pub));
 	}
 }
@@ -1581,7 +1581,7 @@ TEST (ledger, block_destination_source)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair dest;
 	nano::uint128_t balance (nano::genesis_amount);
@@ -1627,7 +1627,7 @@ TEST (ledger, state_account)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1643,7 +1643,7 @@ TEST (ledger, state_send_receive)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1676,7 +1676,7 @@ TEST (ledger, state_receive)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1707,7 +1707,7 @@ TEST (ledger, state_rep_change)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair rep;
 	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1731,7 +1731,7 @@ TEST (ledger, state_open)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1766,7 +1766,7 @@ TEST (ledger, send_after_state_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1784,7 +1784,7 @@ TEST (ledger, receive_after_state_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1802,7 +1802,7 @@ TEST (ledger, change_after_state_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1820,7 +1820,7 @@ TEST (ledger, state_unreceivable_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1844,7 +1844,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1868,7 +1868,7 @@ TEST (ledger, state_no_link_amount_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1886,7 +1886,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1911,7 +1911,7 @@ TEST (ledger, state_open_state_fork)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1932,7 +1932,7 @@ TEST (ledger, state_state_open_fork)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1953,7 +1953,7 @@ TEST (ledger, state_open_previous_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1971,7 +1971,7 @@ TEST (ledger, state_open_source_fail)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1989,7 +1989,7 @@ TEST (ledger, state_send_change)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair rep;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2013,7 +2013,7 @@ TEST (ledger, state_receive_change)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2046,7 +2046,7 @@ TEST (ledger, state_open_old)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2067,7 +2067,7 @@ TEST (ledger, state_receive_old)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2092,7 +2092,7 @@ TEST (ledger, state_rollback_send)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2123,7 +2123,7 @@ TEST (ledger, state_rollback_receive)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2149,7 +2149,7 @@ TEST (ledger, state_rollback_received_send)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2176,7 +2176,7 @@ TEST (ledger, state_rep_change_rollback)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair rep;
 	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2197,7 +2197,7 @@ TEST (ledger, state_open_rollback)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2223,7 +2223,7 @@ TEST (ledger, state_send_change_rollback)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair rep;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2244,7 +2244,7 @@ TEST (ledger, state_receive_change_rollback)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2268,7 +2268,7 @@ TEST (ledger, epoch_blocks_general)
 	nano::keypair epoch_key;
 	nano::ledger ledger (store, stats, 123, epoch_key.pub);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, 123, epoch_key.prv, epoch_key.pub, 0);
@@ -2315,7 +2315,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	nano::keypair epoch_key;
 	nano::ledger ledger (store, stats, 123, epoch_key.pub);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2356,7 +2356,7 @@ TEST (ledger, epoch_blocks_fork)
 	nano::keypair epoch_key;
 	nano::ledger ledger (store, stats, 123, epoch_key.pub);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	nano::send_block send1 (genesis.hash (), nano::account (0), nano::genesis_amount, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2378,7 +2378,7 @@ TEST (ledger, could_fit)
 	ledger.epoch_link = 123;
 	ledger.epoch_signer = epoch_signer.pub;
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair destination;
 	// Test legacy and state change blocks could_fit
@@ -2446,7 +2446,7 @@ TEST (ledger, unchecked_epoch)
 	node1.block_processor.add (epoch1);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
 		auto blocks (node1.store.unchecked_get (transaction, epoch1->previous ()));
@@ -2457,7 +2457,7 @@ TEST (ledger, unchecked_epoch)
 	node1.block_processor.add (open1);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, epoch1->hash ()));
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
@@ -2487,7 +2487,7 @@ TEST (ledger, unchecked_epoch_invalid)
 	node1.block_processor.add (epoch2);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 2);
 		auto blocks (node1.store.unchecked_get (transaction, epoch1->previous ()));
@@ -2499,7 +2499,7 @@ TEST (ledger, unchecked_epoch_invalid)
 	node1.block_processor.add (open1);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_FALSE (node1.store.block_exists (transaction, epoch1->hash ()));
 		ASSERT_TRUE (node1.store.block_exists (transaction, epoch2->hash ()));
 		ASSERT_TRUE (node1.active.empty ());
@@ -2529,7 +2529,7 @@ TEST (ledger, unchecked_open)
 	node1.block_processor.add (open2);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
 		auto blocks (node1.store.unchecked_get (transaction, open1->source ()));
@@ -2539,7 +2539,7 @@ TEST (ledger, unchecked_open)
 	node1.block_processor.add (send1);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, open1->hash ()));
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
@@ -2565,7 +2565,7 @@ TEST (ledger, unchecked_receive)
 	node1.block_processor.flush ();
 	// Previous block for receive1 is unknown, signature cannot be validated
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
 		auto blocks (node1.store.unchecked_get (transaction, receive1->previous ()));
@@ -2576,7 +2576,7 @@ TEST (ledger, unchecked_receive)
 	node1.block_processor.flush ();
 	// Previous block for receive1 is known, signature was validated
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
 		auto blocks (node1.store.unchecked_get (transaction, receive1->source ()));
@@ -2586,7 +2586,7 @@ TEST (ledger, unchecked_receive)
 	node1.block_processor.add (send2);
 	node1.block_processor.flush ();
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, receive1->hash ()));
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
@@ -2601,7 +2601,7 @@ TEST (ledger, confirmation_height_not_updated)
 	ASSERT_TRUE (!error);
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	nano::genesis genesis;
 	store.initialize (transaction, genesis);
 	nano::account_info account_info;

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -174,7 +174,7 @@ TEST (network, send_discarded_publish)
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, system.work.generate (1)));
 	nano::genesis genesis;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		system.nodes[0]->network.flood_block (block);
 		ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, nano::test_genesis_key.pub));
 		ASSERT_EQ (genesis.hash (), system.nodes[1]->latest (nano::test_genesis_key.pub));
@@ -184,7 +184,7 @@ TEST (network, send_discarded_publish)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, nano::test_genesis_key.pub));
 	ASSERT_EQ (genesis.hash (), system.nodes[1]->latest (nano::test_genesis_key.pub));
 }
@@ -195,7 +195,7 @@ TEST (network, send_invalid_publish)
 	nano::genesis genesis;
 	auto block (std::make_shared<nano::send_block> (1, 1, 20, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (1)));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		system.nodes[0]->network.flood_block (block);
 		ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, nano::test_genesis_key.pub));
 		ASSERT_EQ (genesis.hash (), system.nodes[1]->latest (nano::test_genesis_key.pub));
@@ -205,7 +205,7 @@ TEST (network, send_invalid_publish)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	ASSERT_EQ (genesis.hash (), system.nodes[0]->ledger.latest (transaction, nano::test_genesis_key.pub));
 	ASSERT_EQ (genesis.hash (), system.nodes[1]->latest (nano::test_genesis_key.pub));
 }
@@ -344,7 +344,7 @@ TEST (network, receive_weight_change)
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
 	{
-		auto transaction (system.nodes[1]->wallets.tx_begin (true));
+		auto transaction (system.nodes[1]->wallets.tx_begin_write ());
 		system.wallet (1)->store.representative_set (transaction, key2.pub);
 	}
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
@@ -1610,7 +1610,7 @@ TEST (confirmation_height, gap_bootstrap)
 
 	// Confirmation heights should not be updated
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 2);
 
@@ -1625,7 +1625,7 @@ TEST (confirmation_height, gap_bootstrap)
 
 	// Confirmation height should still be 0 and unchecked should now be 0
 	{
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto unchecked_count (node1.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
 
@@ -1699,7 +1699,7 @@ TEST (confirmation_height, gap_live)
 		}
 
 		// This should confirm the open block and the source of the receive blocks
-		auto transaction (node->store.tx_begin ());
+		auto transaction (node->store.tx_begin_read ());
 		auto unchecked_count (node->store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
 
@@ -1770,7 +1770,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	auto transaction (node->store.tx_begin ());
+	auto transaction (node->store.tx_begin_read ());
 
 	nano::account_info account_info;
 	ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
@@ -1829,7 +1829,7 @@ TEST (confirmation_height, send_receive_self)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	auto transaction (node->store.tx_begin ());
+	auto transaction (node->store.tx_begin_read ());
 	nano::account_info account_info;
 	ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
 	ASSERT_EQ (7, account_info.confirmation_height);
@@ -1920,7 +1920,7 @@ TEST (confirmation_height, all_block_types)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	auto transaction (node->store.tx_begin ());
+	auto transaction (node->store.tx_begin_read ());
 	nano::account_info account_info;
 	ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
 	ASSERT_EQ (3, account_info.confirmation_height);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -60,7 +60,7 @@ TEST (node, balance)
 {
 	nano::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto transaction (system.nodes[0]->store.tx_begin (true));
+	auto transaction (system.nodes[0]->store.tx_begin_write ());
 	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max (), system.nodes[0]->ledger.account_balance (transaction, nano::test_genesis_key.pub));
 }
 
@@ -69,7 +69,7 @@ TEST (node, representative)
 	nano::system system (24000, 1);
 	auto block1 (system.nodes[0]->representative (nano::test_genesis_key.pub));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_TRUE (system.nodes[0]->ledger.store.block_exists (transaction, block1));
 	}
 	nano::keypair key;
@@ -405,7 +405,7 @@ TEST (node, unlock_search)
 	nano::keypair key2;
 	nano::uint128_t balance (system.nodes[0]->balance (nano::test_genesis_key.pub));
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin (true));
+		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
 		system.wallet (0)->store.rekey (transaction, "");
 	}
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
@@ -426,7 +426,7 @@ TEST (node, unlock_search)
 	}
 	auto node (system.nodes[0]);
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin (true));
+		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
 		ASSERT_FALSE (system.wallet (0)->enter_password (transaction, ""));
 	}
 	system.deadline_set (10s);
@@ -484,7 +484,7 @@ TEST (node, confirm_locked)
 {
 	nano::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	system.wallet (0)->enter_password (transaction, "1");
 	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::keypair ().prv, 0, 0));
 	system.nodes[0]->network.flood_block (block);
@@ -900,7 +900,7 @@ TEST (node, fork_publish)
 		auto existing1 (election->last_votes.find (nano::test_genesis_key.pub));
 		ASSERT_NE (election->last_votes.end (), existing1);
 		ASSERT_EQ (send1->hash (), existing1->second.hash);
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		auto winner (*election->tally (transaction).begin ());
 		ASSERT_EQ (*send1, *winner.second);
 		ASSERT_EQ (nano::genesis_amount - 100, winner.first);
@@ -939,8 +939,8 @@ TEST (node, fork_keep)
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	lock.unlock ();
 	{
-		auto transaction0 (system.nodes[0]->store.tx_begin ());
-		auto transaction1 (system.nodes[1]->store.tx_begin ());
+		auto transaction0 (system.nodes[0]->store.tx_begin_read ());
+		auto transaction1 (system.nodes[1]->store.tx_begin_read ());
 		ASSERT_TRUE (system.nodes[0]->store.block_exists (transaction0, send1->hash ()));
 		ASSERT_TRUE (system.nodes[1]->store.block_exists (transaction1, send1->hash ()));
 	}
@@ -950,8 +950,8 @@ TEST (node, fork_keep)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	auto transaction0 (system.nodes[0]->store.tx_begin ());
-	auto transaction1 (system.nodes[1]->store.tx_begin ());
+	auto transaction0 (system.nodes[0]->store.tx_begin_read ());
+	auto transaction1 (system.nodes[1]->store.tx_begin_read ());
 	// The vote should be in agreement with what we already have.
 	lock.lock ();
 	auto winner (*votes1->tally (transaction1).begin ());
@@ -995,11 +995,11 @@ TEST (node, fork_flip)
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	lock.unlock ();
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, publish1.block->hash ()));
 	}
 	{
-		auto transaction (system.nodes[1]->store.tx_begin ());
+		auto transaction (system.nodes[1]->store.tx_begin_read ());
 		ASSERT_TRUE (node2.store.block_exists (transaction, publish2.block->hash ()));
 	}
 	system.deadline_set (10s);
@@ -1009,8 +1009,8 @@ TEST (node, fork_flip)
 		ASSERT_NO_ERROR (system.poll ());
 		done = node2.ledger.block_exists (publish1.block->hash ());
 	}
-	auto transaction1 (system.nodes[0]->store.tx_begin ());
-	auto transaction2 (system.nodes[1]->store.tx_begin ());
+	auto transaction1 (system.nodes[0]->store.tx_begin_read ());
+	auto transaction2 (system.nodes[1]->store.tx_begin_read ());
 	lock.lock ();
 	auto winner (*votes1->tally (transaction2).begin ());
 	ASSERT_EQ (*publish1.block, *winner.second);
@@ -1056,11 +1056,11 @@ TEST (node, fork_multi_flip)
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	lock.unlock ();
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, publish1.block->hash ()));
 	}
 	{
-		auto transaction (system.nodes[1]->store.tx_begin ());
+		auto transaction (system.nodes[1]->store.tx_begin_read ());
 		ASSERT_TRUE (node2.store.block_exists (transaction, publish2.block->hash ()));
 		ASSERT_TRUE (node2.store.block_exists (transaction, publish3.block->hash ()));
 	}
@@ -1071,8 +1071,8 @@ TEST (node, fork_multi_flip)
 		ASSERT_NO_ERROR (system.poll ());
 		done = node2.ledger.block_exists (publish1.block->hash ());
 	}
-	auto transaction1 (system.nodes[0]->store.tx_begin ());
-	auto transaction2 (system.nodes[1]->store.tx_begin ());
+	auto transaction1 (system.nodes[0]->store.tx_begin_read ());
+	auto transaction2 (system.nodes[1]->store.tx_begin_read ());
 	lock.lock ();
 	auto winner (*votes1->tally (transaction2).begin ());
 	ASSERT_EQ (*publish1.block, *winner.second);
@@ -1103,7 +1103,7 @@ TEST (node, fork_bootstrap_flip)
 	node2.block_processor.add (send2, nano::seconds_since_epoch ());
 	node2.block_processor.flush ();
 	{
-		auto transaction (node2.store.tx_begin ());
+		auto transaction (node2.store.tx_begin_read ());
 		ASSERT_TRUE (node2.store.block_exists (transaction, send2->hash ()));
 	}
 	nano::transport::channel_udp channel (node1.network.udp_channels, node2.network.endpoint ());
@@ -1121,7 +1121,7 @@ TEST (node, fork_bootstrap_flip)
 	{
 		ASSERT_NO_ERROR (system0.poll ());
 		ASSERT_NO_ERROR (system1.poll ());
-		auto transaction (node2.store.tx_begin ());
+		auto transaction (node2.store.tx_begin_read ());
 		again = !node2.store.block_exists (transaction, send1->hash ());
 	}
 }
@@ -1197,8 +1197,8 @@ TEST (node, fork_open_flip)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	node2.block_processor.flush ();
-	auto transaction1 (system.nodes[0]->store.tx_begin ());
-	auto transaction2 (system.nodes[1]->store.tx_begin ());
+	auto transaction1 (system.nodes[0]->store.tx_begin_read ());
+	auto transaction2 (system.nodes[1]->store.tx_begin_read ());
 	lock.lock ();
 	auto winner (*votes1->tally (transaction2).begin ());
 	ASSERT_EQ (*open1, *winner.second);
@@ -1213,7 +1213,7 @@ TEST (node, coherent_observer)
 	nano::system system (24000, 1);
 	auto & node1 (*system.nodes[0]);
 	node1.observers.blocks.add ([&node1](std::shared_ptr<nano::block> block_a, nano::account const &, nano::uint128_t const &, bool) {
-		auto transaction (node1.store.tx_begin ());
+		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, block_a->hash ()));
 	});
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
@@ -1232,7 +1232,7 @@ TEST (node, fork_no_vote_quorum)
 	system.wallet (0)->send_action (nano::test_genesis_key.pub, key4, nano::genesis_amount / 4);
 	auto key1 (system.wallet (1)->deterministic_insert ());
 	{
-		auto transaction (system.wallet (1)->wallets.tx_begin (true));
+		auto transaction (system.wallet (1)->wallets.tx_begin_write ());
 		system.wallet (1)->store.representative_set (transaction, key1);
 	}
 	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1, node1.config.receive_minimum.number ()));
@@ -1252,7 +1252,7 @@ TEST (node, fork_no_vote_quorum)
 	auto key2 (system.wallet (2)->deterministic_insert ());
 	auto send2 (std::make_shared<nano::send_block> (block->hash (), key2, (nano::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (block->hash ())));
 	nano::raw_key key3;
-	auto transaction (system.wallet (1)->wallets.tx_begin ());
+	auto transaction (system.wallet (1)->wallets.tx_begin_read ());
 	ASSERT_FALSE (system.wallet (1)->store.fetch (transaction, key1, key3));
 	auto vote (std::make_shared<nano::vote> (key1, key3, 0, send2));
 	nano::confirm_ack confirm (vote);
@@ -1284,13 +1284,13 @@ TEST (node, DISABLED_fork_pre_confirm)
 	nano::keypair key1;
 	system.wallet (1)->insert_adhoc (key1.prv);
 	{
-		auto transaction (system.wallet (1)->wallets.tx_begin (true));
+		auto transaction (system.wallet (1)->wallets.tx_begin_write ());
 		system.wallet (1)->store.representative_set (transaction, key1.pub);
 	}
 	nano::keypair key2;
 	system.wallet (2)->insert_adhoc (key2.prv);
 	{
-		auto transaction (system.wallet (2)->wallets.tx_begin (true));
+		auto transaction (system.wallet (2)->wallets.tx_begin_write ());
 		system.wallet (2)->store.representative_set (transaction, key2.pub);
 	}
 	system.deadline_set (30s);
@@ -1354,9 +1354,9 @@ TEST (node, DISABLED_fork_stale)
 	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Mxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
 	{
-		auto transaction1 (node1.store.tx_begin (true));
+		auto transaction1 (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction1, *send1).code);
-		auto transaction2 (node2.store.tx_begin (true));
+		auto transaction2 (node2.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node2.ledger.process (transaction2, *send2).code);
 	}
 	node1.process_active (send1);
@@ -1384,9 +1384,9 @@ TEST (node, broadcast_elected)
 	//std::cerr << "Small: " << rep_small.pub.to_account () << std::endl;
 	//std::cerr << "Other: " << rep_other.pub.to_account () << std::endl;
 	{
-		auto transaction0 (node0->store.tx_begin (true));
-		auto transaction1 (node1->store.tx_begin (true));
-		auto transaction2 (node2->store.tx_begin (true));
+		auto transaction0 (node0->store.tx_begin_write ());
+		auto transaction1 (node1->store.tx_begin_write ());
+		auto transaction2 (node2->store.tx_begin_write ());
 		nano::send_block fund_big (node0->ledger.latest (transaction0, nano::test_genesis_key.pub), rep_big.pub, nano::Gxrb_ratio * 5, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 		nano::open_block open_big (fund_big.hash (), rep_big.pub, rep_big.pub, rep_big.prv, rep_big.pub, 0);
 		nano::send_block fund_small (fund_big.hash (), rep_small.pub, nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -1449,7 +1449,7 @@ TEST (node, rep_self_vote)
 	auto node0 (system.nodes[0]);
 	nano::keypair rep_big;
 	{
-		auto transaction0 (node0->store.tx_begin (true));
+		auto transaction0 (node0->store.tx_begin_write ());
 		nano::send_block fund_big (node0->ledger.latest (transaction0, nano::test_genesis_key.pub), rep_big.pub, nano::uint128_t ("0xb0000000000000000000000000000000"), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 		nano::open_block open_big (fund_big.hash (), rep_big.pub, rep_big.pub, rep_big.prv, rep_big.pub, 0);
 		node0->work_generate_blocking (fund_big);
@@ -1475,7 +1475,7 @@ TEST (node, rep_self_vote)
 	while (election->last_votes_size () != 3)
 	{
 		lock.lock ();
-		auto transaction (node0->store.tx_begin ());
+		auto transaction (node0->store.tx_begin_read ());
 		election->compute_rep_votes (transaction);
 		lock.unlock ();
 		node0->vote_processor.flush ();
@@ -1498,7 +1498,7 @@ TEST (node, DISABLED_bootstrap_no_publish)
 	// node0 knows about send0 but node1 doesn't.
 	nano::send_block send0 (system0.nodes[0]->latest (nano::test_genesis_key.pub), key0.pub, 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	{
-		auto transaction (node0->store.tx_begin (true));
+		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system0.nodes[0]->ledger.process (transaction, send0).code);
 	}
 	ASSERT_FALSE (node1->bootstrap_initiator.in_progress ());
@@ -1528,7 +1528,7 @@ TEST (node, bootstrap_bulk_push)
 	nano::send_block send0 (system0.nodes[0]->latest (nano::test_genesis_key.pub), key0.pub, 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	node0->work_generate_blocking (send0);
 	{
-		auto transaction (node0->store.tx_begin (true));
+		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system0.nodes[0]->ledger.process (transaction, send0).code);
 	}
 	ASSERT_FALSE (node0->bootstrap_initiator.in_progress ());
@@ -1560,8 +1560,8 @@ TEST (node, bootstrap_fork_open)
 	node0->work_generate_blocking (open0);
 	node0->work_generate_blocking (open1);
 	{
-		auto transaction0 (node0->store.tx_begin (true));
-		auto transaction1 (node1->store.tx_begin (true));
+		auto transaction0 (node0->store.tx_begin_write ());
+		auto transaction1 (node1->store.tx_begin_write ());
 		// Both know about send0
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, send0).code);
 		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, send0).code);
@@ -1593,7 +1593,7 @@ TEST (node, bootstrap_confirm_frontiers)
 	nano::send_block send0 (node0->latest (nano::test_genesis_key.pub), key0.pub, nano::genesis_amount - 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	node0->work_generate_blocking (send0);
 	{
-		auto transaction (node0->store.tx_begin (true));
+		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, send0).code);
 	}
 	ASSERT_FALSE (node0->bootstrap_initiator.in_progress ());
@@ -1652,7 +1652,7 @@ TEST (node, DISABLED_unconfirmed_send)
 	auto latest (node1.latest (key0.pub));
 	nano::state_block send2 (key0.pub, latest, nano::genesis_account, nano::Mxrb_ratio, nano::genesis_account, key0.prv, key0.pub, node0.work_generate_blocking (latest));
 	{
-		auto transaction (node1.store.tx_begin (true));
+		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send2).code);
 	}
 	auto send3 (wallet1->send_action (key0.pub, nano::genesis_account, nano::Mxrb_ratio));
@@ -1776,11 +1776,11 @@ TEST (node, vote_replay)
 	system.nodes[0]->work_generate_blocking (*open);
 	for (auto i (0); i < 11000; ++i)
 	{
-		auto transaction (system.nodes[1]->store.tx_begin ());
+		auto transaction (system.nodes[1]->store.tx_begin_read ());
 		auto vote (system.nodes[1]->store.vote_generate (transaction, nano::test_genesis_key.pub, nano::test_genesis_key.prv, open));
 	}
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		std::lock_guard<std::mutex> lock (boost::polymorphic_downcast<nano::mdb_store *> (system.nodes[0]->store_impl.get ())->cache_mutex);
 		auto vote (system.nodes[0]->store.vote_current (transaction, nano::test_genesis_key.pub));
 		ASSERT_EQ (nullptr, vote);
@@ -1793,7 +1793,7 @@ TEST (node, vote_replay)
 	while (!done)
 	{
 		auto ec = system.poll ();
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		std::lock_guard<std::mutex> lock (boost::polymorphic_downcast<nano::mdb_store *> (system.nodes[0]->store_impl.get ())->cache_mutex);
 		auto vote (system.nodes[0]->store.vote_current (transaction, nano::test_genesis_key.pub));
 		done = vote && (vote->sequence >= 10000);
@@ -1901,11 +1901,11 @@ TEST (node, block_confirm)
 	ASSERT_TRUE (system.nodes[1]->ledger.block_exists (send1->hash ()));
 	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (send1->hash ())));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send2).code);
 	}
 	{
-		auto transaction (system.nodes[1]->store.tx_begin (true));
+		auto transaction (system.nodes[1]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[1]->ledger.process (transaction, *send2).code);
 	}
 	system.nodes[0]->block_confirm (send2);
@@ -1973,7 +1973,7 @@ TEST (node, confirm_quorum)
 	nano::uint128_union new_balance (system.nodes[0]->config.online_weight_minimum.number () - nano::Gxrb_ratio);
 	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, new_balance, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send1).code);
 	}
 	system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, new_balance.number ());
@@ -2007,7 +2007,7 @@ TEST (node, local_votes_cache)
 	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (send1->hash ())));
 	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (send2->hash ())));
 	{
-		auto transaction (node.store.tx_begin (true));
+		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send1).code);
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send2).code);
 	}
@@ -2021,13 +2021,13 @@ TEST (node, local_votes_cache)
 	}
 	{
 		std::lock_guard<std::mutex> lock (boost::polymorphic_downcast<nano::mdb_store *> (node.store_impl.get ())->cache_mutex);
-		auto transaction (node.store.tx_begin (false));
+		auto transaction (node.store.tx_begin_read ());
 		auto current_vote (node.store.vote_current (transaction, nano::test_genesis_key.pub));
 		ASSERT_EQ (current_vote->sequence, 2);
 	}
 	// Max cache
 	{
-		auto transaction (node.store.tx_begin (true));
+		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send3).code);
 	}
 	nano::confirm_req message3 (send3);
@@ -2037,7 +2037,7 @@ TEST (node, local_votes_cache)
 	}
 	{
 		std::lock_guard<std::mutex> lock (boost::polymorphic_downcast<nano::mdb_store *> (node.store_impl.get ())->cache_mutex);
-		auto transaction (node.store.tx_begin (false));
+		auto transaction (node.store.tx_begin_read ());
 		auto current_vote (node.store.vote_current (transaction, nano::test_genesis_key.pub));
 		ASSERT_EQ (current_vote->sequence, 3);
 	}
@@ -2429,21 +2429,21 @@ TEST (node, unchecked_cleanup)
 	node.block_processor.flush ();
 	node.config.unchecked_cutoff_time = std::chrono::seconds (2);
 	{
-		auto transaction (node.store.tx_begin ());
+		auto transaction (node.store.tx_begin_read ());
 		auto unchecked_count (node.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
 	}
 	std::this_thread::sleep_for (std::chrono::seconds (1));
 	node.unchecked_cleanup ();
 	{
-		auto transaction (node.store.tx_begin ());
+		auto transaction (node.store.tx_begin_read ());
 		auto unchecked_count (node.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
 	}
 	std::this_thread::sleep_for (std::chrono::seconds (2));
 	node.unchecked_cleanup ();
 	{
-		auto transaction (node.store.tx_begin ());
+		auto transaction (node.store.tx_begin_read ());
 		auto unchecked_count (node.store.unchecked_count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
 	}

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -16,7 +16,7 @@ TEST (processor_service, bad_send_signature)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));
@@ -35,7 +35,7 @@ TEST (processor_service, bad_receive_signature)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::account_info info1;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info1));

--- a/nano/core_test/versioning.cpp
+++ b/nano/core_test/versioning.cpp
@@ -14,7 +14,7 @@ TEST (versioning, account_info_v1)
 		auto error (false);
 		nano::mdb_store store (error, logger, file);
 		ASSERT_FALSE (error);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
 		store.block_put (transaction, open.hash (), open, sideband);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (account), v1.val (), 0));
@@ -26,7 +26,7 @@ TEST (versioning, account_info_v1)
 	auto error (false);
 	nano::mdb_store store (error, logger, file);
 	ASSERT_FALSE (error);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	nano::account_info v_latest;
 	ASSERT_FALSE (store.account_get (transaction, account, v_latest));
 	ASSERT_EQ (open.hash (), v_latest.open_block);
@@ -50,7 +50,7 @@ TEST (versioning, account_info_v5)
 		auto error (false);
 		nano::mdb_store store (error, logger, file);
 		ASSERT_FALSE (error);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
 		store.block_put (transaction, open.hash (), open, sideband);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (account), v5.val (), 0));
@@ -62,7 +62,7 @@ TEST (versioning, account_info_v5)
 	auto error (false);
 	nano::mdb_store store (error, logger, file);
 	ASSERT_FALSE (error);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	nano::account_info v_latest;
 	ASSERT_FALSE (store.account_get (transaction, account, v_latest));
 	ASSERT_EQ (v5.open_block, v_latest.open_block);
@@ -86,7 +86,7 @@ TEST (versioning, account_info_v13)
 		auto error (false);
 		nano::mdb_store store (error, logger, file);
 		ASSERT_FALSE (error);
-		auto transaction (store.tx_begin (true));
+		auto transaction (store.tx_begin_write ());
 		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
 		store.block_put (transaction, open.hash (), open, sideband);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (account), nano::mdb_val (v13), 0));
@@ -98,7 +98,7 @@ TEST (versioning, account_info_v13)
 	auto error (false);
 	nano::mdb_store store (error, logger, file);
 	ASSERT_FALSE (error);
-	auto transaction (store.tx_begin ());
+	auto transaction (store.tx_begin_read ());
 	nano::account_info v_latest;
 	ASSERT_FALSE (store.account_get (transaction, account, v_latest));
 	ASSERT_EQ (v13.open_block, v_latest.open_block);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -12,7 +12,7 @@ TEST (wallet, no_key)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -27,7 +27,7 @@ TEST (wallet, fetch_locked)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_TRUE (wallet.valid_password (transaction));
@@ -49,7 +49,7 @@ TEST (wallet, retrieval)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -71,7 +71,7 @@ TEST (wallet, empty_iteration)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -85,7 +85,7 @@ TEST (wallet, one_item_iteration)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -114,7 +114,7 @@ TEST (wallet, two_item_iteration)
 	std::unordered_set<nano::private_key> prvs;
 	nano::kdf kdf;
 	{
-		nano::transaction transaction (env.tx_begin (true));
+		auto transaction (env.tx_begin_write ());
 		nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 		ASSERT_FALSE (init);
 		wallet.insert_adhoc (transaction, key1.prv);
@@ -156,7 +156,7 @@ TEST (wallet, spend_all_one)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
 	nano::account_info info2;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info2);
 		ASSERT_NE (latest1, info2.head);
 		auto block (system.nodes[0]->store.block_get (transaction, info2.head));
@@ -196,7 +196,7 @@ TEST (wallet, spend)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
 	nano::account_info info2;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info2);
 		ASSERT_NE (latest1, info2.head);
 		auto block (system.nodes[0]->store.block_get (transaction, info2.head));
@@ -234,7 +234,7 @@ TEST (wallet, spend_no_previous)
 	nano::system system (24000, 1);
 	{
 		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		nano::account_info info1;
 		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info1));
 		for (auto i (0); i < 50; ++i)
@@ -253,7 +253,7 @@ TEST (wallet, find_none)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -266,7 +266,7 @@ TEST (wallet, find_existing)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -285,7 +285,7 @@ TEST (wallet, rekey)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -357,7 +357,7 @@ TEST (wallet, hash_password)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (init);
@@ -405,7 +405,7 @@ TEST (wallet, reopen_default_password)
 {
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	ASSERT_FALSE (init);
 	nano::kdf kdf;
 	{
@@ -442,7 +442,7 @@ TEST (wallet, representative)
 	auto error (false);
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (error, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (error);
@@ -463,7 +463,7 @@ TEST (wallet, serialize_json_empty)
 	auto error (false);
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (error);
@@ -488,7 +488,7 @@ TEST (wallet, serialize_json_one)
 	auto error (false);
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (error);
@@ -517,7 +517,7 @@ TEST (wallet, serialize_json_password)
 	auto error (false);
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (error);
@@ -550,7 +550,7 @@ TEST (wallet_store, move)
 	auto error (false);
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::genesis_account, 1, "0");
 	ASSERT_FALSE (error);
@@ -618,7 +618,7 @@ TEST (wallet, work)
 	system.deadline_set (10s);
 	while (!done)
 	{
-		nano::transaction transaction (system.wallet (0)->wallets.tx_begin ());
+		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 		uint64_t work (0);
 		if (!wallet->store.work_get (transaction, nano::test_genesis_key.pub, work))
 		{
@@ -637,13 +637,13 @@ TEST (wallet, work_generate)
 	wallet->insert_adhoc (nano::test_genesis_key.prv);
 	nano::account account1;
 	{
-		nano::transaction transaction (system.nodes[0]->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
 	wallet->send_action (nano::test_genesis_key.pub, key.pub, 100);
 	system.deadline_set (10s);
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	while (system.nodes[0]->ledger.account_balance (transaction, nano::test_genesis_key.pub) == amount1)
 	{
 		ASSERT_NO_ERROR (system.poll ());
@@ -653,8 +653,8 @@ TEST (wallet, work_generate)
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto block_transaction (system.nodes[0]->store.tx_begin ());
-		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		auto block_transaction (system.nodes[0]->store.tx_begin_read ());
+		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 		again = wallet->store.work_get (transaction, account1, work1) || nano::work_validate (system.nodes[0]->ledger.latest_root (block_transaction, account1), work1);
 	}
 }
@@ -664,12 +664,12 @@ TEST (wallet, insert_locked)
 	nano::system system (24000, 1);
 	auto wallet (system.wallet (0));
 	{
-		auto transaction (wallet->wallets.tx_begin (true));
+		auto transaction (wallet->wallets.tx_begin_write ());
 		wallet->store.rekey (transaction, "1");
 		ASSERT_TRUE (wallet->store.valid_password (transaction));
 		wallet->enter_password (transaction, "");
 	}
-	auto transaction (wallet->wallets.tx_begin ());
+	auto transaction (wallet->wallets.tx_begin_read ());
 	ASSERT_FALSE (wallet->store.valid_password (transaction));
 	ASSERT_TRUE (wallet->insert_adhoc (nano::keypair ().prv).is_zero ());
 }
@@ -680,7 +680,7 @@ TEST (wallet, version_1_upgrade)
 	auto wallet (system.wallet (0));
 	wallet->enter_initial_password ();
 	nano::keypair key;
-	auto transaction (wallet->wallets.tx_begin (true));
+	auto transaction (wallet->wallets.tx_begin_write ());
 	ASSERT_TRUE (wallet->store.valid_password (transaction));
 	wallet->store.rekey (transaction, "1");
 	wallet->enter_password (transaction, "");
@@ -719,7 +719,7 @@ TEST (wallet, deterministic_keys)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	nano::raw_key key1;
@@ -765,7 +765,7 @@ TEST (wallet, reseed)
 	bool init;
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
-	nano::transaction transaction (env.tx_begin (true));
+	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store wallet (init, kdf, transaction, nano::genesis_account, 1, "0");
 	nano::raw_key seed1;
@@ -797,7 +797,7 @@ TEST (wallet, insert_deterministic_locked)
 {
 	nano::system system (24000, 1);
 	auto wallet (system.wallet (0));
-	auto transaction (wallet->wallets.tx_begin (true));
+	auto transaction (wallet->wallets.tx_begin_write ());
 	wallet->store.rekey (transaction, "1");
 	ASSERT_TRUE (wallet->store.valid_password (transaction));
 	wallet->enter_password (transaction, "");
@@ -809,7 +809,7 @@ TEST (wallet, version_2_upgrade)
 {
 	nano::system system (24000, 1);
 	auto wallet (system.wallet (0));
-	auto transaction (wallet->wallets.tx_begin (true));
+	auto transaction (wallet->wallets.tx_begin_write ());
 	wallet->store.rekey (transaction, "1");
 	ASSERT_TRUE (wallet->store.attempt_password (transaction, ""));
 	wallet->store.erase (transaction, nano::wallet_store::deterministic_index_special);
@@ -829,7 +829,7 @@ TEST (wallet, version_3_upgrade)
 {
 	nano::system system (24000, 1);
 	auto wallet (system.wallet (0));
-	auto transaction (wallet->wallets.tx_begin (true));
+	auto transaction (wallet->wallets.tx_begin_write ());
 	wallet->store.rekey (transaction, "1");
 	wallet->enter_password (transaction, "1");
 	ASSERT_TRUE (wallet->store.valid_password (transaction));
@@ -870,7 +870,7 @@ TEST (wallet, no_work)
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
 	ASSERT_FALSE (nano::work_validate (block->root (), block->block_work ()));
-	auto transaction (system.wallet (0)->wallets.tx_begin ());
+	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	uint64_t cached_work (0);
 	system.wallet (0)->store.work_get (transaction, nano::test_genesis_key.pub, cached_work);
 	ASSERT_EQ (0, cached_work);
@@ -896,13 +896,13 @@ TEST (wallet, password_race)
 	system.nodes[0]->background ([&wallet]() {
 		for (int i = 0; i < 100; i++)
 		{
-			auto transaction (wallet->wallets.tx_begin (true));
+			auto transaction (wallet->wallets.tx_begin_write ());
 			wallet->store.rekey (transaction, std::to_string (i));
 		}
 	});
 	for (int i = 0; i < 100; i++)
 	{
-		auto transaction (wallet->wallets.tx_begin ());
+		auto transaction (wallet->wallets.tx_begin_read ());
 		// Password should always be valid, the rekey operation should be atomic.
 		bool ok = wallet->store.valid_password (transaction);
 		EXPECT_TRUE (ok);
@@ -922,7 +922,7 @@ TEST (wallet, password_race_corrupt_seed)
 	auto wallet = system.wallet (0);
 	nano::raw_key seed;
 	{
-		auto transaction (wallet->wallets.tx_begin (true));
+		auto transaction (wallet->wallets.tx_begin_write ());
 		ASSERT_FALSE (wallet->store.rekey (transaction, "4567"));
 		wallet->store.seed (seed, transaction);
 		ASSERT_FALSE (wallet->store.attempt_password (transaction, "4567"));
@@ -932,21 +932,21 @@ TEST (wallet, password_race_corrupt_seed)
 		system.nodes[0]->background ([&wallet]() {
 			for (int i = 0; i < 10; i++)
 			{
-				auto transaction (wallet->wallets.tx_begin (true));
+				auto transaction (wallet->wallets.tx_begin_write ());
 				wallet->store.rekey (transaction, "0000");
 			}
 		});
 		system.nodes[0]->background ([&wallet]() {
 			for (int i = 0; i < 10; i++)
 			{
-				auto transaction (wallet->wallets.tx_begin (true));
+				auto transaction (wallet->wallets.tx_begin_write ());
 				wallet->store.rekey (transaction, "1234");
 			}
 		});
 		system.nodes[0]->background ([&wallet]() {
 			for (int i = 0; i < 10; i++)
 			{
-				auto transaction (wallet->wallets.tx_begin ());
+				auto transaction (wallet->wallets.tx_begin_read ());
 				wallet->store.attempt_password (transaction, "1234");
 			}
 		});
@@ -954,7 +954,7 @@ TEST (wallet, password_race_corrupt_seed)
 	system.stop ();
 	runner.join ();
 	{
-		auto transaction (wallet->wallets.tx_begin (true));
+		auto transaction (wallet->wallets.tx_begin_write ());
 		if (!wallet->store.attempt_password (transaction, "1234"))
 		{
 			nano::raw_key seed_now;

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -107,9 +107,9 @@ TEST (wallets, upgrade)
 	ASSERT_EQ (1, node1->wallets.items.size ());
 	ASSERT_EQ (id.pub, node1->wallets.items.begin ()->first);
 	auto transaction_new (node1->wallets.env.tx_begin_write ());
-	auto tx_new = static_cast<MDB_txn*> (transaction_new.get_handle ());
+	auto tx_new = static_cast<MDB_txn *> (transaction_new.get_handle ());
 	auto transaction_old (node1->store.tx_begin_write ());
-	auto tx_old = static_cast<MDB_txn*> (transaction_old.get_handle ());
+	auto tx_old = static_cast<MDB_txn *> (transaction_old.get_handle ());
 	MDB_dbi old_handle;
 	ASSERT_EQ (MDB_NOTFOUND, mdb_dbi_open (tx_old, id.pub.to_string ().c_str (), 0, &old_handle));
 	MDB_dbi new_handle;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -157,7 +157,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_block_count"))
 		{
 			nano::inactive_node node (data_path);
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 			std::cout << boost::str (boost::format ("Block count: %1%\n") % node.node->store.block_count (transaction).sum ());
 		}
 		else if (vm.count ("debug_bootstrap_generate"))
@@ -235,7 +235,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_dump_representatives"))
 		{
 			nano::inactive_node node (data_path);
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 			nano::uint128_t total;
 			for (auto i (node.node->store.representation_begin (transaction)), n (node.node->store.representation_end ()); i != n; ++i)
 			{
@@ -265,7 +265,7 @@ int main (int argc, char * const * argv)
 			std::cout << "Outputting any frontier hashes which have associated key hashes in the unchecked table (may take some time)...\n";
 
 			// Cache the account heads to make searching quicker against unchecked keys.
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 			std::unordered_set<nano::block_hash> frontier_hashes;
 			for (auto i (node.node->store.latest_begin (transaction)), n (node.node->store.latest_end ()); i != n; ++i)
 			{
@@ -285,7 +285,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_account_count"))
 		{
 			nano::inactive_node node (data_path);
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % node.node->store.account_count (transaction));
 		}
 		else if (vm.count ("debug_mass_activity"))
@@ -606,7 +606,7 @@ int main (int argc, char * const * argv)
 			while (block_count < max_blocks + 1)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (100));
-				auto transaction (node->store.tx_begin ());
+				auto transaction (node->store.tx_begin_read ());
 				block_count = node->store.block_count (transaction).sum ();
 			}
 			auto end (std::chrono::high_resolution_clock::now ());
@@ -765,7 +765,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_validate_blocks"))
 		{
 			nano::inactive_node node (data_path);
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 			std::cerr << boost::str (boost::format ("Performing blocks hash, signature, work validation...\n"));
 			size_t count (0);
 			for (auto i (node.node->store.latest_begin (transaction)), n (node.node->store.latest_end ()); i != n; ++i)
@@ -928,7 +928,7 @@ int main (int argc, char * const * argv)
 			size_t count (0);
 			{
 				nano::inactive_node node (data_path, 24000);
-				auto transaction (node.node->store.tx_begin ());
+				auto transaction (node.node->store.tx_begin_read ());
 				block_count = node.node->store.block_count (transaction).sum ();
 				std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
 				for (auto i (node.node->store.latest_begin (transaction)), n (node.node->store.latest_end ()); i != n; ++i)
@@ -960,7 +960,7 @@ int main (int argc, char * const * argv)
 			while (block_count_2 != block_count)
 			{
 				std::this_thread::sleep_for (std::chrono::seconds (1));
-				auto transaction_2 (node2.node->store.tx_begin ());
+				auto transaction_2 (node2.node->store.tx_begin_read ());
 				block_count_2 = node2.node->store.block_count (transaction_2).sum ();
 				if ((count % 60) == 0)
 				{
@@ -977,7 +977,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_peers"))
 		{
 			nano::inactive_node node (data_path);
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 
 			for (auto i (node.node->store.peers_begin (transaction)), n (node.node->store.peers_end ()); i != n; ++i)
 			{
@@ -987,7 +987,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_cemented_block_count"))
 		{
 			nano::inactive_node node (data_path);
-			auto transaction (node.node->store.tx_begin ());
+			auto transaction (node.node->store.tx_begin_read ());
 
 			uint64_t sum = 0;
 			for (auto i (node.node->store.latest_begin (transaction)), n (node.node->store.latest_end ()); i != n; ++i)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -277,7 +277,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 			}
 			if (config.account.is_zero () || !wallet->exists (config.account))
 			{
-				auto transaction (wallet->wallets.tx_begin (true));
+				auto transaction (wallet->wallets.tx_begin_write ());
 				auto existing (wallet->store.begin (transaction));
 				if (existing != wallet->store.end ())
 				{

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -23,7 +23,7 @@ public:
 	~read_mdb_txn ();
 	void reset () const override;
 	void renew () const override;
-	void * get_handle () const;
+	void * get_handle () const override;
 	MDB_txn * handle;
 };
 
@@ -34,7 +34,7 @@ public:
 	~write_mdb_txn ();
 	void commit () const override;
 	void renew () override;
-	void * get_handle () const;
+	void * get_handle () const override;
 	MDB_txn * handle;
 	nano::mdb_env const & env;
 };

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -16,17 +16,27 @@ namespace nano
 {
 class mdb_env;
 class account_info_v13;
-class mdb_txn : public transaction_impl
+class read_mdb_txn final : public read_transaction_impl
 {
 public:
-	mdb_txn (nano::mdb_env const &, bool = false);
-	mdb_txn (nano::mdb_txn const &) = delete;
-	mdb_txn (nano::mdb_txn &&) = default;
-	~mdb_txn ();
-	nano::mdb_txn & operator= (nano::mdb_txn const &) = delete;
-	nano::mdb_txn & operator= (nano::mdb_txn &&) = default;
-	operator MDB_txn * () const;
+	read_mdb_txn (nano::mdb_env const & environment_a);
+	~read_mdb_txn ();
+	void reset () const override;
+	void renew () const override;
+	void * get_handle () const;
 	MDB_txn * handle;
+};
+
+class write_mdb_txn final : public write_transaction_impl
+{
+public:
+	write_mdb_txn (nano::mdb_env const & environment_a);
+	~write_mdb_txn ();
+	void commit () const override;
+	void renew () override;
+	void * get_handle () const;
+	MDB_txn * handle;
+	nano::mdb_env const & env;
 };
 /**
  * RAII wrapper for MDB_env
@@ -37,8 +47,9 @@ public:
 	mdb_env (bool &, boost::filesystem::path const &, int max_dbs = 128, size_t map_size = 128ULL * 1024 * 1024 * 1024);
 	~mdb_env ();
 	operator MDB_env * () const;
-	nano::transaction tx_begin (bool = false) const;
-	MDB_txn * tx (nano::transaction const &) const;
+	nano::read_transaction tx_begin_read () const;
+	nano::write_transaction tx_begin_write () const;
+	MDB_txn * tx (nano::transaction const & transaction_a) const;
 	MDB_env * environment;
 };
 
@@ -155,9 +166,8 @@ class mdb_store : public block_store
 
 public:
 	mdb_store (bool &, nano::logger_mt &, boost::filesystem::path const &, int lmdb_max_dbs = 128, bool drop_unchecked = false, size_t batch_size = 512);
-	nano::transaction tx_begin_write () override;
-	nano::transaction tx_begin_read () override;
-	nano::transaction tx_begin (bool write = false) override;
+	nano::write_transaction tx_begin_write () override;
+	nano::read_transaction tx_begin_read () override;
 
 	void initialize (nano::transaction const &, nano::genesis const &) override;
 	void block_put (nano::transaction const &, nano::block_hash const &, nano::block const &, nano::block_sideband const &, nano::epoch version = nano::epoch::epoch_0) override;
@@ -394,7 +404,7 @@ private:
 	boost::optional<MDB_val> block_raw_get_by_type (nano::transaction const &, nano::block_hash const &, nano::block_type &) const;
 	void block_raw_put (nano::transaction const &, MDB_dbi, nano::block_hash const &, MDB_val);
 	void clear (MDB_dbi);
-	void do_upgrades (nano::transaction const &, size_t);
+	void do_upgrades (nano::write_transaction &, size_t);
 	void upgrade_v1_to_v2 (nano::transaction const &);
 	void upgrade_v2_to_v3 (nano::transaction const &);
 	void upgrade_v3_to_v4 (nano::transaction const &);
@@ -406,7 +416,7 @@ private:
 	void upgrade_v9_to_v10 (nano::transaction const &);
 	void upgrade_v10_to_v11 (nano::transaction const &);
 	void upgrade_v11_to_v12 (nano::transaction const &);
-	void upgrade_v12_to_v13 (nano::transaction const &, size_t);
+	void upgrade_v12_to_v13 (nano::write_transaction &, size_t);
 	void upgrade_v13_to_v14 (nano::transaction const &);
 	MDB_dbi get_pending_db (nano::epoch epoch_a) const;
 };

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1794,10 +1794,10 @@ void nano::wallets::split_if_needed (nano::transaction & transaction_destination
 	if (store_l != nullptr)
 	{
 		auto transaction_source (store_l->tx_begin_write ());
-		auto tx_source = static_cast<MDB_txn*> (transaction_source.get_handle ());
+		auto tx_source = static_cast<MDB_txn *> (transaction_source.get_handle ());
 		if (items.empty ())
 		{
-			auto tx_destination = static_cast<MDB_txn*> (transaction_destination.get_handle ());
+			auto tx_destination = static_cast<MDB_txn *> (transaction_destination.get_handle ());
 			std::string beginning (nano::uint256_union (0).to_string ());
 			std::string end ((nano::uint256_union (nano::uint256_t (0) - nano::uint256_t (1))).to_string ());
 			nano::store_iterator<std::array<char, 64>, nano::no_value> i (std::make_unique<nano::mdb_iterator<std::array<char, 64>, nano::no_value>> (transaction_source, handle, nano::mdb_val (beginning.size (), const_cast<char *> (beginning.c_str ()))));

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -994,7 +994,7 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 	std::shared_ptr<nano::block> block;
 	{
 		auto transaction (wallets.tx_begin_read ());
-		auto block_transaction (wallets.node.store.tx_begin ());
+		auto block_transaction (wallets.node.store.tx_begin_read ());
 		if (store.valid_password (transaction))
 		{
 			auto existing (store.find (transaction, source_a));
@@ -1034,17 +1034,18 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 
 std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & source_a, nano::account const & account_a, nano::uint128_t const & amount_a, uint64_t work_a, bool generate_work_a, boost::optional<std::string> id_a)
 {
-	std::shared_ptr<nano::block> block;
 	boost::optional<nano::mdb_val> id_mdb_val;
 	if (id_a)
 	{
 		id_mdb_val = nano::mdb_val (id_a->size (), const_cast<char *> (id_a->data ()));
 	}
-	bool error = false;
-	bool cached_block = false;
-	{
-		auto transaction (wallets.tx_begin ((bool)id_mdb_val));
+
+	// clang-format off
+	auto prepare_send = [&id_mdb_val, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a] (const auto & transaction) {
 		auto block_transaction (wallets.node.store.tx_begin_read ());
+		auto error (false);
+		auto cached_block (false);
+		std::shared_ptr<nano::block> block;
 		if (id_mdb_val)
 		{
 			nano::mdb_val result;
@@ -1100,7 +1101,27 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 				}
 			}
 		}
+		return std::make_tuple (block, error, cached_block);
+	};
+	// clang-format on
+
+	std::tuple<std::shared_ptr<nano::block>, bool, bool> result;
+	{
+		if (id_mdb_val)
+		{
+			result = prepare_send (wallets.tx_begin_write ());
+		}
+		else
+		{
+			result = prepare_send (wallets.tx_begin_read ());
+		}
 	}
+
+	std::shared_ptr<nano::block> block;
+	bool error;
+	bool cached_block;
+	std::tie (block, error, cached_block) = result;
+
 	if (!error && block != nullptr && !cached_block)
 	{
 		if (nano::work_validate (*block))
@@ -1717,19 +1738,14 @@ void nano::wallets::stop ()
 	}
 }
 
-nano::transaction nano::wallets::tx_begin_write ()
+nano::write_transaction nano::wallets::tx_begin_write ()
 {
-	return tx_begin (true);
+	return env.tx_begin_write ();
 }
 
-nano::transaction nano::wallets::tx_begin_read ()
+nano::read_transaction nano::wallets::tx_begin_read ()
 {
-	return tx_begin (false);
-}
-
-nano::transaction nano::wallets::tx_begin (bool write_a)
-{
-	return env.tx_begin (write_a);
+	return env.tx_begin_read ();
 }
 
 void nano::wallets::clear_send_ids (nano::transaction const & transaction_a)
@@ -1778,10 +1794,10 @@ void nano::wallets::split_if_needed (nano::transaction & transaction_destination
 	if (store_l != nullptr)
 	{
 		auto transaction_source (store_l->tx_begin_write ());
-		MDB_txn * tx_source (*boost::polymorphic_downcast<nano::mdb_txn *> (transaction_source.impl.get ()));
+		auto tx_source = static_cast<MDB_txn*> (transaction_source.get_handle ());
 		if (items.empty ())
 		{
-			MDB_txn * tx_destination (*boost::polymorphic_downcast<nano::mdb_txn *> (transaction_destination.impl.get ()));
+			auto tx_destination = static_cast<MDB_txn*> (transaction_destination.get_handle ());
 			std::string beginning (nano::uint256_union (0).to_string ());
 			std::string end ((nano::uint256_union (nano::uint256_t (0) - nano::uint256_t (1))).to_string ());
 			nano::store_iterator<std::array<char, 64>, nano::no_value> i (std::make_unique<nano::mdb_iterator<std::array<char, 64>, nano::no_value>> (transaction_source, handle, nano::mdb_val (beginning.size (), const_cast<char *> (beginning.c_str ()))));
@@ -1870,8 +1886,7 @@ environment (error_a, path_a, lmdb_max_dbs, 1ULL * 1024 * 1024 * 1024)
 }
 MDB_txn * nano::wallet_store::tx (nano::transaction const & transaction_a) const
 {
-	auto result (boost::polymorphic_downcast<nano::mdb_txn *> (transaction_a.impl.get ()));
-	return *result;
+	return static_cast<MDB_txn*> (transaction_a.get_handle ());
 }
 
 namespace nano

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1886,7 +1886,7 @@ environment (error_a, path_a, lmdb_max_dbs, 1ULL * 1024 * 1024 * 1024)
 }
 MDB_txn * nano::wallet_store::tx (nano::transaction const & transaction_a) const
 {
-	return static_cast<MDB_txn*> (transaction_a.get_handle ());
+	return static_cast<MDB_txn *> (transaction_a.get_handle ());
 }
 
 namespace nano

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -221,16 +221,10 @@ public:
 	std::atomic<uint64_t> reps_count{ 0 };
 
 	/** Start read-write transaction */
-	nano::transaction tx_begin_write ();
+	nano::write_transaction tx_begin_write ();
 
 	/** Start read-only transaction */
-	nano::transaction tx_begin_read ();
-
-	/**
-	 * Start a read-only or read-write transaction
-	 * @param write If true, start a read-write transaction
-	 */
-	nano::transaction tx_begin (bool write = false);
+	nano::read_transaction tx_begin_read ();
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (wallets & wallets, const std::string & name);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -647,7 +647,7 @@ TEST (rpc, wallet_password_change)
 	ASSERT_EQ (200, response.status);
 	std::string account_text1 (response.json.get<std::string> ("changed"));
 	ASSERT_EQ (account_text1, "1");
-	auto transaction (system.wallet (0)->wallets.tx_begin (true));
+	auto transaction (system.wallet (0)->wallets.tx_begin_write ());
 	ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
 	ASSERT_TRUE (system.wallet (0)->enter_password (transaction, ""));
 	ASSERT_FALSE (system.wallet (0)->store.valid_password (transaction));
@@ -743,7 +743,7 @@ TEST (rpc, wallet_representative_set)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response.status);
-	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 	ASSERT_EQ (key.pub, system.nodes[0]->wallets.items.begin ()->second->store.representative (transaction));
 }
 
@@ -775,7 +775,7 @@ TEST (rpc, wallet_representative_set_force)
 	}
 	ASSERT_EQ (200, response.status);
 	{
-		auto transaction (system.nodes[0]->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 		ASSERT_EQ (key.pub, system.nodes[0]->wallets.items.begin ()->second->store.representative (transaction));
 	}
 	nano::account representative (0);
@@ -956,7 +956,7 @@ TEST (rpc, wallet_export)
 	ASSERT_EQ (200, response.status);
 	std::string wallet_json (response.json.get<std::string> ("json"));
 	bool error (false);
-	auto transaction (system.nodes[0]->wallets.tx_begin (true));
+	auto transaction (system.nodes[0]->wallets.tx_begin_write ());
 	nano::kdf kdf;
 	nano::wallet_store store (error, kdf, transaction, nano::genesis_account, 1, "0", wallet_json);
 	ASSERT_FALSE (error);
@@ -1026,7 +1026,7 @@ TEST (rpc, account_move)
 	ASSERT_EQ ("1", response.json.get<std::string> ("moved"));
 	ASSERT_TRUE (destination->exists (key.pub));
 	ASSERT_TRUE (destination->exists (nano::test_genesis_key.pub));
-	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 	ASSERT_EQ (source->store.end (), source->store.begin (transaction));
 }
 
@@ -1204,7 +1204,7 @@ TEST (rpc, frontier)
 	nano::system system (24000, 1);
 	std::unordered_map<nano::account, nano::block_hash> source;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		for (auto i (0); i < 1000; ++i)
 		{
 			nano::keypair key;
@@ -1251,7 +1251,7 @@ TEST (rpc, frontier_limited)
 	nano::system system (24000, 1);
 	std::unordered_map<nano::account, nano::block_hash> source;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		for (auto i (0); i < 1000; ++i)
 		{
 			nano::keypair key;
@@ -1288,7 +1288,7 @@ TEST (rpc, frontier_startpoint)
 	nano::system system (24000, 1);
 	std::unordered_map<nano::account, nano::block_hash> source;
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		for (auto i (0); i < 1000; ++i)
 		{
 			nano::keypair key;
@@ -1337,7 +1337,7 @@ TEST (rpc, history)
 	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
 	{
-		auto transaction (node0->store.tx_begin (true));
+		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, ureceive).code);
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, uchange).code);
@@ -1903,7 +1903,7 @@ TEST (rpc, payment_begin_end)
 	ASSERT_TRUE (wallet->exists (account));
 	nano::block_hash root1;
 	{
-		auto transaction (node1->store.tx_begin ());
+		auto transaction (node1->store.tx_begin_read ());
 		root1 = node1->ledger.latest_root (transaction, account);
 	}
 	uint64_t work (0);
@@ -1916,7 +1916,7 @@ TEST (rpc, payment_begin_end)
 	while (nano::work_validate (root1, work))
 	{
 		auto ec = system.poll ();
-		auto transaction (wallet->wallets.tx_begin ());
+		auto transaction (wallet->wallets.tx_begin_read ());
 		ASSERT_FALSE (wallet->store.work_get (transaction, account, work));
 		ASSERT_NO_ERROR (ec);
 	}
@@ -1943,7 +1943,7 @@ TEST (rpc, payment_end_nonempty)
 	nano::system system (24000, 1);
 	auto node1 (system.nodes[0]);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto transaction (node1->wallets.tx_begin ());
+	auto transaction (node1->wallets.tx_begin_read ());
 	system.wallet (0)->init_free_accounts (transaction);
 	auto wallet_id (node1->wallets.items.begin ()->first);
 	enable_ipc_transport_tcp (node1->config.ipc_config.transport_tcp);
@@ -1972,7 +1972,7 @@ TEST (rpc, payment_zero_balance)
 	nano::system system (24000, 1);
 	auto node1 (system.nodes[0]);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto transaction (node1->wallets.tx_begin ());
+	auto transaction (node1->wallets.tx_begin_read ());
 	system.wallet (0)->init_free_accounts (transaction);
 	auto wallet_id (node1->wallets.items.begin ()->first);
 	enable_ipc_transport_tcp (node1->config.ipc_config.transport_tcp);
@@ -2060,7 +2060,7 @@ TEST (rpc, payment_begin_locked)
 	nano::keypair wallet_id;
 	auto wallet (node1->wallets.create (wallet_id.pub));
 	{
-		auto transaction (wallet->wallets.tx_begin (true));
+		auto transaction (wallet->wallets.tx_begin_write ());
 		wallet->store.rekey (transaction, "1");
 		ASSERT_TRUE (wallet->store.attempt_password (transaction, ""));
 	}
@@ -2347,7 +2347,7 @@ TEST (rpc, search_pending)
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (latest));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
 	}
 	auto node = system.nodes.front ();
@@ -2401,7 +2401,7 @@ TEST (rpc, version)
 	ASSERT_EQ ("1", response1.json.get<std::string> ("rpc_version"));
 	ASSERT_EQ (200, response1.status);
 	{
-		auto transaction (system.nodes[0]->store.tx_begin ());
+		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_EQ (std::to_string (node1->store.version_get (transaction)), response1.json.get<std::string> ("store_version"));
 	}
 	ASSERT_EQ (std::to_string (nano::protocol_version), response1.json.get<std::string> ("protocol_version"));
@@ -2975,7 +2975,7 @@ TEST (rpc, account_representative_set)
 	nano::block_hash hash;
 	ASSERT_FALSE (hash.decode_hex (block_text1));
 	ASSERT_FALSE (hash.is_zero ());
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	ASSERT_TRUE (system.nodes[0]->store.block_exists (transaction, hash));
 	ASSERT_EQ (rep.pub, system.nodes[0]->store.block_get (transaction, hash)->representative ());
 }
@@ -2987,7 +2987,7 @@ TEST (rpc, bootstrap)
 	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
 	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system1.nodes[0]->work_generate_blocking (latest));
 	{
-		auto transaction (system1.nodes[0]->store.tx_begin (true));
+		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
 	}
 	auto & node = system0.nodes.front ();
@@ -3077,7 +3077,7 @@ TEST (rpc, wallet_seed)
 	nano::system system (24000, 1);
 	nano::raw_key seed;
 	{
-		auto transaction (system.nodes[0]->wallets.tx_begin ());
+		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 		system.wallet (0)->store.seed (seed, transaction);
 	}
 	auto & node = system.nodes.front ();
@@ -3109,7 +3109,7 @@ TEST (rpc, wallet_change_seed)
 	nano::system system0 (24000, 1);
 	nano::keypair seed;
 	{
-		auto transaction (system0.nodes[0]->wallets.tx_begin ());
+		auto transaction (system0.nodes[0]->wallets.tx_begin_read ());
 		nano::raw_key seed0;
 		system0.wallet (0)->store.seed (seed0, transaction);
 		ASSERT_NE (seed.pub, seed0.data);
@@ -3137,7 +3137,7 @@ TEST (rpc, wallet_change_seed)
 	}
 	ASSERT_EQ (200, response.status);
 	{
-		auto transaction (system0.nodes[0]->wallets.tx_begin ());
+		auto transaction (system0.nodes[0]->wallets.tx_begin_read ());
 		nano::raw_key seed0;
 		system0.wallet (0)->store.seed (seed0, transaction);
 		ASSERT_EQ (seed.pub, seed0.data);
@@ -3317,7 +3317,7 @@ TEST (rpc, bootstrap_any)
 	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
 	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system1.nodes[0]->work_generate_blocking (latest));
 	{
-		auto transaction (system1.nodes[0]->store.tx_begin (true));
+		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
 	}
 	auto & node = system0.nodes.front ();
@@ -3425,7 +3425,7 @@ TEST (rpc, deterministic_key)
 	nano::system system0 (24000, 1);
 	nano::raw_key seed;
 	{
-		auto transaction (system0.nodes[0]->wallets.tx_begin ());
+		auto transaction (system0.nodes[0]->wallets.tx_begin_read ());
 		system0.wallet (0)->store.seed (seed, transaction);
 	}
 	nano::account account0 (system0.wallet (0)->deterministic_insert ());
@@ -3699,7 +3699,7 @@ TEST (rpc, wallet_info)
 	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
 	nano::account account (system.wallet (0)->deterministic_insert ());
 	{
-		auto transaction (system.nodes[0]->wallets.tx_begin (true));
+		auto transaction (system.nodes[0]->wallets.tx_begin_write ());
 		system.wallet (0)->store.erase (transaction, account);
 	}
 	account = system.wallet (0)->deterministic_insert ();
@@ -4030,7 +4030,7 @@ TEST (rpc, work_get)
 	ASSERT_EQ (200, response.status);
 	std::string work_text (response.json.get<std::string> ("work"));
 	uint64_t work (1);
-	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 	system.nodes[0]->wallets.items.begin ()->second->store.work_get (transaction, nano::genesis_account, work);
 	ASSERT_EQ (nano::to_string_hex (work), work_text);
 }
@@ -4058,7 +4058,7 @@ TEST (rpc, wallet_work_get)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_EQ (200, response.status);
-	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 	for (auto & works : response.json.get_child ("works"))
 	{
 		std::string account_text (works.first);
@@ -4098,7 +4098,7 @@ TEST (rpc, work_set)
 	std::string success (response.json.get<std::string> ("success"));
 	ASSERT_TRUE (success.empty ());
 	uint64_t work1 (1);
-	auto transaction (system.nodes[0]->wallets.tx_begin ());
+	auto transaction (system.nodes[0]->wallets.tx_begin_read ());
 	system.nodes[0]->wallets.items.begin ()->second->store.work_get (transaction, nano::genesis_account, work1);
 	ASSERT_EQ (work1, work0);
 }
@@ -4110,7 +4110,7 @@ TEST (rpc, search_pending_all)
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (latest));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
 	}
 	auto node = system.nodes.front ();
@@ -5043,7 +5043,7 @@ TEST (rpc, wallet_lock)
 	std::string wallet;
 	system.nodes[0]->wallets.items.begin ()->first.encode_hex (wallet);
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin ());
+		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 		ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
 	}
 	request.put ("wallet", wallet);
@@ -5057,7 +5057,7 @@ TEST (rpc, wallet_lock)
 	ASSERT_EQ (200, response.status);
 	std::string account_text1 (response.json.get<std::string> ("locked"));
 	ASSERT_EQ (account_text1, "1");
-	auto transaction (system.wallet (0)->wallets.tx_begin ());
+	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	ASSERT_FALSE (system.wallet (0)->store.valid_password (transaction));
 }
 
@@ -5517,7 +5517,7 @@ TEST (rpc, block_confirm)
 	nano::genesis genesis;
 	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
 	{
-		auto transaction (system.nodes[0]->store.tx_begin (true));
+		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send1).code);
 	}
 	auto node = system.nodes.front ();

--- a/nano/secure/blockstore.cpp
+++ b/nano/secure/blockstore.cpp
@@ -367,3 +367,43 @@ void nano::representative_visitor::state_block (nano::state_block const & block_
 {
 	result = block_a.hash ();
 }
+
+nano::read_transaction::read_transaction (std::unique_ptr<nano::read_transaction_impl> read_transaction_impl) :
+impl (std::move (read_transaction_impl))
+{
+}
+
+void * nano::read_transaction::get_handle () const
+{
+	return impl->get_handle ();
+}
+
+void nano::read_transaction::reset () const
+{
+	impl->reset ();
+}
+
+void nano::read_transaction::renew () const
+{
+	impl->renew ();
+}
+
+nano::write_transaction::write_transaction (std::unique_ptr<nano::write_transaction_impl> write_transaction_impl) :
+impl (std::move (write_transaction_impl))
+{
+}
+
+void * nano::write_transaction::get_handle () const
+{
+	return impl->get_handle ();
+}
+
+void nano::write_transaction::commit () const
+{
+	impl->commit ();
+}
+
+void nano::write_transaction::renew ()
+{
+	impl->renew ();
+}

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -193,23 +193,23 @@ public:
 	virtual ~read_transaction_impl () = default;
 	virtual void reset () const = 0;
 	virtual void renew () const = 0;
-	virtual void* get_handle () const = 0;
+	virtual void * get_handle () const = 0;
 };
 
 class write_transaction_impl
 {
 public:
 	virtual ~write_transaction_impl () = default;
-	virtual	void commit () const = 0;
-	virtual void renew() = 0;
-	virtual void* get_handle () const = 0;
+	virtual void commit () const = 0;
+	virtual void renew () = 0;
+	virtual void * get_handle () const = 0;
 };
 
 class transaction
 {
 public:
 	virtual ~transaction () = default;
-	virtual void* get_handle () const = 0;
+	virtual void * get_handle () const = 0;
 };
 
 /**

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -187,19 +187,61 @@ private:
 
 class block_predecessor_set;
 
-class transaction_impl
+class read_transaction_impl
 {
 public:
-	virtual ~transaction_impl () = default;
+	virtual ~read_transaction_impl () = default;
+	virtual void reset () const = 0;
+	virtual void renew () const = 0;
+	virtual void* get_handle () const = 0;
 };
+
+class write_transaction_impl
+{
+public:
+	virtual ~write_transaction_impl () = default;
+	virtual	void commit () const = 0;
+	virtual void renew() = 0;
+	virtual void* get_handle () const = 0;
+};
+
+class transaction
+{
+public:
+	virtual ~transaction () = default;
+	virtual void* get_handle () const = 0;
+};
+
 /**
- * RAII wrapper of MDB_txn where the constructor starts the transaction
+ * RAII wrapper of a read MDB_txn where the constructor starts the transaction
+ * and the destructor aborts it.
+ */
+class read_transaction final : public transaction
+{
+public:
+	explicit read_transaction (std::unique_ptr<nano::read_transaction_impl> read_transaction_impl);
+	void * get_handle () const override;
+	void reset () const;
+	void renew () const;
+
+private:
+	std::unique_ptr<nano::read_transaction_impl> impl;
+};
+
+/**
+ * RAII wrapper of a read-write MDB_txn where the constructor starts the transaction
  * and the destructor commits it.
  */
-class transaction final
+class write_transaction final : public transaction
 {
 public:
-	std::unique_ptr<nano::transaction_impl> impl;
+	explicit write_transaction (std::unique_ptr<nano::write_transaction_impl> write_transaction_impl);
+	void * get_handle () const override;
+	void commit () const;
+	void renew ();
+
+private:
+	std::unique_ptr<nano::write_transaction_impl> impl;
 };
 
 /**
@@ -312,15 +354,9 @@ public:
 	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 
 	/** Start read-write transaction */
-	virtual nano::transaction tx_begin_write () = 0;
+	virtual nano::write_transaction tx_begin_write () = 0;
 
 	/** Start read-only transaction */
-	virtual nano::transaction tx_begin_read () = 0;
-
-	/**
-	 * Start a read-only or read-write transaction
-	 * @param write If true, start a read-write transaction
-	 */
-	virtual nano::transaction tx_begin (bool write = false) = 0;
+	virtual nano::read_transaction tx_begin_read () = 0;
 };
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -13,7 +13,7 @@ TEST (system, generate_mass_activity)
 	uint32_t count (20);
 	system.generate_mass_activity (count, *system.nodes[0]);
 	size_t accounts (0);
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	for (auto i (system.nodes[0]->store.latest_begin (transaction)), n (system.nodes[0]->store.latest_end ()); i != n; ++i)
 	{
 		++accounts;
@@ -28,7 +28,7 @@ TEST (system, generate_mass_activity_long)
 	uint32_t count (1000000000);
 	system.generate_mass_activity (count, *system.nodes[0]);
 	size_t accounts (0);
-	auto transaction (system.nodes[0]->store.tx_begin ());
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
 	for (auto i (system.nodes[0]->store.latest_begin (transaction)), n (system.nodes[0]->store.latest_end ()); i != n; ++i)
 	{
 		++accounts;
@@ -58,7 +58,7 @@ TEST (system, receive_while_synchronizing)
 		system.nodes.push_back (node1);
 		system.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (200), ([&system, &key]() {
 			auto hash (system.wallet (0)->send_sync (nano::test_genesis_key.pub, key.pub, system.nodes[0]->config.receive_minimum.number ()));
-			auto transaction (system.nodes[0]->store.tx_begin ());
+			auto transaction (system.nodes[0]->store.tx_begin_read ());
 			auto block (system.nodes[0]->store.block_get (transaction, hash));
 			std::string block_text;
 			block->serialize_json (block_text);
@@ -86,7 +86,7 @@ TEST (ledger, deep_account_compute)
 	nano::stat stats;
 	nano::ledger ledger (store, stats);
 	nano::genesis genesis;
-	auto transaction (store.tx_begin (true));
+	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis);
 	nano::keypair key;
 	auto balance (nano::genesis_amount - 1);
@@ -158,7 +158,7 @@ TEST (store, load)
 		threads.push_back (boost::thread ([&system]() {
 			for (auto i (0); i != 1000; ++i)
 			{
-				auto transaction (system.nodes[0]->store.tx_begin (true));
+				auto transaction (system.nodes[0]->store.tx_begin_write ());
 				for (auto j (0); j != 10; ++j)
 				{
 					nano::block_hash hash;
@@ -196,7 +196,7 @@ TEST (node, fork_storm)
 			system.nodes[i]->work_generate_blocking (*open);
 			auto open_result (system.nodes[i]->process (*open));
 			ASSERT_EQ (nano::process_result::progress, open_result.code);
-			auto transaction (system.nodes[i]->store.tx_begin ());
+			auto transaction (system.nodes[i]->store.tx_begin_read ());
 			system.nodes[i]->network.flood_block (open);
 		}
 	}
@@ -384,10 +384,10 @@ TEST (store, unchecked_load)
 	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	for (auto i (0); i < 1000000; ++i)
 	{
-		auto transaction (node.store.tx_begin (true));
+		auto transaction (node.store.tx_begin_write ());
 		node.store.unchecked_put (transaction, i, block);
 	}
-	auto transaction (node.store.tx_begin ());
+	auto transaction (node.store.tx_begin_read ());
 	auto count (node.store.unchecked_count (transaction));
 	(void)count;
 }
@@ -511,7 +511,7 @@ TEST (confirmation_height, long_chains)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	auto transaction (node->store.tx_begin ());
+	auto transaction (node->store.tx_begin_read ());
 	nano::account_info account_info;
 	ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
 	ASSERT_EQ (num_blocks + 2, account_info.confirmation_height);


### PR DESCRIPTION
This enables long running read transactions to be broken up and reuse the same transaction object instead of creating a new one each time periodically which is more efficient as per the official [documentation](http://www.lmdb.tech/doc/starting.html#optim). This will help with some of the forthcoming transaction breakup tasks.

As read/write now return different concrete objects (to make use of RAII for automatic cleanup) they can no longer be specified by using a `bool` argument (which is a good thing imo). This is what most of the changes done are for.

It is currently possible to pass a read only transaction object to something that expects a write transaction, this is only apparent at run-time. This can now be made a compile-time constraint by specifying a `write_transaction`. Widespread changes can be made to accommodate this but were not done here as to make only necessary changes during the RC.