### PR TITLE
Output error message with qt wallet if RocksDB is enabled in config but is unsupported

### DIFF
--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -250,6 +250,8 @@ std::string nano::error_config_messages::message (int ev) const
 			return "Invalid configuration value";
 		case nano::error_config::missing_value:
 			return "Missing value in configuration";
+		case nano::error_config::rocksdb_enabled_but_not_supported:
+			return "RocksDB has been enabled, but the node has not been built with RocksDB support. Set the CMake flag -DNANO_ROCKSDB=ON";
 	}
 
 	return "Invalid error code";

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -139,6 +139,7 @@ enum class error_config
 	generic = 1,
 	invalid_value,
 	missing_value,
+	rocksdb_enabled_but_not_supported
 };
 } // nano namespace
 

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -66,6 +66,13 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 		error = read_and_update_wallet_config (wallet_config, data_path);
 	}
 
+#if !NANO_ROCKSDB
+	if (!error && config.node.rocksdb_config.enable)
+	{
+		error = nano::error_config::rocksdb_enabled_but_not_supported;
+	}
+#endif
+
 	if (!error)
 	{
 		nano::set_use_memory_pools (config.node.use_memory_pools);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1372,7 +1372,7 @@ std::unique_ptr<nano::block_store> nano::make_store (nano::logger_mt & logger, b
 #if NANO_ROCKSDB
 		return make_rocksdb ();
 #else
-		// Can only use the rocksdb_store if the node has been build with rocksdb support
+		logger.always_log (std::error_code (nano::error_config::rocksdb_enabled_but_not_supported).message ());
 		release_assert (false);
 		return nullptr;
 #endif


### PR DESCRIPTION
Currently it hits a `release_assert` so is non-obvious about why the gui bails. Also logging it when the node is run under the same conditions.