### PR TITLE
Work multiplier format and RPC work_validate fix for lower difficulties

### DIFF
--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -16,43 +16,6 @@ bool blocks_equal (T const & first, nano::block const & second)
 }
 }
 
-std::string nano::to_string_hex (uint64_t value_a)
-{
-	std::stringstream stream;
-	stream << std::hex << std::noshowbase << std::setw (16) << std::setfill ('0');
-	stream << value_a;
-	return stream.str ();
-}
-
-bool nano::from_string_hex (std::string const & value_a, uint64_t & target_a)
-{
-	auto error (value_a.empty ());
-	if (!error)
-	{
-		error = value_a.size () > 16;
-		if (!error)
-		{
-			std::stringstream stream (value_a);
-			stream << std::hex << std::noshowbase;
-			try
-			{
-				uint64_t number_l;
-				stream >> number_l;
-				target_a = number_l;
-				if (!stream.eof ())
-				{
-					error = true;
-				}
-			}
-			catch (std::runtime_error &)
-			{
-				error = true;
-			}
-		}
-	}
-	return error;
-}
-
 std::string nano::block::to_json () const
 {
 	std::string result;

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -12,8 +12,6 @@
 
 namespace nano
 {
-std::string to_string_hex (uint64_t);
-bool from_string_hex (std::string const &, uint64_t &);
 // We operate on streams of uint8_t by convention
 using stream = std::basic_streambuf<uint8_t>;
 // Read a raw byte stream the size of `T' and fill value.

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -811,6 +811,14 @@ bool nano::from_string_hex (std::string const & value_a, uint64_t & target_a)
 	return error;
 }
 
+std::string nano::to_string (double const value_a, int const precision_a)
+{
+	std::stringstream stream;
+	stream << std::setprecision (precision_a) << std::fixed;
+	stream << value_a;
+	return stream.str ();
+}
+
 uint64_t nano::difficulty::from_multiplier (double const multiplier_a, uint64_t const base_difficulty_a)
 {
 	assert (multiplier_a > 0.);

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -774,7 +774,7 @@ std::string nano::uint128_union::to_string_dec () const
 	return result;
 }
 
-std::string nano::to_string_hex (uint64_t value_a)
+std::string nano::to_string_hex (uint64_t const value_a)
 {
 	std::stringstream stream;
 	stream << std::hex << std::noshowbase << std::setw (16) << std::setfill ('0');

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -774,6 +774,43 @@ std::string nano::uint128_union::to_string_dec () const
 	return result;
 }
 
+std::string nano::to_string_hex (uint64_t value_a)
+{
+	std::stringstream stream;
+	stream << std::hex << std::noshowbase << std::setw (16) << std::setfill ('0');
+	stream << value_a;
+	return stream.str ();
+}
+
+bool nano::from_string_hex (std::string const & value_a, uint64_t & target_a)
+{
+	auto error (value_a.empty ());
+	if (!error)
+	{
+		error = value_a.size () > 16;
+		if (!error)
+		{
+			std::stringstream stream (value_a);
+			stream << std::hex << std::noshowbase;
+			try
+			{
+				uint64_t number_l;
+				stream >> number_l;
+				target_a = number_l;
+				if (!stream.eof ())
+				{
+					error = true;
+				}
+			}
+			catch (std::runtime_error &)
+			{
+				error = true;
+			}
+		}
+	}
+	return error;
+}
+
 uint64_t nano::difficulty::from_multiplier (double const multiplier_a, uint64_t const base_difficulty_a)
 {
 	assert (multiplier_a > 0.);

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -131,6 +131,12 @@ nano::public_key pub_key (nano::private_key const &);
 std::string to_string_hex (uint64_t const);
 bool from_string_hex (std::string const &, uint64_t &);
 
+/**
+ * Convert a double to string in fixed format
+ * @param precision_a (optional) use a specific precision (default is the maximum)
+ */
+std::string to_string (double const, int const precision_a = std::numeric_limits<double>::digits10);
+
 namespace difficulty
 {
 	uint64_t from_multiplier (double const, uint64_t const);

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -128,7 +128,7 @@ void deterministic_key (nano::uint256_union const &, uint32_t, nano::uint256_uni
 nano::public_key pub_key (nano::private_key const &);
 
 /* Conversion methods */
-std::string to_string_hex (uint64_t);
+std::string to_string_hex (uint64_t const);
 bool from_string_hex (std::string const &, uint64_t &);
 
 namespace difficulty

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -127,6 +127,10 @@ bool validate_message_batch (const unsigned char **, size_t *, const unsigned ch
 void deterministic_key (nano::uint256_union const &, uint32_t, nano::uint256_union &);
 nano::public_key pub_key (nano::private_key const &);
 
+/* Conversion methods */
+std::string to_string_hex (uint64_t);
+bool from_string_hex (std::string const &, uint64_t &);
+
 namespace difficulty
 {
 	uint64_t from_multiplier (double const, uint64_t const);

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -115,7 +115,7 @@ void nano::work_pool::loop (uint64_t thread)
 			{
 				// If the ticket matches what we started with, we're the ones that found the solution
 				assert (output >= current_l.difficulty);
-				assert (work_value (current_l.item, work) == output);
+				assert (current_l.difficulty == 0 || work_value (current_l.item, work) == output);
 				// Signal other threads to stop their work next time they check ticket
 				++ticket;
 				pending.pop_front ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <boost/array.hpp>
 #include <boost/bind.hpp>
+#include <boost/convert.hpp>
+#include <boost/convert/stream.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/polymorphic_cast.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -839,7 +841,7 @@ void nano::json_handler::active_difficulty ()
 	auto difficulty_active = node.active.active_difficulty ();
 	response_l.put ("difficulty_active", nano::to_string_hex (difficulty_active));
 	auto multiplier = nano::difficulty::to_multiplier (difficulty_active, node.network_params.network.publish_threshold);
-	response_l.put ("multiplier", std::to_string (multiplier));
+	response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());
 	response_errors ();
 }
 
@@ -4363,7 +4365,7 @@ void nano::json_handler::work_generate ()
 				nano::work_validate (hash, work_a.value (), &result_difficulty);
 				response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 				auto multiplier = nano::difficulty::to_multiplier (result_difficulty, this->node.network_params.network.publish_threshold);
-				response_l.put ("multiplier", multiplier);
+				response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());
 				boost::property_tree::write_json (ostream, response_l);
 				rpc_l->response (ostream.str ());
 			}
@@ -4456,7 +4458,7 @@ void nano::json_handler::work_validate ()
 		response_l.put ("valid", valid ? "1" : "0");
 		response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 		auto multiplier = nano::difficulty::to_multiplier (result_difficulty, node.network_params.network.publish_threshold);
-		response_l.put ("multiplier", multiplier);
+		response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());
 	}
 	response_errors ();
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4453,9 +4453,8 @@ void nano::json_handler::work_validate ()
 	if (!ec)
 	{
 		uint64_t result_difficulty (0);
-		bool invalid (nano::work_validate (hash, work, &result_difficulty));
-		bool valid (!invalid && result_difficulty >= difficulty);
-		response_l.put ("valid", valid ? "1" : "0");
+		nano::work_validate (hash, work, &result_difficulty);
+		response_l.put ("valid", (result_difficulty >= difficulty) ? "1" : "0");
 		response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 		auto multiplier = nano::difficulty::to_multiplier (result_difficulty, node.network_params.network.publish_threshold);
 		response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <boost/array.hpp>
 #include <boost/bind.hpp>
-#include <boost/convert.hpp>
-#include <boost/convert/stream.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/polymorphic_cast.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -841,7 +839,7 @@ void nano::json_handler::active_difficulty ()
 	auto difficulty_active = node.active.active_difficulty ();
 	response_l.put ("difficulty_active", nano::to_string_hex (difficulty_active));
 	auto multiplier = nano::difficulty::to_multiplier (difficulty_active, node.network_params.network.publish_threshold);
-	response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());
+	response_l.put ("multiplier", nano::to_string (multiplier));
 	response_errors ();
 }
 
