### PR TITLE
Move protocol versions to network_params

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -744,10 +744,10 @@ TEST (votes, check_signature)
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
 	auto transaction (node1.store.tx_begin_read ());
-	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (transaction, vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0))));
+	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (transaction, vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0), node1.network_params.protocol.protocol_version)));
 	vote1->signature.bytes[0] ^= 1;
-	ASSERT_EQ (nano::vote_code::vote, node1.vote_processor.vote_blocking (transaction, vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0))));
-	ASSERT_EQ (nano::vote_code::replay, node1.vote_processor.vote_blocking (transaction, vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0))));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_processor.vote_blocking (transaction, vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0), node1.network_params.protocol.protocol_version)));
+	ASSERT_EQ (nano::vote_code::replay, node1.vote_processor.vote_blocking (transaction, vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0), node1.network_params.protocol.protocol_version)));
 }
 
 TEST (votes, add_one)
@@ -876,7 +876,7 @@ TEST (votes, add_old)
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
 	std::lock_guard<std::mutex> lock (node1.active.mutex);
 	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
-	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
+	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
@@ -913,7 +913,7 @@ TEST (votes, add_old_different_account)
 	ASSERT_EQ (1, votes1->last_votes.size ());
 	ASSERT_EQ (1, votes2->last_votes.size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
-	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
+	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	auto vote_result1 (node1.vote_processor.vote_blocking (transaction, vote1, channel));
 	ASSERT_EQ (nano::vote_code::vote, vote_result1);
 	ASSERT_EQ (2, votes1->last_votes.size ());
@@ -948,7 +948,7 @@ TEST (votes, add_cooldown)
 	std::unique_lock<std::mutex> lock (node1.active.mutex);
 	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
-	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint ()));
+	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -40,6 +40,7 @@ TEST (message, keepalive_deserialize)
 
 TEST (message, publish_serialization)
 {
+	nano::network_params params;
 	nano::publish publish (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	ASSERT_EQ (nano::block_type::send, publish.header.block_type ());
 	std::vector<uint8_t> bytes;
@@ -50,9 +51,9 @@ TEST (message, publish_serialization)
 	ASSERT_EQ (8, bytes.size ());
 	ASSERT_EQ (0x52, bytes[0]);
 	ASSERT_EQ (0x41, bytes[1]);
-	ASSERT_EQ (nano::protocol_version, bytes[2]);
-	ASSERT_EQ (nano::protocol_version, bytes[3]);
-	ASSERT_EQ (nano::protocol_version_min, bytes[4]);
+	ASSERT_EQ (params.protocol.protocol_version, bytes[2]);
+	ASSERT_EQ (params.protocol.protocol_version, bytes[3]);
+	ASSERT_EQ (params.protocol.protocol_version_min, bytes[4]);
 	ASSERT_EQ (static_cast<uint8_t> (nano::message_type::publish), bytes[5]);
 	ASSERT_EQ (0x00, bytes[6]); // extensions
 	ASSERT_EQ (static_cast<uint8_t> (nano::block_type::send), bytes[7]);
@@ -60,9 +61,9 @@ TEST (message, publish_serialization)
 	auto error (false);
 	nano::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::protocol_version_min, header.version_min);
-	ASSERT_EQ (nano::protocol_version, header.version_using);
-	ASSERT_EQ (nano::protocol_version, header.version_max);
+	ASSERT_EQ (params.protocol.protocol_version_min, header.version_min);
+	ASSERT_EQ (params.protocol.protocol_version, header.version_using);
+	ASSERT_EQ (params.protocol.protocol_version, header.version_max);
 	ASSERT_EQ (nano::message_type::publish, header.type);
 }
 

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -76,7 +76,7 @@ TEST (network, send_node_id_handshake)
 	system.nodes.push_back (node1);
 	auto initial (system.nodes[0]->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in));
 	auto initial_node1 (node1->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in));
-	auto channel (std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, node1->network.endpoint ()));
+	auto channel (std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, node1->network.endpoint (), node1->network_params.protocol.protocol_version));
 	system.nodes[0]->network.send_keepalive (channel);
 	ASSERT_EQ (0, system.nodes[0]->network.size ());
 	ASSERT_EQ (0, node1->network.size ());
@@ -165,7 +165,7 @@ TEST (network, last_contacted)
 	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, nano::endpoint (boost::asio::ip::address_v6::loopback (), 24000)));
