### PR TITLE
Replace account_info::rep_block with representative account

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -812,8 +812,8 @@ TEST (mdb_block_store, upgrade_v2_v3)
 		ASSERT_EQ (6, ledger.weight (transaction, key2.pub));
 		nano::account_info info;
 		ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info));
-		info.rep_block = 42;
-		nano::account_info_v5 info_old (info.head, info.rep_block, info.open_block, info.balance, info.modified);
+		auto rep_block = ledger.representative (transaction, ledger.latest (transaction, nano::test_genesis_key.pub));
+		nano::account_info_v5 info_old (info.head, rep_block, info.open_block, info.balance, info.modified);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (sizeof (info_old), &info_old), 0));
 		(void)status;
 		assert (status == 0);
@@ -829,7 +829,7 @@ TEST (mdb_block_store, upgrade_v2_v3)
 	ASSERT_EQ (0, ledger.weight (transaction, key2.pub));
 	nano::account_info info;
 	ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, info));
-	ASSERT_EQ (change_hash, info.rep_block);
+	ASSERT_EQ (change_hash, ledger.representative (transaction, ledger.latest (transaction, nano::test_genesis_key.pub)));
 }
 
 TEST (mdb_block_store, upgrade_v3_v4)
@@ -1767,7 +1767,9 @@ TEST (block_store, upgrade_confirmation_height_many)
 		for (auto i = 0; i < total_num_accounts - 1; ++i)
 		{
 			nano::account account (i);
-			nano::open_block open (1, 2, 3, nullptr);
+			nano::open_block open (1, nano::genesis_account, 3, nullptr);
+			nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0);
+			store.block_put (transaction, open.hash (), open, sideband);
 			nano::account_info_v13 account_info_v13 (open.hash (), open.hash (), open.hash (), 3, 4, 1, nano::epoch::epoch_1);
 			auto status (mdb_put (store.env.tx (transaction), store.accounts_v1, nano::mdb_val (account), nano::mdb_val (account_info_v13), 0));
 			ASSERT_EQ (status, 0);
