### PR TITLE
Fix failing slow_tests

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1703,7 +1703,9 @@ TEST (node, rep_self_vote)
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
-	auto node0 = system.add_node (node_config);
+	nano::node_flags node_flags;
+	node_flags.delay_frontier_confirmation_height_updating = true;
+	auto node0 = system.add_node (node_config, node_flags);
 	nano::keypair rep_big;
 	{
 		auto transaction0 (node0->store.tx_begin_write ());

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -173,6 +173,9 @@ private:
 
 	friend class confirmation_height_prioritize_frontiers_Test;
 	friend class confirmation_height_prioritize_frontiers_overwrite_Test;
+	friend class confirmation_height_many_accounts_single_confirmation_Test;
+	friend class confirmation_height_many_accounts_many_confirmations_Test;
+	friend class confirmation_height_long_chains_Test;
 };
 
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transactions & active_transactions, const std::string & name);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -320,7 +320,7 @@ TEST (broadcast, world_broadcast_simulate)
 
 TEST (broadcast, sqrt_broadcast_simulate)
 {
-	auto node_count (200);
+	auto node_count (10000);
 	auto broadcast_count (std::ceil (std::sqrt (node_count)));
 	// 0 = starting state
 	// 1 = heard transaction
@@ -388,19 +388,20 @@ TEST (peer_container, random_set)
 	(void)new_ms;
 }
 
+// Can take up to 2 hours
 TEST (store, unchecked_load)
 {
 	nano::system system (24000, 1);
 	auto & node (*system.nodes[0]);
 	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	constexpr auto num_unchecked = 1000000;
 	for (auto i (0); i < 1000000; ++i)
 	{
 		auto transaction (node.store.tx_begin_write ());
 		node.store.unchecked_put (transaction, i, block);
 	}
 	auto transaction (node.store.tx_begin_read ());
-	auto count (node.store.unchecked_count (transaction));
-	(void)count;
+	ASSERT_EQ (num_unchecked, node.store.unchecked_count (transaction));
 }
 
 TEST (store, vote_load)
@@ -454,6 +455,8 @@ TEST (node, mass_vote_by_hash)
 	}
 }
 
+namespace nano
+{
 TEST (confirmation_height, many_accounts_single_confirmation)
 {
 	nano::system system;
@@ -463,6 +466,12 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	node_flags.delay_frontier_confirmation_height_updating = true;
 	auto node = system.add_node (node_config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+
+	// As this test can take a while extend the next frontier check
+	{
+		std::lock_guard<std::mutex> guard (node->active.mutex);
+		node->active.next_frontier_check = std::chrono::steady_clock::now () + 7200s;
+	}
 
 	// The number of frontiers should be more than the batch_write_size to test the amount of blocks confirmed is correct.
 	auto num_accounts = nano::confirmation_height_processor::batch_write_size * 2 + 50;
@@ -475,7 +484,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 			nano::keypair key;
 			system.wallet (0)->insert_adhoc (key.prv);
 
-			nano::send_block send (last_open_hash, key.pub, nano::Gxrb_ratio, last_keypair.prv, last_keypair.pub, system.work.generate (last_open_hash));
+			nano::send_block send (last_open_hash, key.pub, node->config.online_weight_minimum.number (), last_keypair.prv, last_keypair.pub, system.work.generate (last_open_hash));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
 			nano::open_block open (send.hash (), last_keypair.pub, key.pub, key.prv, key.pub, system.work.generate (key.pub));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
@@ -519,6 +528,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_accounts * 2 - 2);
 }
 
+// Can take up to 10 minutes
 TEST (confirmation_height, many_accounts_many_confirmations)
 {
 	nano::system system;
@@ -528,6 +538,12 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	node_flags.delay_frontier_confirmation_height_updating = true;
 	auto node = system.add_node (node_config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+
+	// As this test can take a while extend the next frontier check
+	{
+		std::lock_guard<std::mutex> guard (node->active.mutex);
+		node->active.next_frontier_check = std::chrono::steady_clock::now () + 7200s;
+	}
 
 	auto num_accounts = 10000;
 	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
@@ -539,7 +555,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 			nano::keypair key;
 			system.wallet (0)->insert_adhoc (key.prv);
 
-			nano::send_block send (latest_genesis, key.pub, nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (latest_genesis));
+			nano::send_block send (latest_genesis, key.pub, node->config.online_weight_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (latest_genesis));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
 			auto open = std::make_shared<nano::open_block> (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, system.work.generate (key.pub));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
@@ -571,6 +587,12 @@ TEST (confirmation_height, long_chains)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key1.prv);
+
+	// As this test can take a while extend the next frontier check
+	{
+		std::lock_guard<std::mutex> guard (node->active.mutex);
+		node->active.next_frontier_check = std::chrono::steady_clock::now () + 7200s;
+	}
 
 	constexpr auto num_blocks = 10000;
 
@@ -604,8 +626,9 @@ TEST (confirmation_height, long_chains)
 	nano::send_block send1 (previous_destination_chain_hash, nano::test_genesis_key.pub, nano::Gxrb_ratio - 2, key1.prv, key1.pub, system.work.generate (previous_destination_chain_hash));
 	auto receive1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous_genesis_chain_hash, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio + 1, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (previous_genesis_chain_hash)));
 
-	// Unpocketed
-	nano::state_block send2 (nano::genesis_account, receive1->hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (receive1->hash ()));
+	// Unpocketed. Send to a non-existing account to prevent auto receives from the wallet adjusting expected confirmation height
+	nano::keypair key2;
+	nano::state_block send2 (nano::genesis_account, receive1->hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work.generate (receive1->hash ()));
 
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -645,8 +668,7 @@ TEST (confirmation_height, long_chains)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks * 2 + 2);
 }
 
-namespace nano
-{
+// Can take up to 1 hour
 TEST (confirmation_height, prioritize_frontiers_overwrite)
 {
 	nano::system system;
@@ -659,7 +681,7 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	// As this test can take a while extend the next frontier check
 	{
 		std::lock_guard<std::mutex> guard (node->active.mutex);
-		node->active.next_frontier_check = std::chrono::steady_clock::now () + 3600s;
+		node->active.next_frontier_check = std::chrono::steady_clock::now () + 7200s;
 	}
 
 	auto num_accounts = node->active.max_priority_cementable_frontiers * 2;


### PR DESCRIPTION
`confirmation_height.prioritize_frontiers_overwrite` didn't take into account the new node wallet prioritised frontiers.

The other tests were being hit by the background confirming after the delay (will be solved by the disabled conf height mode in #2175), but have increased the delay for the next frontier confirm request for now anyway.

Also fixes a TSAN error in `node.rep_self_vote`