### PR TITLE
RPC stop action can take a long time to close the node down

### DIFF
--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -135,7 +135,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 						}
 						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, config.rpc, [&ipc_server, &alarm, &io_ctx]() {
 							ipc_server.stop ();
-							alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (3), [&io_ctx]() {		
+							alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (3), [&io_ctx]() {
 								io_ctx.stop ();
 							});
 						});

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -133,8 +133,11 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 						{
 							throw std::runtime_error ("Could not deserialize rpc_config file");
 						}
-						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, config.rpc, [&ipc_server]() {
+						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, config.rpc, [&ipc_server, &alarm, &io_ctx]() {
 							ipc_server.stop ();
+							alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (3), [&io_ctx]() {		
+								io_ctx.stop ();
+							});
 						});
 						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
 						rpc->start ();

--- a/nano/node/ipc.cpp
+++ b/nano/node/ipc.cpp
@@ -129,6 +129,9 @@ public:
 		// Note that if the rpc action is async, the shared_ptr<json_handler> lifetime will be extended by the action handler
 		auto handler (std::make_shared<nano::json_handler> (node, server.node_rpc_config, body, response_handler_l, [& server = server]() {
 			server.stop ();
+			server.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (3), [& io_ctx = server.node.alarm.io_ctx]() {
+				io_ctx.stop ();
+			});
 		}));
 		// For unsafe actions to be allowed, the unsafe encoding must be used AND the transport config must allow it
 		handler->process_request (allow_unsafe && config_transport.allow_unsafe);


### PR DESCRIPTION
The node sometimes takes a few minutes to shutdown when using the `stop` action RPC command. Various things are still run in the background which I tried to explicitly check for and was able to "mostly" get it to shutdown within a couple seconds, but depending on timing some things may send a request and then just timeout waiting for it. I now just call `io_ctx.stop ();` as a "catch all" to explicitly cleanup all the sockets after a few seconds if it hasn't happened already.

I've also optimised the conf height processor slightly by checking if it has been stopped while traversing an account chain in case it is on a very long one.