### PR TITLE
Handle work generation failure and cancel

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -812,10 +812,10 @@ TEST (bootstrap_processor, lazy_hash)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (receive1->hash ())));
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, system.nodes[0]->work_generate_blocking (key2.pub)));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
+	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (key2.pub)));
 	// Processing test chain
 	system.nodes[0]->block_processor.add (send1);
 	system.nodes[0]->block_processor.add (receive1);
@@ -842,13 +842,13 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (receive1->hash ())));
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, system.nodes[0]->work_generate_blocking (key2.pub)));
-	auto change1 (std::make_shared<nano::state_block> (key2.pub, receive2->hash (), key1.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, system.nodes[0]->work_generate_blocking (receive2->hash ())));
-	auto change2 (std::make_shared<nano::state_block> (key2.pub, change1->hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, system.nodes[0]->work_generate_blocking (change1->hash ())));
-	auto change3 (std::make_shared<nano::state_block> (key2.pub, change2->hash (), key2.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, system.nodes[0]->work_generate_blocking (change2->hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
+	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (key2.pub)));
+	auto change1 (std::make_shared<nano::state_block> (key2.pub, receive2->hash (), key1.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (receive2->hash ())));
+	auto change2 (std::make_shared<nano::state_block> (key2.pub, change1->hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (change1->hash ())));
+	auto change3 (std::make_shared<nano::state_block> (key2.pub, change2->hash (), key2.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (change2->hash ())));
 	// Processing test chain
 	system.nodes[0]->block_processor.add (send1);
 	system.nodes[0]->block_processor.add (receive1);
@@ -878,10 +878,10 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (receive1->hash ())));
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, system.nodes[0]->work_generate_blocking (key2.pub)));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
+	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (key2.pub)));
 	// Processing test chain
 	system.nodes[0]->block_processor.add (send1);
 	system.nodes[0]->block_processor.add (receive1);
@@ -911,9 +911,9 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, system.nodes[0]->work_generate_blocking (receive1->hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
 	// Processing test chain
 	system.nodes[0]->block_processor.add (send1);
 	system.nodes[0]->block_processor.add (receive1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1912,7 +1912,7 @@ TEST (node, DISABLED_unconfirmed_send)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	auto latest (node1.latest (key0.pub));
-	nano::state_block send2 (key0.pub, latest, nano::genesis_account, nano::Mxrb_ratio, nano::genesis_account, key0.prv, key0.pub, node0.work_generate_blocking (latest));
+	nano::state_block send2 (key0.pub, latest, nano::genesis_account, nano::Mxrb_ratio, nano::genesis_account, key0.prv, key0.pub, *node0.work_generate_blocking (latest));
 	{
 		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send2).code);
@@ -2210,7 +2210,7 @@ TEST (node, block_confirm)
 		nano::genesis genesis;
 		nano::keypair key;
 		system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
-		auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
+		auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
 		system.nodes[0]->block_processor.add (send1, nano::seconds_since_epoch ());
 		system.nodes[1]->block_processor.add (send1, nano::seconds_since_epoch ());
 		system.deadline_set (std::chrono::seconds (5));
@@ -2220,7 +2220,7 @@ TEST (node, block_confirm)
 		}
 		ASSERT_TRUE (system.nodes[0]->ledger.block_exists (send1->hash ()));
 		ASSERT_TRUE (system.nodes[1]->ledger.block_exists (send1->hash ()));
-		auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (send1->hash ())));
+		auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (send1->hash ())));
 		{
 			auto transaction (system.nodes[0]->store.tx_begin_write ());
 			ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send2).code);
@@ -2293,7 +2293,7 @@ TEST (node, confirm_quorum)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	// Put greater than online_weight_minimum in pending so quorum can't be reached
 	nano::uint128_union new_balance (system.nodes[0]->config.online_weight_minimum.number () - nano::Gxrb_ratio);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, new_balance, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, new_balance, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send1).code);
@@ -2327,9 +2327,9 @@ TEST (node, local_votes_cache)
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (genesis.hash ())));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (send1->hash ())));
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (send2->hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (send1->hash ())));
+	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (send2->hash ())));
 	{
 		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send1).code);
@@ -2378,8 +2378,8 @@ TEST (node, local_votes_cache_generate_new_vote)
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (genesis.hash ())));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node.work_generate_blocking (send1->hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (send1->hash ())));
 	{
 		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send1).code);
@@ -3102,7 +3102,7 @@ TEST (node, bidirectional_tcp)
 	// Test block propagation from node 1
 	nano::genesis genesis;
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1->work_generate_blocking (genesis.hash ())));
 	node1->process_active (send1);
 	node1->block_processor.flush ();
 	system.deadline_set (5s);
@@ -3126,7 +3126,7 @@ TEST (node, bidirectional_tcp)
 		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
 		system.wallet (0)->store.erase (transaction, nano::test_genesis_key.pub);
 	}
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1->work_generate_blocking (send1->hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1->work_generate_blocking (send1->hash ())));
 	node2->process_active (send2);
 	node2->block_processor.flush ();
 	system.deadline_set (5s);
