### PR TITLE
Add configurable vote generator delay and bundling test

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -705,6 +705,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_FALSE (tree.get_optional_child ("external_address"));
 	ASSERT_FALSE (tree.get_optional_child ("external_port"));
 	ASSERT_FALSE (tree.get_optional_child ("tcp_incoming_connections_max"));
+	ASSERT_FALSE (tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_FALSE (tree.get_optional_child ("diagnostics"));
 
 	config.deserialize_json (upgraded, tree);
@@ -714,6 +715,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_TRUE (!!tree.get_optional_child ("external_address"));
 	ASSERT_TRUE (!!tree.get_optional_child ("external_port"));
 	ASSERT_TRUE (!!tree.get_optional_child ("tcp_incoming_connections_max"));
+	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_TRUE (!!tree.get_optional_child ("diagnostics"));
 
 	ASSERT_TRUE (upgraded);
@@ -740,6 +742,7 @@ TEST (node_config, v17_values)
 		tree.put ("external_address", "::1");
 		tree.put ("external_port", 0);
 		tree.put ("tcp_incoming_connections_max", 1);
+		tree.put ("vote_generator_delay", 50);
 		nano::jsonconfig txn_tracking_l;
 		txn_tracking_l.put ("enable", false);
 		txn_tracking_l.put ("min_read_txn_time", 0);
@@ -768,6 +771,7 @@ TEST (node_config, v17_values)
 	tree.put ("external_address", "::ffff:192.168.1.1");
 	tree.put ("external_port", std::numeric_limits<uint16_t>::max () - 1);
 	tree.put ("tcp_incoming_connections_max", std::numeric_limits<unsigned>::max ());
+	tree.put ("vote_generator_delay", std::numeric_limits<unsigned long>::max () - 100);
 	nano::jsonconfig txn_tracking_l;
 	txn_tracking_l.put ("enable", true);
 	txn_tracking_l.put ("min_read_txn_time", 1234);
@@ -785,6 +789,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.external_address, boost::asio::ip::address_v6::from_string ("::ffff:192.168.1.1"));
 	ASSERT_EQ (config.external_port, std::numeric_limits<uint16_t>::max () - 1);
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
+	ASSERT_EQ (config.vote_generator_delay.count (), std::numeric_limits<unsigned long>::max () - 100);
 	ASSERT_TRUE (config.diagnostics_config.txn_tracking.enable);
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_read_txn_time.count (), 1234);
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
@@ -2177,6 +2182,37 @@ TEST (node, vote_republish)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	while (system.nodes[0]->balance (key2.pub) != system.nodes[0]->config.receive_minimum.number () * 2)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (node, vote_by_hash_bundle)
+{
+	nano::system system (24000, 1);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key1;
+	system.wallet (0)->insert_adhoc (key1.prv);
+
+	std::atomic<size_t> max_hashes{ 0 };
+	system.nodes[0]->observers.vote.add ([&max_hashes](nano::transaction const & transaction, std::shared_ptr<nano::vote> vote_a, std::shared_ptr<nano::transport::channel> channel_a) {
+		if (vote_a->blocks.size () > max_hashes)
+		{
+			max_hashes = vote_a->blocks.size ();
+		}
+	});
+
+	nano::genesis genesis;
+	for (int i = 1; i <= 200; i++)
+	{
+		auto send (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, std::numeric_limits<nano::uint128_t>::max () - (system.nodes[0]->config.receive_minimum.number () * i), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (genesis.hash ())));
+		system.nodes[0]->block_confirm (send);
+	}
+
+	// Verify bundling. We're content with 8 hashes for the test, although
+	// reaching 12 should be common on most hardware.
+	system.deadline_set (10s);
+	while (max_hashes.load () < 8)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -113,6 +113,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
 	json.put ("allow_local_peers", allow_local_peers);
 	json.put ("vote_minimum", vote_minimum.to_string_dec ());
+	json.put ("vote_generator_delay", vote_generator_delay.count ());
 	json.put ("unchecked_cutoff_time", unchecked_cutoff_time.count ());
 	json.put ("tcp_io_timeout", tcp_io_timeout.count ());
 	json.put ("pow_sleep_interval", pow_sleep_interval.count ());
@@ -243,6 +244,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("external_address", external_address.to_string ());
 			json.put ("external_port", external_port);
 			json.put ("tcp_incoming_connections_max", tcp_incoming_connections_max);
+			json.put ("vote_generator_delay", vote_generator_delay.count ());
 		}
 		case 17:
 			break;
@@ -337,6 +339,9 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("vote_minimum contains an invalid decimal amount");
 		}
+
+		auto vote_generator_delay_l (json.get<unsigned long> ("vote_generator_delay"));
+		vote_generator_delay = std::chrono::milliseconds (vote_generator_delay_l);
 
 		auto block_processor_batch_max_time_l (json.get<unsigned long> ("block_processor_batch_max_time"));
 		block_processor_batch_max_time = std::chrono::milliseconds (block_processor_batch_max_time_l);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -37,6 +37,7 @@ public:
 	unsigned bootstrap_fraction_numerator{ 1 };
 	nano::amount receive_minimum{ nano::xrb_ratio };
 	nano::amount vote_minimum{ nano::Gxrb_ratio };
+	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (50) };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
 	unsigned online_weight_quorum{ 50 };
 	unsigned password_fanout{ 1024 };

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -1,6 +1,8 @@
 #include <nano/node/node.hpp>
 #include <nano/node/voting.hpp>
 
+#include <chrono>
+
 nano::vote_generator::vote_generator (nano::node & node_a) :
 node (node_a),
 stopped (false),
@@ -66,15 +68,35 @@ void nano::vote_generator::run ()
 	lock.unlock ();
 	condition.notify_all ();
 	lock.lock ();
+	auto min (std::numeric_limits<std::chrono::steady_clock::time_point>::min ());
+	auto cutoff (min);
 	while (!stopped)
 	{
-		if (!hashes.empty ())
+		auto now (std::chrono::steady_clock::now ());
+		if (hashes.size () >= 12)
 		{
 			send (lock);
 		}
-		else
+		else if (cutoff == min) // && hashes.size () < 12
 		{
-			condition.wait (lock);
+			cutoff = now + node.config.vote_generator_delay;
+			condition.wait_until (lock, cutoff);
+		}
+		else if (now < cutoff) // && hashes.size () < 12
+		{
+			condition.wait_until (lock, cutoff);
+		}
+		else // now >= cutoff && hashes.size () < 12
+		{
+			cutoff = min;
+			if (!hashes.empty ())
+			{
+				send (lock);
+			}
+			else
+			{
+				condition.wait (lock);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Puts back the delay logic, but with a lower (and now configurable) delay based on load testing performed by @guilhermelawless (thanks!). Adds a unit test to verify that bundling occurs.