### PR TITLE
[TSAN] Use only async signal safe functions in signal handlers

### DIFF
--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -224,7 +224,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (work_pool & work_p
 
 	size_t count = 0;
 	{
-		std::lock_guard<std::mutex> (work_pool.mutex);
+		std::lock_guard<std::mutex> guard (work_pool.mutex);
 		count = work_pool.pending.size ();
 	}
 	auto sizeof_element = sizeof (decltype (work_pool.pending)::value_type);

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -44,6 +44,8 @@ constexpr auto rpc_port_start = 60000;
 constexpr auto peering_port_start = 61000;
 constexpr auto ipc_port_start = 62000;
 
+volatile sig_atomic_t sig_int_or_term = 0;
+
 void write_config_files (boost::filesystem::path const & data_path, int index)
 {
 	nano::daemon_config daemon_config (data_path);
@@ -481,6 +483,7 @@ int main (int argc, char * const * argv)
 	assert (!nano::signal_handler_impl);
 	nano::signal_handler_impl = [&ioc]() {
 		ioc.stop ();
+		sig_int_or_term = 1;
 	};
 
 	std::signal (SIGINT, &nano::signal_handler);
@@ -595,8 +598,14 @@ int main (int argc, char * const * argv)
 		stop_rpc (ioc, primary_node_results);
 	});
 	nano::thread_runner runner (ioc, simultaneous_process_calls);
-	t.join ();
 	runner.join ();
+	if (sig_int_or_term)
+	{
+		// User killed the process so just exit, don't wait until other processes are finished (could take a while)
+		std::exit (2);
+	}
+
+	t.join ();
 
 #if BOOST_PROCESS_SUPPORTED
 	for (auto & node : nodes)

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -49,19 +49,20 @@ namespace
 #include <sys/stat.h>
 #include <unistd.h>
 
