### PR TITLE
Secondary list of peers for generating work

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -160,6 +160,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.lmdb_max_dbs, defaults.node.lmdb_max_dbs);
 	ASSERT_EQ (conf.node.max_work_generate_multiplier, defaults.node.max_work_generate_multiplier);
 	ASSERT_EQ (conf.node.network_threads, defaults.node.network_threads);
+	ASSERT_EQ (conf.node.new_work_peers, defaults.node.new_work_peers);
 	ASSERT_EQ (conf.node.work_watcher_period, defaults.node.work_watcher_period);
 	ASSERT_EQ (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
 	ASSERT_EQ (conf.node.online_weight_quorum, defaults.node.online_weight_quorum);
@@ -391,6 +392,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	io_threads = 999
 	lmdb_max_dbs = 999
 	network_threads = 999
+	new_work_peers = ["test.org:998"]
 	online_weight_minimum = "999"
 	online_weight_quorum = 99
 	password_fanout = 999
@@ -542,6 +544,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.max_work_generate_multiplier, defaults.node.max_work_generate_multiplier);
 	ASSERT_NE (conf.node.frontiers_confirmation, defaults.node.frontiers_confirmation);
 	ASSERT_NE (conf.node.network_threads, defaults.node.network_threads);
+	ASSERT_NE (conf.node.new_work_peers, defaults.node.new_work_peers);
 	ASSERT_NE (conf.node.work_watcher_period, defaults.node.work_watcher_period);
 	ASSERT_NE (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
 	ASSERT_NE (conf.node.online_weight_quorum, defaults.node.online_weight_quorum);

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -160,7 +160,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.lmdb_max_dbs, defaults.node.lmdb_max_dbs);
 	ASSERT_EQ (conf.node.max_work_generate_multiplier, defaults.node.max_work_generate_multiplier);
 	ASSERT_EQ (conf.node.network_threads, defaults.node.network_threads);
-	ASSERT_EQ (conf.node.new_work_peers, defaults.node.new_work_peers);
+	ASSERT_EQ (conf.node.secondary_work_peers, defaults.node.secondary_work_peers);
 	ASSERT_EQ (conf.node.work_watcher_period, defaults.node.work_watcher_period);
 	ASSERT_EQ (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
 	ASSERT_EQ (conf.node.online_weight_quorum, defaults.node.online_weight_quorum);
@@ -392,7 +392,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	io_threads = 999
 	lmdb_max_dbs = 999
 	network_threads = 999
-	new_work_peers = ["test.org:998"]
 	online_weight_minimum = "999"
 	online_weight_quorum = 99
 	password_fanout = 999
@@ -494,6 +493,9 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	num_memtables = 3
 	total_memtable_size = 0
 
+	[node.experimental]
+	secondary_work_peers = ["test.org:998"]
+
 	[opencl]
 	device = 999
 	enable = true
@@ -544,7 +546,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.max_work_generate_multiplier, defaults.node.max_work_generate_multiplier);
 	ASSERT_NE (conf.node.frontiers_confirmation, defaults.node.frontiers_confirmation);
 	ASSERT_NE (conf.node.network_threads, defaults.node.network_threads);
-	ASSERT_NE (conf.node.new_work_peers, defaults.node.new_work_peers);
+	ASSERT_NE (conf.node.secondary_work_peers, defaults.node.secondary_work_peers);
 	ASSERT_NE (conf.node.work_watcher_period, defaults.node.work_watcher_period);
 	ASSERT_NE (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
 	ASSERT_NE (conf.node.online_weight_quorum, defaults.node.online_weight_quorum);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1214,7 +1214,7 @@ TEST (wallet, work_watcher_generation_disabled)
 		updated_difficulty = existing->difficulty;
 	}
 	ASSERT_EQ (updated_difficulty, difficulty);
