### PR TITLE
[WIP] Websockets: vote received/replay/sent

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -2387,7 +2387,7 @@ public:
 			auto cookie (connection->node->network.tcp_channels.assign_syn_cookie (connection->remote_endpoint));
 			nano::node_id_handshake response_message (cookie, response);
 			auto bytes = response_message.to_bytes ();
-			connection->socket->async_write (bytes, [ bytes, connection = connection ](boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_write (bytes, [bytes, connection = connection](boost::system::error_code const & ec, size_t size_a) {
 				if (ec)
 				{
 					if (connection->node->config.logging.network_node_id_handshake_logging ())

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -2387,7 +2387,7 @@ public:
 			auto cookie (connection->node->network.tcp_channels.assign_syn_cookie (connection->remote_endpoint));
 			nano::node_id_handshake response_message (cookie, response);
 			auto bytes = response_message.to_bytes ();
-			connection->socket->async_write (bytes, [bytes, connection = connection](boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_write (bytes, [ bytes, connection = connection ](boost::system::error_code const & ec, size_t size_a) {
 				if (ec)
 				{
 					if (connection->node->config.logging.network_node_id_handshake_logging ())

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1385,8 +1385,7 @@ startup_time (std::chrono::steady_clock::now ())
 			}
 		});
 		observers.vote.add ([this](boost::optional<nano::transaction const &> transaction_opt_a, std::shared_ptr<nano::vote> vote_a, std::shared_ptr<nano::transport::channel> channel_a, nano::vote_code code_a) {
-			assert (transaction_opt_a.is_initialized ());
-			if (code_a == nano::vote_code::vote && transaction_opt_a)
+			if (transaction_opt_a.is_initialized () && code_a == nano::vote_code::vote)
 			{
 				this->gap_cache.vote (vote_a);
 				this->online_reps.observe (vote_a->account);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -953,7 +953,7 @@ void nano::vote_processor::vote (std::shared_ptr<nano::vote> vote_a, std::shared
 {
 	{
 		boost::optional<nano::transaction const &> empty_transaction_l;
-		node.observers.vote.notify (empty_transaction_l, vote_a, channel_a, nano::vote_code::outgoing);
+		node.observers.vote.notify (empty_transaction_l, vote_a, channel_a, nano::vote_code::sent);
 	}
 	std::unique_lock<std::mutex> lock (mutex);
 	if (!stopped)
@@ -1069,7 +1069,7 @@ nano::vote_code nano::vote_processor::vote_blocking (nano::transaction const & t
 					channel_a->send_buffer (confirm.to_bytes (), nano::stat::detail::confirm_ack);
 				}
 				break;
-			case nano::vote_code::outgoing:
+			case nano::vote_code::sent:
 			case nano::vote_code::invalid:
 				assert (false);
 				break;
@@ -1090,7 +1090,7 @@ nano::vote_code nano::vote_processor::vote_blocking (nano::transaction const & t
 			status = "Vote";
 			node.stats.inc (nano::stat::type::vote, nano::stat::detail::vote_valid);
 			break;
-		case nano::vote_code::outgoing:
+		case nano::vote_code::sent:
 			release_assert (false);
 			break;
 	}

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -14,7 +14,7 @@ public:
 	using blocks_t = nano::observer_set<std::shared_ptr<nano::block>, nano::account const &, nano::uint128_t const &, bool>;
 	blocks_t blocks;
 	nano::observer_set<bool> wallet;
-	nano::observer_set<nano::transaction const &, std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>> vote;
+	nano::observer_set<boost::optional<nano::transaction const &>, std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>, nano::vote_code> vote;
 	nano::observer_set<nano::account const &, bool> account_balance;
 	nano::observer_set<std::shared_ptr<nano::transport::channel>> endpoint;
 	nano::observer_set<> disconnect;

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -453,7 +453,7 @@ nano::websocket::message nano::websocket::message_builder::block_confirmed (std:
 	return message_l;
 }
 
-nano::websocket::message nano::websocket::message_builder::vote_received (std::shared_ptr<nano::vote> vote_a)
+nano::websocket::message nano::websocket::message_builder::vote_received (std::shared_ptr<nano::vote> vote_a, nano::vote_code code_a)
 {
 	nano::websocket::message message_l (nano::websocket::topic::vote);
 	set_common_fields (message_l);
@@ -461,6 +461,7 @@ nano::websocket::message nano::websocket::message_builder::vote_received (std::s
 	// Vote information
 	boost::property_tree::ptree vote_node_l;
 	vote_a->serialize_json (vote_node_l);
+	vote_node_l.put ("code", code_a == nano::vote_code::invalid ? "invalid" : code_a == nano::vote_code::replay ? "replay" : code_a == nano::vote_code::vote ? "received" : code_a == nano::vote_code::outgoing ? "outgoing" : "unknown");
 	message_l.contents.add_child ("message", vote_node_l);
 	return message_l;
 }

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -461,7 +461,7 @@ nano::websocket::message nano::websocket::message_builder::vote_received (std::s
 	// Vote information
 	boost::property_tree::ptree vote_node_l;
 	vote_a->serialize_json (vote_node_l);
-	vote_node_l.put ("code", code_a == nano::vote_code::invalid ? "invalid" : code_a == nano::vote_code::replay ? "replay" : code_a == nano::vote_code::vote ? "received" : code_a == nano::vote_code::outgoing ? "outgoing" : "unknown");
+	vote_node_l.put ("code", code_a == nano::vote_code::invalid ? "invalid" : code_a == nano::vote_code::replay ? "replay" : code_a == nano::vote_code::vote ? "received" : code_a == nano::vote_code::sent ? "sent" : "unknown");
 	message_l.contents.add_child ("message", vote_node_l);
 	return message_l;
 }

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -76,7 +76,7 @@ namespace websocket
 	{
 	public:
 		message block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype);
-		message vote_received (std::shared_ptr<nano::vote> vote_a);
+		message vote_received (std::shared_ptr<nano::vote> vote_a, nano::vote_code code_a);
 
 	private:
 		/** Set the common fields for messages: timestamp and topic. */

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -269,7 +269,7 @@ enum class vote_code
 	invalid, // Vote is not signed correctly
 	replay, // Vote does not have the highest sequence number, it's a replay
 	vote, // Vote has the highest sequence number
-	outgoing // Vote is generated in this node
+	sent // Vote is generated in this node
 };
 
 enum class process_result

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -268,7 +268,8 @@ enum class vote_code
 {
 	invalid, // Vote is not signed correctly
 	replay, // Vote does not have the highest sequence number, it's a replay
-	vote // Vote has the highest sequence number
+	vote, // Vote has the highest sequence number
+	outgoing // Vote is generated in this node
 };
 
 enum class process_result


### PR DESCRIPTION
- Adds a `vote_code::sent` that is only used for the purpose of websocket broadcasting.
- Only `vote_code::vote` votes are processed in the first observer notify, to keep the same functionality.

Todo:
- [ ]  Validate the approach
- [ ]  Confirm all locations of vote processing are covered
- [ ]  Add websocket tests
- [ ]  Add filtering options by vote type
- [ ]  Add filtering tests
- [ ]  Documentation

@zhyatt I checked and for the v19RC1&2 tests on the beta network, only `received` votes were broadcasted through the websocket. No `replay` nor `sent` votes were there. This is because the `replay` votes don't enter the notify branch on [this switch](https://github.com/nanocurrency/nano-node/blob/V19.0RC2/nano/node/node.cpp#L856).

I updated my analysis script based on this PR as of commit 0b8ca62 and am attaching a sample. See the head of the file for a description. I guess that all recorded `sent` votes that are not from my representative is my own node rebroadcasting votes.

[vote_batching.zip](https://github.com/nanocurrency/nano-node/files/3211857/vote_batching.zip)