@@ -3299,7 +3299,7 @@ TEST (confirmation_height, frontiers_confirmation_mode)
 		nano::node_config node_config (24000, system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 		auto node = system.add_node (node_config);
-		nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node->work_generate_blocking (genesis.hash ()));
+		nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
@@ -3316,7 +3316,7 @@ TEST (confirmation_height, frontiers_confirmation_mode)
 		nano::node_config node_config (24000, system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::automatic;
 		auto node = system.add_node (node_config);
-		nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node->work_generate_blocking (genesis.hash ()));
+		nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
@@ -3333,7 +3333,7 @@ TEST (confirmation_height, frontiers_confirmation_mode)
 		nano::node_config node_config (24000, system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config);
-		nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node->work_generate_blocking (genesis.hash ()));
+		nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1191,7 +1191,7 @@ TEST (wallet, work_watcher_cancel)
 	wallet.insert_adhoc (nano::test_genesis_key.prv, false);
 	nano::keypair key;
 	auto work1 (node.work_generate_blocking (nano::test_genesis_key.pub));
-	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100, work1, false));
+	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100, *work1, false));
 	uint64_t difficulty1 (0);
 	nano::work_validate (*block1, &difficulty1);
 	{

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -54,6 +54,8 @@ std::string nano::error_common_messages::message (int ev) const
 			return "Bad wallet number";
 		case nano::error_common::bad_work_format:
 			return "Bad work";
+		case nano::error_common::failure_work_generation:
+			return "Work generation cancellation or failure";
 		case nano::error_common::insufficient_balance:
 			return "Insufficient balance";
 		case nano::error_common::invalid_amount:

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -32,6 +32,7 @@ enum class error_common
 	bad_threshold,
 	bad_wallet_number,
 	bad_work_format,
+	failure_work_generation,
 	missing_account,
 	missing_balance,
 	missing_link,

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -19,7 +19,8 @@ backoff (backoff_a),
 node (node_a),
 root (root_a),
 need_resolve (node.config.work_peers),
-difficulty (difficulty_a)
+difficulty (difficulty_a),
+elapsed (nano::timer_state::started, "distributed work generation timer")
 {
 	assert (!completed);
 }
@@ -257,6 +258,11 @@ void nano::distributed_work::set_once (boost::optional<uint64_t> work_a)
 	if (!completed.exchange (true))
 	{
 		callback (work_a);
+		if (node.config.logging.work_generation_time ())
+		{
+			node.logger.try_log (boost::str (boost::format ("Work generation for %1%, with a threshold difficulty of %2% (multiplier %3%x) complete: %4% ms")
+			% root.to_string () % nano::to_string_hex (difficulty) % nano::to_string (nano::difficulty::to_multiplier (difficulty, node.network_params.network.publish_threshold), 2) % elapsed.stop ().count ()));
+		}
 	}
 }
 
@@ -270,12 +276,19 @@ void nano::distributed_work::handle_failure (bool const last)
 {
 	if (last && !completed)
 	{
-		node.unresponsive_work_peers = true;
+		if (!stopped) // stopped early = cancel
+		{
+			node.unresponsive_work_peers = true;
+		}
 		if (!local_generation_started)
 		{
 			if (stopped)
 			{
 				callback (boost::none);
+				if (node.config.logging.work_generation_time ())
+				{
+					node.logger.try_log (boost::str (boost::format ("Work generation for %1% was cancelled after %2% ms") % root.to_string () % elapsed.stop ().count ()));
+				}
 			}
 			else
 			{

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -260,8 +260,9 @@ void nano::distributed_work::set_once (boost::optional<uint64_t> work_a)
 		callback (work_a);
 		if (node.config.logging.work_generation_time ())
 		{
-			node.logger.try_log (boost::str (boost::format ("Work generation for %1%, with a threshold difficulty of %2% (multiplier %3%x) complete: %4% ms")
-			% root.to_string () % nano::to_string_hex (difficulty) % nano::to_string (nano::difficulty::to_multiplier (difficulty, node.network_params.network.publish_threshold), 2) % elapsed.stop ().count ()));
+			boost::format unformatted_l ("Work generation for %1%, with a threshold difficulty of %2% (multiplier %3%x) complete: %4% ms");
+			auto multiplier_text_l (nano::to_string (nano::difficulty::to_multiplier (difficulty, node.network_params.network.publish_threshold), 2));
+			node.logger.try_log (boost::str (unformatted_l % root.to_string () % nano::to_string_hex (difficulty) % multiplier_text_l % elapsed.stop ().count ()));
 		}
 	}
 }

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -3,6 +3,7 @@
 #include <nano/boost/asio.hpp>
 #include <nano/boost/beast.hpp>
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/timer.hpp>
 
 #include <boost/optional.hpp>
 
@@ -61,6 +62,7 @@ public:
 	std::atomic<bool> completed{ false };
 	std::atomic<bool> local_generation_started{ false };
 	std::atomic<bool> stopped{ false };
+	nano::timer<std::chrono::milliseconds> elapsed; // logging only
 };
 
 class distributed_work_factory final

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1376,22 +1376,33 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							work = node.work_generate_blocking (previous.is_zero () ? pub : previous);
+							auto opt_work_l (node.work_generate_blocking (previous.is_zero () ? pub : previous));
+							if (opt_work_l.is_initialized ())
+							{
+								work = *opt_work_l;
+							}
+							else
+							{
+								ec = nano::error_common::failure_work_generation;
+							}
 						}
