### PR TITLE
Pass command line arguments (network/data_path) to nano_rpc child process

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -116,6 +116,22 @@ public:
 		return err;
 	}
 
+	constexpr const char * get_current_network_as_string ()  const
+	{
+		switch (current_network)
+		{
+		case nano_networks::nano_live_network:
+			return "live";
+		case nano_networks::nano_beta_network:
+			return "beta";
+		case nano_networks::nano_test_network:
+			return "test";
+		}
+
+		assert (false);
+		return "test";
+	}
+
 	bool is_live_network () const
 	{
 		return current_network == nano_networks::nano_live_network;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -118,18 +118,7 @@ public:
 
 	const char * get_current_network_as_string () const
 	{
-		switch (current_network)
-		{
-			case nano_networks::nano_live_network:
-				return "live";
-			case nano_networks::nano_beta_network:
-				return "beta";
-			case nano_networks::nano_test_network:
-				return "test";
-		}
-
-		assert (false);
-		return "test";
+		return is_live_network () ? "live" : is_beta_network () ? "beta" : "test";
 	}
 
 	bool is_live_network () const

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -116,7 +116,7 @@ public:
 		return err;
 	}
 
-	constexpr const char * get_current_network_as_string ()  const
+	const char * get_current_network_as_string ()  const
 	{
 		switch (current_network)
 		{

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -116,16 +116,16 @@ public:
 		return err;
 	}
 
-	const char * get_current_network_as_string ()  const
+	const char * get_current_network_as_string () const
 	{
 		switch (current_network)
 		{
-		case nano_networks::nano_live_network:
-			return "live";
-		case nano_networks::nano_beta_network:
-			return "beta";
-		case nano_networks::nano_test_network:
-			return "test";
+			case nano_networks::nano_live_network:
+				return "live";
+			case nano_networks::nano_beta_network:
+				return "beta";
+			case nano_networks::nano_test_network:
+				return "test";
 		}
 
 		assert (false);

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -71,10 +71,16 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 					}
 					else
 					{
+						if (!boost::filesystem::exists (config.rpc.rpc_path))
+						{
+							throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.rpc_path);
+						}
+
+						auto network = node->network_params.network.get_current_network_as_string ();
 #if BOOST_PROCESS_SUPPORTED
-						rpc_process = std::make_unique<boost::process::child> (config.rpc.rpc_path, "--daemon");
+						rpc_process = std::make_unique<boost::process::child> (config.rpc.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
 #else
-						auto rpc_exe_command = boost::str (boost::format ("%1% %2%") % config.rpc.rpc_path % "--daemon");
+						auto rpc_exe_command = boost::str (boost::format ("%1% --daemon --data_path=%2% --network=%3%") % config.rpc.rpc_path % data_path % network);
 						// clang-format off
 						rpc_process_thread = std::make_unique<std::thread> ([rpc_exe_command, &logger = node->logger]() {
 							nano::thread_role::set (nano::thread_role::name::rpc_process_container);

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -72,9 +72,10 @@ int main (int argc, char * const * argv)
 	// clang-format off
 	description.add_options ()
 		("help", "Print out options")
-		("version", "Prints out version")
 		("daemon", "Start RPC daemon")
-		("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory");
+		("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
+		("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or test)")
+		("version", "Prints out version");
 	// clang-format on
 
 	boost::program_options::variables_map vm;

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -315,8 +315,14 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 				}
 				else
 				{
+					if (!boost::filesystem::exists (config.rpc.rpc_path))
+					{
+						throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.rpc_path);
+					}
+
+					auto network = node->network_params.network.get_current_network_as_string ();
 #if BOOST_PROCESS_SUPPORTED
-					rpc_process = std::make_unique<boost::process::child> (config.rpc.rpc_path, "--daemon");
+					rpc_process = std::make_unique<boost::process::child> (config.rpc.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
 #else
 					show_error ("rpc_enable is set to true in the config. Set it to false and start the RPC server manually.");
 #endif

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -44,7 +44,7 @@ void nano::rpc::start ()
 
 void nano::rpc::accept ()
 {
-	auto connection (std::make_shared<nano::rpc_connection> (config, network_constants, io_ctx, logger, rpc_handler_interface));
+	auto connection (std::make_shared<nano::rpc_connection> (config, io_ctx, logger, rpc_handler_interface));
 	acceptor.async_accept (connection->socket, [this, connection](boost::system::error_code const & ec) {
 		if (ec != boost::asio::error::operation_aborted && acceptor.is_open ())
 		{

--- a/nano/rpc/rpc.hpp
+++ b/nano/rpc/rpc.hpp
@@ -22,7 +22,6 @@ public:
 	boost::asio::ip::tcp::acceptor acceptor;
 	nano::logger_mt logger;
 	boost::asio::io_context & io_ctx;
-	nano::network_constants network_constants;
 	nano::rpc_handler_interface & rpc_handler_interface;
 	bool stopped{ false };
 };

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -8,12 +8,11 @@
 #include <nano/rpc/rpc_connection.hpp>
 #include <nano/rpc/rpc_handler.hpp>
 
-nano::rpc_connection::rpc_connection (nano::rpc_config const & rpc_config, nano::network_constants const & network_constants, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface) :
+nano::rpc_connection::rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface) :
 socket (io_ctx),
 io_ctx (io_ctx),
 logger (logger),
 rpc_config (rpc_config),
-network_constants (network_constants),
 rpc_handler_interface (rpc_handler_interface)
 {
 	responded.clear ();

--- a/nano/rpc/rpc_connection.hpp
+++ b/nano/rpc/rpc_connection.hpp
@@ -9,12 +9,11 @@ namespace nano
 class logger_mt;
 class rpc_config;
 class rpc_handler_interface;
-class network_constants;
 
 class rpc_connection : public std::enable_shared_from_this<nano::rpc_connection>
 {
 public:
-	rpc_connection (nano::rpc_config const & rpc_config, nano::network_constants const & network_constants, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface_a);
+	rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface_a);
 	virtual ~rpc_connection () = default;
 	virtual void parse_connection ();
 	virtual void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc_connection);
@@ -31,7 +30,6 @@ public:
 	boost::asio::io_context & io_ctx;
 	nano::logger_mt & logger;
 	nano::rpc_config const & rpc_config;
-	nano::network_constants const & network_constants;
 	nano::rpc_handler_interface & rpc_handler_interface;
 };
 }


### PR DESCRIPTION
When `nano_rpc` is used in-process it now gets passed network/data_path command line arguments so that it is in sync with `nano_node` should they not be the defaults.

Improve error message when `rpc_path` does not point to a valid file.

Removed unused `network_params` variables from some rpc code