### PR TITLE
Decrease logging level for "Reserved sender" message

### DIFF
--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -524,7 +524,7 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 	}
 	else
 	{
-		if (node.config.logging.network_packet_logging_value ())
+		if (node.config.logging.network_packet_logging ())
 		{
 			node.logger.try_log (boost::str (boost::format ("Reserved sender %1%") % data_a->endpoint));
 		}

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -524,9 +524,9 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 	}
 	else
 	{
-		if (node.config.logging.network_logging ())
+		if (node.config.logging.network_packet_logging_value ())
 		{
-			node.logger.try_log (boost::str (boost::format ("Reserved sender %1%") % data_a->endpoint.address ().to_string ()));
+			node.logger.try_log (boost::str (boost::format ("Reserved sender %1%") % data_a->endpoint));
 		}
 
 		node.stats.inc_detail_only (nano::stat::type::error, nano::stat::detail::bad_sender);


### PR DESCRIPTION
filtering data for DoS purposes. Packet logging should be required