### PR TITLE
[Valgrind] Various uninitialized data accesses

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -733,7 +733,7 @@ TEST (websocket, work)
 	ASSERT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::work));
 
 	// Generate work
-	nano::block_hash hash;
+	nano::block_hash hash{ 1 };
 	auto work (node1->work_generate_blocking (hash));
 	ASSERT_TRUE (work.is_initialized ());
 

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -792,14 +792,12 @@ bool nano::frontier_req::operator== (nano::frontier_req const & other_a) const
 }
 
 nano::bulk_pull::bulk_pull () :
-message (nano::message_type::bulk_pull),
-count (0)
+message (nano::message_type::bulk_pull)
 {
 }
 
 nano::bulk_pull::bulk_pull (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a),
-count (0)
+message (header_a)
 {
 	if (!error_a)
 	{

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -355,9 +355,9 @@ public:
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
-	nano::hash_or_account start;
-	nano::block_hash end;
-	count_t count;
+	nano::hash_or_account start{ 0 };
+	nano::block_hash end{ 0 };
+	count_t count{ 0 };
 	bool is_count_present () const;
 	void set_count_present (bool);
 	static size_t constexpr count_present_flag = nano::message_header::bulk_pull_count_present_flag;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -111,7 +111,7 @@ public:
 	static size_t const seed_iv_index;
 	static int const special_count;
 	nano::kdf & kdf;
-	MDB_dbi handle;
+	MDB_dbi handle{ 0 };
 	std::recursive_mutex mutex;
 
 private:

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -977,6 +977,7 @@ TEST (rpc, wallet_create_seed)
 	nano::system system (24000, 1);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::raw_key seed;
+	seed.data = 1;
 	auto prv = nano::deterministic_key (seed, 0);
 	auto pub (nano::pub_key (prv));
 	auto node = system.nodes.front ();

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3576,9 +3576,11 @@ TEST (rpc, wallet_change_seed)
 {
 	nano::system system0 (24000, 1);
 	nano::raw_key seed;
+	seed.data = 1;
 	{
 		auto transaction (system0.nodes[0]->wallets.tx_begin_read ());
 		nano::raw_key seed0;
+		seed0.data = 2;
 		system0.wallet (0)->store.seed (seed0, transaction);
 		ASSERT_NE (seed, seed0);
 	}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -977,7 +977,7 @@ TEST (rpc, wallet_create_seed)
 	nano::system system (24000, 1);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::raw_key seed;
-	seed.data = 1;
+	nano::random_pool::generate_block (seed.data.bytes.data (), seed.data.bytes.size ());
 	auto prv = nano::deterministic_key (seed, 0);
 	auto pub (nano::pub_key (prv));
 	auto node = system.nodes.front ();
@@ -3576,11 +3576,11 @@ TEST (rpc, wallet_change_seed)
 {
 	nano::system system0 (24000, 1);
 	nano::raw_key seed;
-	seed.data = 1;
+	nano::random_pool::generate_block (seed.data.bytes.data (), seed.data.bytes.size ());
 	{
 		auto transaction (system0.nodes[0]->wallets.tx_begin_read ());
 		nano::raw_key seed0;
-		seed0.data = 2;
+		nano::random_pool::generate_block (seed0.data.bytes.data (), seed0.data.bytes.size ());
 		system0.wallet (0)->store.seed (seed0, transaction);
 		ASSERT_NE (seed, seed0);
 	}


### PR DESCRIPTION
1. In `bulk_pull` class https://gist.github.com/wezrule/387084bf4189f5dd85fb044abd917d1c
2. In `websocket.work` test https://gist.github.com/wezrule/174edc5e141143fb5656dbe7ad9a5522
3. In `rpc.wallet_create_seed` test https://gist.github.com/wezrule/05b1a84d0582b40cc3f7c16932f3367c (same in `rpc.wallet_change_seed`)
4. In `rpc.wallet_create_fail` https://gist.github.com/wezrule/014686344f0ff43470143d1fa25a7a55