### PR TITLE
Stop node when using an incompatible ledger

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1653,7 +1653,7 @@ TEST (block_store, upgrade_confirmation_height_many)
 	}
 }
 
-// Upgrade many accounts to add a confirmation height of 0
+// Ledger versions are not forward compatible
 TEST (block_store, incompatible_version)
 {
 	auto path (nano::unique_path ());

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1653,6 +1653,29 @@ TEST (block_store, upgrade_confirmation_height_many)
 	}
 }
 
+// Upgrade many accounts to add a confirmation height of 0
+TEST (block_store, incompatible_version)
+{
+	auto path (nano::unique_path ());
+	nano::logger_mt logger;
+	{
+		auto error (false);
+		nano::mdb_store store (error, logger, path);
+		ASSERT_FALSE (error);
+
+		// Put version to an unreachable number so that it should always be incompatible
+		auto transaction (store.tx_begin_write ());
+		store.version_put (transaction, std::numeric_limits<unsigned>::max ());
+	}
+
+	// Now try and read it, should give an error
+	{
+		auto error (false);
+		nano::mdb_store store (error, logger, path);
+		ASSERT_TRUE (error);
+	}
+}
+
 namespace
 {
 // These functions take the latest account_info and create a legacy one so that upgrade tests can be emulated more easily.

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -843,8 +843,8 @@ env (error_a, path_a, lmdb_max_dbs)
 		}
 		if (!error_a)
 		{
-			do_upgrades (transaction, batch_size);
-			if (drop_unchecked)
+			error_a |= do_upgrades (transaction, batch_size);
+			if (!error_a && drop_unchecked)
 			{
 				unchecked_clear (transaction);
 			}
@@ -959,9 +959,11 @@ nano::store_iterator<nano::endpoint_key, nano::no_value> nano::mdb_store::peers_
 	return result;
 }
 
-void nano::mdb_store::do_upgrades (nano::write_transaction & transaction_a, size_t batch_size)
+bool nano::mdb_store::do_upgrades (nano::write_transaction & transaction_a, size_t batch_size)
 {
-	switch (version_get (transaction_a))
+	auto error (false);
+	auto version_l = version_get (transaction_a);
+	switch (version_l)
 	{
 		case 1:
 			upgrade_v1_to_v2 (transaction_a);
@@ -992,8 +994,11 @@ void nano::mdb_store::do_upgrades (nano::write_transaction & transaction_a, size
 		case 14:
 			break;
 		default:
-			assert (false);
+			logger.always_log (boost::str (boost::format ("The version of the ledger (%1%) is too high for this node") % version_l));
+			error = true;
+			break;
 	}
+	return error;
 }
 
 void nano::mdb_store::upgrade_v1_to_v2 (nano::transaction const & transaction_a)

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -404,7 +404,7 @@ private:
 	boost::optional<MDB_val> block_raw_get_by_type (nano::transaction const &, nano::block_hash const &, nano::block_type &) const;
 	void block_raw_put (nano::transaction const &, MDB_dbi, nano::block_hash const &, MDB_val);
 	void clear (MDB_dbi);
-	void do_upgrades (nano::write_transaction &, size_t);
+	bool do_upgrades (nano::write_transaction &, size_t);
 	void upgrade_v1_to_v2 (nano::transaction const &);
 	void upgrade_v2_to_v3 (nano::transaction const &);
 	void upgrade_v3_to_v4 (nano::transaction const &);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -287,7 +287,6 @@ public:
 	bool error () const;
 	bool block_store_init{ false };
 	bool wallets_store_init{ false };
-	bool wallet_init{ false };
 };
 
 class vote_processor final

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1497,7 +1497,7 @@ void nano::wallets::do_wallet_actions ()
 	}
 }
 
-nano::wallets::wallets (bool & error_a, nano::node & node_a) :
+nano::wallets::wallets (bool error_a, nano::node & node_a) :
 observer ([](bool) {}),
 node (node_a),
 env (boost::polymorphic_downcast<nano::mdb_wallets_store *> (node_a.wallets_store_impl.get ())->environment),

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -182,7 +182,7 @@ public:
 class wallets final
 {
 public:
-	wallets (bool &, nano::node &);
+	wallets (bool, nano::node &);
 	~wallets ();
 	std::shared_ptr<nano::wallet> open (nano::uint256_union const &);
 	std::shared_ptr<nano::wallet> create (nano::uint256_union const &);


### PR DESCRIPTION
The node should be incompatible with a future version. Currently it is possible to start a v18 node with a v19 ledger, while we cannot retrofit this to existing versions, any future ledger version will be incompatible with this one and so on.
 
`wallet_init` is unused so have gotten rid of it and pass `wallets_store_init` in its place.

There is a lot of unnecessary work done after there is a database initialization error in the `node::node` constructor, it is now checked at the start.
