### PR TITLE
Fix some time-related configs being overriden with 0

### DIFF
--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -135,9 +135,9 @@ nano::error nano::logging::deserialize_toml (nano::tomlconfig & toml)
 	toml.get<bool> ("single_line_record", single_line_record_value);
 	toml.get<uintmax_t> ("max_size", max_size);
 	toml.get<uintmax_t> ("rotation_size", rotation_size);
-	uintmax_t min_time_between_log_output_raw;
-	toml.get<uintmax_t> ("min_time_between_output", min_time_between_log_output_raw);
-	min_time_between_log_output = std::chrono::milliseconds (min_time_between_log_output_raw);
+	auto min_time_between_log_output_l = min_time_between_log_output.count ();
+	toml.get ("min_time_between_output", min_time_between_log_output_l);
+	min_time_between_log_output = std::chrono::milliseconds (min_time_between_log_output_l);
 
 	return toml.get_error ();
 }

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -257,8 +257,10 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 
 		toml.get<unsigned> ("vote_generator_threshold", vote_generator_threshold);
 
-		auto block_processor_batch_max_time_l (toml.get<unsigned long> ("block_processor_batch_max_time"));
+		auto block_processor_batch_max_time_l = block_processor_batch_max_time.count ();
+		toml.get ("block_processor_batch_max_time", block_processor_batch_max_time_l);
 		block_processor_batch_max_time = std::chrono::milliseconds (block_processor_batch_max_time_l);
+
 		auto unchecked_cutoff_time_l = static_cast<unsigned long> (unchecked_cutoff_time.count ());
 		toml.get ("unchecked_cutoff_time", unchecked_cutoff_time_l);
 		unchecked_cutoff_time = std::chrono::seconds (unchecked_cutoff_time_l);


### PR DESCRIPTION
TODO in another PR: Extend deserialize default test for full coverage of configs