### PR TITLE
Suppress RocksDB TSAN warnings with Clang

### DIFF
--- a/tsan_suppressions
+++ b/tsan_suppressions
@@ -1,1 +1,2 @@
 race:mdb.c
+race:rocksdb


### PR DESCRIPTION
While running TSAN on the tests with `TEST_USE_ROCKSDB=1` (and node built with -`DNANO_ROCKSDB=ON`), on Ubuntu 18.04 with Clang I get the following TSAN output:
https://gist.github.com/wezrule/a64b810c9203ae2a231f14b190529155

This is very similar to ones reported here:
https://github.com/facebook/rocksdb/issues/642

It didn't seem to have a resolution, so I'm just going to suppress them for now. I tried forever to suppress just these singular files/functions in the `tsan_clang_blacklist` file, but it just wouldn't work. In the end I am just using the runtime suppressions file which was originally only required for GCC, will update the docs accordingly.

A gcc build I did on another machine didn't have these tsan errors, but it does use a different version of RocksDB which may be a factor, however it uses this file anyway so would get caught too.