@@ -1875,32 +1877,38 @@ TEST (block_store, rocksdb_force_test_env_variable)
 namespace
 {
 // These functions take the latest account_info and create a legacy one so that upgrade tests can be emulated more easily.
-void modify_account_info_to_v13 (nano::mdb_store & store, nano::transaction const & transaction_a, nano::account const & account)
+void modify_account_info_to_v13 (nano::mdb_store & store, nano::transaction const & transaction, nano::account const & account)
 {
 	nano::account_info info;
-	ASSERT_FALSE (store.account_get (transaction_a, account, info));
-	nano::account_info_v13 account_info_v13 (info.head, info.rep_block, info.open_block, info.balance, info.modified, info.block_count, info.epoch);
-	auto status (mdb_put (store.env.tx (transaction_a), store.get_account_db (info.epoch) == nano::tables::accounts_v0 ? store.accounts_v0 : store.accounts_v1, nano::mdb_val (account), nano::mdb_val (account_info_v13), 0));
+	ASSERT_FALSE (store.account_get (transaction, account, info));
+	nano::representative_visitor visitor (transaction, store);
+	visitor.compute (info.head);
+	nano::account_info_v13 account_info_v13 (info.head, visitor.result, info.open_block, info.balance, info.modified, info.block_count, info.epoch);
+	auto status (mdb_put (store.env.tx (transaction), store.get_account_db (info.epoch) == nano::tables::accounts_v0 ? store.accounts_v0 : store.accounts_v1, nano::mdb_val (account), nano::mdb_val (account_info_v13), 0));
 	(void)status;
 	assert (status == 0);
 }
 
-void modify_account_info_to_v14 (nano::mdb_store & store, nano::transaction const & transaction_a, nano::account const & account, uint64_t confirmation_height)
+void modify_account_info_to_v14 (nano::mdb_store & store, nano::transaction const & transaction, nano::account const & account, uint64_t confirmation_height)
 {
 	nano::account_info info;
-	ASSERT_FALSE (store.account_get (transaction_a, account, info));
-	nano::account_info_v14 account_info_v14 (info.head, info.rep_block, info.open_block, info.balance, info.modified, info.block_count, confirmation_height, info.epoch);
-	auto status (mdb_put (store.env.tx (transaction_a), store.get_account_db (info.epoch) == nano::tables::accounts_v0 ? store.accounts_v0 : store.accounts_v1, nano::mdb_val (account), nano::mdb_val (account_info_v14), 0));
+	ASSERT_FALSE (store.account_get (transaction, account, info));
+	nano::representative_visitor visitor (transaction, store);
+	visitor.compute (info.head);
+	nano::account_info_v14 account_info_v14 (info.head, visitor.result, info.open_block, info.balance, info.modified, info.block_count, confirmation_height, info.epoch);
+	auto status (mdb_put (store.env.tx (transaction), store.get_account_db (info.epoch) == nano::tables::accounts_v0 ? store.accounts_v0 : store.accounts_v1, nano::mdb_val (account), nano::mdb_val (account_info_v14), 0));
 	(void)status;
 	assert (status == 0);
 }
 
-void modify_genesis_account_info_to_v5 (nano::mdb_store & store, nano::transaction const & transaction_a)
+void modify_genesis_account_info_to_v5 (nano::mdb_store & store, nano::transaction const & transaction)
 {
 	nano::account_info info;
-	store.account_get (transaction_a, nano::test_genesis_key.pub, info);
-	nano::account_info_v5 info_old (info.head, info.rep_block, info.open_block, info.balance, info.modified);
-	auto status (mdb_put (store.env.tx (transaction_a), store.accounts_v0, nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (sizeof (info_old), &info_old), 0));
+	store.account_get (transaction, nano::test_genesis_key.pub, info);
+	nano::representative_visitor visitor (transaction, store);
+	visitor.compute (info.head);
+	nano::account_info_v5 info_old (info.head, visitor.result, info.open_block, info.balance, info.modified);
+	auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (sizeof (info_old), &info_old), 0));
 	(void)status;
 	assert (status == 0);
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -294,11 +294,11 @@ TEST (ledger, rollback_representation)
 	ASSERT_EQ (nano::genesis_amount - 1, ledger.weight (transaction, key4.pub));
 	nano::account_info info1;
 	ASSERT_FALSE (store->account_get (transaction, key2.pub, info1));
-	ASSERT_EQ (open.hash (), info1.rep_block);
+	ASSERT_EQ (key4.pub, info1.representative);
 	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
 	nano::account_info info2;
 	ASSERT_FALSE (store->account_get (transaction, key2.pub, info2));
-	ASSERT_EQ (open.hash (), info2.rep_block);
+	ASSERT_EQ (key4.pub, info2.representative);
 	ASSERT_EQ (0, ledger.weight (transaction, key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (transaction, key4.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, open.hash ()));
@@ -308,11 +308,11 @@ TEST (ledger, rollback_representation)
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (transaction, key3.pub));
 	nano::account_info info3;
 	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info3));
-	ASSERT_EQ (change2.hash (), info3.rep_block);
+	ASSERT_EQ (key3.pub, info3.representative);
 	ASSERT_FALSE (ledger.rollback (transaction, change2.hash ()));
 	nano::account_info info4;
 	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info4));
-	ASSERT_EQ (change1.hash (), info4.rep_block);
+	ASSERT_EQ (key5.pub, info4.representative);
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (transaction, key5.pub));
 	ASSERT_EQ (0, ledger.weight (transaction, key3.pub));
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -67,13 +67,13 @@ TEST (node, balance)
 TEST (node, representative)
 {
 	nano::system system (24000, 1);
-	auto block1 (system.nodes[0]->representative (nano::test_genesis_key.pub));
+	auto block1 (system.nodes[0]->rep_block (nano::test_genesis_key.pub));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_TRUE (system.nodes[0]->ledger.store.block_exists (transaction, block1));
 	}
 	nano::keypair key;
