### PR TITLE
Filter recent elections in update_active_difficulty

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -623,9 +623,11 @@ void nano::active_transactions::update_active_difficulty (std::unique_lock<std::
 	{
 		std::vector<uint64_t> active_root_difficulties;
 		active_root_difficulties.reserve (roots.size ());
+		auto min_election_time (std::chrono::milliseconds (node.network_params.network.is_test_network () ? 0 : 2000));
+		auto cutoff (std::chrono::steady_clock::now () - min_election_time);
 		for (auto & root : roots)
 		{
-			if (!root.election->confirmed && !root.election->stopped)
+			if (!root.election->confirmed && !root.election->stopped && root.election->election_start < cutoff)
 			{
 				active_root_difficulties.push_back (root.adjusted_difficulty);
 			}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -623,7 +623,7 @@ void nano::active_transactions::update_active_difficulty (std::unique_lock<std::
 	{
 		std::vector<uint64_t> active_root_difficulties;
 		active_root_difficulties.reserve (roots.size ());
-		auto min_election_time (std::chrono::milliseconds (node.network_params.network.is_test_network () ? 0 : 2000));
+		auto min_election_time (std::chrono::milliseconds (node.network_params.network.request_interval_ms));
 		auto cutoff (std::chrono::steady_clock::now () - min_election_time);
 		for (auto & root : roots)
 		{


### PR DESCRIPTION
If an election was inserted within the current loop, don't consider it for the median calculation.

This should solve the effect during low load where active difficulty gets quite high while sampling only one or two very recent elections.