### PR TITLE
Add unnecessary lambda capture to please VS2017

### DIFF
--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -87,7 +87,9 @@ TEST (socket, concurrent_writes)
 	auto client (clients[0]);
 	for (int i = 0; i < client_count; i++)
 	{
-		std::thread runner ([&client]() {
+		// Note: this gives a warning on most compilers because message_count is constexpr and a
+		// capture isn't needed. However, removing it fails to compile on VS2017 due to a known compiler bug.
+		std::thread runner ([&client, &message_count]() {
 			for (int i = 0; i < message_count; i++)
 			{
 				auto buff (std::make_shared<std::vector<uint8_t>> ());


### PR DESCRIPTION
Thanks to @SergiySW for reporting and @wezrule for finding https://developercommunity.visualstudio.com/content/problem/1997/constexpr-not-implicitely-captured-in-lambdas.html