### PR TITLE
Websocket subscription for work notifications

### DIFF
--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -32,39 +32,43 @@ TEST (distributed_work, no_peers)
 
 TEST (distributed_work, no_peers_cancel)
 {
-	nano::system system (24000, 1);
-	auto node (system.nodes[0]);
+	nano::system system (24000, 0);
+	nano::node_config node_config (24000, system.logging);
+	node_config.max_work_generate_multiplier = 1e6;
+	node_config.max_work_generate_difficulty = nano::difficulty::from_multiplier (node_config.max_work_generate_multiplier, nano::network_constants::publish_test_threshold);
+	auto & node = *system.add_node (node_config);
 	nano::block_hash hash;
 	bool done{ false };
 	auto callback_to_cancel = [&done](boost::optional<uint64_t> work_a) {
 		ASSERT_FALSE (work_a.is_initialized ());
 		done = true;
 	};
-	node->distributed_work.make (hash, callback_to_cancel, nano::difficulty::from_multiplier (1000000, node->network_params.network.publish_threshold));
-	ASSERT_EQ (1, node->distributed_work.work.size ());
+	node.distributed_work.make (hash, callback_to_cancel, nano::difficulty::from_multiplier (1e6, node.network_params.network.publish_threshold));
+	ASSERT_EQ (1, node.distributed_work.work.size ());
 	// cleanup should not cancel or remove an ongoing work
-	node->distributed_work.cleanup_finished ();
-	ASSERT_EQ (1, node->distributed_work.work.size ());
+	node.distributed_work.cleanup_finished ();
+	ASSERT_EQ (1, node.distributed_work.work.size ());
 
 	// manually cancel
-	node->distributed_work.cancel (hash, true); // forces local stop
-	system.deadline_set (5s);
+	node.distributed_work.cancel (hash, true); // forces local stop
+	system.deadline_set (20s);
 	while (!done)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_TRUE (node->distributed_work.work.empty ());
+	ASSERT_TRUE (node.distributed_work.work.empty ());
 
 	// now using observer
 	done = false;
-	node->distributed_work.make (hash, callback_to_cancel, nano::difficulty::from_multiplier (1000000, node->network_params.network.publish_threshold));
-	ASSERT_EQ (1, node->distributed_work.work.size ());
-	node->observers.work_cancel.notify (hash);
+	node.distributed_work.make (hash, callback_to_cancel, nano::difficulty::from_multiplier (1000000, node.network_params.network.publish_threshold));
+	ASSERT_EQ (1, node.distributed_work.work.size ());
+	node.observers.work_cancel.notify (hash);
+	system.deadline_set (20s);
 	while (!done)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_TRUE (node->distributed_work.work.empty ());
+	ASSERT_TRUE (node.distributed_work.work.empty ());
 }
 
 TEST (distributed_work, no_peers_multi)

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -26,8 +26,11 @@ TEST (distributed_work, no_peers)
 	ASSERT_FALSE (nano::work_validate (hash, *work));
 	// should only be removed after cleanup
 	ASSERT_EQ (1, node->distributed_work.work.size ());
-	node->distributed_work.cleanup_finished ();
-	ASSERT_EQ (0, node->distributed_work.work.size ());
+	while (!node->distributed_work.work.empty ())
+	{
+		node->distributed_work.cleanup_finished ();
+		ASSERT_NO_ERROR (system.poll ());
+	}
 }
 
 TEST (distributed_work, no_peers_cancel)
@@ -99,8 +102,12 @@ TEST (distributed_work, no_peers_multi)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	node->distributed_work.cleanup_finished ();
-	ASSERT_EQ (0, node->distributed_work.work.size ());
+	system.deadline_set (5s);
+	while (node->distributed_work.work.empty ())
+	{
+		node->distributed_work.cleanup_finished ();
+		ASSERT_NO_ERROR (system.poll ());
+	}
 	count = 0;
 	// Test many works for different roots
 	for (unsigned i{ 0 }; i < total; ++i)
