### PR TITLE
generate sample node and rpc toml after building nano_node target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,7 @@ if (NANO_TEST OR RAIBLOCKS_TEST)
 		set (gtest_force_shared_crt ON)
 	else ()
 		set (gtest_force_shared_crt OFF)
-endif()
+	endif()
 
 	add_subdirectory(nano/load_test)
 
@@ -374,6 +374,8 @@ endif()
 endif ()
 
 if (NANO_GUI OR RAIBLOCKS_GUI)
+	install (FILES ${PROJECT_BINARY_DIR}/config-node.toml.sample DESTINATION .)
+	install (FILES ${PROJECT_BINARY_DIR}/config-rpc.toml.sample DESTINATION .)
 	if (WIN32)
 		set (PLATFORM_QT_PACKAGES WinExtras)
 	else ()

--- a/nano/nano_node/CMakeLists.txt
+++ b/nano/nano_node/CMakeLists.txt
@@ -27,6 +27,11 @@ set_target_properties (nano_node
 		COMPILE_FLAGS
 			"-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")
 
+add_custom_command(TARGET nano_node
+				   POST_BUILD
+				   COMMAND nano_node --generate_config node > ${PROJECT_BINARY_DIR}/config-node.toml.sample
+				   COMMAND nano_node --generate_config rpc > ${PROJECT_BINARY_DIR}/config-rpc.toml.sample)
+
 if ((NANO_GUI OR RAIBLOCKS_GUI) AND NOT APPLE)
 	install(TARGETS nano_node
 			RUNTIME DESTINATION .


### PR DESCRIPTION
install samples to root of installers, This allows for those on mac to not have to dig for the samples within the app
formatting