### PR TITLE
Add database vendor string to RPC version

### DIFF
--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -59,12 +59,11 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 			auto node (std::make_shared<nano::node> (io_ctx, data_path, alarm, config.node, opencl_work, flags));
 			if (!node->init_error ())
 			{
-				auto database_backend = dynamic_cast<nano::mdb_store *> (node->store_impl.get ()) ? "LMDB" : "RocksDB";
 				auto network_label = node->network_params.network.get_current_network_as_string ();
 				std::cout << "Network: " << network_label << ", version: " << NANO_VERSION_STRING << "\n"
 				          << "Path: " << node->application_path.string () << "\n"
 				          << "Build Info: " << BUILD_INFO << "\n"
-				          << "Database backend: " << database_backend << std::endl;
+				          << "Database backend: " << node->store.vendor_get () << std::endl;
 
 				node->start ();
 				nano::ipc::ipc_server ipc_server (*node, config.rpc);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4100,6 +4100,7 @@ void nano::json_handler::version ()
 	response_l.put ("store_version", std::to_string (node.store_version ()));
 	response_l.put ("protocol_version", std::to_string (node.network_params.protocol.protocol_version));
 	response_l.put ("node_vendor", boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING));
+	response_l.put ("store_vendor", node.store.vendor_get ());
 	response_l.put ("network", node.network_params.network.get_current_network_as_string ());
 	response_l.put ("network_identifier", nano::genesis ().hash ().to_string ());
 	response_l.put ("build_info", BUILD_INFO);

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -136,6 +136,11 @@ nano::read_transaction nano::mdb_store::tx_begin_read ()
 	return env.tx_begin_read (create_txn_callbacks ());
 }
 
+std::string nano::mdb_store::vendor_get () const
+{
+	return boost::str (boost::format ("LMDB %1%.%2%.%3%") % MDB_VERSION_MAJOR % MDB_VERSION_MINOR % MDB_VERSION_PATCH);
+}
+
 nano::mdb_txn_callbacks nano::mdb_store::create_txn_callbacks ()
 {
 	nano::mdb_txn_callbacks mdb_txn_callbacks;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -36,6 +36,8 @@ public:
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
 	nano::read_transaction tx_begin_read () override;
 
+	std::string vendor_get () const override;
+
 	bool block_info_get (nano::transaction const &, nano::block_hash const &, nano::block_info &) const override;
 
 	void version_put (nano::write_transaction const &, int) override;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -366,6 +366,7 @@ startup_time (std::chrono::steady_clock::now ())
 
 		logger.always_log ("Node starting, version: ", NANO_VERSION_STRING);
 		logger.always_log ("Build information: ", BUILD_INFO);
+		logger.always_log ("Database backend: ", store.vendor_get ());
 
 		auto network_label = network_params.network.get_current_network_as_string ();
 		logger.always_log ("Active network: ", network_label);

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -136,6 +136,11 @@ nano::read_transaction nano::rocksdb_store::tx_begin_read ()
 	return nano::read_transaction{ std::make_unique<nano::read_rocksdb_txn> (db) };
 }
 
+std::string nano::rocksdb_store::vendor_get () const
+{
+	return boost::str (boost::format ("RocksDB %1%.%2%.%3%") % ROCKSDB_MAJOR % ROCKSDB_MINOR % ROCKSDB_PATCH);
+}
+
 rocksdb::ColumnFamilyHandle * nano::rocksdb_store::table_to_column_family (tables table_a) const
 {
 	auto & handles_l = handles;

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -30,6 +30,8 @@ public:
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
 	nano::read_transaction tx_begin_read () override;
 
+	std::string vendor_get () const override;
+
 	bool block_info_get (nano::transaction const &, nano::block_hash const &, nano::block_info &) const override;
 	size_t count (nano::transaction const & transaction_a, tables table_a) const override;
 	void version_put (nano::write_transaction const &, int) override;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2686,6 +2686,21 @@ TEST (rpc, version)
 	}
 	ASSERT_EQ (std::to_string (node1->network_params.protocol.protocol_version), response1.json.get<std::string> ("protocol_version"));
 	ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING), response1.json.get<std::string> ("node_vendor"));
+	auto store_vendor = response1.json.get<std::string> ("store_vendor");
+	auto use_rocksdb_str = std::getenv ("TEST_USE_ROCKSDB");
+	if (use_rocksdb_str && boost::lexical_cast<int> (use_rocksdb_str) == 1)
+	{
+		bool built_with_rocksdb{ false };
+#if NANO_ROCKSDB
+		build_with_rocksdb = true;
+		ASSERT_EQ (boost::str (boost::format ("RocksDB %1%.%2%.%3%") % ROCKSDB_MAJOR % ROCKSDB_MINOR % ROCKSDB_PATCH), store_vendor);
+#endif
+		ASSERT_TRUE (built_with_rocksdb);
+	}
+	else
+	{
+		ASSERT_EQ (boost::str (boost::format ("LMDB %1%.%2%.%3%") % MDB_VERSION_MAJOR % MDB_VERSION_MINOR % MDB_VERSION_PATCH), store_vendor);
+	}
 	auto network_label (node1->network_params.network.get_current_network_as_string ());
 	ASSERT_EQ (network_label, response1.json.get<std::string> ("network"));
 	auto genesis_open (node1->latest (nano::test_genesis_key.pub));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2686,21 +2686,7 @@ TEST (rpc, version)
 	}
 	ASSERT_EQ (std::to_string (node1->network_params.protocol.protocol_version), response1.json.get<std::string> ("protocol_version"));
 	ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING), response1.json.get<std::string> ("node_vendor"));
-	auto store_vendor = response1.json.get<std::string> ("store_vendor");
-	auto use_rocksdb_str = std::getenv ("TEST_USE_ROCKSDB");
-	if (use_rocksdb_str && boost::lexical_cast<int> (use_rocksdb_str) == 1)
-	{
-		bool built_with_rocksdb{ false };
-#if NANO_ROCKSDB
-		build_with_rocksdb = true;
-		ASSERT_EQ (boost::str (boost::format ("RocksDB %1%.%2%.%3%") % ROCKSDB_MAJOR % ROCKSDB_MINOR % ROCKSDB_PATCH), store_vendor);
-#endif
-		ASSERT_TRUE (built_with_rocksdb);
-	}
-	else
-	{
-		ASSERT_EQ (boost::str (boost::format ("LMDB %1%.%2%.%3%") % MDB_VERSION_MAJOR % MDB_VERSION_MINOR % MDB_VERSION_PATCH), store_vendor);
-	}
+	ASSERT_EQ (node1->store.vendor_get (), response1.json.get<std::string> ("store_vendor"));
 	auto network_label (node1->network_params.network.get_current_network_as_string ());
 	ASSERT_EQ (network_label, response1.json.get<std::string> ("network"));
 	auto genesis_open (node1->latest (nano::test_genesis_key.pub));

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -743,6 +743,8 @@ public:
 
 	/** Start read-only transaction */
 	virtual nano::read_transaction tx_begin_read () = 0;
+
+	virtual std::string vendor_get () const = 0;
 };
 
 std::unique_ptr<nano::block_store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, bool open_read_only = false, bool add_db_postfix = false, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), int lmdb_max_dbs = 128, size_t batch_size = 512, bool backup_before_upgrade = false, bool rocksdb_backend = false);


### PR DESCRIPTION
`"store_vendor": "RocksDB 6.6.0"` or `"LMDB 0.9.23"` in my case.

Also logs the same string on node startup, currently it's only printing to stdcout.