@@ -119,7 +126,11 @@ TEST (distributed_work, no_peers_multi)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	node->distributed_work.cleanup_finished ();
-	ASSERT_EQ (0, node->distributed_work.work.size ());
+	system.deadline_set (5s);
+	while (node->distributed_work.work.empty ())
+	{
+		node->distributed_work.cleanup_finished ();
+		ASSERT_NO_ERROR (system.poll ());
+	}
 	count = 0;
 }

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -745,14 +745,14 @@ TEST (websocket, work)
 	auto work (node1->work_generate_blocking (hash));
 	ASSERT_TRUE (work.is_initialized ());
 
-	// Wait to receive the active_difficulty message
+	// Wait for the work notification
 	system.deadline_set (5s);
 	while (client_future.wait_for (std::chrono::seconds (0)) != std::future_status::ready)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	// Check active_difficulty response
+	// Check the work notification message
 	auto response = client_future.get ();
 	ASSERT_TRUE (response);
 	std::stringstream stream;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -767,6 +767,7 @@ TEST (websocket, work)
 
 	ASSERT_EQ (1, contents.count ("request"));
 	auto & request = contents.get_child ("request");
+	ASSERT_EQ (request.get<std::string> ("hash"), hash.to_string ());
 	ASSERT_EQ (request.get<std::string> ("difficulty"), nano::to_string_hex (node1->network_params.network.publish_threshold));
 	ASSERT_EQ (request.get<double> ("multiplier"), 1.0);
 

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -708,3 +708,79 @@ TEST (websocket, vote_options)
 	client_thread_2.join ();
 	node1->stop ();
 }
+
+// Test client subscribing to notifications for work generation
+TEST (websocket, work)
+{
+	nano::system system (24000, 1);
+	nano::node_config config;
+	nano::node_flags node_flags;
+	config.websocket_config.enabled = true;
+	config.websocket_config.port = 24078;
+
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), system.alarm, config, system.work, node_flags));
+	node1->start ();
+	system.nodes.push_back (node1);
+
+	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::work));
+
+	// Subscribe to work and wait for response asynchronously
+	ack_ready = false;
+	auto client_task = ([]() -> boost::optional<std::string> {
+		auto response = websocket_test_call ("::1", "24078", R"json({"action": "subscribe", "topic": "work", "ack": true})json", true, true);
+		return response;
+	});
+	auto client_future = std::async (std::launch::async, client_task);
+
+	// Wait for acknowledge
+	system.deadline_set (5s);
+	while (!ack_ready)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::work));
+
+	// Generate work
+	nano::block_hash hash;
+	auto work (node1->work_generate_blocking (hash));
+	ASSERT_TRUE (work.is_initialized ());
+
+	// Wait to receive the active_difficulty message
+	system.deadline_set (5s);
+	while (client_future.wait_for (std::chrono::seconds (0)) != std::future_status::ready)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	// Check active_difficulty response
+	auto response = client_future.get ();
+	ASSERT_TRUE (response);
+	std::stringstream stream;
+	stream << response;
+	boost::property_tree::ptree event;
+	boost::property_tree::read_json (stream, event);
+	ASSERT_EQ (event.get<std::string> ("topic"), "work");
+
+	auto & contents = event.get_child ("message");
+	ASSERT_EQ (contents.get<std::string> ("success"), "true");
+	ASSERT_LT (contents.get<unsigned> ("duration"), 10000);
+
+	ASSERT_EQ (1, contents.count ("request"));
+	auto & request = contents.get_child ("request");
+	ASSERT_EQ (request.get<std::string> ("difficulty"), nano::to_string_hex (node1->network_params.network.publish_threshold));
+	ASSERT_EQ (request.get<double> ("multiplier"), 1.0);
+
+	ASSERT_EQ (1, contents.count ("result"));
+	auto & result = contents.get_child ("result");
+	uint64_t result_difficulty;
+	nano::from_string_hex (result.get<std::string> ("difficulty"), result_difficulty);
+	ASSERT_GE (result_difficulty, node1->network_params.network.publish_threshold);
+	ASSERT_NEAR (result.get<double> ("multiplier"), nano::difficulty::to_multiplier (result_difficulty, node1->network_params.network.publish_threshold), 1e-6);
+	ASSERT_EQ (result.get<std::string> ("work"), nano::to_string_hex (work.get ()));
+
+	ASSERT_EQ (1, contents.count ("bad_peers"));
+	auto & bad_peers = contents.get_child ("bad_peers");
+	ASSERT_TRUE (bad_peers.empty ());
+
+	ASSERT_EQ (contents.get<std::string> ("reason"), "");
+}

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -28,7 +28,7 @@ elapsed (nano::timer_state::started, "distributed work generation timer")
 
 nano::distributed_work::~distributed_work ()
 {
-	if (node.websocket_server->any_subscriber (nano::websocket::topic::work))
+	if (node.websocket_server && node.websocket_server->any_subscriber (nano::websocket::topic::work))
 	{
 		nano::websocket::message_builder builder;
 		if (completed)

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -289,7 +289,7 @@ void nano::distributed_work::success (std::string const & body_a, boost::asio::i
 	}
 }
 
-void nano::distributed_work::set_once (uint64_t work_a, std::string source_a)
+void nano::distributed_work::set_once (uint64_t work_a, std::string const & source_a)
 {
 	if (!completed.exchange (true))
 	{
@@ -339,6 +339,10 @@ void nano::distributed_work::handle_failure (bool const last_a)
 					}
 				});
 				// clang-format on
