### PR TITLE
Fix distributed_work segfault when local work generation fails

### DIFF
--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -25,23 +25,25 @@ need_resolve (peers_a),
 difficulty (difficulty_a),
 elapsed (nano::timer_state::started, "distributed work generation timer")
 {
-	assert (!completed);
+	assert (!finished);
+	assert (status == nano::work_generation_status::ongoing);
 }
 
 nano::distributed_work::~distributed_work ()
 {
+	assert (status != nano::work_generation_status::ongoing);
 	if (!node.stopped && node.websocket_server && node.websocket_server->any_subscriber (nano::websocket::topic::work))
 	{
 		nano::websocket::message_builder builder;
-		if (completed)
+		if (status == nano::work_generation_status::success)
 		{
 			node.websocket_server->broadcast (builder.work_generation (root, work_result, difficulty, node.network_params.network.publish_threshold, elapsed.value (), winner, bad_peers));
 		}
-		else if (cancelled)
+		else if (status == nano::work_generation_status::cancelled)
 		{
 			node.websocket_server->broadcast (builder.work_cancelled (root, difficulty, node.network_params.network.publish_threshold, elapsed.value (), bad_peers));
 		}
-		else
+		else if (status == nano::work_generation_status::failure)
 		{
 			node.websocket_server->broadcast (builder.work_failed (root, difficulty, node.network_params.network.publish_threshold, elapsed.value (), bad_peers));
 		}
@@ -102,9 +104,13 @@ void nano::distributed_work::start_work ()
 			{
 				this_l->set_once (*work_a);
 			}
-			else if (!this_l->cancelled && !this_l->completed)
+			else if (!this_l->finished.exchange (true))
 			{
-				this_l->callback (boost::none);
+				this_l->status = nano::work_generation_status::failure;
+				if (this_l->callback)
+				{
+					this_l->callback (boost::none);
+				}
 			}
 			this_l->stop_once (false);
 		},
@@ -187,7 +193,7 @@ void nano::distributed_work::start_work ()
 		}
 	}
 
-	if (!local_generation_started && outstanding.empty ())
+	if (!local_generation_started && outstanding.empty () && callback)
 	{
 		callback (boost::none);
 	}
