### PR TITLE
Remove copies of blocks container from network::flood_block_batch

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -280,7 +280,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 	// Rebroadcast unconfirmed blocks
 	if (!rebroadcast_bundle.empty ())
 	{
-		node.network.flood_block_batch (rebroadcast_bundle);
+		node.network.flood_block_batch (std::move (rebroadcast_bundle));
 	}
 	// Batch confirmation request
 	if (!node.network_params.network.is_live_network () && !requests_bundle.empty ())

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3239,7 +3239,7 @@ void nano::json_handler::republish ()
 				}
 				hash = node.store.block_successor (transaction, hash);
 			}
-			node.network.flood_block_batch (republish_bundle, 25);
+			node.network.flood_block_batch (std::move (republish_bundle), 25);
 			response_l.put ("success", ""); // obsolete
 			response_l.add_child ("blocks", blocks);
 		}
@@ -4318,7 +4318,7 @@ void nano::json_handler::wallet_republish ()
 				blocks.push_back (std::make_pair ("", entry));
 			}
 		}
-		node.network.flood_block_batch (republish_bundle, 25);
+		node.network.flood_block_batch (std::move (republish_bundle), 25);
 		response_l.add_child ("blocks", blocks);
 	}
 	response_errors ();

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -233,12 +233,14 @@ void nano::network::flood_block_batch (std::deque<std::shared_ptr<nano::block>> 
 	if (!blocks_a.empty ())
 	{
 		std::weak_ptr<nano::node> node_w (node.shared ());
-		node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (delay_a + std::rand () % delay_a), [node_w, blocks_a, delay_a]() {
+		// clang-format off
+		node.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (delay_a + std::rand () % delay_a), [node_w, blocks (std::move (blocks_a)), delay_a]() {
 			if (auto node_l = node_w.lock ())
 			{
-				node_l->network.flood_block_batch (blocks_a, delay_a);
+				node_l->network.flood_block_batch (std::move (blocks), delay_a);
 			}
 		});
+		// clang-format on
 	}
 }
 


### PR DESCRIPTION
There are 2 copies of the blocks `deque` per iteration, and potentially 1000 iterations (`rebroadcast_bundle` max size) for each call to `flood_block_batch` from `active_transactions::request_confirm`. Profiling CPU cycles on the node over a random segment for a few seconds (it must have been in this loop at the time) showed 36% of the time was spent in this function:
https://imgur.com/1wiQDNn

I didn't expect it to be this high, but this was on a Debug build at the time (RelWithDebInfo give more accurate results) so iterator debugging probably played some part, but it's a suitable optimization none-the-less.

Removed an initial copy from the RPC calls as well while I was at it.