### PR TITLE
Websocket/extended confirmation support

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -296,7 +296,7 @@ TEST (websocket, confirmation_options)
 	std::thread client_thread ([&client_thread_finished]() {
 		// Subscribe initially with a specific invalid account
 		auto response = websocket_test_call ("::1", "24078",
-		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"accounts": ["xrb_invalid"]}})json", true, true, 1s);
+		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "accounts": ["xrb_invalid"]}})json", true, true, 1s);
 
 		ASSERT_FALSE (response);
 		client_thread_finished = true;
@@ -334,7 +334,7 @@ TEST (websocket, confirmation_options)
 	std::thread client_thread_2 ([&client_thread_2_finished]() {
 		// Re-subscribe with options for all local wallet accounts
 		auto response = websocket_test_call ("::1", "24078",
-		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"all_local_accounts": "true"}})json", true, true);
+		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true"}})json", true, true);
 
 		ASSERT_TRUE (response);
 		boost::property_tree::ptree event;
@@ -375,7 +375,7 @@ TEST (websocket, confirmation_options)
 	std::atomic<bool> client_thread_3_finished{ false };
 	std::thread client_thread_3 ([&client_thread_3_finished]() {
 		auto response = websocket_test_call ("::1", "24078",
-		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"all_local_accounts": "true"}})json", true, true, 1s);
+		R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true"}})json", true, true, 1s);
 
 		ASSERT_FALSE (response);
 		client_thread_3_finished = true;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -45,7 +45,6 @@ enum class election_status_type : uint8_t
 	active_confirmed_quorum = 1,
 	active_confirmation_height = 2,
 	inactive_confirmation_height = 3,
-	rpc_confirmation_height = 4,
 	stopped = 5
 };
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -944,7 +944,7 @@ void nano::json_handler::block_confirm ()
 			else
 			{
 				// Add record in confirmation history for confirmed block
-				nano::election_status status{ block_l, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), nano::election_status_type::rpc_confirmation_height };
+				nano::election_status status{ block_l, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), nano::election_status_type::active_confirmation_height };
 				{
 					std::lock_guard<std::mutex> lock (node.active.mutex);
 					node.active.confirmed.push_back (status);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -314,6 +314,21 @@ startup_time (std::chrono::steady_clock::now ())
 		if (websocket_server)
 		{
 			observers.blocks.add ([this](nano::election_status const & status_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
+				// can this be fired?
+				assert (status_a.type != nano::election_status_type::ongoing);
+
+				if (status_a.type == nano::election_status_type::active_confirmation_height)
+				{
+				}
+
+				if (status_a.type == nano::election_status_type::active_confirmed_quorum)
+				{
+				}
+
+				if (status_a.type == nano::election_status_type::inactive_confirmation_height)
+				{
+				}
+
 				if (this->websocket_server->any_subscriber (nano::websocket::topic::confirmation))
 				{
 					auto block_a (status_a.winner);
@@ -340,8 +355,16 @@ startup_time (std::chrono::steady_clock::now ())
 							}
 						}
 
-						this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype);
+						this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype, status_a.type);
 					}
+				}
+			});
+
+			observers.active_stopped.add ([this](nano::block_hash const & hash_a) {
+				if (this->websocket_server->any_subscriber (nano::websocket::topic::stopped_election))
+				{
+					nano::websocket::message_builder builder;
+					this->websocket_server->broadcast (builder.stopped_election (hash_a));
 				}
 			});
 		}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -339,9 +339,8 @@ startup_time (std::chrono::steady_clock::now ())
 								subtype = "receive";
 							}
 						}
-						nano::websocket::message_builder builder;
-						auto msg (builder.block_confirmed (block_a, account_a, amount_a, subtype));
-						this->websocket_server->broadcast (msg);
+
+						this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype);
 					}
 				}
 			});

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -314,20 +314,7 @@ startup_time (std::chrono::steady_clock::now ())
 		if (websocket_server)
 		{
 			observers.blocks.add ([this](nano::election_status const & status_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
-				// can this be fired?
 				assert (status_a.type != nano::election_status_type::ongoing);
-
-				if (status_a.type == nano::election_status_type::active_confirmation_height)
-				{
-				}
-
-				if (status_a.type == nano::election_status_type::active_confirmed_quorum)
-				{
-				}
-
-				if (status_a.type == nano::election_status_type::inactive_confirmation_height)
-				{
-				}
 
 				if (this->websocket_server->any_subscriber (nano::websocket::topic::confirmation))
 				{

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -88,11 +88,11 @@ bool nano::websocket::confirmation_options::should_filter (nano::websocket::mess
 	{
 		should_filter_conf_type_l = false;
 	}
-	if (type_text_l == "active_confirmation_height" && confirmation_types & type_active_confirmation_height)
+	else if (type_text_l == "active_confirmation_height" && confirmation_types & type_active_confirmation_height)
 	{
 		should_filter_conf_type_l = false;
 	}
-	if (type_text_l == "inactive" && confirmation_types & type_inactive)
+	else if (type_text_l == "inactive" && confirmation_types & type_inactive)
 	{
 		should_filter_conf_type_l = false;
 	}

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -10,7 +10,7 @@
 nano::websocket::confirmation_options::confirmation_options (boost::property_tree::ptree const & options_a, nano::node & node_a) :
 node (node_a)
 {
-	// Non-filtering options
+	// Non-account filtering options
 	include_block = options_a.get<bool> ("include_block", true);
 
 	confirmation_types = 0;
@@ -37,7 +37,7 @@ node (node_a)
 		confirmation_types = type_all;
 	}
 
-	// Filtering options
+	// Account filtering options
 	auto all_local_accounts_l (options_a.get_optional<bool> ("all_local_accounts"));
 	if (all_local_accounts_l.is_initialized ())
 	{


### PR DESCRIPTION
Part 2 of #2058.

Includes stopped-election subscription, and option to get confirmations without full block info.

A documentation PR remains.

This could probably use some more unit tests. If we want this in quickly for testing confirmation callbacks, I could add those to a separate PR, otherwise I'll mark as incomplete.