### PR TITLE
Add log when a block difficulty is updated in active transactions

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -200,6 +200,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.logging.rotation_size, defaults.node.logging.rotation_size);
 	ASSERT_EQ (conf.node.logging.single_line_record_value, defaults.node.logging.single_line_record_value);
 	ASSERT_EQ (conf.node.logging.timing_logging_value, defaults.node.logging.timing_logging_value);
+	ASSERT_EQ (conf.node.logging.active_update_value, defaults.node.logging.active_update_value);
 	ASSERT_EQ (conf.node.logging.upnp_details_logging_value, defaults.node.logging.upnp_details_logging_value);
 	ASSERT_EQ (conf.node.logging.vote_logging_value, defaults.node.logging.vote_logging_value);
 	ASSERT_EQ (conf.node.logging.work_generation_time_value, defaults.node.logging.work_generation_time_value);
@@ -447,6 +448,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	rotation_size = 999
 	single_line_record = true
 	timing = true
+	active_update = true
 	upnp_details = true
 	vote = true
 	work_generation_time = false
@@ -562,6 +564,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.logging.rotation_size, defaults.node.logging.rotation_size);
 	ASSERT_NE (conf.node.logging.single_line_record_value, defaults.node.logging.single_line_record_value);
 	ASSERT_NE (conf.node.logging.timing_logging_value, defaults.node.logging.timing_logging_value);
+	ASSERT_NE (conf.node.logging.active_update_value, defaults.node.logging.active_update_value);
 	ASSERT_NE (conf.node.logging.upnp_details_logging_value, defaults.node.logging.upnp_details_logging_value);
 	ASSERT_NE (conf.node.logging.vote_logging_value, defaults.node.logging.vote_logging_value);
 	ASSERT_NE (conf.node.logging.work_generation_time_value, defaults.node.logging.work_generation_time_value);

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -613,6 +613,10 @@ void nano::active_transactions::update_difficulty (nano::block const & block_a)
 		assert (!error);
 		if (difficulty > existing->difficulty)
 		{
+			if (node.config.logging.active_update_logging ())
+			{
+				node.logger.try_log (boost::str (boost::format ("Block %1% was updated from difficulty %2% to %3%") % block_a.hash ().to_string () % nano::to_string_hex (existing->difficulty) % nano::to_string_hex (difficulty)));
+			}
 			roots.modify (existing, [difficulty](nano::conflict_info & info_a) {
 				info_a.difficulty = difficulty;
 			});

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -101,6 +101,7 @@ nano::error nano::logging::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("work_generation_time", work_generation_time_value, "Log work generation timing information\ntype:bool");
 	toml.put ("upnp_details", upnp_details_logging_value, "Log UPNP discovery details. WARNING: this may include information\nabout discovered devices, such as product identification. Please review before sharing logs.\ntype:bool");
 	toml.put ("timing", timing_logging_value, "Log detailed timing information for various node operations\ntype:bool");
+	toml.put ("active_update", active_update_value, "Log when a block is updated while in active transactions\ntype:bool");
 	toml.put ("log_to_cerr", log_to_cerr_value, "Log to standard error in addition to the log file\ntype:bool");
 	toml.put ("max_size", max_size, "Maximum log file size in bytes\ntype:uint64");
 	toml.put ("rotation_size", rotation_size, "Log file rotation size in character count\ntype:uint64");
@@ -130,6 +131,7 @@ nano::error nano::logging::deserialize_toml (nano::tomlconfig & toml)
 	toml.get<bool> ("work_generation_time", work_generation_time_value);
 	toml.get<bool> ("upnp_details", upnp_details_logging_value);
 	toml.get<bool> ("timing", timing_logging_value);
+	toml.get<bool> ("active_update", active_update_value);
 	toml.get<bool> ("log_to_cerr", log_to_cerr_value);
 	toml.get<bool> ("flush", flush);
 	toml.get<bool> ("single_line_record", single_line_record_value);
@@ -345,6 +347,11 @@ bool nano::logging::upnp_details_logging () const
 bool nano::logging::timing_logging () const
 {
 	return timing_logging_value;
+}
+
+bool nano::logging::active_update_logging () const
+{
+	return active_update_value;
 }
 
 bool nano::logging::log_to_cerr () const

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -42,6 +42,7 @@ public:
 	bool bulk_pull_logging () const;
 	bool callback_logging () const;
 	bool work_generation_time () const;
+	bool active_update_logging () const;
 	bool log_to_cerr () const;
 	bool single_line_record () const;
 	void init (boost::filesystem::path const &);
@@ -63,6 +64,7 @@ public:
 	bool work_generation_time_value{ true };
 	bool upnp_details_logging_value{ false };
 	bool timing_logging_value{ false };
+	bool active_update_value{ false };
 	bool log_to_cerr_value{ false };
 	bool flush{ true };
 	uintmax_t max_size{ 128 * 1024 * 1024 };


### PR DESCRIPTION
This log is to aid in testing of prioritization. Wasn't sure whether to include the root in the log, thoughts?