### PR TITLE
Websockets: prevent re-sub

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -71,7 +71,8 @@ boost::optional<std::string> websocket_test_call (std::string host, std::string 
 	{
 		boost::beast::error_code ec_ignored;
 		ws.async_close (boost::beast::websocket::close_code::normal, [](boost::beast::error_code const & ec) {
-			//
+			// A synchronous close usually hangs in tests when the server's io_context stops looping
+			// An async_close solves this problem
 		});
 	}
 	return ret;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -137,6 +137,7 @@ TEST (websocket, subscription_edge)
 	}
 
 	// Second unsub, should acknowledge but not decrease subscriber count
+	std::this_thread::sleep_for (50ms);
 	{
 		ack_ready = false;
 		std::thread unsub_thread ([]() {

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -70,7 +70,9 @@ boost::optional<std::string> websocket_test_call (std::string host, std::string 
 	if (ws.is_open ())
 	{
 		boost::beast::error_code ec_ignored;
-		ws.close (boost::beast::websocket::close_code::normal, ec_ignored);
+		ws.async_close (boost::beast::websocket::close_code::normal, [](boost::beast::error_code const & ec) {
+			//
+		});
 	}
 	return ret;
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1177,7 +1177,7 @@ startup_time (std::chrono::steady_clock::now ())
 		if (websocket_server)
 		{
 			observers.blocks.add ([this](std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
-				if (this->websocket_server->any_subscribers (nano::websocket::topic::confirmation))
+				if (this->websocket_server->any_subscriber (nano::websocket::topic::confirmation))
 				{
 					if (this->block_arrival.recent (block_a->hash ()))
 					{
@@ -1254,7 +1254,7 @@ startup_time (std::chrono::steady_clock::now ())
 		if (this->websocket_server)
 		{
 			observers.vote.add ([this](nano::transaction const & transaction, std::shared_ptr<nano::vote> vote_a, std::shared_ptr<nano::transport::channel> channel_a) {
-				if (this->websocket_server->any_subscribers (nano::websocket::topic::vote))
+				if (this->websocket_server->any_subscriber (nano::websocket::topic::vote))
 				{
 					nano::websocket::message_builder builder;
 					auto msg (builder.vote_received (vote_a));

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -21,7 +21,7 @@ all_local_accounts (options_a.get<bool> ("all_local_accounts", false))
 			}
 			else
 			{
-				node.logger.always_log (boost::str (boost::format ("Websocket: invalid account provided for filtering blocks: %1%") % account_l.second.data ()));
+				node.logger.always_log ("Websocket: invalid account provided for filtering blocks: ", account_l.second.data ());
 			}
 		}
 	}
@@ -75,7 +75,7 @@ node (node_a)
 			}
 			else
 			{
-				node.logger.always_log (boost::str (boost::format ("Websocket: invalid account given to filter votes: %1%") % representative_l.second.data ()));
+				node.logger.always_log ("Websocket: invalid account given to filter votes: ", representative_l.second.data ());
 			}
 		}
 	}
@@ -312,12 +312,12 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		if (existing != subscriptions.end ())
 		{
 			existing->second = std::move (options_l);
-			ws_listener.get_node ().logger.always_log (boost::str (boost::format ("Websocket: updated subscription to topic: %1%") % from_topic (topic_l)));
+			ws_listener.get_node ().logger.always_log ("Websocket: updated subscription to topic: ", from_topic (topic_l));
 		}
 		else
 		{
 			subscriptions.insert (std::make_pair (topic_l, std::move (options_l)));
-			ws_listener.get_node ().logger.always_log (boost::str (boost::format ("Websocket: new subscription to topic: %1%") % from_topic (topic_l)));
+			ws_listener.get_node ().logger.always_log ("Websocket: new subscription to topic: ", from_topic (topic_l));
 			ws_listener.increase_subscriber_count (topic_l);
 		}
 		action_succeeded = true;
@@ -327,7 +327,7 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		std::lock_guard<std::mutex> lk (subscriptions_mutex);
 		if (subscriptions.erase (topic_l))
 		{
-			ws_listener.get_node ().logger.always_log (boost::str (boost::format ("Websocket: removed subscription to topic: %1%") % from_topic (topic_l)));
+			ws_listener.get_node ().logger.always_log ("Websocket: removed subscription to topic: ", from_topic (topic_l));
 			ws_listener.decrease_subscriber_count (topic_l);
 		}
 		action_succeeded = true;

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -110,7 +110,7 @@ nano::websocket::session::~session ()
 		std::unique_lock<std::mutex> lk (subscriptions_mutex);
 		for (auto & subscription : subscriptions)
 		{
-			ws_listener.decrease_subscription_count (subscription.first);
+			ws_listener.subscriber_count (subscription.first);
 		}
 	}
 
@@ -314,7 +314,7 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		{
 			subscriptions.insert (std::make_pair (topic_l, std::move (options_l)));
 			ws_listener.get_node ().logger.always_log (boost::str (boost::format ("Websocket: new subscription to topic: %1%") % from_topic (topic_l)));
-			ws_listener.increase_subscription_count (topic_l);
+			ws_listener.subscriber_count (topic_l);
 		}
 		action_succeeded = true;
 	}
@@ -324,7 +324,7 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		if (subscriptions.erase (topic_l))
 		{
 			ws_listener.get_node ().logger.always_log (boost::str (boost::format ("Websocket: removed subscription to topic: %1%") % from_topic (topic_l)));
-			ws_listener.decrease_subscription_count (topic_l);
+			ws_listener.decrease_subscriber_count (topic_l);
 		}
 		action_succeeded = true;
 	}
@@ -421,19 +421,19 @@ void nano::websocket::listener::broadcast (nano::websocket::message message_a)
 	sessions.erase (std::remove_if (sessions.begin (), sessions.end (), [](auto & elem) { return elem.expired (); }), sessions.end ());
 }
 
-bool nano::websocket::listener::any_subscribers (nano::websocket::topic const & topic_a)
+bool nano::websocket::listener::any_subscriber (nano::websocket::topic const & topic_a)
 {
-	return topic_subscription_count[static_cast<std::size_t> (topic_a)] > 0;
+	return topic_subscriber_count[static_cast<std::size_t> (topic_a)] > 0;
 }
 
-void nano::websocket::listener::increase_subscription_count (nano::websocket::topic const & topic_a)
+void nano::websocket::listener::subscriber_count (nano::websocket::topic const & topic_a)
 {
-	topic_subscription_count[static_cast<std::size_t> (topic_a)] += 1;
+	topic_subscriber_count[static_cast<std::size_t> (topic_a)] += 1;
 }
 
-void nano::websocket::listener::decrease_subscription_count (nano::websocket::topic const & topic_a)
+void nano::websocket::listener::decrease_subscriber_count (nano::websocket::topic const & topic_a)
 {
-	auto & count (topic_subscription_count[static_cast<std::size_t> (topic_a)]);
+	auto & count (topic_subscriber_count[static_cast<std::size_t> (topic_a)]);
 	release_assert (count > 0);
 	count -= 1;
 }

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -110,7 +110,7 @@ nano::websocket::session::~session ()
 		std::unique_lock<std::mutex> lk (subscriptions_mutex);
 		for (auto & subscription : subscriptions)
 		{
-			ws_listener.subscriber_count (subscription.first);
+			ws_listener.increase_subscriber_count (subscription.first);
 		}
 	}
 
@@ -314,7 +314,7 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		{
 			subscriptions.insert (std::make_pair (topic_l, std::move (options_l)));
 			ws_listener.get_node ().logger.always_log (boost::str (boost::format ("Websocket: new subscription to topic: %1%") % from_topic (topic_l)));
-			ws_listener.subscriber_count (topic_l);
+			ws_listener.increase_subscriber_count (topic_l);
 		}
 		action_succeeded = true;
 	}
@@ -421,12 +421,7 @@ void nano::websocket::listener::broadcast (nano::websocket::message message_a)
 	sessions.erase (std::remove_if (sessions.begin (), sessions.end (), [](auto & elem) { return elem.expired (); }), sessions.end ());
 }
 
