### PR TITLE
Docker USER support

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -14,13 +14,21 @@ RUN mkdir /tmp/build && \
     echo ${NETWORK} > /etc/nano-network
 
 FROM ubuntu:16.04
+
+RUN groupadd --gid 1000 nanocurrency && \
+    useradd --uid 1000 --gid nanocurrency --shell /bin/bash --create-home nanocurrency
+
 COPY --from=0 /tmp/build/nano_node /usr/bin
 COPY --from=0 /tmp/build/nano_rpc /usr/bin
 COPY --from=0 /etc/nano-network /etc
-COPY docker/node/entry.sh /entry.sh
+COPY docker/node/entry.sh /usr/bin/entry.sh
 COPY docker/node/config /usr/share/nano/config
-RUN chmod +x /entry.sh
+RUN chmod +x /usr/bin/entry.sh
 RUN ln -s /usr/bin/nano_node /usr/bin/rai_node
+
+WORKDIR /root
+USER root
+
 ENV PATH="${PATH}:/usr/bin"
-ENTRYPOINT ["/bin/bash",  "/entry.sh"]
+ENTRYPOINT ["/bin/bash",  "/usr/bin/entry.sh"]
 CMD ["nano_node daemon -l"]


### PR DESCRIPTION
Currently our docker image runs as root
This will provide people with the opportunity to migrate over to the new nanocurrency(1000:1000) user setup without forcing the hand quite yet.

If you want to start the migration early `sudo chown -R 1000:1000 /local/mount/path` and then add the following switch to your docker run command [--user=nanocurrency](https://docs.docker.com/engine/reference/run/#user) and [-w=/home/nanocurrency](https://docs.docker.com/engine/reference/run/#workdir) and adjust your mount to `-v <local/mount/path>:/home/nanocurrency`

To preserve existing installations root(0:0) and /root are used if no user & workdir are specified