+	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, nano::endpoint (boost::asio::ip::address_v6::loopback (), 24000), node1->network_params.protocol.protocol_version));
 	node1->network.send_keepalive (channel1);
 	system.deadline_set (10s);
 
@@ -202,7 +202,7 @@ TEST (network, multi_keepalive)
 	node1->start ();
 	system.nodes.push_back (node1);
 	ASSERT_EQ (0, node1->network.size ());
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, system.nodes[0]->network.endpoint ()));
+	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version));
 	node1->network.send_keepalive (channel1);
 	ASSERT_EQ (0, node1->network.size ());
 	ASSERT_EQ (0, system.nodes[0]->network.size ());
@@ -216,7 +216,7 @@ TEST (network, multi_keepalive)
 	ASSERT_FALSE (init2.error ());
 	node2->start ();
 	system.nodes.push_back (node2);
-	auto channel2 (std::make_shared<nano::transport::channel_udp> (node2->network.udp_channels, system.nodes[0]->network.endpoint ()));
+	auto channel2 (std::make_shared<nano::transport::channel_udp> (node2->network.udp_channels, system.nodes[0]->network.endpoint (), node2->network_params.protocol.protocol_version));
 	node2->network.send_keepalive (channel2);
 	system.deadline_set (10s);
 	while (node1->network.size () != 2 || system.nodes[0]->network.size () != 2 || node2->network.size () != 2)
@@ -330,7 +330,7 @@ TEST (network, send_insufficient_work)
 	auto block (std::make_shared<nano::send_block> (0, 1, 20, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	nano::publish publish (block);
 	auto node1 (system.nodes[1]->shared ());
-	nano::transport::channel_udp channel (system.nodes[0]->network.udp_channels, system.nodes[1]->network.endpoint ());
+	nano::transport::channel_udp channel (system.nodes[0]->network.udp_channels, system.nodes[1]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version);
 	channel.send (publish, [](boost::system::error_code const & ec, size_t size) {});
 	ASSERT_EQ (0, system.nodes[0]->stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
 	system.deadline_set (10s);
@@ -843,7 +843,7 @@ TEST (bootstrap_processor, lazy_hash)
 	system.nodes[0]->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), nano::protocol_version);
+	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash ());
 	// Check processed blocks
 	system.deadline_set (10s);
@@ -880,7 +880,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	system.nodes[0]->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), nano::protocol_version);
+	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
 	system.deadline_set (10s);
@@ -911,7 +911,7 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	system.nodes[0]->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), nano::protocol_version);
+	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
 	auto wallet (node1->wallets.create (nano::uint256_union ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -943,7 +943,7 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	system.nodes[0]->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), nano::protocol_version);
+	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
 	auto wallet (node1->wallets.create (nano::uint256_union ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -2334,7 +2334,7 @@ TEST (network, replace_port)
 	node1->start ();
 	system.nodes.push_back (node1);
 	{
-		auto channel (system.nodes[0]->network.udp_channels.insert (nano::endpoint (node1->network.endpoint ().address (), 23000), nano::protocol_version));
+		auto channel (system.nodes[0]->network.udp_channels.insert (nano::endpoint (node1->network.endpoint ().address (), 23000), node1->network_params.protocol.protocol_version));
 		if (channel)
 		{
 			channel->set_node_id (node1->node_id.pub);
@@ -2342,7 +2342,7 @@ TEST (network, replace_port)
 	}
 	auto peers_list (system.nodes[0]->network.list (std::numeric_limits<size_t>::max ()));
 	ASSERT_EQ (peers_list[0]->get_node_id (), node1->node_id.pub);
-	auto channel (std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, node1->network.endpoint ()));
+	auto channel (std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, node1->network.endpoint (), node1->network_params.protocol.protocol_version));
 	system.nodes[0]->network.send_keepalive (channel);
 	system.deadline_set (5s);
 	while (!system.nodes[0]->network.udp_channels.channel (node1->network.endpoint ()))

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -21,9 +21,9 @@ TEST (peer_container, no_recontact)
 	ASSERT_EQ (0, network.size ());
 	network.channel_observer = [&observed_peer](std::shared_ptr<nano::transport::channel>) { ++observed_peer; };
 	system.nodes[0]->network.disconnect_observer = [&observed_disconnect]() { observed_disconnect = true; };
-	auto channel (network.udp_channels.insert (endpoint1, nano::protocol_version));
+	auto channel (network.udp_channels.insert (endpoint1, system.nodes[0]->network_params.protocol.protocol_version));
 	ASSERT_EQ (1, network.size ());
-	ASSERT_EQ (channel, network.udp_channels.insert (endpoint1, nano::protocol_version));
+	ASSERT_EQ (channel, network.udp_channels.insert (endpoint1, system.nodes[0]->network_params.protocol.protocol_version));
 	system.nodes[0]->network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (5));
 	ASSERT_TRUE (network.empty ());
 	ASSERT_EQ (1, observed_peer);
