### PR TITLE
Simplify vote generator logic with a dual sleep

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -842,6 +842,59 @@ TEST (node_config, v17_values)
 	ASSERT_EQ (config.conf_height_processor_batch_min_time.count (), 500);
 }
 
+TEST (node_config, v17_v18_upgrade)
+{
+	auto path (nano::unique_path ());
+	nano::jsonconfig tree;
+	add_required_children_node_config_tree (tree);
+	tree.put ("version", "17");
+
+	auto upgraded (false);
+	nano::node_config config;
+	config.logging.init (path);
+	// These config options should not be present
+	//...
+
+	config.deserialize_json (upgraded, tree);
+
+	// The config options should be added after the upgrade
+	// ...
+
+	ASSERT_TRUE (upgraded);
+	auto version (tree.get<std::string> ("version"));
+
+	// Check version is updated
+	ASSERT_GT (std::stoull (version), 17);
+}
+
+TEST (node_config, v18_values)
+{
+	nano::jsonconfig tree;
+	add_required_children_node_config_tree (tree);
+
+	auto path (nano::unique_path ());
+	auto upgraded (false);
+	nano::node_config config;
+	config.logging.init (path);
+
+	// Check config is correct
+	{
+		tree.put ("vote_generator_delay", 100);
+	}
+
+	config.deserialize_json (upgraded, tree);
+	ASSERT_FALSE (upgraded);
+	ASSERT_EQ (config.vote_generator_delay.count (), 100);
+
+	// Check config is correct with other values
+	tree.put ("vote_generator_delay", std::numeric_limits<unsigned long>::max () - 100);
+
+	upgraded = false;
+	config.deserialize_json (upgraded, tree);
+	ASSERT_FALSE (upgraded);
+	ASSERT_EQ (config.vote_generator_delay.count (), std::numeric_limits<unsigned long>::max () - 100);
+}
+
 // Regression test to ensure that deserializing includes changes node via get_required_child
 TEST (node_config, required_child)
 {

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -87,13 +87,15 @@ TEST (wallets, upgrade)
 		nano::node_init init1;
 		auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, path, system.alarm, system.logging, system.work));
 		ASSERT_FALSE (init1.error ());
-		node1->wallets.create (id.pub);
+		bool error (false);
+		nano::wallets wallets (error, *node1);
+		wallets.create (id.pub);
 		auto transaction_source (node1->wallets.env.tx_begin_write ());
 		auto tx_source = static_cast<MDB_txn *> (transaction_source.get_handle ());
 		auto & mdb_store (dynamic_cast<nano::mdb_store &> (node1->store));
 		auto transaction_destination (mdb_store.tx_begin_write ());
 		auto tx_destination = static_cast<MDB_txn *> (transaction_destination.get_handle ());
-		node1->wallets.move_table (id.pub.to_string (), tx_source, tx_destination);
+		wallets.move_table (id.pub.to_string (), tx_source, tx_destination);
 		node1->store.version_put (transaction_destination, 11);
 
 		nano::account_info info;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -258,6 +258,9 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			json.put ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time.count ());
 		}
 		case 17:
+			// Update values
+			json.put ("vote_generator_delay", vote_generator_delay.count ());
+		case 18:
 			break;
 		default:
 			throw std::runtime_error ("Unknown node_config version");
@@ -436,9 +439,9 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("bandwidth_limit unbounded = 0, default = 5242880, max = 18446744073709551615");
 		}
-		if (vote_generator_threshold < 1 || vote_generator_threshold > 12)
+		if (vote_generator_threshold < 1 || vote_generator_threshold > 11)
 		{
-			json.get_error ().set ("vote_generator_threshold must be a number between 1 and 12");
+			json.get_error ().set ("vote_generator_threshold must be a number between 1 and 11");
 		}
 	}
 	catch (std::runtime_error const & ex)

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -37,7 +37,7 @@ public:
 	unsigned bootstrap_fraction_numerator{ 1 };
 	nano::amount receive_minimum{ nano::xrb_ratio };
 	nano::amount vote_minimum{ nano::Gxrb_ratio };
-	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (50) };
+	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (100) };
 	unsigned vote_generator_threshold{ 3 };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
 	unsigned online_weight_quorum{ 50 };
@@ -79,7 +79,7 @@ public:
 	std::chrono::milliseconds conf_height_processor_batch_min_time{ 50 };
 	static unsigned json_version ()
 	{
-		return 17;
+		return 18;
 	}
 };
 

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -36,7 +36,6 @@ private:
 	nano::network_params network_params;
 	bool stopped{ false };
 	bool started{ false };
-	bool wakeup{ false };
 	boost::thread thread;
 
 	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);


### PR DESCRIPTION
Also adds the RPC upgrade path for v18 config.

This is a simpler approach than before:
1. Sleep 100ms, only interruptible to send 12 hashes
2. If 3+ hashes arrived, sleep 100ms more
3. Send anything at the end
4. Repeat

This re-uses previous RPC config options. The current set of choices means that, on average:
- Votes will have 12 hashes at ~60 tps  (`12 / (2*0.100)`)
- Up to ~30 tps (`3 / 0.100`) the delay is 100ms
- Above ~30 tps, the delay is 200ms
- The min delay is increase from 50ms to 100ms

These targets are slightly more conservative (favor packaging more than latency) than currently.