### PR TITLE
Fix deadlock in tests (Continued)

### DIFF
--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -251,7 +251,7 @@ public:
 private:
 	nano::node & node;
 	std::shared_ptr<nano::bootstrap_attempt> attempt;
-	bool stopped;
+	std::atomic<bool> stopped;
 	std::mutex mutex;
 	std::condition_variable condition;
 	std::mutex observers_mutex;


### PR DESCRIPTION
Following on from #2043 I am still getting a deadlock on Windows from a similar issue where the last `node` shared_ptr reference is freed while holding the mutex of `bootstrap_initiator` and the `~bootstrap_initiator` destructor is implicitly called (and hence `stop`) which then has the same problem as before as it then locks the same mutex while already holding it. Made `stopped` a `std::atomic<bool>` so that it can be checked without locking the mutex. The `thread` can already be joined, so have moved this inside the `stopped` function (when `stopped` is false) to avoid an already joined error.