### PR TITLE
Prevent supurious wakeup in active transactions request loop

### DIFF
--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -83,12 +83,12 @@ TEST (distributed_work, no_peers_multi)
 	{
 		node->distributed_work.make (hash, callback, nano::difficulty::from_multiplier (10, node->network_params.network.publish_threshold));
 	}
-	// 1 root, and _total_ requests for that root are expected
+	// 1 root, and _total_ requests for that root are expected, but some may have already finished
 	ASSERT_EQ (1, node->distributed_work.work.size ());
 	{
 		auto requests (node->distributed_work.work.begin ());
 		ASSERT_EQ (hash, requests->first);
-		ASSERT_EQ (total, requests->second.size ());
+		ASSERT_GE (requests->second.size (), total - 4);
 	}
 	system.deadline_set (5s);
 	while (count < total)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1130,11 +1130,11 @@ TEST (wallet, work_watcher_update)
 		//fill multipliers_cb and update active difficulty;
 		for (auto i (0); i < node.active.multipliers_cb.size (); i++)
 		{
-			node.active.multipliers_cb.push_back (multiplier * (2 + i / 100.));
+			node.active.multipliers_cb.push_back (multiplier * (1.5 + i / 100.));
 		}
 		node.active.update_active_difficulty (lock);
 	}
