### PR TITLE
Fix duplicate iterating in conf height processor with self and circular sends

### DIFF
--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -29,6 +29,7 @@ private:
 	/** This is the last block popped off the confirmation height pending collection */
 	nano::block_hash current_hash{ 0 };
 	friend class confirmation_height_processor;
+	friend class confirmation_height_pending_observer_callbacks_Test;
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (pending_confirmation_height &, const std::string &);
@@ -86,6 +87,7 @@ private:
 	bool write_pending (std::deque<conf_height_details> &, int64_t);
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (confirmation_height_processor &, const std::string &);
+	friend class confirmation_height_pending_observer_callbacks_Test;
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (confirmation_height_processor &, const std::string &);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -319,31 +319,28 @@ startup_time (std::chrono::steady_clock::now ())
 				if (this->websocket_server->any_subscriber (nano::websocket::topic::confirmation))
 				{
 					auto block_a (status_a.winner);
-					if (this->block_arrival.recent (block_a->hash ()))
+					std::string subtype;
+					if (is_state_send_a)
 					{
-						std::string subtype;
-						if (is_state_send_a)
-						{
-							subtype = "send";
-						}
-						else if (block_a->type () == nano::block_type::state)
-						{
-							if (block_a->link ().is_zero ())
-							{
-								subtype = "change";
-							}
-							else if (amount_a == 0 && !this->ledger.epoch_link.is_zero () && this->ledger.is_epoch_link (block_a->link ()))
-							{
-								subtype = "epoch";
-							}
-							else
-							{
-								subtype = "receive";
-							}
-						}
-
-						this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype, status_a.type);
+						subtype = "send";
 					}
+					else if (block_a->type () == nano::block_type::state)
+					{
+						if (block_a->link ().is_zero ())
+						{
+							subtype = "change";
+						}
+						else if (amount_a == 0 && !this->ledger.epoch_link.is_zero () && this->ledger.is_epoch_link (block_a->link ()))
+						{
+							subtype = "epoch";
+						}
+						else
+						{
+							subtype = "receive";
+						}
+					}
+
+					this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype, status_a.type);
 				}
 			});
 


### PR DESCRIPTION
There were reports of duplicates found in the callbacks, and this was cause by self sends and sends to accounts who sent back to the originating account. While this didn't compromise the actual confirmation heights being set it did extra processing for no reason and in the observer multiple callbacks for the same inactive blocks could be sent. This has been rectified by having a separate "iterated" height in addition to a pending confirmation height and checking this. I've updated all confirmation_height tests to check callback counts and a new test to check for the case where a block was being confirmed and it iterates over a block which was voted on previously and added to pending_confirmation_height. So the callback is called after the election, then it is seen as inactive when it gets iterated over by a successor and another callback is made for that.

Also removed the block arrival check in the websockets as it didn't report all inactive blocks, found during a discussion with @cryptocode & @SergiySW.