### PR TITLE
Active elections loop tuning

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -895,7 +895,7 @@ TEST (confirmation_height, prioritize_frontiers)
 	transaction.refresh ();
 	node->active.prioritize_frontiers_for_confirmation (transaction, std::chrono::seconds (1), std::chrono::seconds (1));
 	ASSERT_TRUE (priority_orders_match (node->active.priority_wallet_cementable_frontiers, std::array<nano::account, num_accounts>{ key3.pub, nano::genesis_account, key4.pub, key1.pub, key2.pub }));
-	node->active.confirm_frontiers (transaction);
+	node->active.search_frontiers (transaction);
 
 	// Check that the active transactions roots contains the frontiers
 	system.deadline_set (std::chrono::seconds (10));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -205,7 +205,7 @@ TEST (node, node_receive_quorum)
 			nano::lock_guard<std::mutex> guard (system.nodes[0]->active.mutex);
 			auto info (system.nodes[0]->active.roots.find (nano::qualified_root (previous, previous)));
 			ASSERT_NE (system.nodes[0]->active.roots.end (), info);
-			done = info->election->confirmation_request_count > nano::active_transactions::minimum_confirmation_request_count;
+			done = info->election->confirmation_request_count > 2;
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -850,11 +850,21 @@ TEST (node_config, v17_v18_upgrade)
 	auto upgraded (false);
 	nano::node_config config;
 	config.logging.init (path);
+
+	// Initial values for configs that should be upgraded
+	config.active_elections_size = 50000;
+	config.vote_generator_delay = 500ms;
+
 	// These config options should not be present
 	ASSERT_FALSE (tree.get_optional_child ("backup_before_upgrade"));
 	ASSERT_FALSE (tree.get_optional_child ("work_watcher_period"));
 
 	config.deserialize_json (upgraded, tree);
+
+	// These configs should have been upgraded
+	ASSERT_EQ (100, tree.get<unsigned> ("vote_generator_delay"));
+	ASSERT_EQ (10000, tree.get<unsigned long long> ("active_elections_size"));
+
 	// The config options should be added after the upgrade
 	ASSERT_TRUE (!!tree.get_optional_child ("backup_before_upgrade"));
 	ASSERT_TRUE (!!tree.get_optional_child ("work_watcher_period"));
@@ -878,6 +888,7 @@ TEST (node_config, v18_values)
 
 	// Check config is correct
 	{
+		tree.put ("active_elections_size", 10000);
 		tree.put ("vote_generator_delay", 100);
 		tree.put ("backup_before_upgrade", true);
 		tree.put ("work_watcher_period", 5);
@@ -885,11 +896,13 @@ TEST (node_config, v18_values)
 
 	config.deserialize_json (upgraded, tree);
 	ASSERT_FALSE (upgraded);
+	ASSERT_EQ (config.active_elections_size, 10000);
 	ASSERT_EQ (config.vote_generator_delay.count (), 100);
 	ASSERT_EQ (config.backup_before_upgrade, true);
 	ASSERT_EQ (config.work_watcher_period.count (), 5);
 
 	// Check config is correct with other values
+	tree.put ("active_elections_size", 5);
 	tree.put ("vote_generator_delay", std::numeric_limits<unsigned long>::max () - 100);
 	tree.put ("backup_before_upgrade", false);
 	tree.put ("work_watcher_period", 999);
@@ -897,6 +910,7 @@ TEST (node_config, v18_values)
 	upgraded = false;
 	config.deserialize_json (upgraded, tree);
 	ASSERT_FALSE (upgraded);
+	ASSERT_EQ (config.active_elections_size, 5);
 	ASSERT_EQ (config.vote_generator_delay.count (), std::numeric_limits<unsigned long>::max () - 100);
 	ASSERT_EQ (config.backup_before_upgrade, false);
 	ASSERT_EQ (config.work_watcher_period.count (), 999);
@@ -2315,7 +2329,7 @@ TEST (node, confirm_quorum)
 			nano::lock_guard<std::mutex> guard (system.nodes[0]->active.mutex);
 			auto info (system.nodes[0]->active.roots.find (nano::qualified_root (send1->hash (), send1->hash ())));
 			ASSERT_NE (system.nodes[0]->active.roots.end (), info);
-			done = info->election->confirmation_request_count > nano::active_transactions::minimum_confirmation_request_count;
+			done = info->election->confirmation_request_count > 2;
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -69,7 +69,7 @@ public:
 		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : 45000;
 		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : 46000;
 		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : 47000;
-		request_interval_ms = is_test_network () ? (is_sanitizer_build ? 100 : 20) : 16000;
+		request_interval_ms = is_test_network () ? (is_sanitizer_build ? 100 : 20) : 500;
 	}
 
 	/** Network work thresholds. ~5 seconds of work for the live network */

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -285,7 +285,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 				}
 			}
 			// Confirmation requesting
