### PR TITLE
Fix link ordering issues

### DIFF
--- a/nano/nano_rpc/CMakeLists.txt
+++ b/nano/nano_rpc/CMakeLists.txt
@@ -5,8 +5,8 @@ target_link_libraries (nano_rpc
 	rpc
 	secure
 	Boost::filesystem
-	Boost::log
 	Boost::log_setup
+	Boost::log
 	Boost::program_options
 	Boost::system
 	Boost::thread

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -128,8 +128,8 @@ target_link_libraries (node
 	argon2
 	lmdb
 	Boost::filesystem
-	Boost::log
 	Boost::log_setup
+	Boost::log
 	Boost::program_options
 	Boost::system
 	Boost::thread


### PR DESCRIPTION
Building on ubuntu/boost 1.71 failed for nano_rpc, @wezrule suggested a link ordering fix, similar to #933