### PR TITLE
tsan: fix race in inactive_votes_cache_multiple_votes

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -333,7 +333,8 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	// Batched confirmation requests
 	if (!batched_confirm_req_bundle_l.empty ())
 	{
-		node.network.broadcast_confirm_req_batched_many (batched_confirm_req_bundle_l, [this]() {
+		node.network.broadcast_confirm_req_batched_many (
+		batched_confirm_req_bundle_l, [this]() {
 			{
 				nano::lock_guard<std::mutex> guard_l (this->mutex);
 				--this->ongoing_broadcasts;

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -1,8 +1,8 @@
 #include <nano/secure/versioning.hpp>
 
-#include <lmdb/libraries/liblmdb/lmdb.h>
-
 #include <boost/endian/conversion.hpp>
+
+#include <lmdb/libraries/liblmdb/lmdb.h>
 
 nano::account_info_v1::account_info_v1 (MDB_val const & val_a)
 {


### PR DESCRIPTION
Includes a couple of formatting fixes for master (according my version of clang-format at least)