### PR TITLE
Add support for election info in websocket confirmations

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -260,7 +260,7 @@ startup_time (std::chrono::steady_clock::now ())
 						}
 					}
 
-					this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype, status_a.type);
+					this->websocket_server->broadcast_confirmation (block_a, account_a, amount_a, subtype, status_a);
 				}
 			});
 

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -36,6 +36,7 @@ enum class election_status_type : uint8_t;
 namespace websocket
 {
 	class listener;
+	class confirmation_options;
 
 	/** Supported topics */
 	enum class topic
@@ -78,7 +79,7 @@ namespace websocket
 	class message_builder final
 	{
 	public:
-		message block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, bool include_block, nano::election_status_type election_status_type_a);
+		message block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, bool include_block, nano::election_status const & election_status_a, nano::websocket::confirmation_options const & options_a);
 		message stopped_election (nano::block_hash const & hash_a);
 		message vote_received (std::shared_ptr<nano::vote> vote_a);
 		message difficulty_changed (uint64_t publish_threshold, uint64_t difficulty_active);
@@ -117,7 +118,7 @@ namespace websocket
 	class confirmation_options final : public options
 	{
 	public:
-		confirmation_options ();
+		confirmation_options (nano::node & node_a);
 		confirmation_options (boost::property_tree::ptree const & options_a, nano::node & node_a);
 
 		/**
@@ -133,6 +134,12 @@ namespace websocket
 			return include_block;
 		}
 
+		/** Returns whether or not to include election info, such as tally and duration */
+		bool get_include_election_info () const
+		{
+			return include_election_info;
+		}
+
 		static constexpr const uint8_t type_active_quorum = 1;
 		static constexpr const uint8_t type_active_confirmation_height = 2;
 		static constexpr const uint8_t type_inactive = 4;
@@ -141,6 +148,7 @@ namespace websocket
 
 	private:
 		nano::node & node;
+		bool include_election_info{ false };
 		bool include_block{ true };
 		bool has_account_filtering_options{ false };
 		bool all_local_accounts{ false };
@@ -241,7 +249,7 @@ namespace websocket
 		void stop ();
 
 		/** Broadcast block confirmation. The content of the message depends on subscription options (such as "include_block") */
-		void broadcast_confirmation (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, nano::election_status_type election_status_type_a);
+		void broadcast_confirmation (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, nano::election_status const & election_status_a);
 
 		/** Broadcast \p message to all session subscribing to the message topic. */
 		void broadcast (nano::websocket::message message_a);


### PR DESCRIPTION
Closes https://github.com/nanocurrency/nano-node/issues/2190

The election info fields matches those of `confirmation_history`
