### PR TITLE
Use node_flags for delay_frontier_confirmation_height_updating

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -8,11 +8,12 @@ using namespace std::chrono_literals;
 
 TEST (active_transactions, adjusted_difficulty_priority)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
-	auto & node1 = *system.add_node (node_config, delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto & node1 = *system.add_node (node_config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1, key2, key3;
 
@@ -85,13 +86,15 @@ TEST (active_transactions, adjusted_difficulty_priority)
 
 TEST (active_transactions, keep_local)
 {
-	//delay_frontier_confirmation_height_updating to allow the test to before
 	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
 	node_config.active_elections_size = 3; //bound to 3, wont drop wallet created transactions, but good to test dropping remote
-	auto & node1 = *system.add_node (node_config, delay_frontier_confirmation_height_updating);
+	//delay_frontier_confirmation_height_updating to allow the test to before
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto & node1 = *system.add_node (node_config, node_flags);
 	auto & wallet (*system.wallet (0));
 	nano::genesis genesis;
 	//key 1/2 will be managed by the wallet
@@ -140,13 +143,14 @@ TEST (active_transactions, keep_local)
 
 TEST (active_transactions, prioritize_chains)
 {
-	//delay_frontier_confirmation_height_updating to allow the test to before
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.enable_voting = false;
 	node_config.active_elections_size = 4; //bound to 3, wont drop wallet created transactions, but good to test dropping remote
-	auto & node1 = *system.add_node (node_config, delay_frontier_confirmation_height_updating);
+	//delay_frontier_confirmation_height_updating to allow the test to before
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto & node1 = *system.add_node (node_config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1, key2, key3;
 

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -192,9 +192,10 @@ TEST (conflicts, reprioritize)
 
 TEST (conflicts, dependency)
 {
-	bool delay_frontier_confirmation_height_updating (true);
 	nano::system system;
-	auto node1 = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node1 = system.add_node (nano::node_config (24000, system.logging), node_flags);
 	nano::genesis genesis;
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::xrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -810,11 +810,12 @@ TEST (votes, add_two)
 // Higher sequence numbers change the vote
 TEST (votes, add_existing)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
-	auto & node1 = *system.add_node (node_config, delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto & node1 = *system.add_node (node_config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1545,10 +1545,11 @@ TEST (confirmation_height, single)
 
 TEST (confirmation_height, multiple_accounts)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	system.add_node (nano::node_config (24001, system.logging), delay_frontier_confirmation_height_updating);
-	system.add_node (nano::node_config (24002, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	system.add_node (nano::node_config (24001, system.logging), node_flags);
+	system.add_node (nano::node_config (24002, system.logging), node_flags);
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::keypair key3;
@@ -1731,10 +1732,11 @@ TEST (confirmation_height, gap_bootstrap)
 
 TEST (confirmation_height, gap_live)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	system.add_node (nano::node_config (24001, system.logging), delay_frontier_confirmation_height_updating);
-	system.add_node (nano::node_config (24002, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	system.add_node (nano::node_config (24001, system.logging), node_flags);
+	system.add_node (nano::node_config (24002, system.logging), node_flags);
 	nano::keypair destination;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	system.wallet (1)->insert_adhoc (destination.prv);
@@ -1805,9 +1807,10 @@ TEST (confirmation_height, gap_live)
 
 TEST (confirmation_height, send_receive_between_2_accounts)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (nano::node_config (24000, system.logging), node_flags);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
@@ -1878,9 +1881,10 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 
 TEST (confirmation_height, send_receive_self)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (nano::node_config (24000, system.logging), node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
 
@@ -1931,9 +1935,10 @@ TEST (confirmation_height, send_receive_self)
 
 TEST (confirmation_height, all_block_types)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (nano::node_config (24000, system.logging), node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
 	nano::keypair key1;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1675,10 +1675,11 @@ TEST (node, bootstrap_bulk_push)
 // Bootstrapping a forked open block should succeed.
 TEST (node, bootstrap_fork_open)
 {
-	auto delay_frontier_confirmation_height_updating = true;
 	nano::system system0;
-	auto node0 = system0.add_node (nano::node_config (24000, system0.logging), delay_frontier_confirmation_height_updating);
-	auto node1 = system0.add_node (nano::node_config (24001, system0.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node0 = system0.add_node (nano::node_config (24000, system0.logging), node_flags);
+	auto node1 = system0.add_node (nano::node_config (24001, system0.logging), node_flags);
 	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key0;
 	nano::send_block send0 (system0.nodes[0]->latest (nano::test_genesis_key.pub), key0.pub, nano::genesis_amount - 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
@@ -2333,10 +2334,11 @@ TEST (node, vote_by_hash_epoch_block_republish)
 
 TEST (node, epoch_conflict_confirm)
 {
-	auto delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node0 = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
-	auto node1 = system.add_node (nano::node_config (24001, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node0 = system.add_node (nano::node_config (24000, system.logging), node_flags);
+	auto node1 = system.add_node (nano::node_config (24001, system.logging), node_flags);
 	nano::keypair key;
 	nano::genesis genesis;
 	nano::keypair epoch_signer (nano::test_genesis_key);
@@ -2533,9 +2535,10 @@ TEST (node, block_processor_reject_state)
 
 TEST (node, block_processor_reject_rolled_back)
 {
-	auto delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto & node = *system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto & node = *system.add_node (nano::node_config (24000, system.logging), node_flags);
 	nano::genesis genesis;
 	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node.work_generate_blocking (*send1);
@@ -2765,10 +2768,11 @@ namespace nano
 {
 TEST (confirmation_height, prioritize_frontiers)
 {
-	// Prevent frontiers being confirmed as it will affect the priorization checking
-	auto delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node = system.add_node (nano::node_config (24001, system.logging), delay_frontier_confirmation_height_updating);
+	// Prevent frontiers being confirmed as it will affect the priorization checking
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (nano::node_config (24001, system.logging), node_flags);
 
 	nano::keypair key1;
 	nano::keypair key2;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -9,11 +9,11 @@ size_t constexpr nano::active_transactions::max_broadcast_queue;
 
 using namespace std::chrono;
 
-nano::active_transactions::active_transactions (nano::node & node_a, bool delay_frontier_confirmation_height_updating) :
+nano::active_transactions::active_transactions (nano::node & node_a) :
 node (node_a),
 multipliers_cb (20, 1.),
 trended_active_difficulty (node.network_params.network.publish_threshold),
-next_frontier_check (steady_clock::now () + (delay_frontier_confirmation_height_updating ? 60s : 0s)),
+next_frontier_check (steady_clock::now () + (node_a.flags.delay_frontier_confirmation_height_updating ? 60s : 0s)),
 thread ([this]() {
 	nano::thread_role::set (nano::thread_role::name::request_loop);
 	request_loop ();

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -78,7 +78,7 @@ public:
 class active_transactions final
 {
 public:
-	explicit active_transactions (nano::node &, bool delay_frontier_confirmation_height_updating = false);
+	explicit active_transactions (nano::node &);
 	~active_transactions ();
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -194,7 +194,7 @@ node (init_a, io_ctx_a, application_path_a, alarm_a, nano::node_config (peering_
 {
 }
 
-nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, bool delay_frontier_confirmation_height_updating) :
+nano::node::node (nano::node_init & init_a, boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a) :
 io_ctx (io_ctx_a),
 node_initialized_latch (1),
 config (config_a),
@@ -225,7 +225,7 @@ block_processor_thread ([this]() {
 }),
 online_reps (*this, config.online_weight_minimum.number ()),
 vote_uniquer (block_uniquer),
-active (*this, delay_frontier_confirmation_height_updating),
+active (*this),
 confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, logger),
 payment_observer_processor (observers.blocks),
 wallets (init_a.wallets_store_init, *this),

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -108,7 +108,7 @@ class node final : public std::enable_shared_from_this<nano::node>
 {
 public:
 	node (nano::node_init &, boost::asio::io_context &, uint16_t, boost::filesystem::path const &, nano::alarm &, nano::logging const &, nano::work_pool &);
-	node (nano::node_init &, boost::asio::io_context &, boost::filesystem::path const &, nano::alarm &, nano::node_config const &, nano::work_pool &, nano::node_flags = nano::node_flags (), bool delay_frontier_confirmation_height_updating = false);
+	node (nano::node_init &, boost::asio::io_context &, boost::filesystem::path const &, nano::alarm &, nano::node_config const &, nano::work_pool &, nano::node_flags = nano::node_flags ());
 	~node ();
 	template <typename T>
 	void background (T action_a)

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -93,6 +93,7 @@ public:
 	bool disable_unchecked_cleanup{ false };
 	bool disable_unchecked_drop{ true };
 	bool fast_bootstrap{ false };
+	bool delay_frontier_confirmation_height_updating{ false };
 	size_t sideband_batch_size{ 512 };
 	size_t block_processor_batch_size{ 0 };
 	size_t block_processor_full_size{ 65536 };

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -23,10 +23,10 @@ std::string nano::error_system_messages::message (int ev) const
 }
 
 /** Returns the node added. */
-std::shared_ptr<nano::node> nano::system::add_node (nano::node_config const & node_config_a, bool delay_frontier_confirmation_height_updating_a, nano::transport::transport_type type_a)
+std::shared_ptr<nano::node> nano::system::add_node (nano::node_config const & node_config_a, nano::node_flags node_flags_a, nano::transport::transport_type type_a)
 {
 	nano::node_init init;
-	auto node (std::make_shared<nano::node> (init, io_ctx, nano::unique_path (), alarm, node_config_a, work, node_flags (), delay_frontier_confirmation_height_updating_a));
+	auto node (std::make_shared<nano::node> (init, io_ctx, nano::unique_path (), alarm, node_config_a, work, node_flags_a));
 	assert (!init.error ());
 	node->start ();
 	nano::uint256_union wallet;
@@ -115,7 +115,7 @@ system ()
 	for (uint16_t i (0); i < count_a; ++i)
 	{
 		nano::node_config config (port_a + i, logging);
-		nano::system::add_node (config, false, type_a);
+		nano::system::add_node (config, nano::node_flags (), type_a);
 	}
 }
 

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -41,7 +41,7 @@ public:
 	std::error_code poll (const std::chrono::nanoseconds & sleep_time = std::chrono::milliseconds (50));
 	void stop ();
 	void deadline_set (const std::chrono::duration<double, std::nano> & delta);
-	std::shared_ptr<nano::node> add_node (nano::node_config const &, bool = false, nano::transport::transport_type = nano::transport::transport_type::tcp);
+	std::shared_ptr<nano::node> add_node (nano::node_config const &, nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
 	boost::asio::io_context io_ctx;
 	nano::alarm alarm{ io_ctx };
 	std::vector<std::shared_ptr<nano::node>> nodes;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5458,9 +5458,10 @@ TEST (rpc, online_reps)
 TEST (rpc, confirmation_height_currently_processing)
 {
 	// The chains should be longer than the	batch_write_size to test the amount of blocks confirmed is correct.
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (nano::node_config (24000, system.logging), node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
 	// Do enough blocks to reliably call RPC before the confirmation height has finished

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -448,11 +448,12 @@ TEST (node, mass_vote_by_hash)
 
 TEST (confirmation_height, many_accounts)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.online_weight_minimum = 100;
-	auto node = system.add_node (node_config, delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (node_config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
 	// The number of frontiers should be more than the batch_write_size to test the amount of blocks confirmed is correct.
@@ -517,9 +518,10 @@ TEST (confirmation_height, many_accounts)
 
 TEST (confirmation_height, long_chains)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
-	auto node = system.add_node (nano::node_config (24000, system.logging), delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (nano::node_config (24000, system.logging), node_flags);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
@@ -599,10 +601,11 @@ namespace nano
 {
 TEST (confirmation_height, prioritize_frontiers_overwrite)
 {
-	bool delay_frontier_confirmation_height_updating = true;
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
-	auto node = system.add_node (node_config, delay_frontier_confirmation_height_updating);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node = system.add_node (node_config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
 	// As this test can take a while extend the next frontier check


### PR DESCRIPTION
to simplify code and allow different flags usage in tests, i.e. disable bootstrap or UDP