### PR TITLE
Add --config option to rpc process

### DIFF
--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -187,7 +187,7 @@ nano::error nano::rpc_config::deserialize_toml (nano::tomlconfig & toml)
 
 namespace nano
 {
-nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a)
+nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides)
 {
 	nano::error error;
 	auto json_config_path = nano::get_rpc_config_path (data_path_a);
@@ -233,10 +233,21 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 	// Parse and deserialize
 	nano::tomlconfig toml;
 
+	std::stringstream config_overrides_stream;
+	for (auto const & entry : config_overrides)
+	{
+		config_overrides_stream << entry << std::endl;
+	}
+	config_overrides_stream << std::endl;
+
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
 	if (!error && boost::filesystem::exists (toml_config_path))
 	{
-		error = toml.read (toml_config_path);
+		error = toml.read (config_overrides_stream, toml_config_path);
+	}
+	else if (!error)
+	{
+		toml.read (config_overrides_stream);
 	}
 
 	if (!error)

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -241,13 +241,16 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 	config_overrides_stream << std::endl;
 
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
-	if (!error && boost::filesystem::exists (toml_config_path))
+	if (!error)
 	{
-		error = toml.read (config_overrides_stream, toml_config_path);
-	}
-	else if (!error)
-	{
-		toml.read (config_overrides_stream);
+		if (boost::filesystem::exists (toml_config_path))
+		{
+			error = toml.read (config_overrides_stream, toml_config_path);
+		}
+		else
+		{
+			toml.read (config_overrides_stream);
+		}
 	}
 
 	if (!error)

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -8,6 +8,7 @@
 #include <boost/thread.hpp>
 
 #include <string>
+#include <vector>
 
 namespace nano
 {
@@ -75,7 +76,7 @@ public:
 	}
 };
 
-nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a);
+nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
 nano::error read_and_update_rpc_config (boost::filesystem::path const & data_path, nano::rpc_config & config_a);
 
 std::string get_default_rpc_filepath ();

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -210,13 +210,16 @@ nano::error read_node_config_toml (boost::filesystem::path const & data_path_a, 
 	config_overrides_stream << std::endl;
 
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
-	if (!error && boost::filesystem::exists (toml_config_path))
+	if (!error)
 	{
-		error = toml.read (config_overrides_stream, toml_config_path);
-	}
-	else if (!error)
-	{
-		toml.read (config_overrides_stream);
+		if (boost::filesystem::exists (toml_config_path))
+		{
+			error = toml.read (config_overrides_stream, toml_config_path);
+		}
+		else
+		{
+			toml.read (config_overrides_stream);
+		}
 	}
 
 	if (!error)

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -202,21 +202,21 @@ nano::error read_node_config_toml (boost::filesystem::path const & data_path_a, 
 	// Parse and deserialize
 	nano::tomlconfig toml;
 
-	std::stringstream config_stream;
+	std::stringstream config_overrides_stream;
 	for (auto const & entry : config_overrides)
 	{
-		config_stream << entry << std::endl;
+		config_overrides_stream << entry << std::endl;
 	}
-	config_stream << std::endl;
+	config_overrides_stream << std::endl;
 
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
 	if (!error && boost::filesystem::exists (toml_config_path))
 	{
-		toml.read (config_stream, toml_config_path);
+		error = toml.read (config_overrides_stream, toml_config_path);
 	}
 	else if (!error)
 	{
-		toml.read (config_stream);
+		toml.read (config_overrides_stream);
 	}
 
 	if (!error)


### PR DESCRIPTION
Same option as for the node, allowing toml options to be passed to the RPC daemon via arguments. Includes a var name change for consistency.

Example: `nano_rpc --daemon --config port=9999`

Not adding a doc tag as there's already https://github.com/nanocurrency/nano-docs/issues/94