-						nano::state_block state (pub, previous, representative, balance, link, prv, pub, work);
-						response_l.put ("hash", state.hash ().to_string ());
-						bool json_block_l = request.get<bool> ("json_block", false);
-						if (json_block_l)
+						if (!ec)
 						{
-							boost::property_tree::ptree block_node_l;
-							state.serialize_json (block_node_l);
-							response_l.add_child ("block", block_node_l);
-						}
-						else
-						{
-							std::string contents;
-							state.serialize_json (contents);
-							response_l.put ("block", contents);
+							nano::state_block state (pub, previous, representative, balance, link, prv, pub, work);
+							response_l.put ("hash", state.hash ().to_string ());
+							bool json_block_l = request.get<bool> ("json_block", false);
+							if (json_block_l)
+							{
+								boost::property_tree::ptree block_node_l;
+								state.serialize_json (block_node_l);
+								response_l.add_child ("block", block_node_l);
+							}
+							else
+							{
+								std::string contents;
+								state.serialize_json (contents);
+								response_l.put ("block", contents);
+							}
 						}
 					}
 					else
@@ -1405,13 +1416,24 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							work = node.work_generate_blocking (pub);
+							auto opt_work_l (node.work_generate_blocking (pub));
+							if (opt_work_l.is_initialized ())
+							{
+								work = *opt_work_l;
+							}
+							else
+							{
+								ec = nano::error_common::failure_work_generation;
+							}
 						}
-						nano::open_block open (source, representative, pub, prv, pub, work);
-						response_l.put ("hash", open.hash ().to_string ());
-						std::string contents;
-						open.serialize_json (contents);
-						response_l.put ("block", contents);
+						if (!ec)
+						{
+							nano::open_block open (source, representative, pub, prv, pub, work);
+							response_l.put ("hash", open.hash ().to_string ());
+							std::string contents;
+							open.serialize_json (contents);
+							response_l.put ("block", contents);
+						}
 					}
 					else
 					{
@@ -1424,13 +1446,24 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							work = node.work_generate_blocking (previous);
+							auto opt_work_l (node.work_generate_blocking (previous));
+							if (opt_work_l.is_initialized ())
+							{
+								work = *opt_work_l;
+							}
+							else
+							{
+								ec = nano::error_common::failure_work_generation;
+							}
 						}
-						nano::receive_block receive (previous, source, prv, pub, work);
-						response_l.put ("hash", receive.hash ().to_string ());
-						std::string contents;
-						receive.serialize_json (contents);
-						response_l.put ("block", contents);
+						if (!ec)
+						{
+							nano::receive_block receive (previous, source, prv, pub, work);
+							response_l.put ("hash", receive.hash ().to_string ());
+							std::string contents;
+							receive.serialize_json (contents);
+							response_l.put ("block", contents);
+						}
 					}
 					else
 					{
@@ -1443,13 +1476,24 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							work = node.work_generate_blocking (previous);
+							auto opt_work_l (node.work_generate_blocking (previous));
+							if (opt_work_l.is_initialized ())
+							{
+								work = *opt_work_l;
+							}
+							else
+							{
+								ec = nano::error_common::failure_work_generation;
+							}
 						}
