### PR TITLE
Prevent concurrent bootstrap populate_connections ()

### DIFF
--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -231,7 +231,7 @@ void nano::bootstrap_attempt::run_start (nano::unique_lock<std::mutex> & lock_a)
 void nano::bootstrap_attempt::run ()
 {
 	assert (!node->flags.disable_legacy_bootstrap);
-	populate_connections ();
+	start_populate_connections ();
 	nano::unique_lock<std::mutex> lock (mutex);
 	run_start (lock);
 	while (still_pulling ())
@@ -448,6 +448,14 @@ void nano::bootstrap_attempt::populate_connections ()
 				this_l->populate_connections ();
 			}
 		});
+	}
+}
+
+void nano::bootstrap_attempt::start_populate_connections ()
+{
+	if (!populate_connections_started.exchange (true))
+	{
+		populate_connections ();
 	}
 }
 
@@ -879,7 +887,7 @@ void nano::bootstrap_attempt::lazy_clear ()
 void nano::bootstrap_attempt::lazy_run ()
 {
 	assert (!node->flags.disable_lazy_bootstrap);
-	populate_connections ();
+	start_populate_connections ();
 	auto start_time (std::chrono::steady_clock::now ());
 	auto max_time (std::chrono::minutes (node->flags.disable_legacy_bootstrap ? 7 * 24 * 60 : 30));
 	nano::unique_lock<std::mutex> lock (mutex);
@@ -1232,7 +1240,7 @@ bool nano::bootstrap_attempt::wallet_finished ()
 void nano::bootstrap_attempt::wallet_run ()
 {
 	assert (!node->flags.disable_wallet_bootstrap);
-	populate_connections ();
+	start_populate_connections ();
 	auto start_time (std::chrono::steady_clock::now ());
 	auto max_time (std::chrono::minutes (10));
 	nano::unique_lock<std::mutex> lock (mutex);

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -65,6 +65,7 @@ public:
 	std::shared_ptr<nano::bootstrap_client> connection (nano::unique_lock<std::mutex> &);
 	bool consume_future (std::future<bool> &);
 	void populate_connections ();
+	void start_populate_connections ();
 	bool request_frontier (nano::unique_lock<std::mutex> &);
 	void request_pull (nano::unique_lock<std::mutex> &);
 	void request_push (nano::unique_lock<std::mutex> &);
@@ -125,6 +126,7 @@ public:
 	std::vector<std::pair<nano::block_hash, nano::block_hash>> bulk_push_targets;
 	std::atomic<bool> frontiers_received{ false };
 	std::atomic<bool> frontiers_confirmed{ false };
+	std::atomic<bool> populate_connections_started{ false };
 	std::atomic<bool> stopped{ false };
 	std::chrono::steady_clock::time_point attempt_start{ std::chrono::steady_clock::now () };
 	nano::bootstrap_mode mode;


### PR DESCRIPTION
From run (), lazy_run () etc. if there are several runs in single bootstrap attempt