### PR TITLE
Use correct index when iterating prioritized frontiers

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2868,7 +2868,7 @@ TEST (confirmation_height, prioritize_frontiers)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	std::array <nano::qualified_root, num_accounts> frontiers { send17.qualified_root (), send6.qualified_root (), send7.qualified_root (), open2.qualified_root (), send11.qualified_root () };
+	std::array<nano::qualified_root, num_accounts> frontiers{ send17.qualified_root (), send6.qualified_root (), send7.qualified_root (), open2.qualified_root (), send11.qualified_root () };
 	for (auto & frontier : frontiers)
 	{
 		ASSERT_NE (node->active.roots.find (frontier), node->active.roots.end ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -335,6 +335,12 @@ void nano::active_transactions::request_loop ()
 	{
 		request_confirm (lock);
 		update_active_difficulty (lock);
+
+		// This prevents unnecessary waiting if stopped is set in-between the above check and now
+		if (stopped)
+		{
+			break;
+		}
 		const auto extra_delay (std::min (roots.size (), max_broadcast_queue) * node.network.broadcast_interval_ms * 2);
 		condition.wait_for (lock, std::chrono::milliseconds (node.network_params.network.request_interval_ms + extra_delay));
 	}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -152,6 +152,7 @@ private:
 	boost::thread thread;
 
 	friend class confirmation_height_prioritize_frontiers_Test;
+	friend class confirmation_height_prioritize_frontiers_overwrite_Test;
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transactions & active_transactions, const std::string & name);

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -147,6 +147,7 @@ private:
 	boost::multi_index::member<nano::cementable_account, uint64_t, &nano::cementable_account::blocks_uncemented>,
 	std::greater<uint64_t>>>>
 	priority_cementable_frontiers;
+	bool frontiers_fully_confirmed{ false };
 	static size_t constexpr max_priority_cementable_frontiers{ 100000 };
 	static size_t constexpr confirmed_frontiers_max_pending_cut_off{ 1000 };
 	boost::thread thread;


### PR DESCRIPTION
#2053 changed the collection used for prioritizing frontiers to be a `boost::multi_index` container, but was iterating over the default (wrong) index afterwards. There's not really a way to test this as the active roots has no "insertion" order, I do however check that the `roots` does contain the expected frontier hashes though.

I've also modified the `prioritize_frontiers_for_confirmation` so that instead of stopping iterating when the container is full, it continues and replaces the frontier with the lowest amount of uncemented blocks with higher ones.