### PR TITLE
Configurable confirmation history container

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -707,7 +707,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_FALSE (tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_FALSE (tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_FALSE (tree.get_optional_child ("diagnostics"));
-	ASSERT_FALSE (tree.get_optional_child ("election_history_size"));
+	ASSERT_FALSE (tree.get_optional_child ("confirmation_history_size"));
 
 	config.deserialize_json (upgraded, tree);
 	// The config options should be added after the upgrade
@@ -718,7 +718,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_TRUE (!!tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_TRUE (!!tree.get_optional_child ("diagnostics"));
-	ASSERT_TRUE (!!tree.get_optional_child ("election_history_size"));
+	ASSERT_TRUE (!!tree.get_optional_child ("confirmation_history_size"));
 
 	ASSERT_TRUE (upgraded);
 	auto version (tree.get<std::string> ("version"));
@@ -753,7 +753,7 @@ TEST (node_config, v17_values)
 		nano::jsonconfig diagnostics_l;
 		diagnostics_l.put_child ("txn_tracking", txn_tracking_l);
 		tree.put_child ("diagnostics", diagnostics_l);
-		tree.put ("election_history_size", 2048);
+		tree.put ("confirmation_history_size", 2048);
 	}
 
 	config.deserialize_json (upgraded, tree);
@@ -767,7 +767,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_read_txn_time.count (), 0);
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_write_txn_time.count (), 0);
 	ASSERT_TRUE (config.diagnostics_config.txn_tracking.ignore_writes_below_block_processor_max_time);
-	ASSERT_EQ (config.election_history_size, 2048);
+	ASSERT_EQ (config.confirmation_history_size, 2048);
 
 	// Check config is correct with other values
 	tree.put ("tcp_io_timeout", std::numeric_limits<unsigned long>::max () - 100);
@@ -784,7 +784,7 @@ TEST (node_config, v17_values)
 	nano::jsonconfig diagnostics_l;
 	diagnostics_l.replace_child ("txn_tracking", txn_tracking_l);
 	tree.replace_child ("diagnostics", diagnostics_l);
-	tree.put ("election_history_size", std::numeric_limits<unsigned long long>::max ());
+	tree.put ("confirmation_history_size", std::numeric_limits<unsigned long long>::max ());
 
 	upgraded = false;
 	config.deserialize_json (upgraded, tree);
@@ -800,7 +800,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_write_txn_time.count (), std::numeric_limits<unsigned>::max ());
 	ASSERT_FALSE (config.diagnostics_config.txn_tracking.ignore_writes_below_block_processor_max_time);
-	ASSERT_EQ (config.election_history_size, std::numeric_limits<unsigned long long>::max ());
+	ASSERT_EQ (config.confirmation_history_size, std::numeric_limits<unsigned long long>::max ());
 }
 
 // Regression test to ensure that deserializing includes changes node via get_required_child

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -707,6 +707,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_FALSE (tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_FALSE (tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_FALSE (tree.get_optional_child ("diagnostics"));
+	ASSERT_FALSE (tree.get_optional_child ("election_history_size"));
 
 	config.deserialize_json (upgraded, tree);
 	// The config options should be added after the upgrade
@@ -717,6 +718,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_TRUE (!!tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_TRUE (!!tree.get_optional_child ("diagnostics"));
+	ASSERT_TRUE (!!tree.get_optional_child ("election_history_size"));
 
 	ASSERT_TRUE (upgraded);
 	auto version (tree.get<std::string> ("version"));
@@ -751,6 +753,7 @@ TEST (node_config, v17_values)
 		nano::jsonconfig diagnostics_l;
 		diagnostics_l.put_child ("txn_tracking", txn_tracking_l);
 		tree.put_child ("diagnostics", diagnostics_l);
+		tree.put ("election_history_size", 2048);
 	}
 
 	config.deserialize_json (upgraded, tree);
@@ -764,6 +767,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_read_txn_time.count (), 0);
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_write_txn_time.count (), 0);
 	ASSERT_TRUE (config.diagnostics_config.txn_tracking.ignore_writes_below_block_processor_max_time);
+	ASSERT_EQ (config.election_history_size, 2048);
 
 	// Check config is correct with other values
 	tree.put ("tcp_io_timeout", std::numeric_limits<unsigned long>::max () - 100);
@@ -780,6 +784,7 @@ TEST (node_config, v17_values)
 	nano::jsonconfig diagnostics_l;
 	diagnostics_l.replace_child ("txn_tracking", txn_tracking_l);
 	tree.replace_child ("diagnostics", diagnostics_l);
+	tree.put ("election_history_size", std::numeric_limits<unsigned long long>::max ());
 
 	upgraded = false;
 	config.deserialize_json (upgraded, tree);
@@ -795,6 +800,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_write_txn_time.count (), std::numeric_limits<unsigned>::max ());
 	ASSERT_FALSE (config.diagnostics_config.txn_tracking.ignore_writes_below_block_processor_max_time);
