### PR TITLE
Improve distributed_work stopping with ongoing worker tasks

### DIFF
--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -167,7 +167,7 @@ void nano::work_pool::cancel (nano::root const & root_a)
 			}
 		}
 		pending.remove_if ([&root_a](decltype (pending)::value_type const & item_a) {
-			bool result;
+			bool result{ false };
 			if (item_a.item == root_a)
 			{
 				if (item_a.callback)
@@ -175,10 +175,6 @@ void nano::work_pool::cancel (nano::root const & root_a)
 					item_a.callback (boost::none);
 				}
 				result = true;
-			}
-			else
-			{
-				result = false;
 			}
 			return result;
 		});

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -456,9 +456,8 @@ void nano::distributed_work_factory::cleanup_finished ()
 
 void nano::distributed_work_factory::stop ()
 {
-	if (!stopped)
+	if (!stopped.exchange (true))
 	{
-		stopped = true;
 		// Cancel any ongoing work
 		std::unordered_set<nano::root> roots_l;
 		nano::unique_lock<std::mutex> lock_l (mutex);

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -457,7 +457,7 @@ void nano::distributed_work_factory::stop ()
 	std::unordered_set<nano::root> roots_l;
 	{
 		nano::lock_guard<std::mutex> guard_l (mutex);
-		for (auto & item_l : items)
+		for (auto const & item_l : items)
 		{
 			roots_l.insert (item_l.first);
 		}

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -87,6 +87,7 @@ public:
 	nano::node & node;
 	std::unordered_map<nano::root, std::vector<std::weak_ptr<nano::distributed_work>>> items;
 	std::mutex mutex;
+	bool stopped{ false };
 };
 
 class seq_con_info_component;

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -77,10 +77,12 @@ class distributed_work_factory final
 {
 public:
 	distributed_work_factory (nano::node &);
+	~distributed_work_factory ();
 	void make (nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	void make (unsigned int, nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	void cancel (nano::root const &, bool const local_stop = false);
 	void cleanup_finished ();
+	void stop ();
 
 	nano::node & node;
 	std::unordered_map<nano::root, std::vector<std::weak_ptr<nano::distributed_work>>> items;

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -78,8 +78,8 @@ class distributed_work_factory final
 public:
 	distributed_work_factory (nano::node &);
 	~distributed_work_factory ();
-	void make (nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
-	void make (unsigned int, nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	bool make (nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	bool make (unsigned int, nano::root const &, std::vector<std::pair<std::string, uint16_t>> const &, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	void cancel (nano::root const &, bool const local_stop = false);
 	void cleanup_finished ();
 	void stop ();

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -87,7 +87,7 @@ public:
 	nano::node & node;
 	std::unordered_map<nano::root, std::vector<std::weak_ptr<nano::distributed_work>>> items;
 	std::mutex mutex;
-	bool stopped{ false };
+	std::atomic<bool> stopped{ false };
 };
 
 class seq_con_info_component;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1010,11 +1010,11 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const &
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a)
 {
-	std::promise<uint64_t> promise;
-	std::future<uint64_t> future = promise.get_future ();
+	std::promise<boost::optional<uint64_t>> promise;
+	auto future (promise.get_future ());
 	// clang-format off
-	work_generate (root_a, [&promise](boost::optional<uint64_t> work_a) {
-		promise.set_value (work_a.value_or (0));
+	work_generate (root_a, [&promise](boost::optional<uint64_t> opt_work_a) {
+		promise.set_value (opt_work_a);
 	},
 	difficulty_a, account_a);
 	// clang-format on

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1000,7 +1000,10 @@ void nano::node::work_generate (nano::root const & root_a, std::function<void(bo
 void nano::node::work_generate (nano::root const & root_a, std::function<void(boost::optional<uint64_t>)> callback_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a, bool secondary_work_peers_a)
 {
 	auto const & peers_l (secondary_work_peers_a ? config.secondary_work_peers : config.work_peers);
-	distributed_work.make (root_a, peers_l, callback_a, difficulty_a, account_a);
+	if (distributed_work.make (root_a, peers_l, callback_a, difficulty_a, account_a))
+	{
+		callback_a (boost::none);
+	}
 }
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a, boost::optional<nano::account> const & account_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -692,6 +692,7 @@ void nano::node::stop ()
 	{
 		logger.always_log ("Node stopping");
 		write_database_queue.stop ();
+		distributed_work.stop ();
 		block_processor.stop ();
 		if (block_processor_thread.joinable ())
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1011,14 +1011,13 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const &
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a, uint64_t difficulty_a, boost::optional<nano::account> const & account_a)
 {
 	std::promise<boost::optional<uint64_t>> promise;
-	auto future (promise.get_future ());
 	// clang-format off
 	work_generate (root_a, [&promise](boost::optional<uint64_t> opt_work_a) {
 		promise.set_value (opt_work_a);
 	},
 	difficulty_a, account_a);
 	// clang-format on
-	return future.get ();
+	return promise.get_future ().get ();
 }
 
 void nano::node::add_initial_peers ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1002,6 +1002,7 @@ void nano::node::work_generate (nano::root const & root_a, std::function<void(bo
 	auto const & peers_l (secondary_work_peers_a ? config.secondary_work_peers : config.work_peers);
 	if (distributed_work.make (root_a, peers_l, callback_a, difficulty_a, account_a))
 	{
+		// Error in creating the job (either stopped or work generation is not possible)
 		callback_a (boost::none);
 	}
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -692,7 +692,6 @@ void nano::node::stop ()
 	{
 		logger.always_log ("Node stopping");
 		write_database_queue.stop ();
-		distributed_work.stop ();
 		block_processor.stop ();
 		if (block_processor_thread.joinable ())
 		{
@@ -713,6 +712,7 @@ void nano::node::stop ()
 		wallets.stop ();
 		stats.stop ();
 		worker.stop ();
+		distributed_work.stop ();
 		// work pool is not stopped on purpose due to testing setup
 	}
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1376,7 +1376,7 @@ void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::r
 				work_update (transaction_l, account_a, root_a, *opt_work_l);
 			}
 		}
-		else
+		else if (!wallets.node.stopped)
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Could not precache work for root %1 due to work generation failure") % root_a.to_string ()));
 		}


### PR DESCRIPTION
Found while running RPC `epoch_upgrade` which places the task in `nano::worker`. When preemptively stopping the node (with SIGINT, not RPC "stop") the I/O threads are destroyed and the background `work_generate_blocking` task can't complete if using work peers.

This adds manual canceling of all ongoing work before attempting to destroy the `worker`.

Also fixes an issue where canceled work would turn into zero-filled work, which was only a problem when stopping the node.