### PR TITLE
Update stringstream test sink to bounds check the strings

### DIFF
--- a/nano/core_test/testutil.hpp
+++ b/nano/core_test/testutil.hpp
@@ -57,7 +57,7 @@ public:
 	std::streamsize write (const char * string_to_write, std::streamsize size)
 	{
 		std::lock_guard<std::mutex> guard (mutex);
-		ss << string_to_write;
+		ss << std::string (string_to_write, size);
 		return size;
 	}
 


### PR DESCRIPTION
@SergiySW found an ASAN warning when running the `confirmation_height.conflict_rollback_cemented` test. The `const char *` does not appear to be null terminated. Cannot use `std::stringstream::read` as it expects a non-const char array and would prefer not to introduce a `const_cast`. It's only used in tests so just going to construct a new string of the expected size.