### PR TITLE
Fix test by disabling confirmation, as a result the block wont be con…

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2570,8 +2570,11 @@ TEST (node, dont_write_lock_node)
 
 TEST (active_difficulty, recalculate_work)
 {
-	nano::system system (24000, 1);
-	auto & node1 (*system.nodes[0]);
+	nano::system system;
+	nano::node_config node_config (24000, system.logging);
+	node_config.enable_voting = false;
+	auto & node1 = *system.add_node (node_config);
+	auto & wallet (*system.wallet (0));
 	nano::genesis genesis;
 	nano::keypair key1;
 	ASSERT_EQ (node1.network_params.network.publish_threshold, node1.active.active_difficulty ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2574,7 +2574,6 @@ TEST (active_difficulty, recalculate_work)
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
 	auto & node1 = *system.add_node (node_config);
-	auto & wallet (*system.wallet (0));
 	nano::genesis genesis;
 	nano::keypair key1;
 	ASSERT_EQ (node1.network_params.network.publish_threshold, node1.active.active_difficulty ());


### PR DESCRIPTION
as a result the block wont be confirmed, so work is recalculated, instead of confirming and creating a new block