-// Only on linux. This outputs the load addresses for the executable and shared libraries.
+// This outputs the load addresses for the executable and shared libraries.
 // Useful for debugging should the virtual addresses be randomized.
 int output_memory_load_address (dl_phdr_info * info, size_t, void *)
 {
 	static int counter = 0;
-	assert (counter < 99);
+	assert (counter <= 99);
 	// Create filename
 	const char file_prefix[] = "nano_node_crash_load_address_dump_";
-	std::array<char, sizeof (file_prefix) + 6> buf;
-	sprintf (buf.data (), "%s%d.txt", file_prefix, counter);
+	// Holds the filename prefix, a unique (max 2 digits) number and extension (null terminator is included in file_prefix size)
+	char filename[sizeof (file_prefix) + 2 + 4];
+	snprintf (filename, sizeof (filename), "%s%d.txt", file_prefix, counter);
 
 	// Open file
-	const auto file_descriptor = ::open (buf.data (), O_CREAT | O_WRONLY | O_TRUNC,
+	const auto file_descriptor = ::open (filename, O_CREAT | O_WRONLY | O_TRUNC,
 #if defined(S_IWRITE) && defined(S_IREAD)
 	S_IWRITE | S_IREAD
 #else

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -43,31 +43,59 @@
 namespace
 {
 #ifdef __linux__
+
+#include <fcntl.h>
 #include <link.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 // Only on linux. This outputs the load addresses for the executable and shared libraries.
 // Useful for debugging should the virtual addresses be randomized.
 int output_memory_load_address (dl_phdr_info * info, size_t, void *)
 {
 	static int counter = 0;
-	std::ostringstream ss;
-	ss << "nano_node_crash_load_address_dump_" << counter << ".txt";
-	std::ofstream file (ss.str ());
-	file << "Name: " << info->dlpi_name << "\n";
+	assert (counter < 99);
+	// Create filename
+	const char file_prefix[] = "nano_node_crash_load_address_dump_";
+	std::array<char, sizeof (file_prefix) + 6> buf;
+	sprintf (buf.data (), "%s%d.txt", file_prefix, counter);
 
+	// Open file
+	const auto file_descriptor = ::open (buf.data (), O_CREAT | O_WRONLY | O_TRUNC,
+#if defined(S_IWRITE) && defined(S_IREAD)
+	S_IWRITE | S_IREAD
+#else
+	0
+#endif
+	);
+
+	// Write the name of shared library
+	::write (file_descriptor, "Name: ", 6);
+	::write (file_descriptor, info->dlpi_name, strlen (info->dlpi_name));
+	::write (file_descriptor, "\n", 1);
+
+	// Write the first load address found
 	for (auto i = 0; i < info->dlpi_phnum; ++i)
 	{
-		// Only care about the first load address
 		if (info->dlpi_phdr[i].p_type == PT_LOAD)
 		{
-			file << std::hex << (void *)(info->dlpi_addr + info->dlpi_phdr[i].p_vaddr);
+			auto load_address = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
+
+			// Each byte of the pointer is two hexadecimal characters, plus the 0x prefix and null terminator
+			char load_address_as_hex_str[sizeof (load_address) * 2 + 2 + 1];
+			snprintf (load_address_as_hex_str, sizeof (load_address_as_hex_str), "%p", (void *)load_address);
+			::write (file_descriptor, load_address_as_hex_str, strlen (load_address_as_hex_str));
 			break;
 		}
 	}
+
+	::close (file_descriptor);
 	++counter;
 	return 0;
 }
 #endif
 
+// Only async-signal-safe functions are allowed to be called here
 void my_abort_signal_handler (int signum)
 {
 	std::signal (signum, SIG_DFL);
@@ -77,6 +105,11 @@ void my_abort_signal_handler (int signum)
 	dl_iterate_phdr (output_memory_load_address, nullptr);
 #endif
 }
+}
+
+namespace
+{
+volatile sig_atomic_t sig_int_or_term = 0;
 }
 
 void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::node_flags const & flags)
@@ -164,14 +197,9 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 				}
 
 				assert (!nano::signal_handler_impl);
-				nano::signal_handler_impl = [&io_ctx, &ipc_server, &rpc, &node]() {
-					ipc_server.stop ();
-					node->stop ();
-					if (rpc)
-					{
-						rpc->stop ();
-					}
+				nano::signal_handler_impl = [&io_ctx]() {
 					io_ctx.stop ();
+					sig_int_or_term = 1;
 				};
 
 				std::signal (SIGINT, &nano::signal_handler);
@@ -179,6 +207,16 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 
 				runner = std::make_unique<nano::thread_runner> (io_ctx, node->config.io_threads);
 				runner->join ();
+
+				if (sig_int_or_term == 1)
+				{
+					ipc_server.stop ();
+					node->stop ();
+					if (rpc)
+					{
+						rpc->stop ();
+					}
+				}
 #if BOOST_PROCESS_SUPPORTED
 				if (rpc_process)
 				{

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -307,7 +307,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & v
 	size_t representatives_3_count = 0;
 
 	{
-		std::lock_guard<std::mutex> (vote_processor.mutex);
+		std::lock_guard<std::mutex> guard (vote_processor.mutex);
 		votes_count = vote_processor.votes.size ();
 		representatives_1_count = vote_processor.representatives_1.size ();
 		representatives_2_count = vote_processor.representatives_2.size ();

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -120,6 +120,5 @@ void signal_handler (int sig)
 	{
 		signal_handler_impl ();
 	}
-	std::exit (sig);
 }
 }


### PR DESCRIPTION
Very little is allowed in signal handlers, specifically only async-signal-safe functions. This is because code can be halted at any point, if a mutex is already locked elsewhere for instance this will result in deadlock. TSAN gives many warnings when closing the daemon when the SIGTERM/SIGINT and SIGSEGV signals are raised. Instead of calling our application specific code in the signal handler I just stop the io_context (which is done in a few asio examples), the rest of the cleanup code is now done by checking a `sigatomic_t` variable after the asio loop has finished.

Now also using specific Linux file descriptor commands which are known to be async-signal-safe (looked at how the boost stacktrace dump does it as it states signal safety) in the segfault/abort signal handler.

(Unrelated) I noticed 2 places where there was an unnamed `std::lock_guard` being used.