### PR TITLE
Fix jumping peer stake total

### DIFF
--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -18,6 +18,26 @@ nano::protocol_constants const & get_protocol_constants ()
 	return params.protocol;
 }
 }
+
+uint64_t nano::ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint16_t port)
+{
+	static nano::random_constants constants;
+	assert (ip_a.is_v6 ());
+	uint64_t result;
+	nano::uint128_union address;
+	address.bytes = ip_a.to_v6 ().to_bytes ();
+	blake2b_state state;
+	blake2b_init (&state, sizeof (result));
+	blake2b_update (&state, constants.random_128.bytes.data (), constants.random_128.bytes.size ());
+	if (port != 0)
+	{
+		blake2b_update (&state, &port, sizeof (port));
+	}
+	blake2b_update (&state, address.bytes.data (), address.bytes.size ());
+	blake2b_final (&state, &result, sizeof (result));
+	return result;
+}
+
 nano::message_header::message_header (nano::message_type type_a) :
 version_max (get_protocol_constants ().protocol_version),
 version_using (get_protocol_constants ().protocol_version),

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -17,36 +17,19 @@ bool parse_address_port (std::string const &, boost::asio::ip::address &, uint16
 using tcp_endpoint = boost::asio::ip::tcp::endpoint;
 bool parse_endpoint (std::string const &, nano::endpoint &);
 bool parse_tcp_endpoint (std::string const &, nano::tcp_endpoint &);
+uint64_t ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint16_t port = 0);
 }
 
 namespace
 {
-uint64_t ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint16_t port = 0)
-{
-	static nano::random_constants constants;
-	assert (ip_a.is_v6 ());
-	uint64_t result;
-	nano::uint128_union address;
-	address.bytes = ip_a.to_v6 ().to_bytes ();
-	blake2b_state state;
-	blake2b_init (&state, sizeof (result));
-	blake2b_update (&state, constants.random_128.bytes.data (), constants.random_128.bytes.size ());
-	if (port != 0)
-	{
-		blake2b_update (&state, &port, sizeof (port));
-	}
-	blake2b_update (&state, address.bytes.data (), address.bytes.size ());
-	blake2b_final (&state, &result, sizeof (result));
-	return result;
-}
 uint64_t endpoint_hash_raw (nano::endpoint const & endpoint_a)
 {
-	uint64_t result (ip_address_hash_raw (endpoint_a.address (), endpoint_a.port ()));
+	uint64_t result (nano::ip_address_hash_raw (endpoint_a.address (), endpoint_a.port ()));
 	return result;
 }
 uint64_t endpoint_hash_raw (nano::tcp_endpoint const & endpoint_a)
 {
-	uint64_t result (ip_address_hash_raw (endpoint_a.address (), endpoint_a.port ()));
+	uint64_t result (nano::ip_address_hash_raw (endpoint_a.address (), endpoint_a.port ()));
 	return result;
 }
 
@@ -91,7 +74,7 @@ struct ip_address_hash<8>
 {
 	size_t operator() (boost::asio::ip::address const & ip_address_a) const
 	{
-		return ip_address_hash_raw (ip_address_a);
+		return nano::ip_address_hash_raw (ip_address_a);
 	}
 };
 template <>
@@ -99,7 +82,7 @@ struct ip_address_hash<4>
 {
 	size_t operator() (boost::asio::ip::address const & ip_address_a) const
 	{
-		uint64_t big (ip_address_hash_raw (ip_address_a));
+		uint64_t big (nano::ip_address_hash_raw (ip_address_a));
 		uint32_t result (static_cast<uint32_t> (big) ^ static_cast<uint32_t> (big >> 32));
 		return result;
 	}


### PR DESCRIPTION
The issue was tracked down to the hash of an endpoint inside a boost::multi_index_container being different depending on where it was called. Unfortunately it seemed that it was only easily reproducible on a release configuration on Windows which made debugging a bit harder. The culprit was the `ip_address_hash_raw` function which assumes that the same random constants variable is used each time. This is the case in the same translation unit, but because it is defined inside an unnamed namespace in a header, each translation unit which includes this (common.hpp) gets its own copy and hence each initialises its own static `random_constants`. Why it is a problem for some compilers/configurations and not others probably boils down to some compiler specific optimisations.