### PR TITLE
Verify pubkey against special keys in wallet

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -160,11 +160,13 @@ TEST (active_transactions, adjusted_difficulty_overflow_max)
 		auto send2_root (node1.active.roots.find (send2->qualified_root ()));
 		auto open1_root (node1.active.roots.find (open1->qualified_root ()));
 		auto open2_root (node1.active.roots.find (open2->qualified_root ()));
+		// clang-format off
 		auto modify_difficulty = [& roots = node1.active.roots](auto & existing_root) {
 			roots.modify (existing_root, [](nano::conflict_info & info_a) {
 				info_a.difficulty = std::numeric_limits<std::uint64_t>::max ();
 			});
 		};
+		// clang-format on
 		modify_difficulty (send1_root);
 		modify_difficulty (send2_root);
 		modify_difficulty (open1_root);
@@ -213,11 +215,13 @@ TEST (active_transactions, adjusted_difficulty_overflow_min)
 		auto open1_root (node1.active.roots.find (open1->qualified_root ()));
 		auto open2_root (node1.active.roots.find (open2->qualified_root ()));
 		auto send3_root (node1.active.roots.find (send3->qualified_root ()));
+		// clang-format off
 		auto modify_difficulty = [& roots = node1.active.roots](auto & existing_root) {
 			roots.modify (existing_root, [](nano::conflict_info & info_a) {
 				info_a.difficulty = std::numeric_limits<std::uint64_t>::min () + 1;
 			});
 		};
+		// clang-format on
 		modify_difficulty (send1_root);
 		modify_difficulty (send2_root);
 		modify_difficulty (open1_root);

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -160,8 +160,7 @@ TEST (active_transactions, adjusted_difficulty_overflow_max)
 		auto send2_root (node1.active.roots.find (send2->qualified_root ()));
 		auto open1_root (node1.active.roots.find (open1->qualified_root ()));
 		auto open2_root (node1.active.roots.find (open2->qualified_root ()));
