### PR TITLE
Ignoring unreachable work peers

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4561,7 +4561,7 @@ void nano::json_handler::work_peer_add ()
 	{
 		auto peer (std::make_pair (address_text, port));
 		node.config.work_peers.insert (peer);
-		node.blacklisted_work_peers.erase (peer);
+		node.excluded_work_peers.erase (peer);
 		response_l.put ("success", "");
 	}
 	else
@@ -4581,29 +4581,29 @@ void nano::json_handler::work_peers ()
 		work_peers_l.push_back (std::make_pair ("", entry));
 	}
 	response_l.add_child ("work_peers", work_peers_l);
-	boost::property_tree::ptree blacklisted_work_peers_l;
-	for (auto i (node.blacklisted_work_peers.begin ()), n (node.blacklisted_work_peers.end ()); i != n; ++i)
+	boost::property_tree::ptree excluded_work_peers_l;
+	for (auto i (node.excluded_work_peers.begin ()), n (node.excluded_work_peers.end ()); i != n; ++i)
 	{
 		boost::property_tree::ptree entry;
 		entry.put ("", boost::str (boost::format ("%1%:%2%") % i->first % i->second));
-		blacklisted_work_peers_l.push_back (std::make_pair ("", entry));
+		excluded_work_peers_l.push_back (std::make_pair ("", entry));
 	}
-	response_l.add_child ("blacklisted", blacklisted_work_peers_l);
+	response_l.add_child ("excluded", excluded_work_peers_l);
 	response_errors ();
 }
 
 void nano::json_handler::work_peers_clear ()
 {
 	node.config.work_peers.clear ();
-	node.blacklisted_work_peers.clear ();
+	node.excluded_work_peers.clear ();
 	response_l.put ("success", "");
 	response_errors ();
 }
 
 void nano::json_handler::work_peers_reset ()
 {
-	node.config.work_peers.insert (node.blacklisted_work_peers.begin (), node.blacklisted_work_peers.end ());
-	node.blacklisted_work_peers.clear ();
+	node.config.work_peers.insert (node.excluded_work_peers.begin (), node.excluded_work_peers.end ());
+	node.excluded_work_peers.clear ();
 	response_l.put ("success", "");
 	response_errors ();
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4559,7 +4559,9 @@ void nano::json_handler::work_peer_add ()
 	uint16_t port;
 	if (!nano::parse_port (port_text, port))
 	{
-		node.config.work_peers.push_back (std::make_pair (address_text, port));
+		auto peer (std::make_pair (address_text, port));
+		node.config.work_peers.insert (peer);
+		node.blacklisted_work_peers.erase (peer);
 		response_l.put ("success", "");
 	}
 	else
@@ -4600,10 +4602,7 @@ void nano::json_handler::work_peers_clear ()
 
 void nano::json_handler::work_peers_reset ()
 {
-	for (auto & peer : node.blacklisted_work_peers)
-	{
-		node.config.work_peers.push_back (peer);
-	}
+	node.config.work_peers.insert (node.blacklisted_work_peers.begin (), node.blacklisted_work_peers.end ());
 	node.blacklisted_work_peers.clear ();
 	response_l.put ("success", "");
 	response_errors ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4593,6 +4593,18 @@ void nano::json_handler::work_peers ()
 void nano::json_handler::work_peers_clear ()
 {
 	node.config.work_peers.clear ();
+	node.blacklisted_work_peers.clear ();
+	response_l.put ("success", "");
+	response_errors ();
+}
+
+void nano::json_handler::work_peers_reset ()
+{
+	for (auto & peer : node.blacklisted_work_peers)
+	{
+		node.config.work_peers.push_back (peer);
+	}
+	node.blacklisted_work_peers.clear ();
 	response_l.put ("success", "");
 	response_errors ();
 }
@@ -4739,6 +4751,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("work_peer_add", &nano::json_handler::work_peer_add);
 	no_arg_funcs.emplace ("work_peers", &nano::json_handler::work_peers);
 	no_arg_funcs.emplace ("work_peers_clear", &nano::json_handler::work_peers_clear);
+	no_arg_funcs.emplace ("work_peers_reset", &nano::json_handler::work_peers_reset);
 	return no_arg_funcs;
 }
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4579,6 +4579,14 @@ void nano::json_handler::work_peers ()
 		work_peers_l.push_back (std::make_pair ("", entry));
 	}
 	response_l.add_child ("work_peers", work_peers_l);
