### PR TITLE
[Valgrind] Check if running under valgrind before doing death tests

### DIFF
--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/config.hpp>
 #include <nano/lib/numbers.hpp>
 
 #include <gtest/gtest.h>
@@ -27,8 +28,12 @@ TEST (difficulty, multipliers)
 		uint64_t difficulty_nil = 0;
 		double multiplier_nil = 0.;
 #ifndef NDEBUG
-		ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::to_multiplier (difficulty_nil, base), "");
-		ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::from_multiplier (multiplier_nil, base), "");
+		// Causes valgrind to be noisy
+		if (!nano::running_within_valgrind ())
+		{
+			ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::to_multiplier (difficulty_nil, base), "");
+			ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::from_multiplier (multiplier_nil, base), "");
+		}
 #endif
 	}
 }

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -1,9 +1,16 @@
 #include <nano/lib/config.hpp>
 
+#include <valgrind/valgrind.h>
+
 namespace nano
 {
 void force_nano_test_network ()
 {
 	nano::network_constants::set_active_network (nano::nano_networks::nano_test_network);
+}
+
+bool running_within_valgrind ()
+{
+	return (RUNNING_ON_VALGRIND > 0);
 }
 }

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -156,4 +156,7 @@ inline boost::filesystem::path get_rpc_config_path (boost::filesystem::path cons
 
 /** Called by gtest_main to enforce test network */
 void force_nano_test_network ();
+
+/** Checks if we are running inside a valgrind instance */
+bool running_within_valgrind ();
 }

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -9,8 +9,6 @@
 
 #include <queue>
 
-#include <valgrind/valgrind.h>
-
 nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, int max_dbs_a, bool use_no_mem_init_a, size_t map_size_a)
 {
 	boost::system::error_code error_mkdir, error_chmod;
@@ -24,10 +22,9 @@ nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, 
 			release_assert (status1 == 0);
 			auto status2 (mdb_env_set_maxdbs (environment, max_dbs_a));
 			release_assert (status2 == 0);
-			auto running_within_valgrind = (RUNNING_ON_VALGRIND > 0);
 			auto map_size = map_size_a;
 			auto max_valgrind_map_size = 16 * 1024 * 1024;
-			if (running_within_valgrind && map_size_a > max_valgrind_map_size)
+			if (running_within_valgrind () && map_size_a > max_valgrind_map_size)
 			{
 				// In order to run LMDB under Valgrind, the maximum map size must be smaller than half your available RAM
 				map_size = max_valgrind_map_size;
@@ -39,7 +36,7 @@ nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, 
 			// MDB_NORDAHEAD will allow platforms that support it to load the DB in memory as needed.
 			// MDB_NOMEMINIT prevents zeroing malloc'ed pages. Can provide improvement for non-sensitive data but may make memory checkers noisy (e.g valgrind).
 			auto environment_flags = MDB_NOSUBDIR | MDB_NOTLS | MDB_NORDAHEAD;
-			if (!running_within_valgrind && use_no_mem_init_a)
+			if (!running_within_valgrind () && use_no_mem_init_a)
 			{
 				environment_flags |= MDB_NOMEMINIT;
 			}


### PR DESCRIPTION
Valgrind is noisy with tests which use `ASSERT_DEATH_IF_SUPPORTED` as it basically forks a new process which is killed. I think it's better we don't output this during valgrind runs.