### PR TITLE
Checking for frontiers only if necessary

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -116,7 +116,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	/* Confirm frontiers when there aren't many confirmations already pending and node finished initial bootstrap
 	In auto mode start confirm only if node contains almost principal representative (half of required for principal weight) */
 	lock_a.unlock ();
-	if (node.config.frontiers_confirmation != nano::frontiers_confirmation_mode::disabled && node.ledger.block_count_cache > node.ledger.cemented_count && node.pending_confirmation_height.size () < confirmed_frontiers_max_pending_cut_off && node.ledger.block_count_cache >= node.ledger.bootstrap_weight_max_blocks)
+	if (node.config.frontiers_confirmation != nano::frontiers_confirmation_mode::disabled && node.ledger.block_count_cache > node.ledger.cemented_count + roots.size () && node.pending_confirmation_height.size () < confirmed_frontiers_max_pending_cut_off && node.ledger.block_count_cache >= node.ledger.bootstrap_weight_max_blocks)
 	{
 		confirm_frontiers (transaction);
 	}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -169,7 +169,6 @@ private:
 	prioritize_num_uncemented priority_cementable_frontiers;
 	std::unordered_set<nano::account> wallet_accounts_already_iterated;
 	std::unordered_map<nano::uint256_union, nano::account> next_wallet_frontier_accounts;
-	bool frontiers_fully_confirmed{ false };
 	bool skip_wallets{ false };
 	void prioritize_account_for_confirmation (prioritize_num_uncemented &, size_t &, nano::account const &, nano::account_info const &, uint64_t);
 	static size_t constexpr max_priority_cementable_frontiers{ 100000 };


### PR DESCRIPTION
Using the new efficient block count and cemented count caches