### PR TITLE
create build cache for mac qt in external repo and pull in for testing and artifacts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       if: tag =~RC|DB
       script: 
         - if [ -n "$DOCKER_PASSWORD" ]; then TRAVIS_TAG="${TRAVIS_TAG}" ci/deploy-docker.sh; fi;
+
     - stage: tag_test
       name: "gcc"
       if: tag is present
@@ -39,7 +40,6 @@ jobs:
       before_install:
         - sudo mkdir -p /etc/docker && echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json && sudo service docker restart;
         - ci/build-docker-image.sh docker/ci/Dockerfile-gcc nanocurrency/nano-env:gcc; 
-      
     - name: "clang"
       if: tag is present
       os: linux
@@ -49,7 +49,6 @@ jobs:
       before_install:
         - sudo mkdir -p /etc/docker && echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json && sudo service docker restart;
         - ci/build-docker-image.sh docker/ci/Dockerfile-clang nanocurrency/nano-env:clang;
-      
     - name: "osx clang"
       if: tag is present
       os: osx
@@ -58,10 +57,10 @@ jobs:
         - RELEASE=1
       before_install:
         - brew update;
-        - brew install qt5;
         - brew cask install xquartz;
         - brew upgrade cmake;
         - brew install rocksdb;
+        - util/build_prep/macosx/build_qt.sh
       install:
         - brew install ccache;
         - export PATH="/usr/local/opt/ccache/libexec:$PATH";
@@ -94,13 +93,14 @@ jobs:
       compiler: clang
       before_install:
         - brew update;
-        - brew install qt5;
         - brew cask install xquartz;
         - brew upgrade cmake;
         - brew install rocksdb;
+        - util/build_prep/macosx/build_qt.sh
       install:
         - brew install ccache;
         - export PATH="/usr/local/opt/ccache/libexec:$PATH";
+
     - stage: artifacts_live
       name: "live docker"
       if: tag IS present AND !tag=~RC|DB
@@ -128,17 +128,16 @@ jobs:
         - brew cask install xquartz;
         - brew upgrade cmake;
         - brew install rocksdb;
-        - git clone https://github.com/benlau/qtci.git; 
-        - source qtci/path.env; 
-        - install-qt-online qt.qt5.5130.clang_64 ~/
+        - util/build_prep/macosx/build_qt.sh
       install:
         - pip install --user awscli
         - brew install ccache;
         - export PATH="$HOME/Library/Python/2.7/bin:/usr/local/opt/ccache/libexec:$PATH";
         - aws --version
       script:
-        - ci/build-deploy.sh "~/qt/5.13.0/clang_64/lib/cmake/Qt5"; 
+        - ci/build-deploy.sh "/tmp/qt/lib/cmake/Qt5"; 
         - if [[ -n "$TRAVIS_TAG" ]]; then if [[ ! "${TRAVIS_TAG-0}" =~ ("RC"|"DB") ]]; then ci/deploy-travis.sh; fi; fi;
+
     - stage: artifacts_beta
       name: "beta docker"
       if: tag =~RC|DB
@@ -171,16 +170,14 @@ jobs:
         - brew cask install xquartz;
         - brew upgrade cmake;
         - brew install rocksdb;
-        - git clone https://github.com/benlau/qtci.git; 
-        - source qtci/path.env; 
-        - install-qt-online qt.qt5.5130.clang_64 ~/
+        - util/build_prep/build_qt.sh
       install:
         - pip install --user awscli
         - brew install ccache;
         - export PATH="$HOME/Library/Python/2.7/bin:/usr/local/opt/ccache/libexec:$PATH";
         - aws --version
       script:
-        - ci/build-deploy.sh "~/qt/5.13.0/clang_64/lib/cmake/Qt5"; 
+        - ci/build-deploy.sh "/tmp/qt/lib/cmake/Qt5"; 
         - ci/deploy-travis.sh;
 cache:
   - ccache: true
@@ -188,12 +185,14 @@ cache:
     - $HOME/.local
     - $HOME/Library/Caches/Homebrew
     - $TRAVIS_BUILD_DIR/load-tester/target
+    - /tmp/qt/
 script:
   - if [ -n "$ONE_TIME_TESTS" ]; then ci/check-commit-format.sh; fi
   - if [ -n "$ONE_TIME_TESTS" ]; then doxygen doxygen.config; fi # TODO also deploy the built HTML
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then RELEASE=${RELEASE} ci/build-travis.sh "/usr/local/opt/qt5/lib/cmake/Qt5"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then RELEASE=${RELEASE} ci/build-travis.sh "/tmp/qt/lib/cmake/Qt5"; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run -v $TRAVIS_BUILD_DIR:/workspace -v $HOME/.ccache:/ccache nanocurrency/nano-env:$TRAVIS_COMPILER /bin/bash -c "apt install ccache; cd /workspace && RELEASE=${RELEASE} ASAN=${ASAN} TSAN=${TSAN} CCACHE_DIR=/ccache ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"; fi
 env:
   global:
     - secure: "k8kmpD+xRS57ukdvlvaXT0WN4H0rr/aHSjV+l5IUUFpKx5N+DEsb+7ElIepKzqQrGG6qE71cFwDyn6rDwW/Objb9aiEITnvJBzk1XrOVgbc5AnlqDm8LKvqToD/VnQiojyXhBQe2wa//nEZ3PC9dv7hE5zb/K/U5z+LaE9T1cPPk1jHQMCUAFT7QGCK0YeX/gAZqPbLZdHHQChEi+Gu/XY0gc5Bl8Idbp8W7Aky9Ps06lKXPORkE1G2xQfJFrNPB3CKjxev/eoXGBJmNYzxkJlUHmyenjwgdDh9TWiOK2uKH1K6olLIx/qFuIgFRVJFv0QFzCjqqjOJJF1EN9i1M21Lm4wi1iJxYShAP86ZKkC/WmtRn1xNTEMHZJeZ3TXX+B3ybLEWTamHS1Ia8HOif18nrQE3O0aRC/NNfH1kewX+94UNxmSfHtL5Waa41shxeG5waemyQg+HR5zCEtrb5l1btgbfGrR8BMbHYLLe4ywJqMx3n8Iy6ZzC6Xx8+X1zTZZ3zDYPBHUalA+ZoYu2rrFG2+SARP0W/VKqCIKaB+lQKYpbv7ojXGrrDJe7MA/raTLL2pTfSkcx0qxJvcsbPLGI1MdG3mD7M8HncrZbw+sKI1LZ04gyWt3til6d3vSlbIkd6kCxxZh69nd1/KJy8rYrMYjqxxNSTctkGyVb2DtY=" 
     - RELEASE=0
+    - AWS_BUCKET=repo.nano.org

--- a/util/build_prep/macosx/build_qt.sh
+++ b/util/build_prep/macosx/build_qt.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [[ ! -d "/tmp/qt/lib/cmake" ]]; then
+	pushd /tmp
+	wget -O qtbase-latest.tgz https://s3.us-east-2.amazonaws.com/$AWS_BUCKET/artifacts/qtbase-latest.tgz
+	tar -zxf qtbase-latest.tgz
+	mv tmp/* .
+	rm -fr tmp
+	popd
+fi


### PR DESCRIPTION
Seed cache with qt built on travis at https://github.com/nanocurrency/travis-cache
AWS_BUCKET will be needed by PR's to complete tests and so is needed in the config
AWS_BUCKET does not need to be secure as it is already provided by the artifact downloads
convert tests to use prebuilt
format travis.yml for readability