### PR TITLE
Set wallet representative with RPC receive on unopened accounts

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3373,10 +3373,14 @@ void nano::json_handler::receive ()
 					}
 					if (!ec)
 					{
+						// Representative is only used by receive_action when opening accounts
+						// Set a wallet default representative for new accounts
+						nano::account representative (wallet->store.representative (node.wallets.tx_begin_read ()));
+
 						bool generate_work (work == 0); // Disable work generation if "work" option is provided
 						auto response_a (response);
 						// clang-format off
-						wallet->receive_async(std::move(block), account, node.network_params.ledger.genesis_amount, [response_a](std::shared_ptr<nano::block> block_a) {
+						wallet->receive_async(std::move(block), representative, node.network_params.ledger.genesis_amount, [response_a](std::shared_ptr<nano::block> block_a) {
 							if (block_a != nullptr)
 							{
 								boost::property_tree::ptree response_l;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3335,9 +3335,9 @@ void nano::json_handler::receive ()
 	auto hash (hash_impl ("block"));
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		wallet_locked_impl (transaction, wallet);
-		wallet_account_impl (transaction, wallet, account);
+		auto wallet_transaction (node.wallets.tx_begin_read ());
+		wallet_locked_impl (wallet_transaction, wallet);
+		wallet_account_impl (wallet_transaction, wallet, account);
 		if (!ec)
 		{
 			auto block_transaction (node.store.tx_begin_read ());
@@ -3375,8 +3375,7 @@ void nano::json_handler::receive ()
 					{
 						// Representative is only used by receive_action when opening accounts
 						// Set a wallet default representative for new accounts
-						nano::account representative (wallet->store.representative (node.wallets.tx_begin_read ()));
-
+						nano::account representative (wallet->store.representative (wallet_transaction));
 						bool generate_work (work == 0); // Disable work generation if "work" option is provided
 						auto response_a (response);
 						// clang-format off


### PR DESCRIPTION
Closes #2418 

Will update documentation, should state that the wallet representative will be used from V21, and the own account is used in V20 and before, for unopened accounts.

Adds a suite of tests for RPC receive.