### PR TITLE
WIP: Ensure the winner of an election is always in confirmation or confirmed

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -9,18 +9,18 @@ using namespace std::chrono_literals;
 
 TEST (active_transactions, confirm_one)
 {
-	nano::system system;
-	nano::node_config node_config (24000, system.logging);
-	auto & node1 = *system.add_node (node_config);
+	nano::system system (1);
+	auto & node1 = *system.nodes[0];
 	// Send and vote for a block before peering with node2
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::node_config node_config;
 	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node_config.receive_minimum.number ()));
 	system.deadline_set (5s);
 	while (!node1.active.empty () && !node1.block_confirmed_or_being_confirmed (node1.store.tx_begin_read (), send->hash ()))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	node_config.peering_port = 24001;
+	node_config.peering_port = nano::get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 	system.deadline_set (5s);
 	// Let node2 know about the block
@@ -29,17 +29,9 @@ TEST (active_transactions, confirm_one)
 		node1.network.flood_block (send, false);
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	while (!node2.active.empty ())
+	while (node2.ledger.cemented_count < 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-	}
-	ASSERT_EQ (0, node2.active.dropped_elections_cache_size ());
-	nano::unique_lock<std::mutex> active_lock (node2.active.mutex);
-	while (node2.active.confirmed.empty ())
-	{
-		active_lock.unlock ();
-		ASSERT_NO_ERROR (system.poll ());
-		active_lock.lock ();
 	}
 }
 
@@ -77,26 +69,19 @@ TEST (active_transactions, adjusted_difficulty_priority)
 	}
 
 	// Confirm elections
-	while (node1.active.size () != 0)
+	system.deadline_set (10s);
+	while (!node1.active.empty ())
 	{
 		nano::lock_guard<std::mutex> active_guard (node1.active.mutex);
-		auto it (node1.active.roots.begin ());
-		while (!node1.active.roots.empty () && it != node1.active.roots.end ())
+		if (!node1.active.roots.empty ())
 		{
-			auto election (it->election);
-			election->confirm_once ();
-			it = node1.active.roots.begin ();
+			node1.active.roots.begin ()->election->confirm_once ();
 		}
 	}
+	system.deadline_set (10s);
+	while (node1.ledger.cemented_count < 5)
 	{
-		system.deadline_set (10s);
-		nano::unique_lock<std::mutex> active_lock (node1.active.mutex);
-		while (node1.active.confirmed.size () != 4)
-		{
-			active_lock.unlock ();
-			ASSERT_NO_ERROR (system.poll ());
-			active_lock.lock ();
-		}
+		ASSERT_NO_ERROR (system.poll ());
 	}
 
 	//genesis and key1,key2 are opened
@@ -280,11 +265,9 @@ TEST (active_transactions, keep_local)
 	while (!node.active.empty ())
 	{
 		nano::lock_guard<std::mutex> active_guard (node.active.mutex);
-		auto it (node.active.roots.begin ());
-		while (!node.active.roots.empty () && it != node.active.roots.end ())
+		if (!node.active.roots.empty ())
 		{
-			(it->election)->confirm_once ();
-			it = node.active.roots.begin ();
+			node.active.roots.begin ()->election->confirm_once ();
 		}
 	}
 	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, node.config.receive_minimum.number (), send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
@@ -339,18 +322,14 @@ TEST (active_transactions, prioritize_chains)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	while (node1.active.size () != 0)
+	while (!node1.active.empty ())
 	{
 		nano::lock_guard<std::mutex> active_guard (node1.active.mutex);
-		auto it (node1.active.roots.get<1> ().begin ());
-		while (!node1.active.roots.empty () && it != node1.active.roots.get<1> ().end ())
+		if (!node1.active.roots.empty ())
 		{
-			auto election (it->election);
-			election->confirm_once ();
-			it = node1.active.roots.get<1> ().begin ();
+			node1.active.roots.begin ()->election->confirm_once ();
 		}
 	}
-
 	node1.process_active (send2);
 	node1.process_active (send3);
 	node1.process_active (send4);
@@ -388,27 +367,28 @@ TEST (active_transactions, prioritize_chains)
 TEST (active_transactions, inactive_votes_cache)
 {
 	nano::system system (1);
-	nano::block_hash latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node = *system.nodes[0];
+	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key;
 	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
 	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send->hash ())));