+	boost::property_tree::ptree blacklisted_work_peers_l;
+	for (auto i (node.blacklisted_work_peers.begin ()), n (node.blacklisted_work_peers.end ()); i != n; ++i)
+	{
+		boost::property_tree::ptree entry;
+		entry.put ("", boost::str (boost::format ("%1%:%2%") % i->first % i->second));
+		blacklisted_work_peers_l.push_back (std::make_pair ("", entry));
+	}
+	response_l.add_child ("blacklisted", blacklisted_work_peers_l);
 	response_errors ();
 }
 

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -130,6 +130,7 @@ public:
 	void work_peer_add ();
 	void work_peers ();
 	void work_peers_clear ();
+	void work_peers_reset ();
 	void work_set ();
 	void work_validate ();
 	std::string body;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1007,7 +1007,7 @@ public:
 					}
 					else
 					{
-						this_l->node->logger.try_log (boost::str (boost::format ("Error resolving work peer, blacklisting: %1%:%2%: %3%") % current.first % current.second % ec.message ()));
+						this_l->node->logger.always_log (boost::str (boost::format ("Error resolving work peer, blacklisting: %1%:%2%: %3%") % current.first % current.second % ec.message ()));
 						this_l->blacklist (current);
 					}
 					this_l->start ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -967,10 +967,10 @@ public:
 	backoff (backoff_a),
 	node (node_a),
 	root (root_a),
-	need_resolve (node_a->config.work_peers),
 	difficulty (difficulty_a)
 	{
 		assert (node_a != nullptr);
+		need_resolve.insert (need_resolve.end (), node_a->config.work_peers.begin (), node_a->config.work_peers.end ());
 		completed.clear ();
 	}
 	void start ()
@@ -1218,8 +1218,8 @@ public:
 	}
 	void blacklist (std::pair<std::string, uint16_t> const & peer)
 	{
-		node->blacklisted_work_peers.push_back (peer);
-		node->config.work_peers.erase (std::remove (node->config.work_peers.begin (), node->config.work_peers.end (), peer), node->config.work_peers.end ());
+		node->blacklisted_work_peers.insert (peer);
+		node->config.work_peers.erase (peer);
 	}
 	void blacklist (boost::asio::ip::address const & address)
 	{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1169,7 +1169,12 @@ public:
 		handle_failure (last);
 		if (blacklist)
 		{
-			node->config.work_peers.erase (std::remove (node->config.work_peers.begin (), node->config.work_peers.end (), lookup[address]), node->config.work_peers.end ());
+			auto peer (lookup.find (address));
+			if (peer != lookup.end ())
+			{
+				node->blacklisted_work_peers.push_back (peer->second);
+				node->config.work_peers.erase (std::remove (node->config.work_peers.begin (), node->config.work_peers.end (), peer->second), node->config.work_peers.end ());
+			}
 		}
 	}
 	void handle_failure (bool last)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1007,8 +1007,8 @@ public:
 					}
 					else
 					{
-						this_l->node->logger.always_log (boost::str (boost::format ("Error resolving work peer, blacklisting: %1%:%2%: %3%") % current.first % current.second % ec.message ()));
-						this_l->blacklist (current);
+						this_l->node->logger.always_log (boost::str (boost::format ("Error resolving work peer, excluding: %1%:%2%: %3%") % current.first % current.second % ec.message ()));
+						this_l->exclude (current);
 					}
 					this_l->start ();
 				});
@@ -1079,9 +1079,9 @@ public:
 						}
 						else
 						{
-							this_l->node->logger.always_log (boost::str (boost::format ("Unable to connect to work_peer, blacklisting %1% %2%: %3% (%4%)") % connection->address % connection->port % ec.message () % ec.value ()));
+							this_l->node->logger.always_log (boost::str (boost::format ("Unable to connect to work_peer, excluding %1% %2%: %3% (%4%)") % connection->address % connection->port % ec.message () % ec.value ()));
 							this_l->failure (connection->address);
-							this_l->blacklist (connection->address);
+							this_l->exclude (connection->address);
 						}
 					});
 				});
