### PR TITLE
Improve batching multiple blocks pending confirmation height processing

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -715,6 +715,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_FALSE (tree.get_optional_child ("confirmation_history_size"));
 	ASSERT_FALSE (tree.get_optional_child ("active_elections_size"));
 	ASSERT_FALSE (tree.get_optional_child ("bandwidth_limit"));
+	ASSERT_FALSE (tree.get_optional_child ("conf_height_processor_batch_min_time"));
 
 	config.deserialize_json (upgraded, tree);
 	// The config options should be added after the upgrade
@@ -729,6 +730,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_TRUE (!!tree.get_optional_child ("confirmation_history_size"));
 	ASSERT_TRUE (!!tree.get_optional_child ("active_elections_size"));
 	ASSERT_TRUE (!!tree.get_optional_child ("bandwidth_limit"));
+	ASSERT_TRUE (!!tree.get_optional_child ("conf_height_processor_batch_min_time"));
 
 	ASSERT_TRUE (upgraded);
 	auto version (tree.get<std::string> ("version"));
@@ -767,6 +769,7 @@ TEST (node_config, v17_values)
 		tree.put ("confirmation_history_size", 2048);
 		tree.put ("active_elections_size", 8000);
 		tree.put ("bandwidth_limit", 1572864);
+		tree.put ("conf_height_processor_batch_min_time", 0);
 	}
 
 	config.deserialize_json (upgraded, tree);
@@ -784,6 +787,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.confirmation_history_size, 2048);
 	ASSERT_EQ (config.active_elections_size, 8000);
 	ASSERT_EQ (config.bandwidth_limit, 1572864);
+	ASSERT_EQ (config.conf_height_processor_batch_min_time.count (), 0);
 
 	// Check config is correct with other values
 	tree.put ("tcp_io_timeout", std::numeric_limits<unsigned long>::max () - 100);
@@ -804,6 +808,7 @@ TEST (node_config, v17_values)
 	tree.put ("confirmation_history_size", std::numeric_limits<unsigned long long>::max ());
 	tree.put ("active_elections_size", std::numeric_limits<unsigned long long>::max ());
 	tree.put ("bandwidth_limit", std::numeric_limits<size_t>::max ());
+	tree.put ("conf_height_processor_batch_min_time", 500);
 
 	upgraded = false;
 	config.deserialize_json (upgraded, tree);
@@ -823,6 +828,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.confirmation_history_size, std::numeric_limits<unsigned long long>::max ());
 	ASSERT_EQ (config.active_elections_size, std::numeric_limits<unsigned long long>::max ());
 	ASSERT_EQ (config.bandwidth_limit, std::numeric_limits<size_t>::max ());
