### PR TITLE
TSAN error in node.peers test

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -52,10 +52,7 @@ disconnect_observer ([]() {})
 
 nano::network::~network ()
 {
-	for (auto & thread : packet_processing_threads)
-	{
-		thread.join ();
-	}
+	stop ();
 }
 
 void nano::network::start ()
@@ -75,10 +72,17 @@ void nano::network::start ()
 
 void nano::network::stop ()
 {
-	udp_channels.stop ();
-	tcp_channels.stop ();
-	resolver.cancel ();
-	buffer_container.stop ();
+	if (!stopped.exchange (true))
+	{
+		udp_channels.stop ();
+		tcp_channels.stop ();
+		resolver.cancel ();
+		buffer_container.stop ();
+		for (auto & thread : packet_processing_threads)
+		{
+			thread.join ();
+		}
+	}
 }
 
 void nano::network::send_keepalive (std::shared_ptr<nano::transport::channel> channel_a)

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -161,6 +161,7 @@ public:
 	std::function<void()> disconnect_observer;
 	// Called when a new channel is observed
 	std::function<void(std::shared_ptr<nano::transport::channel>)> channel_observer;
+	std::atomic<bool> stopped{ false };
 	static unsigned const broadcast_interval_ms = 10;
 	static size_t const buffer_size = 512;
 	static size_t const confirm_req_hashes_max = 7;


### PR DESCRIPTION
I get this TSAN `thread_leak` error at the end of `node.peers` test on Ubuntu & MacOS with Clang:
https://gist.github.com/wezrule/4635dbf9e588bcdd90c27abdc8ec70de

The `~network` destructor is not getting called, something is holding onto the node reference preventing its destructor being called and hence the packet threads are not being joined. We quite often have a pattern of `join`ing threads in the `stop` function and then calling `stop ()` in the destructor protected by a `stopped` atomic variable. This is what I have done here, this is probably just masking a deeper timing issue somewhere else completely unrelated, but to solve that is probably quite a lot of work. This reduces the symptoms at least and is only in shutting down code, so not a high priority