### PR TITLE
Classify traffic stats correctly

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -415,11 +415,11 @@ std::string nano::stat::type_to_string (uint32_t key)
 		case nano::stat::type::rollback:
 			res = "rollback";
 			break;
-		case nano::stat::type::traffic:
-			res = "traffic";
+		case nano::stat::type::traffic_udp:
+			res = "traffic_udp";
 			break;
 		case nano::stat::type::traffic_tcp:
-			res = "traffic_bootstrap";
+			res = "traffic_tcp";
 			break;
 		case nano::stat::type::vote:
 			res = "vote";

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -220,7 +220,7 @@ public:
 	/** Primary statistics type */
 	enum class type : uint8_t
 	{
-		traffic,
+		traffic_udp,
 		traffic_tcp,
 		error,
 		message,

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -48,7 +48,7 @@ std::function<void(boost::system::error_code const &, size_t)> nano::transport::
 			}
 			if (size_a > 0)
 			{
-				node_l->stats.add (nano::stat::type::traffic, nano::stat::dir::out, size_a);
+				node_l->stats.add (nano::stat::type::traffic_udp, nano::stat::dir::out, size_a);
 			}
 
 			if (callback_a)
@@ -544,7 +544,7 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 		}
 		else
 		{
-			node.stats.add (nano::stat::type::traffic, nano::stat::dir::in, data_a->size);
+			node.stats.add (nano::stat::type::traffic_udp, nano::stat::dir::in, data_a->size);
 		}
 	}
 	else

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -829,7 +829,7 @@ void nano_qt::stats_viewer::refresh_stats ()
 				detail = "total";
 			}
 
-			if (type == "traffic" || type == "traffic_bootstrap")
+			if (type == "traffic_udp" || type == "traffic_tcp")
 			{
 				const std::vector<std::string> units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
 				double bytes = std::stod (value);


### PR DESCRIPTION
traffic -> traffic_udp
traffic_bootstrap -> traffic_tcp

Most traffic will now be on `traffic_tcp`, so we might want to consider splitting it up into more fine grained stats at some point.

Docs PR at https://github.com/nanocurrency/nano-docs/pull/118