### PR TITLE
Fixes account_history RPC to include receive blocks when filtering accounts.

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2134,7 +2134,8 @@ public:
 			}
 			else
 			{
-				if (should_ignore_account (block_a.hashables.link))
+				auto account (handler.node.ledger.account (transaction, block_a.hashables.link));
+				if (should_ignore_account (account))
 				{
 					tree.clear ();
 					return;
@@ -2147,7 +2148,7 @@ public:
 				{
 					tree.put ("type", "receive");
 				}
-				tree.put ("account", handler.node.ledger.account (transaction, block_a.hashables.link).to_account ());
+				tree.put ("account", account.to_account ());
 				tree.put ("amount", (balance - previous_balance).convert_to<std::string> ());
 			}
 		}


### PR DESCRIPTION
Previously receive blocks were filtered out as it was comparing link hash instead of link as account.

Also added test case for receive blocks in addition to existing send block test case.