### PR TITLE
Fix off by one error in frontier req server

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -3018,7 +3018,7 @@ count (0)
 
 void nano::frontier_req_server::send_next ()
 {
-	if (!current.is_zero () && count <= request->count)
+	if (!current.is_zero () && count < request->count)
 	{
 		{
 			send_buffer->clear ();


### PR DESCRIPTION
The current implementation will send 1 too many items, since count starts at 0.