### PR TITLE
update beta network header_magic_number to finalize beta network reset

### DIFF
--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -67,7 +67,7 @@ network (network_a), ledger (network), voting (network), node (network), portmap
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_test_work = 8;
 	kdf_work = network.is_test_network () ? kdf_test_work : kdf_full_work;
-	header_magic_number = network.is_test_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'R', 'B' } } : std::array<uint8_t, 2>{ { 'R', 'C' } };
+	header_magic_number = network.is_test_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'N', 'B' } } : std::array<uint8_t, 2>{ { 'R', 'C' } };
 }
 
 nano::ledger_constants::ledger_constants (nano::network_constants & network_constants) :


### PR DESCRIPTION
Update beta network header_magic_number to finalize de-peering of pre beta reset nodes