### PR TITLE
Snapshot/Vacuum should use the rocksdb config option

### DIFF
--- a/nano/node/cli.hpp
+++ b/nano/node/cli.hpp
@@ -13,7 +13,8 @@ enum class error_cli
 	parse_error = 2,
 	invalid_arguments = 3,
 	unknown_command = 4,
-	database_write_error = 5
+	database_write_error = 5,
+	reading_config = 6
 };
 
 void add_node_options (boost::program_options::options_description &);


### PR DESCRIPTION
@SergiySW spotted that snapshot/vacuum didn't use the config, but rather was using the build options in deciding which backend to use. The CLI commands don't have support for the `--config` options currently, is probably a worthy enhancement but reading from the config file should do for now.

Best reviewed without whitespace changes.