-			else
+			else if (election_l->confirmation_request_count % 4 == 0)
 			{
 				std::unordered_set<std::shared_ptr<nano::transport::channel>> rep_channels_missing_vote_l;
 				// Add all rep endpoints that haven't already voted
@@ -314,7 +314,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 					single_confirm_req_bundle_l.push_back (std::make_pair (election_l->status.winner, vec));
 				}
 				// Alternate elections getting confirmation requests every loop
-				else if (election_l->confirmation_request_count % 4 == 0)
+				else
 				{
 					auto single_confirm_req_channels_l (std::make_shared<std::vector<std::shared_ptr<nano::transport::channel>>> ());
 					for (auto & rep : rep_channels_missing_vote_l)

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -160,7 +160,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 
 	lock_a.unlock ();
 
-	/**
+	/*
 	 * Confirm frontiers when there aren't many confirmations already pending and node finished initial bootstrap
 	 * In auto mode start confirm only if node contains almost principal representative (half of required for principal weight)
 	 */
@@ -189,7 +189,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	auto & sorted_roots_l = roots.get<1> ();
 	size_t count_l{ 0 };
 
-	/**
+	/*
 	 * Loop through active elections in descending order of proof-of-work difficulty, requesting confirmation
 	 *
 	 * Only up to a certain amount of elections are queued for confirmation request and block rebroadcasting. The remaining elections can still be confirmed if votes arrive

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -247,6 +247,7 @@ std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pa
 			vec->push_back (i);
 		}
 		single_confirm_req_bundle_l.push_back (std::make_pair (election_l->status.winner, vec));
+		inserted_into_any_bundle = true;
 	}
 	else
 	{
@@ -279,13 +280,13 @@ std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pa
 			else
 			{
 				single_confirm_req_channels_l->push_back (rep);
-				inserted_into_any_bundle = true;
 			}
 		}
 		// broadcast_confirm_req_base modifies reps, so we clone it once to avoid aliasing
 		if (single_confirm_req_bundle_l.size () < max_confirm_req && !single_confirm_req_channels_l->empty ())
 		{
 			single_confirm_req_bundle_l.push_back (std::make_pair (election_l->status.winner, single_confirm_req_channels_l));
+			inserted_into_any_bundle = true;
 		}
 	}
 	return inserted_into_any_bundle;
@@ -364,7 +365,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 				election_escalate (election_l, transaction_l, roots_size_l);
 			}
 			// Block broadcasting
-			if (election_l->confirmation_request_count % 8 == 1)
+			if (election_l->confirmation_request_count % 8 == 1 || (election_l->confirmation_request_count % 8 == 0 && node.network_params.network.is_test_network ()))
 			{
 				election_broadcast (election_l, transaction_l, blocks_bundle_l, inactive_l, root_l);
 			}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -365,7 +365,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 				election_escalate (election_l, transaction_l, roots_size_l);
 			}
 			// Block broadcasting
-			if (election_l->confirmation_request_count % 8 == 1 || (election_l->confirmation_request_count % 8 == 0 && node.network_params.network.is_test_network ()))
+			if (election_l->confirmation_request_count % 8 == 1 || node.network_params.network.is_test_network ())
 			{
 				election_broadcast (election_l, transaction_l, blocks_bundle_l, inactive_l, root_l);
 			}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -86,7 +86,7 @@ public:
 	// Start an election for a block
 	// Call action with confirmed block, may be different than what we started with
 	// clang-format off
-	bool start (std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
+	bool start (std::shared_ptr<nano::block>, bool const = false, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	// If this returns true, the vote is a replay
 	// If this returns false, the vote may or may not be a replay
@@ -101,8 +101,6 @@ public:
 	uint64_t limited_active_difficulty ();
 	std::deque<std::shared_ptr<nano::block>> list_blocks (bool = false);
 	void erase (nano::block const &);
-	//drop 2 from roots based on adjusted_difficulty
-	void flush_lowest ();
 	bool empty ();
 	size_t size ();
 	void stop ();
@@ -126,12 +124,15 @@ public:
 	nano::gap_information find_inactive_votes_cache (nano::block_hash const &);
 	nano::node & node;
 	std::mutex mutex;
-	// Minimum number of confirmation requests
-	static unsigned constexpr minimum_confirmation_request_count = 2;
-	// Threshold for considering confirmation request count high
-	static unsigned constexpr high_confirmation_request_count = 2;
-	size_t long_unconfirmed_size = 0;
-	static size_t constexpr max_broadcast_queue = 1000;
+	std::chrono::seconds const long_election_threshold;
+	// Delay until requesting confirmation for an election
+	std::chrono::milliseconds const election_request_delay;
+	// Maximum time an election can be kept active if it is extending the container
+	std::chrono::seconds const election_time_to_live;
+	static size_t constexpr max_block_broadcasts = 30;
+	static size_t constexpr max_confirm_representatives = 30;
+	static size_t constexpr max_confirm_req_batches = 20;
+	static size_t constexpr max_confirm_req = 15;
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;
 	size_t priority_cementable_frontiers_size ();
@@ -144,7 +145,7 @@ public:
 private:
 	// Call action with confirmed block, may be different than what we started with
 	// clang-format off
-	bool add (std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
+	bool add (std::shared_ptr<nano::block>, bool const = false, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	void request_loop ();
 	void request_confirm (nano::unique_lock<std::mutex> &);

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -4,6 +4,8 @@
 #include <nano/lib/timer.hpp>
 #include <nano/node/gap_cache.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/node/transport/transport.hpp>
+#include <nano/node/repcrawler.hpp>
 
 #include <boost/circular_buffer.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -148,8 +150,13 @@ private:
 	bool add (std::shared_ptr<nano::block>, bool const = false, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	void request_loop ();
+	void search_frontiers (nano::transaction const &);
+	void election_escalate (std::shared_ptr<nano::election> &, nano::transaction const &, size_t const &);
+	void election_broadcast (std::shared_ptr<nano::election> &, nano::transaction const &, std::deque<std::shared_ptr<nano::block>> &, std::unordered_set<nano::qualified_root> &, nano::qualified_root &);
+	bool election_request_confirm (std::shared_ptr<nano::election> &, std::vector<nano::representative> const &, size_t const &,
+		std::deque<std::pair<std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>>> & single_confirm_req_bundle_l,
+		std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::root>>> & batched_confirm_req_bundle_l);
 	void request_confirm (nano::unique_lock<std::mutex> &);
-	void confirm_frontiers (nano::transaction const &);
 	nano::account next_frontier_account{ 0 };
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
 	nano::condition_variable condition;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -3,9 +3,9 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/gap_cache.hpp>
-#include <nano/secure/common.hpp>
-#include <nano/node/transport/transport.hpp>
 #include <nano/node/repcrawler.hpp>
+#include <nano/node/transport/transport.hpp>
+#include <nano/secure/common.hpp>
 
 #include <boost/circular_buffer.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -154,8 +154,8 @@ private:
 	void election_escalate (std::shared_ptr<nano::election> &, nano::transaction const &, size_t const &);
 	void election_broadcast (std::shared_ptr<nano::election> &, nano::transaction const &, std::deque<std::shared_ptr<nano::block>> &, std::unordered_set<nano::qualified_root> &, nano::qualified_root &);
 	bool election_request_confirm (std::shared_ptr<nano::election> &, std::vector<nano::representative> const &, size_t const &,
-		std::deque<std::pair<std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>>> & single_confirm_req_bundle_l,
-		std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::root>>> & batched_confirm_req_bundle_l);
+	std::deque<std::pair<std::shared_ptr<nano::block>, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>>>> & single_confirm_req_bundle_l,
+	std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::root>>> & batched_confirm_req_bundle_l);
 	void request_confirm (nano::unique_lock<std::mutex> &);
 	nano::account next_frontier_account{ 0 };
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -369,7 +369,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 void nano::block_processor::process_live (nano::block_hash const & hash_a, std::shared_ptr<nano::block> block_a, const bool watch_work_a)
 {
 	// Start collecting quorum on block
-	node.active.start (block_a);
+	node.active.start (block_a, false);
 	//add block to watcher if desired after block has been added to active
 	if (watch_work_a)
 	{
@@ -382,28 +382,6 @@ void nano::block_processor::process_live (nano::block_hash const & hash_a, std::
 		// Announce our weighted vote to the network
 		generator.add (hash_a);
 	}
-	// Request confirmation for new block with delay
-	std::weak_ptr<nano::node> node_w (node.shared ());
-	node.alarm.add (std::chrono::steady_clock::now () + confirmation_request_delay, [node_w, block_a]() {
-		if (auto node_l = node_w.lock ())
-		{
-			// Check if votes were already requested
-			bool send_request (false);
-			{
-				nano::lock_guard<std::mutex> lock (node_l->active.mutex);
-				auto existing (node_l->active.blocks.find (block_a->hash ()));
-				if (existing != node_l->active.blocks.end () && !existing->second->confirmed && !existing->second->stopped && existing->second->confirmation_request_count == 0)
-				{
-					send_request = true;
-				}
-			}
-			// Request votes
-			if (send_request)
-			{
-				node_l->network.broadcast_confirm_req (block_a);
-			}
-		}
-	});
 }
 
 nano::process_return nano::block_processor::process_one (nano::write_transaction const & transaction_a, nano::unchecked_info info_a, const bool watch_work_a)

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -34,7 +34,7 @@ class election final : public std::enable_shared_from_this<nano::election>
 	std::function<void(std::shared_ptr<nano::block>)> confirmation_action;
 
 public:
-	election (nano::node &, std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const &);
+	election (nano::node &, std::shared_ptr<nano::block>, bool const, std::function<void(std::shared_ptr<nano::block>)> const &);
 	nano::election_vote_result vote (nano::account, uint64_t, nano::block_hash);
 	nano::tally_t tally ();
 	// Check if we have vote quorum
@@ -57,10 +57,11 @@ public:
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
 	std::chrono::steady_clock::time_point election_start;
 	nano::election_status status;
+	bool skip_delay;
 	std::atomic<bool> confirmed;
 	bool stopped;
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
-	unsigned confirmation_request_count;
+	unsigned confirmation_request_count{ 0 };
 	std::unordered_set<nano::block_hash> dependent_blocks;
 	std::chrono::seconds late_blocks_delay{ 5 };
 };

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1911,7 +1911,7 @@ void nano::json_handler::confirmation_quorum ()
 	if (request.get<bool> ("peer_details", false))
 	{
 		boost::property_tree::ptree peers;
-		for (auto & peer : node.rep_crawler.representatives_by_weight ())
+		for (auto & peer : node.rep_crawler.representatives ())
 		{
 			boost::property_tree::ptree peer_node;
 			peer_node.put ("account", peer.account.to_account ());

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -331,7 +331,7 @@ void nano::network::broadcast_confirm_req_batched_many (std::unordered_map<std::
 		node.logger.try_log (boost::str (boost::format ("Broadcasting batch confirm req to %1% representatives") % request_bundle_a.size ()));
 	}
 
-	for (size_t count_l{ 0 }; !request_bundle_a.empty () && count_l < burst_size_l; ++count_l)
+	for (size_t count_l (0); !request_bundle_a.empty () && count_l < burst_size_l; ++count_l)
 	{
 		auto j (request_bundle_a.begin ());
 		while (j != request_bundle_a.end ())

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -323,20 +323,19 @@ void nano::network::broadcast_confirm_req_base (std::shared_ptr<nano::block> blo
 	}
 }
 
-void nano::network::broadcast_confirm_req_batched_many (std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::root>>> request_bundle_a, std::function<void()> callback_a, unsigned delay_a, bool resumption)
+void nano::network::broadcast_confirm_req_batched_many (std::unordered_map<std::shared_ptr<nano::transport::channel>, std::deque<std::pair<nano::block_hash, nano::root>>> request_bundle_a, std::function<void()> callback_a, unsigned delay_a, bool resumption_a)
 {
-	const size_t max_reps = 50;
-	if (!resumption && node.config.logging.network_logging ())
+	const size_t burst_size_l{ 5 };
+	if (!resumption_a && node.config.logging.network_logging ())
 	{
 		node.logger.try_log (boost::str (boost::format ("Broadcasting batch confirm req to %1% representatives") % request_bundle_a.size ()));
 	}
-	auto count_l (0);
-	while (!request_bundle_a.empty () && count_l < max_reps)
+
+	for (size_t count_l{ 0 }; !request_bundle_a.empty () && count_l < burst_size_l; ++count_l)
 	{
 		auto j (request_bundle_a.begin ());
 		while (j != request_bundle_a.end ())
 		{
-			++count_l;
 			std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes_l;
 			// Limit max request size hash + root to 7 pairs
 			while (roots_hashes_l.size () < confirm_req_hashes_max && !j->second.empty ())

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -557,7 +557,7 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 		if (ledger_block && !block_confirmed_or_being_confirmed (transaction_a, ledger_block->hash ()))
 		{
 			std::weak_ptr<nano::node> this_w (shared_from_this ());
-			if (!active.start (ledger_block, [this_w, root](std::shared_ptr<nano::block>) {
+			if (!active.start (ledger_block, false, [this_w, root](std::shared_ptr<nano::block>) {
 				    if (auto this_l = this_w.lock ())
 				    {
 					    auto attempt (this_l->bootstrap_initiator.current_attempt ());
@@ -1035,7 +1035,7 @@ void nano::node::add_initial_peers ()
 
 void nano::node::block_confirm (std::shared_ptr<nano::block> block_a)
 {
-	active.start (block_a);
+	active.start (block_a, false);
 	network.broadcast_confirm_req (block_a);
 	// Calculate votes for local representatives
 	if (config.enable_voting && active.active (*block_a))

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -577,7 +577,8 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 		}
 		case 17:
 		{
-			json.put ("vote_generator_delay", vote_generator_delay.count ()); // Update value
+			json.put ("active_elections_size", 10000); // Update value
+			json.put ("vote_generator_delay", 100); // Update value
 			json.put ("backup_before_upgrade", backup_before_upgrade);
 			json.put ("work_watcher_period", work_watcher_period.count ());
 		}

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -79,7 +79,7 @@ public:
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_test_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
-	size_t active_elections_size{ 50000 };
+	size_t active_elections_size{ 10000 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
 	unsigned tcp_incoming_connections_max{ 1024 };
 	bool use_memory_pools{ true };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -163,18 +163,6 @@ nano::uint128_t nano::rep_crawler::total_weight () const
 	return result;
 }
 
-std::vector<nano::representative> nano::rep_crawler::representatives_by_weight ()
-{
-	std::vector<nano::representative> result;
-	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
-	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n; ++i)
-	{
-		assert (i->weight.number () > 0);
-		result.push_back (*i);
-	}
-	return result;
-}
-
 void nano::rep_crawler::on_rep_request (std::shared_ptr<nano::transport::channel> channel_a)
 {
 	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
@@ -257,7 +245,6 @@ void nano::rep_crawler::update_weights ()
 std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a)
 {
 	std::vector<representative> result;
-	result.reserve (count_a);
 	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
 	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)
 	{

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -257,7 +257,7 @@ void nano::rep_crawler::update_weights ()
 std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a)
 {
 	std::vector<representative> result;
-	result.reserve (std::min (count_a, size_t (16)));
+	result.reserve (count_a);
 	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
 	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)
 	{

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -100,14 +100,11 @@ public:
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;
 
-	/** Request a list of the top \p count_a known representatives. */
-	std::vector<representative> representatives (size_t count_a);
+	/** Request a list of the top \p count_a known representatives in descending order of weight. */
+	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max ());
 
 	/** Request a list of the top \p count_a known representative endpoints. */
 	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (size_t count_a);
