### PR TITLE
Clean up json upgrade code/unused variables

### DIFF
--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -36,7 +36,6 @@ public:
 	bool upgrade_json (unsigned version_a, nano::jsonconfig & json)
 	{
 		json.put ("version", json_version ());
-		auto upgraded (false);
 		switch (version_a)
 		{
 			case 1:
@@ -46,7 +45,6 @@ public:
 				json.erase ("account");
 				json.put ("account", account.to_account ());
 				json.erase ("version");
-				upgraded = true;
 			}
 			case 2:
 			{
@@ -55,7 +53,6 @@ public:
 				json.put ("rpc_enable", "false");
 				json.put_child ("rpc", rpc_l);
 				json.erase ("version");
-				upgraded = true;
 			}
 			case 3:
 			{
@@ -71,14 +68,13 @@ public:
 					opencl.serialize_json (opencl_l);
 					json.put_child ("opencl", opencl_l);
 				}
-				upgraded = true;
 			}
 			case 4:
 				break;
 			default:
 				throw std::runtime_error ("Unknown qt_wallet_config version");
 		}
-		return upgraded;
+		return version_a < json_version ();
 	}
 
 	nano::error deserialize_json (bool & upgraded_a, nano::jsonconfig & json)
@@ -326,8 +322,8 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 						throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
 					}
 
-					auto network = node->network_params.network.get_current_network_as_string ();
 #if BOOST_PROCESS_SUPPORTED
+					auto network = node->network_params.network.get_current_network_as_string ();
 					rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
 #else
 					show_error ("rpc_enable is set to true in the config. Set it to false and start the RPC server manually.");

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -77,7 +77,6 @@ nano::error nano::daemon_config::deserialize_json (bool & upgraded_a, nano::json
 bool nano::daemon_config::upgrade_json (unsigned version_a, nano::jsonconfig & json)
 {
 	json.put ("version", json_version ());
-	auto upgraded_l (false);
 	switch (version_a)
 	{
 		case 1:
@@ -95,14 +94,13 @@ bool nano::daemon_config::upgrade_json (unsigned version_a, nano::jsonconfig & j
 				opencl.serialize_json (opencl_l);
 				json.put_child ("opencl", opencl_l);
 			}
-			upgraded_l = true;
 		}
 		case 2:
 			break;
 		default:
 			throw std::runtime_error ("Unknown daemon_config version");
 	}
-	return upgraded_l;
+	return version_a < json_version ();
 }
 
 namespace nano

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -62,36 +62,29 @@ nano::error nano::logging::serialize_json (nano::jsonconfig & json) const
 bool nano::logging::upgrade_json (unsigned version_a, nano::jsonconfig & json)
 {
 	json.put ("version", json_version ());
-	auto upgraded_l (false);
 	switch (version_a)
 	{
 		case 1:
 			json.put ("vote", vote_logging_value);
-			upgraded_l = true;
 		case 2:
 			json.put ("rotation_size", rotation_size);
 			json.put ("flush", true);
-			upgraded_l = true;
 		case 3:
 			json.put ("network_node_id_handshake", false);
-			upgraded_l = true;
 		case 4:
 			json.put ("upnp_details", "false");
 			json.put ("timing", "false");
-			upgraded_l = true;
 		case 5:
 			uintmax_t config_max_size;
 			json.get<uintmax_t> ("max_size", config_max_size);
 			max_size = std::max (max_size, config_max_size);
 			json.put ("max_size", max_size);
 			json.put ("log_ipc", true);
-			upgraded_l = true;
 		case 6:
 			json.put ("min_time_between_output", min_time_between_log_output.count ());
 			json.put ("network_timeout", network_timeout_logging_value);
 			json.erase ("log_rpc");
 			json.put ("long_database_txns", false);
-			upgraded_l = true;
 			break;
 		case 7:
 			break;
@@ -99,7 +92,7 @@ bool nano::logging::upgrade_json (unsigned version_a, nano::jsonconfig & json)
 			throw std::runtime_error ("Unknown logging_config version");
 			break;
 	}
-	return upgraded_l;
+	return version_a < json_version ();
 }
 
 nano::error nano::logging::deserialize_json (bool & upgraded_a, nano::jsonconfig & json)

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -135,7 +135,6 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & json)
 {
 	json.put ("version", json_version ());
-	auto upgraded (false);
 	switch (version_a)
 	{
 		case 1:
@@ -149,7 +148,6 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			});
 
 			json.replace_child ("preconfigured_representatives", reps);