@@ -121,7 +121,7 @@ TEST (peer_container, list_fanout)
 	ASSERT_TRUE (list1.empty ());
 	for (auto i (0); i < 1000; ++i)
 	{
-		ASSERT_NE (nullptr, system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000 + i), nano::protocol_version));
+		ASSERT_NE (nullptr, system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000 + i), system.nodes[0]->network_params.protocol.protocol_version));
 	}
 	auto list2 (system.nodes[0]->network.list_fanout ());
 	ASSERT_EQ (32, list2.size ());
@@ -133,7 +133,7 @@ TEST (peer_container, reachout)
 	nano::system system (24000, 1);
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), 24000);
 	// Make sure having been contacted by them already indicates we shouldn't reach out
-	system.nodes[0]->network.udp_channels.insert (endpoint0, nano::protocol_version);
+	system.nodes[0]->network.udp_channels.insert (endpoint0, system.nodes[0]->network_params.protocol.protocol_version);
 	ASSERT_TRUE (system.nodes[0]->network.reachout (endpoint0));
 	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), 24001);
 	ASSERT_FALSE (system.nodes[0]->network.reachout (endpoint1));

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -764,7 +764,7 @@ int main (int argc, char * const * argv)
 			while (!votes.empty ())
 			{
 				auto vote (votes.front ());
-				auto channel (std::make_shared<nano::transport::channel_udp> (node->network.udp_channels, node->network.endpoint ()));
+				auto channel (std::make_shared<nano::transport::channel_udp> (node->network.udp_channels, node->network.endpoint (), node->network_params.protocol.protocol_version));
 				node->vote_processor.vote (vote, channel);
 				votes.pop_front ();
 			}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -242,7 +242,7 @@ void nano::active_transactions::request_confirm (std::unique_lock<std::mutex> & 
 				auto single_confirm_req_channels (std::make_shared<std::vector<std::shared_ptr<nano::transport::channel>>> ());
 				for (auto & rep : *rep_channels)
 				{
-					if (rep->get_network_version () >= nano::tcp_realtime_protocol_version_min)
+					if (rep->get_network_version () >= node.network_params.protocol.tcp_realtime_protocol_version_min)
 					{
 						// Send batch request to peers supporting confirm_req by hash + root
 						auto rep_request (requests_bundle.find (rep));

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1683,7 +1683,7 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 {
 	if (add_to_peers)
 	{
-		node.network.udp_channels.insert (nano::transport::map_endpoint_to_v6 (endpoint_a), nano::protocol_version);
+		node.network.udp_channels.insert (nano::transport::map_endpoint_to_v6 (endpoint_a), node.network_params.protocol.protocol_version);
 	}
 	std::unique_lock<std::mutex> lock (mutex);
 	if (!stopped)

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -10,11 +10,18 @@
 
 std::bitset<16> constexpr nano::message_header::block_type_mask;
 std::bitset<16> constexpr nano::message_header::count_mask;
-
+namespace
+{
+nano::protocol_constants const & get_protocol_constants ()
+{
+	static nano::network_params params;
+	return params.protocol;
+}
+}
 nano::message_header::message_header (nano::message_type type_a) :
-version_max (nano::protocol_version),
-version_using (nano::protocol_version),
-version_min (nano::protocol_version_min),
+version_max (get_protocol_constants ().protocol_version),
+version_using (get_protocol_constants ().protocol_version),
+version_min (get_protocol_constants ().protocol_version_min),
 type (type_a)
 {
 }
@@ -278,11 +285,7 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 		nano::message_header header (error, stream);
 		if (!error)
 		{
-			if (network_constants.is_beta_network () && header.version_using < nano::protocol_version_reasonable_min)
-			{
-				status = parse_status::outdated_version;
-			}
-			else if (header.version_using < nano::protocol_version_min)
+			if (header.version_using < get_protocol_constants ().protocol_version_min)
 			{
 				status = parse_status::outdated_version;
 			}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -27,7 +27,7 @@ void nano::election::compute_rep_votes (nano::transaction const & transaction_a)
 	{
 		node.wallets.foreach_representative (transaction_a, [this, &transaction_a](nano::public_key const & pub_a, nano::raw_key const & prv_a) {
 			auto vote (this->node.store.vote_generate (transaction_a, pub_a, prv_a, status.winner));
-			this->node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (this->node.network.udp_channels, this->node.network.endpoint ()));
+			this->node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (this->node.network.udp_channels, this->node.network.endpoint (), this->node.network_params.protocol.protocol_version));
 		});
 	}
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3785,7 +3785,7 @@ void nano::json_handler::version ()
 {
 	response_l.put ("rpc_version", "1");
 	response_l.put ("store_version", std::to_string (node.store_version ()));
-	response_l.put ("protocol_version", std::to_string (nano::protocol_version));
+	response_l.put ("protocol_version", std::to_string (node.network_params.protocol.protocol_version));
 	response_l.put ("node_vendor", boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING));
 	response_l.put ("network", node.network_params.network.get_current_network_as_string ());
 	response_l.put ("network_identifier", nano::genesis ().hash ().to_string ());

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -246,7 +246,7 @@ void nano::network::flood_block_batch (std::deque<std::shared_ptr<nano::block>> 
 void nano::network::send_confirm_req (std::shared_ptr<nano::transport::channel> channel_a, std::shared_ptr<nano::block> block_a)
 {
 	// Confirmation request with hash + root
-	if (channel_a->get_network_version () >= nano::tcp_realtime_protocol_version_min)
+	if (channel_a->get_network_version () >= node.network_params.protocol.tcp_realtime_protocol_version_min)
 	{
 		nano::confirm_req req (block_a->hash (), block_a->root ());
 		channel_a->send (req);
@@ -689,7 +689,7 @@ nano::tcp_endpoint nano::network::bootstrap_peer ()
 	bool use_udp_peer (nano::random_pool::generate_word32 (0, 1));
 	if (use_udp_peer || tcp_channels.size () == 0)
 	{
-		result = udp_channels.bootstrap_peer ();
+		result = udp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_bootstrap_min);
 	}
 	if (result == nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0))
 	{

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<nano::node> nano::system::add_node (nano::node_config const & no
 			else
 			{
 				// UDP connection
-				auto channel (std::make_shared<nano::transport::channel_udp> ((*j)->network.udp_channels, (*i)->network.endpoint ()));
+				auto channel (std::make_shared<nano::transport::channel_udp> ((*j)->network.udp_channels, (*i)->network.endpoint (), node1->network_params.protocol.protocol_version));
 				(*j)->network.send_keepalive (channel);
 			}
 			do

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -224,7 +224,7 @@ nano::tcp_endpoint nano::transport::tcp_channels::bootstrap_peer ()
 	std::lock_guard<std::mutex> lock (mutex);
 	for (auto i (channels.get<last_bootstrap_attempt_tag> ().begin ()), n (channels.get<last_bootstrap_attempt_tag> ().end ()); i != n;)
 	{
-		if (i->channel->get_network_version () >= protocol_version_reasonable_min)
+		if (i->channel->get_network_version () >= node.network_params.protocol.protocol_version_bootstrap_min)
 		{
 			result = i->endpoint ();
 			channels.get<last_bootstrap_attempt_tag> ().modify (i, [](channel_tcp_wrapper & wrapper_a) {
@@ -312,7 +312,7 @@ void nano::transport::tcp_channels::process_keepalive (nano::keepalive const & m
 		{
 			node.network.response_channels.add (endpoint_a, insert_response_channels);
 		}
-		auto udp_channel (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, nano::transport::map_tcp_to_endpoint (endpoint_a)));
+		auto udp_channel (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, nano::transport::map_tcp_to_endpoint (endpoint_a), node.network_params.protocol.protocol_version));
 		node.network.process_message (message_a, udp_channel);
 	}
 }
@@ -418,7 +418,7 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 		size_t random_count (std::min (static_cast<size_t> (6), static_cast<size_t> (std::ceil (std::sqrt (node.network.udp_channels.size ())))));
 		for (auto i (0); i <= random_count; ++i)
 		{
-			auto tcp_endpoint (node.network.udp_channels.bootstrap_peer (nano::tcp_realtime_protocol_version_min));
+			auto tcp_endpoint (node.network.udp_channels.bootstrap_peer (node.network_params.protocol.tcp_realtime_protocol_version_min));
 			if (tcp_endpoint != invalid_endpoint && find_channel (tcp_endpoint) == nullptr)
 			{
 				start_tcp (nano::transport::map_tcp_to_endpoint (tcp_endpoint));
@@ -534,7 +534,7 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 				auto error (false);
 				nano::bufferstream stream (receive_buffer_a->data (), size_a);
 				nano::message_header header (error, stream);
-				if (!error && header.type == nano::message_type::node_id_handshake && header.version_using >= nano::protocol_version_min)
+				if (!error && header.type == nano::message_type::node_id_handshake && header.version_using >= node_l->network_params.protocol.protocol_version_min)
 				{
 					nano::node_id_handshake message (error, stream, header);
 					if (!error && message.response && message.query)

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -73,6 +73,7 @@ nano::transport::channel::channel (nano::node & node_a) :
 limiter (node_a.config.bandwidth_limit),
 node (node_a)
 {
+	set_network_version (node_a.network_params.protocol.protocol_version);
 }
 
 void nano::transport::channel::send (nano::message const & message_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, bool const is_droppable_a)

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -122,12 +122,12 @@ namespace transport
 			node_id = node_id_a;
 		}
 
-		unsigned get_network_version () const
+		uint8_t get_network_version () const
 		{
 			return network_version;
 		}
 
-		void set_network_version (unsigned network_version_a)
+		void set_network_version (uint8_t network_version_a)
 		{
 			network_version = network_version_a;
 		}
@@ -140,7 +140,7 @@ namespace transport
 		std::chrono::steady_clock::time_point last_packet_received{ std::chrono::steady_clock::time_point () };
 		std::chrono::steady_clock::time_point last_packet_sent{ std::chrono::steady_clock::time_point () };
 		boost::optional<nano::account> node_id{ boost::none };
-		std::atomic<unsigned> network_version{ nano::protocol_version };
+		std::atomic<uint8_t> network_version{ 0 };
 
 	protected:
 		nano::node & node;

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -3,12 +3,12 @@
 #include <nano/node/node.hpp>
 #include <nano/node/transport/udp.hpp>
 
-nano::transport::channel_udp::channel_udp (nano::transport::udp_channels & channels_a, nano::endpoint const & endpoint_a, unsigned network_version_a) :
+nano::transport::channel_udp::channel_udp (nano::transport::udp_channels & channels_a, nano::endpoint const & endpoint_a, uint8_t protocol_version_a) :
 channel (channels_a.node),
 endpoint (endpoint_a),
 channels (channels_a)
 {
-	set_network_version (network_version_a);
+	set_network_version (protocol_version_a);
 	assert (endpoint_a.address ().is_v6 ());
 }
 
@@ -368,7 +368,7 @@ public:
 				else if (!node.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (endpoint)))
 				{
 					// Don't start connection if TCP channel to same IP:port exists
-					find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint);
+					find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint, node.network_params.protocol.protocol_version);
 					node.network.send_node_id_handshake (find_channel, *cookie, boost::none);
 				}
 			}
@@ -455,7 +455,7 @@ public:
 			auto find_channel (node.network.udp_channels.channel (endpoint));
 			if (!find_channel)
 			{
-				find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint);
+				find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint, node.network_params.protocol.protocol_version);
 			}
 			node.network.send_node_id_handshake (find_channel, out_query, out_respond_to);
 		}
@@ -574,7 +574,7 @@ void nano::transport::udp_channels::process_packets ()
 
 std::shared_ptr<nano::transport::channel> nano::transport::udp_channels::create (nano::endpoint const & endpoint_a)
 {
-	return std::make_shared<nano::transport::channel_udp> (*this, endpoint_a);
+	return std::make_shared<nano::transport::channel_udp> (*this, endpoint_a, node.network_params.protocol.protocol_version);
 }
 
 bool nano::transport::udp_channels::max_ip_connections (nano::endpoint const & endpoint_a)

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -24,7 +24,7 @@ namespace transport
 		friend class nano::transport::udp_channels;
 
 	public:
-		channel_udp (nano::transport::udp_channels &, nano::endpoint const &, unsigned = nano::protocol_version);
+		channel_udp (nano::transport::udp_channels &, nano::endpoint const &, uint8_t protocol_version);
 		size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
 		void send_buffer (std::shared_ptr<std::vector<uint8_t>>, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) override;
@@ -73,7 +73,7 @@ namespace transport
 		void clean_node_id (nano::account const &);
 		void clean_node_id (nano::endpoint const &, nano::account const &);
 		// Get the next peer for attempting a tcp bootstrap connection
-		nano::tcp_endpoint bootstrap_peer (uint8_t connection_protocol_version_min = nano::protocol_version_reasonable_min);
+		nano::tcp_endpoint bootstrap_peer (uint8_t connection_protocol_version_min);
 		void receive ();
 		void start ();
 		void stop ();

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -53,7 +53,7 @@ void nano::vote_generator::send (std::unique_lock<std::mutex> & lock_a)
 		auto transaction (node.store.tx_begin_read ());
 		node.wallets.foreach_representative (transaction, [this, &hashes_l, &transaction](nano::public_key const & pub_a, nano::raw_key const & prv_a) {
 			auto vote (this->node.store.vote_generate (transaction, pub_a, prv_a, hashes_l));
-			this->node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (this->node.network.udp_channels, this->node.network.endpoint ()));
+			this->node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (this->node.network.udp_channels, this->node.network.endpoint (), this->node.network_params.protocol.protocol_version));
 			this->node.votes_cache.add (vote);
 		});
 	}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2291,7 +2291,7 @@ TEST (rpc, peers)
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::endpoint endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
 	auto node = system.nodes.front ();
