### PR TITLE
Updates to TOML generated docs

### DIFF
--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -143,7 +143,7 @@ nano::error nano::rpc_config::serialize_toml (nano::tomlconfig & toml) const
 {
 	toml.put ("address", address.to_string (), "Bind address for the RPC server.\ntype:string,ip");
 	toml.put ("port", port, "Listening port for the RPC server.\ntype:uint16");
-	toml.put ("enable_control", enable_control, "Enable or disable control-level requests.\ntype:bool");
+	toml.put ("enable_control", enable_control, "Enable or disable control-level requests.\nWARNING: Enabling this gives anyone with RPC access the ability to stop the node and access wallet funds.\ntype:bool");
 	toml.put ("max_json_depth", max_json_depth, "Maximum number of levels in JSON requests.\ntype:uint8");
 	toml.put ("max_request_size", max_request_size, "Maximum number of bytes allowed in request bodies.\ntype:uint64");
 

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -541,9 +541,9 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 
 		if (valid_type)
 		{
-			std::cout << "# This is an example configuration file for nano_node. Visit https://docs.nano.org/running-a-node/configuration/ for more information.\n#\n"
-			          << "# Fields are defined in the context of the [category] above them.\n"
-			          << "# The desired configuration changes should be placed in a config-node.toml in the node data path.\n"
+			std::cout << "# This is an example configuration file for Nano. Visit https://docs.nano.org/running-a-node/configuration/ for more information.\n#\n"
+			          << "# Fields may need to be defined in the context of a [category] above them.\n"
+			          << "# The desired configuration changes should be placed in config-" << type << ".toml in the node data path.\n"
 			          << "# To change a value from its default, uncomment (erasing #) the corresponding field.\n"
 			          << "# It is not recommended to uncomment every field, as the default value for important fields may change in the future. Only change what you need.\n"
 			          << "# Additional information for notable configuration options is available in https://docs.nano.org/running-a-node/configuration/#notable-configuration-options\n";


### PR DESCRIPTION
- Adds a warning to the enable_control setting
- Generated header always referred to config-node.toml, even though the same header is used for the RPC config
- In the RPC config, most flags are top-level, so the category comment reflects this.