### PR TITLE
Update slow_test

### DIFF
--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -239,8 +239,14 @@ void nano::system::generate_rollback (nano::node & node_a, std::vector<nano::acc
 		{
 			accounts_a[index] = accounts_a[accounts_a.size () - 1];
 			accounts_a.pop_back ();
-			auto error = node_a.ledger.rollback (transaction, hash);
+			std::vector<std::shared_ptr<nano::block>> rollback_list;
+			auto error = node_a.ledger.rollback (transaction, hash, rollback_list);
 			assert (!error);
+			for (auto & i : rollback_list)
+			{
+				node_a.wallets.watcher.remove (i);
+				node_a.active.erase (*i);
+			}
 		}
 	}
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1412,11 +1412,16 @@ void nano::work_watcher::run ()
 		{
 			std::unique_lock<std::mutex> active_lock (node.active.mutex);
 			auto confirmed (false);
-			auto existing (node.active.roots.find ((i->second)->qualified_root ()));
+			auto existing (node.active.roots.find (i->first));
 			if (node.active.roots.end () != existing)
 			{
 				//block may not be in existing yet
 				confirmed = existing->election->confirmed.load ();
+			}
+			else if (i->second == nullptr)
+			{
+				// removed
+				confirmed = true;
 			}
 			else
 			{
@@ -1442,9 +1447,13 @@ void nano::work_watcher::run ()
 		for (auto & i : blocks)
 		{
 			uint64_t difficulty (0);
-			auto root = i.second->root ();
-			nano::work_validate (root, i.second->block_work (), &difficulty);
-			if (node.active.active_difficulty () > difficulty)
+			nano::block_hash root (0);
+			if (i.second != nullptr)
+			{
+				root = i.second->root ();
+				nano::work_validate (root, i.second->block_work (), &difficulty);
+			}
+			if (node.active.active_difficulty () > difficulty && i.second != nullptr)
 			{
 				auto qualified_root = i.second->qualified_root ();
 				auto hash = i.second->hash ();
@@ -1466,7 +1475,7 @@ void nano::work_watcher::run ()
 							{
 								election->status.winner = block;
 							}
-							auto current (election->blocks.find (block->hash ()));
+							auto current (election->blocks.find (hash));
 							assert (current != election->blocks.end ());
 							current->second = block;
 						}
@@ -1478,7 +1487,10 @@ void nano::work_watcher::run ()
 					{
 						break;
 					}
-					i.second = block;
+					if (i.second != nullptr)
+					{
+						i.second = block;
+					}
 					lock.unlock ();
 				}
 				lock.lock ();
@@ -1498,6 +1510,17 @@ void nano::work_watcher::add (std::shared_ptr<nano::block> block_a)
 	{
 		std::lock_guard<std::mutex> lock (mutex);
 		blocks[block_l->qualified_root ()] = block_l;
+	}
+}
+
+void nano::work_watcher::remove (std::shared_ptr<nano::block> block_a)
+{
+	auto root (block_a->qualified_root ());
+	std::lock_guard<std::mutex> lock (mutex);
+	auto existing (blocks.find (root));
+	if (existing != blocks.end () && existing->second->hash () == block_a->hash ())
+	{
+		existing->second = nullptr;
 	}
 }
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -170,6 +170,7 @@ public:
 	void stop ();
 	void run ();
 	void add (std::shared_ptr<nano::block>);
+	void remove (std::shared_ptr<nano::block>);
 	bool is_watched (nano::qualified_root const &);
 	std::mutex mutex;
 	nano::node & node;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -12,7 +12,7 @@ namespace
 class rollback_visitor : public nano::block_visitor
 {
 public:
-	rollback_visitor (nano::transaction const & transaction_a, nano::ledger & ledger_a, std::vector<nano::block_hash> & list_a) :
+	rollback_visitor (nano::transaction const & transaction_a, nano::ledger & ledger_a, std::vector<std::shared_ptr<nano::block>> & list_a) :
 	transaction (transaction_a),
 	ledger (ledger_a),
 	list (list_a)
@@ -153,7 +153,7 @@ public:
 	}
 	nano::transaction const & transaction;
 	nano::ledger & ledger;
-	std::vector<nano::block_hash> & list;
+	std::vector<std::shared_ptr<nano::block>> & list;
 	bool error{ false };
 };
 
@@ -832,7 +832,7 @@ nano::uint128_t nano::ledger::weight (nano::transaction const & transaction_a, n
 }
 
 // Rollback blocks until `block_a' doesn't exist or it tries to penetrate the confirmation height
-bool nano::ledger::rollback (nano::transaction const & transaction_a, nano::block_hash const & block_a, std::vector<nano::block_hash> & list_a)
+bool nano::ledger::rollback (nano::transaction const & transaction_a, nano::block_hash const & block_a, std::vector<std::shared_ptr<nano::block>> & list_a)
 {
 	assert (store.block_exists (transaction_a, block_a));
 	auto account_l (account (transaction_a, block_a));
@@ -847,7 +847,7 @@ bool nano::ledger::rollback (nano::transaction const & transaction_a, nano::bloc
 		if (block_account_height > account_info.confirmation_height)
 		{
 			auto block (store.block_get (transaction_a, account_info.head));
-			list_a.push_back (account_info.head);
+			list_a.push_back (block);
 			block->visit (rollback);
 			error = rollback.error;
 		}
@@ -861,7 +861,7 @@ bool nano::ledger::rollback (nano::transaction const & transaction_a, nano::bloc
 
 bool nano::ledger::rollback (nano::transaction const & transaction_a, nano::block_hash const & block_a)
 {
-	std::vector<nano::block_hash> rollback_list;
+	std::vector<std::shared_ptr<nano::block>> rollback_list;
 	return rollback (transaction_a, block_a, rollback_list);
 }
 

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -41,7 +41,7 @@ public:
 	nano::block_hash block_destination (nano::transaction const &, nano::block const &);
 	nano::block_hash block_source (nano::transaction const &, nano::block const &);
 	nano::process_return process (nano::transaction const &, nano::block const &, nano::signature_verification = nano::signature_verification::unknown);
-	bool rollback (nano::transaction const &, nano::block_hash const &, std::vector<nano::block_hash> &);
+	bool rollback (nano::transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::transaction const &, nano::block_hash const &);
 	void change_latest (nano::transaction const &, nano::account const &, nano::block_hash const &, nano::account const &, nano::uint128_union const &, uint64_t, bool = false, nano::epoch = nano::epoch::epoch_0);
 	void dump_account_chain (nano::account const &);


### PR DESCRIPTION
* prevent block cementing for tests with generate_mass_activity
* stop wallets work_watcher for system.generate_mass_activity_long
* add work to processed blocks
* remove rolled back blocks from wallets work_watcher & active transactions