### PR TITLE
Vacuum after upgrade

### DIFF
--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -79,7 +79,7 @@ txn_tracking_enabled (txn_tracking_config_a.enable)
 			if (needs_vacuuming)
 			{
 				auto vacuum_success = vacuum_after_upgrade (path_a, lmdb_max_dbs);
-				logger.always_log (vacuum_success ? "Vacuum succeeded." : "Failed to vacuum.");
+				logger.always_log (vacuum_success ? "Vacuum succeeded." : "Failed to vacuum. (Optional) Ensure enough disk space is available for a copy of the database and try to vacuum after shutting down the node");
 			}
 		}
 		else

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -219,7 +219,7 @@ public:
 	nano::uint128_t block_balance_computed_v14 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 
 private:
-	bool do_upgrades (nano::write_transaction &, size_t);
+	bool do_upgrades (nano::write_transaction &, bool &, size_t);
 	void upgrade_v1_to_v2 (nano::write_transaction const &);
 	void upgrade_v2_to_v3 (nano::write_transaction const &);
 	void upgrade_v3_to_v4 (nano::write_transaction const &);
@@ -232,7 +232,7 @@ private:
 	void upgrade_v11_to_v12 (nano::write_transaction const &);
 	void upgrade_v12_to_v13 (nano::write_transaction &, size_t);
 	void upgrade_v13_to_v14 (nano::write_transaction const &);
-	void upgrade_v14_to_v15 (nano::write_transaction const &);
+	void upgrade_v14_to_v15 (nano::write_transaction &);
 	void open_databases (bool &, nano::transaction const &, unsigned);
 
 	int drop (nano::write_transaction const & transaction_a, tables table_a) override;
@@ -249,6 +249,8 @@ private:
 	bool txn_tracking_enabled;
 
 	size_t count (nano::transaction const & transaction_a, tables table_a) const override;
+
+	bool vacuum_after_upgrade (boost::filesystem::path const & path_a, int lmdb_max_dbs);
 
 	class upgrade_counters
 	{

--- a/nano/node/lmdb/lmdb_env.cpp
+++ b/nano/node/lmdb/lmdb_env.cpp
@@ -2,6 +2,11 @@
 
 nano::mdb_env::mdb_env (bool & error_a, boost::filesystem::path const & path_a, int max_dbs_a, bool use_no_mem_init_a, size_t map_size_a)
 {
+	init (error_a, path_a, max_dbs_a, use_no_mem_init_a, map_size_a);
+}
+
+void nano::mdb_env::init (bool & error_a, boost::filesystem::path const & path_a, int max_dbs_a, bool use_no_mem_init_a, size_t map_size_a)
+{
 	boost::system::error_code error_mkdir, error_chmod;
 	if (path_a.has_parent_path ())
 	{

--- a/nano/node/lmdb/lmdb_env.hpp
+++ b/nano/node/lmdb/lmdb_env.hpp
@@ -12,6 +12,7 @@ class mdb_env final
 {
 public:
 	mdb_env (bool &, boost::filesystem::path const &, int max_dbs = 128, bool use_no_mem_init = false, size_t map_size = 128ULL * 1024 * 1024 * 1024);
+	void init (bool &, boost::filesystem::path const &, int max_dbs, bool use_no_mem_init, size_t map_size = 128ULL * 1024 * 1024 * 1024);
 	~mdb_env ();
 	operator MDB_env * () const;
 	// clang-format off


### PR DESCRIPTION
During the v14 to v15 database upgrade, the ledger grows from 16GB to 24GB, vacuuming is now done after the upgrade. Vacuuming can take substantial time on lower end devices, for instance my 1vCPU, 2GB Ram droplet took 16 minutes for the upgrade itself (swap space was not used) and a further 20 minutes for the vacuum. On Windows, 3.4GHZ, 16GB RAM, the upgrade and vacuum took under 10 minutes in total, both tests were done with the RelWithDebInfo configuration. Additional log entries were added near the beginning upgrade steps. The following was logged for the 1vCPU droplet where it didn't have enough space for the vacuum (only difference is the last log entry which would say successful if it was):
```
[2019-Oct-29 11:43:41.891987]: Preparing v14 to v15 upgrade...
[2019-Oct-29 11:48:08.388623]: Finished extracting confirmation height to its own database
[2019-Oct-29 11:48:09.311279]: Epoch merge upgrade: Finished accounts, now doing state blocks
[2019-Oct-29 11:48:36.018710]: Database epoch merge upgrade 1 million state blocks upgraded
[2019-Oct-29 11:49:02.430585]: Database epoch merge upgrade 2 million state blocks upgraded
[2019-Oct-29 11:49:27.786613]: Database epoch merge upgrade 3 million state blocks upgraded
[2019-Oct-29 11:49:54.404330]: Database epoch merge upgrade 4 million state blocks upgraded
[2019-Oct-29 11:50:21.338800]: Database epoch merge upgrade 5 million state blocks upgraded
[2019-Oct-29 11:50:47.403554]: Database epoch merge upgrade 6 million state blocks upgraded
[2019-Oct-29 11:51:14.383416]: Database epoch merge upgrade 7 million state blocks upgraded
[2019-Oct-29 11:51:39.606213]: Database epoch merge upgrade 8 million state blocks upgraded
[2019-Oct-29 11:52:06.788994]: Database epoch merge upgrade 9 million state blocks upgraded
[2019-Oct-29 11:52:33.615898]: Database epoch merge upgrade 10 million state blocks upgraded
[2019-Oct-29 11:52:59.939875]: Database epoch merge upgrade 11 million state blocks upgraded
[2019-Oct-29 11:53:26.321183]: Database epoch merge upgrade 12 million state blocks upgraded
[2019-Oct-29 11:53:56.704467]: Database epoch merge upgrade 13 million state blocks upgraded
[2019-Oct-29 11:54:24.592489]: Database epoch merge upgrade 14 million state blocks upgraded
[2019-Oct-29 11:54:51.010085]: Database epoch merge upgrade 15 million state blocks upgraded
[2019-Oct-29 11:55:19.274183]: Database epoch merge upgrade 16 million state blocks upgraded
[2019-Oct-29 11:55:44.799214]: Database epoch merge upgrade 17 million state blocks upgraded
[2019-Oct-29 11:56:11.730480]: Database epoch merge upgrade 18 million state blocks upgraded
[2019-Oct-29 11:56:39.118995]: Database epoch merge upgrade 19 million state blocks upgraded
[2019-Oct-29 11:57:07.463607]: Database epoch merge upgrade 20 million state blocks upgraded
[2019-Oct-29 11:57:34.400243]: Database epoch merge upgrade 21 million state blocks upgraded
[2019-Oct-29 11:58:00.615955]: Database epoch merge upgrade 22 million state blocks upgraded
[2019-Oct-29 11:58:16.030137]: Epoch merge upgrade: Finished state blocks, now doing pending blocks
[2019-Oct-29 11:59:34.224127]: Finished epoch merge upgrade. Preparing vacuum...
[2019-Oct-29 12:02:09.408374]: Failed to vacuum. (Optional) Ensure enough disk space is available for a copy of the database and try to vacuum after shutting down the node
```