### PR TITLE
[Valgrind] Increase deadline timer in the rpc.simultaneous_calls test to account for valgrind slowness

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6425,7 +6425,7 @@ TEST (rpc, simultaneous_calls)
 
 	promise.get_future ().wait ();
 
-	system.deadline_set (10s);
+	system.deadline_set (60s);
 	while (std::any_of (test_responses.begin (), test_responses.end (), [](const auto & test_response) { return test_response->status == 0; }))
 	{
 		ASSERT_NO_ERROR (system.poll ());


### PR DESCRIPTION
Running valgrind on rpc_tests come up with a failure:
https://gist.github.com/wezrule/217fbebde0b68394391feb18d35fbd92

This just seems to be because the test can't complete due the deadline timer not being long enough when running under valgrind. 60 seconds seems to be sufficient on my VM