### PR TITLE
ASAN leak when exiting node

### DIFF
--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -281,7 +281,10 @@ void nano::worker::push_task (std::function<void()> func_a)
 {
 	{
 		nano::lock_guard<std::mutex> guard (mutex);
-		queue.emplace_back (func_a);
+		if (!stopped)
+		{
+			queue.emplace_back (func_a);
+		}
 	}
 
 	cv.notify_one ();
@@ -292,6 +295,7 @@ void nano::worker::stop ()
 	{
 		nano::unique_lock<std::mutex> lk (mutex);
 		stopped = true;
+		queue.clear ();
 	}
 	cv.notify_one ();
 	if (thread.joinable ())


### PR DESCRIPTION
The following ASAN output was generated with the node.peers test, but it's not specific to this test, just seems to be easily reproducible there. Found on Ubuntu 18.04 with Clang, couldn't reproduce on MacOS:
https://gist.github.com/wezrule/17cb9b81ceeaf1a5ccfcec900f666b82

Was a bit of a bugger to locate as anything could have been causing it, but I knew the node destructor was not being called so something must have been holding a `shared_ptr` reference to it, but wasn't sure what. I ended up rolling back commits to find the culprit, which ended up being https://github.com/nanocurrency/nano-node/pull/1264. In particular (for this example at least) it was this callback:
```
node_l->worker.push_task ([node_l]() {
    node_l->ongoing_peer_store ();
});
``` 
The `worker::stop` function is called but it doesn't remove the callbacks that have been added. So it maintains this node reference. And because `class node` has a reference to the worker, they end up keeping each other alive when the test is finished. Passing in a `weak_ptr` of the node solves this issue and is what we do in a lot of places in our code but not all. To have a "catch all" I'm removing all the callbacks when the worker is stopped and preventing other ones being added which can happen in other threads.