### PR TITLE
Fix TSAN error with test confirmation_height.conflict_rollback_cemented

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,3 +1,4 @@
+#include <boost/iostreams/stream_buffer.hpp>
 #include <boost/thread.hpp>
 #include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
@@ -1954,6 +1955,9 @@ TEST (confirmation_height, all_block_types)
 /* Bulk of the this test was taken from the node.fork_flip test */
 TEST (confirmation_height, conflict_rollback_cemented)
 {
+	boost::iostreams::stream_buffer<nano::stringstream_mt_sink> sb;
+	sb.open (nano::stringstream_mt_sink{});
+	nano::boost_log_cerr_redirect redirect_cerr (&sb);
 	nano::system system (24000, 2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
@@ -2005,16 +2009,13 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		node1.store.account_put (transaction, nano::genesis_account, info);
 	}
 
-	std::stringstream ss;
-	nano::boost_log_cerr_redirect redirect_cerr (ss.rdbuf ());
-
 	auto rollback_log_entry = boost::str (boost::format ("Failed to roll back %1%") % send2->hash ().to_string ());
 	system.deadline_set (10s);
 	auto done (false);
 	while (!done)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		done = (ss.str ().find (rollback_log_entry) != std::string::npos);
+		done = (sb.component ()->str ().find (rollback_log_entry) != std::string::npos);
 	}
 	auto transaction1 (system.nodes[0]->store.tx_begin_read ());
 	auto transaction2 (system.nodes[1]->store.tx_begin_read ());

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5378,7 +5378,7 @@ TEST (rpc, confirmation_height_currently_processing)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
 	// Do enough blocks to reliably call RPC before the confirmation height has finished
-	constexpr auto num_blocks = 500;
+	constexpr auto num_blocks = 1000;
 	auto previous_genesis_chain_hash = node->latest (nano::test_genesis_key.pub);
 	{
 		auto transaction = node->store.tx_begin_write ();


### PR DESCRIPTION
The `std::stringstream` used to redirect `cerr` is not thread safe as it can be modifed when logging is done in the background while we are trying to read from it. I've wrapped it in a boost sink which gives exclusive access now with a mutex, this is only used in tests. I also don't think it is thread-safe to add a sink on the fly so am doing this at the start of the test as well.

Add more blocks to use in `rpc.confirmation_height_currently_processing` to prevent it failing when run under ASAN.