@@ -1216,17 +1216,17 @@ public:
 		outstanding.erase (address);
 		return outstanding.empty ();
 	}
-	void blacklist (std::pair<std::string, uint16_t> const & peer)
+	void exclude (std::pair<std::string, uint16_t> const & peer)
 	{
-		node->blacklisted_work_peers.insert (peer);
+		node->excluded_work_peers.insert (peer);
 		node->config.work_peers.erase (peer);
 	}
-	void blacklist (boost::asio::ip::address const & address)
+	void exclude (boost::asio::ip::address const & address)
 	{
 		auto peer (lookup.find (address));
 		if (peer != lookup.end ())
 		{
-			blacklist (peer->second);
+			exclude (peer->second);
 		}
 	}
 	std::function<void(uint64_t)> callback;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -181,6 +181,7 @@ public:
 	nano::confirmation_height_processor confirmation_height_processor;
 	nano::payment_observer_processor payment_observer_processor;
 	nano::wallets wallets;
+	std::vector<std::pair<std::string, uint16_t>> blacklisted_work_peers;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> stopped{ false };

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -182,7 +182,7 @@ public:
 	nano::confirmation_height_processor confirmation_height_processor;
 	nano::payment_observer_processor payment_observer_processor;
 	nano::wallets wallets;
-	std::unordered_set<std::pair<std::string, uint16_t>, boost::hash<std::pair<std::string, uint16_t>>> blacklisted_work_peers;
+	std::unordered_set<std::pair<std::string, uint16_t>, boost::hash<std::pair<std::string, uint16_t>>> excluded_work_peers;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> stopped{ false };

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -38,6 +38,7 @@
 #include <condition_variable>
 #include <memory>
 #include <queue>
+#include <unordered_set>
 #include <vector>
 
 namespace nano
@@ -181,7 +182,7 @@ public:
 	nano::confirmation_height_processor confirmation_height_processor;
 	nano::payment_observer_processor payment_observer_processor;
 	nano::wallets wallets;
-	std::vector<std::pair<std::string, uint16_t>> blacklisted_work_peers;
+	std::unordered_set<std::pair<std::string, uint16_t>, boost::hash<std::pair<std::string, uint16_t>>> blacklisted_work_peers;
 	const std::chrono::steady_clock::time_point startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> stopped{ false };

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -298,7 +298,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 				if (!result)
 				{
 					auto address (entry.substr (0, port_position));
-					this->work_peers.push_back (std::make_pair (address, port));
+					this->work_peers.insert (std::make_pair (address, port));
 				}
 			}
 		});

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -12,6 +12,7 @@
 #include <nano/secure/common.hpp>
 
 #include <chrono>
+#include <unordered_set>
 #include <vector>
 
 namespace nano
@@ -31,7 +32,7 @@ public:
 	nano::network_params network_params;
 	uint16_t peering_port{ 0 };
 	nano::logging logging;
-	std::vector<std::pair<std::string, uint16_t>> work_peers;
+	std::unordered_set<std::pair<std::string, uint16_t>, boost::hash<std::pair<std::string, uint16_t>>> work_peers;
 	std::vector<std::string> preconfigured_peers;
 	std::vector<nano::account> preconfigured_representatives;
 	unsigned bootstrap_fraction_numerator{ 1 };

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -165,6 +165,7 @@ std::unordered_set<std::string> create_rpc_control_impls ()
 	set.emplace ("work_peer_add");
 	set.emplace ("work_peers");
 	set.emplace ("work_peers_clear");
+	set.emplace ("work_peers_reset");
 	set.emplace ("wallet_seed");
 	return set;
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2703,6 +2703,39 @@ TEST (rpc, work_peer_bad)
 		ASSERT_EQ (address_invalid + ":" + std::to_string (port), blacklisted[0]);
 		ASSERT_EQ (address + ":" + std::to_string (port), blacklisted[1]);
 	}
