### PR TITLE
ws keepalive

### DIFF
--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -428,6 +428,12 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		}
 		action_succeeded = true;
 	}
+	else if (action == "ping")
+	{
+		action_succeeded = true;
+		ack_l = "true";
+		action = "pong";
+	}
 	if (ack_l && action_succeeded)
 	{
 		send_ack (action, id_l);


### PR DESCRIPTION
provides a keep alive in the form of action
```
{
    "action":"ping"
{
```
with a response of
```
{
    "ack": "pong",
    "time": "<ms since epoch>"
}
```
This allows for checking liveliness of websocket without refreshing or creating a subscription