### PR TITLE
Set application/json as header content type for work peer requests

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1019,6 +1019,7 @@ public:
 							}
 							auto request (std::make_shared<boost::beast::http::request<boost::beast::http::string_body>> ());
 							request->method (boost::beast::http::verb::post);
+							request->set (boost::beast::http::field::content_type, "application/json");
 							request->target ("/");
 							request->version (11);
 							request->body () = request_string;
@@ -1086,6 +1087,7 @@ public:
 				}
 				boost::beast::http::request<boost::beast::http::string_body> request;
 				request.method (boost::beast::http::verb::post);
+				request.set (boost::beast::http::field::content_type, "application/json");
 				request.target ("/");
 				request.version (11);
 				request.body () = request_string;


### PR DESCRIPTION
Closes #2224 
Tested with a work peer requiring the header.