### PR TITLE
Use confirmation request count instead of announcement term

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -207,7 +207,7 @@ TEST (node, node_receive_quorum)
 			std::lock_guard<std::mutex> guard (system.nodes[0]->active.mutex);
 			auto info (system.nodes[0]->active.roots.find (nano::qualified_root (previous, previous)));
 			ASSERT_NE (system.nodes[0]->active.roots.end (), info);
-			done = info->election->announcements > nano::active_transactions::announcement_min;
+			done = info->election->confirmation_request_count > nano::active_transactions::minimum_confirmation_request_count;
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -2197,7 +2197,7 @@ TEST (node, confirm_quorum)
 			std::lock_guard<std::mutex> guard (system.nodes[0]->active.mutex);
 			auto info (system.nodes[0]->active.roots.find (nano::qualified_root (send1->hash (), send1->hash ())));
 			ASSERT_NE (system.nodes[0]->active.roots.end (), info);
-			done = info->election->announcements > nano::active_transactions::announcement_min;
+			done = info->election->confirmation_request_count > nano::active_transactions::minimum_confirmation_request_count;
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -98,8 +98,8 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 	std::unordered_set<nano::qualified_root> inactive;
 	auto transaction (node.store.tx_begin_read ());
 	unsigned unconfirmed_count (0);
-	unsigned unconfirmed_announcements (0);
-	unsigned could_fit_delay = node.network_params.network.is_test_network () ? announcement_long - 1 : 1;
+	unsigned unconfirmed_request_count (0);
+	unsigned could_fit_delay = node.network_params.network.is_test_network () ? high_confirmation_request_count - 1 : 1;
 	std::unordered_map<std::shared_ptr<nano::transport::channel>, std::vector<std::pair<nano::block_hash, nano::block_hash>>> requests_bundle;
 	std::deque<std::shared_ptr<nano::block>> rebroadcast_bundle;
 	std::deque<std::pair<std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>>> confirm_req_bundle;
@@ -109,7 +109,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 	{
 		auto root (i->root);
 		auto election_l (i->election);
-		if ((election_l->confirmed || election_l->stopped) && election_l->announcements >= announcement_min - 1)
+		if ((election_l->confirmed || election_l->stopped) && election_l->confirmation_request_count >= minimum_confirmation_request_count - 1)
 		{
 			if (election_l->confirmed)
 			{
@@ -119,12 +119,12 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 		}
 		else
 		{
-			if (election_l->announcements > announcement_long)
+			if (election_l->confirmation_request_count > high_confirmation_request_count)
 			{
 				++unconfirmed_count;
-				unconfirmed_announcements += election_l->announcements;
+				unconfirmed_request_count += election_l->confirmation_request_count;
 				// Log votes for very long unconfirmed elections
-				if (election_l->announcements % 50 == 1)
+				if (election_l->confirmation_request_count % 50 == 1)
 				{
 					auto tally_l (election_l->tally (transaction));
 					election_l->log_votes (tally_l);
@@ -132,7 +132,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				/* Escalation for long unconfirmed elections
 				Start new elections for previous block & source
 				if there are less than 100 active elections */
-				if (election_l->announcements % announcement_long == 1 && roots_size < 100 && !node.network_params.network.is_test_network ())
+				if (election_l->confirmation_request_count % high_confirmation_request_count == 1 && roots_size < 100 && !node.network_params.network.is_test_network ())
 				{
 					bool escalated (false);
 					std::shared_ptr<nano::block> previous;
@@ -167,7 +167,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 					}
 				}
 			}
-			if (election_l->announcements < announcement_long || election_l->announcements % announcement_long == could_fit_delay)
+			if (election_l->confirmation_request_count < high_confirmation_request_count || election_l->confirmation_request_count % high_confirmation_request_count == could_fit_delay)
 			{
 				if (node.ledger.could_fit (transaction, *election_l->status.winner))
 				{
@@ -179,14 +179,14 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				}
 				else
 				{
-					if (election_l->announcements != 0)
+					if (election_l->confirmation_request_count != 0)
 					{
 						election_l->stop ();
 						inactive.insert (root);
 					}
 				}
 			}
-			if (election_l->announcements % announcement_long == 1)
+			if (election_l->confirmation_request_count % high_confirmation_request_count == 1)
 			{
 				auto rep_channels (std::make_shared<std::vector<std::shared_ptr<nano::transport::channel>>> ());
 				auto reps (node.rep_crawler.representatives (std::numeric_limits<size_t>::max ()));
@@ -274,7 +274,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				}
 			}
 		}
-		++election_l->announcements;
+		++election_l->confirmation_request_count;
 	}
 	lock_a.unlock ();
 	// Rebroadcast unconfirmed blocks
