### PR TITLE
Fix RPC secure build

### DIFF
--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -18,7 +18,6 @@ TEST (difficulty, multipliers)
 		uint64_t difficulty = 0xfffffe0000000000;
 		double expected_multiplier = 0.125;
 
-		auto multiplier = nano::difficulty::to_multiplier (difficulty, base);
 		ASSERT_NEAR (expected_multiplier, nano::difficulty::to_multiplier (difficulty, base), 1e-10);
 		ASSERT_EQ (difficulty, nano::difficulty::from_multiplier (expected_multiplier, base));
 	}

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -88,12 +88,12 @@ class receive_session final : public std::enable_shared_from_this<receive_sessio
 public:
 	receive_session (boost::asio::io_context & ioc, std::atomic<int> & send_calls_remaining, std::string const & wallet, std::string const & account, std::string const & block, tcp::resolver::results_type const & results) :
 	socket (ioc),
+	strand (socket.get_executor ()),
 	send_calls_remaining (send_calls_remaining),
 	wallet (wallet),
 	account (account),
 	block (block),
-	results (results),
-	strand (socket.get_executor ())
+	results (results)
 	{
 	}
 
@@ -164,12 +164,12 @@ class send_session final : public std::enable_shared_from_this<send_session>
 public:
 	send_session (boost::asio::io_context & ioc, std::atomic<int> & send_calls_remaining, std::string const & wallet, std::string const & source, std::string const & destination, tcp::resolver::results_type const & results) :
 	socket (ioc),
+	strand (socket.get_executor ()),
 	send_calls_remaining (send_calls_remaining),
 	wallet (wallet),
 	source (source),
 	destination (destination),
-	results (results),
-	strand (socket.get_executor ())
+	results (results)
 	{
 	}
 
@@ -377,7 +377,6 @@ int main (int argc, char * const * argv)
 		return 1;
 	}
 	boost::program_options::notify (vm);
-	int result (0);
 
 	auto node_count = vm.find ("node_count")->second.as<int> ();
 	auto destination_count = vm.find ("destination_count")->second.as<int> ();

--- a/nano/rpc/rpc_connection_secure.cpp
+++ b/nano/rpc/rpc_connection_secure.cpp
@@ -3,8 +3,8 @@
 
 #include <boost/polymorphic_pointer_cast.hpp>
 
-nano::rpc_connection_secure::rpc_connection_secure (nano::rpc_config const & rpc_config, nano::network_constants const & network_constants, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface, boost::asio::ssl::context & ssl_context) :
-nano::rpc_connection (rpc_config, network_constants, io_ctx, logger, rpc_handler_interface),
+nano::rpc_connection_secure::rpc_connection_secure (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface, boost::asio::ssl::context & ssl_context) :
+nano::rpc_connection (rpc_config, io_ctx, logger, rpc_handler_interface),
 stream (socket, ssl_context)
 {
 }

--- a/nano/rpc/rpc_connection_secure.hpp
+++ b/nano/rpc/rpc_connection_secure.hpp
@@ -12,7 +12,7 @@ namespace nano
 class rpc_connection_secure : public rpc_connection
 {
 public:
-	rpc_connection_secure (nano::rpc_config const & rpc_config, nano::network_constants const & network_constants, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface_a, boost::asio::ssl::context & ssl_context);
+	rpc_connection_secure (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface_a, boost::asio::ssl::context & ssl_context);
 	void parse_connection () override;
 	void write_completion_handler (std::shared_ptr<nano::rpc_connection> rpc) override;
 	/** The TLS handshake callback */

--- a/nano/rpc/rpc_secure.cpp
+++ b/nano/rpc/rpc_secure.cpp
@@ -99,7 +99,7 @@ ssl_context (boost::asio::ssl::context::tlsv12_server)
 
 void nano::rpc_secure::accept ()
 {
-	auto connection (std::make_shared<nano::rpc_connection_secure> (config, network_constants, io_ctx, logger, rpc_handler_interface, this->ssl_context));
+	auto connection (std::make_shared<nano::rpc_connection_secure> (config, io_ctx, logger, rpc_handler_interface, this->ssl_context));
 	acceptor.async_accept (connection->socket, [this, connection](boost::system::error_code const & ec) {
 		if (acceptor.is_open ())
 		{


### PR DESCRIPTION
The secure RPC build (using `-DNANO_SECURE_RPC=ON`) is failing due to a parameter no longer being used.

Have also fixed a couple other MAC warnings.