### PR TITLE
Disable unchecked cleanup if node is not synchronized

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -915,6 +915,10 @@ void nano::node::unchecked_cleanup ()
 			}
 		}
 	}
+	if (!cleaning_list.empty ())
+	{
+		logger.always_log (boost::str (boost::format ("Deleting %1% old unchecked blocks") % cleaning_list.size ()));
+	}
 	// Delete old unchecked keys in batches
 	while (!cleaning_list.empty ())
 	{
@@ -931,7 +935,7 @@ void nano::node::unchecked_cleanup ()
 
 void nano::node::ongoing_unchecked_cleanup ()
 {
-	if (!bootstrap_initiator.in_progress ())
+	if (!bootstrap_initiator.in_progress () && ledger.block_count () >= ledger.bootstrap_weight_max_blocks)
 	{
 		unchecked_cleanup ();
 	}

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1127,6 +1127,13 @@ bool nano::ledger::block_not_confirmed_or_not_exists (nano::block const & block_
 	return result;
 }
 
+size_t nano::ledger::block_count () const
+{
+	auto transaction (store.tx_begin_read ());
+	auto result (store.block_count (transaction).sum ());
+	return result;
+}
+
 namespace nano
 {
 std::unique_ptr<seq_con_info_component> collect_seq_con_info (ledger & ledger, const std::string & name)

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -48,6 +48,7 @@ public:
 	void dump_account_chain (nano::account const &);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool is_epoch_link (nano::uint256_union const &);
+	size_t block_count () const;
 	static nano::uint128_t const unit;
 	nano::network_params network_params;
 	nano::block_store & store;


### PR DESCRIPTION
Based on built-in bootstrap_weight_max_blocks
Similar to https://github.com/nanocurrency/nano-node/pull/2257