### PR TITLE
TCP: Don't connect to or log invalid peers

### DIFF
--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -377,7 +377,7 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 		for (auto i (0); i <= random_count; ++i)
 		{
 			auto tcp_endpoint (node.network.udp_channels.bootstrap_peer (nano::tcp_realtime_protocol_version_min));
-			if (find_channel (tcp_endpoint) == nullptr && tcp_endpoint != invalid_endpoint)
+			if (tcp_endpoint != invalid_endpoint && find_channel (tcp_endpoint) == nullptr)
 			{
 				start_tcp (nano::transport::map_tcp_to_endpoint (tcp_endpoint));
 			}

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -370,13 +370,14 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 		channel->send (message);
 	}
 	// Attempt to start TCP connections to known UDP peers
+	nano::tcp_endpoint invalid_endpoint (boost::asio::ip::address_v6::any (), 0);
 	if (!node.network_params.network.is_test_network () && !node.flags.disable_udp)
 	{
 		size_t random_count (std::min (static_cast<size_t> (6), static_cast<size_t> (std::ceil (std::sqrt (node.network.udp_channels.size ())))));
 		for (auto i (0); i <= random_count; ++i)
 		{
 			auto tcp_endpoint (node.network.udp_channels.bootstrap_peer (nano::tcp_realtime_protocol_version_min));
-			if (find_channel (tcp_endpoint) == nullptr)
+			if (find_channel (tcp_endpoint) == nullptr && tcp_endpoint != invalid_endpoint)
 			{
 				start_tcp (nano::transport::map_tcp_to_endpoint (tcp_endpoint));
 			}


### PR DESCRIPTION
My log had a lot of Disconnecting from 0.0.0.0... messages. Turns out it's logging as timeout when remote has already closed, thus the endpoint is invalidated. Also prevents connecting to the default endpoint (0.0.0.0:0), which bootstrap_peer returns if there isn't a suitable channel.