### PR TITLE
Only use -Werror by default with ci

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set (NANO_GUI OFF CACHE BOOL "")
 set (NANO_TEST OFF CACHE BOOL "")
 set (NANO_SECURE_RPC OFF CACHE BOOL "")
 set (NANO_ROCKSDB OFF CACHE BOOL "")
+set (NANO_WARN_TO_ERR OFF CACHE BOOL "")
 
 option(NANO_ASAN_INT "Enable ASan+UBSan+Integer overflow" OFF)
 option(NANO_ASAN "Enable ASan+UBSan" OFF)
@@ -58,7 +59,9 @@ if (WIN32)
 	endif()
 
 else ()
-	add_compile_options(-Werror)
+	if (NANO_WARN_TO_ERR)
+		add_compile_options(-Werror)
+	endif ()
 
 	if ((${USING_TSAN} AND ${USING_ASAN}) OR
 	    (${USING_TSAN} AND ${USING_ASAN_INT}))

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -27,6 +27,7 @@ cmake \
     -DNANO_TEST=ON \
     -DNANO_GUI=ON \
     -DNANO_ROCKSDB=ON \
+    -DNANO_WARN_TO_ERR=ON \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DBOOST_ROOT=/usr/local \


### PR DESCRIPTION
To prevent inevitable warnings from different compilers/systems which are not caught by the versions of gcc/clang we use, this is now only turned on by default for our ci. It can still be turned on by setting the `NANO_WARN_TO_ERR` CMake flag though.