### PR TITLE
Fix UPnP

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -101,7 +101,9 @@ void nano::network::send_keepalive_self (std::shared_ptr<nano::transport::channe
 		if (external_address.address () != boost::asio::ip::address_v4::any ())
 		{
 			message.peers[0] = nano::endpoint (boost::asio::ip::address_v6{}, endpoint ().port ());
-			message.peers[1] = external_address;
+			boost::system::error_code ec;
+			auto external_v6 = boost::asio::ip::address_v6::from_string(external_address.address().to_string(), ec);
+			message.peers[1] = nano::endpoint (external_v6, external_address.port());
 		}
 		else
 		{

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -102,8 +102,8 @@ void nano::network::send_keepalive_self (std::shared_ptr<nano::transport::channe
 		{
 			message.peers[0] = nano::endpoint (boost::asio::ip::address_v6{}, endpoint ().port ());
 			boost::system::error_code ec;
-			auto external_v6 = boost::asio::ip::address_v6::from_string(external_address.address().to_string(), ec);
-			message.peers[1] = nano::endpoint (external_v6, external_address.port());
+			auto external_v6 = boost::asio::ip::address_v6::from_string (external_address.address ().to_string (), ec);
+			message.peers[1] = nano::endpoint (external_v6, external_address.port ());
 		}
 		else
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -676,7 +676,7 @@ void nano::node::start ()
 			this_l->bootstrap_wallet ();
 		});
 	}
-	if (config.external_address == boost::asio::ip::address_v6{}.any())
+	if (config.external_address == boost::asio::ip::address_v6{}.any ())
 	{
 		port_mapping.start ();
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -676,7 +676,7 @@ void nano::node::start ()
 			this_l->bootstrap_wallet ();
 		});
 	}
-	if (config.external_address != boost::asio::ip::address_v6{} && config.external_port != 0)
+	if (config.external_address == boost::asio::ip::address_v6{}.any())
 	{
 		port_mapping.start ();
 	}

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -70,7 +70,7 @@ void nano::port_mapping::refresh_mapping ()
 	{
 		nano::lock_guard<std::mutex> lock (mutex);
 		auto node_port (std::to_string (node.network.endpoint ().port ()));
-		auto config_port(node.config.external_port != 0 ? std::to_string(node.config.external_port) : node_port);
+		auto config_port (node.config.external_port != 0 ? std::to_string (node.config.external_port) : node_port);
 
 		// We don't map the RPC port because, unless RPC authentication was added, this would almost always be a security risk
 		for (auto & protocol : protocols)
@@ -78,12 +78,12 @@ void nano::port_mapping::refresh_mapping ()
 			auto add_port_mapping_error (UPNP_AddPortMapping (urls.controlURL, data.first.servicetype, config_port.c_str (), node_port.c_str (), address.to_string ().c_str (), nullptr, protocol.name, nullptr, nullptr));
 			if (check_count % 15 == 0)
 			{
-				node.logger.always_log (boost::str (boost::format ("UPnP %1% port mapping response: %2%")% protocol.name % add_port_mapping_error));
+				node.logger.always_log (boost::str (boost::format ("UPnP %1% port mapping response: %2%") % protocol.name % add_port_mapping_error));
 			}
 			if (add_port_mapping_error == UPNPCOMMAND_SUCCESS)
 			{
 				node.logger.always_log (boost::str (boost::format ("%1% mapped to %2%") % config_port % node_port));
-				protocol.external_port = static_cast<uint16_t> (std::atoi(config_port.data()));
+				protocol.external_port = static_cast<uint16_t> (std::atoi (config_port.data ()));
 			}
 			else
 			{
@@ -102,7 +102,7 @@ int nano::port_mapping::check_mapping ()
 		// Long discovery time and fast setup/teardown make this impractical for testing
 		nano::lock_guard<std::mutex> lock (mutex);
 		auto node_port (std::to_string (node.network.endpoint ().port ()));
-		auto config_port(node.config.external_port != 0 ? std::to_string(node.config.external_port) : node_port);
+		auto config_port (node.config.external_port != 0 ? std::to_string (node.config.external_port) : node_port);
 		for (auto & protocol : protocols)
 		{
 			std::array<char, 64> int_client;
@@ -112,7 +112,7 @@ int nano::port_mapping::check_mapping ()
 			auto verify_port_mapping_error (UPNP_GetSpecificPortMappingEntry (urls.controlURL, data.first.servicetype, config_port.c_str (), protocol.name, nullptr, int_client.data (), int_port.data (), nullptr, nullptr, remaining_mapping_duration.data ()));
 			if (verify_port_mapping_error == UPNPCOMMAND_SUCCESS)
 			{
-				protocol.remaining = std::atoi(remaining_mapping_duration.data());
+				protocol.remaining = std::atoi (remaining_mapping_duration.data ());
 			}
 			else
 			{


### PR DESCRIPTION
Currently UPnP doesnt work with a lot of routers as the command being used to map random ports is not supported by a lot of routers. So instead we specify the mapping we want. If there is no external port configured the default is 0, and the mapping will use the peering port from the config instead and map 1 to 1. Logging is also improved to better report errors from upnp