### PR TITLE
No longer need enable_control when getting the cemented count

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1206,13 +1206,7 @@ void nano::json_handler::block_count ()
 	auto transaction (node.store.tx_begin_read ());
 	response_l.put ("count", std::to_string (node.store.block_count (transaction).sum ()));
 	response_l.put ("unchecked", std::to_string (node.store.unchecked_count (transaction)));
-
-	const auto include_cemented = request.get<bool> ("include_cemented", false);
-	if (include_cemented)
-	{
-		response_l.put ("cemented", std::to_string (node.store.cemented_count (transaction)));
-	}
-
+	response_l.put ("cemented", std::to_string (node.store.cemented_count (transaction)));
 	response_errors ();
 }
 

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -95,16 +95,6 @@ void nano::rpc_handler::process_request ()
 						error = true;
 					}
 				}
-				else if (action == "block_count")
-				{
-					// Cemented blocks can take a while to generate so require control
-					auto include_cemented = request.get_optional<bool> ("include_cemented");
-					if (include_cemented.is_initialized () && *include_cemented && !rpc_config.enable_control)
-					{
-						json_error_response (response, rpc_control_disabled_ec.message ());
-						error = true;
-					}
-				}
 			}
 
 			if (!error)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2961,24 +2961,11 @@ TEST (rpc, block_count)
 			ASSERT_EQ (200, response1.status);
 			ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
 			ASSERT_EQ ("0", response1.json.get<std::string> ("unchecked"));
-			{
-				ASSERT_FALSE (response1.json.get_optional<std::string> ("cemented").is_initialized ());
-			}
+			ASSERT_EQ ("1", response1.json.get<std::string> ("cemented"));
 		}
-		request1.put ("include_cemented", "true");
-		test_response response1 (request1, rpc.config.port, system.io_ctx);
-		system.deadline_set (5s);
-		while (response1.status == 0)
-		{
-			ASSERT_NO_ERROR (system.poll ());
-		}
-		ASSERT_EQ (200, response1.status);
-		ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
-		ASSERT_EQ ("0", response1.json.get<std::string> ("unchecked"));
-		ASSERT_EQ ("1", response1.json.get<std::string> ("cemented"));
 	}
 
-	// Should not be able to get the cemented count when enable_control is false.
+	// Should be able to get all counts even when enable_control is false.
 	{
 		nano::system system (24000, 1);
 		auto & node1 (*system.nodes[0]);
@@ -2991,7 +2978,6 @@ TEST (rpc, block_count)
 		rpc.start ();
 		boost::property_tree::ptree request1;
 		request1.put ("action", "block_count");
-		request1.put ("include_cemented", "true");
 		{
 			test_response response1 (request1, rpc.config.port, system.io_ctx);
 			system.deadline_set (5s);
@@ -3000,8 +2986,9 @@ TEST (rpc, block_count)
 				ASSERT_NO_ERROR (system.poll ());
 			}
 			ASSERT_EQ (200, response1.status);
-			std::error_code ec (nano::error_rpc::rpc_control_disabled);
-			ASSERT_EQ (response1.json.get<std::string> ("error"), ec.message ());
+			ASSERT_EQ ("1", response1.json.get<std::string> ("count"));
+			ASSERT_EQ ("0", response1.json.get<std::string> ("unchecked"));
+			ASSERT_EQ ("1", response1.json.get<std::string> ("cemented"));
 		}
 	}
 }


### PR DESCRIPTION
`enable_control` should not have been required to get the cemented count via RPC, should help some services.