### PR TITLE
Improve bootstrap attempt locking

### DIFF
--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -15,8 +15,8 @@ if [[ $(grep -rl --exclude="*asio.hpp" "asio::async_write" ./nano) ]]; then
 fi
 
 # prevent unsolicited use of std::lock_guard & std::unique_lock outside of allowed areas
-if [[ $(grep -rl --exclude={"*random_pool.cpp","*random_pool.hpp","*locks.hpp"} "std::unique_lock\|std::lock_guard" ./nano) ]]; then
-    echo "using std::unique_lock or std::lock_guard is not permitted (except in nano/lib/locks.hpp and non-nano dependent libraries). Use the nano::* versions instead"
+if [[ $(grep -rl --exclude={"*random_pool.cpp","*random_pool.hpp","*locks.hpp","*locks.cpp"} "std::unique_lock\|std::lock_guard\|std::condition_variable" ./nano) ]]; then
+    echo "using std::unique_lock, std::lock_guard or std::condition_variable is not permitted (except in nano/lib/locks.hpp and non-nano dependent libraries). Use the nano::* versions instead"
     exit 1
 fi
 

--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -7,7 +7,10 @@ namespace
 template <typename Mutex>
 void output (const char * str, std::chrono::milliseconds time, Mutex & mutex)
 {
+	static std::mutex cout_mutex;
 	auto stacktrace = nano::generate_stacktrace ();
+	// Guard standard out to keep the output from being interleaved
+	std::lock_guard<std::mutex> guard (cout_mutex);
 	std::cout << std::addressof (mutex) << " Mutex " << str << " for: " << time.count () << "ms\n"
 	          << stacktrace << std::endl;
 }

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -85,7 +85,7 @@ nano::bootstrap_attempt::~bootstrap_attempt ()
 
 bool nano::bootstrap_attempt::should_log ()
 {
-	nano::lock_guard<std::mutex> lock (mutex);
+	nano::lock_guard<std::mutex> guard (next_log_mutex);
 	auto result (false);
 	auto now (std::chrono::steady_clock::now ());
 	if (next_log < now)

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -80,6 +80,7 @@ public:
 	void wallet_run ();
 	void wallet_start (std::deque<nano::account> &);
 	bool wallet_finished ();
+	std::mutex next_log_mutex;
 	std::chrono::steady_clock::time_point next_log;
 	std::deque<std::weak_ptr<nano::bootstrap_client>> clients;
 	std::weak_ptr<nano::bootstrap_client> connection_frontier_request;
@@ -97,7 +98,7 @@ public:
 	std::atomic<bool> stopped;
 	nano::bootstrap_mode mode;
 	std::mutex mutex;
-	std::condition_variable condition;
+	nano::condition_variable condition;
 	// Lazy bootstrap
 	std::unordered_set<nano::block_hash> lazy_blocks;
 	std::unordered_map<nano::block_hash, std::pair<nano::block_hash, nano::uint128_t>> lazy_state_unknown;
@@ -176,7 +177,7 @@ private:
 	std::shared_ptr<nano::bootstrap_attempt> attempt;
 	std::atomic<bool> stopped;
 	std::mutex mutex;
-	std::condition_variable condition;
+	nano::condition_variable condition;
 	std::mutex observers_mutex;
 	std::vector<std::function<void(bool)>> observers;
 	boost::thread thread;

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -19,7 +19,6 @@ pull (pull_a),
 pull_blocks (0),
 unexpected_count (0)
 {
-	nano::lock_guard<std::mutex> mutex (connection->attempt->mutex);
 	connection->attempt->condition.notify_all ();
 }
 


### PR DESCRIPTION
using `-DNANO_TIMED_LOCKS=50`, there was a lot of output from `bootstrap_attempt::should_log` and the `bulk_pull_client` constructor (some of the stack trace has been removed to limit noise) after launching the node:
```
0000020C01E330F0 Mutex held for: 7511ms
 4# nano::lock_guard<std::mutex>::~lock_guard<std::mutex> at C:\Users\Wesley\Documents\Nano\raiblocks\nano\lib\locks.cpp:53
 5# nano::bootstrap_attempt::should_log at C:\Users\Wesley\Documents\Nano\raiblocks\nano\node\bootstrap\bootstrap.cpp:96
 6# nano::bulk_pull_client::request at C:\Users\Wesley\Documents\Nano\raiblocks\nano\node\bootstrap\bootstrap_bulk_pull.cpp:68
 7# boost::asio::asio_handler_invoke<<lambda_f0cf6567c36477560ddca8004bc29bbb> > at C:\Boost_1_70_0\include\boost\asio\handler_invoke_hook.hpp:69
```
```
0000020C01E330F0 Mutex held for: 3028ms
C:\Users\Wesley\Documents\Nano\raiblocks\nano\lib\locks.cpp:25
 4# nano::lock_guard<std::mutex>::~lock_guard<std::mutex> at C:\Users\Wesley\Documents\Nano\raiblocks\nano\lib\locks.cpp:53
 5# nano::bulk_pull_client::bulk_pull_client at C:\Users\Wesley\Documents\Nano\raiblocks\nano\node\bootstrap\bootstrap_bulk_pull.cpp:24
 6# std::make_shared<nano::bulk_pull_client,std::shared_ptr<nano::bootstrap_client> const &,nano::pull_info const &> at C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\include\memory:1608
 7# boost::asio::asio_handler_invoke<<lambda_f0cf6567c36477560ddca8004bc29bbb> > at C:\Boost_1_70_0\include\boost\asio\handler_invoke_hook.hpp:69
```

This ends up blocking a lot of the io threads for long periods of time. Instead of using the same mutex in `should_log` which the rest of the class uses, I've made the scope smaller with another mutex. The `lock_guard` used in `bulk_pull_client` is not even needed so was removed. `should_log` only ends up getting called if `bulk_pull` or `network` logging is enabled, `network` logging is enabled by default so users would encounter this by default.

(Unrelated) Some `std::condition_variable` objects had crept in which make the MSVC build fail. Realised this wasn't checked in travis so added it. The output is a bit interleaved due to multiple threads accessing `std::cout` so I've added a mutex around it.