-	ASSERT_TRUE (system.nodes[0]->representative (key.pub).is_zero ());
+	ASSERT_TRUE (system.nodes[0]->rep_block (key.pub).is_zero ());
 }
 
 TEST (node, send_unkeyed)

--- a/nano/core_test/versioning.cpp
+++ b/nano/core_test/versioning.cpp
@@ -33,7 +33,7 @@ TEST (versioning, account_info_v1)
 	ASSERT_EQ (v1.balance, v_latest.balance);
 	ASSERT_EQ (v1.head, v_latest.head);
 	ASSERT_EQ (v1.modified, v_latest.modified);
-	ASSERT_EQ (v1.rep_block, v_latest.rep_block);
+	ASSERT_EQ (v1.rep_block, open.hash ());
 	ASSERT_EQ (1, v_latest.block_count);
 	uint64_t confirmation_height;
 	ASSERT_FALSE (store.confirmation_height_get (transaction, account, confirmation_height));
@@ -69,7 +69,7 @@ TEST (versioning, account_info_v5)
 	ASSERT_EQ (v5.balance, v_latest.balance);
 	ASSERT_EQ (v5.head, v_latest.head);
 	ASSERT_EQ (v5.modified, v_latest.modified);
-	ASSERT_EQ (v5.rep_block, v_latest.rep_block);
+	ASSERT_EQ (v5.rep_block, open.hash ());
 	ASSERT_EQ (1, v_latest.block_count);
 	uint64_t confirmation_height;
 	ASSERT_FALSE (store.confirmation_height_get (transaction, account, confirmation_height));
@@ -105,7 +105,7 @@ TEST (versioning, account_info_v13)
 	ASSERT_EQ (v13.balance, v_latest.balance);
 	ASSERT_EQ (v13.head, v_latest.head);
 	ASSERT_EQ (v13.modified, v_latest.modified);
-	ASSERT_EQ (v13.rep_block, v_latest.rep_block);
+	ASSERT_EQ (v13.rep_block, open.hash ());
 	ASSERT_EQ (v13.block_count, v_latest.block_count);
 	uint64_t confirmation_height;
 	ASSERT_FALSE (store.confirmation_height_get (transaction, account, confirmation_height));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -215,10 +215,10 @@ TEST (wallet, change)
 	nano::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key2;
-	auto block1 (system.nodes[0]->representative (nano::test_genesis_key.pub));
+	auto block1 (system.nodes[0]->rep_block (nano::test_genesis_key.pub));
 	ASSERT_FALSE (block1.is_zero ());
 	ASSERT_NE (nullptr, system.wallet (0)->change_action (nano::test_genesis_key.pub, key2.pub));
-	auto block2 (system.nodes[0]->representative (nano::test_genesis_key.pub));
+	auto block2 (system.nodes[0]->rep_block (nano::test_genesis_key.pub));
 	ASSERT_FALSE (block2.is_zero ());
 	ASSERT_NE (block1, block2);
 }

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -100,7 +100,8 @@ TEST (wallets, upgrade)
 
 		nano::account_info info;
 		ASSERT_FALSE (mdb_store.account_get (transaction_destination, nano::genesis_account, info));
-		nano::account_info_v13 account_info_v13 (info.head, info.rep_block, info.open_block, info.balance, info.modified, info.block_count, info.epoch);
+		auto rep_block = node1->rep_block (nano::genesis_account);
+		nano::account_info_v13 account_info_v13 (info.head, rep_block, info.open_block, info.balance, info.modified, info.block_count, info.epoch);
 		auto status (mdb_put (mdb_store.env.tx (transaction_destination), mdb_store.get_account_db (info.epoch) == nano::tables::accounts_v0 ? mdb_store.accounts_v0 : mdb_store.accounts_v1, nano::mdb_val (nano::test_genesis_key.pub), nano::mdb_val (account_info_v13), 0));
 		(void)status;
 		assert (status == 0);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -831,7 +831,7 @@ int main (int argc, char * const * argv)
 				auto block (node.node->store.block_get (transaction, hash, &sideband)); // Block data
 				uint64_t height (0);
 				uint64_t previous_timestamp (0);
