### PR TITLE
Use default vote_generator_delay if missing (for RC updates)

### DIFF
--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -348,8 +348,9 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 			json.get_error ().set ("vote_minimum contains an invalid decimal amount");
 		}
 
-		auto vote_generator_delay_l (json.get<unsigned long> ("vote_generator_delay"));
-		vote_generator_delay = std::chrono::milliseconds (vote_generator_delay_l);
+		unsigned long delay_l = vote_generator_delay.count ();
+		json.get<unsigned long> ("vote_generator_delay", delay_l);
+		vote_generator_delay = std::chrono::milliseconds (delay_l);
 
 		auto block_processor_batch_max_time_l (json.get<unsigned long> ("block_processor_batch_max_time"));
 		block_processor_batch_max_time = std::chrono::milliseconds (block_processor_batch_max_time_l);


### PR DESCRIPTION
#2028 puts back a vote delay, but it's likely ineffective on some RC installations since we don't have upgrade paths for RC's and not everyone updates the config manually/generate new ones. With this PR, the node will use the default delay if missing in config so everyone's using a delay in the next RC.