### PR TITLE
WIP: Passive elections

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -423,7 +423,7 @@ TEST (bootstrap_processor, frontiers_confirmed)
 	auto node1 = system.add_node (node_config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1, key2;
-	// Generating invalid chain
+	// Generating test chain
 	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
 	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -144,6 +144,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.rpc.child_process.rpc_path, defaults.rpc.child_process.rpc_path);
 
 	ASSERT_EQ (conf.node.active_elections_size, defaults.node.active_elections_size);
+	ASSERT_EQ (conf.node.passive_elections_size, defaults.node.passive_elections_size);
 	ASSERT_EQ (conf.node.allow_local_peers, defaults.node.allow_local_peers);
 	ASSERT_EQ (conf.node.backup_before_upgrade, defaults.node.backup_before_upgrade);
 	ASSERT_EQ (conf.node.bandwidth_limit, defaults.node.bandwidth_limit);
@@ -377,6 +378,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ss << R"toml(
 	[node]
 	active_elections_size = 999
+	passive_elections_size = 9999
 	allow_local_peers = false
 	backup_before_upgrade = true
 	bandwidth_limit = 999
@@ -529,6 +531,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.rpc.child_process.rpc_path, defaults.rpc.child_process.rpc_path);
 
 	ASSERT_NE (conf.node.active_elections_size, defaults.node.active_elections_size);
+	ASSERT_NE (conf.node.passive_elections_size, defaults.node.passive_elections_size);
 	ASSERT_NE (conf.node.allow_local_peers, defaults.node.allow_local_peers);
 	ASSERT_NE (conf.node.backup_before_upgrade, defaults.node.backup_before_upgrade);
 	ASSERT_NE (conf.node.bandwidth_limit, defaults.node.bandwidth_limit);

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -437,6 +437,9 @@ std::string nano::stat::type_to_string (uint32_t key)
 			break;
 		case nano::stat::type::drop:
 			res = "drop";
+			break;
+		case nano::stat::type::active_transactions:
+			res = "active_transactions";
 	}
 	return res;
 }
@@ -635,6 +638,15 @@ std::string nano::stat::detail_to_string (uint32_t key)
 			break;
 		case nano::stat::detail::blocks_confirmed:
 			res = "blocks_confirmed";
+			break;
+		case nano::stat::detail::active:
+			res = "active";
+			break;
+		case nano::stat::detail::passive:
+			res = "passive";
+			break;
+		case nano::stat::detail::drop:
+			res = "drop";
 	}
 	return res;
 }

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -197,7 +197,8 @@ public:
 		udp,
 		observer,
 		confirmation_height,
-		drop
+		drop,
+		active_transactions
 	};
 
 	/** Optional detail type */
@@ -291,7 +292,12 @@ public:
 
 		// confirmation height
 		blocks_confirmed,
-		invalid_block
+		invalid_block,
+
+		// active transactions
+		active,
+		passive,
+		drop
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -107,6 +107,10 @@ public:
 	{
 		return state == state_impl::existing_passive || state == state_impl::inserted_passive;
 	}
+	operator bool () const
+	{
+		return exists ();
+	}
 	std::shared_ptr<nano::block> current_election_winner{ nullptr };
 };
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -207,8 +207,6 @@ public:
 	size_t inactive_votes_cache_size ();
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> pending_conf_height;
 	void clear_block (nano::block_hash const & hash_a);
-	// Generate votes for the winner of each election if not found in the votes cache
-	void generate_votes (std::vector<std::weak_ptr<nano::election>> const &);
 
 private:
 	// Call action with confirmed block, may be different than what we started with

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -140,7 +140,9 @@ void nano::confirmation_height_processor::add_confirmation_height (nano::block_h
 			}
 		}
 
-		auto block_height (ledger.store.block_account_height (read_transaction, current));
+		auto block_height_opt (ledger.store.block_account_height (read_transaction, current));
+		release_assert (block_height_opt.is_initialized ());
+		auto block_height (block_height_opt.get ());
 		nano::account account (ledger.store.block_account (read_transaction, current));
 		uint64_t confirmation_height;
 		release_assert (!ledger.store.confirmation_height_get (read_transaction, account, confirmation_height));

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -3,8 +3,8 @@
 
 #include <boost/format.hpp>
 
