### PR TITLE
Improve block deletion and RocksDB deletion in general

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -74,7 +74,7 @@ TEST (block_store, add_item)
 	ASSERT_EQ (block, *latest2);
 	ASSERT_TRUE (store->block_exists (transaction, hash1));
 	ASSERT_FALSE (store->block_exists (transaction, hash1.number () - 1));
-	store->block_del (transaction, hash1);
+	store->block_del (transaction, hash1, block.type ());
 	auto latest3 (store->block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest3);
 }
@@ -1137,7 +1137,7 @@ TEST (block_store, state_block)
 		auto transaction (store->tx_begin_write ());
 		auto count (store->block_count (transaction));
 		ASSERT_EQ (1, count.state);
-		store->block_del (transaction, block1.hash ());
+		store->block_del (transaction, block1.hash (), block1.type ());
 		ASSERT_FALSE (store->block_exists (transaction, block1.hash ()));
 	}
 	auto transaction (store->tx_begin_read ());
@@ -1200,7 +1200,7 @@ TEST (mdb_block_store, upgrade_sideband_two_blocks)
 		nano::state_block block (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
 		hash2 = block.hash ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
-		store.block_del (transaction, hash2);
+		store.block_del (transaction, hash2, block.type ());
 		mdb_dbi_open (store.env.tx (transaction), "state_v1", MDB_CREATE, &store.state_blocks_v1);
 		mdb_dbi_open (store.env.tx (transaction), "state", MDB_CREATE, &store.state_blocks_v0);
 		write_sideband_v12 (store, transaction, *genesis.open, hash2, store.open_blocks);
@@ -1246,8 +1246,8 @@ TEST (mdb_block_store, upgrade_sideband_two_accounts)
 		nano::state_block block2 (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, hash2, key.prv, key.pub, *pool.generate (key.pub));
 		hash3 = block2.hash ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-		store.block_del (transaction, hash2);
-		store.block_del (transaction, hash3);
+		store.block_del (transaction, hash2, block1.type ());
+		store.block_del (transaction, hash3, block2.type ());
 		mdb_dbi_open (store.env.tx (transaction), "state_v1", MDB_CREATE, &store.state_blocks_v1);
 		mdb_dbi_open (store.env.tx (transaction), "state", MDB_CREATE, &store.state_blocks_v0);
 		write_sideband_v12 (store, transaction, *genesis.open, hash2, store.open_blocks);
@@ -1331,8 +1331,8 @@ TEST (mdb_block_store, upgrade_sideband_epoch)
 		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_v1", MDB_CREATE, &store.state_blocks_v1));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 		ASSERT_EQ (nano::epoch::epoch_1, store.block_version (transaction, hash2));
-		store.block_del (transaction, hash2);
-		store.block_del (transaction, genesis.open->hash ());
+		store.block_del (transaction, hash2, block1.type ());
+		store.block_del (transaction, genesis.open->hash (), genesis.open->type ());
 		write_sideband_v12 (store, transaction, *genesis.open, hash2, store.open_blocks);
 		write_sideband_v12 (store, transaction, block1, 0, store.state_blocks_v1);
 
@@ -1653,8 +1653,8 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		write_sideband_v14 (store, transaction, epoch, store.state_blocks_v1);
 
 		// Remove from state table
-		store.block_del (transaction, state_send.hash ());
-		store.block_del (transaction, epoch.hash ());
+		store.block_del (transaction, state_send.hash (), state_send.type ());
+		store.block_del (transaction, epoch.hash (), epoch.type ());
 
 		// Turn pending into v14
 		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v0, nano::mdb_val (nano::pending_key (nano::test_genesis_key.pub, send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_0)), 0));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -712,7 +712,7 @@ TEST (confirmation_height, modified_chain)
 		while (!node->write_database_queue.contains (nano::writer::confirmation_height))
 			;
 
