### PR TITLE
Vote generator max latency

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -717,6 +717,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_FALSE (tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_FALSE (tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_FALSE (tree.get_optional_child ("vote_generator_threshold"));
+	ASSERT_FALSE (tree.get_optional_child ("vote_generator_maximum_latency"));
 	ASSERT_FALSE (tree.get_optional_child ("diagnostics"));
 	ASSERT_FALSE (tree.get_optional_child ("use_memory_pools"));
 	ASSERT_FALSE (tree.get_optional_child ("confirmation_history_size"));
@@ -733,6 +734,7 @@ TEST (node_config, v16_v17_upgrade)
 	ASSERT_TRUE (!!tree.get_optional_child ("tcp_incoming_connections_max"));
 	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_delay"));
 	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_threshold"));
+	ASSERT_TRUE (!!tree.get_optional_child ("vote_generator_maximum_latency"));
 	ASSERT_TRUE (!!tree.get_optional_child ("diagnostics"));
 	ASSERT_TRUE (!!tree.get_optional_child ("use_memory_pools"));
 	ASSERT_TRUE (!!tree.get_optional_child ("confirmation_history_size"));
@@ -766,6 +768,7 @@ TEST (node_config, v17_values)
 		tree.put ("tcp_incoming_connections_max", 1);
 		tree.put ("vote_generator_delay", 50);
 		tree.put ("vote_generator_threshold", 3);
+		tree.put ("vote_generator_maximum_latency", 250);
 		nano::jsonconfig txn_tracking_l;
 		txn_tracking_l.put ("enable", false);
 		txn_tracking_l.put ("min_read_txn_time", 0);
@@ -806,6 +809,7 @@ TEST (node_config, v17_values)
 	tree.put ("tcp_incoming_connections_max", std::numeric_limits<unsigned>::max ());
 	tree.put ("vote_generator_delay", std::numeric_limits<unsigned long>::max () - 100);
 	tree.put ("vote_generator_threshold", 10);
+	tree.put ("vote_generator_maximum_latency", std::numeric_limits<unsigned long>::max () - 100);
 	nano::jsonconfig txn_tracking_l;
 	txn_tracking_l.put ("enable", true);
 	txn_tracking_l.put ("min_read_txn_time", 1234);
@@ -830,6 +834,7 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());
 	ASSERT_EQ (config.vote_generator_delay.count (), std::numeric_limits<unsigned long>::max () - 100);
 	ASSERT_EQ (config.vote_generator_threshold, 10);
+	ASSERT_EQ (config.vote_generator_maximum_latency.count (), std::numeric_limits<unsigned long>::max () - 100);
 	ASSERT_TRUE (config.diagnostics_config.txn_tracking.enable);
 	ASSERT_EQ (config.diagnostics_config.txn_tracking.min_read_txn_time.count (), 1234);
 	ASSERT_EQ (config.tcp_incoming_connections_max, std::numeric_limits<unsigned>::max ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -768,7 +768,7 @@ TEST (node_config, v17_values)
 		tree.put ("tcp_incoming_connections_max", 1);
 		tree.put ("vote_generator_delay", 50);
 		tree.put ("vote_generator_threshold", 3);
-		tree.put ("vote_generator_maximum_latency", 250);
+		tree.put ("vote_generator_maximum_latency", 150);
 		nano::jsonconfig txn_tracking_l;
 		txn_tracking_l.put ("enable", false);
 		txn_tracking_l.put ("min_read_txn_time", 0);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -115,6 +115,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("vote_minimum", vote_minimum.to_string_dec ());
 	json.put ("vote_generator_delay", vote_generator_delay.count ());
 	json.put ("vote_generator_threshold", vote_generator_threshold);
+	json.put ("vote_generator_maximum_latency", vote_generator_maximum_latency.count ());
 	json.put ("unchecked_cutoff_time", unchecked_cutoff_time.count ());
 	json.put ("tcp_io_timeout", tcp_io_timeout.count ());
 	json.put ("pow_sleep_interval", pow_sleep_interval.count ());
@@ -251,6 +252,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("tcp_incoming_connections_max", tcp_incoming_connections_max);
 			json.put ("vote_generator_delay", vote_generator_delay.count ());
 			json.put ("vote_generator_threshold", vote_generator_threshold);
+			json.put ("vote_generator_maximum_latency", vote_generator_maximum_latency.count ());
 			json.put ("use_memory_pools", use_memory_pools);
 			json.put ("confirmation_history_size", confirmation_history_size);
 			json.put ("active_elections_size", active_elections_size);
@@ -356,6 +358,10 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		vote_generator_delay = std::chrono::milliseconds (delay_l);
 
 		json.get<unsigned> ("vote_generator_threshold", vote_generator_threshold);
+
+		unsigned long maximum_latency_l = vote_generator_maximum_latency.count ();
+		json.get<unsigned long> ("vote_generator_maximum_latency", maximum_latency_l);
+		vote_generator_maximum_latency = std::chrono::milliseconds (maximum_latency_l);
 
 		auto block_processor_batch_max_time_l (json.get<unsigned long> ("block_processor_batch_max_time"));
 		block_processor_batch_max_time = std::chrono::milliseconds (block_processor_batch_max_time_l);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -39,7 +39,7 @@ public:
 	nano::amount vote_minimum{ nano::Gxrb_ratio };
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (50) };
 	unsigned vote_generator_threshold{ 3 };
-	std::chrono::milliseconds vote_generator_maximum_latency{ std::chrono::milliseconds (250) };
+	std::chrono::milliseconds vote_generator_maximum_latency{ std::chrono::milliseconds (150) };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
 	unsigned online_weight_quorum{ 50 };
 	unsigned password_fanout{ 1024 };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -39,6 +39,7 @@ public:
 	nano::amount vote_minimum{ nano::Gxrb_ratio };
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (50) };
 	unsigned vote_generator_threshold{ 3 };
