### PR TITLE
Adjust single-hash confirm requests

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -399,7 +399,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 			}
 			this->condition.notify_all ();
 		},
-		10); // 500ms / (10ms / 1 block) > 30 blocks
+		10); // 10ms/block * 30blocks = 300ms < 500ms
 	}
 	// Batch confirmation request
 	if (!batched_confirm_req_bundle_l.empty ())
@@ -412,7 +412,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 			}
 			this->condition.notify_all ();
 		},
-		20); // 500ms / (20ms / 5 batch size) > (20*7 = 140) batches
+		15); // 15ms/batch * 20batches = 300ms < 500ms
 	}
 	// Single confirmation requests
 	if (!single_confirm_req_bundle_l.empty ())
@@ -425,7 +425,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 			}
 			this->condition.notify_all ();
 		},
-		10); // 500ms / (10-20ms / 1 req) > 15 reqs
+		30); // 30~60ms/req * 5 reqs = 150~300ms < 500ms
 	}
 	lock_a.lock ();
 	// Erase inactive elections

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -135,7 +135,7 @@ public:
 	static size_t constexpr max_block_broadcasts = 30;
 	static size_t constexpr max_confirm_representatives = 30;
 	static size_t constexpr max_confirm_req_batches = 20;
-	static size_t constexpr max_confirm_req = 15;
+	static size_t constexpr max_confirm_req = 5;
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;
 	size_t priority_cementable_frontiers_size ();


### PR DESCRIPTION
From 15 to 5 every 500ms to focus more bandwidth on batched requests.

It also removes the burst of batched requests in order to spread them out more over the 500ms loop (was done in 80ms before, now 300ms). Comments about the timings are now clearer.