### PR TITLE
Makes sure a write lock can be avoided when launching an inactive_node

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2477,6 +2477,8 @@ TEST (node, dont_write_lock_node)
 	.detach ();
 	// clang-format off
 
+	write_lock_held_promise.get_future ().wait ();
+
 	// Check inactive node can finish executing while a write lock is open
 	nano::inactive_node node (path);
 	finished_promise.set_value ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2451,6 +2451,26 @@ TEST (node, unchecked_cleanup)
 	}
 }
 
+/** This checks that a  node can be opened (without being blocked) when a write lock is held elsewhere */
+TEST (node, dont_write_lock_node)
+{
+	auto path = nano::unique_path ();
+	nano::logger_mt logger;
+	bool init (false);
+	nano::mdb_store store (init, logger, path / "data.ldb");
+	nano::genesis genesis;
+	{
+		auto transaction (store.tx_begin_write ());
+		store.initialize (transaction, genesis);
+	}
+
+	// Hold write lock open
+	auto transaction (store.tx_begin_write ());
+
+	// Check inactive node can finish
+	nano::inactive_node node (path);
+}
+
 TEST (active_difficulty, recalculate_work)
 {
 	nano::system system (24000, 1);

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -91,7 +91,9 @@ nano::read_mdb_txn::read_mdb_txn (nano::mdb_env const & environment_a)
 
 nano::read_mdb_txn::~read_mdb_txn ()
 {
-	mdb_txn_abort (handle);
+	// This uses commit rather than abort, as it is needed when opening databases with a read only transaction
+	auto status (mdb_txn_commit (handle));
+	release_assert (status == MDB_SUCCESS);
 }
 
 void nano::read_mdb_txn::reset () const
@@ -819,35 +821,39 @@ env (error_a, path_a, lmdb_max_dbs)
 {
 	if (!error_a)
 	{
-		auto transaction (tx_begin_write ());
-		error_a |= mdb_dbi_open (env.tx (transaction), "frontiers", MDB_CREATE, &frontiers) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "accounts", MDB_CREATE, &accounts_v0) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "accounts_v1", MDB_CREATE, &accounts_v1) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "send", MDB_CREATE, &send_blocks) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "receive", MDB_CREATE, &receive_blocks) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "open", MDB_CREATE, &open_blocks) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "change", MDB_CREATE, &change_blocks) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "state", MDB_CREATE, &state_blocks_v0) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "state_v1", MDB_CREATE, &state_blocks_v1) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "pending", MDB_CREATE, &pending_v0) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "pending_v1", MDB_CREATE, &pending_v1) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "representation", MDB_CREATE, &representation) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "unchecked", MDB_CREATE, &unchecked) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "vote", MDB_CREATE, &vote) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "online_weight", MDB_CREATE, &online_weight) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "meta", MDB_CREATE, &meta) != 0;
-		error_a |= mdb_dbi_open (env.tx (transaction), "peers", MDB_CREATE, &peers) != 0;
-		if (!full_sideband (transaction))
+		auto is_fully_upgraded (false);
 		{
-			error_a |= mdb_dbi_open (env.tx (transaction), "blocks_info", MDB_CREATE, &blocks_info) != 0;
-		}
-		if (!error_a)
-		{
-			do_upgrades (transaction, batch_size);
-			if (drop_unchecked)
+			auto transaction (tx_begin_read ());
+			auto err = mdb_dbi_open (env.tx (transaction), "meta", 0, &meta);
+			if (err == MDB_SUCCESS)
 			{
-				unchecked_clear (transaction);
+				is_fully_upgraded = (version_get (transaction) == version);
+				mdb_dbi_close (env, meta);
 			}
+		}
+
+		// Only open a write lock when upgrades are needed. This is because CLI commands
+		// open inactive nodes which can otherwise be locked here if there is a long write
+		// (can be a few minutes with the --fastbootstrap flag for instance)
+		if (!is_fully_upgraded)
+		{
+			auto transaction (tx_begin_write ());
+			open_databases (error_a, transaction, MDB_CREATE);
+			if (!error_a)
+			{
+				do_upgrades (transaction, batch_size);
+			}
+		}
+		else
+		{
+			auto transaction (tx_begin_read ());
+			open_databases (error_a, transaction, 0);
+		}
+
+		if (!error_a && drop_unchecked)
+		{
+			auto transaction (tx_begin_write ());
+			unchecked_clear (transaction);
 		}
 	}
 }
@@ -876,6 +882,31 @@ void nano::mdb_store::initialize (nano::transaction const & transaction_a, nano:
 	account_put (transaction_a, network_params.ledger.genesis_account, { hash_l, genesis_a.open->hash (), genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, 1, nano::epoch::epoch_0 });
 	representation_put (transaction_a, network_params.ledger.genesis_account, std::numeric_limits<nano::uint128_t>::max ());
 	frontier_put (transaction_a, hash_l, network_params.ledger.genesis_account);
+}
+
+void nano::mdb_store::open_databases (bool & error_a, nano::transaction const & transaction_a, unsigned flags)
+{
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "frontiers", flags, &frontiers) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "accounts", flags, &accounts_v0) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "accounts_v1", flags, &accounts_v1) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "send", flags, &send_blocks) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "receive", flags, &receive_blocks) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "open", flags, &open_blocks) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "change", flags, &change_blocks) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "state", flags, &state_blocks_v0) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "state_v1", flags, &state_blocks_v1) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "pending", flags, &pending_v0) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "pending_v1", flags, &pending_v1) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "representation", flags, &representation) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "unchecked", flags, &unchecked) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "vote", flags, &vote) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peers) != 0;
+	if (!full_sideband (transaction_a))
+	{
+		error_a |= mdb_dbi_open (env.tx (transaction_a), "blocks_info", flags, &blocks_info) != 0;
+	}
 }
 
 void nano::mdb_store::version_put (nano::transaction const & transaction_a, int version_a)

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -419,6 +419,8 @@ private:
 	void upgrade_v12_to_v13 (nano::write_transaction &, size_t);
 	void upgrade_v13_to_v14 (nano::transaction const &);
 	MDB_dbi get_pending_db (nano::epoch epoch_a) const;
