### PR TITLE
Configurable work watcher period

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -854,10 +854,12 @@ TEST (node_config, v17_v18_upgrade)
 	config.logging.init (path);
 	// These config options should not be present
 	ASSERT_FALSE (tree.get_optional_child ("backup_before_upgrade"));
+	ASSERT_FALSE (tree.get_optional_child ("work_watcher_period"));
 
 	config.deserialize_json (upgraded, tree);
 	// The config options should be added after the upgrade
 	ASSERT_TRUE (!!tree.get_optional_child ("backup_before_upgrade"));
+	ASSERT_TRUE (!!tree.get_optional_child ("work_watcher_period"));
 
 	ASSERT_TRUE (upgraded);
 	auto version (tree.get<std::string> ("version"));
@@ -880,22 +882,26 @@ TEST (node_config, v18_values)
 	{
 		tree.put ("vote_generator_delay", 100);
 		tree.put ("backup_before_upgrade", true);
+		tree.put ("work_watcher_period", 5);
 	}
 
 	config.deserialize_json (upgraded, tree);
 	ASSERT_FALSE (upgraded);
 	ASSERT_EQ (config.vote_generator_delay.count (), 100);
 	ASSERT_EQ (config.backup_before_upgrade, true);
+	ASSERT_EQ (config.work_watcher_period.count (), 5);
 
 	// Check config is correct with other values
 	tree.put ("vote_generator_delay", std::numeric_limits<unsigned long>::max () - 100);
 	tree.put ("backup_before_upgrade", false);
+	tree.put ("work_watcher_period", 999);
 
 	upgraded = false;
 	config.deserialize_json (upgraded, tree);
 	ASSERT_FALSE (upgraded);
 	ASSERT_EQ (config.vote_generator_delay.count (), std::numeric_limits<unsigned long>::max () - 100);
 	ASSERT_EQ (config.backup_before_upgrade, false);
+	ASSERT_EQ (config.work_watcher_period.count (), 999);
 }
 
 // Regression test to ensure that deserializing includes changes node via get_required_child

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -450,6 +450,10 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("vote_generator_threshold must be a number between 1 and 11");
 		}
+		if (work_watcher_period < std::chrono::seconds (1))
+		{
+			json.get_error ().set ("work_watcher_period must be equal or larger than 1");
+		}
 	}
 	catch (std::runtime_error const & ex)
 	{

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -132,6 +132,7 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("active_elections_size", active_elections_size);
 	json.put ("bandwidth_limit", bandwidth_limit);
 	json.put ("backup_before_upgrade", backup_before_upgrade);
+	json.put ("work_watcher_period", work_watcher_period.count ());
 
 	return json.get_error ();
 }
@@ -259,6 +260,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 		{
 			json.put ("vote_generator_delay", vote_generator_delay.count ()); // Update value
 			json.put ("backup_before_upgrade", backup_before_upgrade);
+			json.put ("work_watcher_period", work_watcher_period.count ());
 		}
 		case 18:
 			break;
@@ -413,6 +415,10 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<size_t> ("active_elections_size", active_elections_size);
 		json.get<size_t> ("bandwidth_limit", bandwidth_limit);
 		json.get<bool> ("backup_before_upgrade", backup_before_upgrade);
+
+		auto work_watcher_period_l = work_watcher_period.count ();
+		json.get ("work_watcher_period", work_watcher_period_l);
+		work_watcher_period = std::chrono::seconds (work_watcher_period_l);
 
 		auto conf_height_processor_batch_min_time_l (conf_height_processor_batch_min_time.count ());
 		json.get ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time_l);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -78,6 +78,7 @@ public:
 	size_t bandwidth_limit{ 5 * 1024 * 1024 }; // 5Mb/s
 	std::chrono::milliseconds conf_height_processor_batch_min_time{ 50 };
 	bool backup_before_upgrade{ false };
+	std::chrono::seconds work_watcher_period{ std::chrono::seconds (5) };
 	static unsigned json_version ()
 	{
 		return 18;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1518,9 +1518,12 @@ void nano::work_watcher::run ()
 			}
 		}
 
-		condition.wait_until (lock, next_attempt, [this, &next_attempt]() {
-			return stopped || next_attempt < std::chrono::steady_clock::now ();
-		});
+		if (!stopped)
+		{
+			condition.wait_until (lock, next_attempt, [this, &next_attempt]() {
+				return stopped || next_attempt < std::chrono::steady_clock::now ();
+			});
+		}
 	} // !stopped
 }
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1424,7 +1424,7 @@ void nano::work_watcher::run ()
 	std::chrono::steady_clock::time_point next_attempt;
 	while (!stopped)
 	{
-		next_attempt = std::chrono::steady_clock::now () + std::chrono::seconds (5);
+		next_attempt = std::chrono::steady_clock::now () + node.config.work_watcher_period;
 		for (auto i (blocks.begin ()), n (blocks.end ()); i != n;)
 		{
 			std::unique_lock<std::mutex> active_lock (node.active.mutex);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1424,9 +1424,6 @@ void nano::work_watcher::run ()
 	std::chrono::steady_clock::time_point next_attempt;
 	while (!stopped)
 	{
-		condition.wait_until (lock, next_attempt, [this, &next_attempt]() {
-			return stopped || next_attempt < std::chrono::steady_clock::now ();
-		});
 		next_attempt = std::chrono::steady_clock::now () + std::chrono::seconds (5);
 		for (auto i (blocks.begin ()), n (blocks.end ()); i != n;)
 		{
@@ -1520,6 +1517,10 @@ void nano::work_watcher::run ()
 				}
 			}
 		}
+
+		condition.wait_until (lock, next_attempt, [this, &next_attempt]() {
+			return stopped || next_attempt < std::chrono::steady_clock::now ();
+		});
 	} // !stopped
 }
 


### PR DESCRIPTION
New option `work_watcher_period` defaulting to 5 seconds.

Also moved the `condition.wait` to the end of the loop so that `stopped` is checked before going through blocks.