### PR TITLE
Fix delay in stopping the node

### DIFF
--- a/nano/node/bootstrap.cpp
+++ b/nano/node/bootstrap.cpp
@@ -1689,7 +1689,9 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 		if (attempt != nullptr)
 		{
 			attempt->stop ();
-			condition.wait (lock, [attempt = attempt] { return attempt == nullptr; });
+			// clang-format off
+			condition.wait (lock, [attempt = attempt, &stopped = stopped] { return stopped || attempt == nullptr; });
+			// clang-format on
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate, nano::stat::dir::out);
 		attempt = std::make_shared<nano::bootstrap_attempt> (node.shared ());
@@ -1707,7 +1709,9 @@ void nano::bootstrap_initiator::bootstrap_lazy (nano::block_hash const & hash_a,
 			if (attempt != nullptr)
 			{
 				attempt->stop ();
-				condition.wait (lock, [attempt = attempt] { return attempt == nullptr; });
+				// clang-format off
+				condition.wait (lock, [attempt = attempt, &stopped = stopped] { return stopped || attempt == nullptr; });
+				// clang-format on
 			}
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate_lazy, nano::stat::dir::out);


### PR DESCRIPTION
Bug introduced in #2263 . Conditions without predicates would wake up when `node.stop ()` is ran, but with predicates we have to manually add each one.