-bool nano::websocket::listener::any_subscriber (nano::websocket::topic const & topic_a)
-{
-	return topic_subscriber_count[static_cast<std::size_t> (topic_a)] > 0;
-}
-
-void nano::websocket::listener::subscriber_count (nano::websocket::topic const & topic_a)
+void nano::websocket::listener::increase_subscriber_count (nano::websocket::topic const & topic_a)
 {
 	topic_subscriber_count[static_cast<std::size_t> (topic_a)] += 1;
 }

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -219,7 +219,7 @@ void nano::websocket::session::read ()
 				self_l->ws_listener.get_node ().logger.try_log ("Websocket: json parsing failed: ", ex.what ());
 			}
 		}
-		else
+		else if (ec != boost::asio::error::eof) // connection was closed cleanly if EOF
 		{
 			self_l->ws_listener.get_node ().logger.try_log ("Websocket: read failed: ", ec.message ());
 		}

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -110,7 +110,7 @@ nano::websocket::session::~session ()
 		std::unique_lock<std::mutex> lk (subscriptions_mutex);
 		for (auto & subscription : subscriptions)
 		{
-			ws_listener.increase_subscriber_count (subscription.first);
+			ws_listener.decrease_subscriber_count (subscription.first);
 		}
 	}
 

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -230,19 +230,23 @@ namespace websocket
 		 * Per-topic subscribers check. Relies on all sessions correctly increasing and
 		 * decreasing the subscriber counts themselves.
 		 */
