### PR TITLE
Add confirmation request count to election_status

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -465,8 +465,10 @@ TEST (websocket, confirmation_options)
 			boost::property_tree::ptree election_info = event.get_child ("message.election_info");
 			auto tally (election_info.get<std::string> ("tally"));
 			auto time (election_info.get<std::string> ("time"));
-			election_info.get<std::string> ("duration");
-			// Make sure tally and time are non-zero. Duration may be zero on testnet, so we only check that it's present (exception thrown otherwise)
+			// Duration and request count may be zero on testnet, so we only check that they're present
+			ASSERT_EQ (1, election_info.count ("duration"));
+			ASSERT_EQ (1, election_info.count ("request_count"));
+			// Make sure tally and time are non-zero.
 			ASSERT_NE ("0", tally);
 			ASSERT_NE ("0", time);
 		}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -110,7 +110,7 @@ void nano::active_transactions::post_confirmation_height_set (nano::transaction 
 		bool is_state_send (false);
 		nano::account pending_account (0);
 		node.process_confirmed_data (transaction_a, block_a, block_a->hash (), sideband_a, account, amount, is_state_send, pending_account);
-		node.observers.blocks.notify (nano::election_status{ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), nano::election_status_type::inactive_confirmation_height }, account, amount, is_state_send);
+		node.observers.blocks.notify (nano::election_status{ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, nano::election_status_type::inactive_confirmation_height }, account, amount, is_state_send);
 	}
 	else
 	{
@@ -131,6 +131,7 @@ void nano::active_transactions::post_confirmation_height_set (nano::transaction 
 				nano::account pending_account (0);
 				node.process_confirmed_data (transaction_a, block_a, hash, sideband_a, account, amount, is_state_send, pending_account);
 				election->status.type = election_status_type_a;
+				election->status.confirmation_request_count = election->confirmation_request_count;
 				node.observers.blocks.notify (election->status, account, amount, is_state_send);
 				if (amount > 0)
 				{

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -57,6 +57,7 @@ public:
 	nano::amount tally;
 	std::chrono::milliseconds election_end;
 	std::chrono::milliseconds election_duration;
+	unsigned confirmation_request_count;
 	election_status_type type;
 };
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -11,7 +11,7 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> bloc
 confirmation_action (confirmation_action_a),
 node (node_a),
 election_start (std::chrono::steady_clock::now ()),
-status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), nano::election_status_type::ongoing }),
+status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, nano::election_status_type::ongoing }),
 confirmed (false),
 stopped (false),
 confirmation_request_count (0)
@@ -38,6 +38,7 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 	{
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
+		status.confirmation_request_count = confirmation_request_count;
 		status.type = type_a;
 		auto status_l (status);
 		auto node_l (node.shared ());
@@ -65,6 +66,7 @@ void nano::election::stop ()
 		stopped = true;
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
+		status.confirmation_request_count = confirmation_request_count;
 		status.type = nano::election_status_type::stopped;
 	}
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1001,7 +1001,7 @@ void nano::json_handler::block_confirm ()
 			else
 			{
 				// Add record in confirmation history for confirmed block
-				nano::election_status status{ block_l, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), nano::election_status_type::active_confirmation_height };
+				nano::election_status status{ block_l, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, nano::election_status_type::active_confirmation_height };
 				{
 					nano::lock_guard<std::mutex> lock (node.active.mutex);
 					node.active.confirmed.push_back (status);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1795,6 +1795,7 @@ void nano::json_handler::confirmation_history ()
 				election.put ("duration", i->election_duration.count ());
 				election.put ("time", i->election_end.count ());
 				election.put ("tally", i->tally.to_string_dec ());
+				election.put ("request_count", i->confirmation_request_count);
 				elections.push_back (std::make_pair ("", election));
 			}
 			running_total += i->election_duration;

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -79,7 +79,7 @@ node (node_a)
 		}
 	}
 	// Warn the user if the options resulted in an empty filter
-	if (!all_local_accounts && accounts.empty ())
+	if (has_account_filtering_options && !all_local_accounts && accounts.empty ())
 	{
 		node.logger.always_log ("Websocket: provided options resulted in an empty block confirmation filter");
 	}

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -629,6 +629,7 @@ nano::websocket::message nano::websocket::message_builder::block_confirmed (std:
 		election_node_l.add ("duration", election_status_a.election_duration.count ());
 		election_node_l.add ("time", election_status_a.election_end.count ());
 		election_node_l.add ("tally", election_status_a.tally.to_string_dec ());
+		election_node_l.add ("request_count", election_status_a.confirmation_request_count);
 		message_node_l.add_child ("election_info", election_node_l);
 	}
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6002,8 +6002,9 @@ TEST (rpc, confirmation_history)
 	ASSERT_NE (representatives.end (), item);
 	auto hash (item->second.get<std::string> ("hash"));
 	auto tally (item->second.get<std::string> ("tally"));
-	ASSERT_FALSE (item->second.get<std::string> ("duration", "").empty ());
-	ASSERT_FALSE (item->second.get<std::string> ("time", "").empty ());
+	ASSERT_EQ (1, item->second.count ("duration"));
+	ASSERT_EQ (1, item->second.count ("time"));
+	ASSERT_EQ (1, item->second.count ("request_count"));
 	ASSERT_EQ (block->hash ().to_string (), hash);
 	nano::amount tally_num;
 	tally_num.decode_dec (tally);


### PR DESCRIPTION
Used in the block confirmation websocket to keep track of confirmation request counts outside the node.