### PR TITLE
Some minor cleanup

### DIFF
--- a/nano/core_test/epochs.cpp
+++ b/nano/core_test/epochs.cpp
@@ -13,10 +13,4 @@ TEST (epochs, is_epoch_link)
 	epochs.add (nano::epoch::epoch_1, key1.pub, 42);
 	ASSERT_TRUE (epochs.is_epoch_link (42));
 	ASSERT_FALSE (epochs.is_epoch_link (43));
-	/*epochs.add (nano::epoch::epoch_2, key2.pub, 43);
-	ASSERT_TRUE (epochs.is_epoch_link (43));
-	ASSERT_EQ (key1.pub, epochs.signer (nano::epoch::epoch_1));
-	ASSERT_EQ (key2.pub, epochs.signer (nano::epoch::epoch_2));
-	ASSERT_EQ (nano::uint256_union (42), epochs.link (nano::epoch::epoch_1));
-	ASSERT_EQ (nano::uint256_union (43), epochs.link (nano::epoch::epoch_2));*/
 }

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -14,14 +14,13 @@
 #include <cassert>
 #include <numeric>
 
-nano::confirmation_height_processor::confirmation_height_processor (nano::pending_confirmation_height & pending_confirmation_height_a, nano::ledger & ledger_a, nano::active_transactions & active_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logger_mt & logger_a, std::atomic<uint64_t> & cemented_count_a) :
+nano::confirmation_height_processor::confirmation_height_processor (nano::pending_confirmation_height & pending_confirmation_height_a, nano::ledger & ledger_a, nano::active_transactions & active_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logger_mt & logger_a) :
 pending_confirmations (pending_confirmation_height_a),
 ledger (ledger_a),
 active (active_a),
 logger (logger_a),
 write_database_queue (write_database_queue_a),
 batch_separate_pending_min_time (batch_separate_pending_min_time_a),
