### PR TITLE
Add block and voters count in election information

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -468,6 +468,8 @@ TEST (websocket, confirmation_options)
 			// Duration and request count may be zero on testnet, so we only check that they're present
 			ASSERT_EQ (1, election_info.count ("duration"));
 			ASSERT_EQ (1, election_info.count ("request_count"));
+			ASSERT_EQ (1, election_info.count ("voters"));
+			ASSERT_GE (1, election_info.get<unsigned> ("blocks"));
 			// Make sure tally and time are non-zero.
 			ASSERT_NE ("0", tally);
 			ASSERT_NE ("0", time);

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -111,7 +111,7 @@ void nano::active_transactions::post_confirmation_height_set (nano::transaction 
 		bool is_state_send (false);
 		nano::account pending_account (0);
 		node.process_confirmed_data (transaction_a, block_a, block_a->hash (), sideband_a, account, amount, is_state_send, pending_account);
-		node.observers.blocks.notify (nano::election_status{ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, nano::election_status_type::inactive_confirmation_height }, account, amount, is_state_send);
+		node.observers.blocks.notify (nano::election_status{ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::inactive_confirmation_height }, account, amount, is_state_send);
 	}
 	else
 	{

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -61,6 +61,8 @@ public:
 	std::chrono::milliseconds election_end;
 	std::chrono::milliseconds election_duration;
 	unsigned confirmation_request_count;
+	unsigned block_count;
+	unsigned voter_count;
 	election_status_type type;
 };
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -11,7 +11,7 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> bloc
 confirmation_action (confirmation_action_a),
 node (node_a),
 election_start (std::chrono::steady_clock::now ()),
-status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, nano::election_status_type::ongoing }),
+status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
 skip_delay (skip_delay_a),
 confirmed (false),
 stopped (false)
@@ -34,11 +34,14 @@ void nano::election::compute_rep_votes (nano::transaction const & transaction_a)
 
 void nano::election::confirm_once (nano::election_status_type type_a)
 {
+	assert (!node.active.mutex.try_lock ());
 	if (!confirmed.exchange (true))
 	{
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		status.confirmation_request_count = confirmation_request_count;
+		status.block_count = blocks.size ();
+		status.voter_count = last_votes.size ();
 		status.type = type_a;
 		auto status_l (status);
 		auto node_l (node.shared ());
@@ -57,12 +60,15 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 
 void nano::election::stop ()
 {
+	assert (!node.active.mutex.try_lock ());
 	if (!stopped && !confirmed)
 	{
 		stopped = true;
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		status.confirmation_request_count = confirmation_request_count;
+		status.block_count = blocks.size ();
+		status.voter_count = last_votes.size ();
 		status.type = nano::election_status_type::stopped;
 	}
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1848,8 +1848,8 @@ void nano::json_handler::confirmation_info ()
 		if (conflict_info != node.active.roots.end ())
 		{
 			auto election (conflict_info->election);
-			response_l.put ("announcements", std::to_string (election->status.confirmation_request_count));
-			response_l.put ("voters", std::to_string (election->status.voter_count));
+			response_l.put ("announcements", std::to_string (election->confirmation_request_count));
+			response_l.put ("voters", std::to_string (election->last_votes.size ()));
 			response_l.put ("last_winner", election->status.winner->hash ().to_string ());
 			nano::uint128_t total (0);
 			auto tally_l (election->tally ());

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1849,7 +1849,6 @@ void nano::json_handler::confirmation_info ()
 		{
 			auto election (conflict_info->election);
 			response_l.put ("announcements", std::to_string (election->status.confirmation_request_count));
-			response_l.put ("blocks", std::to_string (election->status.block_count));
 			response_l.put ("voters", std::to_string (election->status.voter_count));
 			response_l.put ("last_winner", election->status.winner->hash ().to_string ());
 			nano::uint128_t total (0);

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -629,7 +629,9 @@ nano::websocket::message nano::websocket::message_builder::block_confirmed (std:
 		election_node_l.add ("duration", election_status_a.election_duration.count ());
 		election_node_l.add ("time", election_status_a.election_end.count ());
 		election_node_l.add ("tally", election_status_a.tally.to_string_dec ());
-		election_node_l.add ("request_count", election_status_a.confirmation_request_count);
+		election_node_l.add ("blocks", std::to_string (election_status_a.block_count));
+		election_node_l.add ("voters", std::to_string (election_status_a.voter_count));
+		election_node_l.add ("request_count", std::to_string (election_status_a.confirmation_request_count));
 		message_node_l.add_child ("election_info", election_node_l);
 	}
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6140,6 +6140,8 @@ TEST (rpc, confirmation_history)
 	ASSERT_EQ (1, item->second.count ("duration"));
 	ASSERT_EQ (1, item->second.count ("time"));
 	ASSERT_EQ (1, item->second.count ("request_count"));
+	ASSERT_EQ (1, item->second.count ("voters"));
+	ASSERT_GE (1, item->second.get<unsigned> ("blocks"));
 	ASSERT_EQ (block->hash ().to_string (), hash);
 	nano::amount tally_num;
 	tally_num.decode_dec (tally);


### PR DESCRIPTION
Considered adding more details such as the number of votes for each block, but would need to tally up each election.

Similar to a previous PR, uses `assert (!node.active.mutex.try_lock ());` which can have [undefined behavior](https://en.cppreference.com/w/cpp/thread/mutex/try_lock), but only used in Debug. Don't see an easy alternative in this case, and it was already used in `election.cpp`.