-						nano::change_block change (previous, representative, prv, pub, work);
-						response_l.put ("hash", change.hash ().to_string ());
-						std::string contents;
-						change.serialize_json (contents);
-						response_l.put ("block", contents);
+						if (!ec)
+						{
+							nano::change_block change (previous, representative, prv, pub, work);
+							response_l.put ("hash", change.hash ().to_string ());
+							std::string contents;
+							change.serialize_json (contents);
+							response_l.put ("block", contents);
+						}
 					}
 					else
 					{
@@ -1464,13 +1508,24 @@ void nano::json_handler::block_create ()
 						{
 							if (work == 0)
 							{
-								work = node.work_generate_blocking (previous);
+								auto opt_work_l (node.work_generate_blocking (previous));
+								if (opt_work_l.is_initialized ())
+								{
+									work = *opt_work_l;
+								}
+								else
+								{
+									ec = nano::error_common::failure_work_generation;
+								}
 							}
-							nano::send_block send (previous, destination, balance.number () - amount.number (), prv, pub, work);
-							response_l.put ("hash", send.hash ().to_string ());
-							std::string contents;
-							send.serialize_json (contents);
-							response_l.put ("block", contents);
+							if (!ec)
+							{
+								nano::send_block send (previous, destination, balance.number () - amount.number (), prv, pub, work);
+								response_l.put ("hash", send.hash ().to_string ());
+								std::string contents;
+								send.serialize_json (contents);
+								response_l.put ("block", contents);
+							}
 						}
 						else
 						{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -962,14 +962,19 @@ int nano::node::price (nano::uint128_t const & balance_a, int amount_a)
 	return static_cast<int> (result * 100.0);
 }
 
-void nano::node::work_generate_blocking (nano::block & block_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a)
 {
-	work_generate_blocking (block_a, network_params.network.publish_threshold);
+	return work_generate_blocking (block_a, network_params.network.publish_threshold);
 }
 
-void nano::node::work_generate_blocking (nano::block & block_a, uint64_t difficulty_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a, uint64_t difficulty_a)
 {
-	block_a.block_work_set (work_generate_blocking (block_a.root (), difficulty_a));
+	auto opt_work_l (work_generate_blocking (block_a.root (), difficulty_a));
+	if (opt_work_l.is_initialized ())
+	{
+		block_a.block_work_set (*opt_work_l);
+	}
+	return opt_work_l;
 }
 
 void nano::node::work_generate (nano::uint256_union const & hash_a, std::function<void(boost::optional<uint64_t>)> callback_a)
@@ -982,12 +987,12 @@ void nano::node::work_generate (nano::uint256_union const & hash_a, std::functio
 	distributed_work.make (hash_a, callback_a, difficulty_a);
 }
 
-uint64_t nano::node::work_generate_blocking (nano::uint256_union const & block_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_union const & block_a)
 {
 	return work_generate_blocking (block_a, network_params.network.publish_threshold);
 }
 
-uint64_t nano::node::work_generate_blocking (nano::uint256_union const & hash_a, uint64_t difficulty_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_union const & hash_a, uint64_t difficulty_a)
 {
 	std::promise<uint64_t> promise;
 	std::future<uint64_t> future = promise.get_future ();

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -123,10 +123,10 @@ public:
 	void bootstrap_wallet ();
 	void unchecked_cleanup ();
 	int price (nano::uint128_t const &, int);
-	void work_generate_blocking (nano::block &, uint64_t);
-	void work_generate_blocking (nano::block &);
-	uint64_t work_generate_blocking (nano::uint256_union const &, uint64_t);
-	uint64_t work_generate_blocking (nano::uint256_union const &);
+	boost::optional<uint64_t> work_generate_blocking (nano::block &, uint64_t);
+	boost::optional<uint64_t> work_generate_blocking (nano::block &);
+	boost::optional<uint64_t> work_generate_blocking (nano::uint256_union const &, uint64_t);
+	boost::optional<uint64_t> work_generate_blocking (nano::uint256_union const &);
 	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>, uint64_t);
 	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>);
 	void add_initial_peers ();

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1133,11 +1133,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> block_a, nano::
 		if (nano::work_validate (*block_a))
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));
-			if (!wallets.node.work_generate_blocking (*block_a, wallets.node.active.limited_active_difficulty ()).is_initialized ())
-			{
-				wallets.node.logger.try_log (boost::str (boost::format ("Work generation failed or cancelled for %1%") % block_a->hash ().to_string ()));
-				error = true;
-			}
+			error = !wallets.node.work_generate_blocking (*block_a, wallets.node.active.limited_active_difficulty ()).is_initialized ();
 		}
 		if (!error)
 		{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1125,7 +1125,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 	return block;
 }
 
-bool nano::wallet::action_complete (std::shared_ptr<nano::block> block_a, nano::account const & account_a, bool const generate_work_a)
+bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, bool const generate_work_a)
 {
 	bool error{ false };
 	if (block_a != nullptr)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -975,20 +975,9 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block const & s
 	}
 	if (block != nullptr)
 	{
-		if (nano::work_validate (*block))
+		if (action_complete (block, account, generate_work_a))
 		{
-			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block->hash ().to_string () % account.to_account ()));
-			wallets.node.work_generate_blocking (*block, wallets.node.active.limited_active_difficulty ());
-		}
-		wallets.watcher->add (block);
-		bool error (wallets.node.process_local (block).code != nano::process_result::progress);
-		if (!error && generate_work_a)
-		{
-			work_ensure (account, block->hash ());
-		}
-		// Return null block after ledger process error
-		if (error)
-		{
+			// Return null block after work generation or ledger process error
 			block = nullptr;
 		}
 	}
@@ -1024,20 +1013,9 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 	}
 	if (block != nullptr)
 	{
-		if (nano::work_validate (*block))
+		if (action_complete (block, source_a, generate_work_a))
 		{
-			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block->hash ().to_string () % source_a.to_account ()));
-			wallets.node.work_generate_blocking (*block, wallets.node.active.limited_active_difficulty ());
-		}
-		wallets.watcher->add (block);
-		bool error (wallets.node.process_local (block).code != nano::process_result::progress);
-		if (!error && generate_work_a)
-		{
-			work_ensure (source_a, block->hash ());
-		}
-		// Return null block after ledger process error
-		if (error)
-		{
+			// Return null block after work generation or ledger process error
 			block = nullptr;
 		}
 	}
