### PR TITLE
Increase lifetime of temporary rep variable

### DIFF
--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -623,7 +623,7 @@ public:
 	virtual nano::epoch block_version (nano::transaction const &, nano::block_hash const &) = 0;
 
 	virtual nano::uint128_t representation_get (nano::transaction const &, nano::account const &) = 0;
-	virtual void representation_put (nano::transaction const &, nano::account const &, nano::uint128_t const &) = 0;
+	virtual void representation_put (nano::transaction const &, nano::account const &, nano::uint128_union const &) = 0;
 	virtual void representation_add (nano::transaction const &, nano::account const &, nano::uint128_t const &) = 0;
 	virtual nano::store_iterator<nano::account, nano::uint128_union> representation_begin (nano::transaction const &) = 0;
 	virtual nano::store_iterator<nano::account, nano::uint128_union> representation_end () = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -550,9 +550,9 @@ public:
 		return result;
 	}
 
-	void representation_put (nano::transaction const & transaction_a, nano::account const & account_a, nano::uint128_t const & representation_a) override
+	void representation_put (nano::transaction const & transaction_a, nano::account const & account_a, nano::uint128_union const & representation_a) override
 	{
-		nano::db_val<Val> rep{ nano::uint128_union (representation_a) };
+		nano::db_val<Val> rep (representation_a);
 		auto status (put (transaction_a, tables::representation, account_a, rep));
 		release_assert (success (status));
 	}


### PR DESCRIPTION
The `nano::uint128_union` passed in is not copied, pointers are made to it inside `nano::db_val` which then goes out of scope (stack lifetime issue). To make sure this doesn't happen again (with this function at least), passing in the type directly to ensure lifetime during this function call. This was only found in release builds on mac/linux, so release builds in ci are being implemented soon to hopefully catch issues like this and others in the future.

(Unrelated) Changed to bracket initialization, because hardly anything else in this file uses it.