### PR TITLE
Fix vote_generator loop inconsistency during high load

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1414,7 +1414,7 @@ TEST (bulk_pull_account, basics)
 	auto send1 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 25));
 	auto send2 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 10));
 	auto send3 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 2));
-	system.deadline_set (10s);
+	system.deadline_set (5s);
 	while (system.nodes[0]->balance (key1.pub) != 25)
 	{
 		ASSERT_NO_ERROR (system.poll ());

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1414,7 +1414,7 @@ TEST (bulk_pull_account, basics)
 	auto send1 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 25));
 	auto send2 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 10));
 	auto send3 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 2));
-	system.deadline_set (5s);
+	system.deadline_set (10s);
 	while (system.nodes[0]->balance (key1.pub) != 25)
 	{
 		ASSERT_NO_ERROR (system.poll ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -710,6 +710,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_FALSE (tree.get_optional_child ("external_port"));
 	ASSERT_FALSE (tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_FALSE (tree.get_optional_child ("vote_generator_delay"));
+	ASSERT_FALSE (tree.get_optional_child ("vote_generator_threshold"));
 	ASSERT_FALSE (tree.get_optional_child ("diagnostics"));
 	ASSERT_FALSE (tree.get_optional_child ("use_memory_pools"));
 	ASSERT_FALSE (tree.get_optional_child ("confirmation_history_size"));
@@ -724,6 +725,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_TRUE (!!tree.get_optional_child ("external_port"));
 	ASSERT_TRUE (!!tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_delay"));
+	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_threshold"));
 	ASSERT_TRUE (!!tree.get_optional_child ("diagnostics"));
 	ASSERT_TRUE (!!tree.get_optional_child ("use_memory_pools"));
 	ASSERT_TRUE (!!tree.get_optional_child ("confirmation_history_size"));
@@ -755,6 +757,7 @@ TEST (node_config, v17_values)
 		tree.put ("external_port", 0);
 		tree.put ("tcp_incoming_connections_max", 1);
 		tree.put ("vote_generator_delay", 50);
+		tree.put ("vote_generator_threshold", 3);
 		nano::jsonconfig txn_tracking_l;
 		txn_tracking_l.put ("enable", false);
 		txn_tracking_l.put ("min_read_txn_time", 0);
@@ -792,6 +795,7 @@ TEST (node_config, v17_values)
 	tree.put ("external_port", std::numeric_limits<uint16_t>::max () - 1);
 	tree.put ("tcp_incoming_connections_max", std::numeric_limits<unsigned>::max ());
 	tree.put ("vote_generator_delay", std::numeric_limits<unsigned long>::max () - 100);
+	tree.put ("vote_generator_threshold", 10);
 	nano::jsonconfig txn_tracking_l;
 	txn_tracking_l.put ("enable", true);
 	txn_tracking_l.put ("min_read_txn_time", 1234);
@@ -814,6 +818,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.external_port, std::numeric_limits<uint16_t>::max () - 1);
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
 	ASSERT_EQ (config.vote_generator_delay.count (), std::numeric_limits<unsigned long>::max () - 100);
+	ASSERT_EQ (config.vote_generator_threshold, 10);
 	ASSERT_TRUE (config.diagnostics_config.txn_tracking.enable);
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_read_txn_time.count (), 1234);
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
@@ -2793,7 +2798,7 @@ TEST (confirmation_height, prioritize_frontiers)
 	nano::send_block send5 (send4.hash (), key3.pub, node->config.online_weight_minimum.number () + 6500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (send4.hash ()));
 	nano::send_block send6 (send5.hash (), key4.pub, node->config.online_weight_minimum.number () + 6000, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (send5.hash ()));
 
-	// Open all accounts and add other sends to get different uncemented counts (as well as some which are the same) 
+	// Open all accounts and add other sends to get different uncemented counts (as well as some which are the same)
 	nano::open_block open1 (send1.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, system.work.generate (key1.pub));
 	nano::send_block send7 (open1.hash (), nano::test_genesis_key.pub, 500, key1.prv, key1.pub, system.work.generate (open1.hash ()));
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -114,6 +114,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("allow_local_peers", allow_local_peers);
 	json.put ("vote_minimum", vote_minimum.to_string_dec ());
 	json.put ("vote_generator_delay", vote_generator_delay.count ());
+	json.put ("vote_generator_threshold", vote_generator_threshold);
 	json.put ("unchecked_cutoff_time", unchecked_cutoff_time.count ());
 	json.put ("tcp_io_timeout", tcp_io_timeout.count ());
 	json.put ("pow_sleep_interval", pow_sleep_interval.count ());
@@ -249,6 +250,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("external_port", external_port);
 			json.put ("tcp_incoming_connections_max", tcp_incoming_connections_max);
 			json.put ("vote_generator_delay", vote_generator_delay.count ());
+			json.put ("vote_generator_threshold", vote_generator_threshold);
 			json.put ("use_memory_pools", use_memory_pools);
 			json.put ("confirmation_history_size", confirmation_history_size);
 			json.put ("active_elections_size", active_elections_size);
@@ -352,6 +354,10 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<unsigned long> ("vote_generator_delay", delay_l);
 		vote_generator_delay = std::chrono::milliseconds (delay_l);
 
+		unsigned threshold_l = vote_generator_threshold;
+		json.get<unsigned> ("vote_generator_threshold", threshold_l);
+		vote_generator_threshold = threshold_l;
+
 		auto block_processor_batch_max_time_l (json.get<unsigned long> ("block_processor_batch_max_time"));
 		block_processor_batch_max_time = std::chrono::milliseconds (block_processor_batch_max_time_l);
 		auto unchecked_cutoff_time_l = static_cast<unsigned long> (unchecked_cutoff_time.count ());
@@ -412,7 +418,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		}
 		if (password_fanout < 16 || password_fanout > 1024 * 1024)
 		{
-			json.get_error ().set ("password_fanout must a number between 16 and 1048576");
+			json.get_error ().set ("password_fanout must be a number between 16 and 1048576");
 		}
 		if (io_threads == 0)
 		{
@@ -425,6 +431,10 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		if (bandwidth_limit > std::numeric_limits<size_t>::max ())
 		{
 			json.get_error ().set ("bandwidth_limit unbounded = 0, default = 1572864, max = 18446744073709551615");
+		}
+		if (vote_generator_threshold < 1 || vote_generator_threshold > 12)
+		{
+			json.get_error ().set ("vote_generator_threshold must be a number between 1 and 12");
 		}
 	}
 	catch (std::runtime_error const & ex)

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -354,9 +354,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<unsigned long> ("vote_generator_delay", delay_l);
 		vote_generator_delay = std::chrono::milliseconds (delay_l);
 
-		unsigned threshold_l = vote_generator_threshold;
-		json.get<unsigned> ("vote_generator_threshold", threshold_l);
-		vote_generator_threshold = threshold_l;
+		json.get<unsigned> ("vote_generator_threshold", vote_generator_threshold);
 
 		auto block_processor_batch_max_time_l (json.get<unsigned long> ("block_processor_batch_max_time"));
 		block_processor_batch_max_time = std::chrono::milliseconds (block_processor_batch_max_time_l);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -38,6 +38,7 @@ public:
 	nano::amount receive_minimum{ nano::xrb_ratio };
 	nano::amount vote_minimum{ nano::Gxrb_ratio };
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (50) };
+	unsigned vote_generator_threshold{ 3 };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
 	unsigned online_weight_quorum{ 50 };
 	unsigned password_fanout{ 1024 };

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -34,8 +34,9 @@ private:
 	std::condition_variable condition;
 	std::deque<nano::block_hash> hashes;
 	nano::network_params network_params;
