### PR TITLE
TSAN error for send_node_id_handshake test

### DIFF
--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -456,6 +456,9 @@ public:
 	/** Returns a new JSON log sink */
 	std::unique_ptr<stat_log_sink> log_sink_json () const;
 
+	/** Stop stats being output */
+	void stop ();
+
 private:
 	static std::string type_to_string (uint32_t key);
 	static std::string detail_to_string (uint32_t key);
@@ -499,6 +502,9 @@ private:
 	std::map<uint32_t, std::shared_ptr<nano::stat_entry>> entries;
 	std::chrono::steady_clock::time_point log_last_count_writeout{ std::chrono::steady_clock::now () };
 	std::chrono::steady_clock::time_point log_last_sample_writeout{ std::chrono::steady_clock::now () };
+
+	/** Whether stats should be output */
+	bool stopped{ false };
 
 	/** All access to stat is thread safe, including calls from observers on the same thread */
 	std::mutex stat_mutex;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -197,6 +197,7 @@ node (init_a, io_ctx_a, application_path_a, alarm_a, nano::node_config (peering_
 nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, bool delay_frontier_confirmation_height_updating) :
 io_ctx (io_ctx_a),
 config (config_a),
+stats (config.stat_config),
 flags (flags_a),
 alarm (alarm_a),
 work (work_a),
@@ -222,7 +223,6 @@ block_processor_thread ([this]() {
 	this->block_processor.process_blocks ();
 }),
 online_reps (*this, config.online_weight_minimum.number ()),
-stats (config.stat_config),
 vote_uniquer (block_uniquer),
 active (*this, delay_frontier_confirmation_height_updating),
 confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, logger),
@@ -826,6 +826,7 @@ void nano::node::stop ()
 		port_mapping.stop ();
 		checker.stop ();
 		wallets.stop ();
+		stats.stop ();
 	}
 }
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -210,6 +210,7 @@ public:
 	boost::latch node_initialized_latch;
 	nano::network_params network_params;
 	nano::node_config config;
+	nano::stat stats;
 	std::shared_ptr<nano::websocket::listener> websocket_server;
 	nano::node_flags flags;
 	nano::alarm & alarm;
@@ -236,7 +237,6 @@ public:
 	nano::block_arrival block_arrival;
 	nano::online_reps online_reps;
 	nano::votes_cache votes_cache;
-	nano::stat stats;
 	nano::keypair node_id;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;


### PR DESCRIPTION
When running Clang/TSAN I get the following:
https://gist.github.com/wezrule/279062783ed1ed2a2066ba5c79db0b83

What appears to happen is that the last `std::shared_ptr<nano::node>` reference gets released by an `alarm` operation which then calls the ~stat destructor. This modifies the `map` (unprotected) and at the same time a packet is processed and a `stat` is trying to be incremented. I don't think this is the fault of stats rather the slightly random nature where the last `node` shared_ptr reference is released which can cause problems in quite a few areas. But as this is the one that TSAN is warning about I have fixed it. Just adding a `stop` variable/function to prevent modifying stats when closing down the node. Have moved stats higher up the member list as most things have a dependency on it.