+	ASSERT_EQ (config.election_history_size, std::numeric_limits<unsigned long long>::max ());
 }
 
 // Regression test to ensure that deserializing includes changes node via get_required_child

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -109,7 +109,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 			if (election_l->confirmed)
 			{
 				confirmed.push_back (election_l->status);
-				if (confirmed.size () > election_history_size)
+				if (confirmed.size () > node.config.election_history_size)
 				{
 					confirmed.pop_front ();
 				}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -109,7 +109,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 			if (election_l->confirmed)
 			{
 				confirmed.push_back (election_l->status);
-				if (confirmed.size () > node.config.election_history_size)
+				if (confirmed.size () > node.config.confirmation_history_size)
 				{
 					confirmed.pop_front ();
 				}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -131,7 +131,6 @@ public:
 	// Threshold to start logging blocks haven't yet been confirmed
 	static unsigned constexpr announcement_long = 20;
 	size_t long_unconfirmed_size = 0;
-	static size_t constexpr election_history_size = 2048;
 	static size_t constexpr max_broadcast_queue = 1000;
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -952,7 +952,7 @@ void nano::json_handler::block_confirm ()
 				{
 					std::lock_guard<std::mutex> lock (node.active.mutex);
 					node.active.confirmed.push_back (status);
-					if (node.active.confirmed.size () > node.active.election_history_size)
+					if (node.active.confirmed.size () > node.config.election_history_size)
 					{
 						node.active.confirmed.pop_front ();
 					}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -952,7 +952,7 @@ void nano::json_handler::block_confirm ()
 				{
 					std::lock_guard<std::mutex> lock (node.active.mutex);
 					node.active.confirmed.push_back (status);
-					if (node.active.confirmed.size () > node.config.election_history_size)
+					if (node.active.confirmed.size () > node.config.confirmation_history_size)
 					{
 						node.active.confirmed.pop_front ();
 					}

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -129,6 +129,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	nano::jsonconfig diagnostics_l;
 	diagnostics_config.serialize_json (diagnostics_l);
 	json.put_child ("diagnostics", diagnostics_l);
+	json.put ("election_history_size", election_history_size);
 
 	return json.get_error ();
 }
@@ -245,6 +246,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("external_port", external_port);
 			json.put ("tcp_incoming_connections_max", tcp_incoming_connections_max);
 			json.put ("vote_generator_delay", vote_generator_delay.count ());
+			json.put ("election_history_size", election_history_size);
 		}
 		case 17:
 			break;
@@ -391,6 +393,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		auto pow_sleep_interval_l (pow_sleep_interval.count ());
 		json.get (pow_sleep_interval_key, pow_sleep_interval_l);
 		pow_sleep_interval = std::chrono::nanoseconds (pow_sleep_interval_l);
+		json.get<size_t> ("election_history_size", election_history_size);
 
 		// Validate ranges
 		if (online_weight_quorum > 100)

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -129,7 +129,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	nano::jsonconfig diagnostics_l;
 	diagnostics_config.serialize_json (diagnostics_l);
 	json.put_child ("diagnostics", diagnostics_l);
-	json.put ("election_history_size", election_history_size);
+	json.put ("confirmation_history_size", confirmation_history_size);
 
 	return json.get_error ();
 }
@@ -246,7 +246,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("external_port", external_port);
 			json.put ("tcp_incoming_connections_max", tcp_incoming_connections_max);
 			json.put ("vote_generator_delay", vote_generator_delay.count ());
-			json.put ("election_history_size", election_history_size);
+			json.put ("confirmation_history_size", confirmation_history_size);
 		}
 		case 17:
 			break;
@@ -393,7 +393,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		auto pow_sleep_interval_l (pow_sleep_interval.count ());
 		json.get (pow_sleep_interval_key, pow_sleep_interval_l);
 		pow_sleep_interval = std::chrono::nanoseconds (pow_sleep_interval_l);
-		json.get<size_t> ("election_history_size", election_history_size);
+		json.get<size_t> ("confirmation_history_size", confirmation_history_size);
 
 		// Validate ranges
 		if (online_weight_quorum > 100)

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -50,7 +50,7 @@ public:
 	unsigned bootstrap_connections_max{ 64 };
 	nano::websocket::config websocket_config;
 	nano::diagnostics_config diagnostics_config;
-	size_t election_history_size{ 2048 };
+	size_t confirmation_history_size{ 2048 };
 	std::string callback_address;
 	uint16_t callback_port{ 0 };
 	std::string callback_target;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -50,6 +50,7 @@ public:
 	unsigned bootstrap_connections_max{ 64 };
 	nano::websocket::config websocket_config;
 	nano::diagnostics_config diagnostics_config;
+	size_t election_history_size{ 2048 };
 	std::string callback_address;
 	uint16_t callback_port{ 0 };
 	std::string callback_target;


### PR DESCRIPTION
defaults to maintain existing behavior 2048
update tests for v17 and upgrade path
rename variable to confirmation_history_size to be more accurate