### PR TITLE
Fix disabled ongoing unchecked cleanup

### DIFF
--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -259,7 +259,10 @@ void nano::bootstrap_attempt::run ()
 			lazy_run ();
 			lock.lock ();
 		}
-		node->unchecked_cleanup ();
+		if (!stopped)
+		{
+			node->unchecked_cleanup ();
+		}
 	}
 	stopped = true;
 	condition.notify_all ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -651,7 +651,7 @@ void nano::node::start ()
 	{
 		ongoing_bootstrap ();
 	}
-	else if (!flags.disable_unchecked_cleanup)
+	if (!flags.disable_unchecked_cleanup)
 	{
 		auto this_l (shared ());
 		worker.push_task ([this_l]() {


### PR DESCRIPTION
And prevent a post-bootstrap cleanup if the node was stopped.