### PR TITLE
[MSAN] remove zero_key from ledger_constants

### DIFF
--- a/nano/core_test/testutil.hpp
+++ b/nano/core_test/testutil.hpp
@@ -38,7 +38,6 @@ namespace nano
 using uint128_t = boost::multiprecision::uint128_t;
 class keypair;
 class public_key;
-extern nano::keypair const & zero_key;
 extern nano::keypair const & test_genesis_key;
 extern std::string const & nano_test_genesis;
 extern std::string const & genesis_block;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -80,7 +80,6 @@ ledger_constants (network_constants.network ())
 }
 
 nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
-zero_key ("0"),
 test_genesis_key (test_private_key_data),
 nano_test_account (test_public_key_data),
 nano_beta_account (beta_public_key_data),
@@ -154,7 +153,6 @@ namespace
 nano::ledger_constants test_constants (nano::nano_networks::nano_test_network);
 }
 
-nano::keypair const & nano::zero_key (test_constants.zero_key);
 nano::keypair const & nano::test_genesis_key (test_constants.test_genesis_key);
 nano::account const & nano::nano_test_account (test_constants.nano_test_account);
 std::string const & nano::nano_test_genesis (test_constants.nano_test_genesis);

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -354,7 +354,6 @@ class ledger_constants
 public:
 	ledger_constants (nano::network_constants & network_constants);
 	ledger_constants (nano::nano_networks network_a);
-	nano::keypair zero_key;
 	nano::keypair test_genesis_key;
 	nano::account nano_test_account;
 	nano::account nano_beta_account;


### PR DESCRIPTION
This was found when trying MSAN. This is the first error encountered, it complains about generating the keypair from the `"0"` string, inside `nano::decode_hex`. `zero_key` isn't used so just removing it.