### PR TITLE
Warn if control is enabled with non-local bind address

### DIFF
--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -29,6 +29,12 @@ nano::rpc::~rpc ()
 void nano::rpc::start ()
 {
 	auto endpoint (boost::asio::ip::tcp::endpoint (config.address, config.port));
+	if (!endpoint.address ().is_loopback () && config.enable_control)
+	{
+		auto warning = boost::str (boost::format ("WARNING: control-level RPCs are enabled on non-local address %1%, potentially allowing wallet access outside local computer") % endpoint.address ().to_string ());
+		std::cout << warning << std::endl;
+		logger.always_log (warning);
+	}
 	acceptor.open (endpoint.protocol ());
 	acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
 


### PR DESCRIPTION
Emits a warning in the log, and to stdout, if control is enabled and a non-loopback (which also means non-default) RPC bind address is used. This applies to the external RPC process as well.