### PR TITLE
Reduce time holding read transaction in vote processor

### DIFF
--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -64,6 +64,7 @@ void nano::vote_processor::process_loop ()
 					if (count % 100 == 0)
 					{
 						active_single_lock.unlock ();
+						transaction.refresh ();
 						active_single_lock.lock ();
 					}
 					count++;


### PR DESCRIPTION
The read transaction is refreshed after 100 votes (like the active mutex)

Before (using the database txn tracker config option):
>[2019-Aug-20 18:37:07.195274]: 8913ms read held on thread Vote processing
[2019-Aug-20 18:37:07.195274]: Processed 1080 votes in 9719 milliseconds (rate of 111 votes per second)

After the changes, it was left running for 10x longer and no long read transactions were held in the vote processor. Even with:
> Processed 4608 votes in 36809 milliseconds (rate of 125 votes per second)