@@ -312,7 +312,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 	long_unconfirmed_size = unconfirmed_count;
 	if (unconfirmed_count > 0)
 	{
-		node.logger.try_log (boost::str (boost::format ("%1% blocks have been unconfirmed averaging %2% announcements") % unconfirmed_count % (unconfirmed_announcements / unconfirmed_count)));
+		node.logger.try_log (boost::str (boost::format ("%1% blocks have been unconfirmed averaging %2% confirmation requests") % unconfirmed_count % (unconfirmed_request_count / unconfirmed_count)));
 	}
 }
 
@@ -708,7 +708,7 @@ void nano::active_transactions::flush_lowest ()
 		if (count != 2)
 		{
 			auto election = it->election;
-			if (election->announcements > announcement_long && !election->confirmed && !election->stopped && !node.wallets.watcher.is_watched (it->root))
+			if (election->confirmation_request_count > high_confirmation_request_count && !election->confirmed && !election->stopped && !node.wallets.watcher.is_watched (it->root))
 			{
 				it = decltype (it){ sorted_roots.erase (std::next (it).base ()) };
 				election->stop ();

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -119,12 +119,10 @@ public:
 	void add_confirmed (nano::election_status const &, nano::qualified_root const &);
 	nano::node & node;
 	std::mutex mutex;
-	// Maximum number of conflicts to vote on per interval, lowest root hash first
-	static unsigned constexpr announcements_per_interval = 32;
-	// Minimum number of block announcements
-	static unsigned constexpr announcement_min = 2;
-	// Threshold to start logging blocks haven't yet been confirmed
-	static unsigned constexpr announcement_long = 2;
+	// Minimum number of confirmation requests
+	static unsigned constexpr minimum_confirmation_request_count = 2;
+	// Threshold for considering confirmation request count high
+	static unsigned constexpr high_confirmation_request_count = 2;
 	size_t long_unconfirmed_size = 0;
 	static size_t constexpr max_broadcast_queue = 1000;
 	boost::circular_buffer<double> multipliers_cb;

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -368,7 +368,7 @@ void nano::block_processor::process_live (nano::block_hash const & hash_a, std::
 			{
 				std::lock_guard<std::mutex> lock (node_l->active.mutex);
 				auto existing (node_l->active.blocks.find (block_a->hash ()));
-				if (existing != node_l->active.blocks.end () && !existing->second->confirmed && !existing->second->stopped && existing->second->announcements == 0)
+				if (existing != node_l->active.blocks.end () && !existing->second->confirmed && !existing->second->stopped && existing->second->confirmation_request_count == 0)
 				{
 					send_request = true;
 				}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -14,7 +14,7 @@ election_start (std::chrono::steady_clock::now ()),
 status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), nano::election_status_type::ongoing }),
 confirmed (false),
 stopped (false),
-announcements (0)
+confirmation_request_count (0)
 {
 	last_votes.insert (std::make_pair (node.network_params.random.not_an_account, nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () }));
 	blocks.insert (std::make_pair (block_a->hash (), block_a));
@@ -46,7 +46,7 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 			node_l->process_confirmed (status_l);
 			confirmation_action_l (status_l.winner);
 		});
-		if (announcements > node.active.announcement_long)
+		if (confirmation_request_count > node.active.high_confirmation_request_count)
 		{
 			--node.active.long_unconfirmed_size;
 		}

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -59,7 +59,7 @@ public:
 	std::atomic<bool> confirmed;
 	bool stopped;
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
-	unsigned announcements;
+	unsigned confirmation_request_count;
 	std::unordered_set<nano::block_hash> dependent_blocks;
 };
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1629,7 +1629,7 @@ void nano::json_handler::confirmation_active ()
 		std::lock_guard<std::mutex> lock (node.active.mutex);
 		for (auto i (node.active.roots.begin ()), n (node.active.roots.end ()); i != n; ++i)
 		{
-			if (i->election->announcements >= announcements && !i->election->confirmed && !i->election->stopped)
+			if (i->election->confirmation_request_count >= announcements && !i->election->confirmed && !i->election->stopped)
 			{
 				boost::property_tree::ptree entry;
 				entry.put ("", i->root.to_string ());
@@ -1706,7 +1706,7 @@ void nano::json_handler::confirmation_info ()
 		auto conflict_info (node.active.roots.find (root));
 		if (conflict_info != node.active.roots.end ())
 		{
-			response_l.put ("announcements", std::to_string (conflict_info->election->announcements));
+			response_l.put ("announcements", std::to_string (conflict_info->election->confirmation_request_count));
 			auto election (conflict_info->election);
 			nano::uint128_t total (0);
 			response_l.put ("last_winner", election->status.winner->hash ().to_string ());


### PR DESCRIPTION
There used to be a vote announcement loop, but that one is now mostly about vote solicitation. I think renaming accordingly makes the code a bit easier to follow. 

I haven't updated the two confirmation RPCs which uses "announcements" as that would be a breaking change. The corresponding variable names are retained as well in the json handler.

`announcements_per_interval` wasn't used and is thus removed.