### PR TITLE
Remove representation table during v15 upgrade

### DIFF
--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -239,6 +239,7 @@ private:
 	void upgrade_v12_to_v13 (nano::write_transaction &, size_t);
 	void upgrade_v13_to_v14 (nano::write_transaction const &);
 	void upgrade_v14_to_v15 (nano::write_transaction &);
+	void upgrade_v15_to_v16 (nano::write_transaction &);
 	void open_databases (bool &, nano::transaction const &, unsigned);
 
 	int drop (nano::write_transaction const & transaction_a, tables table_a) override;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -770,7 +770,7 @@ protected:
 	nano::network_params network_params;
 	std::unordered_map<nano::account, std::shared_ptr<nano::vote>> vote_cache_l1;
 	std::unordered_map<nano::account, std::shared_ptr<nano::vote>> vote_cache_l2;
-	static int constexpr version{ 15 };
+	static int constexpr version{ 16 };
 
 	template <typename T>
 	std::shared_ptr<nano::block> block_random (nano::transaction const & transaction_a, tables table_a)


### PR DESCRIPTION
This was meant to be removed during the upgrade from v14, however the `representation` table was not being opened in the mdb_store constructor (thanks @SergiySW), it had a test which checked it didn't exist, but not that it existed in the first place. Creating a new upgrade path v15 -> v16 which correctly removed this.