### PR TITLE
Improve docker build speed on multi-core machines

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -3,11 +3,13 @@ FROM nanocurrency/nano-env:gcc
 ARG NETWORK=live
 ADD ./ /tmp/src
 
+RUN num_cores=$(($(grep -c ^processor /proc/cpuinfo) + 1))
+
 RUN mkdir /tmp/build && \
     cd /tmp/build && \
     cmake /tmp/src -DBOOST_ROOT=${BOOST_ROOT} -DACTIVE_NETWORK=nano_${NETWORK}_network && \
-    make nano_node && \
-    make nano_rpc && \
+    make nano_node -j $num_cores && \
+    make nano_rpc -j $num_cores && \
     cd .. && \
     echo ${NETWORK} > /etc/nano-network
 


### PR DESCRIPTION
Building the docker image was quite slow, investigated and found it can be sped up by specifying the number of jobs to `make`, at least of machines with many cores. Consensus seems to be use cores + 1 https://stackoverflow.com/questions/3025587/whats-best-value-for-make-j