@@ -4365,7 +4363,7 @@ void nano::json_handler::work_generate ()
 				nano::work_validate (hash, work_a.value (), &result_difficulty);
 				response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 				auto multiplier = nano::difficulty::to_multiplier (result_difficulty, this->node.network_params.network.publish_threshold);
-				response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());
+				response_l.put ("multiplier", nano::to_string (multiplier));
 				boost::property_tree::write_json (ostream, response_l);
 				rpc_l->response (ostream.str ());
 			}
@@ -4457,7 +4455,7 @@ void nano::json_handler::work_validate ()
 		response_l.put ("valid", (result_difficulty >= difficulty) ? "1" : "0");
 		response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 		auto multiplier = nano::difficulty::to_multiplier (result_difficulty, node.network_params.network.publish_threshold);
-		response_l.put ("multiplier", boost::convert<std::string> (multiplier, boost::cnv::cstream () (std::fixed) (std::setprecision (std::numeric_limits<double>::digits10))).value ());
+		response_l.put ("multiplier", nano::to_string (multiplier));
 	}
 	response_errors ();
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2462,7 +2462,7 @@ TEST (rpc, work_generate)
 	ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
 	ASSERT_EQ (result_difficulty, response_difficulty);
 	auto multiplier = response.json.get<double> ("multiplier");
-	ASSERT_EQ (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier);
+	ASSERT_NEAR (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier, 1e-6);
 }
 
 TEST (rpc, work_generate_difficulty)


### PR DESCRIPTION
Reported by @cryptocode , thanks.

`{"action": "work_validate", "work":"4f4a0cfb4a25dc78", "hash":"0000000000000000000000000000000000000000000000000000000000000002", "difficulty":"000000000000001"}`

Before:
```json
{
"valid": "0",
"difficulty": "82ddbf2c0bd1ae98",
"multiplier": "3.0484946624529728e-08"
}
```

Now:
```json
{
"valid": "1",
"difficulty": "82ddbf2c0bd1ae98",
"multiplier": "0.000000030484947"
}
```

---

Note valid 1 (c6d7f18) and the format fix. Precision is 15 decimal cases, even with higher difficulties.