@@ -297,10 +303,14 @@ void nano::distributed_work::stop_once (bool const local_stop_a)
 
 void nano::distributed_work::set_once (uint64_t work_a, std::string const & source_a)
 {
-	if (!cancelled && !completed.exchange (true))
+	if (!finished.exchange (true))
 	{
 		elapsed.stop ();
-		callback (work_a);
+		status = nano::work_generation_status::success;
+		if (callback)
+		{
+			callback (work_a);
+		}
 		winner = source_a;
 		work_result = work_a;
 		if (node.config.logging.work_generation_time ())
@@ -314,10 +324,14 @@ void nano::distributed_work::set_once (uint64_t work_a, std::string const & sour
 
 void nano::distributed_work::cancel_once ()
 {
-	if (!completed && !cancelled.exchange (true))
+	if (!finished.exchange (true))
 	{
 		elapsed.stop ();
-		callback (boost::none);
+		status = nano::work_generation_status::cancelled;
+		if (callback)
+		{
+			callback (boost::none);
+		}
 		stop_once (true);
 		if (node.config.logging.work_generation_time ())
 		{
@@ -334,7 +348,7 @@ void nano::distributed_work::failure (boost::asio::ip::address const & address_a
 
 void nano::distributed_work::handle_failure (bool const last_a)
 {
-	if (last_a && !completed && !cancelled)
+	if (last_a && !finished)
 	{
 		node.unresponsive_work_peers = true;
 		if (!local_generation_started)

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -26,24 +26,24 @@ difficulty (difficulty_a),
 elapsed (nano::timer_state::started, "distributed work generation timer")
 {
 	assert (!finished);
-	assert (status == nano::work_generation_status::ongoing);
+	assert (status == work_generation_status::ongoing);
 }
 
 nano::distributed_work::~distributed_work ()
 {
-	assert (status != nano::work_generation_status::ongoing);
+	assert (status != work_generation_status::ongoing);
 	if (!node.stopped && node.websocket_server && node.websocket_server->any_subscriber (nano::websocket::topic::work))
 	{
 		nano::websocket::message_builder builder;
-		if (status == nano::work_generation_status::success)
+		if (status == work_generation_status::success)
 		{
 			node.websocket_server->broadcast (builder.work_generation (root, work_result, difficulty, node.network_params.network.publish_threshold, elapsed.value (), winner, bad_peers));
 		}
-		else if (status == nano::work_generation_status::cancelled)
+		else if (status == work_generation_status::cancelled)
 		{
 			node.websocket_server->broadcast (builder.work_cancelled (root, difficulty, node.network_params.network.publish_threshold, elapsed.value (), bad_peers));
 		}
-		else if (status == nano::work_generation_status::failure_local || status == nano::work_generation_status::failure_peers)
+		else if (status == work_generation_status::failure_local || status == work_generation_status::failure_peers)
 		{
 			node.websocket_server->broadcast (builder.work_failed (root, difficulty, node.network_params.network.publish_threshold, elapsed.value (), bad_peers));
 		}
@@ -106,7 +106,7 @@ void nano::distributed_work::start_work ()
 			}
 			else if (!this_l->finished.exchange (true))
 			{
-				this_l->status = nano::work_generation_status::failure_local;
+				this_l->status = work_generation_status::failure_local;
 				if (this_l->callback)
 				{
 					this_l->callback (boost::none);
@@ -306,7 +306,7 @@ void nano::distributed_work::set_once (uint64_t work_a, std::string const & sour
 	if (!finished.exchange (true))
 	{
 		elapsed.stop ();
-		status = nano::work_generation_status::success;
+		status = work_generation_status::success;
 		if (callback)
 		{
 			callback (work_a);
@@ -327,7 +327,7 @@ void nano::distributed_work::cancel_once ()
 	if (!finished.exchange (true))
 	{
 		elapsed.stop ();
-		status = nano::work_generation_status::cancelled;
+		status = work_generation_status::cancelled;
 		if (callback)
 		{
 			callback (boost::none);
@@ -353,7 +353,7 @@ void nano::distributed_work::handle_failure (bool const last_a)
 		node.unresponsive_work_peers = true;
 		if (!local_generation_started && !finished.exchange (true))
 		{
-			status = nano::work_generation_status::failure_peers;
+			status = work_generation_status::failure_peers;
 			if (backoff == 1 && node.config.logging.work_generation_time ())
 			{
 				node.logger.always_log ("Work peer(s) failed to generate work for root ", root.to_string (), ", retrying...");

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -32,6 +32,14 @@ public:
 	boost::asio::ip::tcp::socket socket;
 };
 
+enum class work_generation_status
+{
+	ongoing,
+	success,
+	cancelled,
+	failure
+};
+
 /**
  * distributed_work cancels local and peer work requests when going out of scope
  */
@@ -64,10 +72,10 @@ public:
 	std::vector<std::pair<std::string, uint16_t>> need_resolve;
 	uint64_t difficulty;
 	uint64_t work_result{ 0 };
-	std::atomic<bool> completed{ false };
-	std::atomic<bool> cancelled{ false };
+	std::atomic<bool> finished{ false };
 	std::atomic<bool> stopped{ false };
 	std::atomic<bool> local_generation_started{ false };
+	nano::work_generation_status status{ nano::work_generation_status::ongoing };
 	nano::timer<std::chrono::milliseconds> elapsed; // logging only
 	std::vector<std::string> bad_peers; // websocket
 	std::string winner; // websocket

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -37,7 +37,8 @@ enum class work_generation_status
 	ongoing,
 	success,
 	cancelled,
-	failure
+	failure_local,
+	failure_peers
 };
 
 /**

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -32,20 +32,20 @@ public:
 	boost::asio::ip::tcp::socket socket;
 };
 
-enum class work_generation_status
-{
-	ongoing,
-	success,
-	cancelled,
-	failure_local,
-	failure_peers
-};
-
 /**
  * distributed_work cancels local and peer work requests when going out of scope
  */
 class distributed_work final : public std::enable_shared_from_this<nano::distributed_work>
 {
+	enum class work_generation_status
+	{
+		ongoing,
+		success,
+		cancelled,
+		failure_local,
+		failure_peers
+	};
+
 public:
 	distributed_work (nano::node &, nano::root const &, std::vector<std::pair<std::string, uint16_t>> const & peers_a, unsigned int, std::function<void(boost::optional<uint64_t>)> const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	~distributed_work ();
@@ -76,7 +76,7 @@ public:
 	std::atomic<bool> finished{ false };
 	std::atomic<bool> stopped{ false };
 	std::atomic<bool> local_generation_started{ false };
-	nano::work_generation_status status{ nano::work_generation_status::ongoing };
+	work_generation_status status{ work_generation_status::ongoing };
 	nano::timer<std::chrono::milliseconds> elapsed; // logging only
 	std::vector<std::string> bad_peers; // websocket
 	std::string winner; // websocket


### PR DESCRIPTION
In start_work () :
`else if (!this_l->cancelled && !this_l->completed)`

Was not setting any of these atomics to true, so the same callback would possibly be called in `cancel_once`. Not normally an issue, but can happen and came up with Serg's epoch storm test. Instead of making a new atomic, joined both into a single `finished` atomic, and added a `work_generation_status` enum.

Also added a check `if (callback)` on every call.