-	node->network.udp_channels.insert (endpoint, nano::protocol_version);
+	node->network.udp_channels.insert (endpoint, node->network_params.protocol.protocol_version);
 	enable_ipc_transport_tcp (node->config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -2310,11 +2310,11 @@ TEST (rpc, peers)
 	ASSERT_EQ (200, response.status);
 	auto & peers_node (response.json.get_child ("peers"));
 	ASSERT_EQ (2, peers_node.size ());
-	ASSERT_EQ (std::to_string (nano::protocol_version), peers_node.get<std::string> ("[::1]:24001"));
+	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), peers_node.get<std::string> ("[::1]:24001"));
 	// Previously "[::ffff:80.80.80.80]:4000", but IPv4 address cause "No such node thrown in the test body" issue with peers_node.get
 	std::stringstream endpoint_text;
 	endpoint_text << endpoint;
-	ASSERT_EQ (std::to_string (nano::protocol_version), peers_node.get<std::string> (endpoint_text.str ()));
+	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), peers_node.get<std::string> (endpoint_text.str ()));
 }
 
 TEST (rpc, peers_node_id)
@@ -2323,7 +2323,7 @@ TEST (rpc, peers_node_id)
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::endpoint endpoint (boost::asio::ip::address_v6::from_string ("fc00::1"), 4000);
 	auto node = system.nodes.front ();
