### PR TITLE
ASAN error in vote_by_hash test

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2486,12 +2486,13 @@ TEST (node, vote_republish)
 
 TEST (node, vote_by_hash_bundle)
 {
+	// Keep max_hashes above system to ensure it is kept in scope as votes can be added during system destruction
+	std::atomic<size_t> max_hashes{ 0 };
 	nano::system system (24000, 1);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (key1.prv);
 
-	std::atomic<size_t> max_hashes{ 0 };
 	system.nodes[0]->observers.vote.add ([&max_hashes](std::shared_ptr<nano::vote> vote_a, std::shared_ptr<nano::transport::channel> channel_a) {
 		if (vote_a->blocks.size () > max_hashes)
 		{


### PR DESCRIPTION
The following ASAN error appears on both Mac/Ubuntu with clang:
https://gist.github.com/wezrule/2ecb809cacc393835b65e22f27b485cd

It is due to `max_hashes` being used vote observer callback after it has been destructed. This gets called inside of the `system::~system` when stopping the node. The simplest solution is to just put it above system so that it remains in scope.