### PR TITLE
Set genesis account to have a confirmation height of 1 after initial upgrade

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1573,10 +1573,10 @@ TEST (block_store, upgrade_v13_v14)
 	ASSERT_FALSE (error);
 	auto transaction (store.tx_begin_write ());
 
-	// This should now work and have confirmation height of 0
+	// This should now work and have a confirmation height of 1
 	nano::account_info account_info;
 	ASSERT_FALSE (store.account_get (transaction, nano::genesis_account, account_info));
-	ASSERT_EQ (account_info.confirmation_height, 0);
+	ASSERT_EQ (account_info.confirmation_height, 1);
 	ASSERT_LT (13, store.version_get (transaction));
 
 	// Test deleting node ID
@@ -1631,7 +1631,7 @@ TEST (block_store, confirmation_height)
 	ASSERT_EQ (stored_account_info.confirmation_height, 0);
 }
 
-// Upgrade many accounts to add a confirmation height of 0
+// Upgrade many accounts and check they all have a confirmation height of 0 (except genesis which should have 1)
 TEST (block_store, upgrade_confirmation_height_many)
 {
 	auto error (false);
@@ -1661,7 +1661,7 @@ TEST (block_store, upgrade_confirmation_height_many)
 		ASSERT_EQ (store.account_count (transaction), total_num_accounts);
 	}
 
-	// Loop over them all and confirm all have a confirmation height of 0
+	// Loop over them all and confirm they all have the correct confirmation heights
 	nano::logger_mt logger;
 	nano::mdb_store store (error, logger, path);
 	auto transaction (store.tx_begin_read ());
@@ -1669,8 +1669,15 @@ TEST (block_store, upgrade_confirmation_height_many)
 
 	for (auto i (store.latest_begin (transaction)), n (store.latest_end ()); i != n; ++i)
 	{
-		nano::account_info current (i->second);
-		ASSERT_EQ (current.confirmation_height, 0);
+		nano::account_info & current (i->second);
+		if (i->first == nano::genesis_account)
+		{
+			ASSERT_EQ (current.confirmation_height, 1);
+		}
+		else
+		{
+			ASSERT_EQ (current.confirmation_height, 0);
+		}
 	}
 }
 

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -316,8 +316,19 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				if (!node.node->store.account_get (transaction, account, account_info))
 				{
 					auto transaction (node.node->store.tx_begin_write ());
-					node.node->store.confirmation_height_clear (transaction, account, account_info);
-					std::cout << "Confirmation height of account " << account_str << " is set to 0" << std::endl;
+					auto conf_height_reset_num = 0;
+					if (account == node.node->network_params.ledger.genesis_account)
+					{
+						conf_height_reset_num = 1;
+						account_info.confirmation_height = conf_height_reset_num;
+						node.node->store.account_put (transaction, account, account_info);
+					}
+					else
+					{
+						node.node->store.confirmation_height_clear (transaction, account, account_info);
+					}
+
+					std::cout << "Confirmation height of account " << account_str << " is set to " << conf_height_reset_num << std::endl;
 				}
 				else
 				{

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -1331,31 +1331,37 @@ void nano::mdb_store::upgrade_v12_to_v13 (nano::write_transaction & transaction_
 	}
 	if (account == not_an_account)
 	{
-		logger.always_log (boost::str (boost::format ("Completed sideband upgrade")));
+		logger.always_log ("Completed sideband upgrade");
 		version_put (transaction_a, 13);
 	}
 }
 
 void nano::mdb_store::upgrade_v13_to_v14 (nano::transaction const & transaction_a)
 {
-	// Upgrade all accounts to have a confirmation of 0
+	// Upgrade all accounts to have a confirmation of 0 (except genesis which should have 1)
 	version_put (transaction_a, 14);
 	nano::store_iterator<nano::account, nano::account_info_v13> i (std::make_unique<nano::mdb_merge_iterator<nano::account, nano::account_info_v13>> (transaction_a, accounts_v0, accounts_v1));
 	nano::store_iterator<nano::account, nano::account_info_v13> n (nullptr);
-	constexpr uint64_t zeroed_confirmation_height (0);
 
 	std::vector<std::pair<nano::account, nano::account_info>> account_infos;
 	account_infos.reserve (account_count (transaction_a));
 	for (; i != n; ++i)
 	{
 		nano::account_info_v13 const & account_info_v13 (i->second);
-		account_infos.emplace_back (i->first, nano::account_info{ account_info_v13.head, account_info_v13.rep_block, account_info_v13.open_block, account_info_v13.balance, account_info_v13.modified, account_info_v13.block_count, zeroed_confirmation_height, account_info_v13.epoch });
+		uint64_t confirmation_height = 0;
+		if (i->first == network_params.ledger.genesis_account)
+		{
+			confirmation_height = 1;
+		}
+		account_infos.emplace_back (i->first, nano::account_info{ account_info_v13.head, account_info_v13.rep_block, account_info_v13.open_block, account_info_v13.balance, account_info_v13.modified, account_info_v13.block_count, confirmation_height, account_info_v13.epoch });
 	}
 
 	for (auto const & account_info : account_infos)
 	{
 		account_put (transaction_a, account_info.first, account_info.second);
 	}
+
+	logger.always_log ("Completed confirmation height upgrade");
 
 	nano::uint256_union node_id_mdb_key (3);
 	auto error (mdb_del (env.tx (transaction_a), meta, nano::mdb_val (node_id_mdb_key), nullptr));


### PR DESCRIPTION
We want the genesis account to have a minimum cemented count of 1 at all times. This is done elsewhere but not during the initial upgrade.