### PR TITLE
boost 1.70 requires log_setup component specifically updated CMAKE 1.…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ set(Boost_USE_MULTITHREADED      ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package (Boost 1.67.0 REQUIRED COMPONENTS filesystem log thread program_options system)
+find_package (Boost 1.67.0 REQUIRED COMPONENTS filesystem log log_setup thread program_options system)
 if (NANO_ROCKSDB)
 	find_package (RocksDB REQUIRED)
 	find_package (ZLIB REQUIRED)

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -26,7 +26,7 @@ while getopts 'hmcCkpvB:' OPT; do
 			exit 0
 			;;
 		m)
-			bootstrapArgs+=('--with-libraries=thread,log,filesystem,program_options')
+			bootstrapArgs+=('--with-libraries=system,thread,log,filesystem,program_options')
 			;;
 		c)
 			useClang='true'


### PR DESCRIPTION
…67 and 1.69 dont require explicit but will use

update boostrap_boost.sh to mirror https://docs.nano.org/integration-guides/build-options/