### PR TITLE
Fix initialization order bug in nano::node

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -8,7 +8,6 @@ size_t constexpr nano::active_transactions::max_broadcast_queue;
 using namespace std::chrono;
 
 nano::active_transactions::active_transactions (nano::node & node_a, bool delay_frontier_confirmation_height_updating) :
-counter (),
 node (node_a),
 multipliers_cb (20, 1.),
 trended_active_difficulty (node.network_params.network.publish_threshold),

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -541,12 +541,12 @@ block_processor_thread ([this]() {
 	this->block_processor.process_blocks ();
 }),
 online_reps (*this, config.online_weight_minimum.number ()),
-wallets (init_a.wallets_store_init, *this),
 stats (config.stat_config),
 vote_uniquer (block_uniquer),
 active (*this, delay_frontier_confirmation_height_updating),
 confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, logger),
 payment_observer_processor (observers.blocks),
+wallets (init_a.wallets_store_init, *this),
 startup_time (std::chrono::steady_clock::now ())
 {
 	if (!init_a.error ())

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -547,6 +547,7 @@ active (*this, delay_frontier_confirmation_height_updating),
 confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, logger),
 payment_observer_processor (observers.blocks),
 wallets (init_a.wallets_store_init, *this),
+node_initialized_latch (1),
 startup_time (std::chrono::steady_clock::now ())
 {
 	if (!init_a.error ())
@@ -796,6 +797,7 @@ startup_time (std::chrono::steady_clock::now ())
 			}
 		}
 	}
+	node_initialized_latch.count_down ();
 }
 
 nano::node::~node ()

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -263,7 +263,6 @@ public:
 	boost::thread block_processor_thread;
 	nano::block_arrival block_arrival;
 	nano::online_reps online_reps;
-	nano::wallets wallets;
 	nano::votes_cache votes_cache;
 	nano::stat stats;
 	nano::keypair node_id;
@@ -273,6 +272,7 @@ public:
 	nano::active_transactions active;
 	nano::confirmation_height_processor confirmation_height_processor;
 	nano::payment_observer_processor payment_observer_processor;
+	nano::wallets wallets;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	static double constexpr price_max = 16.0;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -26,6 +26,7 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
+#include <boost/thread/latch.hpp>
 #include <boost/thread/thread.hpp>
 
 #include <atomic>
@@ -236,6 +237,7 @@ public:
 	void ongoing_online_weight_calculation_queue ();
 	bool online () const;
 	boost::asio::io_context & io_ctx;
+	boost::latch node_initialized_latch;
 	nano::network_params network_params;
 	nano::node_config config;
 	std::shared_ptr<nano::websocket::listener> websocket_server;


### PR DESCRIPTION
The wallet depends on confirmation_height_processor, and search_pending sometimes calls it before the node is fully constructed, causing a segfault.