### PR TITLE
Quality of life updates for distributed work

### DIFF
--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -17,7 +17,7 @@ TEST (distributed_work, no_peers)
 		work = work_a;
 		done = true;
 	};
-	node->distributed_work.make (hash, callback, node->network_params.network.publish_threshold);
+	node->distributed_work.make (hash, callback, node->network_params.network.publish_threshold, nano::account ());
 	system.deadline_set (5s);
 	while (!done)
 	{

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -38,7 +38,7 @@ public:
 class distributed_work final : public std::enable_shared_from_this<nano::distributed_work>
 {
 public:
-	distributed_work (unsigned int, nano::node &, nano::block_hash const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t);
+	distributed_work (unsigned int, nano::node &, nano::block_hash const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	~distributed_work ();
 	void start ();
 	void start_work ();
@@ -56,6 +56,7 @@ public:
 	unsigned int backoff; // in seconds
 	nano::node & node;
 	nano::block_hash root;
+	boost::optional<nano::account> const & account;
 	std::mutex mutex;
 	std::map<boost::asio::ip::address, uint16_t> outstanding;
 	std::vector<std::weak_ptr<nano::work_peer_request>> connections;
@@ -75,8 +76,8 @@ class distributed_work_factory final
 {
 public:
 	distributed_work_factory (nano::node &);
-	void make (nano::block_hash const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t);
-	void make (unsigned int, nano::block_hash const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t);
+	void make (nano::block_hash const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	void make (unsigned int, nano::block_hash const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	void cancel (nano::block_hash const &, bool const local_stop = false);
 	void cleanup_finished ();
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1372,7 +1372,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (previous.is_zero () ? pub : previous, account));
+							auto opt_work_l (node.work_generate_blocking (previous.is_zero () ? pub : previous, nano::account (pub)));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1412,7 +1412,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (pub, account));
+							auto opt_work_l (node.work_generate_blocking (pub, nano::account (pub)));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1442,7 +1442,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (previous, account));
+							auto opt_work_l (node.work_generate_blocking (previous, nano::account (pub)));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1472,7 +1472,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (previous, account));
+							auto opt_work_l (node.work_generate_blocking (previous, nano::account (pub)));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1504,7 +1504,7 @@ void nano::json_handler::block_create ()
 						{
 							if (work == 0)
 							{
-								auto opt_work_l (node.work_generate_blocking (previous, account));
+								auto opt_work_l (node.work_generate_blocking (previous, nano::account (pub)));
 								if (opt_work_l.is_initialized ())
 								{
 									work = *opt_work_l;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1372,7 +1372,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (previous.is_zero () ? pub : previous));
+							auto opt_work_l (node.work_generate_blocking (previous.is_zero () ? pub : previous, account));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1412,7 +1412,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (pub));
+							auto opt_work_l (node.work_generate_blocking (pub, account));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1442,7 +1442,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (previous));
+							auto opt_work_l (node.work_generate_blocking (previous, account));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1472,7 +1472,7 @@ void nano::json_handler::block_create ()
 					{
 						if (work == 0)
 						{
-							auto opt_work_l (node.work_generate_blocking (previous));
+							auto opt_work_l (node.work_generate_blocking (previous, account));
 							if (opt_work_l.is_initialized ())
 							{
 								work = *opt_work_l;
@@ -1504,7 +1504,7 @@ void nano::json_handler::block_create ()
 						{
 							if (work == 0)
 							{
-								auto opt_work_l (node.work_generate_blocking (previous));
+								auto opt_work_l (node.work_generate_blocking (previous, account));
 								if (opt_work_l.is_initialized ())
 								{
 									work = *opt_work_l;
@@ -4481,44 +4481,54 @@ void nano::json_handler::wallet_work_get ()
 
 void nano::json_handler::work_generate ()
 {
-	auto hash (hash_impl ());
-	auto difficulty (difficulty_optional_impl ());
-	multiplier_optional_impl (difficulty);
-	if (!ec && (difficulty > node.config.max_work_generate_difficulty || difficulty < node.network_params.network.publish_threshold))
+	boost::optional<nano::account> account;
+	auto account_opt (request.get_optional<std::string> ("account"));
+	if (account_opt.is_initialized ())
 	{
-		ec = nano::error_rpc::difficulty_limit;
+		account = account_impl (account_opt.get ());
 	}
 	if (!ec)
 	{
-		bool use_peers (request.get_optional<bool> ("use_peers") == true);
-		auto rpc_l (shared_from_this ());
-		auto callback = [rpc_l, hash, this](boost::optional<uint64_t> const & work_a) {
-			if (work_a)
+		auto hash (hash_impl ());
+		auto difficulty (difficulty_optional_impl ());
+		multiplier_optional_impl (difficulty);
+		if (!ec && (difficulty > node.config.max_work_generate_difficulty || difficulty < node.network_params.network.publish_threshold))
+		{
+			ec = nano::error_rpc::difficulty_limit;
+		}
+		if (!ec)
+		{
+			bool use_peers (request.get_optional<bool> ("use_peers") == true);
+			auto rpc_l (shared_from_this ());
+			auto callback = [rpc_l, hash, this](boost::optional<uint64_t> const & work_a) {
+				if (work_a)
+				{
+					boost::property_tree::ptree response_l;
+					response_l.put ("hash", hash.to_string ());
+					uint64_t work (work_a.value ());
+					response_l.put ("work", nano::to_string_hex (work));
+					std::stringstream ostream;
+					uint64_t result_difficulty;
+					nano::work_validate (hash, work, &result_difficulty);
+					response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
+					auto result_multiplier = nano::difficulty::to_multiplier (result_difficulty, this->node.network_params.network.publish_threshold);
+					response_l.put ("multiplier", nano::to_string (result_multiplier));
+					boost::property_tree::write_json (ostream, response_l);
+					rpc_l->response (ostream.str ());
+				}
+				else
+				{
+					json_error_response (rpc_l->response, "Cancelled");
+				}
+			};
+			if (!use_peers)
 			{
-				uint64_t work (work_a.value ());
-				boost::property_tree::ptree response_l;
-				response_l.put ("work", nano::to_string_hex (work));
-				std::stringstream ostream;
-				uint64_t result_difficulty;
-				nano::work_validate (hash, work, &result_difficulty);
-				response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
-				auto result_multiplier = nano::difficulty::to_multiplier (result_difficulty, this->node.network_params.network.publish_threshold);
-				response_l.put ("multiplier", nano::to_string (result_multiplier));
-				boost::property_tree::write_json (ostream, response_l);
-				rpc_l->response (ostream.str ());
+				node.work.generate (hash, callback, difficulty);
 			}
 			else
 			{
-				json_error_response (rpc_l->response, "Cancelled");
+				node.work_generate (hash, callback, difficulty, account);
 			}
-		};
-		if (!use_peers)
-		{
-			node.work.generate (hash, callback, difficulty);
-		}
-		else
-		{
-			node.work_generate (hash, callback, difficulty);
 		}
 	}
 	// Because of callback

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -967,7 +967,7 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & bloc
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a, uint64_t difficulty_a)
 {
-	auto opt_work_l (work_generate_blocking (block_a.root (), difficulty_a));
+	auto opt_work_l (work_generate_blocking (block_a.root (), difficulty_a, block_a.account ()));
 	if (opt_work_l.is_initialized ())
 	{
 		block_a.block_work_set (*opt_work_l);
@@ -975,22 +975,22 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & bloc
 	return opt_work_l;
 }
 
-void nano::node::work_generate (nano::uint256_union const & hash_a, std::function<void(boost::optional<uint64_t>)> callback_a)
+void nano::node::work_generate (nano::uint256_union const & hash_a, std::function<void(boost::optional<uint64_t>)> callback_a, boost::optional<nano::account> const & account_a)
 {
-	work_generate (hash_a, callback_a, network_params.network.publish_threshold);
+	work_generate (hash_a, callback_a, network_params.network.publish_threshold, account_a);
 }
 
-void nano::node::work_generate (nano::uint256_union const & hash_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a)
+void nano::node::work_generate (nano::uint256_union const & hash_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a)
 {
-	distributed_work.make (hash_a, callback_a, difficulty_a);
+	distributed_work.make (hash_a, callback_a, difficulty_a, account_a);
 }
 
-boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_union const & block_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_union const & hash_a, boost::optional<nano::account> const & account_a)
 {
-	return work_generate_blocking (block_a, network_params.network.publish_threshold);
+	return work_generate_blocking (hash_a, network_params.network.publish_threshold, account_a);
 }
 
-boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_union const & hash_a, uint64_t difficulty_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_union const & hash_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a)
 {
 	std::promise<uint64_t> promise;
 	std::future<uint64_t> future = promise.get_future ();
@@ -998,7 +998,7 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::uint256_unio
 	work_generate (hash_a, [&promise](boost::optional<uint64_t> work_a) {
 		promise.set_value (work_a.value_or (0));
 	},
-	difficulty_a);
+	difficulty_a, account_a);
 	// clang-format on
 	return future.get ();
 }

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -125,10 +125,10 @@ public:
 	int price (nano::uint128_t const &, int);
 	boost::optional<uint64_t> work_generate_blocking (nano::block &, uint64_t);
 	boost::optional<uint64_t> work_generate_blocking (nano::block &);
-	boost::optional<uint64_t> work_generate_blocking (nano::uint256_union const &, uint64_t);
-	boost::optional<uint64_t> work_generate_blocking (nano::uint256_union const &);
-	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>, uint64_t);
-	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>);
+	boost::optional<uint64_t> work_generate_blocking (nano::uint256_union const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	boost::optional<uint64_t> work_generate_blocking (nano::uint256_union const &, boost::optional<nano::account> const & = boost::none);
+	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>, uint64_t, boost::optional<nano::account> const & = boost::none);
+	void work_generate (nano::uint256_union const &, std::function<void(boost::optional<uint64_t>)>, boost::optional<nano::account> const & = boost::none);
 	void add_initial_peers ();
 	void block_confirm (std::shared_ptr<nano::block>);
 	bool block_confirmed_or_being_confirmed (nano::transaction const &, nano::block_hash const &);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1368,7 +1368,7 @@ bool nano::wallet::live ()
 
 void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::block_hash const & root_a)
 {
-	auto opt_work_l (wallets.node.work_generate_blocking (root_a));
+	auto opt_work_l (wallets.node.work_generate_blocking (root_a, account_a));
 	if (opt_work_l.is_initialized ())
 	{
 		auto transaction_l (wallets.tx_begin_write ());
@@ -1482,7 +1482,7 @@ void nano::work_watcher::watching (nano::qualified_root const & root_a, std::sha
 							}
 						}
 					},
-					active_difficulty);
+					active_difficulty, block_a->account ());
 				}
 				else
 				{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2621,23 +2621,47 @@ TEST (rpc, work_generate)
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
 	request.put ("hash", hash.to_string ());
-	test_response response (request, rpc.config.port, system.io_ctx);
-	system.deadline_set (5s);
-	while (response.status == 0)
 	{
-		ASSERT_NO_ERROR (system.poll ());
+		test_response response (request, rpc.config.port, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		ASSERT_EQ (hash.to_string (), response.json.get<std::string> ("hash"));
+		auto work_text (response.json.get<std::string> ("work"));
+		uint64_t work, result_difficulty;
+		ASSERT_FALSE (nano::from_string_hex (work_text, work));
+		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
+		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
+		uint64_t response_difficulty;
+		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
+		ASSERT_EQ (result_difficulty, response_difficulty);
+		auto multiplier = response.json.get<double> ("multiplier");
+		ASSERT_NEAR (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier, 1e-6);
 	}
-	ASSERT_EQ (200, response.status);
-	auto work_text (response.json.get<std::string> ("work"));
-	uint64_t work, result_difficulty;
-	ASSERT_FALSE (nano::from_string_hex (work_text, work));
-	ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
-	auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
-	uint64_t response_difficulty;
-	ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
-	ASSERT_EQ (result_difficulty, response_difficulty);
-	auto multiplier = response.json.get<double> ("multiplier");
-	ASSERT_NEAR (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier, 1e-6);
+	request.put ("use_peers", "true");
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		ASSERT_EQ (hash.to_string (), response.json.get<std::string> ("hash"));
+		auto work_text (response.json.get<std::string> ("work"));
+		uint64_t work, result_difficulty;
+		ASSERT_FALSE (nano::from_string_hex (work_text, work));
+		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
+		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
+		uint64_t response_difficulty;
+		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
+		ASSERT_EQ (result_difficulty, response_difficulty);
+		auto multiplier = response.json.get<double> ("multiplier");
+		ASSERT_NEAR (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier, 1e-6);
+	}
 }
 
 TEST (rpc, work_generate_difficulty)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2621,7 +2621,7 @@ TEST (rpc, work_generate)
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
 	request.put ("hash", hash.to_string ());
-	{
+	auto verify_response = [node, &rpc, &system](auto & request, auto & hash) {
 		test_response response (request, rpc.config.port, system.io_ctx);
 		system.deadline_set (5s);
 		while (response.status == 0)
@@ -2640,28 +2640,10 @@ TEST (rpc, work_generate)
 		ASSERT_EQ (result_difficulty, response_difficulty);
 		auto multiplier = response.json.get<double> ("multiplier");
 		ASSERT_NEAR (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier, 1e-6);
-	}
+	};
+	verify_response (request, hash);
 	request.put ("use_peers", "true");
-	{
-		test_response response (request, rpc.config.port, system.io_ctx);
-		system.deadline_set (5s);
-		while (response.status == 0)
-		{
-			ASSERT_NO_ERROR (system.poll ());
-		}
-		ASSERT_EQ (200, response.status);
-		ASSERT_EQ (hash.to_string (), response.json.get<std::string> ("hash"));
-		auto work_text (response.json.get<std::string> ("work"));
-		uint64_t work, result_difficulty;
-		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
-		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
-		uint64_t response_difficulty;
-		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
-		ASSERT_EQ (result_difficulty, response_difficulty);
-		auto multiplier = response.json.get<double> ("multiplier");
-		ASSERT_NEAR (nano::difficulty::to_multiplier (result_difficulty, node->network_params.network.publish_threshold), multiplier, 1e-6);
-	}
+	verify_response (request, hash);
 }
 
 TEST (rpc, work_generate_difficulty)


### PR DESCRIPTION
- Send `account` to work peers via distributed work, to facilitate tracking for precaching. Optional so as to not break tests.
- Return hash on work responses, useful as an id despite not being unique (i.e., there can be two work requests for the same hash).