-	bool stopped;
-	bool started;
+	bool stopped{ false };
+	bool started{ false };
+	bool wakeup{ false };
 	boost::thread thread;
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);


### PR DESCRIPTION
Adds a `vote_generator_threshold` config option ( between 1 and 12 ) and new logic for the vote generator loop. The goal is to make it behave like a deadline timer which is reset when new hashes arrive, and when fired sends the hashes.

- The loop still waits on a condition_variable for up to `vote_generator_delay` (50ms default)
- The cv can be notified by `vote_generator::add` when a new hash arrives, which makes the loop **not** send the votes yet, but wait for more. This happens when hashes are arriving fast.
- When the cv is notified, that means hashes are not arriving sufficiently fast, so the loop sends the votes

The addition of `vote_generator_threshold` helps in configuring what the "high load threshold" should be.

Approximate equation (assumes constant rate during sleep time): `hash_arrival_rate * sleep_time = hash` . By setting `hashes` to our threshold (default 3), and sleeping the default 50ms, we expect to enter the high load mode at a vote rate of 60. Above that number, if consistent, and we should only see packs of 12 votes. In reality it's lower, at 40 or 45.

So we can play with the delay and threshold to achieve a desired configuration. By default, anything below 40 tps and the node should not take more than 50ms to vote for a transaction. ~~Above~~ Around 40-60 it should take around 200ms, **decreasing for higher hash arrival rates**.

----

I've tested this pretty successfully on beta already. Would be interesting to see in RC5 if no issues arise. With a 100tps push of ~2000 blocks by Json:
`117,63,0,0,0,0,1,0,0,0,0,176`   ,  where the first number is votes with 1 hash and the last is votes with 12 hashes