-
-	/** Returns all representatives registered with weight in descending order */
-	std::vector<nano::representative> representatives_by_weight ();
 
 	/** Total number of representatives */
 	size_t representative_count ();

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -100,10 +100,10 @@ public:
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;
 
-	/** Request a list of the top \p count_a known representatives. The maximum number of reps returned is 16. */
+	/** Request a list of the top \p count_a known representatives. */
 	std::vector<representative> representatives (size_t count_a);
 
-	/** Request a list of the top \p count_a known representative endpoints. The maximum number of reps returned is 16. */
+	/** Request a list of the top \p count_a known representative endpoints. */
 	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (size_t count_a);
 
 	/** Returns all representatives registered with weight in descending order */

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -80,7 +80,7 @@ protected:
 	std::atomic<uint64_t> last_completion_time;
 	std::atomic<bool> timed_out{ false };
 	boost::optional<std::chrono::seconds> io_timeout;
-	size_t const queue_size_max = 128;
+	size_t const queue_size_max = 512;
 
 	/** Set by close() - completion handlers must check this. This is more reliable than checking
 	 error codes as the OS may have already completed the async operation. */

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -80,7 +80,7 @@ protected:
 	std::atomic<uint64_t> last_completion_time;
 	std::atomic<bool> timed_out{ false };
 	boost::optional<std::chrono::seconds> io_timeout;
