### PR TITLE
Account creation refresh in qt wallet

### DIFF
--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -189,31 +189,33 @@ wallet (wallet_a)
 		this->wallet.pop_main_stack ();
 	});
 	QObject::connect (create_account, &QPushButton::released, [this]() {
-		auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-		if (this->wallet.wallet_m->store.valid_password (transaction))
 		{
-			this->wallet.wallet_m->deterministic_insert (transaction);
-			show_button_success (*create_account);
-			create_account->setText ("New account was created");
-			refresh ();
-			this->wallet.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [this]() {
-				this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this]() {
-					show_button_ok (*create_account);
-					create_account->setText ("Create account");
-				}));
-			});
+			auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
+			if (this->wallet.wallet_m->store.valid_password (transaction))
+			{
+				this->wallet.wallet_m->deterministic_insert (transaction);
+				show_button_success (*create_account);
+				create_account->setText ("New account was created");
+				this->wallet.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [this]() {
+					this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this]() {
+						show_button_ok (*create_account);
+						create_account->setText ("Create account");
+					}));
+				});
+			}
+			else
+			{
+				show_button_error (*create_account);
+				create_account->setText ("Wallet is locked, unlock it to create account");
+				this->wallet.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [this]() {
+					this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this]() {
+						show_button_ok (*create_account);
+						create_account->setText ("Create account");
+					}));
+				});
+			}
 		}
-		else
-		{
-			show_button_error (*create_account);
-			create_account->setText ("Wallet is locked, unlock it to create account");
-			this->wallet.node.alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (5), [this]() {
-				this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this]() {
-					show_button_ok (*create_account);
-					create_account->setText ("Create account");
-				}));
-			});
-		}
+		refresh ();
 	});
 	QObject::connect (import_wallet, &QPushButton::released, [this]() {
 		this->wallet.push_main_stack (this->wallet.import.window);


### PR DESCRIPTION
Fixes an annoyance in the Qt wallet where creating new accounts doesn't update the account list properly.

Moves `refresh()` out of the tx scope, so it's almost all whitespace changes.