-	system.nodes[0]->vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
+	node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	system.deadline_set (5s);
-	while (system.nodes[0]->active.inactive_votes_cache_size () != 1)
+	while (node.active.inactive_votes_cache_size () != 1)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	system.nodes[0]->process_active (send);
-	system.nodes[0]->block_processor.flush ();
+	node.process_active (send);
+	node.block_processor.flush ();
 	bool confirmed (false);
 	system.deadline_set (5s);
 	while (!confirmed)
 	{
-		auto transaction (system.nodes[0]->store.tx_begin_read ());
-		confirmed = system.nodes[0]->ledger.block_confirmed (transaction, send->hash ());
+		auto transaction (node.store.tx_begin_read ());
+		confirmed = node.ledger.block_confirmed (transaction, send->hash ());
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
 TEST (active_transactions, inactive_votes_cache_existing_vote)
@@ -416,47 +396,47 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	auto node = system.add_node (node_config);
-	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+	auto & node = *system.add_node (node_config);
+	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key;
 	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100 * nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
 	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, 100 * nano::Gxrb_ratio, send->hash (), key.prv, key.pub, *system.work.generate (key.pub))); // Increase key weight
-	node->process_active (send);
-	node->block_processor.add (open);
-	node->block_processor.flush ();
+	node.process_active (send);
+	node.block_processor.add (open);
+	node.block_processor.flush ();
 	system.deadline_set (5s);
-	while (node->active.size () != 1)
+	while (node.active.size () != 1)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	std::shared_ptr<nano::election> election;
 	{
-		nano::lock_guard<std::mutex> active_guard (node->active.mutex);
-		auto it (node->active.roots.begin ());
-		ASSERT_NE (node->active.roots.end (), it);
+		nano::lock_guard<std::mutex> active_guard (node.active.mutex);
+		auto it (node.active.roots.begin ());
+		ASSERT_NE (node.active.roots.end (), it);
 		election = it->election;
 	}
-	ASSERT_GT (node->weight (key.pub), node->minimum_principal_weight ());
+	ASSERT_GT (node.weight (key.pub), node.minimum_principal_weight ());
 	// Insert vote
 	auto vote1 (std::make_shared<nano::vote> (key.pub, key.prv, 1, std::vector<nano::block_hash> (1, send->hash ())));
-	node->vote_processor.vote (vote1, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
+	node.vote_processor.vote (vote1, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	system.deadline_set (5s);
 	bool done (false);
 	while (!done)
 	{
-		nano::unique_lock<std::mutex> active_lock (node->active.mutex);
+		nano::unique_lock<std::mutex> active_lock (node.active.mutex);
 		done = (election->last_votes.size () == 2);
 		active_lock.unlock ();
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::election, nano::stat::detail::vote_new));
-	nano::lock_guard<std::mutex> active_guard (node->active.mutex);
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_new));
+	nano::lock_guard<std::mutex> active_guard (node.active.mutex);
 	auto last_vote1 (election->last_votes[key.pub]);
 	ASSERT_EQ (send->hash (), last_vote1.hash);
 	ASSERT_EQ (1, last_vote1.sequence);
 	// Attempt to change vote with inactive_votes_cache
-	node->active.add_inactive_votes_cache (send->hash (), key.pub);
-	ASSERT_EQ (1, node->active.find_inactive_votes_cache (send->hash ()).voters.size ());
+	node.active.add_inactive_votes_cache (send->hash (), key.pub);
+	ASSERT_EQ (1, node.active.find_inactive_votes_cache (send->hash ()).voters.size ());
 	election->insert_inactive_votes_cache ();
 	// Check that election data is not changed
 	ASSERT_EQ (2, election->last_votes.size ());
@@ -464,7 +444,7 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	ASSERT_EQ (last_vote1.hash, last_vote2.hash);
 	ASSERT_EQ (last_vote1.sequence, last_vote2.sequence);
 	ASSERT_EQ (last_vote1.time, last_vote2.time);
-	ASSERT_EQ (0, system.nodes[0]->stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
 TEST (active_transactions, inactive_votes_cache_multiple_votes)
@@ -472,43 +452,43 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	auto node = system.add_node (node_config);
-	nano::block_hash latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	auto & node = *system.add_node (node_config);
+	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - 100 * nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
 	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 100 * nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ()))); // Decrease genesis weight to prevent election confirmation
 	auto open (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 100 * nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub))); // Increase key1 weight