-	size_t const queue_size_max = 512;
+	size_t const queue_size_max = 128;
 
 	/** Set by close() - completion handlers must check this. This is more reliable than checking
 	 error codes as the OS may have already completed the async operation. */

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -1,8 +1,8 @@
 #include <nano/secure/versioning.hpp>
 
-#include <lmdb/libraries/liblmdb/lmdb.h>
-
 #include <boost/endian/conversion.hpp>
+
+#include <lmdb/libraries/liblmdb/lmdb.h>
 
 nano::account_info_v1::account_info_v1 (MDB_val const & val_a)
 {


### PR DESCRIPTION
Closes #2137 , closes #2139  (alternative to both)

**Todo**
- [x] Adjust frontier confirmation mode timings with the decreased elections size and loop time
- [x] Allow a certain time for low-difficulty elections before flushing
- [x] Split into smaller, contained PRs #2327 

**Documentation**
- [x] active_difficulty updates are now done every ~500ms (give or take), and not 16-36 seconds

**PR Description**
This PR has 2 main changes:
- Disables per-block confirm_req in the block processor
- Changes the confirmation loop such that it has a period of 0.5s instead of 16-36 seconds.

Other things had to be tuned consequently, such as frontier prioritization timings. Data collected on the beta network shows there are large improvements to bandwidth usage under high load, much more agile PoW prioritization, and reduced tcp write drops.

The optimized bandwidth allows for doing a larger number of batch confirm_req directly to representatives in the same amount of time. The PoW prioritization being more agile means even under saturation the network should correctly prioritize blocks with the highest PoW such that those are confirmed fastest.

The active elections container is reduced to 10k soft maximum. As blocks arrive that would immediately be dropped due to a low work difficulty, the election is allowed to live for up to 10 seconds, after which it is dropped.

There is a minimum time of 1 second until an election is considered for confirm_req, and the same time for being consider for active difficulty.

**Future improvements**
- Using a passive elections container to store a larger amount of elections that would otherwise be dropped. If the size of a passive election is small and not many operations are performed on the container, it can possibly be in the order of 100k in memory.

- Consider not rebroadcasting votes if the node is saturating, at least for blocks that would go into passive elections. This means all blocks would be confirmed via confirm_req. A better alternative would be #1006 . Currently, even under saturation, there's a change that blocks are confirmed via live elections even if they have a low PoW difficulty. 

**Acknowledgments**
Thanks to @Srayman for the enormous help in tuning and testing, and @Joohansson for the blocks.