-		auto modify_difficulty = [& roots = node1.active.roots](auto & existing_root)
-		{
+		auto modify_difficulty = [& roots = node1.active.roots](auto & existing_root) {
 			roots.modify (existing_root, [](nano::conflict_info & info_a) {
 				info_a.difficulty = std::numeric_limits<std::uint64_t>::max ();
 			});
@@ -214,8 +213,7 @@ TEST (active_transactions, adjusted_difficulty_overflow_min)
 		auto open1_root (node1.active.roots.find (open1->qualified_root ()));
 		auto open2_root (node1.active.roots.find (open2->qualified_root ()));
 		auto send3_root (node1.active.roots.find (send3->qualified_root ()));
-		auto modify_difficulty = [& roots = node1.active.roots](auto & existing_root)
-		{
+		auto modify_difficulty = [& roots = node1.active.roots](auto & existing_root) {
 			roots.modify (existing_root, [](nano::conflict_info & info_a) {
 				info_a.difficulty = std::numeric_limits<std::uint64_t>::min () + 1;
 			});

--- a/nano/core_test/epochs.cpp
+++ b/nano/core_test/epochs.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-
 #include <nano/secure/common.hpp>
 #include <nano/secure/epoch.hpp>
+
+#include <gtest/gtest.h>
 
 TEST (epochs, is_epoch_link)
 {

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3891,10 +3891,16 @@ void nano::json_handler::wallet_add_watch ()
 					auto account (rpc_l->account_impl (accounts.second.data ()));
 					if (!rpc_l->ec)
 					{
-						wallet->insert_watch (transaction, account);
+						if (wallet->insert_watch (transaction, account))
+						{
+							rpc_l->ec = nano::error_common::bad_public_key;
+						}
 					}
 				}
-				rpc_l->response_l.put ("success", "");
+				if (!rpc_l->ec)
+				{
+					rpc_l->response_l.put ("success", "");
+				}
 			}
 			else
 			{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -411,9 +411,14 @@ nano::public_key nano::wallet_store::insert_adhoc (nano::transaction const & tra
 	return pub;
 }
 
-void nano::wallet_store::insert_watch (nano::transaction const & transaction_a, nano::public_key const & pub)
+bool nano::wallet_store::insert_watch (nano::transaction const & transaction_a, nano::public_key const & pub_a)
 {
-	entry_put_raw (transaction_a, pub, nano::wallet_value (nano::uint256_union (0), 0));
+	bool error (!valid_public_key (pub_a));
+	if (!error)
+	{
+		entry_put_raw (transaction_a, pub_a, nano::wallet_value (nano::uint256_union (0), 0));
+	}
+	return error;
 }
 
 void nano::wallet_store::erase (nano::transaction const & transaction_a, nano::public_key const & pub)
@@ -523,9 +528,14 @@ bool nano::wallet_store::fetch (nano::transaction const & transaction_a, nano::p
 	return result;
 }
 
+bool nano::wallet_store::valid_public_key (nano::public_key const & pub)
+{
+	return pub.number () >= special_count;
+}
+
 bool nano::wallet_store::exists (nano::transaction const & transaction_a, nano::public_key const & pub)
 {
-	return !pub.is_zero () && find (transaction_a, pub) != end ();
+	return valid_public_key (pub) && find (transaction_a, pub) != end ();
 }
 
 void nano::wallet_store::serialize_json (nano::transaction const & transaction_a, std::string & string_a)
@@ -868,9 +878,9 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & account_a, bo
 	return result;
 }
 
-void nano::wallet::insert_watch (nano::transaction const & transaction_a, nano::public_key const & pub_a)
+bool nano::wallet::insert_watch (nano::transaction const & transaction_a, nano::public_key const & pub_a)
 {
-	store.insert_watch (transaction_a, pub_a);
+	return store.insert_watch (transaction_a, pub_a);
 }
 
 bool nano::wallet::exists (nano::public_key const & account_a)
@@ -1430,7 +1440,8 @@ void nano::work_watcher::watching (nano::qualified_root const & root_a, std::sha
 				auto active_difficulty (watcher_l->node.active.limited_active_difficulty ());
 				if (active_difficulty > difficulty)
 				{
-					watcher_l->node.work_generate (root_l, [watcher_l, block_a, root_a](boost::optional<uint64_t> work_a) {
+					watcher_l->node.work_generate (
+					root_l, [watcher_l, block_a, root_a](boost::optional<uint64_t> work_a) {
 						if (block_a != nullptr && watcher_l != nullptr && !watcher_l->stopped)
 						{
 							bool updated_l{ false };

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -53,6 +53,7 @@ public:
 	nano::uint256_union check (nano::transaction const &);
 	bool rekey (nano::transaction const &, std::string const &);
 	bool valid_password (nano::transaction const &);
+	bool valid_public_key (nano::public_key const &);
 	bool attempt_password (nano::transaction const &, std::string const &);
 	void wallet_key (nano::raw_key &, nano::transaction const &);
 	void seed (nano::raw_key &, nano::transaction const &);
@@ -69,7 +70,7 @@ public:
 	nano::account representative (nano::transaction const &);
 	void representative_set (nano::transaction const &, nano::account const &);
 	nano::public_key insert_adhoc (nano::transaction const &, nano::raw_key const &);
-	void insert_watch (nano::transaction const &, nano::public_key const &);
+	bool insert_watch (nano::transaction const &, nano::public_key const &);
 	void erase (nano::transaction const &, nano::public_key const &);
 	nano::wallet_value entry_get_raw (nano::transaction const &, nano::public_key const &);
 	void entry_put_raw (nano::transaction const &, nano::public_key const &, nano::wallet_value const &);
@@ -130,7 +131,7 @@ public:
 	bool enter_password (nano::transaction const &, std::string const &);
 	nano::public_key insert_adhoc (nano::raw_key const &, bool = true);
 	nano::public_key insert_adhoc (nano::transaction const &, nano::raw_key const &, bool = true);
-	void insert_watch (nano::transaction const &, nano::public_key const &);
+	bool insert_watch (nano::transaction const &, nano::public_key const &);
 	nano::public_key deterministic_insert (nano::transaction const &, bool = true);
 	nano::public_key deterministic_insert (uint32_t, bool = true);
 	nano::public_key deterministic_insert (bool = true);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5736,6 +5736,23 @@ TEST (rpc, wallet_add_watch)
 	std::string success (response.json.get<std::string> ("success"));
 	ASSERT_TRUE (success.empty ());
 	ASSERT_TRUE (system.wallet (0)->exists (nano::test_genesis_key.pub));
+
+	// Make sure using special wallet key as pubkey fails
+	nano::public_key bad_key (1);
+	entry.put ("", bad_key.to_account ());
+	peers_l.push_back (std::make_pair ("", entry));
+	request.erase ("accounts");
+	request.add_child ("accounts", peers_l);
+
+	test_response response_error (request, rpc.config.port, system.io_ctx);
+	system.deadline_set (5s);
+	while (response_error.status == 0)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (200, response_error.status);
+	std::error_code ec (nano::error_common::bad_public_key);
+	ASSERT_EQ (response_error.json.get<std::string> ("error"), ec.message ());
 }
 
 TEST (rpc, online_reps)


### PR DESCRIPTION
Marking as a breaking RPC change, since wallet_add_watch may now fail after pubkey validation. Contains some unrelated formatting fixes on master.