### PR TITLE
Update broadcast_confirm_req_batch to handle PoW priority

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -113,7 +113,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	unsigned unconfirmed_count (0);
 	unsigned unconfirmed_request_count (0);
 	unsigned could_fit_delay = node.network_params.network.is_test_network () ? high_confirmation_request_count - 1 : 1;
-	std::unordered_map<std::shared_ptr<nano::transport::channel>, std::vector<std::pair<nano::block_hash, nano::block_hash>>> requests_bundle;
+	std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::block_hash>>> requests_bundle;
 	std::deque<std::shared_ptr<nano::block>> rebroadcast_bundle;
 	std::deque<std::pair<std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>>> confirm_req_bundle;
 
@@ -255,8 +255,8 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 						{
 							if (requests_bundle.size () < max_broadcast_queue)
 							{
-								std::vector<std::pair<nano::block_hash, nano::block_hash>> insert_vector = { root_hash };
-								requests_bundle.insert (std::make_pair (rep, insert_vector));
+								std::deque<std::pair<nano::block_hash, nano::block_hash>> insert_root_hash = { root_hash };
+								requests_bundle.insert (std::make_pair (rep, insert_root_hash));
 							}
 						}
 						else if (rep_request->second.size () < max_broadcast_queue * nano::network::confirm_req_hashes_max)

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -319,7 +319,7 @@ void nano::network::broadcast_confirm_req_base (std::shared_ptr<nano::block> blo
 	}
 }
 
-void nano::network::broadcast_confirm_req_batch (std::unordered_map<std::shared_ptr<nano::transport::channel>, std::vector<std::pair<nano::block_hash, nano::block_hash>>> request_bundle_a, unsigned delay_a, bool resumption)
+void nano::network::broadcast_confirm_req_batch (std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::block_hash>>> request_bundle_a, unsigned delay_a, bool resumption)
 {
 	const size_t max_reps = 50;
 	if (!resumption && node.config.logging.network_logging ())
@@ -337,8 +337,9 @@ void nano::network::broadcast_confirm_req_batch (std::unordered_map<std::shared_
 			// Limit max request size hash + root to 7 pairs
 			while (roots_hashes.size () < confirm_req_hashes_max && !j->second.empty ())
 			{
-				roots_hashes.push_back (j->second.back ());
-				j->second.pop_back ();
+				// expects ordering by priority, descending
+				roots_hashes.push_back (j->second.front ());
+				j->second.pop_front ();
 			}
 			nano::confirm_req req (roots_hashes);
 			j->first->send (req);

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -125,7 +125,7 @@ public:
 	void send_confirm_req (std::shared_ptr<nano::transport::channel>, std::shared_ptr<nano::block>);
 	void broadcast_confirm_req (std::shared_ptr<nano::block>);
 	void broadcast_confirm_req_base (std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>, unsigned, bool = false);
-	void broadcast_confirm_req_batch (std::unordered_map<std::shared_ptr<nano::transport::channel>, std::vector<std::pair<nano::block_hash, nano::block_hash>>>, unsigned = broadcast_interval_ms, bool = false);
+	void broadcast_confirm_req_batch (std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::block_hash>>>, unsigned = broadcast_interval_ms, bool = false);
 	void broadcast_confirm_req_batch (std::deque<std::pair<std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>>>, unsigned = broadcast_interval_ms);
 	void confirm_hashes (nano::transaction const &, std::shared_ptr<nano::transport::channel>, std::vector<nano::block_hash>);
 	bool send_votes_cache (std::shared_ptr<nano::transport::channel>, nano::block_hash const &);


### PR DESCRIPTION
Changing requests_bundle to use deque instead of vector and then pop_front instead of pop_back.  This resolves the inverse PoW priority issues seen during active transaction processing.  Live traffic is still unaffected as this only takes effect once active transaction processing starts.

There are some other version difference between the images below, but PoW priority is shown.

Bootstrapping V20.0 Beta Before the change ...
![image](https://user-images.githubusercontent.com/42743016/64916855-5765eb80-d755-11e9-9bd3-5a112fc2aca0.png)

Compared to bootstrapping V20.0 Beta after the change ...
![image](https://user-images.githubusercontent.com/42743016/64916862-85e3c680-d755-11e9-850f-ac340844c066.png)

