### PR TITLE
Add observer stats for confirmations

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -256,6 +256,12 @@ TEST (node, auto_bootstrap)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	};
+	system.deadline_set (5s);
+	while (node1->stats.count (nano::stat::type::observer, nano::stat::detail::observer_confirmation_active_quorum, nano::stat::dir::out) < 0 || node1->stats.count (nano::stat::type::observer, nano::stat::detail::observer_confirmation_active_conf_height, nano::stat::dir::out) < 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
 	node1->stop ();
 }
 
@@ -1564,6 +1570,11 @@ TEST (node, broadcast_elected)
 			ASSERT_TRUE (node0->ledger.block_exists (fork0->hash ()));
 			ASSERT_TRUE (node1->ledger.block_exists (fork0->hash ()));
 			ASSERT_NO_ERROR (ec);
+		}
+		system.deadline_set (5s);
+		while (node1->stats.count (nano::stat::type::observer, nano::stat::detail::observer_confirmation_inactive, nano::stat::dir::out) < 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
 		}
 	}
 }

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -377,6 +377,9 @@ std::string nano::stat::type_to_string (uint32_t key)
 		case nano::stat::type::message:
 			res = "message";
 			break;
+		case nano::stat::type::observer:
+			res = "observer";
+			break;
 		case nano::stat::type::confirmation_height:
 			res = "confirmation_height";
 			break;
@@ -421,6 +424,15 @@ std::string nano::stat::detail_to_string (uint32_t key)
 			break;
 		case nano::stat::detail::bulk_push:
 			res = "bulk_push";
+			break;
+		case nano::stat::detail::observer_confirmation_active_quorum:
+			res = "observer_confirmation_active_quorum";
+			break;
+		case nano::stat::detail::observer_confirmation_active_conf_height:
+			res = "observer_confirmation_active_conf_height";
+			break;
+		case nano::stat::detail::observer_confirmation_inactive:
+			res = "observer_confirmation_inactive";
 			break;
 		case nano::stat::detail::error_socket_close:
 			res = "error_socket_close";

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -232,6 +232,7 @@ public:
 		ipc,
 		tcp,
 		udp,
+		observer,
 		confirmation_height,
 		drop
 	};
@@ -246,6 +247,11 @@ public:
 		insufficient_work,
 		http_callback,
 		unreachable_host,
+
+		// observer specific
+		observer_confirmation_active_quorum,
+		observer_confirmation_active_conf_height,
+		observer_confirmation_inactive,
 
 		// ledger, block, bootstrap
 		send,

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -352,6 +352,24 @@ startup_time (std::chrono::steady_clock::now ())
 				}
 			});
 		}
+		// Add block confirmation type stats regardless of http-callback and websocket subscriptions
+		observers.blocks.add ([this](nano::election_status const & status_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
+			assert (status_a.type != nano::election_status_type::ongoing);
+			switch (status_a.type)
+			{
+				case nano::election_status_type::active_confirmed_quorum:
+					this->stats.inc (nano::stat::type::observer, nano::stat::detail::observer_confirmation_active_quorum, nano::stat::dir::out);
+					break;
+				case nano::election_status_type::active_confirmation_height:
+					this->stats.inc (nano::stat::type::observer, nano::stat::detail::observer_confirmation_active_conf_height, nano::stat::dir::out);
+					break;
+				case nano::election_status_type::inactive_confirmation_height:
+					this->stats.inc (nano::stat::type::observer, nano::stat::detail::observer_confirmation_inactive, nano::stat::dir::out);
+					break;
+				default:
+					break;
+			}
+		});
 		observers.endpoint.add ([this](std::shared_ptr<nano::transport::channel> channel_a) {
 			if (channel_a->get_type () == nano::transport::transport_type::udp)
 			{


### PR DESCRIPTION
The observer stats facilitate debugging callbacks and websockets. The subtotal for stats "observer/confirmation*" should match the stat "confirmation/blocks_confirmed" if everything works as expected (notification is async so numbers may be slightly out of sync for short periods of time)

If a websocket client has a different count, it indicates a bug in websockets, the external client, or the configuration/subscription (though beware intermittent network issues may cause lost messages as WS doesn't guarantee delivery; a queue system like mqtt is needed for that)
