### PR TITLE
Disable vote rebroadcasting while cemented count is below hardcoded bootstrap block count

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -692,7 +692,7 @@ bool nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool s
 		{
 			lock = nano::unique_lock<std::mutex> (mutex);
 		}
-		for (auto vote_block : vote_a->blocks)
+		for (auto & vote_block : vote_a->blocks)
 		{
 			nano::election_vote_result result;
 			if (vote_block.which ())
@@ -725,7 +725,7 @@ bool nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool s
 			processed = processed || result.processed;
 		}
 	}
-	if (processed)
+	if (processed && node.ledger.cemented_count >= node.ledger.bootstrap_weight_max_blocks)
 	{
 		node.network.flood_vote (vote_a);
 	}


### PR DESCRIPTION
Closes #2410 . It's an heuristic since blocks that don't go towards the bootstrap block count can be cemented, but close enough. Other heuristics can follow in the future to understand the likelihood of a vote being useful to the network.

One thing to take into account is nodes with disabled frontier confirmation ( #2175 ); it's likely they also reach this cemented count through the confirmation height processor trickling down through millions of blocks. Disabling vote rebroadcasting completely for these nodes would be another option.