### PR TITLE
Improve bootstrap frontiers confirmation

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -348,6 +348,7 @@ TEST (bootstrap_processor, frontiers_unconfirmed)
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.disable_wallet_bootstrap = true;
+	node_flags.disable_rep_crawler = true;
 	auto node1 = system.add_node (node_config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1, key2;
@@ -363,6 +364,7 @@ TEST (bootstrap_processor, frontiers_unconfirmed)
 
 	node_config.peering_port = 24001;
 	node_flags.disable_bootstrap_bulk_pull_server = false;
+	node_flags.disable_rep_crawler = false;
 	auto node2 = system.add_node (node_config, node_flags);
 	// Generating valid chain
 	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
@@ -407,6 +409,7 @@ TEST (bootstrap_processor, frontiers_confirmed)
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.disable_wallet_bootstrap = true;
+	node_flags.disable_rep_crawler = true;
 	auto node1 = system.add_node (node_config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1, key2;
@@ -424,6 +427,7 @@ TEST (bootstrap_processor, frontiers_confirmed)
 	// Test node to bootstrap
 	node_config.peering_port = 24001;
 	node_flags.disable_legacy_bootstrap = false;
+	node_flags.disable_rep_crawler = false;
 	auto node2 = system.add_node (node_config, node_flags);
 	system.deadline_set (5s);
 	while (node2->rep_crawler.representative_count () == 0)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -233,7 +233,8 @@ TEST (node, auto_bootstrap)
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	auto send1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, send1);
 	system.deadline_set (10s);
 	while (system.nodes[0]->balance (key2.pub) != system.nodes[0]->config.receive_minimum.number ())
 	{
@@ -260,8 +261,16 @@ TEST (node, auto_bootstrap)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	ASSERT_TRUE (node1->ledger.block_exists (send1->hash ()));
+	// Wait block receive
 	system.deadline_set (5s);
-	while (node1->stats.count (nano::stat::type::observer, nano::stat::detail::observer_confirmation_active_quorum, nano::stat::dir::out) + node1->stats.count (nano::stat::type::observer, nano::stat::detail::observer_confirmation_active_conf_height, nano::stat::dir::out) < 2)
+	while (node1->ledger.block_count_cache < 3)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	// Confirmation for all blocks
+	system.deadline_set (5s);
+	while (node1->ledger.cemented_count < 3)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -1312,15 +1312,12 @@ nano::bootstrap_initiator::~bootstrap_initiator ()
 void nano::bootstrap_initiator::bootstrap (bool force)
 {
 	nano::unique_lock<std::mutex> lock (mutex);
-	if (force)
+	if (force && attempt != nullptr)
 	{
-		if (attempt != nullptr)
-		{
-			attempt->stop ();
-			// clang-format off
-			condition.wait (lock, [&attempt = attempt, &stopped = stopped] { return stopped || attempt == nullptr; });
-			// clang-format on
-		}
+		attempt->stop ();
+		// clang-format off
+		condition.wait (lock, [&attempt = attempt, &stopped = stopped] { return stopped || attempt == nullptr; });
+		// clang-format on
 	}
 	if (!stopped && attempt == nullptr)
 	{
@@ -1365,15 +1362,12 @@ void nano::bootstrap_initiator::bootstrap_lazy (nano::hash_or_account const & ha
 {
 	{
 		nano::unique_lock<std::mutex> lock (mutex);
-		if (force)
+		if (force && attempt != nullptr)
 		{
-			if (attempt != nullptr)
-			{
-				attempt->stop ();
-				// clang-format off
-				condition.wait (lock, [&attempt = attempt, &stopped = stopped] { return stopped || attempt == nullptr; });
-				// clang-format on
-			}
+			attempt->stop ();
+			// clang-format off
+			condition.wait (lock, [&attempt = attempt, &stopped = stopped] { return stopped || attempt == nullptr; });
+			// clang-format on
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate_lazy, nano::stat::dir::out);
 		if (attempt == nullptr)

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -81,7 +81,7 @@ public:
 	bool should_log ();
 	void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	void attempt_restart_check (nano::unique_lock<std::mutex> &);
-	void confirm_frontiers (nano::unique_lock<std::mutex> &);
+	bool confirm_frontiers (nano::unique_lock<std::mutex> &);
 	bool process_block (std::shared_ptr<nano::block>, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	/** Lazy bootstrap */
 	void lazy_run ();

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -62,11 +62,11 @@ public:
 	explicit bootstrap_attempt (std::shared_ptr<nano::node> node_a, nano::bootstrap_mode mode_a = nano::bootstrap_mode::legacy);
 	~bootstrap_attempt ();
 	void run ();
-	std::shared_ptr<nano::bootstrap_client> connection (nano::unique_lock<std::mutex> &);
+	std::shared_ptr<nano::bootstrap_client> connection (nano::unique_lock<std::mutex> &, bool = false);
 	bool consume_future (std::future<bool> &);
 	void populate_connections ();
 	void start_populate_connections ();
-	bool request_frontier (nano::unique_lock<std::mutex> &);
+	bool request_frontier (nano::unique_lock<std::mutex> &, bool = false);
 	void request_pull (nano::unique_lock<std::mutex> &);
 	void request_push (nano::unique_lock<std::mutex> &);
 	void add_connection (nano::endpoint const &);
@@ -237,7 +237,7 @@ public:
 	explicit bootstrap_initiator (nano::node &);
 	~bootstrap_initiator ();
 	void bootstrap (nano::endpoint const &, bool add_to_peers = true, bool frontiers_confirmed = false);
-	void bootstrap ();
+	void bootstrap (bool force = false);
 	void bootstrap_lazy (nano::hash_or_account const &, bool force = false, bool confirmed = true);
 	void bootstrap_wallet (std::deque<nano::account> &);
 	void run_bootstrap ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1630,9 +1630,10 @@ void nano::json_handler::bootstrap ()
 
 void nano::json_handler::bootstrap_any ()
 {
+	const bool force = request.get<bool> ("force", false);
 	if (!node.flags.disable_legacy_bootstrap)
 	{
-		node.bootstrap_initiator.bootstrap ();
+		node.bootstrap_initiator.bootstrap (force);
 		response_l.put ("success", "");
 	}
 	else

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -659,7 +659,10 @@ void nano::node::start ()
 		});
 	}
 	ongoing_store_flush ();
-	rep_crawler.start ();
+	if (!flags.disable_rep_crawler)
+	{
+		rep_crawler.start ();
+	}
 	ongoing_rep_calculation ();
 	ongoing_peer_store ();
 	ongoing_online_weight_calculation_queue ();
@@ -1041,7 +1044,10 @@ void nano::node::add_initial_peers ()
 				if (auto node_l = node_w.lock ())
 				{
 					node_l->network.send_keepalive (channel_a);
-					node_l->rep_crawler.query (channel_a);
+					if (!node_l->flags.disable_rep_crawler)
+					{
+						node_l->rep_crawler.query (channel_a);
+					}
 				}
 			});
 		}

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -117,6 +117,7 @@ public:
 	bool disable_bootstrap_listener{ false };
 	bool disable_bootstrap_bulk_pull_server{ false };
 	bool disable_bootstrap_bulk_push_client{ false };
+	bool disable_rep_crawler{ false };
 	bool disable_tcp_realtime{ false };
 	bool disable_udp{ false };
 	bool disable_unchecked_cleanup{ false };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -4,9 +4,12 @@
 nano::rep_crawler::rep_crawler (nano::node & node_a) :
 node (node_a)
 {
-	node.observers.endpoint.add ([this](std::shared_ptr<nano::transport::channel> channel_a) {
-		this->query (channel_a);
-	});
+	if (!node.flags.disable_rep_crawler)
+	{
+		node.observers.endpoint.add ([this](std::shared_ptr<nano::transport::channel> channel_a) {
+			this->query (channel_a);
+		});
+	}
 }
 
 void nano::rep_crawler::add (nano::block_hash const & hash_a)


### PR DESCRIPTION
* start new bootstrap attempt after failed confirmation
* prevent duplicates in frontiers vector
* increase chances of starting first bootstrap connection to requested peer
* disable rep crawler for specific tests (it can start elections)
* return confirmation status in confirm_frontiers () function
* add `force` option to `bootstrap_any` RPC