-nano::election_vote_result::election_vote_result (bool const replay_a, bool const processed_a, bool const active_a) :
-replay (replay_a), processed (processed_a), active (active_a)
+nano::election_vote_result::election_vote_result (bool const replay_a, bool const processed_a) :
+replay (replay_a), processed (processed_a)
 {
 }
 
@@ -171,7 +171,6 @@ nano::election_vote_result nano::election::vote (nano::account rep, uint64_t seq
 	auto online_stake (node.online_reps.online_stake ());
 	auto weight (node.ledger.weight (rep));
 	auto should_process (false);
-	bool active_l = active.load ();
 	if (node.network_params.network.is_test_network () || weight > node.minimum_principal_weight (online_stake))
 	{
 		unsigned int cooldown;
@@ -217,7 +216,7 @@ nano::election_vote_result nano::election::vote (nano::account rep, uint64_t seq
 			}
 		}
 	}
-	return nano::election_vote_result (replay, should_process, active_l);
+	return nano::election_vote_result (replay, should_process);
 }
 
 bool nano::election::publish (std::shared_ptr<nano::block> block_a)

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -61,7 +61,6 @@ public:
 	std::unordered_map<nano::account, nano::vote_info> last_votes;
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
 	std::chrono::steady_clock::time_point election_start;
-	// status.winner protected by winner_mutex
 	nano::election_status status;
 	bool skip_delay;
 	std::atomic<bool> active;
@@ -71,6 +70,5 @@ public:
 	unsigned confirmation_request_count{ 0 };
 	std::unordered_set<nano::block_hash> dependent_blocks;
 	std::chrono::seconds late_blocks_delay{ 5 };