-	node->block_processor.add (send1);
-	node->block_processor.add (send2);
-	node->block_processor.add (open);
-	node->block_processor.flush ();
+	node.block_processor.add (send1);
+	node.block_processor.add (send2);
+	node.block_processor.add (open);
+	node.block_processor.flush ();
 	// Process votes
 	auto vote1 (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
-	system.nodes[0]->vote_processor.vote (vote1, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
+	node.vote_processor.vote (vote1, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
-	system.nodes[0]->vote_processor.vote (vote2, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
+	node.vote_processor.vote (vote2, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	system.deadline_set (5s);
 	while (true)
 	{
 		{
-			nano::lock_guard<std::mutex> active_guard (system.nodes[0]->active.mutex);
-			if (system.nodes[0]->active.find_inactive_votes_cache (send1->hash ()).voters.size () == 2)
+			nano::lock_guard<std::mutex> active_guard (node.active.mutex);
+			if (node.active.find_inactive_votes_cache (send1->hash ()).voters.size () == 2)
 			{
 				break;
 			}
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (1, system.nodes[0]->active.inactive_votes_cache_size ());
+	ASSERT_EQ (1, node.active.inactive_votes_cache_size ());
 	// Start election
-	system.nodes[0]->active.start (send1);
+	node.active.start (send1);
 	{
-		nano::lock_guard<std::mutex> active_guard (system.nodes[0]->active.mutex);
-		auto it (system.nodes[0]->active.roots.begin ());
-		ASSERT_NE (system.nodes[0]->active.roots.end (), it);
+		nano::lock_guard<std::mutex> active_guard (node.active.mutex);
+		auto it (node.active.roots.begin ());
+		ASSERT_NE (node.active.roots.end (), it);
 		ASSERT_EQ (3, it->election->last_votes.size ()); // 2 votes and 1 default not_an_acount
 	}
-	ASSERT_EQ (2, system.nodes[0]->stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
+	ASSERT_EQ (2, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
 TEST (active_transactions, update_difficulty)
@@ -646,5 +626,34 @@ TEST (active_transactions, restart_dropped)
 	{
 		auto block (node.store.block_get (node.store.tx_begin_read (), send1->hash ()));
 		ASSERT_EQ (work2, block->block_work ());
+	}
+}
+
+// Blocks that won an election must always be seen as confirming or cemented
+TEST (active_transactions, confirmation_consistency)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto & node = *system.add_node (node_config);
+	nano::genesis genesis;
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	for (unsigned i = 0; i < 10; ++i)
+	{
+		auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node.config.receive_minimum.number ()));
+		ASSERT_NE (nullptr, block);
+		system.deadline_set (3s);
+		ASSERT_FALSE (node.active.empty ());
+		while (!node.active.empty ())
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		auto transaction (node.store.tx_begin_read ());
+		while (node.block_confirmed_or_being_confirmed (transaction, block->hash ()))
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		// If the block is no longer confirming then it must be cemented
+		ASSERT_TRUE (node.ledger.block_confirmed (node.store.tx_begin_read (), block->hash ()));
 	}
 }

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -757,22 +757,15 @@ TEST (confirmation_height, pending_observer_callbacks)
 			break;
 		}
 	}
-	// Can have timing issues.
 	node->confirmation_height_processor.add (send.hash ());
+	system.deadline_set (5s);
+	while (node->ledger.cemented_count < 3)
 	{
-		nano::unique_lock<std::mutex> lk (node->pending_confirmation_height.mutex);
-		while (!node->pending_confirmation_height.current_hash.is_zero ())
-		{
-			lk.unlock ();
-			std::this_thread::yield ();
-			lk.lock ();
-		}
+		ASSERT_NO_ERROR (system.poll ());
 	}
-
 	// Confirm the callback is not called under this circumstance
 	ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 	ASSERT_EQ (0, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out));
-	ASSERT_EQ (3, node->ledger.cemented_count);
 }
 
 TEST (confirmation_height, prioritize_frontiers)

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -117,6 +117,7 @@ public:
 	void stop ();
 	bool publish (std::shared_ptr<nano::block> block_a);
 	boost::optional<nano::election_status_type> confirm_block (nano::transaction const &, std::shared_ptr<nano::block>);
+	bool is_pending_confirmation (nano::block_hash const &);
 	void post_confirmation_height_set (nano::transaction const & transaction_a, std::shared_ptr<nano::block> block_a, nano::block_sideband const & sideband_a, nano::election_status_type election_status_type_a);
 	// clang-format off
 	boost::multi_index_container<nano::conflict_info,

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -28,6 +28,7 @@ public:
 private:
 	std::mutex mutex;
 	std::unordered_set<nano::block_hash> pending;
+	std::unordered_set<nano::block_hash> writing;
 	/** This is the last block popped off the confirmation height pending collection */
 	nano::block_hash current_hash{ 0 };
 	friend class confirmation_height_processor;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -45,6 +45,10 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 		status.block_count = blocks.size ();
 		status.voter_count = last_votes.size ();
 		status.type = type_a;
+		node.active.pending_conf_height.emplace (status.winner->hash (), shared_from_this ());
+		clear_blocks ();
+		clear_dependent ();
+		node.active.roots.erase (status.winner->qualified_root ());
 		auto status_l (status);
 		auto node_l (node.shared ());
 		auto confirmation_action_l (confirmation_action);
@@ -52,11 +56,6 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 			node_l->process_confirmed (status_l);
 			confirmation_action_l (status_l.winner);
 		});
