### PR TITLE
Non-blocking work watcher loop

### DIFF
--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -5,6 +5,9 @@
 
 TEST (difficulty, multipliers)
 {
+	// For ASSERT_DEATH_IF_SUPPORTED
+	testing::FLAGS_gtest_death_test_style = "threadsafe";
+
 	{
 		uint64_t base = 0xff00000000000000;
 		uint64_t difficulty = 0xfff27e7a57c285cd;

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -11,13 +11,15 @@ TEST (distributed_work, no_peers)
 	auto node (system.nodes[0]);
 	nano::block_hash hash;
 	boost::optional<uint64_t> work;
-	auto callback = [&work](boost::optional<uint64_t> work_a) {
+	std::atomic<bool> done{ false };
+	auto callback = [&work, &done](boost::optional<uint64_t> work_a) {
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = work_a;
+		done = true;
 	};
 	node->distributed_work.make (hash, callback, node->network_params.network.publish_threshold);
 	system.deadline_set (5s);
-	while (!work.is_initialized ())
+	while (!done)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1162,12 +1162,12 @@ TEST (wallet, work_watcher_removed)
 	auto & wallet (*system.wallet (0));
 	wallet.insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key;
-	ASSERT_EQ (0, wallet.wallets.watcher->watched.size ());
+	ASSERT_EQ (0, wallet.wallets.watcher->size ());
 	auto const block (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
-	ASSERT_EQ (1, wallet.wallets.watcher->watched.size ());
+	ASSERT_EQ (1, wallet.wallets.watcher->size ());
 	auto transaction (wallet.wallets.tx_begin_write ());
 	system.deadline_set (3s);
-	while (!wallet.wallets.watcher->watched.empty ())
+	while (0 == wallet.wallets.watcher->size ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -170,7 +170,10 @@ void nano::work_pool::cancel (nano::uint256_union const & root_a)
 			bool result;
 			if (item_a.item == root_a)
 			{
-				item_a.callback (boost::none);
+				if (item_a.callback)
+				{
+					item_a.callback (boost::none);
+				}
 				result = true;
 			}
 			else
@@ -225,6 +228,12 @@ uint64_t nano::work_pool::generate (nano::uint256_union const & hash_a, uint64_t
 	// clang-format on
 	auto result (future.get ());
 	return result.value ();
+}
+
+size_t nano::work_pool::size ()
+{
+	std::lock_guard<std::mutex> lock (mutex);
+	return pending.size ();
 }
 
 namespace nano

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -38,6 +38,7 @@ public:
 	void generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t> const &)>, uint64_t);
 	uint64_t generate (nano::uint256_union const &);
 	uint64_t generate (nano::uint256_union const &, uint64_t);
+	size_t size ();
 	nano::network_constants network_constants;
 	std::atomic<int> ticket;
 	bool done;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1514,9 +1514,15 @@ void nano::work_watcher::remove (std::shared_ptr<nano::block> block_a)
 
 bool nano::work_watcher::is_watched (nano::qualified_root const & root_a)
 {
-	std::unique_lock<std::mutex> lock (mutex);
+	std::lock_guard<std::mutex> guard (mutex);
 	auto exists (watched.find (root_a));
 	return exists != watched.end ();
+}
+
+size_t nano::work_watcher::size ()
+{
+	std::lock_guard<std::mutex> guard (mutex);
+	return watched.size ();
 }
 
 void nano::wallets::do_wallet_actions ()

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -172,6 +172,7 @@ public:
 	void watching (nano::qualified_root const &, std::shared_ptr<nano::state_block>);
 	void remove (std::shared_ptr<nano::block>);
 	bool is_watched (nano::qualified_root const &);
+	size_t size ();
 	std::mutex mutex;
 	nano::node & node;
 	std::unordered_map<nano::qualified_root, std::shared_ptr<nano::state_block>> watched;


### PR DESCRIPTION
Work watcher was blocking IO threads by waiting for work. Switched to use a callback (within a callback) and adjusted tests.

Solved a few other TSAN issues from recent tests with distributed_work.