### PR TITLE
Remove extra core utilised during docker deployment build

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -3,13 +3,11 @@ FROM nanocurrency/nano-env:gcc
 ARG NETWORK=live
 ADD ./ /tmp/src
 
-RUN num_cores=$(($(grep -c ^processor /proc/cpuinfo) + 1))
-
 RUN mkdir /tmp/build && \
     cd /tmp/build && \
     cmake /tmp/src -DBOOST_ROOT=${BOOST_ROOT} -DACTIVE_NETWORK=nano_${NETWORK}_network && \
-    make nano_node -j $num_cores && \
-    make nano_rpc -j $num_cores && \
+    make nano_node -j $(nproc) && \
+    make nano_rpc -j $(nproc) && \
     cd .. && \
     echo ${NETWORK} > /etc/nano-network
 


### PR DESCRIPTION
The travis docker deployment cannot handle the additional core added in #2148, otherwise the error
`virtual memory exhausted: Cannot allocate memory` is given near the end of the build many times. It can handle the same number though, so I'm just removing the extra one. Using `nproc` instead now which is simpler than how I was determining the number of cores before.

For my sanity next time (and in case anyone else needs to do this), the following steps can be done to check the deployment build without have to merge into master:
1 - `.travis.yml` - Under `stages`, remove all except `deploy`. Under `jobs` -> `include`, remove all except deploy.
2 - `ci/deploy-docker.sh` - Replace this file with:
```
#!/bin/bash
set -e
docker build --build-arg NETWORK=live -f docker/node/Dockerfile -t any_name_you_want .
```