@@ -1138,24 +1116,40 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 
 	if (!error && block != nullptr && !cached_block)
 	{
-		if (nano::work_validate (*block))
+		if (action_complete (block, source_a, generate_work_a))
 		{
-			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block->hash ().to_string () % account_a.to_account ()));
-			wallets.node.work_generate_blocking (*block, wallets.node.active.limited_active_difficulty ());
-		}
-		wallets.watcher->add (block);
-		error = (wallets.node.process_local (block).code != nano::process_result::progress);
-		if (!error && generate_work_a)
-		{
-			work_ensure (source_a, block->hash ());
-		}
-		// Return null block after ledger process error
-		if (error)
-		{
+			// Return null block after work generation or ledger process error
 			block = nullptr;
 		}
 	}
 	return block;
+}
+
+bool nano::wallet::action_complete (std::shared_ptr<nano::block> block_a, nano::account const & account_a, bool const generate_work_a)
+{
+	bool error{ false };
+	if (block_a != nullptr)
+	{
+		if (nano::work_validate (*block_a))
+		{
+			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));
+			if (!wallets.node.work_generate_blocking (*block_a, wallets.node.active.limited_active_difficulty ()).is_initialized ())
+			{
+				wallets.node.logger.try_log (boost::str (boost::format ("Work generation failed or cancelled for %1%") % block_a->hash ().to_string ()));
+				error = true;
+			}
+		}
+		if (!error)
+		{
+			wallets.watcher->add (block_a);
+			error = wallets.node.process_local (block_a).code != nano::process_result::progress;
+		}
+		if (!error && generate_work_a)
+		{
+			work_ensure (account_a, block_a->hash ());
+		}
+	}
+	return error;
 }
 
 bool nano::wallet::change_sync (nano::account const & source_a, nano::account const & representative_a)
@@ -1373,22 +1367,27 @@ bool nano::wallet::live ()
 
 void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::block_hash const & root_a)
 {
-	auto begin (std::chrono::steady_clock::now ());
-	auto work (wallets.node.work_generate_blocking (root_a));
-	if (wallets.node.config.logging.work_generation_time ())
+	nano::timer<std::chrono::milliseconds> elapsed_l;
+	uint64_t work_l{ 0 };
+	auto opt_work_l (wallets.node.work_generate_blocking (root_a));
+	if (opt_work_l.is_initialized ())
 	{
-		/*
-		 * The difficulty parameter is the second parameter for `work_generate_blocking()`,
-		 * currently we don't supply one so we must fetch the default value.
-		 */
-		auto difficulty (wallets.node.network_params.network.publish_threshold);
+		work_l = *opt_work_l;
+		if (wallets.node.config.logging.work_generation_time ())
+		{
+			/*
+		 	 * The difficulty parameter is the second parameter for `work_generate_blocking()`,
+		 	 * currently we don't supply one so we must fetch the default value.
+		 	*/
+			auto difficulty_l (wallets.node.network_params.network.publish_threshold);
 
-		wallets.node.logger.try_log ("Work generation for ", root_a.to_string (), ", with a difficulty of ", difficulty, " complete: ", (std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - begin).count ()), " us");
+			wallets.node.logger.try_log ("Work generation for ", root_a.to_string (), ", with a difficulty of ", difficulty_l, " complete: ", elapsed_l.stop ().count (), " ms");
+		}
 	}
-	auto transaction (wallets.tx_begin_write ());
-	if (live () && store.exists (transaction, account_a))
+	auto transaction_l (wallets.tx_begin_write ());
+	if (live () && store.exists (transaction_l, account_a))
 	{
-		work_update (transaction, account_a, root_a, work);
+		work_update (transaction_l, account_a, root_a, work_l);
 	}
 }
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -123,6 +123,7 @@ public:
 	std::shared_ptr<nano::block> change_action (nano::account const &, nano::account const &, uint64_t = 0, bool = true);
 	std::shared_ptr<nano::block> receive_action (nano::block const &, nano::account const &, nano::uint128_union const &, uint64_t = 0, bool = true);
 	std::shared_ptr<nano::block> send_action (nano::account const &, nano::account const &, nano::uint128_t const &, uint64_t = 0, bool = true, boost::optional<std::string> = {});
+	bool action_complete (std::shared_ptr<nano::block>, nano::account const &, bool const);
 	wallet (bool &, nano::transaction &, nano::wallets &, std::string const &);
 	wallet (bool &, nano::transaction &, nano::wallets &, std::string const &, std::string const &);
 	void enter_initial_password ();

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -123,7 +123,7 @@ public:
 	std::shared_ptr<nano::block> change_action (nano::account const &, nano::account const &, uint64_t = 0, bool = true);
 	std::shared_ptr<nano::block> receive_action (nano::block const &, nano::account const &, nano::uint128_union const &, uint64_t = 0, bool = true);
 	std::shared_ptr<nano::block> send_action (nano::account const &, nano::account const &, nano::uint128_t const &, uint64_t = 0, bool = true, boost::optional<std::string> = {});
-	bool action_complete (std::shared_ptr<nano::block>, nano::account const &, bool const);
+	bool action_complete (std::shared_ptr<nano::block> const &, nano::account const &, bool const);
 	wallet (bool &, nano::transaction &, nano::wallets &, std::string const &);
 	wallet (bool &, nano::transaction &, nano::wallets &, std::string const &, std::string const &);
 	void enter_initial_password ();

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2306,7 +2306,7 @@ void nano_qt::block_creation::create_receive ()
 							auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
 							assert (rep_block != nullptr);
 							nano::state_block receive (pending_key.account, info.head, rep_block->representative (), info.balance.number () + pending.amount.number (), source_l, key, pending_key.account, 0);
