### PR TITLE
Fix deadlock in tests

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1912,9 +1912,8 @@ nano::bootstrap_server::~bootstrap_server ()
 
 void nano::bootstrap_server::stop ()
 {
-	if (!stopped)
+	if (!stopped.exchange (true))
 	{
-		stopped = true;
 		std::lock_guard<std::mutex> lock (mutex);
 		if (socket != nullptr)
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1120,25 +1120,31 @@ void nano::node::start ()
 
 void nano::node::stop ()
 {
-	logger.always_log ("Node stopping");
-	block_processor.stop ();
-	if (block_processor_thread.joinable ())
+	std::unique_lock<std::mutex> lk (stopped_mutex);
+	if (!stopped)
 	{
-		block_processor_thread.join ();
+		stopped = true;
+		lk.unlock ();
+		logger.always_log ("Node stopping");
+		block_processor.stop ();
+		if (block_processor_thread.joinable ())
+		{
+			block_processor_thread.join ();
+		}
+		vote_processor.stop ();
+		confirmation_height_processor.stop ();
+		active.stop ();
+		network.stop ();
+		if (websocket_server)
+		{
+			websocket_server->stop ();
+		}
+		bootstrap_initiator.stop ();
+		bootstrap.stop ();
+		port_mapping.stop ();
+		checker.stop ();
+		wallets.stop ();
 	}
-	vote_processor.stop ();
-	confirmation_height_processor.stop ();
-	active.stop ();
-	network.stop ();
-	if (websocket_server)
-	{
-		websocket_server->stop ();
-	}
-	bootstrap_initiator.stop ();
-	bootstrap.stop ();
-	port_mapping.stop ();
-	checker.stop ();
-	wallets.stop ();
 }
 
 void nano::node::keepalive_preconfigured (std::vector<std::string> const & peers_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1120,11 +1120,8 @@ void nano::node::start ()
 
 void nano::node::stop ()
 {
-	std::unique_lock<std::mutex> lk (stopped_mutex);
-	if (!stopped)
+	if (!stopped.exchange (true))
 	{
-		stopped = true;
-		lk.unlock ();
 		logger.always_log ("Node stopping");
 		block_processor.stop ();
 		if (block_processor_thread.joinable ())

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -275,8 +275,7 @@ public:
 	nano::payment_observer_processor payment_observer_processor;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
-	std::mutex stopped_mutex;
-	bool stopped{ false };
+	std::atomic<bool> stopped{ false };
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
 };

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -275,6 +275,8 @@ public:
 	nano::payment_observer_processor payment_observer_processor;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
+	std::mutex stopped_mutex;
+	bool stopped{ false };
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
 };


### PR DESCRIPTION
On Windows (at least) when running the tests it would often crash on `node.fork_bootstrap_flip` among other tests due to a mutex being locked which is already locked higher up in the stack. It is caused by `bootstrap_initiator.stop ()` being called while the mutex is locked before the `attempt = nullptr` call. The `attempt` is holding the last reference to the `node` shared_ptr which may already have been stopped by the `system::~system` destructor which explicitly calls `node->stop ()`. It then eventually calls `bootstrap_initiator.stop ()` which leaks to a deadlock. There's probably a few ways to solve this, but this could be a problem with other node members (I have seen similar errors before) so I decided to add a check in `node::stop` to see if it has been stopped already before trying to stop again