+	std::chrono::milliseconds vote_generator_maximum_latency{ std::chrono::milliseconds (250) };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
 	unsigned online_weight_quorum{ 50 };
 	unsigned password_fanout{ 1024 };

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -17,7 +17,7 @@ void nano::vote_generator::add (nano::block_hash const & hash_a)
 	std::unique_lock<std::mutex> lock (mutex);
 	if (hashes.empty ())
 	{
-		vote_start = std::chrono::steady_clock::now ();
+		timer.restart ();
 	}
 	hashes.push_back (hash_a);
 	if (hashes.size () >= node.config.vote_generator_threshold)
@@ -84,7 +84,7 @@ void nano::vote_generator::run ()
 			wakeup = false;
 			auto triggered = condition.wait_for (lock, node.config.vote_generator_delay, [this]() { return this->wakeup; });
 			// Pack and send vote with lower number of hashes if the condition timed out or the latency limit was reached
-			if (!hashes.empty () && (!triggered || std::chrono::steady_clock::now () - vote_start > node.config.vote_generator_maximum_latency))
+			if (!hashes.empty () && (!triggered || timer.since_start () > node.config.vote_generator_maximum_latency))
 			{
 				send (lock);
 			}

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -38,7 +38,7 @@ private:
 	bool stopped{ false };
 	bool started{ false };
 	bool wakeup{ false };
-	std::chrono::steady_clock::time_point vote_start;
+	nano::timer<std::chrono::milliseconds> timer;
 	boost::thread thread;
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -12,6 +12,7 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/thread.hpp>
 
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -37,6 +38,7 @@ private:
 	bool stopped{ false };
 	bool started{ false };
 	bool wakeup{ false };
+	std::chrono::steady_clock::time_point vote_start;
 	boost::thread thread;
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);


### PR DESCRIPTION
Some things only show up during beta net testing due to the variety of hardware. I am seeing some nodes pack many votes even at 1 tps - which should not happen, they should be sent after 50ms with a single hash.

Likeliest explanation for me is that these are lower core count nodes where threads are fighting each other for time. Votes get queued up and hit `vote_generator::add` in quick succession, going over `vote_generator_threshold` and so the node continues to wait for more.

I'm adding a check that does not change current logic besides adding a maximum latency limit.

This change prevents slower nodes from packing too many hashes at low load, something that increases confirmation time (although bounded to around 500ms). A config option `vote_generator_maximum_latency` is added, defaulting to 150ms. This is the absolute maximum delay (counting from the first hash being inserted), after which the node will immediately send the vote.

This change only matters for low-medium load (up to `12/.150 = 80`tps), and it ensures we should continue to see sub-second confirmation while still enjoying the benefit of VBH at any load.

A discussion point would be which maximum latency to go for.