-		bool any_subscribers (nano::websocket::topic const & topic_a);
-		/** Adds to subscription count of a specific topic*/
-		void increase_subscription_count (nano::websocket::topic const & topic_a);
-		/** Removes from subscription count of a specific topic*/
-		void decrease_subscription_count (nano::websocket::topic const & topic_a);
+		bool any_subscriber (nano::websocket::topic const & topic_a);
 
 	private:
+		/** A websocket session can increase and decrease subscription counts. */
+		friend nano::websocket::session;
+
+		/** Adds to subscription count of a specific topic*/
+		void increase_subscriber_count (nano::websocket::topic const & topic_a);
+		/** Removes from subscription count of a specific topic*/
+		void decrease_subscriber_count (nano::websocket::topic const & topic_a);
+
 		nano::node & node;
 		boost::asio::ip::tcp::acceptor acceptor;
 		socket_type socket;
 		std::mutex sessions_mutex;
 		std::vector<std::weak_ptr<session>> sessions;
-		std::array<std::atomic<std::size_t>, number_topics> topic_subscription_count{};
+		std::array<std::atomic<std::size_t>, number_topics> topic_subscriber_count{};
 		std::atomic<bool> stopped{ false };
 	};
 }

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -230,7 +230,15 @@ namespace websocket
 		 * Per-topic subscribers check. Relies on all sessions correctly increasing and
 		 * decreasing the subscriber counts themselves.
 		 */
-		bool any_subscriber (nano::websocket::topic const & topic_a);
+		bool any_subscriber (nano::websocket::topic const & topic_a) const
+		{
+			return subscriber_count (topic_a) > 0;
+		}
+		/** Getter for subscriber count of a specific topic*/
+		size_t subscriber_count (nano::websocket::topic const & topic_a) const
+		{
+			return topic_subscriber_count[static_cast<std::size_t> (topic_a)];
+		}
 
 	private:
 		/** A websocket session can increase and decrease subscription counts. */


### PR DESCRIPTION
- Change variable and method names from "subscription" to "subscriber" in general
- (bug fix) Do not increase subscribers when re-subbing to the same topic, instead update the current one
- (fix) Do not output an error to log if the error code is EOF (session closed cleanly)
- Move increase/decrease_subscriber_count methods to private, and make `session` a friend of `listener`. I tried to make only the 2 functions that need to access them as friends, but one of them is private. Any alternative?
- Add a getter for `subscriber_count` , useful only in the new test for now but you never know.