### PR TITLE
Fix compile errors in release mode after warning->error change

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -835,6 +835,7 @@ TEST (block_store, upgrade_v2_v3)
 		info.rep_block = 42;
 		nano::account_info_v5 info_old (info.head, info.rep_block, info.open_block, info.balance, info.modified);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (sizeof (info_old), &info_old), 0));
+		(void)status;
 		assert (status == 0);
 	}
 	nano::logger_mt logger;
@@ -1746,6 +1747,7 @@ void modify_account_info_to_v13 (nano::mdb_store & store, nano::transaction cons
 	ASSERT_FALSE (store.account_get (transaction_a, account, info));
 	nano::account_info_v13 account_info_v13 (info.head, info.rep_block, info.open_block, info.balance, info.modified, info.block_count, info.epoch);
 	auto status (mdb_put (store.env.tx (transaction_a), store.get_account_db (info.epoch), nano::mdb_val (account), nano::mdb_val (account_info_v13), 0));
+	(void)status;
 	assert (status == 0);
 }
 
@@ -1755,6 +1757,7 @@ void modify_genesis_account_info_to_v5 (nano::mdb_store & store, nano::transacti
 	store.account_get (transaction_a, nano::test_genesis_key.pub, info);
 	nano::account_info_v5 info_old (info.head, info.rep_block, info.open_block, info.balance, info.modified);
 	auto status (mdb_put (store.env.tx (transaction_a), store.accounts_v0, nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (sizeof (info_old), &info_old), 0));
+	(void)status;
 	assert (status == 0);
 }
 }

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -24,10 +24,11 @@ TEST (difficulty, multipliers)
 	}
 
 	{
+#ifndef NDEBUG
 		uint64_t base = 0xffffffc000000000;
 		uint64_t difficulty_nil = 0;
 		double multiplier_nil = 0.;
-#ifndef NDEBUG
+
 		// Causes valgrind to be noisy
 		if (!nano::running_within_valgrind ())
 		{

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -100,6 +100,7 @@ TEST (wallets, upgrade)
 		ASSERT_FALSE (mdb_store.account_get (transaction_destination, nano::genesis_account, info));
 		nano::account_info_v13 account_info_v13 (info.head, info.rep_block, info.open_block, info.balance, info.modified, info.block_count, info.epoch);
 		auto status (mdb_put (mdb_store.env.tx (transaction_destination), mdb_store.get_account_db (info.epoch), nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (account_info_v13), 0));
+		(void)status;
 		assert (status == 0);
 	}
 	nano::node_init init1;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -175,7 +175,7 @@ TEST (websocket, active_difficulty)
 
 	// Subscribe to active_difficulty and wait for response asynchronously
 	ack_ready = false;
-	auto client_task = ([&node1]() -> boost::optional<std::string> {
+	auto client_task = ([]() -> boost::optional<std::string> {
 		auto response = websocket_test_call ("::1", "24078", R"json({"action": "subscribe", "topic": "active_difficulty", "ack": true})json", true, true);
 		return response;
 	});

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -39,6 +39,7 @@ void write (nano::stream & stream_a, T const & value)
 {
 	static_assert (std::is_standard_layout<T>::value, "Can't stream write non-standard layout types");
 	auto amount_written (stream_a.sputn (reinterpret_cast<uint8_t const *> (&value), sizeof (value)));
+	(void)amount_written;
 	assert (amount_written == sizeof (value));
 }
 class block_visitor;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -530,6 +530,7 @@ void nano::active_transactions::update_difficulty (nano::block const & block_a)
 	{
 		uint64_t difficulty;
 		auto error (nano::work_validate (block_a, &difficulty));
+		(void)error;
 		assert (!error);
 		if (difficulty > existing->difficulty)
 		{

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -147,10 +147,12 @@ void nano::frontier_req_client::received_frontier (boost::system::error_code con
 		nano::account account;
 		nano::bufferstream account_stream (connection->receive_buffer->data (), sizeof (account));
 		auto error1 (nano::try_read (account_stream, account));
+		(void)error1;
 		assert (!error1);
 		nano::block_hash latest;
 		nano::bufferstream latest_stream (connection->receive_buffer->data () + sizeof (account), sizeof (latest));
 		auto error2 (nano::try_read (latest_stream, latest));
+		(void)error2;
 		assert (!error2);
 		if (count == 0)
 		{
@@ -693,10 +695,12 @@ void nano::bulk_pull_account_client::receive_pending ()
 				nano::block_hash pending;
 				nano::bufferstream frontier_stream (this_l->connection->receive_buffer->data (), sizeof (nano::uint256_union));
 				auto error1 (nano::try_read (frontier_stream, pending));
+				(void)error1;
 				assert (!error1);
 				nano::amount balance;
 				nano::bufferstream balance_stream (this_l->connection->receive_buffer->data () + sizeof (nano::uint256_union), sizeof (nano::uint128_union));
 				auto error2 (nano::try_read (balance_stream, balance));
+				(void)error2;
 				assert (!error2);
 				if (this_l->total_blocks == 0 || !pending.is_zero ())
 				{
@@ -3297,6 +3301,7 @@ void nano::pulls_cache::add (nano::pull_info const & pull_a)
 		{
 			// Insert new pull
 			auto inserted (cache.insert (nano::cached_pulls{ std::chrono::steady_clock::now (), head_512, pull_a.head }));
+			(void)inserted;
 			assert (inserted.second);
 		}
 		else

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -616,6 +616,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 							nano::account const & account (i->first);
 							nano::raw_key key;
 							auto error (existing->second->store.fetch (transaction, account, key));
+							(void)error;
 							assert (!error);
 							std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key.data.to_string ());
 							if (nano::pub_key (key.data) != account)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -288,6 +288,7 @@ void nano::election::clear_blocks ()
 	{
 		auto & hash (block.first);
 		auto erased (node.active.blocks.erase (hash));
+		(void)erased;
 		// clear_blocks () can be called in active_transactions::publish () before blocks insertion if election was confirmed
 		assert (erased == 1 || confirmed);
 		// Notify observers about dropped elections & blocks lost confirmed elections

--- a/nano/node/lmdb.cpp
+++ b/nano/node/lmdb.cpp
@@ -911,6 +911,7 @@ void nano::mdb_store::upgrade_v8_to_v9 (nano::transaction const & transaction_a)
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (i->second.data ()), i->second.size ());
 		uint64_t sequence;
 		auto error (nano::try_read (stream, sequence));
+		(void)error;
 		// Create a dummy vote with the same sequence number for easy upgrading.  This won't have a valid signature.
 		nano::vote dummy (nano::account (i->first), junk.prv, sequence, block);
 		std::vector<uint8_t> vector;
@@ -1066,7 +1067,7 @@ MDB_dbi nano::mdb_store::block_database (nano::block_type type_a, nano::epoch ep
 	{
 		assert (epoch_a == nano::epoch::epoch_0);
 	}
-	MDB_dbi result;
+	MDB_dbi result = 0;
 	switch (type_a)
 	{
 		case nano::block_type::send:
@@ -1558,8 +1559,10 @@ bool nano::mdb_store::block_info_get (nano::transaction const & transaction_a, n
 		assert (value.size () == sizeof (block_info_a.account.bytes) + sizeof (block_info_a.balance.bytes));
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		auto error1 (nano::try_read (stream, block_info_a.account));
+		(void)error1;
 		assert (!error1);
 		auto error2 (nano::try_read (stream, block_info_a.balance));
+		(void)error2;
 		assert (!error2);
 	}
 	return result;
@@ -1576,6 +1579,7 @@ nano::uint128_t nano::mdb_store::representation_get (nano::transaction const & t
 		nano::uint128_union rep;
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		auto error (nano::try_read (stream, rep));
+		(void)error;
 		assert (!error);
 		result = rep.number ();
 	}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -467,6 +467,7 @@ public:
 						{
 							nano::account_info info;
 							auto error (node.store.account_get (transaction, root_hash.second, info));
+							(void)error;
 							assert (!error);
 							successor = info.open_block;
 						}

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -144,6 +144,7 @@ std::shared_ptr<nano::wallet> nano::system::wallet (size_t index_a)
 {
 	assert (nodes.size () > index_a);
 	auto size (nodes[index_a]->wallets.items.size ());
+	(void)size;
 	assert (size == 1);
 	return nodes[index_a]->wallets.items.begin ()->second;
 }
@@ -241,6 +242,7 @@ void nano::system::generate_rollback (nano::node & node_a, std::vector<nano::acc
 			accounts_a.pop_back ();
 			std::vector<std::shared_ptr<nano::block>> rollback_list;
 			auto error = node_a.ledger.rollback (transaction, hash, rollback_list);
+			(void)error;
 			assert (!error);
 			for (auto & i : rollback_list)
 			{
@@ -342,6 +344,7 @@ void nano::system::generate_send_existing (nano::node & node_a, std::vector<nano
 	if (!amount.is_zero ())
 	{
 		auto hash (wallet (0)->send_sync (source, destination, amount));
+		(void)hash;
 		assert (!hash.is_zero ());
 	}
 }
@@ -353,6 +356,7 @@ void nano::system::generate_change_known (nano::node & node_a, std::vector<nano:
 	{
 		nano::account destination (get_random_account (accounts_a));
 		auto change_error (wallet (0)->change_sync (source, destination));
+		(void)change_error;
 		assert (!change_error);
 	}
 }
@@ -365,6 +369,7 @@ void nano::system::generate_change_unknown (nano::node & node_a, std::vector<nan
 		nano::keypair key;
 		nano::account destination (key.pub);
 		auto change_error (wallet (0)->change_sync (source, destination));
+		(void)change_error;
 		assert (!change_error);
 	}
 }
@@ -384,6 +389,7 @@ void nano::system::generate_send_new (nano::node & node_a, std::vector<nano::acc
 		auto pub (node_a.wallets.items.begin ()->second->deterministic_insert ());
 		accounts_a.push_back (pub);
 		auto hash (wallet (0)->send_sync (source, pub, amount));
+		(void)hash;
 		assert (!hash.is_zero ());
 	}
 }

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -108,6 +108,7 @@ void nano::votes_cache::add (std::shared_ptr<nano::vote> const & vote_a)
 			}
 			// Insert new votes (new hash)
 			auto inserted (cache.insert (nano::cached_votes{ std::chrono::steady_clock::now (), hash, std::vector<std::shared_ptr<nano::vote>> (1, vote_a) }));
+			(void)inserted;
 			assert (inserted.second);
 		}
 		else

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -418,6 +418,7 @@ void nano::wallet_store::insert_watch (nano::transaction const & transaction_a, 
 void nano::wallet_store::erase (nano::transaction const & transaction_a, nano::public_key const & pub)
 {
 	auto status (mdb_del (tx (transaction_a), handle, nano::mdb_val (pub), nullptr));
+	(void)status;
 	assert (status == 0);
 }
 
@@ -441,6 +442,7 @@ nano::wallet_value nano::wallet_store::entry_get_raw (nano::transaction const & 
 void nano::wallet_store::entry_put_raw (nano::transaction const & transaction_a, nano::public_key const & pub_a, nano::wallet_value const & entry_a)
 {
 	auto status (mdb_put (tx (transaction_a), handle, nano::mdb_val (pub_a), nano::mdb_val (sizeof (entry_a), const_cast<nano::wallet_value *> (&entry_a)), 0));
+	(void)status;
 	assert (status == 0);
 }
 
@@ -910,6 +912,7 @@ void nano::wallet::serialize (std::string & json_a)
 void nano::wallet_store::destroy (nano::transaction const & transaction_a)
 {
 	auto status (mdb_drop (tx (transaction_a), handle, 1));
+	(void)status;
 	assert (status == 0);
 	handle = 0;
 }
@@ -1000,9 +1003,11 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			{
 				nano::account_info info;
 				auto error1 (wallets.node.ledger.store.account_get (block_transaction, source_a, info));
+				(void)error1;
 				assert (!error1);
 				nano::raw_key prv;
 				auto error2 (store.fetch (transaction, source_a, prv));
+				(void)error2;
 				assert (!error2);
 				if (work_a == 0)
 				{
@@ -1075,9 +1080,11 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					{
 						nano::account_info info;
 						auto error1 (wallets.node.ledger.store.account_get (block_transaction, source_a, info));
+						(void)error1;
 						assert (!error1);
 						nano::raw_key prv;
 						auto error2 (store.fetch (transaction, source_a, prv));
+						(void)error2;
 						assert (!error2);
 						std::shared_ptr<nano::block> rep_block = wallets.node.ledger.store.block_get (block_transaction, info.rep_block);
 						assert (rep_block != nullptr);
@@ -1755,6 +1762,7 @@ void nano::wallets::foreach_representative (nano::transaction const & transactio
 						{
 							nano::raw_key prv;
 							auto error (wallet.store.fetch (transaction_l, account, prv));
+							(void)error;
 							assert (!error);
 							action_a (account, prv);
 						}
@@ -1813,6 +1821,7 @@ nano::read_transaction nano::wallets::tx_begin_read ()
 void nano::wallets::clear_send_ids (nano::transaction const & transaction_a)
 {
 	auto status (mdb_drop (env.tx (transaction_a), send_action_ids, 0));
+	(void)status;
 	assert (status == 0);
 }
 
@@ -1887,6 +1896,7 @@ void nano::wallets::split_if_needed (nano::transaction & transaction_destination
 					nano::uint256_union id;
 					std::string text (i->first.data (), i->first.size ());
 					auto error1 (id.decode_hex (text));
+					(void)error1;
 					assert (!error1);
 					assert (strlen (text.c_str ()) == text.size ());
 					move_table (text, tx_source, tx_destination);
@@ -1900,12 +1910,15 @@ void nano::wallets::move_table (std::string const & name_a, MDB_txn * tx_source,
 {
 	MDB_dbi handle_source;
 	auto error2 (mdb_dbi_open (tx_source, name_a.c_str (), MDB_CREATE, &handle_source));
+	(void)error2;
 	assert (!error2);
 	MDB_dbi handle_destination;
 	auto error3 (mdb_dbi_open (tx_destination, name_a.c_str (), MDB_CREATE, &handle_destination));
+	(void)error3;
 	assert (!error3);
 	MDB_cursor * cursor;
 	auto error4 (mdb_cursor_open (tx_source, handle_source, &cursor));
+	(void)error4;
 	assert (!error4);
 	MDB_val val_key;
 	MDB_val val_value;
@@ -1913,10 +1926,12 @@ void nano::wallets::move_table (std::string const & name_a, MDB_txn * tx_source,
 	while (cursor_status == MDB_SUCCESS)
 	{
 		auto error5 (mdb_put (tx_destination, handle_destination, &val_key, &val_value, 0));
+		(void)error5;
 		assert (!error5);
 		cursor_status = mdb_cursor_get (cursor, &val_key, &val_value, MDB_NEXT);
 	}
 	auto error6 (mdb_drop (tx_source, handle_source, 1));
+	(void)error6;
 	assert (!error6);
 }
 

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -108,6 +108,8 @@ bool nano::websocket::confirmation_options::should_filter (nano::websocket::mess
 			nano::account source_l (0), destination_l (0);
 			auto decode_source_ok_l (!source_l.decode_account (source_text_l));
 			auto decode_destination_ok_l (!destination_l.decode_account (destination_opt_l.get ()));
+			(void)decode_source_ok_l;
+			(void)decode_destination_ok_l;
 			assert (decode_source_ok_l && decode_destination_ok_l);
 			if (node.wallets.exists (transaction_l, source_l) || node.wallets.exists (transaction_l, destination_l))
 			{

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -172,6 +172,7 @@ wallet (wallet_a)
 		if (selection.size () == 1)
 		{
 			auto error (this->wallet.account.decode_account (model->item (selection[0].row (), 1)->text ().toStdString ()));
+			(void)error;
 			assert (!error);
 			this->wallet.refresh ();
 		}
@@ -2234,6 +2235,7 @@ void nano_qt::block_creation::create_send ()
 					{
 						nano::account_info info;
 						auto error (wallet.node.store.account_get (block_transaction, account_l, info));
+						(void)error;
 						assert (!error);
 						auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
 						assert (rep_block != nullptr);

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -177,6 +177,7 @@ public:
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
 		nano::unchecked_info result;
 		bool error (result.deserialize (stream));
+		(void)error;
 		assert (!error);
 		return result;
 	}
@@ -202,6 +203,7 @@ public:
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
 		std::array<char, 64> result;
 		auto error = nano::try_read (stream, result);
+		(void)error;
 		assert (!error);
 		return result;
 	}
@@ -274,6 +276,7 @@ public:
 		uint64_t result;
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
 		auto error (nano::try_read (stream, result));
+		(void)error;
 		assert (!error);
 		boost::endian::big_to_native_inplace (result);
 		return result;
@@ -788,6 +791,7 @@ public:
 				if (full_sideband (transaction_a) || entry_has_sideband (value.size (), type))
 				{
 					auto error (sideband_a->deserialize (stream));
+					(void)error;
 					assert (!error);
 				}
 				else
@@ -874,6 +878,7 @@ public:
 			assert (value.size () >= result.bytes.size ());
 			nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()) + block_successor_offset (transaction_a, value.size (), type), result.bytes.size ());
 			auto error (nano::try_read (stream, result.bytes));
+			(void)error;
 			assert (!error);
 		}
 		else

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -162,6 +162,7 @@ prv (std::move (prv_a))
 nano::keypair::keypair (std::string const & prv_a)
 {
 	auto error (prv.data.decode_hex (prv_a));
+	(void)error;
 	assert (!error);
 	ed25519_publickey (prv.data.bytes.data (), pub.bytes.data ());
 }

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -32,6 +32,7 @@ public:
 		{
 			nano::account_info info;
 			auto error (ledger.store.account_get (transaction, pending.source, info));
+			(void)error;
 			assert (!error);
 			ledger.store.pending_del (transaction, key);
 			ledger.store.representation_add (transaction, ledger.representative (transaction, hash), pending.amount.number ());
@@ -52,6 +53,7 @@ public:
 		auto source_account (ledger.account (transaction, block_a.hashables.source));
 		nano::account_info info;
 		auto error (ledger.store.account_get (transaction, destination_account, info));
+		(void)error;
 		assert (!error);
 		ledger.store.representation_add (transaction, ledger.representative (transaction, hash), 0 - amount);
 		ledger.change_latest (transaction, destination_account, block_a.hashables.previous, representative, ledger.balance (transaction, block_a.hashables.previous), info.block_count - 1);
@@ -82,6 +84,7 @@ public:
 		auto account (ledger.account (transaction, block_a.hashables.previous));
 		nano::account_info info;
 		auto error (ledger.store.account_get (transaction, account, info));
+		(void)error;
 		assert (!error);
 		auto balance (ledger.balance (transaction, block_a.hashables.previous));
 		ledger.store.representation_add (transaction, representative, balance);
@@ -430,6 +433,7 @@ void ledger_processor::change_block (nano::change_block const & block_a)
 				{
 					nano::account_info info;
 					auto latest_error (ledger.store.account_get (transaction, account, info));
+					(void)latest_error;
 					assert (!latest_error);
 					assert (info.head == block_a.hashables.previous);
 					// Validate block if not verified outside of ledger
@@ -488,6 +492,7 @@ void ledger_processor::send_block (nano::send_block const & block_a)
 						result.verified = nano::signature_verification::valid;
 						nano::account_info info;
 						auto latest_error (ledger.store.account_get (transaction, account, info));
+						(void)latest_error;
 						assert (!latest_error);
 						assert (info.head == block_a.hashables.previous);
 						result.code = info.balance.number () >= block_a.hashables.balance.number () ? nano::process_result::progress : nano::process_result::negative_spend; // Is this trying to spend a negative amount (Malicious)
@@ -559,6 +564,7 @@ void ledger_processor::receive_block (nano::receive_block const & block_a)
 										auto new_balance (info.balance.number () + pending.amount.number ());
 										nano::account_info source_info;
 										auto error (ledger.store.account_get (transaction, pending.source, source_info));
+										(void)error;
 										assert (!error);
 										ledger.store.pending_del (transaction, key);
 										nano::block_sideband sideband (nano::block_type::receive, account, 0, new_balance, info.block_count + 1, nano::seconds_since_epoch ());
@@ -621,6 +627,7 @@ void ledger_processor::open_block (nano::open_block const & block_a)
 							{
 								nano::account_info source_info;
 								auto error (ledger.store.account_get (transaction, pending.source, source_info));
+								(void)error;
 								assert (!error);
 								ledger.store.pending_del (transaction, key);
 								nano::block_sideband sideband (nano::block_type::open, block_a.hashables.account, 0, pending.amount, 1, nano::seconds_since_epoch ());
@@ -843,6 +850,7 @@ bool nano::ledger::rollback (nano::transaction const & transaction_a, nano::bloc
 	while (!error && store.block_exists (transaction_a, block_a))
 	{
 		auto latest_error (store.account_get (transaction_a, account_l, account_info));
+		(void)latest_error;
 		assert (!latest_error);
 		if (block_account_height > account_info.confirmation_height)
 		{
@@ -1015,6 +1023,7 @@ std::shared_ptr<nano::block> nano::ledger::successor (nano::transaction const & 
 	{
 		nano::account_info info;
 		auto error (store.account_get (transaction_a, root_a.uint256s[1], info));
+		(void)error;
 		assert (!error);
 		successor = info.open_block;
 	}
@@ -1041,6 +1050,7 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 	{
 		nano::account_info info;
 		auto error (store.account_get (transaction_a, root, info));
+		(void)error;
 		assert (!error);
 		result = store.block_get (transaction_a, info.open_block);
 		assert (result != nullptr);


### PR DESCRIPTION
Using the (void)var idiom used elsewhere in the code base for unused vars (can move to [[maybe_unused]] in c++17). There's also a default-in-switch-related uninitialized error fixed.