-		store.block_del (store.tx_begin_write (), send->hash ());
+		store.block_del (store.tx_begin_write (), send->hash (), send->type ());
 	}
 
 	while (node->write_database_queue.contains (nano::writer::confirmation_height))

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -209,17 +209,13 @@ bool nano::rocksdb_store::exists (nano::transaction const & transaction_a, table
 int nano::rocksdb_store::del (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a)
 {
 	assert (transaction_a.contains (table_a));
-	if (!exists (transaction_a, table_a, key_a))
+	// RocksDB errors when trying to delete an entry which doesn't exist. It is a pre-condition that the key exists
+	assert (exists (transaction_a, table_a, key_a));
+
+	// Removing an entry so counts may need adjusting
+	if (is_caching_counts (table_a))
 	{
-		return status_code_not_found ();
-	}
-	else
-	{
-		// Adding a new entry so counts need adjusting (use RMW otherwise known as merge)
-		if (is_caching_counts (table_a))
-		{
-			decrement (transaction_a, tables::cached_counts, rocksdb_val (rocksdb::Slice (table_to_column_family (table_a)->GetName ())), 1);
-		}
+		decrement (transaction_a, tables::cached_counts, rocksdb_val (rocksdb::Slice (table_to_column_family (table_a)->GetName ())), 1);
 	}
 
 	return tx (transaction_a)->Delete (table_to_column_family (table_a), key_a).code ();
@@ -227,7 +223,7 @@ int nano::rocksdb_store::del (nano::write_transaction const & transaction_a, tab
 
 bool nano::rocksdb_store::block_info_get (nano::transaction const &, nano::block_hash const &, nano::block_info &) const
 {
-	// Should not be called
+	// Should not be called as the RocksDB backend does not use this table
 	assert (false);
 	return true;
 }

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -642,7 +642,7 @@ public:
 	virtual std::shared_ptr<nano::block> block_get (nano::transaction const &, nano::block_hash const &, nano::block_sideband * = nullptr) const = 0;
 	virtual std::shared_ptr<nano::block> block_get_v14 (nano::transaction const &, nano::block_hash const &, nano::block_sideband_v14 * = nullptr, bool * = nullptr) const = 0;
 	virtual std::shared_ptr<nano::block> block_random (nano::transaction const &) = 0;
-	virtual void block_del (nano::write_transaction const &, nano::block_hash const &) = 0;
+	virtual void block_del (nano::write_transaction const &, nano::block_hash const &, nano::block_type) = 0;
 	virtual bool block_exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual bool block_exists (nano::transaction const &, nano::block_type, nano::block_hash const &) = 0;
 	virtual nano::block_counts block_count (nano::transaction const &) = 0;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -39,7 +39,7 @@ public:
 			ledger.rep_weights.representation_add (info.representative, pending.amount.number ());
 			nano::account_info new_info (block_a.hashables.previous, info.representative, info.open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
 			ledger.change_latest (transaction, pending.source, info, new_info);
-			ledger.store.block_del (transaction, hash);
+			ledger.store.block_del (transaction, hash, block_a.type ());
 			ledger.store.frontier_del (transaction, hash);
 			ledger.store.frontier_put (transaction, block_a.hashables.previous, pending.source);
 			ledger.store.block_successor_clear (transaction, block_a.hashables.previous);
@@ -59,7 +59,7 @@ public:
 		ledger.rep_weights.representation_add (info.representative, 0 - amount);
 		nano::account_info new_info (block_a.hashables.previous, info.representative, info.open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
 		ledger.change_latest (transaction, destination_account, info, new_info);
-		ledger.store.block_del (transaction, hash);
+		ledger.store.block_del (transaction, hash, block_a.type ());
 		ledger.store.pending_put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account, amount, nano::epoch::epoch_0 });
 		ledger.store.frontier_del (transaction, hash);
 		ledger.store.frontier_put (transaction, block_a.hashables.previous, destination_account);
@@ -75,7 +75,7 @@ public:
 		ledger.rep_weights.representation_add (block_a.representative (), 0 - amount);
 		nano::account_info new_info;
 		ledger.change_latest (transaction, destination_account, new_info, new_info);
-		ledger.store.block_del (transaction, hash);
+		ledger.store.block_del (transaction, hash, block_a.type ());
 		ledger.store.pending_put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account, amount, nano::epoch::epoch_0 });
 		ledger.store.frontier_del (transaction, hash);
 		ledger.stats.inc (nano::stat::type::rollback, nano::stat::detail::open);
@@ -95,7 +95,7 @@ public:
 		auto representative = block->representative ();
 		ledger.rep_weights.representation_add (block_a.representative (), 0 - balance);
 		ledger.rep_weights.representation_add (representative, balance);
-		ledger.store.block_del (transaction, hash);
+		ledger.store.block_del (transaction, hash, block_a.type ());
 		nano::account_info new_info (block_a.hashables.previous, representative, info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
 		ledger.change_latest (transaction, account, info, new_info);
 		ledger.store.frontier_del (transaction, hash);
@@ -164,7 +164,7 @@ public:
 		{
 			ledger.stats.inc (nano::stat::type::rollback, nano::stat::detail::open);
 		}
-		ledger.store.block_del (transaction, hash);
+		ledger.store.block_del (transaction, hash, block_a.type ());
 	}
 	nano::write_transaction const & transaction;
 	nano::ledger & ledger;


### PR DESCRIPTION
`block_store_partial::block_del` currently checks all block databases to see if the key (hash) was found an successfully deleted. This involves 5 db accesses for change blocks for instance. This is unnecessary because in all cases `block_del` is called we know what block type and hence what database it will be found in. This wasn't quite the case before, as we had state v0/v1 databases but this is no longer the case, so the block can be deleted with 1 db access now. 

This subsequently also meant that RocksDB no longer needed to check if the key exists (a db read) when deleting because all places have already checked for this, although I still `assert` in a debug build that this is the case.