### PR TITLE
Attempt to fetch account from block hash in RPC work_generate

### DIFF
--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -56,7 +56,7 @@ public:
 	unsigned int backoff; // in seconds
 	nano::node & node;
 	nano::root root;
-	boost::optional<nano::account> const & account;
+	boost::optional<nano::account> const account;
 	std::mutex mutex;
 	std::map<boost::asio::ip::address, uint16_t> outstanding;
 	std::vector<std::weak_ptr<nano::work_peer_request>> connections;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4791,6 +4791,15 @@ void nano::json_handler::work_generate ()
 			}
 			else
 			{
+				if (!account_opt.is_initialized ())
+				{
+					// Fetch account from block if not given
+					auto transaction_l (node.store.tx_begin_read ());
+					if (node.store.block_exists (transaction_l, hash))
+					{
+						account = node.store.block_account (transaction_l, hash);
+					}
+				}
 				auto secondary_work_peers_l (request.get<bool> ("secondary_work_peers", false));
 				auto const & peers_l (secondary_work_peers_l ? node.config.secondary_work_peers : node.config.work_peers);
 				if (node.work_generation_enabled (peers_l))


### PR DESCRIPTION
Also fixes distributed_work relaying the account by not storing as a const ref.