### PR TITLE
allow for updated TARGET usage by updating cmake in nano-env:base

### DIFF
--- a/docker/ci/Dockerfile-base
+++ b/docker/ci/Dockerfile-base
@@ -4,10 +4,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && apt-get install -yqq \
     build-essential \
-    cmake \
     g++ \
     wget \
     python
+
+RUN wget -O cmake_install.sh https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.sh && \
+	chmod +x cmake_install.sh && \
+	./cmake_install.sh --prefix=/usr --exclude-subdir --skip-license
 
 RUN apt-get update -qq && apt-get install -yqq \
     qt5-default \


### PR DESCRIPTION
run the following to test locally changes will not be built until committed to master
```
docker build -f docker/ci/Dockerfile-base -t nanocurrency/nano-env:base .
docker build -f docker/ci/Dockerfile-gcc -t nanocurrency/nano-env:gcc .
docker build --build-arg NETWORK=beta --build-arg CI_BUILD=TRUE --build-arg TRAVIS_TAG=cmake_new -f docker/node/Dockerfile -t nanocurrency/local .
```