+
+	request.put ("action", "work_peers_reset");
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+	}
+
+	request.put ("action", "work_peers");
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & blacklisted_node (response.json.get_child ("blacklisted"));
+		ASSERT_TRUE (blacklisted_node.empty ());
+		auto & peers_node (response.json.get_child ("work_peers"));
+		std::vector<std::string> peers;
+		for (auto i (peers_node.begin ()), n (peers_node.end ()); i != n; ++i)
+		{
+			peers.push_back (i->second.get<std::string> (""));
+		}
+		ASSERT_EQ (2, peers.size ());
+		ASSERT_EQ (address_invalid + ":" + std::to_string (port), peers[0]);
+		ASSERT_EQ (address + ":" + std::to_string (port), peers[1]);
+	}
 }
 
 TEST (rpc, work_peer_one)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2664,11 +2664,11 @@ TEST (rpc, work_peer_bad)
 	// Invalid address, will get blacklisted when resolving
 	std::string address_invalid ("invalid");
 	auto port (0);
-	node1.config.work_peers.push_back (std::make_pair (address_invalid, port));
+	node1.config.work_peers.insert (std::make_pair (address_invalid, port));
 
 	// Valid address but will get blacklisted when failure in trying to reach it
 	auto address (boost::asio::ip::address_v6::any ().to_string ());
-	node1.config.work_peers.push_back (std::make_pair (address, port));
+	node1.config.work_peers.insert (std::make_pair (address, port));
 
 	nano::block_hash hash1 (1);
 	std::atomic<uint64_t> work (0);
@@ -2699,9 +2699,8 @@ TEST (rpc, work_peer_bad)
 			blacklisted.push_back (i->second.get<std::string> (""));
 		}
 		ASSERT_EQ (2, blacklisted.size ());
-		// Unresolved address gets blacklisted first
-		ASSERT_EQ (address_invalid + ":" + std::to_string (port), blacklisted[0]);
-		ASSERT_EQ (address + ":" + std::to_string (port), blacklisted[1]);
+		ASSERT_NE (blacklisted.end (), std::find (blacklisted.begin (), blacklisted.end (), address_invalid + ":" + std::to_string (port)));
+		ASSERT_NE (blacklisted.end (), std::find (blacklisted.begin (), blacklisted.end (), address + ":" + std::to_string (port)));
 	}
 
 	request.put ("action", "work_peers_reset");
@@ -2733,8 +2732,8 @@ TEST (rpc, work_peer_bad)
 			peers.push_back (i->second.get<std::string> (""));
 		}
 		ASSERT_EQ (2, peers.size ());
-		ASSERT_EQ (address_invalid + ":" + std::to_string (port), peers[0]);
-		ASSERT_EQ (address + ":" + std::to_string (port), peers[1]);
+		ASSERT_NE (peers.end (), std::find (peers.begin (), peers.end (), address_invalid + ":" + std::to_string (port)));
+		ASSERT_NE (peers.end (), std::find (peers.begin (), peers.end (), address + ":" + std::to_string (port)));
 	}
 }
 
@@ -2753,7 +2752,7 @@ TEST (rpc, work_peer_one)
 	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
