### PR TITLE
Add ability to start pow server as child process

### DIFF
--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -124,7 +124,28 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 
 #if BOOST_PROCESS_SUPPORTED
 			std::unique_ptr<boost::process::child> rpc_process;
+			std::unique_ptr<boost::process::child> nano_pow_server_process;
 #endif
+
+			if (config.pow_server.enable)
+			{
+				if (!boost::filesystem::exists (config.pow_server.pow_server_path))
+				{
+					splash->hide ();
+					show_error (std::string ("nano_pow_server is configured to start as a child process, however the file cannot be found at: ") + config.pow_server.pow_server_path);
+					std::exit (1);
+				}
+
+#if BOOST_PROCESS_SUPPORTED
+				auto network = node->network_params.network.get_current_network_as_string ();
+				nano_pow_server_process = std::make_unique<boost::process::child> (config.pow_server.pow_server_path, "--config_path", data_path / "config-nano-pow-server.toml");
+#else
+				splash->hide ();
+				show_error ("nano_pow_server is configured to start as a child process, but this is not supported on this system. Disable startup and start the server manually.");
+				std::exit (1);
+#endif
+			}
+
 			std::unique_ptr<nano::rpc> rpc;
 			std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 			if (config.rpc_enable)
@@ -170,6 +191,11 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 				if (rpc_process)
 				{
 					rpc_process->terminate ();
+				}
+
+				if (nano_pow_server_process)
+				{
+					nano_pow_server_process->terminate ();
 				}
 #endif
 				runner.stop_event_processing ();

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -90,6 +90,8 @@ add_library (node
 	payment_observer_processor.cpp
 	portmapping.hpp
 	portmapping.cpp
+	node_pow_server_config.hpp
+	node_pow_server_config.cpp
 	repcrawler.hpp
 	repcrawler.cpp
 	testing.hpp

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -31,13 +31,17 @@ nano::error nano::daemon_config::serialize_toml (nano::tomlconfig & toml)
 	opencl_l.put ("enable", opencl_enable);
 	toml.put_child ("opencl", opencl_l);
 
+	nano::tomlconfig pow_server_l;
+	pow_server.serialize_toml (pow_server_l);
+	nano::tomlconfig pow_server (pow_server_l);
+	toml.put_child ("nano_pow_server", pow_server);
+
 	return toml.get_error ();
 }
 
 nano::error nano::daemon_config::deserialize_toml (nano::tomlconfig & toml)
 {
 	auto rpc_l (toml.get_optional_child ("rpc"));
-
 	if (!toml.get_error () && rpc_l)
 	{
 		rpc_l->get_optional<bool> ("enable", rpc_enable);
@@ -50,14 +54,17 @@ nano::error nano::daemon_config::deserialize_toml (nano::tomlconfig & toml)
 		node.deserialize_toml (*node_l);
 	}
 
-	if (!toml.get_error ())
+	auto opencl_l (toml.get_optional_child ("opencl"));
+	if (!toml.get_error () && opencl_l)
 	{
-		auto opencl_l (toml.get_optional_child ("opencl"));
-		if (!toml.get_error () && opencl_l)
-		{
-			opencl_l->get_optional<bool> ("enable", opencl_enable);
-			opencl.deserialize_toml (*opencl_l);
-		}
+		opencl_l->get_optional<bool> ("enable", opencl_enable);
+		opencl.deserialize_toml (*opencl_l);
+	}
+
+	auto pow_l (toml.get_optional_child ("nano_pow_server"));
+	if (!toml.get_error () && pow_l)
+	{
+		pow_server.deserialize_toml (*pow_l);
 	}
 
 	return toml.get_error ();

--- a/nano/node/daemonconfig.hpp
+++ b/nano/node/daemonconfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/errors.hpp>
+#include <nano/node/node_pow_server_config.hpp>
 #include <nano/node/node_rpc_config.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/openclconfig.hpp>
@@ -25,6 +26,7 @@ public:
 	nano::node_config node;
 	bool opencl_enable{ false };
 	nano::opencl_config opencl;
+	nano::node_pow_server_config pow_server;
 	boost::filesystem::path data_path;
 	unsigned json_version () const
 	{

--- a/nano/node/node_pow_server_config.cpp
+++ b/nano/node/node_pow_server_config.cpp
@@ -1,0 +1,19 @@
+#include <nano/lib/config.hpp>
+#include <nano/lib/rpcconfig.hpp>
+#include <nano/lib/tomlconfig.hpp>
+#include <nano/node/node_pow_server_config.hpp>
+
+nano::error nano::node_pow_server_config::serialize_toml (nano::tomlconfig & toml) const
+{
+	toml.put ("enable", enable, "Enable or disable starting Nano PoW Server as a child process.\ntype:bool");
+	toml.put ("nano_pow_server_path", pow_server_path, "Path to the nano_pow_server executable.\ntype:string,path");
+	return toml.get_error ();
+}
+
+nano::error nano::node_pow_server_config::deserialize_toml (nano::tomlconfig & toml)
+{
+	toml.get_optional<bool> ("enable", enable);
+	toml.get_optional<std::string> ("nano_pow_server_path", pow_server_path);
+
+	return toml.get_error ();
+}

--- a/nano/node/node_pow_server_config.hpp
+++ b/nano/node/node_pow_server_config.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <nano/lib/rpcconfig.hpp>
+
+#include <boost/dll/runtime_symbol_info.hpp>
+#include <boost/filesystem.hpp>
+
+#include <string>
+
+namespace nano
+{
+class tomlconfig;
+
+inline std::string get_default_pow_server_filepath ()
+{
+	boost::system::error_code err;
+	auto running_executable_filepath = boost::dll::program_location (err);
+
+	// Construct the nano_pow_server executable file path based on where the currently running executable is found.
+	auto pow_server_filepath = running_executable_filepath.parent_path () / "nano_pow_server";
+	if (running_executable_filepath.has_extension ())
+	{
+		pow_server_filepath.replace_extension (running_executable_filepath.extension ());
+	}
+
+	return pow_server_filepath.string ();
+}
+
+class node_pow_server_config final
+{
+public:
+	nano::error serialize_toml (nano::tomlconfig & toml) const;
+	nano::error deserialize_toml (nano::tomlconfig & toml);
+
+	bool enable{ false };
+	std::string pow_server_path{ nano::get_default_pow_server_filepath () };
+};
+}


### PR DESCRIPTION
Follows the same pattern as the RPC process.

Not enabled by default for now.