### PR TITLE
Set NANO_ROCKSDB define even when set to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,8 @@ if (${NANO_TIMED_LOCKS} GREATER 0)
 	add_definitions (-DNANO_TIMED_LOCKS=${NANO_TIMED_LOCKS})
 endif ()
 
-if (NANO_ROCKSDB)
-	add_definitions (-DNANO_ROCKSDB=1)
-endif ()
+add_definitions (-DNANO_ROCKSDB=$<STREQUAL:${NANO_ROCKSDB},ON>)
+
 option(NANO_ASAN_INT "Enable ASan+UBSan+Integer overflow" OFF)
 option(NANO_ASAN "Enable ASan+UBSan" OFF)
 option(NANO_TSAN "Enable TSan" OFF)

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -243,16 +243,19 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				{
 					// Note that these throw on failure
 					std::cout << "Finalizing" << std::endl;
-#ifdef NANO_ROCKSDB
-					nano::remove_all_files_in_dir (backup_path);
-					nano::move_all_files_to_dir (source_path, backup_path);
-					nano::move_all_files_to_dir (vacuum_path, source_path);
-					boost::filesystem::remove_all (vacuum_path);
-#else
-					boost::filesystem::remove (backup_path);
-					boost::filesystem::rename (source_path, backup_path);
-					boost::filesystem::rename (vacuum_path, source_path);
-#endif
+					if (using_rocksdb)
+					{
+						nano::remove_all_files_in_dir (backup_path);
+						nano::move_all_files_to_dir (source_path, backup_path);
+						nano::move_all_files_to_dir (vacuum_path, source_path);
+						boost::filesystem::remove_all (vacuum_path);
+					}
+					else
+					{
+						boost::filesystem::remove (backup_path);
+						boost::filesystem::rename (source_path, backup_path);
+						boost::filesystem::rename (vacuum_path, source_path);
+					}
 					std::cout << "Vacuum completed" << std::endl;
 				}
 				else


### PR DESCRIPTION
Currently not defining NANO_ROCKSDB (as @guilhermelawless found) as a CMake variable causes a build failure.

Also found a place that is using `#ifdef NANO_ROCKSDB` where it shouldn't.