### PR TITLE
Backup config files when upgrading

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -889,11 +889,11 @@ TEST (json, backup)
 		}
 		return dir;
 	};
-	// clang-format on
 
-	auto get_file_count = [&dir] () {
+	auto get_file_count = [&dir]() {
 		return std::count_if (boost::filesystem::directory_iterator (dir), boost::filesystem::directory_iterator (), static_cast<bool (*) (const boost::filesystem::path &)> (boost::filesystem::is_regular_file));
 	};
+	// clang-format on
 
 	// There should only be the original file in this directory
 	ASSERT_EQ (get_file_count (), 1);

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -99,6 +99,8 @@ public:
 			*error = object.deserialize_json (updated, *this);
 			if (!*error && updated)
 			{
+				// Before updating the config file during an upgrade make a backup first
+				create_backup_file (path_a);
 				stream.open (path_a.string (), std::ios_base::out | std::ios_base::trunc);
 				try
 				{
@@ -144,6 +146,22 @@ public:
 		}
 
 		stream_a.open (path_a);
+	}
+
+	/** Takes a filepath, appends '_backup_<timestamp>' to the end (but before any extension) and saves that file in the same directory */
+	void create_backup_file (boost::filesystem::path const & filepath_a)
+	{
+		auto extension = filepath_a.extension ();
+		auto filename_without_extension = filepath_a.filename ().replace_extension ("");
+		auto orig_filepath = filepath_a;
+		auto & backup_path = orig_filepath.remove_filename ();
+		auto backup_filename = filename_without_extension;
+		backup_filename += "_backup_";
+		backup_filename += std::to_string (std::chrono::system_clock::now ().time_since_epoch ().count ());
+		backup_filename += extension;
+		auto backup_filepath = backup_path / backup_filename;
+
+		boost::filesystem::copy_file (filepath_a, backup_filepath);
 	}
 
 	/** Returns the boost property node managed by this instance */

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -60,7 +60,6 @@ public:
 	 * Reads a json object from the stream 
 	 * @return nano::error&, including a descriptive error message if the config file is malformed.
 	 */
-	template <typename T>
 	nano::error & read (boost::filesystem::path const & path_a)
 	{
 		std::fstream stream;
@@ -91,7 +90,8 @@ public:
 	template <typename T>
 	nano::error & read_and_update (T & object, boost::filesystem::path const & path_a)
 	{
-		read<T> (path_a);
+		auto file_exists (boost::filesystem::exists (path_a));
+		read (path_a);
 		if (!*error)
 		{
 			std::fstream stream;
@@ -100,7 +100,10 @@ public:
 			if (!*error && updated)
 			{
 				// Before updating the config file during an upgrade make a backup first
-				create_backup_file (path_a);
+				if (file_exists)
+				{
+					create_backup_file (path_a);
+				}
 				stream.open (path_a.string (), std::ios_base::out | std::ios_base::trunc);
 				try
 				{

--- a/nano/node/node_rpc_config.cpp
+++ b/nano/node/node_rpc_config.cpp
@@ -69,7 +69,7 @@ void nano::node_rpc_config::migrate (nano::jsonconfig & json, boost::filesystem:
 {
 	nano::jsonconfig rpc_json;
 	auto rpc_config_path = nano::get_rpc_config_path (data_path);
-	auto rpc_error (rpc_json.read<nano::rpc_config> (rpc_config_path));
+	auto rpc_error (rpc_json.read (rpc_config_path));
 	if (rpc_error || rpc_json.empty ())
 	{
 		// Migrate RPC info across


### PR DESCRIPTION
It's reasonable practice to create backups of files which the user is allowed to modify if you are going to modify them. There were also multiple times during the v19 RC1 period where having the original config file beta testers were using before an upgrade would have been useful.

During any upgrades of the config a new file will be created, for instance: `config_backup_15571460497935531.json`

Note: It might look initially strange during upgrades from v18 as the new `rpc_config.json` will have an initial backup because the migration only copies things from the original `config.json`, all the new options for the rpc are done in an upgrade. This can be added to documentation as expected behaviour.