+			}
+			else
+			{
+				// wait for local work generation to complete
 			}
 		}
 	}

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/distributed_work.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/websocket.hpp>
 
 std::shared_ptr<request_type> nano::work_peer_request::get_prepared_json_request (std::string const & request_string_a) const
 {
@@ -27,6 +28,22 @@ elapsed (nano::timer_state::started, "distributed work generation timer")
 
 nano::distributed_work::~distributed_work ()
 {
+	if (node.websocket_server->any_subscriber (nano::websocket::topic::work))
+	{
+		nano::websocket::message_builder builder;
+		if (completed)
+		{
+			node.websocket_server->broadcast (builder.work_generation (root, work_result, difficulty, node.network_params.network.publish_threshold, elapsed.value (), winner, bad_peers));
+		}
+		else if (stopped)
+		{
+			node.websocket_server->broadcast (builder.work_cancelled (root, difficulty, node.network_params.network.publish_threshold, elapsed.value (), bad_peers));
+		}
+		else
+		{
+			node.websocket_server->broadcast (builder.work_failed (root, difficulty, node.network_params.network.publish_threshold, elapsed.value (), bad_peers));
+		}
+	}
 	stop (true);
 }
 
@@ -116,11 +133,12 @@ void nano::distributed_work::start_work ()
 								{
 									if (connection->response.result () == boost::beast::http::status::ok)
 									{
-										this_l->success (connection->response.body (), connection->address);
+										this_l->success (connection->response.body (), connection->address, connection->port);
 									}
 									else
 									{
 										this_l->node.logger.try_log (boost::str (boost::format ("Work peer responded with an error %1% %2%: %3%") % connection->address % connection->port % connection->response.result ()));
+										this_l->add_bad_peer (connection->address, connection->port);
 										this_l->failure (connection->address);
 									}
 								}
@@ -133,6 +151,7 @@ void nano::distributed_work::start_work ()
 								else
 								{
 									this_l->node.logger.try_log (boost::str (boost::format ("Unable to read from work_peer %1% %2%: %3% (%4%)") % connection->address % connection->port % ec.message () % ec.value ()));
+									this_l->add_bad_peer (connection->address, connection->port);
 									this_l->failure (connection->address);
 								}
 							});
@@ -140,6 +159,7 @@ void nano::distributed_work::start_work ()
 						else
 						{
 							this_l->node.logger.try_log (boost::str (boost::format ("Unable to write to work_peer %1% %2%: %3% (%4%)") % connection->address % connection->port % ec.message () % ec.value ()));
+							this_l->add_bad_peer (connection->address, connection->port);
 							this_l->failure (connection->address);
 						}
 					});
@@ -147,6 +167,7 @@ void nano::distributed_work::start_work ()
 				else
 				{
 					this_l->node.logger.try_log (boost::str (boost::format ("Unable to connect to work_peer %1% %2%: %3% (%4%)") % connection->address % connection->port % ec.message () % ec.value ()));
+					this_l->add_bad_peer (connection->address, connection->port);
 					this_l->failure (connection->address);
 				}
 			});
