### PR TITLE
Set USE_RTTI before building RocksDB in docker

### DIFF
--- a/docker/ci/Dockerfile-clang
+++ b/docker/ci/Dockerfile-clang
@@ -3,6 +3,7 @@ FROM nanocurrency/nano-env:base
 RUN apt-get update -qq && apt-get install -yqq \
     clang-3.9 lldb-3.9 git
 
+ENV USE_RTTI=1
 RUN git clone https://github.com/facebook/rocksdb.git && \
     cd rocksdb && \
     make static_lib && \

--- a/docker/ci/Dockerfile-gcc
+++ b/docker/ci/Dockerfile-gcc
@@ -2,6 +2,7 @@ FROM nanocurrency/nano-env:base
 
 RUN apt-get install -yqq git
 
+ENV USE_RTTI=1
 RUN git clone https://github.com/facebook/rocksdb.git && \
     cd rocksdb && \
     make static_lib && \


### PR DESCRIPTION
The following is output when trying to link a static rocksdb library in some cases:
```
../node/libnode.a(rocksdb.cpp.o):(.data.rel.ro._ZTIN7rocksdb11StackableDBE[_ZTIN7rocksdb11StackableDBE]+0x10): undefined reference to `typeinfo for rocksdb::DB'
```

This wasn't an issue in travis, but DB7 tag seems to be having issues. The solution is to set `USE_RTTI=1` before building the rocksdb library.

https://rocksdb.org/blog/2017/09/28/rocksdb-5-8-released.html