### PR TITLE
[TSAN] Data race in active_difficulty.recalculate_work test

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3203,9 +3203,9 @@ TEST (active_difficulty, recalculate_work)
 	nano::work_validate (*send1, &difficulty2);
 	node1.process_active (send1);
 	node1.active.update_active_difficulty (lock);
-	lock.unlock ();
 	sum = std::accumulate (node1.active.multipliers_cb.begin (), node1.active.multipliers_cb.end (), double(0));
-	ASSERT_EQ (node1.active.active_difficulty (), nano::difficulty::from_multiplier (sum / node1.active.multipliers_cb.size (), node1.network_params.network.publish_threshold));
+	ASSERT_EQ (node1.active.trended_active_difficulty, nano::difficulty::from_multiplier (sum / node1.active.multipliers_cb.size (), node1.network_params.network.publish_threshold));
+	lock.unlock ();
 }
 
 namespace


### PR DESCRIPTION
This failure was tied to a data race on `active_transactions::multipliers_cb`.
```
[ RUN      ] active_difficulty.recalculate_work
/Users/travis/build/guilhermelawless/nano-node/nano/core_test/node.cpp:3208: Failure
Expected equality of these values:
  node1.active.active_difficulty ()
    Which is: 18414790985620493964
  nano::difficulty::from_multiplier (sum / node1.active.multipliers_cb.size (), node1.network_params.network.publish_threshold)
    Which is: 18415888479324436004
[  FAILED  ] active_difficulty.recalculate_work (182 ms)
```