### PR TITLE
message_queue websocket for recording tcp write drops

### DIFF
--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/node.hpp>
 #include <nano/node/socket.hpp>
+#include <nano/node/websocket.hpp>
 
 #include <limits>
 
@@ -76,6 +77,12 @@ void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std:
 				else if (auto node_l = this_l->node.lock ())
 				{
 					node_l->stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out);
+					if (node_l->websocket_server && node_l->websocket_server->any_subscriber (nano::websocket::topic::message_queue))
+					{
+						auto remote_ip = this_l->remote;
+						nano::websocket::message_builder builder;
+						node_l->websocket_server->broadcast (builder.message_queue_size (remote_ip, queue_size));
+					}
 				}
 				if (!write_in_progress)
 				{

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -747,7 +747,7 @@ nano::websocket::message nano::websocket::message_builder::message_queue_size (b
 	// Vote information
 	boost::property_tree::ptree message_queue_l;
 	message_queue_l.put ("remote", remote);
-    message_queue_l.put ("queue_size", queue_size);
+	message_queue_l.put ("queue_size", queue_size);
 	message_l.contents.add_child ("message", message_queue_l);
 	return message_l;
 }

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -331,6 +331,10 @@ nano::websocket::topic to_topic (std::string const & topic_a)
 	{
 		topic = nano::websocket::topic::work;
 	}
+	else if (topic_a == "message_queue")
+	{
+		topic = nano::websocket::topic::message_queue;
+	}
 
 	return topic;
 }
@@ -361,6 +365,10 @@ std::string from_topic (nano::websocket::topic topic_a)
 	else if (topic_a == nano::websocket::topic::work)
 	{
 		topic = "work";
+	}
+	else if (topic_a == nano::websocket::topic::message_queue)
+	{
+		topic = "message_queue";
 	}
 	return topic;
 }
@@ -729,6 +737,19 @@ nano::websocket::message nano::websocket::message_builder::work_cancelled (nano:
 nano::websocket::message nano::websocket::message_builder::work_failed (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a)
 {
 	return work_generation (root_a, 0, difficulty_a, publish_threshold_a, duration_a, "", bad_peers_a, false, false);
+}
+
+nano::websocket::message nano::websocket::message_builder::message_queue_size (boost::asio::ip::tcp::endpoint & remote, size_t const queue_size)
+{
+	nano::websocket::message message_l (nano::websocket::topic::message_queue);
+	set_common_fields (message_l);
+
+	// Vote information
+	boost::property_tree::ptree message_queue_l;
+	message_queue_l.put ("remote", remote);
+    message_queue_l.put ("queue_size", queue_size);
+	message_l.contents.add_child ("message", message_queue_l);
+	return message_l;
 }
 
 void nano::websocket::message_builder::set_common_fields (nano::websocket::message & message_a)

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -54,6 +54,8 @@ namespace websocket
 		active_difficulty,
 		/** Work generation message */
 		work,
+		/** TCP Write Drops */
+		message_queue,
 		/** Auxiliary length, not a valid topic, must be the last enum */
 		_length
 	};
@@ -88,6 +90,7 @@ namespace websocket
 		message work_generation (nano::block_hash const & root_a, uint64_t const work_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::string const & peer_a, std::vector<std::string> const & bad_peers_a, bool const completed_a = true, bool const cancelled_a = false);
 		message work_cancelled (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a);
 		message work_failed (nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a);
+		message message_queue_size (boost::asio::ip::tcp::endpoint & remote, size_t const queue_size);
 
 	private:
 		/** Set the common fields for messages: timestamp and topic. */


### PR DESCRIPTION
Similar to confirmation_quorum peer_details and peers that show relevant information related to peers and vote websocket that can be used to measure vote performance, this websocket sends a message with the endpoint whenever the message queue reaches queue_size_max (eg 128) for a particular endpoint.  Tests so far have shown this could be a way to measure node performance but further tests are needed to confirm and ultimately sampled and averaged across multiple nodes to get usable data.

Core test case only tests the websocket subscription, I'm not sure the best way to automate testing a full message queue, but bootstrapping 600k blocks on beta resulted in 536 tcp_write_drop count which matches the messages returned by the websocket.