### PR TITLE
[TSAN] More data races solved in distributed_work

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3037,7 +3037,7 @@ TEST (rpc, work_peer_many)
 	for (auto i (0); i < 10; ++i)
 	{
 		nano::keypair key1;
-		uint64_t work (0);
+		std::atomic<uint64_t> work (0);
 		node1.work_generate (key1.pub, [&work](boost::optional<uint64_t> work_a) {
 			ASSERT_TRUE (work_a.is_initialized ());
 			work = *work_a;


### PR DESCRIPTION
Use an atomic in `rpc.work_peer_many` and check if the request wasn't `stopped` before proceeding.

Placing the local work generation part at the end of `start_work ()` solves an issue where it would stop and remove the request, resulting in a `heap-after-free` on the `outstanding` object. This only happens in tests.

Still have one data race to be solved between `async_write` and `socket.close` , will need more investigation though. Unless you have any idea @cryptocode ? Does this need a strand?