### PR TITLE
active_transactions test cleanup

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -75,7 +75,6 @@ TEST (active_transactions, adjusted_difficulty_priority)
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
 	auto & node1 = *system.add_node (node_config);
-	auto & wallet (*system.wallet (0));
 	nano::genesis genesis;
 	nano::keypair key1, key2, key3;
 	auto transaction (node1.store.tx_begin_read ());
@@ -147,10 +146,12 @@ TEST (active_transactions, adjusted_difficulty_priority)
 
 TEST (active_transactions, keep_local)
 {
+	//delay_frontier_confirmation_height_updating to allow the test to before
+	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
-	auto & node1 = *system.add_node (node_config);
+	auto & node1 = *system.add_node (node_config, delay_frontier_confirmation_height_updating);
 	auto & wallet (*system.wallet (0));
 	nano::genesis genesis;
 	//key 1/2 will be managed by the wallet
@@ -208,11 +209,12 @@ TEST (active_transactions, keep_local)
 
 TEST (active_transactions, prioritize_chains)
 {
+	//delay_frontier_confirmation_height_updating to allow the test to before
+	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
-	auto & node1 = *system.add_node (node_config);
-	auto & wallet (*system.wallet (0));
+	auto & node1 = *system.add_node (node_config, delay_frontier_confirmation_height_updating);
 	nano::genesis genesis;
 	nano::keypair key1, key2, key3;
 


### PR DESCRIPTION
remove unused &wallet
delay_frontier_confirmation_height_updating to keep unconfirmed transactions in ledger from getting re-added to active_transactions