-	system.deadline_set (10s);
+	system.deadline_set (20s);
 	while (updated_difficulty1 == difficulty1 || updated_difficulty2 == difficulty2)
 	{
 		{

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -238,9 +238,9 @@ thread ([this]() {
 
 void nano::worker::run ()
 {
-	std::unique_lock<std::mutex> lk (mutex);
 	while (!stopped)
 	{
+		std::unique_lock<std::mutex> lk (mutex);
 		if (!queue.empty ())
 		{
 			auto func = queue.front ();
@@ -250,7 +250,6 @@ void nano::worker::run ()
 			// So that we reduce locking for anything being pushed as that will
 			// most likely be on an io-thread
 			std::this_thread::yield ();
-			lk.lock ();
 		}
 		else
 		{

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -238,9 +238,9 @@ thread ([this]() {
 
 void nano::worker::run ()
 {
+	std::unique_lock<std::mutex> lk (mutex);
 	while (!stopped)
 	{
-		std::unique_lock<std::mutex> lk (mutex);
 		if (!queue.empty ())
 		{
 			auto func = queue.front ();

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -20,7 +20,7 @@ thread ([this]() {
 })
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	condition.wait (lock, [this] { return this->started; });
+	condition.wait (lock, [& started = started] { return started; });
 }
 
 nano::active_transactions::~active_transactions ()
@@ -502,7 +502,7 @@ void nano::active_transactions::prioritize_frontiers_for_confirmation (nano::tra
 void nano::active_transactions::stop ()
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	condition.wait (lock, [this] { return this->started; });
+	condition.wait (lock, [& started = started] { return started; });
 	stopped = true;
 	lock.unlock ();
 	condition.notify_all ();

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -20,10 +20,7 @@ thread ([this]() {
 })
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	while (!started)
-	{
-		condition.wait (lock);
-	}
+	condition.wait (lock, [this] { return this->started; });
 }
 
 nano::active_transactions::~active_transactions ()
@@ -340,7 +337,8 @@ void nano::active_transactions::request_loop ()
 			break;
 		}
 		const auto extra_delay (std::min (roots.size (), max_broadcast_queue) * node.network.broadcast_interval_ms * 2);
-		condition.wait_for (lock, std::chrono::milliseconds (node.network_params.network.request_interval_ms + extra_delay));
+		const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (node.network_params.network.request_interval_ms + extra_delay));
+		condition.wait_until (lock, wakeup, [&wakeup] { return std::chrono::steady_clock::now () >= wakeup; });
 	}
 }
 
@@ -504,10 +502,7 @@ void nano::active_transactions::prioritize_frontiers_for_confirmation (nano::tra
 void nano::active_transactions::stop ()
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	while (!started)
-	{
-		condition.wait (lock);
-	}
+	condition.wait (lock, [this] { return this->started; });
 	stopped = true;
 	lock.unlock ();
 	condition.notify_all ();

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -983,7 +983,7 @@ void nano::bootstrap_attempt::run ()
 
 std::shared_ptr<nano::bootstrap_client> nano::bootstrap_attempt::connection (std::unique_lock<std::mutex> & lock_a)
 {
-	condition.wait (lock_a, [this] { return this->stopped || !this->idle.empty (); });
+	condition.wait (lock_a, [& stopped = stopped, &idle = idle] { return stopped || !idle.empty (); });
 	std::shared_ptr<nano::bootstrap_client> result;
 	if (!idle.empty ())
 	{
@@ -1688,7 +1688,7 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 		if (attempt != nullptr)
 		{
 			attempt->stop ();
-			condition.wait (lock, [this] { return this->attempt == nullptr; });
+			condition.wait (lock, [attempt = attempt] { return attempt == nullptr; });
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate, nano::stat::dir::out);
 		attempt = std::make_shared<nano::bootstrap_attempt> (node.shared ());
@@ -1706,7 +1706,7 @@ void nano::bootstrap_initiator::bootstrap_lazy (nano::block_hash const & hash_a,
 			if (attempt != nullptr)
 			{
 				attempt->stop ();
-				condition.wait (lock, [this] { return this->attempt == nullptr; });
+				condition.wait (lock, [attempt = attempt] { return attempt == nullptr; });
 			}
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate_lazy, nano::stat::dir::out);

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -983,7 +983,9 @@ void nano::bootstrap_attempt::run ()
 
 std::shared_ptr<nano::bootstrap_client> nano::bootstrap_attempt::connection (std::unique_lock<std::mutex> & lock_a)
 {
+	// clang-format off
 	condition.wait (lock_a, [& stopped = stopped, &idle = idle] { return stopped || !idle.empty (); });
+	// clang-format on
 	std::shared_ptr<nano::bootstrap_client> result;
 	if (!idle.empty ())
 	{

--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -983,10 +983,7 @@ void nano::bootstrap_attempt::run ()
 
 std::shared_ptr<nano::bootstrap_client> nano::bootstrap_attempt::connection (std::unique_lock<std::mutex> & lock_a)
 {
-	while (!stopped && idle.empty ())
-	{
-		condition.wait (lock_a);
-	}
+	condition.wait (lock_a, [this] { return this->stopped || !this->idle.empty (); });
 	std::shared_ptr<nano::bootstrap_client> result;
 	if (!idle.empty ())
 	{
@@ -1688,10 +1685,10 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 	std::unique_lock<std::mutex> lock (mutex);
 	if (!stopped)
 	{
-		while (attempt != nullptr)
+		if (attempt != nullptr)
 		{
 			attempt->stop ();
-			condition.wait (lock);
+			condition.wait (lock, [this] { return this->attempt == nullptr; });
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate, nano::stat::dir::out);
 		attempt = std::make_shared<nano::bootstrap_attempt> (node.shared ());
@@ -1706,10 +1703,10 @@ void nano::bootstrap_initiator::bootstrap_lazy (nano::block_hash const & hash_a,
 		std::unique_lock<std::mutex> lock (mutex);
 		if (force)
 		{
-			while (attempt != nullptr)
+			if (attempt != nullptr)
 			{
 				attempt->stop ();
-				condition.wait (lock);
+				condition.wait (lock, [this] { return this->attempt == nullptr; });
 			}
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate_lazy, nano::stat::dir::out);

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -842,10 +842,10 @@ stopped (false)
 nano::message_buffer * nano::message_buffer_manager::allocate ()
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	while (!stopped && free.empty () && full.empty ())
+	if (!stopped && free.empty () && full.empty ())
 	{
 		stats.inc (nano::stat::type::udp, nano::stat::detail::blocking, nano::stat::dir::in);
-		condition.wait (lock);
+		condition.wait (lock, [this] { return this->stopped || !this->free.empty () || !this->full.empty (); });
 	}
 	nano::message_buffer * result (nullptr);
 	if (!free.empty ())

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -845,7 +845,9 @@ nano::message_buffer * nano::message_buffer_manager::allocate ()
 	if (!stopped && free.empty () && full.empty ())
 	{
 		stats.inc (nano::stat::type::udp, nano::stat::detail::blocking, nano::stat::dir::in);
+		// clang-format off
 		condition.wait (lock, [& stopped = stopped, &free = free, &full = full] { return stopped || !free.empty () || !full.empty (); });
+		// clang-format on
 	}
 	nano::message_buffer * result (nullptr);
 	if (!free.empty ())

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -845,7 +845,7 @@ nano::message_buffer * nano::message_buffer_manager::allocate ()
 	if (!stopped && free.empty () && full.empty ())
 	{
 		stats.inc (nano::stat::type::udp, nano::stat::detail::blocking, nano::stat::dir::in);
-		condition.wait (lock, [this] { return this->stopped || !this->free.empty () || !this->full.empty (); });
+		condition.wait (lock, [& stopped = stopped, &free = free, &full = full] { return stopped || !free.empty () || !full.empty (); });
 	}
 	nano::message_buffer * result (nullptr);
 	if (!free.empty ())

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -13,10 +13,7 @@ thread ([this]() {
 })
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	while (!started)
-	{
-		condition.wait (lock);
-	}
+	condition.wait (lock, [this] { return this->started; });
 }
 
 void nano::vote_processor::process_loop ()

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -13,7 +13,7 @@ thread ([this]() {
 })
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	condition.wait (lock, [this] { return this->started; });
+	condition.wait (lock, [& started = started] { return started; });
 }
 
 void nano::vote_processor::process_loop ()

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -8,7 +8,7 @@ node (node_a),
 thread ([this]() { run (); })
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	condition.wait (lock, [this] { return this->started; });
+	condition.wait (lock, [& started = started] { return started; });
 }
 
 void nano::vote_generator::add (nano::block_hash const & hash_a)

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -8,10 +8,7 @@ node (node_a),
 thread ([this]() { run (); })
 {
 	std::unique_lock<std::mutex> lock (mutex);
-	while (!started)
-	{
-		condition.wait (lock);
-	}
+	condition.wait (lock, [this] { return this->started; });
 }
 
 void nano::vote_generator::add (nano::block_hash const & hash_a)


### PR DESCRIPTION
Some supurious wakeup prevention:
- Critical: `active_transactions::request_loop ()` has a long wait
- Non-critical: could try to stop attempts more than once in bootstrapping, and increase stats more than once in some places
- Non-functional: writing `while(!predicate) wait(lock)` as `wait(lock, predicate)` 

Also moved the lock creation in `nano::worker::run ()` so it doesn't get re-created every loop