@@ -154,10 +175,10 @@ void nano::distributed_work::start_work ()
 	}
 }
 
-void nano::distributed_work::cancel (std::shared_ptr<nano::work_peer_request> connection)
+void nano::distributed_work::cancel (std::shared_ptr<nano::work_peer_request> connection_a)
 {
 	auto this_l (shared_from_this ());
-	auto cancelling_l (std::make_shared<nano::work_peer_request> (node.io_ctx, connection->address, connection->port));
+	auto cancelling_l (std::make_shared<nano::work_peer_request> (node.io_ctx, connection_a->address, connection_a->port));
 	cancelling_l->socket.async_connect (nano::tcp_endpoint (cancelling_l->address, cancelling_l->port), [this_l, cancelling_l](boost::system::error_code const & ec) {
 		if (!ec)
 		{
@@ -215,9 +236,9 @@ void nano::distributed_work::stop (bool const local_stop_a)
 	}
 }
 
-void nano::distributed_work::success (std::string const & body_a, boost::asio::ip::address const & address)
+void nano::distributed_work::success (std::string const & body_a, boost::asio::ip::address const & address_a, uint16_t port_a)
 {
-	auto last (remove (address));
+	auto last (remove (address_a));
 	std::stringstream istream (body_a);
 	try
 	{
@@ -231,52 +252,59 @@ void nano::distributed_work::success (std::string const & body_a, boost::asio::i
 			if (!nano::work_validate (root, work, &result_difficulty) && result_difficulty >= difficulty)
 			{
 				node.unresponsive_work_peers = false;
-				set_once (work);
+				set_once (work, boost::str (boost::format ("%1%:%2%") % address_a % port_a));
 				stop (true);
 			}
 			else
 			{
-				node.logger.try_log (boost::str (boost::format ("Incorrect work response from %1% for root %2% with diffuculty %3%: %4%") % address % root.to_string () % nano::to_string_hex (difficulty) % work_text));
+				node.logger.try_log (boost::str (boost::format ("Incorrect work response from %1%:%2% for root %3% with diffuculty %4%: %5%") % address_a % port_a % root.to_string () % nano::to_string_hex (difficulty) % work_text));
+				add_bad_peer (address_a, port_a);
 				handle_failure (last);
 			}
 		}
 		else
 		{
-			node.logger.try_log (boost::str (boost::format ("Work response from %1% wasn't a number: %2%") % address % work_text));
+			node.logger.try_log (boost::str (boost::format ("Work response from %1%:%2% wasn't a number: %3%") % address_a % port_a % work_text));
+			add_bad_peer (address_a, port_a);
 			handle_failure (last);
 		}
 	}
 	catch (...)
 	{
-		node.logger.try_log (boost::str (boost::format ("Work response from %1% wasn't parsable: %2%") % address % body_a));
+		node.logger.try_log (boost::str (boost::format ("Work response from %1%:%2% wasn't parsable: %3%") % address_a % port_a % body_a));
+		add_bad_peer (address_a, port_a);
 		handle_failure (last);
 	}
 }
 
-void nano::distributed_work::set_once (boost::optional<uint64_t> work_a)
+void nano::distributed_work::set_once (boost::optional<uint64_t> work_a, std::string source_a)
 {
 	if (!completed.exchange (true))
 	{
 		callback (work_a);
+		elapsed.stop ();
+		winner = source_a;
+		work_result = *work_a;
 		if (node.config.logging.work_generation_time ())
 		{
 			boost::format unformatted_l ("Work generation for %1%, with a threshold difficulty of %2% (multiplier %3%x) complete: %4% ms");
 			auto multiplier_text_l (nano::to_string (nano::difficulty::to_multiplier (difficulty, node.network_params.network.publish_threshold), 2));
-			node.logger.try_log (boost::str (unformatted_l % root.to_string () % nano::to_string_hex (difficulty) % multiplier_text_l % elapsed.stop ().count ()));
+			node.logger.try_log (boost::str (unformatted_l % root.to_string () % nano::to_string_hex (difficulty) % multiplier_text_l % elapsed.value ().count ()));
 		}
 	}
 }
 
-void nano::distributed_work::failure (boost::asio::ip::address const & address)
+void nano::distributed_work::failure (boost::asio::ip::address const & address_a)
 {
-	auto last (remove (address));
+	auto last (remove (address_a));
 	handle_failure (last);
 }
 
-void nano::distributed_work::handle_failure (bool const last)
+void nano::distributed_work::handle_failure (bool const last_a)
 {
-	if (last && !completed)
+	if (last_a && !completed)
 	{
+		elapsed.stop ();
 		if (!stopped) // stopped early = cancel
 		{
 			node.unresponsive_work_peers = true;
@@ -288,7 +316,7 @@ void nano::distributed_work::handle_failure (bool const last)
 				callback (boost::none);
 				if (node.config.logging.work_generation_time ())
 				{
-					node.logger.try_log (boost::str (boost::format ("Work generation for %1% was cancelled after %2% ms") % root.to_string () % elapsed.stop ().count ()));
+					node.logger.try_log (boost::str (boost::format ("Work generation for %1% was cancelled after %2% ms") % root.to_string () % elapsed.value ().count ()));
 				}
 			}
 			else
@@ -315,11 +343,17 @@ void nano::distributed_work::handle_failure (bool const last)
 	}
 }
 
-bool nano::distributed_work::remove (boost::asio::ip::address const & address)
+bool nano::distributed_work::remove (boost::asio::ip::address const & address_a)
 {
 	nano::lock_guard<std::mutex> guard (mutex);
-	outstanding.erase (address);
+	outstanding.erase (address_a);
 	return outstanding.empty ();
+}
+
+void nano::distributed_work::add_bad_peer (boost::asio::ip::address const & address_a, uint16_t port_a)
+{
+	nano::lock_guard<std::mutex> guard (mutex);
+	bad_peers.emplace_back (boost::str (boost::format ("%1%:%2%") % address_a % port_a));
 }
 
 nano::distributed_work_factory::distributed_work_factory (nano::node & node_a) :

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -45,7 +45,7 @@ public:
 	void cancel (std::shared_ptr<nano::work_peer_request>);
 	void stop (bool const);
 	void success (std::string const &, boost::asio::ip::address const &, uint16_t const);
-	void set_once (boost::optional<uint64_t>, std::string source_a = "local");
+	void set_once (uint64_t, std::string source_a = "local");
 	void failure (boost::asio::ip::address const &);
 	void handle_failure (bool const);
 	bool remove (boost::asio::ip::address const &);

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -45,7 +45,7 @@ public:
 	void cancel (std::shared_ptr<nano::work_peer_request>);
 	void stop (bool const);
 	void success (std::string const &, boost::asio::ip::address const &, uint16_t const);
-	void set_once (uint64_t, std::string source_a = "local");
+	void set_once (uint64_t, std::string const & source_a = "local");
 	void failure (boost::asio::ip::address const &);
 	void handle_failure (bool const);
 	bool remove (boost::asio::ip::address const &);

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -44,11 +44,12 @@ public:
 	void start_work ();
 	void cancel (std::shared_ptr<nano::work_peer_request>);
 	void stop (bool const);
-	void success (std::string const &, boost::asio::ip::address const &);
-	void set_once (boost::optional<uint64_t>);
+	void success (std::string const &, boost::asio::ip::address const &, uint16_t const);
+	void set_once (boost::optional<uint64_t>, std::string source_a = "local");
 	void failure (boost::asio::ip::address const &);
 	void handle_failure (bool const);
 	bool remove (boost::asio::ip::address const &);
+	void add_bad_peer (boost::asio::ip::address const &, uint16_t const);
 
 	std::function<void(boost::optional<uint64_t>)> callback;
 	unsigned int backoff; // in seconds
@@ -59,10 +60,13 @@ public:
 	std::vector<std::weak_ptr<nano::work_peer_request>> connections;
 	std::vector<std::pair<std::string, uint16_t>> need_resolve;
 	uint64_t difficulty;
+	uint64_t work_result{ 0 };
 	std::atomic<bool> completed{ false };
 	std::atomic<bool> local_generation_started{ false };
 	std::atomic<bool> stopped{ false };
 	nano::timer<std::chrono::milliseconds> elapsed; // logging only
+	std::vector<std::string> bad_peers; // websocket
+	std::string winner; // websocket
 };
 
 class distributed_work_factory final

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -680,9 +680,9 @@ nano::websocket::message nano::websocket::message_builder::work_generation (nano
 	work_l.put ("success", completed_a ? "true" : "false");
 	work_l.put ("reason", completed_a ? "" : cancelled_a ? "cancelled" : "failure");
 	work_l.put ("duration", duration_a.count ());
-	work_l.put ("hash", root_a.to_string ());
 
 	boost::property_tree::ptree request_l;
+	request_l.put ("hash", root_a.to_string ());
 	request_l.put ("difficulty", nano::to_string_hex (difficulty_a));
 	auto request_multiplier_l (nano::difficulty::to_multiplier (difficulty_a, publish_threshold_a));
 	request_l.put ("multiplier", nano::to_string (request_multiplier_l));

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -327,6 +327,10 @@ nano::websocket::topic to_topic (std::string const & topic_a)
 	{
 		topic = nano::websocket::topic::active_difficulty;
 	}
+	else if (topic_a == "work")
+	{
+		topic = nano::websocket::topic::work;
+	}
 
 	return topic;
 }
@@ -353,6 +357,10 @@ std::string from_topic (nano::websocket::topic topic_a)
 	else if (topic_a == nano::websocket::topic::active_difficulty)
 	{
 		topic = "active_difficulty";
+	}
+	else if (topic_a == nano::websocket::topic::work)
+	{
+		topic = "work";
 	}
 	return topic;
 }