+	ASSERT_EQ (config.conf_height_processor_batch_min_time.count (), 500);
 }
 
 // Regression test to ensure that deserializing includes changes node via get_required_child

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library (node
 	websocket.cpp
 	websocketconfig.hpp
 	websocketconfig.cpp
+	write_database_queue.hpp
+	write_database_queue.cpp
 	xorshift.hpp)
 
 target_link_libraries (node

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -448,8 +448,6 @@ bool nano::active_transactions::add (std::shared_ptr<nano::block> block_a, std::
 		auto existing (roots.find (root));
 		if (existing == roots.end () && confirmed_set.get<1> ().find (root) == confirmed_set.get<1> ().end ())
 		{
-			// Check if existing block is already confirmed
-			assert (node.ledger.block_not_confirmed_or_not_exists (*block_a));
 			auto hash (block_a->hash ());
 			auto election (nano::make_shared<nano::election> (node, block_a, confirmation_action_a));
 			uint64_t difficulty (0);

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -7,12 +7,13 @@
 
 std::chrono::milliseconds constexpr nano::block_processor::confirmation_request_delay;
 
-nano::block_processor::block_processor (nano::node & node_a) :
+nano::block_processor::block_processor (nano::node & node_a, nano::write_database_queue & write_database_queue_a) :
 generator (node_a),
 stopped (false),
 active (false),
 next_log (std::chrono::steady_clock::now ()),
-node (node_a)
+node (node_a),
+write_database_queue (write_database_queue_a)
 {
 }
 
@@ -241,6 +242,7 @@ void nano::block_processor::process_batch (std::unique_lock<std::mutex> & lock_a
 		}
 	}
 	lock_a.unlock ();
+	auto write_guard = write_database_queue.wait (nano::writer::process_batch);
 	auto transaction (node.store.tx_begin_write ());
 	timer_l.restart ();
 	lock_a.lock ();

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -242,7 +242,7 @@ void nano::block_processor::process_batch (std::unique_lock<std::mutex> & lock_a
 		}
 	}
 	lock_a.unlock ();
-	auto write_guard = write_database_queue.wait (nano::writer::process_batch);
+	auto scoped_write_guard = write_database_queue.wait (nano::writer::process_batch);
 	auto transaction (node.store.tx_begin_write ());
 	timer_l.restart ();
 	lock_a.lock ();

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -18,6 +18,7 @@ namespace nano
 {
 class node;
 class transaction;
+class write_database_queue;
 
 class rolled_hash
 {
@@ -32,7 +33,7 @@ public:
 class block_processor final
 {
 public:
-	explicit block_processor (nano::node &);
+	explicit block_processor (nano::node &, nano::write_database_queue &);
 	~block_processor ();
 	void stop ();
 	void flush ();
@@ -70,6 +71,7 @@ private:
 	static size_t const rolled_back_max = 1024;
 	std::condition_variable condition;
 	nano::node & node;
+	nano::write_database_queue & write_database_queue;
 	std::mutex mutex;
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name);

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -72,7 +72,7 @@ void nano::confirmation_height_processor::run ()
 			if (!pending_writes.empty ())
 			{
 				lk.unlock ();
-				auto write_guard = write_database_queue.wait (nano::writer::confirmation_height);
+				auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
 				write_pending (pending_writes);
 				lk.lock ();
 			}
@@ -236,7 +236,7 @@ void nano::confirmation_height_processor::add_confirmation_height (nano::block_h
 		{
 			if (write_database_queue.process (nano::writer::confirmation_height))
 			{
-				auto write_guard = write_database_queue.pop ();
+				auto scoped_write_guard = write_database_queue.pop ();
 				auto error = write_pending (pending_writes);
 				// Don't set any more blocks as confirmed from the original hash if an inconsistency is found
 				if (error)

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -38,7 +38,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (pending_confirmati
 class confirmation_height_processor final
 {
 public:
-	confirmation_height_processor (pending_confirmation_height &, nano::block_store &, nano::stat &, nano::active_transactions &, nano::block_hash const &, nano::write_database_queue &, nano::logger_mt &);
+	confirmation_height_processor (pending_confirmation_height &, nano::block_store &, nano::stat &, nano::active_transactions &, nano::block_hash const &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &);
 	~confirmation_height_processor ();
 	void add (nano::block_hash const &);
 	void stop ();
@@ -95,6 +95,7 @@ private:
 	std::unordered_map<account, confirmed_iterated_pair> confirmed_iterated_pairs;
 	nano::timer<std::chrono::milliseconds> timer;
 	nano::write_database_queue & write_database_queue;
+	std::chrono::milliseconds batch_separate_pending_min_time;
 	std::thread thread;
 
 	void run ();

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -15,6 +15,7 @@ class stat;
 class active_transactions;
 class read_transaction;
 class logger_mt;
+class write_database_queue;
 
 class pending_confirmation_height
 {
@@ -37,7 +38,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (pending_confirmati
 class confirmation_height_processor final
 {
 public:
-	confirmation_height_processor (pending_confirmation_height &, nano::block_store &, nano::stat &, nano::active_transactions &, nano::block_hash const &, nano::logger_mt &);
+	confirmation_height_processor (pending_confirmation_height &, nano::block_store &, nano::stat &, nano::active_transactions &, nano::block_hash const &, nano::write_database_queue &, nano::logger_mt &);
 	~confirmation_height_processor ();
 	void add (nano::block_hash const &);
 	void stop ();
@@ -69,6 +70,14 @@ private:
 		nano::block_hash source_hash;
 	};
 
+	class confirmed_iterated_pair
+	{
+	public:
+		confirmed_iterated_pair (uint64_t confirmed_height_a, uint64_t iterated_height_a);
+		uint64_t confirmed_height;
+		uint64_t iterated_height;
+	};
+
 	std::condition_variable condition;
 	nano::pending_confirmation_height & pending_confirmations;
 	std::atomic<bool> stopped{ false };
@@ -79,12 +88,19 @@ private:
 	nano::logger_mt & logger;
 	std::atomic<uint64_t> receive_source_pairs_size{ 0 };
 	std::vector<receive_source_pair> receive_source_pairs;
+
+	std::deque<conf_height_details> pending_writes;
+	// Store the highest confirmation heights for accounts in pending_writes to reduce unnecessary iterating,
+	// and iterated height to prevent iterating over the same blocks more than once from self-sends or "circular" sends between the same accounts.
+	std::unordered_map<account, confirmed_iterated_pair> confirmed_iterated_pairs;
+	nano::timer<std::chrono::milliseconds> timer;
+	nano::write_database_queue & write_database_queue;
 	std::thread thread;
 
 	void run ();
 	void add_confirmation_height (nano::block_hash const &);
 	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, nano::block_hash const &, nano::account const &, nano::read_transaction const &);
-	bool write_pending (std::deque<conf_height_details> &, int64_t);
+	bool write_pending (std::deque<conf_height_details> &);
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (confirmation_height_processor &, const std::string &);
 	friend class confirmation_height_pending_observer_callbacks_Test;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -226,7 +226,7 @@ block_processor_thread ([this]() {
 online_reps (*this, config.online_weight_minimum.number ()),
 vote_uniquer (block_uniquer),
 active (*this),
-confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, write_database_queue, logger),
+confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, write_database_queue, config.conf_height_processor_batch_min_time, logger),
 payment_observer_processor (observers.blocks),
 wallets (init_a.wallets_store_init, *this),
 startup_time (std::chrono::steady_clock::now ())

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -218,7 +218,7 @@ port_mapping (*this),
 vote_processor (*this),
 rep_crawler (*this),
 warmed_up (0),
-block_processor (*this),
+block_processor (*this, write_database_queue),
 block_processor_thread ([this]() {
 	nano::thread_role::set (nano::thread_role::name::block_processing);
 	this->block_processor.process_blocks ();
@@ -226,7 +226,7 @@ block_processor_thread ([this]() {
 online_reps (*this, config.online_weight_minimum.number ()),
 vote_uniquer (block_uniquer),
 active (*this),
-confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, logger),
+confirmation_height_processor (pending_confirmation_height, store, ledger.stats, active, ledger.epoch_link, write_database_queue, logger),
 payment_observer_processor (observers.blocks),
 wallets (init_a.wallets_store_init, *this),
 startup_time (std::chrono::steady_clock::now ())
@@ -726,6 +726,7 @@ void nano::node::stop ()
 		checker.stop ();
 		wallets.stop ();
 		stats.stop ();
+		write_database_queue.stop ();
 	}
 }
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -20,6 +20,7 @@
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/node/websocket.hpp>
+#include <nano/node/write_database_queue.hpp>
 #include <nano/secure/ledger.hpp>
 
 #include <boost/asio/thread_pool.hpp>
@@ -159,6 +160,7 @@ public:
 	void ongoing_online_weight_calculation ();
 	void ongoing_online_weight_calculation_queue ();
 	bool online () const;
+	nano::write_database_queue write_database_queue;
 	boost::asio::io_context & io_ctx;
 	boost::latch node_initialized_latch;
 	nano::network_params network_params;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -253,6 +253,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("confirmation_history_size", confirmation_history_size);
 			json.put ("active_elections_size", active_elections_size);
 			json.put ("bandwidth_limit", bandwidth_limit);
+			json.put ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time.count ());
 		}
 		case 17:
 			break;
@@ -404,7 +405,12 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<size_t> ("confirmation_history_size", confirmation_history_size);
 		json.get<size_t> ("active_elections_size", active_elections_size);
 		json.get<size_t> ("bandwidth_limit", bandwidth_limit);
-		nano::network_params network;
+
+		auto conf_height_processor_batch_min_time_l (conf_height_processor_batch_min_time.count ());
+		json.get ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time_l);
+		conf_height_processor_batch_min_time = std::chrono::milliseconds (conf_height_processor_batch_min_time_l);
+
+		nano::network_constants network;
 		// Validate ranges
 		if (online_weight_quorum > 100)
 		{
@@ -418,7 +424,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_elections_size <= 250 && !network.network.is_test_network ())
+		if (active_elections_size <= 250 && !network.is_test_network ())
 		{
 			json.get_error ().set ("active_elections_size must be grater than 250");
 		}

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -75,6 +75,7 @@ public:
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
 	size_t bandwidth_limit{ 1536 * 1024 };
+	std::chrono::milliseconds conf_height_processor_batch_min_time{ 50 };
 	static int json_version ()
 	{
 		return 17;

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -24,7 +24,6 @@ guard_finish_callback ([&queue = queue, &mutex = mutex]() {
 {
 }
 
-// Blocks until we are at the head of the queue
 nano::write_guard nano::write_database_queue::wait (nano::writer writer)
 {
 	std::unique_lock<std::mutex> lk (mutex);
@@ -49,7 +48,6 @@ bool nano::write_database_queue::contains (nano::writer writer)
 	return std::find (queue.cbegin (), queue.cend (), writer) != queue.cend ();
 }
 
-// Returns true if this writer is now at the front
 bool nano::write_database_queue::process (nano::writer writer)
 {
 	auto result = false;

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -1,0 +1,85 @@
+#include <nano/node/write_database_queue.hpp>
+
+#include <algorithm>
+
+nano::write_guard::write_guard (std::condition_variable & cv_a, std::function<void()> guard_finish_callback_a) :
+cv (cv_a),
+guard_finish_callback (guard_finish_callback_a)
+{
+}
+
+nano::write_guard::~write_guard ()
+{
+	guard_finish_callback ();
+	cv.notify_all ();
+}
+
+nano::write_database_queue::write_database_queue () :
+// clang-format off
+guard_finish_callback ([&queue = queue, &mutex = mutex]() {
+	std::lock_guard<std::mutex> guard (mutex);
+	queue.pop_front ();
+})
+// clang-format on
+{
+}
+
+// Blocks until we are at the head of the queue
+nano::write_guard nano::write_database_queue::wait (nano::writer writer)
+{
+	std::unique_lock<std::mutex> lk (mutex);
+	// Add writer to the end of the queue if it's not already waiting
+	auto exists = std::find (queue.cbegin (), queue.cend (), writer) != queue.cend ();
+	if (!exists)
+	{
+		queue.push_back (writer);
+	}
+
+	while (!stopped && queue.front () != writer)
+	{
+		cv.wait (lk);
+	}
+
+	return write_guard (cv, guard_finish_callback);
+}
+
+bool nano::write_database_queue::contains (nano::writer writer)
+{
+	std::lock_guard<std::mutex> guard (mutex);
+	return std::find (queue.cbegin (), queue.cend (), writer) != queue.cend ();
+}
+
+// Returns true if this writer is now at the front
+bool nano::write_database_queue::process (nano::writer writer)
+{
+	auto result = false;
+	{
+		std::lock_guard<std::mutex> guard (mutex);
+		// Add writer to the end of the queue if it's not already waiting
+		auto exists = std::find (queue.cbegin (), queue.cend (), writer) != queue.cend ();
+		if (!exists)
+		{
+			queue.push_back (writer);
+		}
+
+		result = (queue.front () == writer);
+	}
+
+	if (!result)
+	{
+		cv.notify_all ();
+	}
+
+	return result;
+}
+
+nano::write_guard nano::write_database_queue::pop ()
+{
+	return write_guard (cv, guard_finish_callback);
+}
+
+void nano::write_database_queue::stop ()
+{
+	stopped = true;
+	cv.notify_all ();
+}

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -8,7 +8,7 @@
 
 namespace nano
 {
-// Order is irrelevant
+/** Distinct areas write locking is done, order is irrelevant */
 enum class writer
 {
 	confirmation_height,
@@ -30,14 +30,19 @@ class write_database_queue final
 {
 public:
 	write_database_queue ();
-	// Blocks until we are at the head of the queue
+	/** Blocks until we are at the head of the queue */
 	write_guard wait (nano::writer writer);
 
-	// Returns true if this writer is now at the front
+	/** Returns true if this writer is now at the front of the queue */
 	bool process (nano::writer writer);
+
+	/** Returns true if this writer is anywhere in the queue */
 	bool contains (nano::writer writer);
 
+	/** Doesn't actually pop anything until the returned write_guard is out of scope */
 	write_guard pop ();
+
+	/** This will release anything which is being blocked by the wait function */
 	void stop ();
 
 private:

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+
+namespace nano
+{
+// Order is irrelevant
+enum class writer
+{
+	confirmation_height,
+	process_batch
+};
+
+class write_guard final
+{
+public:
+	write_guard (std::condition_variable & cv_a, std::function<void()> guard_finish_callback_a);
+	~write_guard ();
+
+private:
+	std::condition_variable & cv;
+	std::function<void()> guard_finish_callback;
+};
+
+class write_database_queue final
+{
+public:
+	write_database_queue ();
+	// Blocks until we are at the head of the queue
+	write_guard wait (nano::writer writer);
+
+	// Returns true if this writer is now at the front
+	bool process (nano::writer writer);
+	bool contains (nano::writer writer);
+
+	write_guard pop ();
+	void stop ();
+
+private:
+	std::deque<nano::writer> queue;
+	std::mutex mutex;
+	std::condition_variable cv;
+	std::function<void()> guard_finish_callback;
+	std::atomic<bool> stopped{ false };
+};
+}


### PR DESCRIPTION
This PR does a few things:
1 - Introduces a minimum time when there are blocks pending confirmation height to batch writes, currently set to 50ms but can be change via a new config option `conf_height_processor_batch_min_time`
2 - Checks whether there are other txn writes pending (currently just `process_batch`). If there is and the confirmation height processor has other blocks pending confirmation height then it will continue processing them until it runs out or the `process_batch` write txn lock is finished. 
3 - (Unrelated) Removing the assert in `nano::active_transactions::add`. We have multiple checks for elections but I still think implicit confirmations can cause issues here (@cryptocode had run into the `assert`) and I think the following can happen:
We check if block is confirmed (no)
Background conf height processor implicitly makes it confirmed
We check it is not confirmed and assert.
4 - (Unrelated) A test didn't exist in the case where blocks differed inbetween reads/writes. Due to the `assert`s which will always fire as the block doesn't exist, I now check whether we are in the `testnet`

Note for beta testers:
Using the following RPC command, check that the `pending_confirmation_height` -> `pending` entry is kept low during any stress tests.
`curl -d '{"action":"stats", "type":"objects"}'`
 Those that have close cemented and total block counts before any such tests, should also see them remain close through any spam as well.
`curl -d '{"action":"block_count", "include_cemented":"true"}'`
Both RPC commands require `enable_control` to be set in `rpc_config.json`