### PR TITLE
Principal representative factor as a network constant

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -63,6 +63,9 @@ public:
 		uint64_t constexpr publish_full_threshold = 0xffffffc000000000;
 		publish_threshold = is_test_network () ? publish_test_threshold : publish_full_threshold;
 
+		// A representative is classified as principal based on its weight and this factor
+		principal_weight_factor = 1000; // 0.1%
+
 		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : 44000;
 		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : 45000;
 		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : 46000;
@@ -73,6 +76,7 @@ public:
 	/** The network this param object represents. This may differ from the global active network; this is needed for certain --debug... commands */
 	nano_networks current_network;
 	uint64_t publish_threshold;
+	unsigned principal_weight_factor;
 	uint16_t default_node_port;
 	uint16_t default_rpc_port;
 	uint16_t default_ipc_port;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -156,7 +156,7 @@ nano::election_vote_result nano::election::vote (nano::account rep, uint64_t seq
 	auto supply (node.online_reps.online_stake ());
 	auto weight (node.ledger.weight (transaction, rep));
 	auto should_process (false);
-	if (node.network_params.network.is_test_network () || weight > supply / 1000) // 0.1% or above
+	if (node.network_params.network.is_test_network () || weight > node.minimum_principal_weight ())
 	{
 		unsigned int cooldown;
 		if (weight < supply / 100) // 0.1% to 1%

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -153,17 +153,17 @@ nano::election_vote_result nano::election::vote (nano::account rep, uint64_t seq
 	// see republish_vote documentation for an explanation of these rules
 	auto transaction (node.store.tx_begin_read ());
 	auto replay (false);
-	auto supply (node.online_reps.online_stake ());
+	auto online_stake (node.online_reps.online_stake ());
 	auto weight (node.ledger.weight (transaction, rep));
 	auto should_process (false);
-	if (node.network_params.network.is_test_network () || weight > node.minimum_principal_weight ())
+	if (node.network_params.network.is_test_network () || weight > node.minimum_principal_weight (online_stake))
 	{
 		unsigned int cooldown;
-		if (weight < supply / 100) // 0.1% to 1%
+		if (weight < online_stake / 100) // 0.1% to 1%
 		{
 			cooldown = 15;
 		}
-		else if (weight < supply / 20) // 1% to 5%
+		else if (weight < online_stake / 20) // 1% to 5%
 		{
 			cooldown = 5;
 		}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -392,12 +392,10 @@ startup_time (std::chrono::steady_clock::now ())
 			this->gap_cache.vote (vote_a);
 			this->online_reps.observe (vote_a->account);
 			nano::uint128_t rep_weight;
-			nano::uint128_t min_rep_weight;
 			{
 				rep_weight = ledger.weight (transaction, vote_a->account);
-				min_rep_weight = online_reps.online_stake () / 1000;
 			}
-			if (rep_weight > min_rep_weight)
+			if (rep_weight > minimum_principal_weight ())
 			{
 				bool rep_crawler_exists (false);
 				for (auto hash : *vote_a)
@@ -807,6 +805,11 @@ nano::account nano::node::representative (nano::account const & account_a)
 		result = info.rep_block;
 	}
 	return result;
+}
+
+nano::uint128_t nano::node::minimum_principal_weight ()
+{
+	return online_reps.online_stake () / 1000; // 0.1% of trended online stake
 }
 
 void nano::node::ongoing_rep_calculation ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -809,7 +809,12 @@ nano::account nano::node::representative (nano::account const & account_a)
 
 nano::uint128_t nano::node::minimum_principal_weight ()
 {
-	return online_reps.online_stake () / network_params.network.principal_weight_factor;
+	return minimum_principal_weight (online_reps.online_stake ());
+}
+
+nano::uint128_t nano::node::minimum_principal_weight (nano::uint128_t const & online_stake)
+{
+	return online_stake / network_params.network.principal_weight_factor;
 }
 
 void nano::node::ongoing_rep_calculation ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -809,7 +809,7 @@ nano::account nano::node::representative (nano::account const & account_a)
 
 nano::uint128_t nano::node::minimum_principal_weight ()
 {
-	return online_reps.online_stake () / 1000; // 0.1% of trended online stake
+	return online_reps.online_stake () / network_params.network.principal_weight_factor;
 }
 
 void nano::node::ongoing_rep_calculation ()

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -134,6 +134,7 @@ public:
 	std::pair<nano::uint128_t, nano::uint128_t> balance_pending (nano::account const &);
 	nano::uint128_t weight (nano::account const &);
 	nano::account representative (nano::account const &);
+	nano::uint128_t minimum_principal_weight ();
 	void ongoing_rep_calculation ();
 	void ongoing_bootstrap ();
 	void ongoing_store_flush ();

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -135,6 +135,7 @@ public:
 	nano::uint128_t weight (nano::account const &);
 	nano::account representative (nano::account const &);
 	nano::uint128_t minimum_principal_weight ();
+	nano::uint128_t minimum_principal_weight (nano::uint128_t const &);
 	void ongoing_rep_calculation ();
 	void ongoing_bootstrap ();
 	void ongoing_store_flush ();


### PR DESCRIPTION
Extract minimum_principal_weight(), and use the 0.1% factor as a network constant which can possibly be changed for other networks in the future.