### PR TITLE
Build RocksDB library as portable in docker

### DIFF
--- a/docker/ci/Dockerfile-clang
+++ b/docker/ci/Dockerfile-clang
@@ -6,7 +6,7 @@ RUN apt-get update -qq && apt-get install -yqq \
 ENV USE_RTTI=1
 RUN git clone https://github.com/facebook/rocksdb.git && \
     cd rocksdb && \
-    make static_lib && \
+    PORTABLE=1 make static_lib && \
     make install
 
 ENV CXX=/usr/bin/clang++

--- a/docker/ci/Dockerfile-gcc
+++ b/docker/ci/Dockerfile-gcc
@@ -5,7 +5,7 @@ RUN apt-get install -yqq git
 ENV USE_RTTI=1
 RUN git clone https://github.com/facebook/rocksdb.git && \
     cd rocksdb && \
-    make static_lib && \
+    PORTABLE=1 make static_lib && \
     make install
 
 ENV BOOST_ROOT=/usr/local


### PR DESCRIPTION
This is required for distribution to older CPUs without AVX2 support. For those wishing to use that instruction set with docker and RocksDB, they should `docker build` themselves while removing `PORTABLE=1` from the appropriate Dockerfile

> By default the binary we produce is optimized for the platform you're compiling on (-march=native or the equivalent). SSE4.2 will thus be enabled automatically if your CPU supports it. To print a warning if your CPU does not support SSE4.2, build with USE_SSE=1 make static_lib or, if using CMake, cmake -DFORCE_SSE42=ON. If you want to build a portable binary, add PORTABLE=1 before your make commands, like this: PORTABLE=1 make static_lib.

https://github.com/facebook/rocksdb/blob/master/INSTALL.md