### PR TITLE
Move io_threads to rpc process config node

### DIFF
--- a/load-tester/src/launch_node_and_rpc.rs
+++ b/load-tester/src/launch_node_and_rpc.rs
@@ -134,9 +134,9 @@ pub fn launch_node_and_rpc(
         "enable_control": "true",
         "max_json_depth": "20",
         "version": "1",
-        "io_threads": "8",
         "process": {
             "ipc_port": ipc_port.to_string (),
+            "io_threads": "8",
             "num_ipc_connections": "8"
         }
     });

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -40,9 +40,9 @@ nano::error nano::rpc_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("enable_control", enable_control);
 	json.put ("max_json_depth", max_json_depth);
 	json.put ("max_request_size", max_request_size);
-	json.put ("io_threads", io_threads);
 
 	nano::jsonconfig rpc_process_l;
+	rpc_process_l.put ("io_threads", rpc_process.io_threads);
 	rpc_process_l.put ("ipc_port", rpc_process.ipc_port);
 	rpc_process_l.put ("num_ipc_connections", rpc_process.num_ipc_connections);
 	json.put_child ("process", rpc_process_l);
@@ -61,9 +61,9 @@ nano::error nano::rpc_config::deserialize_json (bool & upgraded_a, nano::jsoncon
 			json.put ("max_request_size", max_request_size);
 			json.erase ("frontier_request_limit");
 			json.erase ("chain_request_limit");
-			json.put ("io_threads", io_threads);
 
 			nano::jsonconfig rpc_process_l;
+			rpc_process_l.put ("io_threads", rpc_process.io_threads);
 			rpc_process_l.put ("ipc_port", rpc_process.ipc_port);
 			rpc_process_l.put ("num_ipc_connections", rpc_process.num_ipc_connections);
 			json.put_child ("process", rpc_process_l);
@@ -81,11 +81,11 @@ nano::error nano::rpc_config::deserialize_json (bool & upgraded_a, nano::jsoncon
 		json.get_optional<bool> ("enable_control", enable_control);
 		json.get_optional<uint8_t> ("max_json_depth", max_json_depth);
 		json.get_optional<uint64_t> ("max_request_size", max_request_size);
-		json.get_optional<unsigned> ("io_threads", io_threads);
 
 		auto rpc_process_l (json.get_optional_child ("process"));
 		if (rpc_process_l)
 		{
+			rpc_process_l->get_optional<unsigned> ("io_threads", rpc_process.io_threads);
 			rpc_process_l->get_optional<uint16_t> ("ipc_port", rpc_process.ipc_port);
 			rpc_process_l->get_optional<unsigned> ("num_ipc_connections", rpc_process.num_ipc_connections);
 		}

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -38,6 +38,7 @@ class rpc_process_config final
 {
 public:
 	nano::network_constants network_constants;
+	unsigned io_threads{ std::max<unsigned> (4, boost::thread::hardware_concurrency ()) };
 	uint16_t ipc_port{ network_constants.default_ipc_port };
 	unsigned num_ipc_connections{ network_constants.is_live_network () ? 8u : network_constants.is_beta_network () ? 4u : 1u };
 };
@@ -56,7 +57,6 @@ public:
 	rpc_secure_config secure;
 	uint8_t max_json_depth{ 20 };
 	uint64_t max_request_size{ 32 * 1024 * 1024 };
-	unsigned io_threads{ std::max<unsigned> (4, boost::thread::hardware_concurrency ()) };
 	static int json_version ()
 	{
 		return 1;

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -48,7 +48,7 @@ void run (boost::filesystem::path const & data_path)
 			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config);
 			auto rpc = nano::get_rpc (io_ctx, rpc_config, ipc_rpc_processor);
 			rpc->start ();
-			runner = std::make_unique<nano::thread_runner> (io_ctx, rpc_config.io_threads);
+			runner = std::make_unique<nano::thread_runner> (io_ctx, rpc_config.rpc_process.io_threads);
 			runner->join ();
 		}
 		catch (const std::runtime_error & e)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6374,8 +6374,8 @@ TEST (rpc_config, serialization)
 	config1.address = boost::asio::ip::address_v6::any ();
 	config1.port = 10;
 	config1.enable_control = true;
-	config1.io_threads = 2;
 	config1.max_json_depth = 10;
+	config1.rpc_process.io_threads = 2;
 	config1.rpc_process.ipc_port = 2000;
 	config1.rpc_process.num_ipc_connections = 99;
 	nano::jsonconfig tree;
@@ -6384,8 +6384,8 @@ TEST (rpc_config, serialization)
 	ASSERT_NE (config2.address, config1.address);
 	ASSERT_NE (config2.port, config1.port);
 	ASSERT_NE (config2.enable_control, config1.enable_control);
-	ASSERT_NE (config2.io_threads, config1.io_threads);
 	ASSERT_NE (config2.max_json_depth, config1.max_json_depth);
+	ASSERT_NE (config2.rpc_process.io_threads, config1.rpc_process.io_threads);
 	ASSERT_NE (config2.rpc_process.ipc_port, config1.rpc_process.ipc_port);
 	ASSERT_NE (config2.rpc_process.num_ipc_connections, config1.rpc_process.num_ipc_connections);
 	bool upgraded{ false };
@@ -6393,8 +6393,8 @@ TEST (rpc_config, serialization)
 	ASSERT_EQ (config2.address, config1.address);
 	ASSERT_EQ (config2.port, config1.port);
 	ASSERT_EQ (config2.enable_control, config1.enable_control);
-	ASSERT_EQ (config2.io_threads, config1.io_threads);
 	ASSERT_EQ (config2.max_json_depth, config1.max_json_depth);
+	ASSERT_EQ (config2.rpc_process.io_threads, config1.rpc_process.io_threads);
 	ASSERT_EQ (config2.rpc_process.ipc_port, config1.rpc_process.ipc_port);
 	ASSERT_EQ (config2.rpc_process.num_ipc_connections, config1.rpc_process.num_ipc_connections);
 }


### PR DESCRIPTION
#1977 moved a couple config options to a new rpc process config node, `io_threads` should have been moved as well.