### PR TITLE
Fix active_transactions not doing any confirmation request in tests

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -6,6 +6,43 @@
 
 using namespace std::chrono_literals;
 
+TEST (active_transactions, confirm_one)
+{
+	nano::system system;
+	nano::node_config node_config (24000, system.logging);
+	auto & node1 = *system.add_node (node_config);
+	nano::genesis genesis;
+	// Send and vote for a block before peering with node2
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node_config.receive_minimum.number ()));
+	system.deadline_set (5s);
+	while (!node1.active.empty () && !node1.block_confirmed_or_being_confirmed (node1.store.tx_begin_read (), send->hash ()))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	node_config.peering_port = 24001;
+	auto & node2 = *system.add_node (node_config);
+	system.deadline_set (5s);
+	// Let node2 know about the block
+	while (node2.active.empty ())
+	{
+		node1.network.flood_block (send, false);
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	while (!node2.active.empty ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (0, node2.active.dropped_elections_cache_size ());
+	nano::unique_lock<std::mutex> active_lock (node2.active.mutex);
+	while (node2.active.confirmed.empty ())
+	{
+		active_lock.unlock ();
+		ASSERT_NO_ERROR (system.poll ());
+		active_lock.lock ();
+	}
+}
+
 TEST (active_transactions, adjusted_difficulty_priority)
 {
 	nano::system system;

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -11,7 +11,6 @@ TEST (active_transactions, confirm_one)
 	nano::system system;
 	nano::node_config node_config (24000, system.logging);
 	auto & node1 = *system.add_node (node_config);
-	nano::genesis genesis;
 	// Send and vote for a block before peering with node2
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node_config.receive_minimum.number ()));

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -366,12 +366,12 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 				election_escalate (election_l, transaction_l, roots_size_l);
 			}
 			// Block broadcasting
-			if (election_l->confirmation_request_count % 8 == 1 || node.network_params.network.is_test_network ())
+			if (election_l->confirmation_request_count % 8 == 1)
 			{
 				election_broadcast (election_l, transaction_l, blocks_bundle_l, inactive_l, root_l);
 			}
 			// Confirmation requesting
-			else if (election_l->confirmation_request_count % 4 == 0)
+			if (election_l->confirmation_request_count % 4 == 0)
 			{
 				// If failed to insert into any of the bundles (capped), don't increment the counter so that the same root is sent for confirmation in the next loop
 				if (!election_request_confirm (election_l, representatives_l, roots_size_l, single_confirm_req_bundle_l, batched_confirm_req_bundle_l))
@@ -379,7 +379,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 					increment_counter_l = false;
 				}
 			}
-			if (increment_counter_l)
+			if (increment_counter_l || node.network_params.network.is_test_network ())
 			{
 				++election_l->confirmation_request_count;
 			}


### PR DESCRIPTION
Some tests expect an increasing confirmation_request_count even when confirm_req fails (e.g. no reps available), so I made it always increase for the test network.

Without that, note that `bootstrap_processor.lazy_unclear_state_link_not_existing` fails, because active_transactions would not escalate to broadcasting the block.