### PR TITLE
Fix race when notifying bootstrap initiator listeners

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1748,7 +1748,7 @@ void nano::bootstrap_initiator::run_bootstrap ()
 
 void nano::bootstrap_initiator::add_observer (std::function<void(bool)> const & observer_a)
 {
-	std::lock_guard<std::mutex> lock (mutex);
+	std::lock_guard<std::mutex> lock (observers_mutex);
 	observers.push_back (observer_a);
 }
 
@@ -1778,6 +1778,7 @@ void nano::bootstrap_initiator::stop ()
 
 void nano::bootstrap_initiator::notify_listeners (bool in_progress_a)
 {
+	std::lock_guard<std::mutex> lock (observers_mutex);
 	for (auto & i : observers)
 	{
 		i (in_progress_a);
@@ -1791,7 +1792,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiato
 	size_t count = 0;
 	size_t cache_count = 0;
 	{
-		std::lock_guard<std::mutex> guard (bootstrap_initiator.mutex);
+		std::lock_guard<std::mutex> guard (bootstrap_initiator.observers_mutex);
 		count = bootstrap_initiator.observers.size ();
 	}
 	{

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -254,6 +254,7 @@ private:
 	bool stopped;
 	std::mutex mutex;
 	std::condition_variable condition;
+	std::mutex observers_mutex;
 	std::vector<std::function<void(bool)>> observers;
 	boost::thread thread;
 


### PR DESCRIPTION
tsan reported this (the separate mutex to protect the observers is to prevent a deadlock)