@@ -646,20 +654,74 @@ nano::websocket::message nano::websocket::message_builder::vote_received (std::s
 	return message_l;
 }
 
-nano::websocket::message nano::websocket::message_builder::difficulty_changed (uint64_t publish_threshold, uint64_t difficulty_active)
+nano::websocket::message nano::websocket::message_builder::difficulty_changed (uint64_t publish_threshold_a, uint64_t difficulty_active_a)
 {
 	nano::websocket::message message_l (nano::websocket::topic::active_difficulty);
 	set_common_fields (message_l);
 
 	// Active difficulty information
 	boost::property_tree::ptree difficulty_l;
-	difficulty_l.put ("network_minimum", nano::to_string_hex (publish_threshold));
-	difficulty_l.put ("network_current", nano::to_string_hex (difficulty_active));
-	auto multiplier = nano::difficulty::to_multiplier (difficulty_active, publish_threshold);
+	difficulty_l.put ("network_minimum", nano::to_string_hex (publish_threshold_a));
+	difficulty_l.put ("network_current", nano::to_string_hex (difficulty_active_a));
+	auto multiplier = nano::difficulty::to_multiplier (difficulty_active_a, publish_threshold_a);
 	difficulty_l.put ("multiplier", nano::to_string (multiplier));
 
 	message_l.contents.add_child ("message", difficulty_l);
 	return message_l;
+}
+
+nano::websocket::message nano::websocket::message_builder::work_generation (nano::block_hash const & root_a, uint64_t work_a, uint64_t difficulty_a, uint64_t publish_threshold_a, std::chrono::milliseconds const & duration_a, std::string const & peer_a, std::vector<std::string> const & bad_peers_a, bool completed_a, bool cancelled_a)
+{
+	nano::websocket::message message_l (nano::websocket::topic::work);
+	set_common_fields (message_l);
+
+	// Active difficulty information
+	boost::property_tree::ptree work_l;
+	work_l.put ("success", completed_a ? "true" : "false");
+	work_l.put ("reason", completed_a ? "" : cancelled_a ? "cancelled" : "failure");
+	work_l.put ("duration", duration_a.count ());
+	work_l.put ("hash", root_a.to_string ());
+
+	boost::property_tree::ptree request_l;
+	request_l.put ("difficulty", nano::to_string_hex (difficulty_a));
+	auto request_multiplier_l (nano::difficulty::to_multiplier (difficulty_a, publish_threshold_a));
+	request_l.put ("multiplier", nano::to_string (request_multiplier_l));
+	work_l.add_child ("request", request_l);
+
+	if (completed_a)
+	{
+		boost::property_tree::ptree result_l;
+		result_l.put ("source", peer_a);
+		result_l.put ("work", nano::to_string_hex (work_a));
+		uint64_t result_difficulty_l;
+		nano::work_validate (root_a, work_a, &result_difficulty_l);
+		result_l.put ("difficulty", nano::to_string_hex (result_difficulty_l));
+		auto result_multiplier_l (nano::difficulty::to_multiplier (result_difficulty_l, publish_threshold_a));
+		result_l.put ("multiplier", nano::to_string (result_multiplier_l));
+		work_l.add_child ("result", result_l);
+	}
+
+	boost::property_tree::ptree bad_peers_l;
+	for (auto & peer_text : bad_peers_a)
+	{
+		boost::property_tree::ptree entry;
+		entry.put ("", peer_text);
+		bad_peers_l.push_back (std::make_pair ("", entry));
+	}
+	work_l.add_child ("bad_peers", bad_peers_l);
+
+	message_l.contents.add_child ("message", work_l);
+	return message_l;
+}
+
+nano::websocket::message nano::websocket::message_builder::work_cancelled (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a)
+{
+	return work_generation (root_a, 0, difficulty_a, publish_threshold_a, duration_a, "", bad_peers_a, false, true);
+}
+
+nano::websocket::message nano::websocket::message_builder::work_failed (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a)
+{
+	return work_generation (root_a, 0, difficulty_a, publish_threshold_a, duration_a, "", bad_peers_a, false, false);
 }
 
 void nano::websocket::message_builder::set_common_fields (nano::websocket::message & message_a)

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -52,6 +52,8 @@ namespace websocket
 		vote,
 		/** An active difficulty message */
 		active_difficulty,
