### PR TITLE
Node id handshake container not protected during push

### DIFF
--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -484,7 +484,13 @@ bool nano::transport::tcp_channels::node_id_handhake_sockets_empty () const
 	return node_id_handshake_sockets.empty ();
 }
 
-void nano::transport::tcp_channels::remove_node_id_handshake_socket (std::shared_ptr<nano::socket> socket_a)
+void nano::transport::tcp_channels::push_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a)
+{
+	std::lock_guard<std::mutex> guard (mutex);
+	node_id_handshake_sockets.push_back (socket_a);
+}
+
+void nano::transport::tcp_channels::remove_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a)
 {
 	std::weak_ptr<nano::node> node_w (node.shared ());
 	if (auto node_l = node_w.lock ())
@@ -521,7 +527,7 @@ void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint_a
 				}
 				std::shared_ptr<std::vector<uint8_t>> receive_buffer (std::make_shared<std::vector<uint8_t>> ());
 				receive_buffer->resize (256);
-				node_l->network.tcp_channels.node_id_handshake_sockets.push_back (socket);
+				node_l->network.tcp_channels.push_node_id_handshake_socket (socket);
 				channel->send_buffer (bytes, nano::stat::detail::node_id_handshake, [node_w, channel, endpoint_a, receive_buffer, callback_a](boost::system::error_code const & ec, size_t size_a) {
 					if (auto node_l = node_w.lock ())
 					{

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -486,7 +486,7 @@ bool nano::transport::tcp_channels::node_id_handhake_sockets_empty () const
 
 void nano::transport::tcp_channels::push_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a)
 {
-	std::lock_guard<std::mutex> guard (mutex);
+	nano::lock_guard<std::mutex> guard (mutex);
 	node_id_handshake_sockets.push_back (socket_a);
 }
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -104,7 +104,8 @@ namespace transport
 		void start_tcp (nano::endpoint const &, std::function<void(std::shared_ptr<nano::transport::channel>)> const & = nullptr);
 		void start_tcp_receive_node_id (std::shared_ptr<nano::transport::channel_tcp>, nano::endpoint const &, std::shared_ptr<std::vector<uint8_t>>, std::function<void(std::shared_ptr<nano::transport::channel>)> const &);
 		void udp_fallback (nano::endpoint const &, std::function<void(std::shared_ptr<nano::transport::channel>)> const &);
-		void remove_node_id_handshake_socket (std::shared_ptr<nano::socket> socket_a);
+		void push_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a);
+		void remove_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a);
 		bool node_id_handhake_sockets_empty () const;
 		nano::node & node;
 


### PR DESCRIPTION
Found by @SergiySW during bootstrap (segmentation fault). I am unable to reproduce it even with running `node.send_single_many_peers` 100 times with TSAN. The fix is (hopefully) to guard the `push_back` with a `mutex`.