### PR TITLE
Update broadcast_confirm_req to use confirm_req by hash

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -279,16 +279,16 @@ void nano::network::broadcast_confirm_req_base (std::shared_ptr<nano::block> blo
 	while (!endpoints_a->empty () && count < max_reps)
 	{
 		auto channel (endpoints_a->back ());
-		// Confirmation request with hash + root
-		if (!node.network_params.network.is_live_network ()
-		{
-			nano::confirm_req req (block_a->hash (), block_a->root ());
-			channel->send (req);
-		}
 		// Confirmation request with full block
-		else
+		if (node.network_params.network.is_live_network ()
 		{
 			nano::confirm_req req (block_a);
+			channel->send (req);
+		}
+		// Confirmation request with hash + root
+		else
+		{
+			nano::confirm_req req (block_a->hash (), block_a->root ());
 			channel->send (req);
 		}
 		endpoints_a->pop_back ();

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -280,7 +280,7 @@ void nano::network::broadcast_confirm_req_base (std::shared_ptr<nano::block> blo
 	{
 		auto channel (endpoints_a->back ());
 		// Confirmation request with full block
-		if (node.network_params.network.is_live_network ()
+		if (node.network_params.network.is_live_network ())
 		{
 			nano::confirm_req req (block_a);
 			channel->send (req);

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -278,9 +278,19 @@ void nano::network::broadcast_confirm_req_base (std::shared_ptr<nano::block> blo
 	auto count (0);
 	while (!endpoints_a->empty () && count < max_reps)
 	{
-		nano::confirm_req req (block_a);
 		auto channel (endpoints_a->back ());
-		channel->send (req);
+		// Confirmation request with hash + root
+		if (!node.network_params.network.is_live_network ()
+		{
+			nano::confirm_req req (block_a->hash (), block_a->root ());
+			channel->send (req);
+		}
+		// Confirmation request with full block
+		else
+		{
+			nano::confirm_req req (block_a);
+			channel->send (req);
+		}
 		endpoints_a->pop_back ();
 		count++;
 	}


### PR DESCRIPTION
for non-live networks