### PR TITLE
Fix distributed work not triggering callback on work cancel

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1302,7 +1302,7 @@ uint64_t nano::node::work_generate_blocking (nano::uint256_union const & hash_a,
 	std::future<uint64_t> future = promise.get_future ();
 	// clang-format off
 	work_generate (hash_a, [&promise](boost::optional<uint64_t> work_a) {
-		promise.set_value (*work_a);
+		promise.set_value (work_a.value_or (0));
 	},
 	difficulty_a);
 	// clang-format on

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -129,8 +129,8 @@ public:
 	void work_generate_blocking (nano::block &);
 	uint64_t work_generate_blocking (nano::uint256_union const &, uint64_t);
 	uint64_t work_generate_blocking (nano::uint256_union const &);
-	void work_generate (nano::uint256_union const &, std::function<void(uint64_t)>, uint64_t);
-	void work_generate (nano::uint256_union const &, std::function<void(uint64_t)>);
+	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>, uint64_t);
+	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>);
 	void add_initial_peers ();
 	void block_confirm (std::shared_ptr<nano::block>);
 	bool block_confirmed_or_being_confirmed (nano::transaction const &, nano::block_hash const &);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2842,8 +2842,9 @@ TEST (rpc, work_peer_bad)
 	node2.config.work_peers.push_back (std::make_pair (boost::asio::ip::address_v6::any ().to_string (), 0));
 	nano::block_hash hash1 (1);
 	std::atomic<uint64_t> work (0);
-	node2.work_generate (hash1, [&work](uint64_t work_a) {
-		work = work_a;
+	node2.work_generate (hash1, [&work](boost::optional<uint64_t> work_a) {
+		ASSERT_TRUE (work_a.is_initialized ());
+		work = *work_a;
 	});
 	system.deadline_set (5s);
 	while (nano::work_validate (hash1, work))
@@ -2871,8 +2872,9 @@ TEST (rpc, work_peer_one)
 	node2.config.work_peers.push_back (std::make_pair (node1.network.endpoint ().address ().to_string (), rpc.config.port));
 	nano::keypair key1;
 	uint64_t work (0);
-	node2.work_generate (key1.pub, [&work](uint64_t work_a) {
-		work = work_a;
+	node2.work_generate (key1.pub, [&work](boost::optional<uint64_t> work_a) {
+		ASSERT_TRUE (work_a.is_initialized ());
+		work = *work_a;
 	});
 	system.deadline_set (5s);
 	while (nano::work_validate (key1.pub, work))
@@ -2923,8 +2925,9 @@ TEST (rpc, work_peer_many)
 	{
 		nano::keypair key1;
 		uint64_t work (0);
-		node1.work_generate (key1.pub, [&work](uint64_t work_a) {
-			work = work_a;
+		node1.work_generate (key1.pub, [&work](boost::optional<uint64_t> work_a) {
+			ASSERT_TRUE (work_a.is_initialized ());
+			work = *work_a;
 		});
 		while (nano::work_validate (key1.pub, work))
 		{


### PR DESCRIPTION
Callback was never triggered due to the `if (work_a)` check.

Switched the callback functions to boost optionals so that `json_handler::work_generate ()` can properly handle as "Cancelled" the results of distributed work. Implicit conversion from boost::optional ...

For now, `work_generate_blocking` continues to assume correct generation and returns a non-optional. Leaving that for future work, going through all cases and handling bad/cancelled work generation adequately. I assume that might be why we once ran into a `work_validate` assert.