### PR TITLE
generate difficulty was passing hash by ref

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4353,7 +4353,7 @@ void nano::json_handler::work_generate ()
 	{
 		bool use_peers (request.get_optional<bool> ("use_peers") == true);
 		auto rpc_l (shared_from_this ());
-		auto callback = [rpc_l, &hash, this](boost::optional<uint64_t> const & work_a) {
+		auto callback = [rpc_l, hash, this](boost::optional<uint64_t> const & work_a) {
 			if (work_a)
 			{
 				boost::property_tree::ptree response_l;


### PR DESCRIPTION
and could go out of scope before the callback was called
copy into lambda instead