### PR TITLE
Rename active_difficulty RPC response

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -835,9 +835,9 @@ void nano::json_handler::accounts_pending ()
 
 void nano::json_handler::active_difficulty ()
 {
-	response_l.put ("difficulty_threshold", nano::to_string_hex (node.network_params.network.publish_threshold));
+	response_l.put ("network_minimum", nano::to_string_hex (node.network_params.network.publish_threshold));
 	auto difficulty_active = node.active.active_difficulty ();
-	response_l.put ("difficulty_active", nano::to_string_hex (difficulty_active));
+	response_l.put ("network_current", nano::to_string_hex (difficulty_active));
 	auto multiplier = nano::difficulty::to_multiplier (difficulty_active, node.network_params.network.publish_threshold);
 	response_l.put ("multiplier", nano::to_string (multiplier));
 	response_errors ();


### PR DESCRIPTION
difficulty_threshold to network_minimum
difficulty_active to network_current

network_minimum is the minimum required difficulty for the block to have valid work
network_current is the current 5min trended average of the active_transactions adjusted_difficulty