### PR TITLE
Reduce lock time in UDP ongoing keepalive

### DIFF
--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -366,7 +366,6 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 	lock.unlock ();
 	for (auto & channel : send_list)
 	{
-		std::weak_ptr<nano::node> node_w (node.shared ());
 		channel->send (message);
 	}
 	std::weak_ptr<nano::node> node_w (node.shared ());

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -626,12 +626,17 @@ void nano::transport::udp_channels::ongoing_keepalive ()
 {
 	nano::keepalive message;
 	node.network.random_fill (message.peers);
+	std::vector<std::shared_ptr<nano::transport::channel_udp>> send_list;
 	std::unique_lock<std::mutex> lock (mutex);
 	auto keepalive_cutoff (channels.get<last_packet_received_tag> ().lower_bound (std::chrono::steady_clock::now () - node.network_params.node.period));
 	for (auto i (channels.get<last_packet_received_tag> ().begin ()); i != keepalive_cutoff; ++i)
 	{
-		i->channel->set_last_packet_sent (std::chrono::steady_clock::now ());
-		i->channel->send (message);
+		send_list.push_back (i->channel);
+	}
+	lock.unlock ();
+	for (auto & channel : send_list)
+	{
+		channel->send (message);
 	}
 	std::weak_ptr<nano::node> node_w (node.shared ());
 	node.alarm.add (std::chrono::steady_clock::now () + node.network_params.node.period, [node_w]() {


### PR DESCRIPTION
While investigating a long held lock in vote processor, a few things popped up. This PR reduces lock time in UDP ongoing_keepalive the same way it's already done for TCP.

set_last_packet_sent removed since it's already called in channel->send (can you verify this is correct @SergiySW?)

Also removes a left-over weak_ptr.
