### PR TITLE
Change gap cache voters to use a vector

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -967,7 +967,7 @@ void nano::gap_cache::add (nano::transaction const & transaction_a, nano::block_
 	}
 	else
 	{
-		blocks.insert ({ time_point_a, hash_a, std::unordered_set<nano::account> () });
+		blocks.insert ({ time_point_a, hash_a, std::vector<nano::account> () });
 		if (blocks.size () > max)
 		{
 			blocks.get<0> ().erase (blocks.get<0> ().begin ());
@@ -985,7 +985,15 @@ void nano::gap_cache::vote (std::shared_ptr<nano::vote> vote_a)
 		if (existing != blocks.get<1> ().end ())
 		{
 			auto is_new (false);
-			blocks.get<1> ().modify (existing, [&](nano::gap_information & info) { is_new = info.voters.insert (vote_a->account).second; });
+			blocks.get<1> ().modify (existing, [&is_new, &vote_a](nano::gap_information & info) {
+				auto it = std::find (info.voters.begin (), info.voters.end (), vote_a->account);
+				is_new = (it == info.voters.end ());
+				if (is_new)
+				{
+					info.voters.push_back (vote_a->account);
+				}
+			});
+
 			if (is_new)
 			{
 				uint128_t tally;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -31,6 +31,7 @@
 #include <condition_variable>
 #include <memory>
 #include <queue>
+#include <vector>
 
 namespace nano
 {
@@ -110,7 +111,7 @@ class gap_information final
 public:
 	std::chrono::steady_clock::time_point arrival;
 	nano::block_hash hash;
-	std::unordered_set<nano::account> voters;
+	std::vector<nano::account> voters;
 };
 class gap_cache final
 {


### PR DESCRIPTION
While checking for heap memory allocations there is a lot in the [gap_cache::add](https://imgur.com/69Of03U) function (default `std::unordered_set` constructor which sets up the initial hash table). The number of voters is quite small so I decided to benchmark if using a `std::vector` would offer any benefits. As the number of voters gradually increases, where it checks for existing `nano::account` objects and iterates over the whole collection each time, I recorded an equivalent scenario at various intervals with 2 different compilers:
http://quick-bench.com/psAI43n2tRg9ZLw4AER3cehYXJs

| Voters | Clang 7  | gcc 8.2 |
| ------- | ------------- | ------------- |
| 5 | 1.9x  | 3.2x |
| 20 | 2.4x  | 4.3x  |
| 100 | 2.1x | 13x  |
| 255 | 1.6x  | 27x |

The **x** denotes how many times faster the `std::vector` version is over the `std::unordered_set`. The results both show an increase for clang and gcc using a `std::vector`, which is what I've changed it to use.