-							if (wallet.node.work_generate_blocking (receive))
+							if (wallet.node.work_generate_blocking (receive).is_initialized ())
 							{
 								std::string block_l;
 								receive.serialize_json (block_l);

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2232,12 +2232,19 @@ void nano_qt::block_creation::create_send ()
 						auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
 						assert (rep_block != nullptr);
 						nano::state_block send (account_l, info.head, rep_block->representative (), balance - amount_l.number (), destination_l, key, account_l, 0);
-						wallet.node.work_generate_blocking (send);
-						std::string block_l;
-						send.serialize_json (block_l);
-						block->setPlainText (QString (block_l.c_str ()));
-						show_label_ok (*status);
-						status->setText ("Created block");
+						if (wallet.node.work_generate_blocking (send).is_initialized ())
+						{
+							std::string block_l;
+							send.serialize_json (block_l);
+							block->setPlainText (QString (block_l.c_str ()));
+							show_label_ok (*status);
+							status->setText ("Created block");
+						}
+						else
+						{
+							show_label_error (*status);
+							status->setText ("Work generation failure");
+						}
 					}
 					else
 					{
@@ -2299,12 +2306,19 @@ void nano_qt::block_creation::create_receive ()
 							auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
 							assert (rep_block != nullptr);
 							nano::state_block receive (pending_key.account, info.head, rep_block->representative (), info.balance.number () + pending.amount.number (), source_l, key, pending_key.account, 0);
-							wallet.node.work_generate_blocking (receive);
-							std::string block_l;
-							receive.serialize_json (block_l);
-							block->setPlainText (QString (block_l.c_str ()));
-							show_label_ok (*status);
-							status->setText ("Created block");
+							if (wallet.node.work_generate_blocking (receive))
+							{
+								std::string block_l;
+								receive.serialize_json (block_l);
+								block->setPlainText (QString (block_l.c_str ()));
+								show_label_ok (*status);
+								status->setText ("Created block");
+							}
+							else
+							{
+								show_label_error (*status);
+								status->setText ("Work generation failure");
+							}
 						}
 						else
 						{
@@ -2364,12 +2378,19 @@ void nano_qt::block_creation::create_change ()
 				if (!error)
 				{
 					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key, account_l, 0);
-					wallet.node.work_generate_blocking (change);
-					std::string block_l;
-					change.serialize_json (block_l);
-					block->setPlainText (QString (block_l.c_str ()));
-					show_label_ok (*status);
-					status->setText ("Created block");
+					if (wallet.node.work_generate_blocking (change).is_initialized ())
+					{
+						std::string block_l;
+						change.serialize_json (block_l);
+						block->setPlainText (QString (block_l.c_str ()));
+						show_label_ok (*status);
+						status->setText ("Created block");
+					}
+					else
+					{
+						show_label_error (*status);
+						status->setText ("Work generation failure");
+					}
 				}
 				else
 				{
@@ -2427,12 +2448,19 @@ void nano_qt::block_creation::create_open ()
 							if (!error)
 							{
 								nano::state_block open (pending_key.account, 0, representative_l, pending.amount, source_l, key, pending_key.account, 0);
-								wallet.node.work_generate_blocking (open);
-								std::string block_l;
-								open.serialize_json (block_l);
-								block->setPlainText (QString (block_l.c_str ()));
-								show_label_ok (*status);
-								status->setText ("Created block");
+								if (wallet.node.work_generate_blocking (open).is_initialized ())
+								{
+									std::string block_l;
+									open.serialize_json (block_l);
+									block->setPlainText (QString (block_l.c_str ()));
+									show_label_ok (*status);
+									status->setText ("Created block");
+								}
+								else
+								{
+									show_label_error (*status);
+									status->setText ("Work generation failure");
+								}
 							}
 							else
 							{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -259,7 +259,7 @@ TEST (rpc, account_weight)
 	nano::system system (24000, 1);
 	nano::block_hash latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::change_block block (latest, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::change_block block (latest, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	ASSERT_EQ (nano::process_result::progress, node1.process (block).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
@@ -508,7 +508,7 @@ TEST (rpc, send_work)
 	}
 	ASSERT_EQ (std::error_code (nano::error_common::invalid_work).message (), response.json.get<std::string> ("error"));
 	request.erase ("work");
-	request.put ("work", nano::to_string_hex (system.nodes[0]->work_generate_blocking (system.nodes[0]->latest (nano::test_genesis_key.pub))));
+	request.put ("work", nano::to_string_hex (*system.nodes[0]->work_generate_blocking (system.nodes[0]->latest (nano::test_genesis_key.pub))));
 	test_response response2 (request, rpc.config.port, system.io_ctx);
 	system.deadline_set (10s);
 	while (response2.status == 0)
@@ -1400,9 +1400,9 @@ TEST (rpc, history)
 	ASSERT_NE (nullptr, receive);
 	auto node0 (system.nodes[0]);
 	nano::genesis genesis;
-	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (node0->latest (nano::genesis_account)));
-	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (usend.hash ()));
-	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (ureceive.hash ()));
+	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (node0->latest (nano::genesis_account)));
+	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (usend.hash ()));
+	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (ureceive.hash ()));
 	{
 		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
@@ -1470,9 +1470,9 @@ TEST (rpc, account_history)
 	ASSERT_NE (nullptr, receive);
 	auto node0 (system.nodes[0]);
 	nano::genesis genesis;
-	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (node0->latest (nano::genesis_account)));
-	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (usend.hash ()));
-	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (ureceive.hash ()));
+	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (node0->latest (nano::genesis_account)));
+	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (usend.hash ()));
+	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (ureceive.hash ()));
 	{
 		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
@@ -1641,7 +1641,7 @@ TEST (rpc, process_block)
 	nano::keypair key;
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -1738,7 +1738,7 @@ TEST (rpc, process_block_no_work)
 	nano::keypair key;
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	send.block_work_set (0);
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
@@ -1769,7 +1769,7 @@ TEST (rpc, process_republish)
 	nano::keypair key;
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -1803,7 +1803,7 @@ TEST (rpc, process_subtype_send)
 	nano::keypair key;
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -1855,14 +1855,14 @@ TEST (rpc, process_subtype_open)
 	nano::keypair key;
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	{
 		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send).code);
 	}
 	scoped_io_thread_name_change scoped_thread_name_io;
 	node1.active.start (std::make_shared<nano::state_block> (send));
