### PR TITLE
Set minimum difficulty for RPC "work_generate"

### DIFF
--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -153,7 +153,7 @@ std::string nano::error_rpc_messages::message (int ev) const
 		case nano::error_rpc::confirmation_not_found:
 			return "Active confirmation not found";
 		case nano::error_rpc::difficulty_limit:
-			return "Difficulty above config limit";
+			return "Difficulty above config limit or below publish threshold";
 		case nano::error_rpc::invalid_balance:
 			return "Invalid balance number";
 		case nano::error_rpc::invalid_destinations:

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -390,6 +390,11 @@ int main (int argc, char * const * argv)
 						std::cerr << "Invalid difficulty\n";
 						result = -1;
 					}
+					else if (difficulty < network_constants.publish_threshold)
+					{
+						std::cerr << "Difficulty below publish threshold\n";
+						result = -1;
+					}
 				}
 				if (!result)
 				{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4345,7 +4345,7 @@ void nano::json_handler::work_generate ()
 			ec = nano::error_rpc::bad_difficulty_format;
 		}
 	}
-	if (!ec && difficulty > node_rpc_config.max_work_generate_difficulty)
+	if (!ec && (difficulty > node_rpc_config.max_work_generate_difficulty || difficulty < node.network_params.network.publish_threshold))
 	{
 		ec = nano::error_rpc::difficulty_limit;
 	}


### PR DESCRIPTION
to prevent possible OpenCL validation loop
https://github.com/nanocurrency/nano-node/blob/master/nano/node/openclwork.cpp#L698
work_validate is invalid for difficulty < threshold