### PR TITLE
Update test script

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 build_dir=${1-${PWD}}
-TIMEOUT_DEFAULT=120
+TIMEOUT_DEFAULT=180
 
 BUSYBOX_BASH=${BUSYBOX_BASH-0}
 
@@ -44,7 +44,7 @@ run_tests() {
         TIMEOUT_TIME_ARG=""
     fi
 
-    if [ "$(date +%s)" -lt 1555718400 ]; then
+    if [ "$(date +%s)" -lt 1577836799 ]; then
         tries=(_initial_ 1 2 3 4 5 6 7 8 9)
     else
         tries=(_initial_)
@@ -55,7 +55,7 @@ run_tests() {
             echo "core_test failed: ${core_test_res}, retrying (try=${try})"
 
             # Wait a while for sockets to be all cleaned up by the kernel
-            sleep $[60 + (${RANDOM} % 30)]
+            sleep $[30 + (${RANDOM} % 30)]
         fi
 
         ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-${TIMEOUT_DEFAULT}} ./core_test


### PR DESCRIPTION
TIMEOUT_DEFAULT=180 (core_test takes longer than it used to and can sometimes timeout before completion)
retry loop initialized to work until 12-31-2019 23:59:59 UTC
shortened wait for socket cleanup