-	nano::state_block open (key.pub, 0, key.pub, nano::Gxrb_ratio, send.hash (), key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::state_block open (key.pub, 0, key.pub, nano::Gxrb_ratio, send.hash (), key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -1913,14 +1913,14 @@ TEST (rpc, process_subtype_receive)
 	nano::system system (24000, 2);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	{
 		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send).code);
 	}
 	scoped_io_thread_name_change scoped_thread_name_io;
 	node1.active.start (std::make_shared<nano::state_block> (send));
-	nano::state_block receive (nano::test_genesis_key.pub, send.hash (), nano::test_genesis_key.pub, nano::genesis_amount, send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (send.hash ()));
+	nano::state_block receive (nano::test_genesis_key.pub, send.hash (), nano::test_genesis_key.pub, nano::genesis_amount, send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -2521,7 +2521,7 @@ TEST (rpc, search_pending)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	auto wallet (system.nodes[0]->wallets.items.begin ()->first.to_string ());
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (latest));
+	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (latest));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
@@ -3308,7 +3308,7 @@ TEST (rpc, bootstrap)
 	nano::system system0 (24000, 1);
 	nano::system system1 (24001, 1);
 	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system1.nodes[0]->work_generate_blocking (latest));
+	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system1.nodes[0]->work_generate_blocking (latest));
 	{
 		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
@@ -3527,7 +3527,7 @@ TEST (rpc, work_validate)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	nano::block_hash hash (1);
-	uint64_t work1 (node1.work_generate_blocking (hash));
+	uint64_t work1 (*node1.work_generate_blocking (hash));
 	boost::property_tree::ptree request;
 	request.put ("action", "work_validate");
 	request.put ("hash", hash.to_string ());
@@ -3598,7 +3598,7 @@ TEST (rpc, work_validate)
 		bool validate (response.json.get<bool> ("valid"));
 		ASSERT_EQ (result_difficulty >= difficulty4, validate);
 	}
-	uint64_t work3 (node1.work_generate_blocking (hash, difficulty4));
+	uint64_t work3 (*node1.work_generate_blocking (hash, difficulty4));
 	request.put ("work", nano::to_string_hex (work3));
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
@@ -3668,7 +3668,7 @@ TEST (rpc, bootstrap_any)
 	nano::system system0 (24000, 1);
 	nano::system system1 (24001, 1);
 	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system1.nodes[0]->work_generate_blocking (latest));
+	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system1.nodes[0]->work_generate_blocking (latest));
 	{
 		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
@@ -3700,9 +3700,9 @@ TEST (rpc, republish)
 	nano::genesis genesis;
 	auto & node1 (*system.nodes[0]);
 	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
@@ -4484,7 +4484,7 @@ TEST (rpc, search_pending_all)
 	nano::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (latest));
+	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - system.nodes[0]->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (latest));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
@@ -4529,9 +4529,9 @@ TEST (rpc, wallet_republish)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	system.nodes[0]->process (send);
-	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
@@ -4571,9 +4571,9 @@ TEST (rpc, delegators)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	system.nodes[0]->process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -4612,9 +4612,9 @@ TEST (rpc, delegators_count)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
 	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