-			upgraded = true;
 		}
 		case 2:
 		{
@@ -157,43 +155,34 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("password_fanout", std::to_string (1024));
 			json.put ("io_threads", std::to_string (io_threads));
 			json.put ("work_threads", std::to_string (work_threads));
-			upgraded = true;
 		}
 		case 3:
 			json.erase ("receive_minimum");
 			json.put ("receive_minimum", nano::xrb_ratio.convert_to<std::string> ());
-			upgraded = true;
 		case 4:
 			json.erase ("receive_minimum");
 			json.put ("receive_minimum", nano::xrb_ratio.convert_to<std::string> ());
-			upgraded = true;
 		case 5:
 			json.put ("enable_voting", enable_voting);
 			json.erase ("packet_delay_microseconds");
 			json.erase ("rebroadcast_delay");
 			json.erase ("creation_rebroadcast");
-			upgraded = true;
 		case 6:
 			json.put ("bootstrap_connections", 16);
 			json.put ("callback_address", "");
 			json.put ("callback_port", 0);
 			json.put ("callback_target", "");
-			upgraded = true;
 		case 7:
 			json.put ("lmdb_max_dbs", 128);
-			upgraded = true;
 		case 8:
 			json.put ("bootstrap_connections_max", "64");
-			upgraded = true;
 		case 9:
 			json.put ("state_block_parse_canary", nano::block_hash (0).to_string ());
 			json.put ("state_block_generate_canary", nano::block_hash (0).to_string ());
-			upgraded = true;
 		case 10:
 			json.put ("online_weight_minimum", online_weight_minimum.to_string_dec ());
 			json.put ("online_weight_quorom", std::to_string (online_weight_quorum));
 			json.erase ("inactive_supply");
-			upgraded = true;
 		case 11:
 		{
 			// Rename
@@ -201,20 +190,16 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.get<std::string> ("online_weight_quorom", online_weight_quorum_l);
 			json.erase ("online_weight_quorom");
 			json.put ("online_weight_quorum", online_weight_quorum_l);
-			upgraded = true;
 		}
 		case 12:
 			json.erase ("state_block_parse_canary");
 			json.erase ("state_block_generate_canary");
-			upgraded = true;
 		case 13:
 			json.put ("generate_hash_votes_at", 0);
-			upgraded = true;
 		case 14:
 			json.put ("network_threads", std::to_string (network_threads));
 			json.erase ("generate_hash_votes_at");
 			json.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
-			upgraded = true;
 		case 15:
 		{
 			json.put ("allow_local_peers", allow_local_peers);
@@ -244,8 +229,6 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 
 			json.put (signature_checker_threads_key, signature_checker_threads);
 			json.put ("unchecked_cutoff_time", unchecked_cutoff_time.count ());
-
-			upgraded = true;
 		}
 		case 16:
 		{
@@ -260,14 +243,13 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put (pow_sleep_interval_key, pow_sleep_interval.count ());
 			json.put ("external_address", external_address.to_string ());
 			json.put ("external_port", external_port);
-			upgraded = true;
 		}
 		case 17:
 			break;
 		default:
 			throw std::runtime_error ("Unknown node_config version");
 	}
-	return upgraded;
+	return version_a < json_version ();
 }
 
 nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonconfig & json)


### PR DESCRIPTION
Uses the pattern of returning `version_a < json_version ()` everywhere, which should be less error-prone/less code. Also moves the network variable within the ifdef where it's used.