### PR TITLE
Always notify on active difficulty updates

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -638,12 +638,8 @@ void nano::active_transactions::update_active_difficulty (std::unique_lock<std::
 	auto difficulty = nano::difficulty::from_multiplier (sum / multipliers_cb.size (), node.network_params.network.publish_threshold);
 	assert (difficulty >= node.network_params.network.publish_threshold);
 
-	bool notify_change = trended_active_difficulty != difficulty;
 	trended_active_difficulty = difficulty;
-	if (notify_change)
-	{
-		node.observers.difficulty.notify (trended_active_difficulty);
-	}
+	node.observers.difficulty.notify (trended_active_difficulty);
 }
 
 uint64_t nano::active_transactions::active_difficulty ()


### PR DESCRIPTION
Follow-up to #2091 so that observers are always notified (see discussion in original PR)