-	node2.config.work_peers.push_back (std::make_pair (node1.network.endpoint ().address ().to_string (), rpc.config.port));
+	node2.config.work_peers.insert (std::make_pair (node1.network.endpoint ().address ().to_string (), rpc.config.port));
 	nano::keypair key1;
 	uint64_t work (0);
 	node2.work_generate (key1.pub, [&work](uint64_t work_a) {
@@ -2799,9 +2798,9 @@ TEST (rpc, work_peer_many)
 	nano::ipc_rpc_processor ipc_rpc_processor4 (system4.io_ctx, config4);
 	nano::rpc rpc4 (system2.io_ctx, config4, ipc_rpc_processor4);
 	rpc4.start ();
-	node1.config.work_peers.push_back (std::make_pair (node2.network.endpoint ().address ().to_string (), rpc2.config.port));
-	node1.config.work_peers.push_back (std::make_pair (node3.network.endpoint ().address ().to_string (), rpc3.config.port));
-	node1.config.work_peers.push_back (std::make_pair (node4.network.endpoint ().address ().to_string (), rpc4.config.port));
+	node1.config.work_peers.insert (std::make_pair (node2.network.endpoint ().address ().to_string (), rpc2.config.port));
+	node1.config.work_peers.insert (std::make_pair (node3.network.endpoint ().address ().to_string (), rpc3.config.port));
+	node1.config.work_peers.insert (std::make_pair (node4.network.endpoint ().address ().to_string (), rpc4.config.port));
 
 	for (auto i (0); i < 10; ++i)
 	{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2661,12 +2661,12 @@ TEST (rpc, work_peer_bad)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 
-	// Invalid address, will get blacklisted when resolving
+	// Invalid address, will get excluded when resolving
 	std::string address_invalid ("invalid");
 	auto port (0);
 	node1.config.work_peers.insert (std::make_pair (address_invalid, port));
 
-	// Valid address but will get blacklisted when failure in trying to reach it
+	// Valid address but will get excluded when failure in trying to reach it
 	auto address (boost::asio::ip::address_v6::any ().to_string ());
 	node1.config.work_peers.insert (std::make_pair (address, port));
 
@@ -2692,15 +2692,15 @@ TEST (rpc, work_peer_bad)
 		ASSERT_EQ (200, response.status);
 		auto & peers_node (response.json.get_child ("work_peers"));
 		ASSERT_TRUE (peers_node.empty ());
-		auto & blacklisted_node (response.json.get_child ("blacklisted"));
-		std::vector<std::string> blacklisted;
-		for (auto i (blacklisted_node.begin ()), n (blacklisted_node.end ()); i != n; ++i)
+		auto & excluded_node (response.json.get_child ("excluded"));
+		std::vector<std::string> excluded;
+		for (auto i (excluded_node.begin ()), n (excluded_node.end ()); i != n; ++i)
 		{
-			blacklisted.push_back (i->second.get<std::string> (""));
+			excluded.push_back (i->second.get<std::string> (""));
 		}
-		ASSERT_EQ (2, blacklisted.size ());
-		ASSERT_NE (blacklisted.end (), std::find (blacklisted.begin (), blacklisted.end (), address_invalid + ":" + std::to_string (port)));
-		ASSERT_NE (blacklisted.end (), std::find (blacklisted.begin (), blacklisted.end (), address + ":" + std::to_string (port)));
+		ASSERT_EQ (2, excluded.size ());
+		ASSERT_NE (excluded.end (), std::find (excluded.begin (), excluded.end (), address_invalid + ":" + std::to_string (port)));
+		ASSERT_NE (excluded.end (), std::find (excluded.begin (), excluded.end (), address + ":" + std::to_string (port)));
 	}
 
 	request.put ("action", "work_peers_reset");
@@ -2723,8 +2723,8 @@ TEST (rpc, work_peer_bad)
 			ASSERT_NO_ERROR (system.poll ());
 		}
 		ASSERT_EQ (200, response.status);
-		auto & blacklisted_node (response.json.get_child ("blacklisted"));
-		ASSERT_TRUE (blacklisted_node.empty ());
+		auto & excluded_node (response.json.get_child ("excluded"));
+		ASSERT_TRUE (excluded_node.empty ());
 		auto & peers_node (response.json.get_child ("work_peers"));
 		std::vector<std::string> peers;
 		for (auto i (peers_node.begin ()), n (peers_node.end ()); i != n; ++i)


### PR DESCRIPTION
In my network, when a work peer is unavailable, the connection hangs and takes a very long time to timeout, which makes it unusable as the node writes to all peers before falling back to local work generation, so the node itself hangs.

The deadline of 5 seconds, on expiry, closes the socket connection with status 125 (Operation cancelled), and adds the peer to a blacklist in memory only. On resolving addresses, those that error are also added to the list, so that they don't need to be resolved again.

If the failure is temporary due to connection failure (write and read are excluded), it will require a restart of the node, re-adding via RPC `work_peer_add` or using the new RPC `work_peers_reset` (note: not the same as `work_peers_clear`).
