### PR TITLE
[Valgrind] Uninitialized memory in distributed_work.no_peers test

### DIFF
--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -16,7 +16,7 @@ TEST (distributed_work, no_peers)
 {
 	nano::system system (24000, 1);
 	auto node (system.nodes[0]);
-	nano::block_hash hash;
+	nano::block_hash hash{ 1 };
 	boost::optional<uint64_t> work;
 	std::atomic<bool> done{ false };
 	auto callback = [&work, &done](boost::optional<uint64_t> work_a) {


### PR DESCRIPTION
Valgrind output for this test:
https://gist.github.com/wezrule/5fe31826a30ca8b7556208da09e42b18

It's a similar issue to:
https://github.com/nanocurrency/nano-node/pull/2355