### PR TITLE
Use std::condition_variable_any with timed locking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set (NANO_SECURE_RPC OFF CACHE BOOL "")
 set (NANO_ROCKSDB OFF CACHE BOOL "")
 set (NANO_POW_SERVER OFF CACHE BOOL "")
 set (NANO_WARN_TO_ERR OFF CACHE BOOL "")
-set (NANO_TIMED_LOCKS 0 CACHE INTEGER "")
+set (NANO_TIMED_LOCKS 0 CACHE STRING "")
 
 option (NANO_STACKTRACE_BACKTRACE "Use BOOST_STACKTRACE_USE_BACKTRACE in stacktraces, for POSIX" OFF)
 if (NANO_STACKTRACE_BACKTRACE)
@@ -192,11 +192,7 @@ set(Boost_USE_MULTITHREADED      ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-if (${NANO_TIMED_LOCKS} GREATER 0)
-	set (timed_locks_boost_libs context fiber)
-endif ()
-
-find_package (Boost 1.67.0 REQUIRED COMPONENTS filesystem log log_setup thread program_options system ${timed_locks_boost_libs})
+find_package (Boost 1.67.0 REQUIRED COMPONENTS filesystem log log_setup thread program_options system)
 
 if (NANO_ROCKSDB)
 	find_package (RocksDB REQUIRED)

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -10,10 +10,6 @@ else ()
 	error ("Unknown platform: ${CMAKE_SYSTEM_NAME}")
 endif ()
 
-if (${NANO_TIMED_LOCKS} GREATER 0)
-	set (timed_locks_boost_libs Boost::context Boost::fiber)
-endif ()
-
 add_library (nano_lib
 	${platform_sources}
 	alarm.hpp
@@ -68,7 +64,6 @@ target_link_libraries (nano_lib
 	blake2
 	${CRYPTOPP_LIBRARY}
 	${CMAKE_DL_LIBS}
-	${timed_locks_boost_libs}
 	Boost::boost)
 
 if (NANO_STACKTRACE_BACKTRACE)

--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -179,20 +179,5 @@ void unique_lock<Mutex, U>::validate () const
 
 // Explicit instantiations for allowed types
 template class unique_lock<std::mutex>;
-
-void condition_variable::notify_one () noexcept
-{
-	cnd.notify_one ();
-}
-
-void condition_variable::notify_all () noexcept
-{
-	cnd.notify_all ();
-}
-
-void condition_variable::wait (nano::unique_lock<std::mutex> & lk)
-{
-	cnd.wait (lk);
-}
 }
 #endif

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
 #include <nano/lib/timer.hpp>
-#if NANO_TIMED_LOCKS > 0
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <boost/fiber/condition_variable.hpp>
-#endif
+
 #include <condition_variable>
 #include <mutex>
 #include <unordered_map>
@@ -74,59 +69,14 @@ private:
 	void lock_impl ();
 };
 
-class condition_variable final
-{
-private:
-	boost::fibers::condition_variable_any cnd;
-
-public:
-	condition_variable () = default;
-	condition_variable (condition_variable const &) = delete;
-	condition_variable & operator= (condition_variable const &) = delete;
-
-	void notify_one () noexcept;
-	void notify_all () noexcept;
-	void wait (nano::unique_lock<std::mutex> & lt);
-
-	template <typename Pred>
-	void wait (nano::unique_lock<std::mutex> & lt, Pred pred)
-	{
-		cnd.wait (lt, pred);
-	}
-
-	template <typename Clock, typename Duration>
-	void wait_until (nano::unique_lock<std::mutex> & lk, std::chrono::time_point<Clock, Duration> const & timeout_time)
-	{
-		cnd.wait_until (lk, timeout_time);
-	}
-
-	template <typename Clock, typename Duration, typename Pred>
-	bool wait_until (nano::unique_lock<std::mutex> & lk, std::chrono::time_point<Clock, Duration> const & timeout_time, Pred pred)
-	{
-		return cnd.wait_until (lk, timeout_time, pred);
-	}
-
-	template <typename Rep, typename Period>
-	void wait_for (nano::unique_lock<std::mutex> & lk,
-	std::chrono::duration<Rep, Period> const & timeout_duration)
-	{
-		cnd.wait_for (lk, timeout_duration);
-	}
-
-	template <typename Rep, typename Period, typename Pred>
-	bool wait_for (nano::unique_lock<std::mutex> & lk, std::chrono::duration<Rep, Period> const & timeout_duration, Pred pred)
-	{
-		return cnd.wait_for (lk, timeout_duration, pred);
-	}
-};
-
 #else
 template <typename Mutex>
 using lock_guard = std::lock_guard<Mutex>;
 
 template <typename Mutex>
 using unique_lock = std::unique_lock<Mutex>;
-
-using condition_variable = std::condition_variable;
 #endif
+
+// For consistency wrapping the less well known _any variant which can be used with any lockable type
+using condition_variable = std::condition_variable_any;
 }

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -26,7 +26,7 @@ while getopts 'hmcCkpvB:' OPT; do
 			exit 0
 			;;
 		m)
-			bootstrapArgs+=('--with-libraries=system,thread,log,filesystem,program_options,context,fiber')
+			bootstrapArgs+=('--with-libraries=system,thread,log,filesystem,program_options')
 			;;
 		c)
 			useClang='true'


### PR DESCRIPTION
 When https://github.com/nanocurrency/nano-node/pull/2267 was made we exclusively used `std::condition_variable`, this only accepts `std::unique_lock` which made it incompatible with our new `nano::unique_lock`. Unaware of alternatives a new `condition_variable` class was made which unfortunately depended on the boost `context`/`fiber` libraries.

However I recently discovered that there is a `std::condition_variable_any` class which is less constrained and accepts any [BasicLockable](https://en.cppreference.com/w/cpp/named_req/BasicLockable) type, which is compatible with our classes, so I am now using this which has removed the boost dependencies and some other code.

Also removed a CMake warning:
```
CMake Warning (dev) at CMakeLists.txt:35 (set):
implicitly converting 'NUMBER' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```