-	std::mutex winner_mutex;
 };
 }

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -25,21 +25,22 @@ class election_vote_result final
 {
 public:
 	election_vote_result () = default;
-	election_vote_result (bool, bool);
+	election_vote_result (bool const, bool const, bool const);
 	bool replay{ false };
 	bool processed{ false };
+	bool active{ false };
 };
 class election final : public std::enable_shared_from_this<nano::election>
 {
 	std::function<void(std::shared_ptr<nano::block>)> confirmation_action;
 
 public:
-	election (nano::node &, std::shared_ptr<nano::block>, bool const, std::function<void(std::shared_ptr<nano::block>)> const &);
+	election (nano::node &, std::shared_ptr<nano::block>, bool const, bool const, std::function<void(std::shared_ptr<nano::block>)> const &);
 	nano::election_vote_result vote (nano::account, uint64_t, nano::block_hash);
 	nano::tally_t tally ();
 	// Check if we have vote quorum
 	bool have_quorum (nano::tally_t const &, nano::uint128_t) const;
-	// Change our winner to agree with the network
+	// Only used for tests
 	void compute_rep_votes (nano::transaction const &);
 	void confirm_once (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
 	// Confirm this block if quorum is met
@@ -51,18 +52,26 @@ public:
 	void clear_dependent ();
 	void clear_blocks ();
 	void insert_inactive_votes_cache ();
+	/**
+	 * Activate the election to store votes and send local votes
+	 * @return whether the state of the election was changed
+	 */
+	bool activate ();
 	void stop ();
 	nano::node & node;
 	std::unordered_map<nano::account, nano::vote_info> last_votes;
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
 	std::chrono::steady_clock::time_point election_start;
+	// status.winner protected by winner_mutex
 	nano::election_status status;
 	bool skip_delay;
-	std::atomic<bool> confirmed;
-	bool stopped;
+	std::atomic<bool> active;
+	std::atomic<bool> confirmed{ false };
+	bool stopped{ false };
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 	unsigned confirmation_request_count{ 0 };
 	std::unordered_set<nano::block_hash> dependent_blocks;
 	std::chrono::seconds late_blocks_delay{ 5 };
+	std::mutex winner_mutex;
 };
 }

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -25,10 +25,9 @@ class election_vote_result final
 {
 public:
 	election_vote_result () = default;
-	election_vote_result (bool const, bool const, bool const);
+	election_vote_result (bool const, bool const);
 	bool replay{ false };
 	bool processed{ false };
-	bool active{ false };
 };
 class election final : public std::enable_shared_from_this<nano::election>
 {
@@ -53,8 +52,8 @@ public:
 	void clear_blocks ();
 	void insert_inactive_votes_cache ();
 	/**
-	 * Activate the election to store votes and send local votes
-	 * @return whether the state of the election was changed
+	 * Activate the election
+	 * @return true if the election was previously passive
 	 */
 	bool activate ();
 	void stop ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1838,6 +1838,7 @@ void nano::json_handler::confirmation_info ()
 		if (conflict_info != node.active.roots.end ())
 		{
 			auto election (conflict_info->election);
+			response_l.put ("active", election->active);
 			response_l.put ("announcements", std::to_string (election->confirmation_request_count));
 			response_l.put ("voters", std::to_string (election->last_votes.size ()));
 			response_l.put ("last_winner", election->status.winner->hash ().to_string ());
@@ -5103,7 +5104,7 @@ bool block_confirmed (nano::node & node, nano::transaction & transaction, nano::
 	else if (!include_only_confirmed)
 	{
 		auto block (node.store.block_get (transaction, hash));
-		is_confirmed = (block != nullptr && !node.active.active (*block));
+		is_confirmed = (block != nullptr && !node.active.state (*block).exists ());
 	}
 
 	return is_confirmed;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -500,6 +500,7 @@ public:
 				if (active_transaction.active () && active_transaction.current_election_winner)
 				{
 					blocks_bundle.push_back (active_transaction.current_election_winner->hash ());
+					continue;
 				}
 				else if (active_transaction.passive ())
 				{

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -493,21 +493,16 @@ public:
 			{
 				++cached_count;
 				cached_votes.insert (cached_votes.end (), find_votes.begin (), find_votes.end ());
+				blocks_bundle.push_back (root_hash.first);
 			}
-			else
+			else if (auto active_transaction = node.active.state (root_hash.first))
 			{
-				auto active_transaction (node.active.state (root_hash.first));
 				if (active_transaction.active () && active_transaction.current_election_winner)
 				{
 					blocks_bundle.push_back (active_transaction.current_election_winner->hash ());
-					continue;
-				}
-				else if (active_transaction.passive ())
-				{
-					continue;
 				}
 			}
-			if (!find_votes.empty () || (!root_hash.first.is_zero () && node.store.block_exists (transaction, root_hash.first)))
+			else if (!root_hash.first.is_zero () && node.store.block_exists (transaction, root_hash.first))
 			{
 				blocks_bundle.push_back (root_hash.first);
 			}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -558,25 +558,26 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 		if (ledger_block && !block_confirmed_or_being_confirmed (transaction_a, ledger_block->hash ()))
 		{
 			std::weak_ptr<nano::node> this_w (shared_from_this ());
-			if (!active.start (ledger_block, false, [this_w, root](std::shared_ptr<nano::block>) {
-				    if (auto this_l = this_w.lock ())
-				    {
-					    auto attempt (this_l->bootstrap_initiator.current_attempt ());
-					    if (attempt && attempt->mode == nano::bootstrap_mode::legacy)
-					    {
-						    auto transaction (this_l->store.tx_begin_read ());
-						    auto account (this_l->ledger.store.frontier_get (transaction, root));
-						    if (!account.is_zero ())
-						    {
-							    attempt->requeue_pull (nano::pull_info (account, root, root));
-						    }
-						    else if (this_l->ledger.store.account_exists (transaction, root))
-						    {
-							    attempt->requeue_pull (nano::pull_info (root, nano::block_hash (0), nano::block_hash (0)));
-						    }
-					    }
-				    }
-			    }))
+			auto active_transaction (active.start (ledger_block, false, [this_w, root](std::shared_ptr<nano::block>) {
+				if (auto this_l = this_w.lock ())
+				{
+					auto attempt (this_l->bootstrap_initiator.current_attempt ());
+					if (attempt && attempt->mode == nano::bootstrap_mode::legacy)
+					{
+						auto transaction (this_l->store.tx_begin_read ());
+						auto account (this_l->ledger.store.frontier_get (transaction, root));
+						if (!account.is_zero ())
+						{
+							attempt->requeue_pull (nano::pull_info (account, root, root));
+						}
+						else if (this_l->ledger.store.account_exists (transaction, root))
+						{
+							attempt->requeue_pull (nano::pull_info (root, nano::block_hash (0), nano::block_hash (0)));
+						}
+					}
+				}
+			}));
+			if (active_transaction.inserted ())
 			{
 				logger.always_log (boost::str (boost::format ("Resolving fork between our block: %1% and block %2% both with root %3%") % ledger_block->hash ().to_string () % block_a->hash ().to_string () % block_a->root ().to_string ()));
 				network.broadcast_confirm_req (ledger_block);
@@ -1057,12 +1058,15 @@ void nano::node::add_initial_peers ()
 
 void nano::node::block_confirm (std::shared_ptr<nano::block> block_a)
 {
-	active.start (block_a, false);
-	network.broadcast_confirm_req (block_a);
-	// Calculate votes for local representatives
-	if (config.enable_voting && wallets.rep_counts ().voting > 0 && active.active (*block_a))
+	// Existing or new insertion
+	if (active.start (block_a, false).exists ())
 	{
-		block_processor.generator.add (block_a->hash ());
+		network.broadcast_confirm_req (block_a);
+		// Calculate votes for local representatives
+		if (config.enable_voting && wallets.rep_counts ().voting > 0)
+		{
+			block_processor.generator.add (block_a->hash ());
+		}
 	}
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -94,7 +94,8 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("tcp_incoming_connections_max", tcp_incoming_connections_max, "Maximum number of incoming TCP connections.\ntype:uint64");
 	toml.put ("use_memory_pools", use_memory_pools, "If true, allocate memory from memory pools. Enabling this may improve performance. Memory is never released to the OS.\ntype:bool");
 	toml.put ("confirmation_history_size", confirmation_history_size, "Maximum confirmation history size. If tracking the rate of block confirmations, the websocket feature is recommended instead.\ntype:uint64");
-	toml.put ("active_elections_size", active_elections_size, "Number of active elections. Elections beyond this limit have limited survival time.\nWarning: modifying this value may result in a lower confirmation rate.\ntype:uint64,[250..]");
+	toml.put ("active_elections_size", active_elections_size, "Number of active elections. \nWarning: modifying this value may result in a lower confirmation rate.\ntype:uint64,[250..]");
+	toml.put ("passive_elections_size", passive_elections_size, "Number of inactive elections. Together with active_elections_size defines the behavior of the node under saturation.\nWarning: modifying this value may result in a lower confirmation rate.\ntype:uint64,[500..]");
 	toml.put ("bandwidth_limit", bandwidth_limit, "Outbound traffic limit in bytes/sec after which messages will be dropped.\nNote: changing to unlimited bandwidth is not recommended for limited connections.\ntype:uint64");
 	toml.put ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time.count (), "Minimum write batching time when there are blocks pending confirmation height.\ntype:milliseconds");
 	toml.put ("backup_before_upgrade", backup_before_upgrade, "Backup the ledger database before performing upgrades.\nWarning: uses more disk storage and increases startup time when upgrading.\ntype:bool");
@@ -318,6 +319,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get<bool> ("use_memory_pools", use_memory_pools);
 		toml.get<size_t> ("confirmation_history_size", confirmation_history_size);
 		toml.get<size_t> ("active_elections_size", active_elections_size);
+		toml.get<size_t> ("passive_elections_size", passive_elections_size);
 		toml.get<size_t> ("bandwidth_limit", bandwidth_limit);
 		toml.get<bool> ("backup_before_upgrade", backup_before_upgrade);
 
@@ -367,6 +369,10 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		if (active_elections_size <= 250 && !network.is_test_network ())
 		{
 			toml.get_error ().set ("active_elections_size must be greater than 250");
+		}
+		if (passive_elections_size <= 500 && !network.is_test_network ())
+		{
+			toml.get_error ().set ("passive_elections_size must be greater than 500");
 		}
 		if (bandwidth_limit > std::numeric_limits<size_t>::max ())
 		{

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -80,7 +80,8 @@ public:
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_test_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
-	size_t active_elections_size{ 10000 };
+	size_t active_elections_size{ 5000 };
+	size_t passive_elections_size{ 45000 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
 	unsigned tcp_incoming_connections_max{ 1024 };
 	bool use_memory_pools{ true };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -80,8 +80,8 @@ public:
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_test_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
-	size_t active_elections_size{ 5000 };
-	size_t passive_elections_size{ 45000 };
+	size_t active_elections_size{ 2000 };
+	size_t passive_elections_size{ 48000 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
 	unsigned tcp_incoming_connections_max{ 1024 };
 	bool use_memory_pools{ true };

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2495,7 +2495,7 @@ TEST (rpc, pending)
 	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	system.deadline_set (5s);
-	while (system.nodes[0]->active.active (*block1))
+	while (node->active.state (*block1).exists ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -4049,7 +4049,7 @@ TEST (rpc, accounts_pending)
 	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	system.deadline_set (5s);
-	while (system.nodes[0]->active.active (*block1))
+	while (node->active.state (*block1).exists ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -4310,7 +4310,7 @@ TEST (rpc, pending_exists)
 	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	system.deadline_set (5s);
-	while (system.nodes[0]->active.active (*block1))
+	while (node->active.state (*block1).exists ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -4360,7 +4360,7 @@ TEST (rpc, wallet_pending)
 	auto block1 (system0.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
 	auto iterations (0);
 	scoped_io_thread_name_change scoped_thread_name_io;
-	while (system0.nodes[0]->active.active (*block1))
+	while (node->active.state (*block1).exists ())
 	{
 		system0.poll ();
 		++iterations;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -10,6 +10,7 @@
 #include <nano/secure/versioning.hpp>
 
 #include <boost/endian/conversion.hpp>
+#include <boost/optional.hpp>
 #include <boost/polymorphic_cast.hpp>
 
 #include <stack>
@@ -728,7 +729,7 @@ public:
 	virtual nano::store_iterator<nano::account, uint64_t> confirmation_height_begin (nano::transaction const & transaction_a) = 0;
 	virtual nano::store_iterator<nano::account, uint64_t> confirmation_height_end () = 0;
 
-	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	virtual boost::optional<uint64_t> block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 	virtual std::mutex & get_cache_mutex () = 0;
 
 	virtual bool copy_db (boost::filesystem::path const & destination) = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -105,12 +105,11 @@ public:
 	}
 
 	// Converts a block hash to a block height
-	uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
+	boost::optional<uint64_t> block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
 		nano::block_sideband sideband;
 		auto block = block_get (transaction_a, hash_a, &sideband);
-		assert (block != nullptr);
-		return sideband.height;
+		return block != nullptr ? boost::optional<uint64_t> (sideband.height) : boost::optional<uint64_t> (boost::none);
 	}
 
 	std::shared_ptr<nano::block> block_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_sideband * sideband_a = nullptr) const override

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -878,6 +878,7 @@ bool nano::ledger::rollback (nano::write_transaction const & transaction_a, nano
 	assert (store.block_exists (transaction_a, block_a));
 	auto account_l (account (transaction_a, block_a));
 	auto block_account_height (store.block_account_height (transaction_a, block_a));
+	assert (block_account_height.is_initialized ());
 	rollback_visitor rollback (transaction_a, *this, list_a);
 	nano::account_info account_info;
 	auto error (false);
@@ -887,7 +888,7 @@ bool nano::ledger::rollback (nano::write_transaction const & transaction_a, nano
 		auto latest_error = store.confirmation_height_get (transaction_a, account_l, confirmation_height);
 		assert (!latest_error);
 		(void)latest_error;
-		if (block_account_height > confirmation_height)
+		if (*block_account_height > confirmation_height)
 		{
 			latest_error = store.account_get (transaction_a, account_l, account_info);
 			assert (!latest_error);
@@ -1110,7 +1111,7 @@ bool nano::ledger::block_confirmed (nano::transaction const & transaction_a, nan
 {
 	auto confirmed (false);
 	auto block_height (store.block_account_height (transaction_a, hash_a));
-	if (block_height > 0) // 0 indicates that the block doesn't exist
+	if (block_height.is_initialized ())
 	{
 		uint64_t confirmation_height;
 		release_assert (!store.confirmation_height_get (transaction_a, account (transaction_a, hash_a), confirmation_height));


### PR DESCRIPTION
Adds the concept of passive elections, with both local changes to the active_transactions loop and non-breaking rule changes to answering requests for votes.

The goal is to better align the network on the highest priority transactions. One of the current observed issues is a lot of dropped messages under saturation. It is likely that a lot of these messages are blocks that won't be seen by every voting node consistently, resulting in delayed elections. Most changes here affect the behavior of nodes only under saturation.

The PR is split into three parts, described below.

1. Adding the concept of passive elections to active_transactions
    - Instead of dropping elections into a cache (V20 addition), elections are now completely dropped once the `roots` container is full. However, the size of this container is greatly increased (to 50k from 10k, and could likely be larger - tests needed). By default, only 2k elections are active, which the request loop actively goes through and requests confirmations for. The other [up to] 48k elections are passive.
    - Dropped elections can later be confirmed via frontier confirmation, since the dropped cache has been removed for simplicity. Nodes should actively target active difficulty even before pushing a block, or they may see their transactions dropped by representatives. This may need some changes to the node wallet algorithm.
    - Active difficulty is calculated from active elections only. The result would be a higher difficulty than before under saturation. I changed to use the 10th percentile of active difficulties instead of the median, which I think makes more sense here given that we're trying to give users the minimum expected difficulty to have good prioritization. This needs testing.
    - Since there is no random access to the `roots` container, an approximation is made by saving the difficulty of the last active election every loop when under saturation. With this approach, when a new election is started, we know immediately, with the possibility of some error, if the inserted election should be active or passive.
    - I decided against adding a second container of passive roots for 2 reasons: it's faster to sort through a large container than 2 smaller ones (with the same combined size), and it would imply moving memory around.

2. Local actions performed for inserted passive elections
    - The node does not immediately vote for an election inserted as passive. This is the main contributor to hopefully lower overall bandwidth under saturation, thus focusing network resources on the current set of prioritized elections.
    - When an election goes from passive to active, votes are created and pushed via the vote generator for the winner via the vote generator.
    - Since votes for any election (even if passive) are republished, this is only effective network-wise when most nodes are using these changes. While we could have nodes not republish votes for passive elections (this was the case before the second commit here), they would have to be delayed votes to account for timing differences, which creates its own set of problems.

3. Restrictions on replying to vote requests
    - The above changes are a choice of each node, and they cannot be enforced by representatives unless a change is made to how we handle confirm_req. Currently, the following checks are done: 1) votes cache, 2) block exists, 3) root successor exists. This PR adds another case before checking the ledger. If there is an active election containing the hash, then the vote will be for the **election winner**, and if the election is passive, the **request is ignored**. This change forces other nodes to respect the rules laid above. Otherwise, they could bypass them and request confirmation for a low difficulty block.

Finally, there is a change in elections when a new block is the winner - the votes_cache is invalidated and votes are generated for the new winner. This is unrelated but included since changes were made to handling requests.

-----

Notes for reviews:
- The optional return in `block_account_height` is not my favorite approach, but I couldn't think of anything better and easy to use.
- Made a few TSAN runs with no issues and this was run on a stress test on beta. The node does not perform any worse than before, with bandwidth improvements. Once more nodes and especially reps use this PR we may see the other benefits outlined above.

-----

To-do

- [ ] Decide on `active_elections_size` and `passive_elections_size`
- [ ] Decide on percentile for `active_difficulty`
- [ ] Documentation for RPC, stats and active difficulty changes
- [ ] Include "active" state in confirmation callbacks