@@ -4676,7 +4676,7 @@ TEST (rpc, account_info)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	system.nodes[0]->process (send);
 	auto time (nano::seconds_since_epoch ());
 	{
@@ -4789,7 +4789,7 @@ TEST (rpc, json_block_output)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	system.nodes[0]->process (send);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
@@ -5078,9 +5078,9 @@ TEST (rpc, ledger)
 	auto genesis_balance (nano::genesis_amount);
 	auto send_amount (genesis_balance - 100);
 	genesis_balance -= send_amount;
-	nano::send_block send (latest, key.pub, genesis_balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, genesis_balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	auto time (nano::seconds_since_epoch ());
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -5169,7 +5169,7 @@ TEST (rpc, ledger)
 	}
 	auto send2_amount (50);
 	genesis_balance -= send2_amount;
-	nano::send_block send2 (send.hash (), key.pub, genesis_balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (send.hash ()));
+	nano::send_block send2 (send.hash (), key.pub, genesis_balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
 	scoped_thread_name_io.reset ();
 	node1.process (send2);
 	scoped_thread_name_io.renew ();
@@ -5238,9 +5238,9 @@ TEST (rpc, block_create)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
 	auto latest (node1.latest (nano::test_genesis_key.pub));
-	auto send_work = node1.work_generate_blocking (latest);
+	auto send_work = *node1.work_generate_blocking (latest);
 	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, send_work);
-	auto open_work = node1.work_generate_blocking (key.pub);
+	auto open_work = *node1.work_generate_blocking (key.pub);
 	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, open_work);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
@@ -5313,7 +5313,7 @@ TEST (rpc, block_create)
 	ASSERT_EQ (200, response2.status);
 	std::string open2_hash (response2.json.get<std::string> ("hash"));
 	ASSERT_NE (open.hash ().to_string (), open2_hash); // different blocks with wrong representative
-	auto change_work = node1.work_generate_blocking (open.hash ());
+	auto change_work = *node1.work_generate_blocking (open.hash ());
 	nano::change_block change (open.hash (), key.pub, key.prv, key.pub, change_work);
 	request1.put ("type", "change");
 	request1.put ("work", nano::to_string_hex (change_work));
@@ -5333,7 +5333,7 @@ TEST (rpc, block_create)
 	ASSERT_EQ (change.hash (), change_block->hash ());
 	scoped_thread_name_io.reset ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (change).code);
-	nano::send_block send2 (send.hash (), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (send.hash ()));
+	nano::send_block send2 (send.hash (), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (send2).code);
 	scoped_thread_name_io.renew ();
 	boost::property_tree::ptree request2;
@@ -5343,7 +5343,7 @@ TEST (rpc, block_create)
 	request2.put ("account", key.pub.to_account ());
 	request2.put ("source", send2.hash ().to_string ());
 	request2.put ("previous", change.hash ().to_string ());
-	request2.put ("work", nano::to_string_hex (node1.work_generate_blocking (change.hash ())));
+	request2.put ("work", nano::to_string_hex (*node1.work_generate_blocking (change.hash ())));
 	test_response response5 (request2, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
 	while (response5.status == 0)
@@ -5377,7 +5377,7 @@ TEST (rpc, block_create_state)
 	request.put ("representative", nano::test_genesis_key.pub.to_account ());
 	request.put ("balance", (nano::genesis_amount - nano::Gxrb_ratio).convert_to<std::string> ());
 	request.put ("link", key.pub.to_account ());
-	request.put ("work", nano::to_string_hex (system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	request.put ("work", nano::to_string_hex (*system.nodes[0]->work_generate_blocking (genesis.hash ())));
 	auto node = system.nodes.front ();
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node->config.ipc_config.transport_tcp);
@@ -5425,7 +5425,7 @@ TEST (rpc, block_create_state_open)
 	request.put ("representative", nano::test_genesis_key.pub.to_account ());
 	request.put ("balance", nano::Gxrb_ratio.convert_to<std::string> ());
 	request.put ("link", send_block->hash ().to_string ());
-	request.put ("work", nano::to_string_hex (system.nodes[0]->work_generate_blocking (key.pub)));
+	request.put ("work", nano::to_string_hex (*system.nodes[0]->work_generate_blocking (key.pub)));
 	auto node = system.nodes.front ();
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node->config.ipc_config.transport_tcp);
@@ -5512,7 +5512,7 @@ TEST (rpc, block_hash)
 	nano::keypair key;
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
 	auto & node1 (*system.nodes[0]);
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	enable_ipc_transport_tcp (node1.config.ipc_config.transport_tcp);
 	nano::node_rpc_config node_rpc_config;
@@ -5636,9 +5636,9 @@ TEST (rpc, wallet_ledger)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
 	auto latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
 	system.nodes[0]->process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	auto time (nano::seconds_since_epoch ());
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -6041,7 +6041,7 @@ TEST (rpc, block_confirm)
 	nano::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.nodes[0]->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, *send1).code);


### PR DESCRIPTION
Adds handling of work generation failures in critical paths (everything that is not a test). Failure can be a simple work cancellation which can happen for many reasons - even manually.

- Extract `nano::wallet::action_complete` with work validation + generation + block processing. Was repeated in all `*_action`
- Move work generation logging to distributed work, which makes logging now work for 99% of cases rather than only for precaching
- Fix a minor issue in distributed work where work cancellation would make it start local generation immediately the next time