### PR TITLE
Fix lazy bootstrap balances insert

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -470,8 +470,8 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 				connection->start_time = std::chrono::steady_clock::now ();
 			}
 			connection->attempt->total_blocks++;
-			total_blocks++;
 			bool stop_pull (connection->attempt->process_block (block, known_account, total_blocks, block_expected));
+			total_blocks++;
 			if (!stop_pull && !connection->hard_stop.load ())
 			{
 				/* Process block in lazy pull if not stopped

--- a/nano/node/bootstrap.hpp
+++ b/nano/node/bootstrap.hpp
@@ -160,7 +160,7 @@ public:
 	nano::block_hash expected;
 	nano::account known_account;
 	nano::pull_info pull;
-	uint64_t total_blocks;
+	uint64_t pull_blocks;
 	uint64_t unexpected_count;
 };
 class bootstrap_client final : public std::enable_shared_from_this<bootstrap_client>
@@ -203,7 +203,7 @@ public:
 	void receive_pending ();
 	std::shared_ptr<nano::bootstrap_client> connection;
 	nano::account account;
-	uint64_t total_blocks;
+	uint64_t pull_blocks;
 };
 class cached_pulls final
 {


### PR DESCRIPTION
Adding lazy balances check was unreachable
`if (total_blocks == 0)`