### PR TITLE
Add modify callback to prevent violating boost multiindex invariants

### DIFF
--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -58,12 +58,14 @@ TEST (peer_container, split)
 	nano::endpoint endpoint2 (boost::asio::ip::address_v6::loopback (), 101);
 	auto channel1 (system.nodes[0]->network.udp_channels.insert (endpoint1, 0));
 	ASSERT_NE (nullptr, channel1);
-	channel1->set_last_packet_received (now - std::chrono::seconds (1));
-	system.nodes[0]->network.udp_channels.modify (channel1);
+	system.nodes[0]->network.udp_channels.modify (channel1, [&now](auto channel) {
+		channel->set_last_packet_received (now - std::chrono::seconds (1));
+	});
 	auto channel2 (system.nodes[0]->network.udp_channels.insert (endpoint2, 0));
 	ASSERT_NE (nullptr, channel2);
-	channel2->set_last_packet_received (now + std::chrono::seconds (1));
-	system.nodes[0]->network.udp_channels.modify (channel2);
+	system.nodes[0]->network.udp_channels.modify (channel2, [&now](auto channel) {
+		channel->set_last_packet_received (now + std::chrono::seconds (1));
+	});
 	ASSERT_EQ (2, system.nodes[0]->network.size ());
 	ASSERT_EQ (2, system.nodes[0]->network.udp_channels.size ());
 	system.nodes[0]->network.cleanup (now);

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -493,7 +493,9 @@ public:
 					auto channel (node.network.udp_channels.insert (endpoint, message_a.header.version_using));
 					if (channel)
 					{
-						channel->set_node_id (message_a.response->first);
+						node.network.udp_channels.modify (channel, [&message_a](std::shared_ptr<nano::transport::channel_udp> channel_a) {
+							channel_a->set_node_id (message_a.response->first);
+						});
 					}
 				}
 			}
@@ -517,8 +519,9 @@ public:
 		auto channel (node.network.udp_channels.channel (endpoint));
 		if (channel)
 		{
-			channel->set_last_packet_received (std::chrono::steady_clock::now ());
-			node.network.udp_channels.modify (channel);
+			node.network.udp_channels.modify (channel, [](std::shared_ptr<nano::transport::channel_udp> channel_a) {
+				channel_a->set_last_packet_received (std::chrono::steady_clock::now ());
+			});
 			node.process_message (message_a, channel);
 		}
 	}
@@ -833,12 +836,14 @@ std::deque<std::shared_ptr<nano::transport::channel_udp>> nano::transport::udp_c
 	return result;
 }
 
-void nano::transport::udp_channels::modify (std::shared_ptr<nano::transport::channel_udp> channel_a)
+void nano::transport::udp_channels::modify (std::shared_ptr<nano::transport::channel_udp> channel_a, std::function<void(std::shared_ptr<nano::transport::channel_udp>)> modify_callback_a)
 {
 	std::lock_guard<std::mutex> lock (mutex);
 	auto existing (channels.get<endpoint_tag> ().find (channel_a->endpoint));
 	if (existing != channels.get<endpoint_tag> ().end ())
 	{
-		channels.get<endpoint_tag> ().modify (existing, [](channel_udp_wrapper &) {});
+		channels.get<endpoint_tag> ().modify (existing, [modify_callback_a](channel_udp_wrapper & wrapper_a) {
+			modify_callback_a (wrapper_a.channel);
+		});
 	}
 }

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#define BOOST_MULTI_INDEX_ENABLE_SAFE_MODE 1
 #include <mutex>
 #include <nano/node/common.hpp>
 #include <nano/node/stats.hpp>
@@ -124,7 +124,7 @@ namespace transport
 		std::deque<std::shared_ptr<nano::transport::channel_udp>> list (size_t);
 		// A list of random peers sized for the configured rebroadcast fanout
 		std::deque<std::shared_ptr<nano::transport::channel_udp>> list_fanout ();
-		void modify (std::shared_ptr<nano::transport::channel_udp>);
+		void modify (std::shared_ptr<nano::transport::channel_udp>, std::function<void(std::shared_ptr<nano::transport::channel_udp>)>);
 		// Maximum number of peers per IP
 		static size_t constexpr max_peers_per_ip = 10;
 		static std::chrono::seconds constexpr syn_cookie_cutoff = std::chrono::seconds (5);

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#define BOOST_MULTI_INDEX_ENABLE_SAFE_MODE 1
+
 #include <mutex>
 #include <nano/node/common.hpp>
 #include <nano/node/stats.hpp>


### PR DESCRIPTION
We had a crash on master we suspected stemmed from unsynchronized access to a MI container, but it seems everything is protected.

However, `udp_channels::modify` was empty and the actual modification happened separately. This seems like a likely cause. Added a callback from which the modifications are done.