### PR TITLE
Lazy bootstrap memory usage improvements

### DIFF
--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -1184,17 +1184,21 @@ void nano::bootstrap_attempt::lazy_backlog_cleanup ()
 
 void nano::bootstrap_attempt::lazy_destinations_increment (nano::account const & destination_a)
 {
-	// Update accounts counter for send blocks
-	auto existing (lazy_destinations.get<account_tag> ().find (destination_a));
-	if (existing != lazy_destinations.get<account_tag> ().end ())
+	// Enabled only if legacy bootstrap is not available. Legacy bootstrap is a more effective way to receive all existing destinations
+	if (node->flags.disable_legacy_bootstrap)
 	{
-		lazy_destinations.get<account_tag> ().modify (existing, [](nano::lazy_destinations_item & item_a) {
-			++item_a.count;
-		});
-	}
-	else
-	{
-		lazy_destinations.insert (nano::lazy_destinations_item{ destination_a, 1 });
+		// Update accounts counter for send blocks
+		auto existing (lazy_destinations.get<account_tag> ().find (destination_a));
+		if (existing != lazy_destinations.get<account_tag> ().end ())
+		{
+			lazy_destinations.get<account_tag> ().modify (existing, [](nano::lazy_destinations_item & item_a) {
+				++item_a.count;
+			});
+		}
+		else
+		{
+			lazy_destinations.insert (nano::lazy_destinations_item{ destination_a, 1 });
+		}
 	}
 }
 

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -89,6 +89,7 @@ public:
 	void lazy_add (nano::hash_or_account const &, unsigned = std::numeric_limits<unsigned>::max ());
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &, bool);
 	bool lazy_finished ();
+	bool lazy_has_expired () const;
 	void lazy_pull_flush ();
 	void lazy_clear ();
 	bool process_block_lazy (std::shared_ptr<nano::block>, nano::account const &, uint64_t, nano::bulk_pull::count_t, unsigned);
@@ -139,6 +140,7 @@ public:
 	std::unordered_map<nano::block_hash, nano::uint128_t> lazy_balances;
 	std::unordered_set<nano::block_hash> lazy_keys;
 	std::deque<std::pair<nano::hash_or_account, unsigned>> lazy_pulls;
+	std::chrono::steady_clock::time_point lazy_start_time;
 	std::chrono::steady_clock::time_point last_lazy_flush{ std::chrono::steady_clock::now () };
 	class account_tag
 	{
@@ -152,6 +154,7 @@ public:
 	boost::multi_index::ordered_non_unique<boost::multi_index::tag<count_tag>, boost::multi_index::member<lazy_destinations_item, uint64_t, &lazy_destinations_item::count>, std::greater<uint64_t>>,
 	boost::multi_index::hashed_unique<boost::multi_index::tag<account_tag>, boost::multi_index::member<lazy_destinations_item, nano::account, &lazy_destinations_item::account>>>>
 	lazy_destinations;
+	std::atomic<size_t> lazy_blocks_count{ 0 };
 	std::atomic<bool> lazy_destinations_flushed{ false };
 	std::mutex lazy_mutex;
 	// Wallet lazy bootstrap
@@ -284,5 +287,6 @@ public:
 	static constexpr unsigned lazy_destinations_request_limit = 256 * 1024;
 	static constexpr uint64_t lazy_batch_pull_count_resize_blocks_limit = 4 * 1024 * 1024;
 	static constexpr double lazy_batch_pull_count_resize_ratio = 2.0;
+	static constexpr size_t lazy_blocks_restart_limit = 1024 * 1024;
 };
 }

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -223,7 +223,8 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 			}
 			// Is block expected?
 			bool block_expected (false);
-			bool unconfirmed_account_head (pull_blocks == 0 && pull.retry_limit != std::numeric_limits<unsigned>::max () && expected == pull.account_or_head && block->account () == pull.account_or_head);
+			// Unconfirmed head is used only for lazy destinations if legacy bootstrap is not available, see nano::bootstrap_attempt::lazy_destinations_increment (...)
+			bool unconfirmed_account_head (connection->node->flags.disable_legacy_bootstrap && pull_blocks == 0 && pull.retry_limit != std::numeric_limits<unsigned>::max () && expected == pull.account_or_head && block->account () == pull.account_or_head);
 			if (hash == expected || unconfirmed_account_head)
 			{
 				expected = block->previous ();


### PR DESCRIPTION
* Limit bulk pulls memory usage in lazy bootstrap, flush less pulls from lazy_pulls to pulls
* Limit max lazy bootstrap blocks size if legacy bootstrap is enabled (1M lazy blocks limit)
* Prevent lazy destinations usage if legacy bootstrap is enabled

Better to check with hidden whitespace changes