### PR TITLE
Remove raw new operator used with smart pointers

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -11,7 +11,7 @@ TEST (bulk_pull, no_address)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull);
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = 1;
 	req->end = 2;
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -24,7 +24,7 @@ TEST (bulk_pull, genesis_to_end)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::test_genesis_key.pub;
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -38,7 +38,7 @@ TEST (bulk_pull, no_end)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::test_genesis_key.pub;
 	req->end = 1;
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -63,7 +63,7 @@ TEST (bulk_pull, end_not_owned)
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	nano::genesis genesis;
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = key2.pub;
 	req->end = genesis.hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -76,7 +76,7 @@ TEST (bulk_pull, none)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	nano::genesis genesis;
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::test_genesis_key.pub;
 	req->end = genesis.hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -89,7 +89,7 @@ TEST (bulk_pull, get_next_on_open)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::test_genesis_key.pub;
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -106,7 +106,7 @@ TEST (bulk_pull, by_block)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	nano::genesis genesis;
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = genesis.hash ();
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -124,7 +124,7 @@ TEST (bulk_pull, by_block_single)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	nano::genesis genesis;
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = genesis.hash ();
 	req->end = genesis.hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -148,7 +148,7 @@ TEST (bulk_pull, count_limit)
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*receive1).code);
 
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::bulk_pull> req (new nano::bulk_pull{});
+	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = receive1->hash ();
 	req->set_count_present (true);
 	req->count = 2;
@@ -742,7 +742,7 @@ TEST (frontier_req_response, DISABLED_destruction)
 		{
 			nano::system system (1);
 			auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-			std::unique_ptr<nano::frontier_req> req (new nano::frontier_req);
+			auto req = std::make_unique<nano::frontier_req> ();
 			req->start.clear ();
 			req->age = std::numeric_limits<decltype (req->age)>::max ();
 			req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -757,7 +757,7 @@ TEST (frontier_req, begin)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::frontier_req> req (new nano::frontier_req);
+	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -772,7 +772,7 @@ TEST (frontier_req, end)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::frontier_req> req (new nano::frontier_req);
+	auto req = std::make_unique<nano::frontier_req> ();
 	req->start = nano::test_genesis_key.pub.number () + 1;
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -795,7 +795,7 @@ TEST (frontier_req, count)
 	node1.work_generate_blocking (receive1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (receive1).code);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::frontier_req> req (new nano::frontier_req);
+	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = 1;
@@ -809,7 +809,7 @@ TEST (frontier_req, time_bound)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::frontier_req> req (new nano::frontier_req);
+	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = 1;
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -818,7 +818,7 @@ TEST (frontier_req, time_bound)
 	ASSERT_EQ (nano::test_genesis_key.pub, request->current);
 	// Wait 2 seconds until age of account will be > 1 seconds
 	std::this_thread::sleep_for (std::chrono::milliseconds (2100));
-	std::unique_ptr<nano::frontier_req> req2 (new nano::frontier_req);
+	auto req2 (std::make_unique<nano::frontier_req> ());
 	req2->start.clear ();
 	req2->age = 1;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
@@ -832,7 +832,7 @@ TEST (frontier_req, time_cutoff)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-	std::unique_ptr<nano::frontier_req> req (new nano::frontier_req);
+	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = 3;
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -843,7 +843,7 @@ TEST (frontier_req, time_cutoff)
 	ASSERT_EQ (genesis.hash (), request->frontier);
 	// Wait 4 seconds until age of account will be > 3 seconds
 	std::this_thread::sleep_for (std::chrono::milliseconds (4100));
-	std::unique_ptr<nano::frontier_req> req2 (new nano::frontier_req);
+	auto req2 (std::make_unique<nano::frontier_req> ());
 	req2->start.clear ();
 	req2->age = 3;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
@@ -934,7 +934,7 @@ TEST (bulk_pull_account, basics)
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 
 	{
-		std::unique_ptr<nano::bulk_pull_account> req (new nano::bulk_pull_account{});
+		auto req = std::make_unique<nano::bulk_pull_account> ();
 		req->account = key1.pub;
 		req->minimum_amount = 5;
 		req->flags = nano::bulk_pull_account_flags ();
@@ -953,7 +953,7 @@ TEST (bulk_pull_account, basics)
 	}
 
 	{
-		std::unique_ptr<nano::bulk_pull_account> req (new nano::bulk_pull_account{});
+		auto req = std::make_unique<nano::bulk_pull_account> ();
 		req->account = key1.pub;
 		req->minimum_amount = 0;
 		req->flags = nano::bulk_pull_account_flags::pending_address_only;

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1232,50 +1232,32 @@ std::shared_ptr<nano::block> nano::deserialize_block_json (boost::property_tree:
 	try
 	{
 		auto type (tree_a.get<std::string> ("type"));
+		bool error (false);
+		std::unique_ptr<nano::block> obj;
 		if (type == "receive")
 		{
-			bool error (false);
-			std::unique_ptr<nano::receive_block> obj (new nano::receive_block (error, tree_a));
-			if (!error)
-			{
-				result = std::move (obj);
-			}
+			obj = std::make_unique<nano::receive_block> (error, tree_a);
 		}
 		else if (type == "send")
 		{
-			bool error (false);
-			std::unique_ptr<nano::send_block> obj (new nano::send_block (error, tree_a));
-			if (!error)
-			{
-				result = std::move (obj);
-			}
+			obj = std::make_unique<nano::send_block> (error, tree_a);
 		}
 		else if (type == "open")
 		{
-			bool error (false);
-			std::unique_ptr<nano::open_block> obj (new nano::open_block (error, tree_a));
-			if (!error)
-			{
-				result = std::move (obj);
-			}
+			obj = std::make_unique<nano::open_block> (error, tree_a);
 		}
 		else if (type == "change")
 		{
-			bool error (false);
-			std::unique_ptr<nano::change_block> obj (new nano::change_block (error, tree_a));
-			if (!error)
-			{
-				result = std::move (obj);
-			}
+			obj = std::make_unique<nano::change_block> (error, tree_a);
 		}
 		else if (type == "state")
 		{
-			bool error (false);
-			std::unique_ptr<nano::state_block> obj (new nano::state_block (error, tree_a));
-			if (!error)
-			{
-				result = std::move (obj);
-			}
+			obj = std::make_unique<nano::state_block> (error, tree_a);
+		}
+
+		if (!error)
+		{
+			result = std::move (obj);
 		}
 	}
 	catch (std::runtime_error const &)

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -852,8 +852,8 @@ std::pair<std::unique_ptr<nano::pending_key>, std::unique_ptr<nano::pending_info
 			}
 		}
 
-		result.first = std::unique_ptr<nano::pending_key> (new nano::pending_key (key));
-		result.second = std::unique_ptr<nano::pending_info> (new nano::pending_info (info));
+		result.first = std::make_unique<nano::pending_key> (key);
+		result.second = std::make_unique<nano::pending_info> (info);
 
 		break;
 	}

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -189,7 +189,7 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 					node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::bulk_push, nano::stat::dir::in);
 					if (is_bootstrap_connection ())
 					{
-						add_request (std::unique_ptr<nano::message> (new nano::bulk_push (header)));
+						add_request (std::make_unique<nano::bulk_push> (header));
 					}
 					break;
 				}