-	node->network.udp_channels.insert (endpoint, nano::protocol_version);
+	node->network.udp_channels.insert (endpoint, node->network_params.protocol.protocol_version);
 	enable_ipc_transport_tcp (node->config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -2344,12 +2344,12 @@ TEST (rpc, peers_node_id)
 	auto & peers_node (response.json.get_child ("peers"));
 	ASSERT_EQ (2, peers_node.size ());
 	auto tree1 (peers_node.get_child ("[::1]:24001"));
-	ASSERT_EQ (std::to_string (nano::protocol_version), tree1.get<std::string> ("protocol_version"));
+	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), tree1.get<std::string> ("protocol_version"));
 	ASSERT_EQ (system.nodes[1]->node_id.pub.to_node_id (), tree1.get<std::string> ("node_id"));
 	std::stringstream endpoint_text;
 	endpoint_text << endpoint;
 	auto tree2 (peers_node.get_child (endpoint_text.str ()));
-	ASSERT_EQ (std::to_string (nano::protocol_version), tree2.get<std::string> ("protocol_version"));
+	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), tree2.get<std::string> ("protocol_version"));
 	ASSERT_EQ ("", tree2.get<std::string> ("node_id"));
 }
 
@@ -2561,7 +2561,7 @@ TEST (rpc, version)
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_EQ (std::to_string (node1->store.version_get (transaction)), response1.json.get<std::string> ("store_version"));
 	}