+	void open_databases (bool &, nano::transaction const &, unsigned);
+	static int constexpr version{ 14 };
 };
 class wallet_value
 {

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1236,13 +1236,23 @@ startup_time (std::chrono::steady_clock::now ())
 		{
 			logger.always_log ("Constructing node");
 		}
-		nano::genesis genesis;
-		auto transaction (store.tx_begin_write ());
-		if (store.latest_begin (transaction) == store.latest_end ())
+
+		// First do a pass with a read to see if any writing needs doing, this saves needing to open a write lock (and potentially blocking)
+		auto is_initialized (false);
 		{
+			auto transaction (store.tx_begin_read ());
+			is_initialized = (store.latest_begin (transaction) != store.latest_end ());
+		}
+
+		nano::genesis genesis;
+		if (!is_initialized)
+		{
+			auto transaction (store.tx_begin_write ());
 			// Store was empty meaning we just created it, add the genesis block
 			store.initialize (transaction, genesis);
 		}
+
+		auto transaction (store.tx_begin_read ());
 		if (!store.block_exists (transaction, genesis.hash ()))
 		{
 			logger.always_log ("Genesis block not found. Make sure the node network ID is correct.");

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1812,23 +1812,42 @@ void nano::wallets::split_if_needed (nano::transaction & transaction_destination
 	auto store_l (dynamic_cast<nano::mdb_store *> (&store_a));
 	if (store_l != nullptr)
 	{
-		auto transaction_source (store_l->tx_begin_write ());
-		auto tx_source = static_cast<MDB_txn *> (transaction_source.get_handle ());
 		if (items.empty ())
 		{
-			auto tx_destination = static_cast<MDB_txn *> (transaction_destination.get_handle ());
 			std::string beginning (nano::uint256_union (0).to_string ());
 			std::string end ((nano::uint256_union (nano::uint256_t (0) - nano::uint256_t (1))).to_string ());
-			nano::store_iterator<std::array<char, 64>, nano::no_value> i (std::make_unique<nano::mdb_iterator<std::array<char, 64>, nano::no_value>> (transaction_source, handle, nano::mdb_val (beginning.size (), const_cast<char *> (beginning.c_str ()))));
-			nano::store_iterator<std::array<char, 64>, nano::no_value> n (std::make_unique<nano::mdb_iterator<std::array<char, 64>, nano::no_value>> (transaction_source, handle, nano::mdb_val (end.size (), const_cast<char *> (end.c_str ()))));
-			for (; i != n; ++i)
+
+			// clang-format off
+			auto get_store_it = [&handle = handle](nano::transaction const & transaction_source, std::string const & hash) {
+				return nano::store_iterator<std::array<char, 64>, nano::no_value> (std::make_unique<nano::mdb_iterator<std::array<char, 64>, nano::no_value>> (transaction_source, handle, nano::mdb_val (hash.size (), const_cast<char *> (hash.c_str ()))));
+			};
+			// clang-format on
+
+			// First do a read pass to check if there are any wallets that need extracting (to save holding a write lock and potentially being blocked)
+			auto wallets_need_splitting (false);
 			{
-				nano::uint256_union id;
-				std::string text (i->first.data (), i->first.size ());
-				auto error1 (id.decode_hex (text));
-				assert (!error1);
-				assert (strlen (text.c_str ()) == text.size ());
-				move_table (text, tx_source, tx_destination);
+				auto transaction_source (store_l->tx_begin_read ());
+				auto i = get_store_it (transaction_source, beginning);
+				auto n = get_store_it (transaction_source, end);
+				wallets_need_splitting = (i != n);
+			}
+
+			if (wallets_need_splitting)
+			{
+				auto transaction_source (store_l->tx_begin_write ());
+				auto i = get_store_it (transaction_source, beginning);
+				auto n = get_store_it (transaction_source, end);
+				auto tx_source = static_cast<MDB_txn *> (transaction_source.get_handle ());
+				auto tx_destination = static_cast<MDB_txn *> (transaction_destination.get_handle ());
+				for (; i != n; ++i)
+				{
+					nano::uint256_union id;
+					std::string text (i->first.data (), i->first.size ());
+					auto error1 (id.decode_hex (text));
+					assert (!error1);
+					assert (strlen (text.c_str ()) == text.size ());
+					move_table (text, tx_source, tx_destination);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
CLI commands can currently open a write lock on the ledger database when they don't need to. When using `--fast_bootstrap` and aren't synced yet or if there is any other long write transaction running, simple commands like `nano_node --wallet_create` can end up taking a few minutes. A few places where writes were being used are now checked in a pre-pass by using a read transaction to see whether the write is actually required (after first initialization of the ledger, they generally aren't needed).

I found that the read transaction needs to be committed when opening databases (not sure why), but I've replaced abort with that. This is also what it is prior to #1951.