### PR TITLE
docker `--cache-from` set as single string argument with =

### DIFF
--- a/ci/deploy-docker.sh
+++ b/ci/deploy-docker.sh
@@ -35,7 +35,7 @@ if [ -n "$DOCKER_PASSWORD" ]; then
             network_tag_suffix="-beta"
             network="beta"
             # use cache from Master_beta_docker to prevent rebuilds
-            cached="--cache-from nanocurrency/nano-beta:master"
+            cached="--cache-from=nanocurrency/nano-beta:master"
             docker pull nanocurrency/nano-beta:master
         fi
 


### PR DESCRIPTION
without `=` the string isnt properly parsed by the script