-	ASSERT_EQ (std::to_string (nano::protocol_version), response1.json.get<std::string> ("protocol_version"));
+	ASSERT_EQ (std::to_string (node1->network_params.protocol.protocol_version), response1.json.get<std::string> ("protocol_version"));
 	ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING), response1.json.get<std::string> ("node_vendor"));
 	auto network_label (node1->network_params.network.get_current_network_as_string ());
 	ASSERT_EQ (network_label, response1.json.get<std::string> ("network"));

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -62,12 +62,16 @@ network_params (network_constants::active_network)
 }
 
 nano::network_params::network_params (nano::nano_networks network_a) :
-network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
+network (network_a), protocol (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
 {
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_test_work = 8;
 	kdf_work = network.is_test_network () ? kdf_test_work : kdf_full_work;
 	header_magic_number = network.is_test_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'N', 'B' } } : std::array<uint8_t, 2>{ { 'R', 'C' } };
+}
+
+nano::protocol_constants::protocol_constants (nano::nano_networks network_a)
+{
 }
 
 nano::ledger_constants::ledger_constants (nano::network_constants & network_constants) :

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -37,21 +37,6 @@ struct hash<::nano::uint512_union>
 }
 namespace nano
 {
-const uint8_t protocol_version = 0x11;
-const uint8_t protocol_version_min = 0x0d;
-
-/*
- * Do not bootstrap from nodes older than this version.
- * Also, on the beta network do not process messages from
- * nodes older than this version.
- */
-const uint8_t protocol_version_reasonable_min = 0x0d;
-
-/*
- * Do not start TCP realtime network connections to nodes older than this version
- */
-const uint8_t tcp_realtime_protocol_version_min = 0x11;
-
 /**
  * A key pair. The private key is generated from the random pool, or passed in
  * as a hex string. The public key is derived using ed25519.
@@ -316,6 +301,25 @@ public:
 
 class network_params;
 
+/** Protocol versions whose value may depend on the active network */
+class protocol_constants
+{
+public:
+	protocol_constants (nano::nano_networks network_a);
+
+	/** Current protocol version */
+	uint8_t protocol_version = 0x11;
+
+	/** Minimum accepted protocol version */
+	uint8_t protocol_version_min = 0x0d;
+
+	/** Do not bootstrap from nodes older than this version. */
+	uint8_t protocol_version_bootstrap_min = 0x0d;
+
+	/** Do not start TCP realtime network connections to nodes older than this version */
+	uint8_t tcp_realtime_protocol_version_min = 0x11;
+};
+
 /** Genesis keys and ledger constants for network variants */
 class ledger_constants
 {
@@ -406,6 +410,7 @@ public:
 	std::array<uint8_t, 2> header_magic_number;
 	unsigned kdf_work;
 	network_constants network;
+	protocol_constants protocol;
 	ledger_constants ledger;
 	random_constants random;
 	voting_constants voting;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -59,7 +59,7 @@ TEST (system, receive_while_synchronizing)
 		nano::node_init init1;
 		auto node1 (std::make_shared<nano::node> (init1, system.io_ctx, 24001, nano::unique_path (), system.alarm, system.logging, system.work));
 		ASSERT_FALSE (init1.error ());
-		auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, system.nodes[0]->network.endpoint ()));
+		auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version));
 		node1->network.send_keepalive (channel);
 		auto wallet (node1->wallets.create (1));
 		wallet->insert_adhoc (nano::test_genesis_key.prv); // For voting
@@ -412,7 +412,7 @@ TEST (store, vote_load)
 	for (auto i (0); i < 1000000; ++i)
 	{
 		auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, i, block));
-		node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint ()));
+		node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
 	}
 }
 


### PR DESCRIPTION
Make protocol versions depend on network. Currently same value on all networks, but this can be changed, i.e. depeer by minimum version only on beta. This allowed the removal of `protocol_version_reasonable_min`. Most changes are due to removal of default arguments (which are no longer constants) and replacing nano::version -> network_params.