-cemented_count (cemented_count_a),
 thread ([this]() {
 	nano::thread_role::set (nano::thread_role::name::confirmation_height_processing);
 	this->run ();
@@ -302,7 +301,7 @@ bool nano::confirmation_height_processor::write_pending (std::deque<conf_height_
 				ledger.stats.add (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in, pending.height - confirmation_height);
 				assert (pending.num_blocks_confirmed == pending.height - confirmation_height);
 				confirmation_height = pending.height;
-				cemented_count += pending.num_blocks_confirmed;
+				ledger.cemented_count += pending.num_blocks_confirmed;
 				ledger.store.confirmation_height_put (transaction, pending.account, confirmation_height);
 			}
 			total_pending_write_block_count -= pending.num_blocks_confirmed;

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -37,7 +37,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (pending_confirmati
 class confirmation_height_processor final
 {
 public:
-	confirmation_height_processor (pending_confirmation_height &, nano::ledger &, nano::active_transactions &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<uint64_t> &);
+	confirmation_height_processor (pending_confirmation_height &, nano::ledger &, nano::active_transactions &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &);
 	~confirmation_height_processor ();
 	void add (nano::block_hash const &);
 	void stop ();
@@ -93,7 +93,6 @@ private:
 	nano::timer<std::chrono::milliseconds> timer;
 	nano::write_database_queue & write_database_queue;
 	std::chrono::milliseconds batch_separate_pending_min_time;
-	std::atomic<uint64_t> & cemented_count;
 	std::thread thread;
 
 	void run ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -146,7 +146,7 @@ block_processor_thread ([this]() {
 online_reps (*this, config.online_weight_minimum.number ()),
 vote_uniquer (block_uniquer),
 active (*this),
-confirmation_height_processor (pending_confirmation_height, ledger, active, write_database_queue, config.conf_height_processor_batch_min_time, logger, ledger.cemented_count),
+confirmation_height_processor (pending_confirmation_height, ledger, active, write_database_queue, config.conf_height_processor_batch_min_time, logger),
 payment_observer_processor (observers.blocks),
 wallets (wallets_store.init_error (), *this),
 startup_time (std::chrono::steady_clock::now ())

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -40,8 +40,8 @@ add_library (secure
 	blockstore.hpp
 	blockstore_partial.hpp
 	blockstore.cpp
-	epoch.cpp
 	epoch.hpp
+	epoch.cpp
 	ledger.hpp
 	ledger.cpp
 	utility.hpp

--- a/nano/secure/epoch.cpp
+++ b/nano/secure/epoch.cpp
@@ -1,23 +1,23 @@
 #include <nano/secure/epoch.hpp>
 
-nano::uint256_union nano::epochs::link (nano::epoch epoch_a) const
+nano::uint256_union const & nano::epochs::link (nano::epoch epoch_a) const
 {
 	return epochs_m.at (epoch_a).link;
 }
 
 bool nano::epochs::is_epoch_link (nano::uint256_union const & link_a) const
 {
-	return std::any_of (epochs_m.begin (), epochs_m.end (), [link_a](decltype (epochs_m)::value_type const & item_a) { return item_a.second.link == link_a; });
+	return std::any_of (epochs_m.begin (), epochs_m.end (), [&link_a](auto const & item_a) { return item_a.second.link == link_a; });
 }
 
-nano::public_key nano::epochs::signer (nano::epoch epoch_a) const
+nano::public_key const & nano::epochs::signer (nano::epoch epoch_a) const
 {
 	return epochs_m.at (epoch_a).signer;
 }
 
 nano::epoch nano::epochs::epoch (nano::uint256_union const & link_a) const
 {
-	auto existing (std::find_if (epochs_m.begin (), epochs_m.end (), [link_a](decltype (epochs_m)::value_type const & item_a) { return item_a.second.link == link_a; }));
+	auto existing (std::find_if (epochs_m.begin (), epochs_m.end (), [&link_a](auto const & item_a) { return item_a.second.link == link_a; }));
 	assert (existing != epochs_m.end ());
 	return existing->first;
 }

--- a/nano/secure/epoch.hpp
+++ b/nano/secure/epoch.hpp
@@ -43,8 +43,8 @@ class epochs
 {
 public:
 	bool is_epoch_link (nano::uint256_union const & link_a) const;
-	nano::uint256_union link (nano::epoch epoch_a) const;
-	nano::public_key signer (nano::epoch epoch_a) const;
+	nano::uint256_union const & link (nano::epoch epoch_a) const;
+	nano::public_key const & signer (nano::epoch epoch_a) const;
 	nano::epoch epoch (nano::uint256_union const & link_a) const;
 	void add (nano::epoch epoch_a, nano::public_key const & signer_a, nano::uint256_union const & link_a);
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -7,11 +7,6 @@
 
 namespace
 {
-void representation_add (nano::transaction const & transaction_a, nano::ledger & ledger_a, nano::account const & representative_a, nano::uint128_t const & amount_a)
-{
-	ledger_a.rep_weights.representation_add (representative_a, amount_a);
-}
-
 /**
  * Roll back the visited block
  */
@@ -41,7 +36,7 @@ public:
 			(void)error;
 			assert (!error);
 			ledger.store.pending_del (transaction, key);
-			representation_add (transaction, ledger, info.representative, pending.amount.number ());
+			ledger.rep_weights.representation_add (info.representative, pending.amount.number ());
 			nano::account_info new_info (block_a.hashables.previous, info.representative, info.open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
 			ledger.change_latest (transaction, pending.source, info, new_info);
 			ledger.store.block_del (transaction, hash);
@@ -61,7 +56,7 @@ public:
 		auto error (ledger.store.account_get (transaction, destination_account, info));
 		(void)error;
 		assert (!error);
-		representation_add (transaction, ledger, info.representative, 0 - amount);
+		ledger.rep_weights.representation_add (info.representative, 0 - amount);
 		nano::account_info new_info (block_a.hashables.previous, info.representative, info.open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
 		ledger.change_latest (transaction, destination_account, info, new_info);
 		ledger.store.block_del (transaction, hash);
@@ -77,7 +72,7 @@ public:
 		auto amount (ledger.amount (transaction, block_a.hashables.source));
 		auto destination_account (ledger.account (transaction, hash));
 		auto source_account (ledger.account (transaction, block_a.hashables.source));
-		representation_add (transaction, ledger, block_a.representative (), 0 - amount);
+		ledger.rep_weights.representation_add (block_a.representative (), 0 - amount);
 		nano::account_info new_info;
 		ledger.change_latest (transaction, destination_account, new_info, new_info);
 		ledger.store.block_del (transaction, hash);
@@ -98,8 +93,8 @@ public:
 		auto block = ledger.store.block_get (transaction, rep_block);
 		release_assert (block != nullptr);
 		auto representative = block->representative ();
-		representation_add (transaction, ledger, block_a.representative (), 0 - balance);
-		representation_add (transaction, ledger, representative, balance);
+		ledger.rep_weights.representation_add (block_a.representative (), 0 - balance);
+		ledger.rep_weights.representation_add (representative, balance);
 		ledger.store.block_del (transaction, hash);
 		nano::account_info new_info (block_a.hashables.previous, representative, info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
 		ledger.change_latest (transaction, account, info, new_info);
@@ -119,7 +114,7 @@ public:
 		auto balance (ledger.balance (transaction, block_a.hashables.previous));
 		auto is_send (block_a.hashables.balance < balance);
 		// Add in amount delta
-		representation_add (transaction, ledger, block_a.representative (), 0 - block_a.hashables.balance.number ());
+		ledger.rep_weights.representation_add (block_a.representative (), 0 - block_a.hashables.balance.number ());
 		nano::account representative{ 0 };
 		if (!rep_block_hash.is_zero ())
 		{
@@ -127,7 +122,7 @@ public:
 			auto block (ledger.store.block_get (transaction, rep_block_hash));
 			assert (block != nullptr);
 			representative = block->representative ();
-			representation_add (transaction, ledger, representative, balance);
+			ledger.rep_weights.representation_add (representative, balance);
 		}
 
 		nano::account_info info;
@@ -335,13 +330,13 @@ void ledger_processor::state_block_impl (nano::state_block const & block_a)
 					if (!info.representative.is_zero ())
 					{
 						// Move existing representation
-						representation_add (transaction, ledger, info.representative, 0 - info.balance.number ());
+						ledger.rep_weights.representation_add (info.representative, 0 - info.balance.number ());
 					}
 					// Add in amount delta
 					auto block (ledger.store.block_get (transaction, hash));
 					assert (block != nullptr);
 					auto representative = block->representative ();
-					representation_add (transaction, ledger, representative, block_a.hashables.balance.number ());
+					ledger.rep_weights.representation_add (representative, block_a.hashables.balance.number ());
 
 					if (is_send)
 					{
@@ -468,8 +463,8 @@ void ledger_processor::change_block (nano::change_block const & block_a)
 						nano::block_sideband sideband (nano::block_type::change, account, 0, info.balance, info.block_count + 1, nano::seconds_since_epoch ());
 						ledger.store.block_put (transaction, hash, block_a, sideband);
 						auto balance (ledger.balance (transaction, block_a.hashables.previous));
-						representation_add (transaction, ledger, block_a.representative (), balance);
-						representation_add (transaction, ledger, info.representative, 0 - balance);
+						ledger.rep_weights.representation_add (block_a.representative (), balance);
+						ledger.rep_weights.representation_add (info.representative, 0 - balance);
 						nano::account_info new_info (hash, block_a.representative (), info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
 						ledger.change_latest (transaction, account, info, new_info);
 						ledger.store.frontier_del (transaction, block_a.hashables.previous);
@@ -520,7 +515,7 @@ void ledger_processor::send_block (nano::send_block const & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							auto amount (info.balance.number () - block_a.hashables.balance.number ());
-							representation_add (transaction, ledger, info.representative, 0 - amount);
+							ledger.rep_weights.representation_add (info.representative, 0 - amount);
 							nano::block_sideband sideband (nano::block_type::send, account, 0, block_a.hashables.balance /* unused */, info.block_count + 1, nano::seconds_since_epoch ());
 							ledger.store.block_put (transaction, hash, block_a, sideband);
 							nano::account_info new_info (hash, info.representative, info.open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
@@ -593,7 +588,7 @@ void ledger_processor::receive_block (nano::receive_block const & block_a)
 										ledger.store.block_put (transaction, hash, block_a, sideband);
 										nano::account_info new_info (hash, info.representative, info.open_block, new_balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
 										ledger.change_latest (transaction, account, info, new_info);
-										representation_add (transaction, ledger, info.representative, pending.amount.number ());
+										ledger.rep_weights.representation_add (info.representative, pending.amount.number ());
 										ledger.store.frontier_del (transaction, block_a.hashables.previous);
 										ledger.store.frontier_put (transaction, hash, account);
 										result.account = account;
@@ -657,7 +652,7 @@ void ledger_processor::open_block (nano::open_block const & block_a)
 								ledger.store.block_put (transaction, hash, block_a, sideband);
 								nano::account_info new_info (hash, block_a.representative (), hash, pending.amount.number (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0);
 								ledger.change_latest (transaction, block_a.hashables.account, info, new_info);
-								representation_add (transaction, ledger, block_a.representative (), pending.amount.number ());
+								ledger.rep_weights.representation_add (block_a.representative (), pending.amount.number ());
 								ledger.store.frontier_put (transaction, hash, block_a.hashables.account);
 								result.account = block_a.hashables.account;
 								result.amount = pending.amount;
@@ -1031,12 +1026,12 @@ bool nano::ledger::is_epoch_link (nano::uint256_union const & link_a)
 	return network_params.ledger.epochs.is_epoch_link (link_a);
 }
 
-nano::account nano::ledger::signer (nano::uint256_union const & link_a) const
+nano::account const & nano::ledger::signer (nano::uint256_union const & link_a) const
 {
 	return network_params.ledger.epochs.signer (network_params.ledger.epochs.epoch (link_a));
 }
 
-nano::uint256_union nano::ledger::link (nano::epoch epoch_a) const
+nano::uint256_union const & nano::ledger::link (nano::epoch epoch_a) const
 {
 	return network_params.ledger.epochs.link (nano::epoch::epoch_1);
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -48,8 +48,8 @@ public:
 	void dump_account_chain (nano::account const &);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool is_epoch_link (nano::uint256_union const &);
-	nano::account signer (nano::uint256_union const &) const;
-	nano::uint256_union link (nano::epoch) const;
+	nano::account const & signer (nano::uint256_union const &) const;
+	nano::uint256_union const & link (nano::epoch) const;
 	size_t block_count () const;
 	static nano::uint128_t const unit;
 	nano::network_params network_params;


### PR DESCRIPTION
Removed `representation_add ()` in `ledger.cpp`. It has an unused `nano::transaction` parameter and calling the contents of the function (1 line) directly where it's used seems cleaner than the extra indirection of this function.

Removed multi-line commented section of code in `core_test/epochs.cpp`. It references an epoch_2 which doesn't currently exist, so will just confuse anyone looking at it.

`nano/secure/CMakeLists.txt` to be consistent with the rest of the file the header goes before the source file.

The confirmation height processor now has a dependency on the ledger class and the constructor is passed a `cemented_count` cache from the ledger, this can just be called from the ledger object directly now, no need to pass it in.

Some functions in ledger/epoch can return `const &` to avoid a copy.

Using `auto` to simplify some lambda parameters in `epoch.cpp` and pass the `link` capture by reference