### PR TITLE
Optional include_trend for RPC active_difficulty

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -787,6 +787,12 @@ size_t nano::active_transactions::priority_cementable_frontiers_size ()
 	return priority_cementable_frontiers.size ();
 }
 
+boost::circular_buffer<double> nano::active_transactions::difficulty_trend ()
+{
+	std::lock_guard<std::mutex> guard (mutex);
+	return multipliers_cb;
+}
+
 nano::cementable_account::cementable_account (nano::account const & account_a, size_t blocks_uncemented_a) :
 account (account_a), blocks_uncemented (blocks_uncemented_a)
 {

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -130,6 +130,7 @@ public:
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;
 	size_t priority_cementable_frontiers_size ();
+	boost::circular_buffer<double> difficulty_trend ();
 
 private:
 	// Call action with confirmed block, may be different than what we started with

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -836,11 +836,24 @@ void nano::json_handler::accounts_pending ()
 
 void nano::json_handler::active_difficulty ()
 {
+	auto include_trend (request.get<bool> ("include_trend", false));
 	response_l.put ("network_minimum", nano::to_string_hex (node.network_params.network.publish_threshold));
 	auto difficulty_active = node.active.active_difficulty ();
 	response_l.put ("network_current", nano::to_string_hex (difficulty_active));
 	auto multiplier = nano::difficulty::to_multiplier (difficulty_active, node.network_params.network.publish_threshold);
 	response_l.put ("multiplier", nano::to_string (multiplier));
+	if (include_trend)
+	{
+		boost::property_tree::ptree trend_entry_l;
+		auto trend_l (node.active.difficulty_trend ());
+		for (auto multiplier_l : trend_l)
+		{
+			boost::property_tree::ptree entry;
+			entry.put ("", nano::to_string (multiplier_l));
+			trend_entry_l.push_back (std::make_pair ("", entry));
+		}
+		response_l.add_child ("difficulty_trend", trend_entry_l);
+	}
 	response_errors ();
 }
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6441,10 +6441,7 @@ TEST (rpc, active_difficulty)
 		ASSERT_EQ (trend_it++->second.get<double> (""), 1.);
 		ASSERT_EQ (trend_it++->second.get<double> (""), 4.2);
 		ASSERT_EQ (trend_it++->second.get<double> (""), 1.5);
-		while (trend_it != trend.end ())
-		{
-			ASSERT_EQ (trend_it++->second.get<double> (""), 1.);
-		}
+		ASSERT_TRUE (std::all_of (trend_it, trend.end (), [](auto & item) { return item.second.template get<double> ("") == 1.; }));
 	}
 }
 


### PR DESCRIPTION
- Optional `include_trend` returns a copy of `active.multipliers_cb` which has the most recently added difficulties in front.
- Adds a test for `rpc.active_difficulty`.

Example response
```json
{
    "network_minimum": "ffffffc000000000",
    "network_current": "ffffffc1816766f2",
    "multiplier": "1.024089858417128",
    "difficulty_trend": [
        "1.156096135149775",
        "1.190133894573061",
        "1.135567138563921",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000",
        "1.000000000000000"
    ]
}
```