-	ASSERT_TRUE (node.distributed_work.work.empty ());
+	ASSERT_TRUE (node.distributed_work.items.empty ());
 }
 
 TEST (wallet, work_watcher_removed)

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -38,7 +38,7 @@ public:
 class distributed_work final : public std::enable_shared_from_this<nano::distributed_work>
 {
 public:
-	distributed_work (unsigned int, nano::node &, nano::root const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	distributed_work (nano::node &, nano::root const &, std::vector<std::pair<std::string, uint16_t>> const & peers_a, unsigned int, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	~distributed_work ();
 	void start ();
 	void start_work ();
@@ -60,6 +60,7 @@ public:
 	std::mutex mutex;
 	std::map<boost::asio::ip::address, uint16_t> outstanding;
 	std::vector<std::weak_ptr<nano::work_peer_request>> connections;
+	std::vector<std::pair<std::string, uint16_t>> const peers;
 	std::vector<std::pair<std::string, uint16_t>> need_resolve;
 	uint64_t difficulty;
 	uint64_t work_result{ 0 };
@@ -76,13 +77,16 @@ class distributed_work_factory final
 {
 public:
 	distributed_work_factory (nano::node &);
-	void make (nano::root const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
-	void make (unsigned int, nano::root const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	void make (nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	void make (unsigned int, nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	void cancel (nano::root const &, bool const local_stop = false);
 	void cleanup_finished ();
 
-	std::unordered_map<nano::root, std::vector<std::weak_ptr<nano::distributed_work>>> work;
-	std::mutex mutex;
 	nano::node & node;
+	std::unordered_map<nano::root, std::vector<std::weak_ptr<nano::distributed_work>>> items;
+	std::mutex mutex;
 };
+
+class seq_con_info_component;
+std::unique_ptr<seq_con_info_component> collect_seq_con_info (distributed_work_factory & distributed_work, const std::string & name);
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4530,7 +4530,7 @@ void nano::json_handler::work_generate ()
 		}
 		if (!ec)
 		{
-			bool use_peers (request.get_optional<bool> ("use_peers") == true);
+			auto use_peers (request.get<bool> ("use_peers", false));
 			auto rpc_l (shared_from_this ());
 			auto callback = [rpc_l, hash, this](boost::optional<uint64_t> const & work_a) {
 				if (work_a)
@@ -4568,7 +4568,9 @@ void nano::json_handler::work_generate ()
 			{
 				if (node.work_generation_enabled ())
 				{
-					node.work_generate (hash, callback, difficulty, account);
+					// New work peers used for debugging purposes if requested
+					auto use_new_work_peers_l (request.get<bool> ("new_work_peers", false));
+					node.work_generate (hash, callback, difficulty, account, use_new_work_peers_l);
 				}
 				else
 				{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4566,11 +4566,11 @@ void nano::json_handler::work_generate ()
 			}
 			else
 			{
-				if (node.work_generation_enabled ())
+				auto secondary_work_peers_l (request.get<bool> ("secondary_work_peers", false));
+				auto const & peers_l (secondary_work_peers_l ? node.config.secondary_work_peers : node.config.work_peers);
+				if (node.work_generation_enabled (peers_l))
 				{
-					// New work peers used for debugging purposes if requested
-					auto use_new_work_peers_l (request.get<bool> ("new_work_peers", false));
-					node.work_generate (hash, callback, difficulty, account, use_new_work_peers_l);
+					node.work_generate (hash, callback, difficulty, account, secondary_work_peers_l);
 				}
 				else
 				{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -612,6 +612,7 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const
 	composite->add_component (collect_seq_con_info (node.confirmation_height_processor, "confirmation_height_processor"));
 	composite->add_component (collect_seq_con_info (node.pending_confirmation_height, "pending_confirmation_height"));
 	composite->add_component (collect_seq_con_info (node.worker, "worker"));
+	composite->add_component (collect_seq_con_info (node.distributed_work, "distributed_work"));
 	return composite;
 }
 }
@@ -990,9 +991,10 @@ void nano::node::work_generate (nano::root const & root_a, std::function<void(bo
 	work_generate (root_a, callback_a, network_params.network.publish_threshold, account_a);
 }
 
-void nano::node::work_generate (nano::root const & root_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a)
+void nano::node::work_generate (nano::root const & root_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a, bool new_work_peers_a)
 {
-	distributed_work.make (root_a, callback_a, difficulty_a, account_a);
+	auto const & peers_l (new_work_peers_a ? config.new_work_peers : config.work_peers);
+	distributed_work.make (root_a, peers_l, callback_a, difficulty_a, account_a);
 }
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a, boost::optional<nano::account> const & account_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -968,7 +968,12 @@ bool nano::node::local_work_generation_enabled () const
 
 bool nano::node::work_generation_enabled () const
 {
-	return !config.work_peers.empty () || local_work_generation_enabled ();
+	return work_generation_enabled (config.work_peers);
+}
+
+bool nano::node::work_generation_enabled (std::vector<std::pair<std::string, uint16_t>> const & peers_a) const
+{
+	return !peers_a.empty () || local_work_generation_enabled ();
 }
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a)
@@ -991,9 +996,9 @@ void nano::node::work_generate (nano::root const & root_a, std::function<void(bo
 	work_generate (root_a, callback_a, network_params.network.publish_threshold, account_a);
 }
 
-void nano::node::work_generate (nano::root const & root_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a, bool new_work_peers_a)
+void nano::node::work_generate (nano::root const & root_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a, bool secondary_work_peers_a)
 {
-	auto const & peers_l (new_work_peers_a ? config.new_work_peers : config.work_peers);
+	auto const & peers_l (secondary_work_peers_a ? config.secondary_work_peers : config.work_peers);
 	distributed_work.make (root_a, peers_l, callback_a, difficulty_a, account_a);
 }
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -129,7 +129,7 @@ public:
 	boost::optional<uint64_t> work_generate_blocking (nano::block &);
 	boost::optional<uint64_t> work_generate_blocking (nano::root const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	boost::optional<uint64_t> work_generate_blocking (nano::root const &, boost::optional<nano::account> const & = boost::none);
-	void work_generate (nano::root const &, std::function<void(boost::optional<uint64_t>)>, uint64_t, boost::optional<nano::account> const & = boost::none);
+	void work_generate (nano::root const &, std::function<void(boost::optional<uint64_t>)>, uint64_t, boost::optional<nano::account> const & = boost::none, bool const = false);
 	void work_generate (nano::root const &, std::function<void(boost::optional<uint64_t>)>, boost::optional<nano::account> const & = boost::none);
 	void add_initial_peers ();
 	void block_confirm (std::shared_ptr<nano::block>);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -125,6 +125,7 @@ public:
 	int price (nano::uint128_t const &, int);
 	bool local_work_generation_enabled () const;
 	bool work_generation_enabled () const;
+	bool work_generation_enabled (std::vector<std::pair<std::string, uint16_t>> const &) const;
 	boost::optional<uint64_t> work_generate_blocking (nano::block &, uint64_t);
 	boost::optional<uint64_t> work_generate_blocking (nano::block &);
 	boost::optional<uint64_t> work_generate_blocking (nano::root const &, uint64_t, boost::optional<nano::account> const & = boost::none);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -818,7 +818,7 @@ nano::frontiers_confirmation_mode nano::node_config::deserialize_frontiers_confi
 	}
 }
 
-void nano::node_config::deserialize_address (std::string const & entry_a, std::vector<std::string, uint16_t> & container_a) const
+void nano::node_config::deserialize_address (std::string const & entry_a, std::vector<std::pair<std::string, uint16_t>> & container_a) const
 {
 	auto port_position (entry_a.rfind (':'));
 	bool result = (port_position == -1);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -206,40 +206,16 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		if (toml.has_key ("work_peers"))
 		{
 			work_peers.clear ();
-			toml.array_entries_required<std::string> ("work_peers", [this](std::string const & entry) {
-				auto port_position (entry.rfind (':'));
-				bool result = port_position == -1;
-				if (!result)
-				{
-					auto port_str (entry.substr (port_position + 1));
-					uint16_t port;
-					result |= parse_port (port_str, port);
-					if (!result)
-					{
-						auto address (entry.substr (0, port_position));
-						this->work_peers.emplace_back (address, port);
-					}
-				}
+			toml.array_entries_required<std::string> ("work_peers", [this](std::string const & entry_a) {
+				this->deserialize_address (entry_a, this->work_peers);
 			});
 		}
 
 		if (toml.has_key ("new_work_peers"))
 		{
 			new_work_peers.clear ();
-			toml.array_entries_required<std::string> ("new_work_peers", [this](std::string const & entry) {
-				auto port_position (entry.rfind (':'));
-				bool result = port_position == -1;
-				if (!result)
-				{
-					auto port_str (entry.substr (port_position + 1));
-					uint16_t port;
-					result |= parse_port (port_str, port);
-					if (!result)
-					{
-						auto address (entry.substr (0, port_position));
-						this->new_work_peers.emplace_back (address, port);
-					}
-				}
+			toml.array_entries_required<std::string> ("new_work_peers", [this](std::string const & entry_a) {
+				this->deserialize_address (entry_a, this->new_work_peers);
 			});
 		}
 
@@ -839,6 +815,23 @@ nano::frontiers_confirmation_mode nano::node_config::deserialize_frontiers_confi
 	else
 	{
 		return nano::frontiers_confirmation_mode::invalid;
+	}
+}
+
+void nano::node_config::deserialize_address (std::string const & entry_a, std::vector<std::string, uint16_t> & container_a) const
+{
+	auto port_position (entry_a.rfind (':'));
+	bool result = (port_position == -1);
+	if (!result)
+	{
+		auto port_str (entry_a.substr (port_position + 1));
+		uint16_t port;
+		result |= parse_port (port_str, port);
+		if (!result)
+		{
+			auto address (entry_a.substr (0, port_position));
+			container_a.emplace_back (address, port);
+		}
 	}
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -105,6 +105,12 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 		work_peers_l->push_back (boost::str (boost::format ("%1%:%2%") % i->first % i->second));
 	}
 
+	auto new_work_peers_l (toml.create_array ("new_work_peers", "Debugging purposes - A list of \"address:port\" entries to identify work peers to debug secondary work generation"));
+	for (auto i (new_work_peers.begin ()), n (new_work_peers.end ()); i != n; ++i)
+	{
+		new_work_peers_l->push_back (boost::str (boost::format ("%1%:%2%") % i->first % i->second));
+	}
+
 	auto preconfigured_peers_l (toml.create_array ("preconfigured_peers", "A list of \"address:port\" entries to identify preconfigured peers"));
 	for (auto i (preconfigured_peers.begin ()), n (preconfigured_peers.end ()); i != n; ++i)
 	{
@@ -212,6 +218,26 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 					{
 						auto address (entry.substr (0, port_position));
 						this->work_peers.emplace_back (address, port);
+					}
+				}
+			});
+		}
+
+		if (toml.has_key ("new_work_peers"))
+		{
+			new_work_peers.clear ();
+			toml.array_entries_required<std::string> ("new_work_peers", [this](std::string const & entry) {
+				auto port_position (entry.rfind (':'));
+				bool result = port_position == -1;
+				if (!result)
+				{
+					auto port_str (entry.substr (port_position + 1));
+					uint16_t port;
+					result |= parse_port (port_str, port);
+					if (!result)
+					{
+						auto address (entry.substr (0, port_position));
+						this->new_work_peers.emplace_back (address, port);
 					}
 				}
 			});

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -45,7 +45,7 @@ public:
 	uint16_t peering_port{ 0 };
 	nano::logging logging;
 	std::vector<std::pair<std::string, uint16_t>> work_peers;
-	std::vector<std::pair<std::string, uint16_t>> new_work_peers;
+	std::vector<std::pair<std::string, uint16_t>> secondary_work_peers{ { "127.0.0.1", 8076 } }; /* Default of nano-pow-server */
 	std::vector<std::string> preconfigured_peers;
 	std::vector<nano::account> preconfigured_representatives;
 	unsigned bootstrap_fraction_numerator{ 1 };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -45,6 +45,7 @@ public:
 	uint16_t peering_port{ 0 };
 	nano::logging logging;
 	std::vector<std::pair<std::string, uint16_t>> work_peers;
+	std::vector<std::pair<std::string, uint16_t>> new_work_peers;
 	std::vector<std::string> preconfigured_peers;
 	std::vector<nano::account> preconfigured_representatives;
 	unsigned bootstrap_fraction_numerator{ 1 };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -94,10 +94,12 @@ public:
 	double max_work_generate_multiplier{ 64. };
 	uint64_t max_work_generate_difficulty{ nano::network_constants::publish_full_threshold };
 	nano::rocksdb_config rocksdb_config;
-
 	nano::frontiers_confirmation_mode frontiers_confirmation{ nano::frontiers_confirmation_mode::automatic };
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;
 	nano::frontiers_confirmation_mode deserialize_frontiers_confirmation (std::string const &);
+	/** Option is ignored if it cannot be parsed as a valid address:port */
+	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
+
 	static unsigned json_version ()
 	{
 		return 18;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -97,7 +97,7 @@ public:
 	nano::frontiers_confirmation_mode frontiers_confirmation{ nano::frontiers_confirmation_mode::automatic };
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;
 	nano::frontiers_confirmation_mode deserialize_frontiers_confirmation (std::string const &);
-	/** Option is ignored if it cannot be parsed as a valid address:port */
+	/** Entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
 
 	static unsigned json_version ()


### PR DESCRIPTION
This secondary list of peers can be used only via RPC work_generate by setting the option "secondary_work_peers" to "true" along with "use_peers"

- Adds secondary_work_peers under a new "experimental" config
- Changes distributed_work to receive a list of peers
- Some fixes to distributed_work where it wouldn't call the failure callback in edge scenarios
- Collect object stats for distributed_work