-		auto root (status.winner->qualified_root ());
-		node.active.pending_conf_height.emplace (status.winner->hash (), shared_from_this ());
-		clear_blocks ();
-		clear_dependent ();
-		node.active.roots.erase (root);
 	}
 }
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2923,7 +2923,7 @@ void nano::json_handler::pending ()
 	{
 		boost::property_tree::ptree peers_l;
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.pending_begin (transaction, nano::pending_key (account, 0))); nano::pending_key (i->first).account == account && peers_l.size () < count; ++i)
+		for (auto i (node.store.pending_begin (transaction, nano::pending_key (account, 0))), n (node.store.pending_begin (transaction, nano::pending_key (account.number () + 1, 0))); i != n && peers_l.size () < count; ++i)
 		{
 			nano::pending_key const & key (i->first);
 			if (block_confirmed (node, transaction, key.hash, include_active, include_only_confirmed))

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -136,6 +136,7 @@ public:
 	void add_initial_peers ();
 	void block_confirm (std::shared_ptr<nano::block>);
 	bool block_confirmed_or_being_confirmed (nano::transaction const &, nano::block_hash const &);
+	bool block_being_confirmed (nano::block_hash const &);
 	void process_fork (nano::transaction const &, std::shared_ptr<nano::block>);
 	bool validate_block_by_previous (nano::transaction const &, std::shared_ptr<nano::block>);
 	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string>, std::shared_ptr<std::string>, std::shared_ptr<boost::asio::ip::tcp::resolver>);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1268,7 +1268,7 @@ bool nano::wallet::search_pending ()
 					{
 						wallets.node.logger.try_log (boost::str (boost::format ("Found a pending block %1% for account %2%") % hash.to_string () % pending.source.to_account ()));
 						auto block (wallets.node.store.block_get (block_transaction, hash));
-						if (wallets.node.ledger.block_confirmed (block_transaction, hash))
+						if (wallets.node.block_confirmed_or_being_confirmed (block_transaction, hash))
 						{
 							// Receive confirmed block
 							auto node_l (wallets.node.shared ());

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2495,7 +2495,7 @@ TEST (rpc, pending)
 	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	system.deadline_set (5s);
-	while (system.nodes[0]->active.active (*block1))
+	while (node->active.active (*block1))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -6065,7 +6065,7 @@ TEST (rpc, confirmation_height_currently_processing)
 	rpc.start ();
 
 	system.deadline_set (10s);
-	while (!node->pending_confirmation_height.is_processing_block (previous_genesis_chain_hash))
+	while (!node->block_being_confirmed (previous_genesis_chain_hash))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -6910,7 +6910,7 @@ TEST (rpc, block_confirmed)
 	}
 
 	// Should no longer be processing the block after confirmation is set
-	ASSERT_FALSE (node->pending_confirmation_height.is_processing_block (send->hash ()));
+	ASSERT_FALSE (node->block_being_confirmed (send->hash ()));
 
 	// Requesting confirmation for this should now succeed
 	request.put ("hash", send->hash ().to_string ());


### PR DESCRIPTION
Currently, a second election may be started for a confirming block, which is not intended but also not critical. This adds two checks to be sure of the block confirmation state of a block originating from an election (most cases by far after bootstrapping):
- The block is not being committed to the ledger ( `writing` in confirmation height processor )
- The election has finished but the block not yet queued to the confirmation height processor (seems to be usually due to a rollback, otherwise would not have to be done in the background - @SergiySW  ?)

Also cleans up active_transactions tests and, unrelated, RPC pending loop non-functional change, only because this issue was discovered through that RPC.

An intermittent failure in confirmation_height.pending_observer_callbacks is fixed by waiting for cementing.