-				nano::block_hash calculated_representative_block (0);
+				nano::account calculated_representative (0);
 				while (!hash.is_zero () && block != nullptr)
 				{
 					++block_count;
@@ -911,7 +911,7 @@ int main (int argc, char * const * argv)
 					// Calculate representative block
 					if (block->type () == nano::block_type::open || block->type () == nano::block_type::change || block->type () == nano::block_type::state)
 					{
-						calculated_representative_block = hash;
+						calculated_representative = block->representative ();
 					}
 					// Retrieving successor block hash
 					hash = node.node->store.block_successor (transaction, hash);
@@ -937,9 +937,9 @@ int main (int argc, char * const * argv)
 					std::cerr << boost::str (boost::format ("Incorrect frontier for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_hash.to_string () % info.head.to_string ());
 				}
 				// Check account representative block
-				if (info.rep_block != calculated_representative_block)
+				if (info.representative != calculated_representative)
 				{
-					std::cerr << boost::str (boost::format ("Incorrect representative block for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_representative_block.to_string () % info.rep_block.to_string ());
+					std::cerr << boost::str (boost::format ("Incorrect representative for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_representative.to_string () % info.representative.to_string ());
 				}
 			}
 			std::cout << boost::str (boost::format ("%1% accounts validated\n") % count);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -528,7 +528,7 @@ void nano::json_handler::account_info ()
 		{
 			response_l.put ("frontier", info.head.to_string ());
 			response_l.put ("open_block", info.open_block.to_string ());
-			response_l.put ("representative_block", info.rep_block.to_string ());
+			response_l.put ("representative_block", node.ledger.representative (transaction, info.head).to_string ());
 			std::string balance;
 			nano::uint128_union (info.balance).encode_dec (balance);
 			response_l.put ("balance", balance);
@@ -538,9 +538,7 @@ void nano::json_handler::account_info ()
 			response_l.put ("confirmation_height", std::to_string (confirmation_height));
 			if (representative)
 			{
-				auto block (node.store.block_get (transaction, info.rep_block));
-				assert (block != nullptr);
-				response_l.put ("representative", block->representative ().to_account ());
+				response_l.put ("representative", info.representative.to_account ());
 			}
 			if (weight)
 			{
@@ -659,9 +657,7 @@ void nano::json_handler::account_representative ()
 		nano::account_info info;
 		if (!node.store.account_get (transaction, account, info))
 		{
-			auto block (node.store.block_get (transaction, info.rep_block));
-			assert (block != nullptr);
-			response_l.put ("representative", block->representative ().to_account ());
+			response_l.put ("representative", info.representative.to_account ());
 		}
 		else
 		{
@@ -1955,9 +1951,7 @@ void nano::json_handler::delegators ()
 		for (auto i (node.store.latest_begin (transaction)), n (node.store.latest_end ()); i != n; ++i)
 		{
 			nano::account_info const & info (i->second);
-			auto block (node.store.block_get (transaction, info.rep_block));
-			assert (block != nullptr);
-			if (block->representative () == account)
+			if (info.representative == account)
 			{
 				std::string balance;
 				nano::uint128_union (info.balance).encode_dec (balance);
@@ -1980,9 +1974,7 @@ void nano::json_handler::delegators_count ()
 		for (auto i (node.store.latest_begin (transaction)), n (node.store.latest_end ()); i != n; ++i)
 		{
 			nano::account_info const & info (i->second);
-			auto block (node.store.block_get (transaction, info.rep_block));
-			assert (block != nullptr);
-			if (block->representative () == account)
+			if (info.representative == account)
 			{
 				++count;
 			}
@@ -2429,7 +2421,7 @@ void nano::json_handler::ledger ()
 					}
 					response_a.put ("frontier", info.head.to_string ());
 					response_a.put ("open_block", info.open_block.to_string ());
-					response_a.put ("representative_block", info.rep_block.to_string ());
+					response_a.put ("representative_block", node.ledger.representative (transaction, info.head).to_string ());
 					std::string balance;
 					nano::uint128_union (info.balance).encode_dec (balance);
 					response_a.put ("balance", balance);
@@ -2437,9 +2429,7 @@ void nano::json_handler::ledger ()
 					response_a.put ("block_count", std::to_string (info.block_count));
 					if (representative)
 					{
-						auto block (node.store.block_get (transaction, info.rep_block));
-						assert (block != nullptr);
-						response_a.put ("representative", block->representative ().to_account ());
+						response_a.put ("representative", info.representative.to_account ());
 					}
 					if (weight)
 					{
@@ -2483,7 +2473,7 @@ void nano::json_handler::ledger ()
 					}
 					response_a.put ("frontier", info.head.to_string ());
 					response_a.put ("open_block", info.open_block.to_string ());
-					response_a.put ("representative_block", info.rep_block.to_string ());
+					response_a.put ("representative_block", node.ledger.representative (transaction, info.head).to_string ());
 					std::string balance;
 					(i->first).encode_dec (balance);
 					response_a.put ("balance", balance);
@@ -2491,9 +2481,7 @@ void nano::json_handler::ledger ()
 					response_a.put ("block_count", std::to_string (info.block_count));
 					if (representative)
 					{
-						auto block (node.store.block_get (transaction, info.rep_block));
-						assert (block != nullptr);
-						response_a.put ("representative", block->representative ().to_account ());
+						response_a.put ("representative", info.representative.to_account ());
 					}
 					if (weight)
 					{
@@ -4235,7 +4223,7 @@ void nano::json_handler::wallet_ledger ()
 					boost::property_tree::ptree entry;
 					entry.put ("frontier", info.head.to_string ());
 					entry.put ("open_block", info.open_block.to_string ());
-					entry.put ("representative_block", info.rep_block.to_string ());
+					entry.put ("representative_block", node.ledger.representative (block_transaction, info.head).to_string ());
 					std::string balance;
 					nano::uint128_union (info.balance).encode_dec (balance);
 					entry.put ("balance", balance);
@@ -4243,9 +4231,7 @@ void nano::json_handler::wallet_ledger ()
 					entry.put ("block_count", std::to_string (info.block_count));
 					if (representative)
 					{
-						auto block (node.store.block_get (block_transaction, info.rep_block));
-						assert (block != nullptr);
-						entry.put ("representative", block->representative ().to_account ());
+						entry.put ("representative", info.representative.to_account ());
 					}
 					if (weight)
 					{
@@ -4392,9 +4378,7 @@ void nano::json_handler::wallet_representative_set ()
 						nano::account_info info;
 						if (!rpc_l->node.store.account_get (block_transaction, account, info))
 						{
-							auto block (rpc_l->node.store.block_get (block_transaction, info.rep_block));
-							assert (block != nullptr);
-							if (block->representative () != representative)
+							if (info.representative != representative)
 							{
 								accounts.push_back (account);
 							}

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -481,7 +481,11 @@ void nano::mdb_store::upgrade_v14_to_v15 (nano::write_transaction const & transa
 	for (; i != n; ++i)
 	{
 		auto const & account_info_v14 (i->second);
-		account_infos.emplace_back (i->first, nano::account_info{ account_info_v14.head, account_info_v14.rep_block, account_info_v14.open_block, account_info_v14.balance, account_info_v14.modified, account_info_v14.block_count, account_info_v14.epoch });
+
+		// Upgrade rep block to representative account
+		auto rep_block = block_get (transaction_a, account_info_v14.rep_block);
+		release_assert (rep_block != nullptr);
+		account_infos.emplace_back (i->first, nano::account_info{ account_info_v14.head, rep_block->representative (), account_info_v14.open_block, account_info_v14.balance, account_info_v14.modified, account_info_v14.block_count, account_info_v14.epoch });
 		confirmation_height_put (transaction_a, i->first, i->second.confirmation_height);
 	}
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -755,14 +755,14 @@ nano::uint128_t nano::node::weight (nano::account const & account_a)
 	return ledger.weight (transaction, account_a);
 }
 
-nano::account nano::node::representative (nano::account const & account_a)
+nano::block_hash nano::node::rep_block (nano::account const & account_a)
 {
 	auto transaction (store.tx_begin_read ());
 	nano::account_info info;
 	nano::account result (0);
 	if (!store.account_get (transaction, account_a, info))
 	{
-		result = info.rep_block;
+		result = ledger.representative (transaction, info.head);
 	}
 	return result;
 }

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -110,7 +110,7 @@ public:
 	std::shared_ptr<nano::block> block (nano::block_hash const &);
 	std::pair<nano::uint128_t, nano::uint128_t> balance_pending (nano::account const &);
 	nano::uint128_t weight (nano::account const &);
-	nano::account representative (nano::account const &);
+	nano::block_hash rep_block (nano::account const &);
 	nano::uint128_t minimum_principal_weight ();
 	nano::uint128_t minimum_principal_weight (nano::uint128_t const &);
 	void ongoing_rep_calculation ();

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -944,9 +944,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block const & s
 					auto new_account (wallets.node.ledger.store.account_get (block_transaction, account, info));
 					if (!new_account)
 					{
-						std::shared_ptr<nano::block> rep_block = wallets.node.ledger.store.block_get (block_transaction, info.rep_block);
-						assert (rep_block != nullptr);
-						block.reset (new nano::state_block (account, info.head, rep_block->representative (), info.balance.number () + pending_info.amount.number (), hash, prv, account, work_a));
+						block.reset (new nano::state_block (account, info.head, info.representative, info.balance.number () + pending_info.amount.number (), hash, prv, account, work_a));
 					}
 					else
 					{
@@ -1073,13 +1071,11 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						auto error2 (store.fetch (transaction, source_a, prv));
 						(void)error2;
 						assert (!error2);
-						std::shared_ptr<nano::block> rep_block = wallets.node.ledger.store.block_get (block_transaction, info.rep_block);
-						assert (rep_block != nullptr);
 						if (work_a == 0)
 						{
 							store.work_get (transaction, source_a, work_a);
 						}
-						block.reset (new nano::state_block (source_a, info.head, rep_block->representative (), balance - amount_a, account_a, prv, source_a, work_a));
+						block.reset (new nano::state_block (source_a, info.head, info.representative, balance - amount_a, account_a, prv, source_a, work_a));
 						if (id_mdb_val && block != nullptr)
 						{
 							auto status (mdb_put (wallets.env.tx (transaction), wallets.node.wallets.send_action_ids, *id_mdb_val, nano::mdb_val (block->hash ()), 0));

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1673,9 +1673,7 @@ void nano_qt::settings::refresh_representative ()
 	auto error (wallet.node.store.account_get (transaction, this->wallet.account, info));
 	if (!error)
 	{
-		auto block (wallet.node.store.block_get (transaction, info.rep_block));
-		assert (block != nullptr);
-		current_representative->setText (QString (block->representative ().to_account ().c_str ()));
+		current_representative->setText (QString (info.representative.to_account ().c_str ()));
 	}
 	else
 	{
@@ -2229,9 +2227,7 @@ void nano_qt::block_creation::create_send ()
 						auto error (wallet.node.store.account_get (block_transaction, account_l, info));
 						(void)error;
 						assert (!error);
-						auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
-						assert (rep_block != nullptr);
-						nano::state_block send (account_l, info.head, rep_block->representative (), balance - amount_l.number (), destination_l, key, account_l, 0);
+						nano::state_block send (account_l, info.head, info.representative, balance - amount_l.number (), destination_l, key, account_l, 0);
 						if (wallet.node.work_generate_blocking (send).is_initialized ())
 						{
 							std::string block_l;
@@ -2303,9 +2299,7 @@ void nano_qt::block_creation::create_receive ()
 						auto error (wallet.wallet_m->store.fetch (transaction, pending_key.account, key));
 						if (!error)
 						{
-							auto rep_block (wallet.node.store.block_get (block_transaction, info.rep_block));
-							assert (rep_block != nullptr);
-							nano::state_block receive (pending_key.account, info.head, rep_block->representative (), info.balance.number () + pending.amount.number (), source_l, key, pending_key.account, 0);
+							nano::state_block receive (pending_key.account, info.head, info.representative, info.balance.number () + pending.amount.number (), source_l, key, pending_key.account, 0);
 							if (wallet.node.work_generate_blocking (receive).is_initialized ())
 							{
 								std::string block_l;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -832,9 +832,7 @@ TEST (rpc, wallet_representative_set_force)
 		nano::account_info info;
 		if (!system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info))
 		{
-			auto block (system.nodes[0]->store.block_get (transaction, info.rep_block));
-			assert (block != nullptr);
-			representative = block->representative ();
+			representative = info.representative;
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -33,7 +33,7 @@ public:
 		block_put (transaction_a, hash_l, *genesis_a.open, sideband);
 		confirmation_height_put (transaction_a, network_params.ledger.genesis_account, 1);
 		++cemented_count;
-		account_put (transaction_a, network_params.ledger.genesis_account, { hash_l, genesis_a.open->hash (), genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
+		account_put (transaction_a, network_params.ledger.genesis_account, { hash_l, network_params.ledger.genesis_account, genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
 		rep_weights.representation_put (network_params.ledger.genesis_account, std::numeric_limits<nano::uint128_t>::max ());
 		frontier_put (transaction_a, hash_l, network_params.ledger.genesis_account);
 	}

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -178,9 +178,9 @@ void nano::serialize_block (nano::stream & stream_a, nano::block const & block_a
 	block_a.serialize (stream_a);
 }
 
-nano::account_info::account_info (nano::block_hash const & head_a, nano::block_hash const & rep_block_a, nano::block_hash const & open_block_a, nano::amount const & balance_a, uint64_t modified_a, uint64_t block_count_a, nano::epoch epoch_a) :
+nano::account_info::account_info (nano::block_hash const & head_a, nano::account const & representative_a, nano::block_hash const & open_block_a, nano::amount const & balance_a, uint64_t modified_a, uint64_t block_count_a, nano::epoch epoch_a) :
 head (head_a),
-rep_block (rep_block_a),
+representative (representative_a),
 open_block (open_block_a),
 balance (balance_a),
 modified (modified_a),
@@ -195,7 +195,7 @@ bool nano::account_info::deserialize (nano::stream & stream_a)
 	try
 	{
 		nano::read (stream_a, head.bytes);
-		nano::read (stream_a, rep_block.bytes);
+		nano::read (stream_a, representative.bytes);
 		nano::read (stream_a, open_block.bytes);
 		nano::read (stream_a, balance.bytes);
 		nano::read (stream_a, modified);
@@ -211,7 +211,7 @@ bool nano::account_info::deserialize (nano::stream & stream_a)
 
 bool nano::account_info::operator== (nano::account_info const & other_a) const
 {
-	return head == other_a.head && rep_block == other_a.rep_block && open_block == other_a.open_block && balance == other_a.balance && modified == other_a.modified && block_count == other_a.block_count && epoch == other_a.epoch;
+	return head == other_a.head && representative == other_a.representative && open_block == other_a.open_block && balance == other_a.balance && modified == other_a.modified && block_count == other_a.block_count && epoch == other_a.epoch;
 }
 
 bool nano::account_info::operator!= (nano::account_info const & other_a) const
@@ -222,12 +222,12 @@ bool nano::account_info::operator!= (nano::account_info const & other_a) const
 size_t nano::account_info::db_size () const
 {
 	assert (reinterpret_cast<const uint8_t *> (this) == reinterpret_cast<const uint8_t *> (&head));
-	assert (reinterpret_cast<const uint8_t *> (&head) + sizeof (head) == reinterpret_cast<const uint8_t *> (&rep_block));
-	assert (reinterpret_cast<const uint8_t *> (&rep_block) + sizeof (rep_block) == reinterpret_cast<const uint8_t *> (&open_block));
+	assert (reinterpret_cast<const uint8_t *> (&head) + sizeof (head) == reinterpret_cast<const uint8_t *> (&representative));
+	assert (reinterpret_cast<const uint8_t *> (&representative) + sizeof (representative) == reinterpret_cast<const uint8_t *> (&open_block));
 	assert (reinterpret_cast<const uint8_t *> (&open_block) + sizeof (open_block) == reinterpret_cast<const uint8_t *> (&balance));
 	assert (reinterpret_cast<const uint8_t *> (&balance) + sizeof (balance) == reinterpret_cast<const uint8_t *> (&modified));
 	assert (reinterpret_cast<const uint8_t *> (&modified) + sizeof (modified) == reinterpret_cast<const uint8_t *> (&block_count));
-	return sizeof (head) + sizeof (rep_block) + sizeof (open_block) + sizeof (balance) + sizeof (modified) + sizeof (block_count);
+	return sizeof (head) + sizeof (representative) + sizeof (open_block) + sizeof (balance) + sizeof (modified) + sizeof (block_count);
 }
 
 size_t nano::block_counts::sum () const

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -69,13 +69,13 @@ class account_info final
 {
 public:
 	account_info () = default;
-	account_info (nano::block_hash const &, nano::block_hash const &, nano::block_hash const &, nano::amount const &, uint64_t, uint64_t, epoch);
+	account_info (nano::block_hash const &, nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t, uint64_t, epoch);
 	bool deserialize (nano::stream &);
 	bool operator== (nano::account_info const &) const;
 	bool operator!= (nano::account_info const &) const;
 	size_t db_size () const;
 	nano::block_hash head{ 0 };
-	nano::block_hash rep_block{ 0 };
+	nano::account representative{ 0 };
 	nano::block_hash open_block{ 0 };
 	nano::amount balance{ 0 };
 	/** Seconds since posix epoch */

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -44,7 +44,7 @@ public:
 	nano::process_return process (nano::write_transaction const &, nano::block const &, nano::signature_verification = nano::signature_verification::unknown);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
-	void change_latest (nano::write_transaction const &, nano::account const &, nano::block_hash const &, nano::account const &, nano::uint128_union const &, uint64_t, bool = false, nano::epoch = nano::epoch::epoch_0);
+	void change_latest (nano::write_transaction const &, nano::account const &, nano::block_hash const &, nano::account const &, nano::amount const &, uint64_t, bool = false, nano::epoch = nano::epoch::epoch_0);
 	void dump_account_chain (nano::account const &);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool is_epoch_link (nano::uint256_union const &);


### PR DESCRIPTION
Currently to find the representative from the `account_info` an extra read is needed to be done to get the rep block contents and get the representative from that. This causes slow-downs in the initial rep caching and delegator RPCs (so should fix #1517). The `rep_block` has now been replaced with the representative account itself.

To prevent breaking existing service implementations, `rep_block` will be determined on demand for RPCs which currently add to the responses (@guilhermelawless's recommendation), but will be marked as deprecated. In the new RPC 2.0 it `representative` should be returned by default rather than require the flag `"representative":"true"`

Note: Any ledgers used since #2174 will not be valid as this requires a database upgrade and those ledgers will already be on the same version!