### PR TITLE
add master tag for beta and caching for subsequent artifacts_beta builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 stages:
   - build_base
   - build_env
+  - master_beta_docker
   - tag_test
   - test
   - artifacts_beta
@@ -23,6 +24,11 @@ jobs:
       if: branch=master AND type=push
       script: 
         - if [ -n "$DOCKER_PASSWORD" ]; then ci/deploy-docker.sh; fi;
+    - stage: master_beta_docker
+      name: "beta docker master tag"
+      if: tag =~RC|DB
+      script: 
+        - if [ -n "$DOCKER_PASSWORD" ]; then TRAVIS_TAG="${TRAVIS_TAG}" ci/deploy-docker.sh; fi;
     - stage: tag_test
       name: "gcc"
       if: tag is present

--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -20,7 +20,7 @@ if [ -n "$DOCKER_PASSWORD" ]; then
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" =~ "Artifacts" ]]; then
         tags=()
         if [[ "${TRAVIS_TAG}" =~ ("RC"|"DB") ]]; then
-            tags+=("$TRAVIS_TAG" latest-including-rc)
+            tags+=("$TRAVIS_TAG" latest latest-including-rc)
         elif [ -n "$TRAVIS_TAG" ]; then
             tags+=("$TRAVIS_TAG" latest latest-including-rc)
         elif [ -n "$TRAVIS_BRANCH" ]; then

--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -13,7 +13,11 @@ if [ -n "$DOCKER_PASSWORD" ]; then
         "$scripts"/custom-timeout.sh 30 docker push "$ci_image_name"
     fi
 
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" =~ "Artifacts" ]]; then
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Master_beta_docker" ]]; then
+        # quick build and tag beta network master
+        "$scripts"/custom-timeout.sh 30 docker build --build-arg NETWORK=beta --build-arg CI_BUILD=true --build-arg TRAVIS_TAG="$TRAVIS_TAG" -f docker/node/Dockerfile -t nanocurrency/nano-beta:master --cache-from nanocurrency/nano-beta:master .
+        "$scripts"/custom-timeout.sh 30 docker push nanocurrency/nano-beta:master
+    elif [[ "$TRAVIS_BUILD_STAGE_NAME" =~ "Artifacts" ]]; then
         tags=()
         if [[ "${TRAVIS_TAG}" =~ ("RC"|"DB") ]]; then
             tags+=("$TRAVIS_TAG" latest-including-rc)
@@ -26,13 +30,17 @@ if [ -n "$DOCKER_PASSWORD" ]; then
         if [[ "$TRAVIS_JOB_NAME" =~ "live" ]]; then
             network_tag_suffix=''
             network="live"
+            cached=''
         else
             network_tag_suffix="-beta"
             network="beta"
+            # use cache from Master_beta_docker to prevent rebuilds
+            cached="--cache-from nanocurrency/nano-beta:master"
+            docker pull nanocurrency/nano-beta:master
         fi
 
         docker_image_name="nanocurrency/nano${network_tag_suffix}"
-        "$scripts"/custom-timeout.sh 30 docker build --build-arg NETWORK="$network" --build-arg CI_BUILD=true --build-arg TRAVIS_TAG="$TRAVIS_TAG" -f docker/node/Dockerfile -t "$docker_image_name" .
+        "$scripts"/custom-timeout.sh 30 docker build "$cached" --build-arg NETWORK="$network" --build-arg CI_BUILD=true --build-arg TRAVIS_TAG="$TRAVIS_TAG" -f docker/node/Dockerfile -t "$docker_image_name" .
         for tag in "${tags[@]}"; do
             # Sanitize docker tag
             # https://docs.docker.com/engine/reference/commandline/tag/


### PR DESCRIPTION
When building for RC and DB tags start CI by building nanocurrency/nano-beta:master tag for docker
if tests are successful push updated beta docker artifact tags cached from nanocurrency/nano-beta:master docker tag
update latest as well as latest-including-rc for nano-beta docker images