@@ -254,7 +254,7 @@ void nano::bootstrap_server::receive_bulk_pull_action (boost::system::error_code
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::bulk_pull> request (new nano::bulk_pull (error, stream, header_a));
+		auto request (std::make_unique<nano::bulk_pull> (error, stream, header_a));
 		if (!error)
 		{
 			if (node->config.logging.bulk_pull_logging ())
@@ -277,7 +277,7 @@ void nano::bootstrap_server::receive_bulk_pull_account_action (boost::system::er
 		auto error (false);
 		assert (size_a == header_a.payload_length_bytes ());
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::bulk_pull_account> request (new nano::bulk_pull_account (error, stream, header_a));
+		auto request (std::make_unique<nano::bulk_pull_account> (error, stream, header_a));
 		if (!error)
 		{
 			if (node->config.logging.bulk_pull_logging ())
@@ -299,7 +299,7 @@ void nano::bootstrap_server::receive_frontier_req_action (boost::system::error_c
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::frontier_req> request (new nano::frontier_req (error, stream, header_a));
+		auto request (std::make_unique<nano::frontier_req> (error, stream, header_a));
 		if (!error)
 		{
 			if (node->config.logging.bulk_pull_logging ())
@@ -328,7 +328,7 @@ void nano::bootstrap_server::receive_keepalive_action (boost::system::error_code
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::keepalive> request (new nano::keepalive (error, stream, header_a));
+		auto request (std::make_unique<nano::keepalive> (error, stream, header_a));
 		if (!error)
 		{
 			if (is_realtime_connection ())
@@ -353,7 +353,7 @@ void nano::bootstrap_server::receive_publish_action (boost::system::error_code c
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::publish> request (new nano::publish (error, stream, header_a));
+		auto request (std::make_unique<nano::publish> (error, stream, header_a));
 		if (!error)
 		{
 			if (is_realtime_connection ())
@@ -378,7 +378,7 @@ void nano::bootstrap_server::receive_confirm_req_action (boost::system::error_co
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::confirm_req> request (new nano::confirm_req (error, stream, header_a));
+		auto request (std::make_unique<nano::confirm_req> (error, stream, header_a));
 		if (!error)
 		{
 			if (is_realtime_connection ())
@@ -400,7 +400,7 @@ void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_co
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::confirm_ack> request (new nano::confirm_ack (error, stream, header_a));
+		auto request (std::make_unique<nano::confirm_ack> (error, stream, header_a));
 		if (!error)
 		{
 			if (is_realtime_connection ())
@@ -422,7 +422,7 @@ void nano::bootstrap_server::receive_node_id_handshake_action (boost::system::er
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		std::unique_ptr<nano::node_id_handshake> request (new nano::node_id_handshake (error, stream, header_a));
+		auto request (std::make_unique<nano::node_id_handshake> (error, stream, header_a));
 		if (!error)
 		{
 			if (type == nano::bootstrap_server_type::undefined && !node->flags.disable_tcp_realtime)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -207,10 +207,10 @@ void nano::wallet_store::derive_key (nano::raw_key & prv_a, nano::transaction co
 
 nano::fan::fan (nano::uint256_union const & key, size_t count_a)
 {
-	std::unique_ptr<nano::uint256_union> first (new nano::uint256_union (key));
+	auto first (std::make_unique<nano::uint256_union> (key));
 	for (auto i (1); i < count_a; ++i)
 	{
-		std::unique_ptr<nano::uint256_union> entry (new nano::uint256_union);
+		auto entry (std::make_unique<nano::uint256_union> ());
 		nano::random_pool::generate_block (entry->bytes.data (), entry->bytes.size ());
 		*first ^= *entry;
 		values.push_back (std::move (entry));
@@ -898,7 +898,7 @@ bool nano::wallet::import (std::string const & json_a, std::string const & passw
 		auto transaction (wallets.tx_begin_write ());
 		nano::uint256_union id;
 		random_pool::generate_block (id.bytes.data (), id.bytes.size ());
-		temp.reset (new nano::wallet_store (error, wallets.node.wallets.kdf, transaction, 0, 1, id.to_string (), json_a));
+		temp = std::make_unique<nano::wallet_store> (error, wallets.node.wallets.kdf, transaction, 0, 1, id.to_string (), json_a);
 	}
 	if (!error)
 	{
@@ -954,11 +954,11 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block const & s
 					auto new_account (wallets.node.ledger.store.account_get (block_transaction, account, info));
 					if (!new_account)
 					{
-						block.reset (new nano::state_block (account, info.head, info.representative, info.balance.number () + pending_info.amount.number (), hash, prv, account, work_a));
+						block = std::make_shared<nano::state_block> (account, info.head, info.representative, info.balance.number () + pending_info.amount.number (), hash, prv, account, work_a);
 					}
 					else
 					{
-						block.reset (new nano::state_block (account, 0, representative_a, pending_info.amount, reinterpret_cast<nano::link const &> (hash), prv, account, work_a));
+						block = std::make_shared<nano::state_block> (account, 0, representative_a, pending_info.amount, reinterpret_cast<nano::link const &> (hash), prv, account, work_a);
 					}
 				}
 				else
@@ -1015,7 +1015,7 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 				{
 					store.work_get (transaction, source_a, work_a);
 				}
-				block.reset (new nano::state_block (source_a, info.head, representative_a, info.balance, 0, prv, source_a, work_a));
+				block = std::make_shared<nano::state_block> (source_a, info.head, representative_a, info.balance, 0, prv, source_a, work_a);
 			}
 		}
 	}
@@ -1085,7 +1085,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						{
 							store.work_get (transaction, source_a, work_a);
 						}
-						block.reset (new nano::state_block (source_a, info.head, info.representative, balance - amount_a, account_a, prv, source_a, work_a));
+						block = std::make_shared <nano::state_block> (source_a, info.head, info.representative, balance - amount_a, account_a, prv, source_a, work_a);
 						if (id_mdb_val && block != nullptr)
 						{
 							auto status (mdb_put (wallets.env.tx (transaction), wallets.node.wallets.send_action_ids, *id_mdb_val, nano::mdb_val (block->hash ()), 0));


### PR DESCRIPTION
Use `std::make_unique`/`std::make_shared` where appropriate.

Also removed some duplication in `nano::deserialize_block_json`