### PR TITLE
Sort includes by category using clang-format

### DIFF
--- a/.clang-format.base
+++ b/.clang-format.base
@@ -35,4 +35,22 @@ BraceWrapping:
   BeforeElse: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
+SortIncludes: true
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Headers in <> without extension.
+  - Regex:           '<([A-Za-z0-9\/-_])+>'
+    Priority:        5
+  # Headers in the boost library.
+  - Regex:           '<boost/.*>'
+    Priority:        4
+  # Headers in other third party libraries
+  - Regex:           '<(gtest|crypto)/([A-Za-z0-9.\/-_])+>'
+    Priority:        3
+  # Headers from nano workspace.
+  - Regex:           '<nano/([A-Za-z0-9.\/-_])+>'
+    Priority:        2
+  # Headers in ""
+  - Regex:           '"([A-Za-z0-9.\/-_])+"'
+    Priority:        1
 ...

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1,7 +1,8 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -1,13 +1,13 @@
-#include <boost/property_tree/json_parser.hpp>
-
-#include <fstream>
-
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
-
 #include <nano/lib/interface.h>
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <fstream>
 
 #include <crypto/ed25519-donna/ed25519.h>
 

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1,10 +1,11 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
 #include <nano/secure/versioning.hpp>
+
+#include <gtest/gtest.h>
 
 #include <fstream>
 

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -1,6 +1,7 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <nano/lib/numbers.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (difficulty, multipliers)
 {

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -1,6 +1,7 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/interface.cpp
+++ b/nano/core_test/interface.cpp
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
-
-#include <memory>
-
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/interface.h>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/work.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
 
 TEST (interface, xrb_uint128_to_dec)
 {

--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -1,12 +1,15 @@
-#include <boost/property_tree/json_parser.hpp>
-#include <chrono>
-#include <gtest/gtest.h>
-#include <memory>
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/ipc_client.hpp>
 #include <nano/node/ipc.hpp>
 #include <nano/node/testing.hpp>
 #include <nano/rpc/rpc.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <chrono>
+#include <memory>
 #include <sstream>
 #include <vector>
 

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -1,9 +1,10 @@
-#include <crypto/cryptopp/filters.h>
-#include <crypto/cryptopp/randpool.h>
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/stats.hpp>
 #include <nano/node/testing.hpp>
+
+#include <crypto/cryptopp/filters.h>
+#include <crypto/cryptopp/randpool.h>
+#include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/logger.cpp
+++ b/nano/core_test/logger.cpp
@@ -1,9 +1,12 @@
-#include <boost/log/utility/setup/console.hpp>
-#include <chrono>
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/logging.hpp>
 #include <nano/secure/utility.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/log/utility/setup/console.hpp>
+
+#include <chrono>
 #include <regex>
 
 using namespace std::chrono_literals;

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <nano/node/common.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (message, keepalive_serialization)
 {

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
 
 namespace
 {

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,9 +1,11 @@
-#include <boost/iostreams/stream_buffer.hpp>
-#include <boost/thread.hpp>
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/testing.hpp>
 #include <nano/node/transport/udp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/iostreams/stream_buffer.hpp>
+#include <boost/thread.hpp>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,13 +1,15 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/testing.hpp>
 #include <nano/node/transport/udp.hpp>
 #include <nano/node/working.hpp>
-#include <numeric>
+
+#include <gtest/gtest.h>
 
 #include <boost/make_shared.hpp>
 #include <boost/polymorphic_cast.hpp>
+
+#include <numeric>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -1,6 +1,7 @@
-#include <gtest/gtest.h>
 #include <nano/node/node.hpp>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (peer_container, empty_peers)
 {

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -1,6 +1,7 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/node.hpp>
+
+#include <gtest/gtest.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/nano/core_test/signing.cpp
+++ b/nano/core_test/signing.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <nano/node/node.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (signature_checker, empty)
 {

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -1,8 +1,10 @@
-#include <boost/thread.hpp>
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/socket.hpp>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/thread.hpp>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/testutil.hpp
+++ b/nano/core_test/testutil.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <atomic>
+#include <nano/lib/timer.hpp>
+
 #include <boost/iostreams/concepts.hpp>
 #include <boost/log/sources/logger.hpp>
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
+
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <nano/lib/timer.hpp>
 #include <string>
 
 #define GTEST_TEST_ERROR_CODE(expression, text, actual, expected, fail)                       \

--- a/nano/core_test/timer.cpp
+++ b/nano/core_test/timer.cpp
@@ -1,7 +1,9 @@
-#include <chrono>
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/timer.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
 #include <thread>
 
 /* Tests for the timer utility. Note that we use sleep_for in the tests, which

--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
-
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/interface.h>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/secure/common.hpp>
+
+#include <gtest/gtest.h>
 
 namespace
 {

--- a/nano/core_test/versioning.cpp
+++ b/nano/core_test/versioning.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/versioning.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (versioning, account_info_v1)
 {

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1,9 +1,10 @@
-#include <gtest/gtest.h>
-
-#include <fstream>
 #include <nano/core_test/testutil.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
+
+#include <fstream>
 
 using namespace std::chrono_literals;
 

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
-
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/testing.hpp>
 #include <nano/secure/versioning.hpp>
+
+#include <gtest/gtest.h>
 
 #include <boost/polymorphic_cast.hpp>
 

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1,19 +1,22 @@
+#include <nano/core_test/testutil.hpp>
+#include <nano/crypto_lib/random_pool.hpp>
+#include <nano/node/testing.hpp>
+#include <nano/node/websocket.hpp>
+
+#include <gtest/gtest.h>
+
 #include <boost/asio.hpp>
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
 #include <chrono>
 #include <condition_variable>
 #include <cstdlib>
-#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
-#include <nano/core_test/testutil.hpp>
-#include <nano/crypto_lib/random_pool.hpp>
-#include <nano/node/testing.hpp>
-#include <nano/node/websocket.hpp>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
-
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/wallet.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (work, one)
 {

--- a/nano/crypto_lib/interface.cpp
+++ b/nano/crypto_lib/interface.cpp
@@ -1,5 +1,6 @@
-#include <crypto/blake2/blake2.h>
 #include <nano/crypto_lib/random_pool.hpp>
+
+#include <crypto/blake2/blake2.h>
 
 extern "C" {
 #include <crypto/ed25519-donna/ed25519-hash-custom.h>

--- a/nano/crypto_lib/random_pool.hpp
+++ b/nano/crypto_lib/random_pool.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <crypto/cryptopp/osrng.h>
+
 #include <mutex>
 
 namespace nano

--- a/nano/lib/blockbuilders.cpp
+++ b/nano/lib/blockbuilders.cpp
@@ -1,5 +1,7 @@
-#include <crypto/cryptopp/osrng.h>
 #include <nano/lib/blockbuilders.hpp>
+
+#include <crypto/cryptopp/osrng.h>
+
 #include <unordered_map>
 
 namespace

--- a/nano/lib/blockbuilders.hpp
+++ b/nano/lib/blockbuilders.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <memory>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/errors.hpp>
+
+#include <memory>
 
 namespace nano
 {

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -4,9 +4,11 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
 
-#include <boost/property_tree/json_parser.hpp>
-#include <cassert>
 #include <crypto/blake2/blake2.h>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <cassert>
 #include <streambuf>
 #include <unordered_map>
 

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <array>
-#include <boost/filesystem.hpp>
-#include <chrono>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/numbers.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <array>
+#include <chrono>
 #include <string>
 
 #define xstr(a) ver_str (a)

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <algorithm>
+#include <nano/lib/expected.hpp>
+
 #include <boost/system/error_code.hpp>
+
+#include <algorithm>
 #include <cassert>
 #include <memory>
-#include <nano/lib/expected.hpp>
 #include <string>
 #include <system_error>
 #include <type_traits>

--- a/nano/lib/interface.cpp
+++ b/nano/lib/interface.cpp
@@ -1,16 +1,15 @@
-#include <nano/lib/interface.h>
-
-#include <crypto/ed25519-donna/ed25519.h>
-
-#include <boost/property_tree/json_parser.hpp>
-
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
+#include <nano/lib/interface.h>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/work.hpp>
 
+#include <boost/property_tree/json_parser.hpp>
+
 #include <cstring>
+
+#include <crypto/ed25519-donna/ed25519.h>
 
 extern "C" {
 void xrb_uint128_to_dec (xrb_uint128 source, char * destination)

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <atomic>
 #include <boost/asio.hpp>
 #include <boost/property_tree/ptree.hpp>
+
+#include <atomic>
 #include <string>
 
 namespace nano

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -1,7 +1,8 @@
-#include <boost/endian/conversion.hpp>
-#include <boost/polymorphic_cast.hpp>
 #include <nano/lib/ipc.hpp>
 #include <nano/lib/ipc_client.hpp>
+
+#include <boost/endian/conversion.hpp>
+#include <boost/polymorphic_cast.hpp>
 
 namespace
 {

--- a/nano/lib/ipc_client.hpp
+++ b/nano/lib/ipc_client.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <atomic>
-#include <boost/asio.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/ipc.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <atomic>
 #include <string>
 #include <vector>
 

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
+#include <nano/lib/errors.hpp>
+#include <nano/lib/utility.hpp>
+
 #include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
 #include <fstream>
-#include <nano/lib/errors.hpp>
-#include <nano/lib/utility.hpp>
 
 namespace nano
 {

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -1,14 +1,12 @@
-#include <nano/lib/utility.hpp>
-
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/numbers.hpp>
-
-#include <crypto/ed25519-donna/ed25519.h>
+#include <nano/lib/utility.hpp>
 
 #include <crypto/blake2/blake2.h>
-
 #include <crypto/cryptopp/aes.h>
 #include <crypto/cryptopp/modes.h>
+
+#include <crypto/ed25519-donna/ed25519.h>
 
 namespace
 {

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <crypto/cryptopp/osrng.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
 
 namespace nano
 {

--- a/nano/lib/plat/darwin/thread_role.cpp
+++ b/nano/lib/plat/darwin/thread_role.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/utility.hpp>
+
 #include <pthread.h>
 
 void nano::thread_role::set_os_name (std::string const & thread_name)

--- a/nano/lib/plat/freebsd/thread_role.cpp
+++ b/nano/lib/plat/freebsd/thread_role.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/utility.hpp>
+
 #include <pthread.h>
 #include <pthread_np.h>
 

--- a/nano/lib/plat/linux/thread_role.cpp
+++ b/nano/lib/plat/linux/thread_role.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/utility.hpp>
+
 #include <pthread.h>
 
 void nano::thread_role::set_os_name (std::string const & thread_name)

--- a/nano/lib/plat/posix/perms.cpp
+++ b/nano/lib/plat/posix/perms.cpp
@@ -1,6 +1,6 @@
-#include <boost/filesystem.hpp>
-
 #include <nano/lib/utility.hpp>
+
+#include <boost/filesystem.hpp>
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/nano/lib/plat/windows/perms.cpp
+++ b/nano/lib/plat/windows/perms.cpp
@@ -1,6 +1,8 @@
-#include <boost/filesystem.hpp>
-#include <cassert>
 #include <nano/lib/utility.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <cassert>
 
 #include <io.h>
 #include <processthreadsapi.h>

--- a/nano/lib/plat/windows/thread_role.cpp
+++ b/nano/lib/plat/windows/thread_role.cpp
@@ -1,7 +1,7 @@
-#include <windows.h>
-
 #include <nano/lib/utility.hpp>
+
 #include <processthreadsapi.h>
+#include <windows.h>
 
 void nano::thread_role::set_os_name (std::string const & thread_name)
 {

--- a/nano/lib/rpc_handler_interface.hpp
+++ b/nano/lib/rpc_handler_interface.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <string>
+
 namespace nano
 {
 class rpc;

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -1,7 +1,8 @@
-#include <boost/dll/runtime_symbol_info.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/rpcconfig.hpp>
+
+#include <boost/dll/runtime_symbol_info.hpp>
 
 nano::error nano::rpc_secure_config::serialize_json (nano::jsonconfig & json) const
 {

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <nano/lib/config.hpp>
+#include <nano/lib/errors.hpp>
+
 #include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
-#include <nano/lib/config.hpp>
-#include <nano/lib/errors.hpp>
+
 #include <string>
 
 namespace nano

--- a/nano/lib/timer.hpp
+++ b/nano/lib/timer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <chrono>
 #include <iomanip>
 #include <iostream>

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -1,5 +1,6 @@
-#include <iostream>
 #include <nano/lib/utility.hpp>
+
+#include <iostream>
 
 namespace nano
 {

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <boost/optional.hpp>
-#include <boost/thread/thread.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
+
+#include <boost/optional.hpp>
+#include <boost/thread/thread.hpp>
 
 #include <atomic>
 #include <condition_variable>

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -1,3 +1,8 @@
+#include <nano/core_test/testutil.hpp>
+#include <nano/node/daemonconfig.hpp>
+#include <nano/node/testing.hpp>
+#include <nano/secure/utility.hpp>
+
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
@@ -5,11 +10,8 @@
 #include <boost/beast/version.hpp>
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/program_options.hpp>
+
 #include <iomanip>
-#include <nano/core_test/testutil.hpp>
-#include <nano/node/daemonconfig.hpp>
-#include <nano/node/testing.hpp>
-#include <nano/secure/utility.hpp>
 #include <random>
 
 namespace nano

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -1,6 +1,3 @@
-#include <boost/property_tree/json_parser.hpp>
-#include <fstream>
-#include <iostream>
 #include <nano/lib/utility.hpp>
 #include <nano/nano_node/daemon.hpp>
 #include <nano/node/daemonconfig.hpp>
@@ -10,6 +7,11 @@
 #include <nano/node/openclwork.hpp>
 #include <nano/node/working.hpp>
 #include <nano/rpc/rpc.hpp>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <fstream>
+#include <iostream>
 
 #ifndef BOOST_PROCESS_SUPPORTED
 #error BOOST_PROCESS_SUPPORTED must be set, check configuration

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -7,12 +7,13 @@
 #include <nano/node/node.hpp>
 #include <nano/node/payment_observer_processor.hpp>
 #include <nano/node/testing.hpp>
-#include <sstream>
-
-#include <argon2.h>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
+
+#include <sstream>
+
+#include <argon2.h>
 
 namespace
 {

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -1,8 +1,3 @@
-#include <boost/lexical_cast.hpp>
-#include <boost/log/expressions.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
-#include <boost/log/utility/setup/file.hpp>
-#include <boost/program_options.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/utility.hpp>
@@ -12,6 +7,12 @@
 #include <nano/node/working.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/utility/setup/file.hpp>
+#include <boost/program_options.hpp>
 
 namespace
 {

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1,6 +1,6 @@
 #include <nano/node/active_transactions.hpp>
-
 #include <nano/node/node.hpp>
+
 #include <numeric>
 
 size_t constexpr nano::active_transactions::max_broadcast_queue;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -1,12 +1,5 @@
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
-#include <deque>
-#include <memory>
-#include <queue>
-#include <unordered_map>
-
 #include <nano/lib/numbers.hpp>
 #include <nano/secure/common.hpp>
 
@@ -17,6 +10,13 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/thread/thread.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <queue>
+#include <unordered_map>
 
 namespace nano
 {

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -1,8 +1,9 @@
-#include <cassert>
 #include <nano/lib/timer.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/node.hpp>
 #include <nano/secure/blockstore.hpp>
+
+#include <cassert>
 
 std::chrono::milliseconds constexpr nano::block_processor::confirmation_request_delay;
 

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
+#include <nano/lib/blocks.hpp>
+#include <nano/node/voting.hpp>
+#include <nano/secure/common.hpp>
+
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
+
 #include <chrono>
 #include <memory>
-#include <nano/lib/blocks.hpp>
-#include <nano/node/voting.hpp>
-#include <nano/secure/common.hpp>
 #include <unordered_set>
 
 namespace nano

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1,13 +1,13 @@
-#include <nano/node/bootstrap.hpp>
-
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/node/bootstrap.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/tcp.hpp>
 #include <nano/node/transport/udp.hpp>
 
-#include <algorithm>
 #include <boost/log/trivial.hpp>
+
+#include <algorithm>
 
 constexpr double bootstrap_connection_scale_target_blocks = 50000.0;
 constexpr double bootstrap_connection_warmup_time_sec = 5.0;
@@ -2387,6 +2387,7 @@ public:
 			auto cookie (connection->node->network.tcp_channels.assign_syn_cookie (connection->remote_endpoint));
 			nano::node_id_handshake response_message (cookie, response);
 			auto bytes = response_message.to_bytes ();
+			// clang-format off
 			connection->socket->async_write (bytes, [ bytes, connection = connection ](boost::system::error_code const & ec, size_t size_a) {
 				if (ec)
 				{
@@ -2403,6 +2404,7 @@ public:
 					connection->finish_request ();
 				}
 			});
+			// clang-format on
 		}
 		else if (message_a.response)
 		{

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -5,12 +5,6 @@
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/ledger.hpp>
 
-#include <atomic>
-#include <future>
-#include <queue>
-#include <stack>
-#include <unordered_set>
-
 #include <boost/log/sources/logger.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
@@ -18,6 +12,12 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/thread/thread.hpp>
+
+#include <atomic>
+#include <future>
+#include <queue>
+#include <stack>
+#include <unordered_set>
 
 namespace nano
 {

--- a/nano/node/cli.hpp
+++ b/nano/node/cli.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <boost/program_options.hpp>
 #include <nano/lib/errors.hpp>
+
+#include <boost/program_options.hpp>
 
 namespace nano
 {

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1,7 +1,6 @@
 
-#include <nano/node/common.hpp>
-
 #include <nano/lib/work.hpp>
+#include <nano/node/common.hpp>
 #include <nano/node/wallet.hpp>
 
 #include <boost/endian/conversion.hpp>

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -1,14 +1,15 @@
-#include <nano/node/confirmation_height_processor.hpp>
-
-#include <boost/optional.hpp>
-#include <cassert>
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/active_transactions.hpp>
+#include <nano/node/confirmation_height_processor.hpp>
 #include <nano/node/stats.hpp>
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/common.hpp>
+
+#include <boost/optional.hpp>
+
+#include <cassert>
 #include <numeric>
 
 nano::confirmation_height_processor::confirmation_height_processor (nano::pending_confirmation_height & pending_confirmation_height_a, nano::block_store & store_a, nano::stat & stats_a, nano::active_transactions & active_a, nano::block_hash const & epoch_link_a, nano::logger_mt & logger_a) :

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <condition_variable>
-#include <mutex>
 #include <nano/lib/numbers.hpp>
 #include <nano/secure/common.hpp>
+
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <unordered_set>
 

--- a/nano/node/diagnosticsconfig.cpp
+++ b/nano/node/diagnosticsconfig.cpp
@@ -1,6 +1,5 @@
-#include <nano/node/diagnosticsconfig.hpp>
-
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/diagnosticsconfig.hpp>
 
 nano::error nano::diagnostics_config::serialize_json (nano::jsonconfig & json) const
 {

--- a/nano/node/diagnosticsconfig.hpp
+++ b/nano/node/diagnosticsconfig.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <chrono>
 #include <nano/lib/errors.hpp>
+
+#include <chrono>
 
 namespace nano
 {

--- a/nano/node/ipc.cpp
+++ b/nano/node/ipc.cpp
@@ -1,16 +1,3 @@
-#include <algorithm>
-#include <boost/array.hpp>
-#include <boost/bind.hpp>
-#include <boost/endian/conversion.hpp>
-#include <boost/polymorphic_cast.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/thread/thread_time.hpp>
-#include <chrono>
-#include <cstdio>
-#include <fstream>
-#include <future>
-#include <iostream>
 #include <nano/lib/config.hpp>
 #include <nano/lib/ipc.hpp>
 #include <nano/lib/timer.hpp>
@@ -18,6 +5,21 @@
 #include <nano/node/ipc.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node.hpp>
+
+#include <boost/array.hpp>
+#include <boost/bind.hpp>
+#include <boost/endian/conversion.hpp>
+#include <boost/polymorphic_cast.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/thread/thread_time.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <future>
+#include <iostream>
 #include <thread>
 
 using namespace boost::log;

--- a/nano/node/ipc.hpp
+++ b/nano/node/ipc.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <atomic>
 #include <nano/lib/ipc.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/node/node_rpc_config.hpp>
+
+#include <atomic>
 
 namespace nano
 {

--- a/nano/node/ipcconfig.hpp
+++ b/nano/node/ipcconfig.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>
+
 #include <string>
 
 namespace nano

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1,6 +1,13 @@
+#include <nano/lib/config.hpp>
+#include <nano/lib/json_error_response.hpp>
+#include <nano/lib/timer.hpp>
+#include <nano/node/common.hpp>
+#include <nano/node/ipc.hpp>
 #include <nano/node/json_handler.hpp>
+#include <nano/node/json_payment_observer.hpp>
+#include <nano/node/node.hpp>
+#include <nano/node/node_rpc_config.hpp>
 
-#include <algorithm>
 #include <boost/array.hpp>
 #include <boost/bind.hpp>
 #include <boost/endian/conversion.hpp>
@@ -8,19 +15,13 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/thread/thread_time.hpp>
+
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <fstream>
 #include <future>
 #include <iostream>
-#include <nano/lib/config.hpp>
-#include <nano/lib/json_error_response.hpp>
-#include <nano/lib/timer.hpp>
-#include <nano/node/common.hpp>
-#include <nano/node/ipc.hpp>
-#include <nano/node/json_payment_observer.hpp>
-#include <nano/node/node.hpp>
-#include <nano/node/node_rpc_config.hpp>
 #include <thread>
 
 namespace

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <boost/property_tree/ptree.hpp>
-#include <functional>
 #include <nano/lib/numbers.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/rpc/rpc.hpp>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <functional>
 #include <string>
 
 namespace nano
@@ -15,7 +17,8 @@ class node_rpc_config;
 class json_handler : public std::enable_shared_from_this<nano::json_handler>
 {
 public:
-	json_handler (nano::node &, nano::node_rpc_config const &, std::string const &, std::function<void(std::string const &)> const &, std::function<void()> stop_callback = []() {});
+	json_handler (
+	nano::node &, nano::node_rpc_config const &, std::string const &, std::function<void(std::string const &)> const &, std::function<void()> stop_callback = []() {});
 	void process_request (bool unsafe = false);
 	void account_balance ();
 	void account_block_count ();
@@ -158,7 +161,8 @@ public:
 class inprocess_rpc_handler final : public nano::rpc_handler_interface
 {
 public:
-	inprocess_rpc_handler (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a, std::function<void()> stop_callback_a = []() {}) :
+	inprocess_rpc_handler (
+	nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a, std::function<void()> stop_callback_a = []() {}) :
 	node (node_a),
 	stop_callback (stop_callback_a),
 	node_rpc_config (node_rpc_config_a)

--- a/nano/node/json_payment_observer.hpp
+++ b/nano/node/json_payment_observer.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/node/node_observers.hpp>
 #include <nano/node/wallet.hpp>
+
 #include <string>
 #include <vector>
 

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1,8 +1,7 @@
-#include <nano/node/lmdb.hpp>
-
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/common.hpp>
+#include <nano/node/lmdb.hpp>
 #include <nano/secure/versioning.hpp>
 
 #include <boost/endian/conversion.hpp>

--- a/nano/node/lmdb.hpp
+++ b/nano/node/lmdb.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <boost/filesystem.hpp>
-#include <boost/optional.hpp>
-#include <lmdb/libraries/liblmdb/lmdb.h>
-
 #include <nano/lib/config.hpp>
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/numbers.hpp>
@@ -12,7 +8,12 @@
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/common.hpp>
 
+#include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
+
 #include <thread>
+
+#include <lmdb/libraries/liblmdb/lmdb.h>
 
 namespace nano
 {

--- a/nano/node/lmdb_txn_tracker.cpp
+++ b/nano/node/lmdb_txn_tracker.cpp
@@ -1,10 +1,10 @@
-#include <nano/node/lmdb_txn_tracker.hpp>
-
-#include <boost/polymorphic_cast.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/utility.hpp>
+#include <nano/node/lmdb_txn_tracker.hpp>
 #include <nano/secure/blockstore.hpp>
+
+#include <boost/polymorphic_cast.hpp>
 
 // Some builds (mac) fail due to "Boost.Stacktrace requires `_Unwind_Backtrace` function".
 #ifndef _WIN32

--- a/nano/node/lmdb_txn_tracker.hpp
+++ b/nano/node/lmdb_txn_tracker.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/stacktrace/stacktrace_fwd.hpp>
-#include <mutex>
 #include <nano/lib/timer.hpp>
 #include <nano/node/diagnosticsconfig.hpp>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/stacktrace/stacktrace_fwd.hpp>
+
+#include <mutex>
 
 namespace nano
 {

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -1,11 +1,12 @@
+#include <nano/lib/config.hpp>
+#include <nano/node/logging.hpp>
+
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <nano/lib/config.hpp>
-#include <nano/node/logging.hpp>
 
 #ifdef BOOST_WINDOWS
 #include <boost/log/sinks/event_log_backend.hpp>

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
+#include <nano/lib/errors.hpp>
+#include <nano/lib/jsonconfig.hpp>
+#include <nano/lib/logger_mt.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/log/sources/logger.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/file.hpp>
+
 #include <cstdint>
-#include <nano/lib/errors.hpp>
-#include <nano/lib/jsonconfig.hpp>
-#include <nano/lib/logger_mt.hpp>
 
 #define FATAL_LOG_PREFIX "FATAL ERROR: "
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1,20 +1,19 @@
-#include <nano/node/node.hpp>
-
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/interface.h>
 #include <nano/lib/timer.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/common.hpp>
+#include <nano/node/node.hpp>
 #include <nano/rpc/rpc.hpp>
+
+#include <boost/polymorphic_cast.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 #include <algorithm>
 #include <cstdlib>
 #include <future>
 #include <numeric>
 #include <sstream>
-
-#include <boost/polymorphic_cast.hpp>
-#include <boost/property_tree/json_parser.hpp>
 
 double constexpr nano::node::price_max;
 double constexpr nano::node::free_cutoff;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -19,11 +19,6 @@
 #include <nano/node/websocket.hpp>
 #include <nano/secure/ledger.hpp>
 
-#include <atomic>
-#include <condition_variable>
-#include <memory>
-#include <queue>
-
 #include <boost/asio/thread_pool.hpp>
 #include <boost/iostreams/device/array.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -32,6 +27,11 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/thread/thread.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <queue>
 
 namespace nano
 {

--- a/nano/node/node_rpc_config.cpp
+++ b/nano/node/node_rpc_config.cpp
@@ -1,9 +1,8 @@
-#include <nano/node/node_rpc_config.hpp>
-
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/rpcconfig.hpp>
+#include <nano/node/node_rpc_config.hpp>
 
 nano::error nano::node_rpc_config::serialize_json (nano::jsonconfig & json) const
 {

--- a/nano/node/node_rpc_config.hpp
+++ b/nano/node/node_rpc_config.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <boost/filesystem.hpp>
 #include <nano/lib/rpcconfig.hpp>
+
+#include <boost/filesystem.hpp>
+
 #include <string>
 
 namespace nano

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/jsonconfig.hpp>
@@ -11,6 +10,8 @@
 #include <nano/node/stats.hpp>
 #include <nano/node/websocketconfig.hpp>
 #include <nano/secure/common.hpp>
+
+#include <chrono>
 #include <vector>
 
 namespace nano

--- a/nano/node/openclwork.hpp
+++ b/nano/node/openclwork.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <boost/optional.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/openclconfig.hpp>
 #include <nano/node/xorshift.hpp>
+
+#include <boost/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 #include <map>
 #include <mutex>

--- a/nano/node/payment_observer_processor.cpp
+++ b/nano/node/payment_observer_processor.cpp
@@ -1,6 +1,5 @@
-#include <nano/node/payment_observer_processor.hpp>
-
 #include <nano/node/json_payment_observer.hpp>
+#include <nano/node/payment_observer_processor.hpp>
 
 nano::payment_observer_processor::payment_observer_processor (nano::node_observers::blocks_t & blocks)
 {

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/node.hpp>
 #include <nano/node/portmapping.hpp>
+
 #include <upnpcommands.h>
 
 nano::port_mapping::port_mapping (nano::node & node_a) :

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include <boost/asio/ip/address_v4.hpp>
-#include <miniupnp/miniupnpc/miniupnpc.h>
-#include <mutex>
 #include <nano/lib/config.hpp>
+
+#include <boost/asio/ip/address_v4.hpp>
+
+#include <mutex>
+
+#include <miniupnp/miniupnpc/miniupnpc.h>
 
 namespace nano
 {

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <nano/node/common.hpp>
+#include <nano/node/transport/transport.hpp>
+
 #include <boost/asio.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/mem_fun.hpp>
@@ -7,10 +10,9 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
+
 #include <chrono>
 #include <memory>
-#include <nano/node/common.hpp>
-#include <nano/node/transport/transport.hpp>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/nano/node/signatures.hpp
+++ b/nano/node/signatures.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <atomic>
-#include <future>
-#include <mutex>
 #include <nano/lib/utility.hpp>
 
 #include <boost/asio.hpp>
+
+#include <atomic>
+#include <future>
+#include <mutex>
 
 namespace nano
 {

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -1,6 +1,7 @@
-#include <limits>
 #include <nano/node/node.hpp>
 #include <nano/node/socket.hpp>
+
+#include <limits>
 
 nano::socket::socket (std::shared_ptr<nano::node> node_a, boost::optional<std::chrono::seconds> max_idle_time_a, nano::socket::concurrency concurrency_a) :
 strand (node_a->io_ctx.get_executor ()),

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/optional.hpp>
+
 #include <chrono>
 #include <deque>
 #include <memory>

--- a/nano/node/stats.cpp
+++ b/nano/node/stats.cpp
@@ -3,6 +3,7 @@
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
 #include <ctime>
 #include <fstream>
 #include <iostream>

--- a/nano/node/stats.hpp
+++ b/nano/node/stats.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
-#include <atomic>
+#include <nano/lib/errors.hpp>
+#include <nano/lib/jsonconfig.hpp>
+#include <nano/lib/utility.hpp>
+
 #include <boost/circular_buffer.hpp>
 #include <boost/property_tree/ptree.hpp>
+
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
-#include <nano/lib/errors.hpp>
-#include <nano/lib/jsonconfig.hpp>
-#include <nano/lib/utility.hpp>
 #include <string>
 #include <unordered_map>
 

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -1,11 +1,13 @@
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <cstdlib>
 #include <nano/core_test/testutil.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/testing.hpp>
 #include <nano/node/transport/udp.hpp>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <cstdlib>
 
 std::string nano::error_system_messages::message (int ev) const
 {

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <chrono>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/node.hpp>
+
+#include <chrono>
 
 namespace nano
 {

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <boost/asio/buffer.hpp>
-
 #include <nano/node/common.hpp>
 #include <nano/node/stats.hpp>
+
+#include <boost/asio/buffer.hpp>
 
 namespace nano
 {

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <mutex>
 #include <nano/node/common.hpp>
 #include <nano/node/stats.hpp>
 #include <nano/node/transport/transport.hpp>
+
+#include <mutex>
 
 namespace nano
 {

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -1,6 +1,5 @@
-#include <nano/node/voting.hpp>
-
 #include <nano/node/node.hpp>
+#include <nano/node/voting.hpp>
 
 nano::vote_generator::vote_generator (nano::node & node_a) :
 node (node_a),

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1,17 +1,15 @@
-#include <nano/node/wallet.hpp>
-
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/node/xorshift.hpp>
 
-#include <argon2.h>
-
 #include <boost/filesystem.hpp>
 #include <boost/polymorphic_cast.hpp>
 
 #include <future>
+
+#include <argon2.h>
 
 nano::uint256_union nano::wallet_store::check (nano::transaction const & transaction_a)
 {

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <boost/thread/thread.hpp>
-#include <mutex>
 #include <nano/lib/config.hpp>
 #include <nano/node/lmdb.hpp>
 #include <nano/node/openclwork.hpp>
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/common.hpp>
+
+#include <boost/thread/thread.hpp>
+
+#include <mutex>
 #include <unordered_set>
 
 namespace nano

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -1,8 +1,10 @@
-#include <algorithm>
-#include <boost/property_tree/json_parser.hpp>
-#include <chrono>
 #include <nano/node/node.hpp>
 #include <nano/node/websocket.hpp>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <algorithm>
+#include <chrono>
 
 nano::websocket::confirmation_options::confirmation_options (boost::property_tree::ptree const & options_a, nano::node & node_a) :
 node (node_a),

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <algorithm>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/numbers.hpp>
+
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -8,14 +10,14 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+#include <algorithm>
 #include <cstdlib>
 #include <deque>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
-#include <nano/lib/blocks.hpp>
-#include <nano/lib/numbers.hpp>
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/nano/node/websocketconfig.hpp
+++ b/nano/node/websocketconfig.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <boost/asio.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>
+
+#include <boost/asio.hpp>
 
 namespace nano
 {

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1,10 +1,12 @@
+#include <nano/lib/config.hpp>
+#include <nano/qt/qt.hpp>
+
 #include <boost/foreach.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+
 #include <cmath>
 #include <iomanip>
-#include <nano/lib/config.hpp>
-#include <nano/qt/qt.hpp>
 #include <sstream>
 
 namespace

--- a/nano/qt/qt.hpp
+++ b/nano/qt/qt.hpp
@@ -4,10 +4,9 @@
 
 #include <boost/thread.hpp>
 
-#include <set>
-
 #include <QtGui>
 #include <QtWidgets>
+#include <set>
 
 namespace nano_qt
 {

--- a/nano/qt_test/entry.cpp
+++ b/nano/qt_test/entry.cpp
@@ -1,5 +1,6 @@
-#include <QApplication>
 #include <gtest/gtest.h>
+
+#include <QApplication>
 QApplication * test_application = nullptr;
 namespace nano
 {

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -1,15 +1,13 @@
-#include <algorithm>
-
-#include <gtest/gtest.h>
-
 #include <nano/core_test/testutil.hpp>
 #include <nano/node/testing.hpp>
-
 #include <nano/qt/qt.hpp>
+
+#include <gtest/gtest.h>
 
 #include <boost/property_tree/json_parser.hpp>
 
 #include <QTest>
+#include <algorithm>
 #include <thread>
 
 using namespace std::chrono_literals;

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -1,7 +1,8 @@
-#include <boost/format.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_connection.hpp>
+
+#include <boost/format.hpp>
 
 #ifdef NANO_SECURE_RPC
 #include <nano/rpc/rpc_secure.hpp>

--- a/nano/rpc/rpc.hpp
+++ b/nano/rpc/rpc.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <boost/asio.hpp>
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
+
+#include <boost/asio.hpp>
 
 namespace nano
 {

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -1,5 +1,3 @@
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/logger_mt.hpp>
@@ -7,6 +5,9 @@
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/rpc/rpc_connection.hpp>
 #include <nano/rpc/rpc_handler.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/format.hpp>
 
 nano::rpc_connection::rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface) :
 socket (io_ctx),

--- a/nano/rpc/rpc_connection.hpp
+++ b/nano/rpc/rpc_connection.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <atomic>
-#include <boost/beast.hpp>
 #include <nano/rpc/rpc_handler.hpp>
+
+#include <boost/beast.hpp>
+
+#include <atomic>
 
 namespace nano
 {

--- a/nano/rpc/rpc_connection_secure.hpp
+++ b/nano/rpc/rpc_connection_secure.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <boost/asio/ssl/stream.hpp>
 #include <nano/rpc/rpc_connection.hpp>
+
+#include <boost/asio/ssl/stream.hpp>
 
 namespace nano
 {

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -1,11 +1,13 @@
-#include <boost/endian/conversion.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/rpc/rpc_handler.hpp>
+
+#include <boost/endian/conversion.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 #include <unordered_set>
 
 namespace

--- a/nano/rpc/rpc_handler.hpp
+++ b/nano/rpc/rpc_handler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/property_tree/ptree.hpp>
+
 #include <functional>
 #include <string>
 

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <boost/endian/conversion.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/ipc_client.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
@@ -9,6 +7,9 @@
 #include <nano/lib/utility.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_handler.hpp>
+
+#include <boost/endian/conversion.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 namespace nano
 {

--- a/nano/rpc/rpc_secure.cpp
+++ b/nano/rpc/rpc_secure.cpp
@@ -1,7 +1,8 @@
-#include <boost/format.hpp>
-#include <boost/polymorphic_pointer_cast.hpp>
 #include <nano/rpc/rpc_connection_secure.hpp>
 #include <nano/rpc/rpc_secure.hpp>
+
+#include <boost/format.hpp>
+#include <boost/polymorphic_pointer_cast.hpp>
 
 bool nano::rpc_secure::on_verify_certificate (bool preverified, boost::asio::ssl::verify_context & ctx)
 {

--- a/nano/rpc/rpc_secure.hpp
+++ b/nano/rpc/rpc_secure.hpp
@@ -1,7 +1,8 @@
 #pragma once
+#include <nano/rpc/rpc.hpp>
+
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/stream.hpp>
-#include <nano/rpc/rpc.hpp>
 
 namespace nano
 {

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-#include <boost/beast.hpp>
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/ipc.hpp>
 #include <nano/lib/rpcconfig.hpp>
@@ -11,6 +8,12 @@
 #include <nano/node/testing.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/beast.hpp>
+
+#include <algorithm>
 
 using namespace std::chrono_literals;
 

--- a/nano/secure/blockstore.cpp
+++ b/nano/secure/blockstore.cpp
@@ -2,9 +2,8 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/blockstore.hpp>
 
-#include <boost/polymorphic_cast.hpp>
-
 #include <boost/endian/conversion.hpp>
+#include <boost/polymorphic_cast.hpp>
 
 nano::block_sideband::block_sideband (nano::block_type type_a, nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t height_a, uint64_t timestamp_a) :
 type (type_a),

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/config.hpp>
 #include <nano/secure/common.hpp>
+
 #include <stack>
 
 namespace nano

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -1,21 +1,19 @@
-#include <nano/secure/common.hpp>
-
+#include <nano/core_test/testutil.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/config.hpp>
 #include <nano/lib/interface.h>
 #include <nano/lib/numbers.hpp>
 #include <nano/node/common.hpp>
 #include <nano/secure/blockstore.hpp>
+#include <nano/secure/common.hpp>
 #include <nano/secure/versioning.hpp>
 
 #include <boost/endian/conversion.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#include <queue>
-
 #include <iostream>
 #include <limits>
-#include <nano/core_test/testutil.hpp>
-#include <nano/lib/config.hpp>
+#include <queue>
 
 #include <crypto/ed25519-donna/ed25519.h>
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -7,13 +7,13 @@
 #include <nano/lib/utility.hpp>
 #include <nano/secure/utility.hpp>
 
+#include <crypto/blake2/blake2.h>
+
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/variant.hpp>
 
 #include <unordered_map>
-
-#include <crypto/blake2/blake2.h>
 
 namespace boost
 {

--- a/nano/secure/utility.hpp
+++ b/nano/secure/utility.hpp
@@ -1,20 +1,20 @@
 #pragma once
 
-#include <array>
-#include <atomic>
-#include <condition_variable>
-#include <type_traits>
+#include <nano/lib/errors.hpp>
+#include <nano/lib/interface.h>
+#include <nano/lib/numbers.hpp>
+
+#include <crypto/cryptopp/osrng.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-#include <crypto/cryptopp/osrng.h>
-
-#include <nano/lib/errors.hpp>
-#include <nano/lib/interface.h>
-#include <nano/lib/numbers.hpp>
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <type_traits>
 
 namespace nano
 {

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1,8 +1,9 @@
-#include <gtest/gtest.h>
 #include <nano/core_test/testutil.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/node/testing.hpp>
 #include <nano/node/transport/udp.hpp>
+
+#include <gtest/gtest.h>
 
 #include <thread>
 


### PR DESCRIPTION
Header file includes should be placed from most dependent at the top to least dependent. This ensures that the header files themselves are including the correct dependent header files needed to compile correctly without relying on fluky source file include order including dependents for them. We do not generally use "" for files in the same project, so this does not fully adhere as all `nano` headers are grouped together in this PR but it is an improvement at least, the includes are now sorted as follows:

1. "" - Not currently used in our source code
2. \<**nano**/*>
3. \<**crypto**|**gtest**/*>
4. \<**boost**/*>
5. \<**system**>

There were some header files which needed to included to fix some build failures as a result of moving them around.