+		/** Work generation message */
+		work,
 		/** Auxiliary length, not a valid topic, must be the last enum */
 		_length
 	};
@@ -82,7 +84,10 @@ namespace websocket
 		message block_confirmed (std::shared_ptr<nano::block> block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, bool include_block, nano::election_status const & election_status_a, nano::websocket::confirmation_options const & options_a);
 		message stopped_election (nano::block_hash const & hash_a);
 		message vote_received (std::shared_ptr<nano::vote> vote_a);
-		message difficulty_changed (uint64_t publish_threshold, uint64_t difficulty_active);
+		message difficulty_changed (uint64_t publish_threshold_a, uint64_t difficulty_active_a);
+		message work_generation (nano::block_hash const & root_a, uint64_t const work_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::string const & peer_a, std::vector<std::string> const & bad_peers_a, bool const completed_a = true, bool const cancelled_a = false);
+		message work_cancelled (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a);
+		message work_failed (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a);
 
 	private:
 		/** Set the common fields for messages: timestamp and topic. */


### PR DESCRIPTION
No filtering options. Examples:

Generated:
```json
 {
    "success": "true",
    "reason": "",
    "duration": "306",
    "request": {
        "hash": "3ECE2684044C0EAF2CA6B1C72F11AFC5B5A75C00CFF993FB17B6E75F78ABF175",
        "difficulty": "ffffff999999999a",
        "multiplier": "10.000000000009095"
    },
    "result": {
        "source": "192.168.1.101:7000",
        "work": "4352c6e222703c57",
        "difficulty": "ffffffd2ca03b921",
        "multiplier": "22.649415016750655"
    },
    "bad_peers": ""
}
```

Cancelled with one bad peer:
```json
 {
    "success": "false",
    "reason": "cancelled",
    "duration": "539",
    "request": {
        "hash": "3ECE2684044C0EAF2CA6B1C72F11AFC5B5A75C00CFF993FB17B6E75F78ABF175",
        "difficulty": "ffffff999999999a",
        "multiplier": "10.000000000009095"
    },
    "bad_peers": [
        "192.168.1.101:7000"
    ]
}
```

- Duration is in ms.
- Failure is the same as cancelled but `"reason": "failure"`.
- When work generation is done locally it will show `"source": "local"`.

Also fixed another issue in `distributed_work`. It got a little out of hand, especially so soon after a refactor, but it's the price to handle work generation locally and through peers, as well as cancelling.