### PR TITLE
Some code cleanup

### DIFF
--- a/nano/core_test/locks.cpp
+++ b/nano/core_test/locks.cpp
@@ -42,6 +42,9 @@ TEST (locks, no_conflicts)
 
 TEST (locks, lock_guard)
 {
+	// This test can end up taking a long time, as it sleeps for the NANO_TIMED_LOCKS amount
+	ASSERT_LE (NANO_TIMED_LOCKS, 10000);
+
 	std::stringstream ss;
 	nano::cout_redirect redirect (ss.rdbuf ());
 
@@ -72,6 +75,9 @@ TEST (locks, lock_guard)
 
 TEST (locks, unique_lock)
 {
+	// This test can end up taking a long time, as it sleeps for the NANO_TIMED_LOCKS amount
+	ASSERT_LE (NANO_TIMED_LOCKS, 10000);
+
 	std::stringstream ss;
 	nano::cout_redirect redirect (ss.rdbuf ());
 

--- a/nano/lib/alarm.cpp
+++ b/nano/lib/alarm.cpp
@@ -64,18 +64,15 @@ void nano::alarm::add (std::chrono::steady_clock::time_point const & wakeup_a, s
 	condition.notify_all ();
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (alarm & alarm, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (alarm & alarm, const std::string & name)
-{
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	size_t count = 0;
+	size_t count;
 	{
 		nano::lock_guard<std::mutex> guard (alarm.mutex);
 		count = alarm.operations.size ();
 	}
 	auto sizeof_element = sizeof (decltype (alarm.operations)::value_type);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "operations", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "operations", count, sizeof_element }));
 	return composite;
-}
 }

--- a/nano/lib/alarm.hpp
+++ b/nano/lib/alarm.hpp
@@ -42,6 +42,6 @@ public:
 	std::priority_queue<operation, std::vector<operation>, std::greater<operation>> operations;
 	std::thread thread;
 };
-class seq_con_info_component;
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (alarm & alarm, const std::string & name);
+class container_info_component;
+std::unique_ptr<container_info_component> collect_container_info (alarm & alarm, const std::string & name);
 }

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1619,14 +1619,11 @@ size_t nano::block_uniquer::size ()
 	return blocks.size ();
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_uniquer & block_uniquer, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_uniquer & block_uniquer, const std::string & name)
 {
 	auto count = block_uniquer.size ();
 	auto sizeof_element = sizeof (block_uniquer::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", count, sizeof_element }));
 	return composite;
-}
 }

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -357,7 +357,7 @@ private:
 	static unsigned constexpr cleanup_count = 2;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_uniquer & block_uniquer, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (block_uniquer & block_uniquer, const std::string & name);
 
 std::shared_ptr<nano::block> deserialize_block (nano::stream &);
 std::shared_ptr<nano::block> deserialize_block (nano::stream &, nano::block_type, nano::block_uniquer * = nullptr);

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -19,19 +19,19 @@ namespace filesystem
 /**
 * Returns build version information
 */
-static const char * NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
+const char * const NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
 
-static const char * BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
+const char * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
 
 /** Is TSAN/ASAN test build */
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
-static const bool is_sanitizer_build = true;
+const bool is_sanitizer_build = true;
 #else
-static const bool is_sanitizer_build = false;
+const bool is_sanitizer_build = false;
 #endif
 #else
-static const bool is_sanitizer_build = false;
+const bool is_sanitizer_build = false;
 #endif
 
 namespace nano

--- a/nano/lib/rep_weights.cpp
+++ b/nano/lib/rep_weights.cpp
@@ -54,16 +54,16 @@ nano::uint128_t nano::rep_weights::get (nano::account const & account_a)
 	}
 }
 
-std::unique_ptr<nano::seq_con_info_component> nano::collect_seq_con_info (nano::rep_weights & rep_weights, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::rep_weights & rep_weights, const std::string & name)
 {
-	size_t rep_amounts_count = 0;
+	size_t rep_amounts_count;
 
 	{
 		nano::lock_guard<std::mutex> guard (rep_weights.mutex);
 		rep_amounts_count = rep_weights.rep_amounts.size ();
 	}
 	auto sizeof_element = sizeof (decltype (rep_weights.rep_amounts)::value_type);
-	auto composite = std::make_unique<nano::seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<nano::seq_con_info_leaf> (seq_con_info{ "rep_amounts", rep_amounts_count, sizeof_element }));
+	auto composite = std::make_unique<nano::container_info_composite> (name);
+	composite->add_component (std::make_unique<nano::container_info_leaf> (container_info{ "rep_amounts", rep_amounts_count, sizeof_element }));
 	return composite;
 }

--- a/nano/lib/rep_weights.hpp
+++ b/nano/lib/rep_weights.hpp
@@ -26,8 +26,8 @@ private:
 	void put (nano::account const & account_a, nano::uint128_union const & representation_a);
 	nano::uint128_t get (nano::account const & account_a);
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_weights &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (rep_weights &, const std::string &);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_weights &, const std::string &);
+std::unique_ptr<container_info_component> collect_container_info (rep_weights &, const std::string &);
 }

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -2,104 +2,97 @@
 
 #include <iostream>
 
-namespace nano
+namespace
 {
-namespace thread_role
+thread_local nano::thread_role::name current_thread_role = nano::thread_role::name::unknown;
+}
+
+nano::thread_role::name nano::thread_role::get ()
 {
-	/*
-	 * nano::thread_role namespace
-	 *
-	 * Manage thread role
-	 */
-	static thread_local nano::thread_role::name current_thread_role = nano::thread_role::name::unknown;
-	nano::thread_role::name get ()
+	return current_thread_role;
+}
+
+std::string nano::thread_role::get_string (nano::thread_role::name role)
+{
+	std::string thread_role_name_string;
+
+	switch (role)
 	{
-		return current_thread_role;
+		case nano::thread_role::name::unknown:
+			thread_role_name_string = "<unknown>";
+			break;
+		case nano::thread_role::name::io:
+			thread_role_name_string = "I/O";
+			break;
+		case nano::thread_role::name::work:
+			thread_role_name_string = "Work pool";
+			break;
+		case nano::thread_role::name::packet_processing:
+			thread_role_name_string = "Pkt processing";
+			break;
+		case nano::thread_role::name::alarm:
+			thread_role_name_string = "Alarm";
+			break;
+		case nano::thread_role::name::vote_processing:
+			thread_role_name_string = "Vote processing";
+			break;
+		case nano::thread_role::name::block_processing:
+			thread_role_name_string = "Blck processing";
+			break;
+		case nano::thread_role::name::request_loop:
+			thread_role_name_string = "Request loop";
+			break;
+		case nano::thread_role::name::wallet_actions:
+			thread_role_name_string = "Wallet actions";
+			break;
+		case nano::thread_role::name::work_watcher:
+			thread_role_name_string = "Work watcher";
+			break;
+		case nano::thread_role::name::bootstrap_initiator:
+			thread_role_name_string = "Bootstrap init";
+			break;
+		case nano::thread_role::name::voting:
+			thread_role_name_string = "Voting";
+			break;
+		case nano::thread_role::name::signature_checking:
+			thread_role_name_string = "Signature check";
+			break;
+		case nano::thread_role::name::rpc_request_processor:
+			thread_role_name_string = "RPC processor";
+			break;
+		case nano::thread_role::name::rpc_process_container:
+			thread_role_name_string = "RPC process";
+			break;
+		case nano::thread_role::name::confirmation_height_processing:
+			thread_role_name_string = "Conf height";
+			break;
+		case nano::thread_role::name::worker:
+			thread_role_name_string = "Worker";
+			break;
 	}
 
-	std::string get_string (nano::thread_role::name role)
-	{
-		std::string thread_role_name_string;
-
-		switch (role)
-		{
-			case nano::thread_role::name::unknown:
-				thread_role_name_string = "<unknown>";
-				break;
-			case nano::thread_role::name::io:
-				thread_role_name_string = "I/O";
-				break;
-			case nano::thread_role::name::work:
-				thread_role_name_string = "Work pool";
-				break;
-			case nano::thread_role::name::packet_processing:
-				thread_role_name_string = "Pkt processing";
-				break;
-			case nano::thread_role::name::alarm:
-				thread_role_name_string = "Alarm";
-				break;
-			case nano::thread_role::name::vote_processing:
-				thread_role_name_string = "Vote processing";
-				break;
-			case nano::thread_role::name::block_processing:
-				thread_role_name_string = "Blck processing";
-				break;
-			case nano::thread_role::name::request_loop:
-				thread_role_name_string = "Request loop";
-				break;
-			case nano::thread_role::name::wallet_actions:
-				thread_role_name_string = "Wallet actions";
-				break;
-			case nano::thread_role::name::work_watcher:
-				thread_role_name_string = "Work watcher";
-				break;
-			case nano::thread_role::name::bootstrap_initiator:
-				thread_role_name_string = "Bootstrap init";
-				break;
-			case nano::thread_role::name::voting:
-				thread_role_name_string = "Voting";
-				break;
-			case nano::thread_role::name::signature_checking:
-				thread_role_name_string = "Signature check";
-				break;
-			case nano::thread_role::name::rpc_request_processor:
-				thread_role_name_string = "RPC processor";
-				break;
-			case nano::thread_role::name::rpc_process_container:
-				thread_role_name_string = "RPC process";
-				break;
-			case nano::thread_role::name::confirmation_height_processing:
-				thread_role_name_string = "Conf height";
-				break;
-			case nano::thread_role::name::worker:
-				thread_role_name_string = "Worker";
-				break;
-		}
-
-		/*
+	/*
 		 * We want to constrain the thread names to 15
 		 * characters, since this is the smallest maximum
 		 * length supported by the platforms we support
 		 * (specifically, Linux)
 		 */
-		assert (thread_role_name_string.size () < 16);
-		return (thread_role_name_string);
-	}
-
-	std::string get_string ()
-	{
-		return get_string (current_thread_role);
-	}
-
-	void set (nano::thread_role::name role)
-	{
-		auto thread_role_name_string (get_string (role));
-
-		nano::thread_role::set_os_name (thread_role_name_string);
-
-		nano::thread_role::current_thread_role = role;
-	}
+	assert (thread_role_name_string.size () < 16);
+	return (thread_role_name_string);
 }
+
+std::string nano::thread_role::get_string ()
+{
+	return get_string (current_thread_role);
+}
+
+void nano::thread_role::set (nano::thread_role::name role)
+{
+	auto thread_role_name_string (get_string (role));
+
+	nano::thread_role::set_os_name (thread_role_name_string);
+
+	current_thread_role = role;
 }
 
 void nano::thread_attributes::set (boost::thread::attributes & attrs)

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -27,60 +27,57 @@
 #endif
 #endif
 
-namespace nano
-{
-seq_con_info_composite::seq_con_info_composite (const std::string & name) :
+nano::container_info_composite::container_info_composite (const std::string & name) :
 name (name)
 {
 }
 
-bool seq_con_info_composite::is_composite () const
+bool nano::container_info_composite::is_composite () const
 {
 	return true;
 }
 
-void seq_con_info_composite::add_component (std::unique_ptr<seq_con_info_component> child)
+void nano::container_info_composite::add_component (std::unique_ptr<container_info_component> child)
 {
 	children.push_back (std::move (child));
 }
 
-const std::vector<std::unique_ptr<seq_con_info_component>> & seq_con_info_composite::get_children () const
+const std::vector<std::unique_ptr<nano::container_info_component>> & nano::container_info_composite::get_children () const
 {
 	return children;
 }
 
-const std::string & seq_con_info_composite::get_name () const
+const std::string & nano::container_info_composite::get_name () const
 {
 	return name;
 }
 
-seq_con_info_leaf::seq_con_info_leaf (const seq_con_info & info) :
+nano::container_info_leaf::container_info_leaf (const container_info & info) :
 info (info)
 {
 }
 
-bool seq_con_info_leaf::is_composite () const
+bool nano::container_info_leaf::is_composite () const
 {
 	return false;
 }
 
-const seq_con_info & seq_con_info_leaf::get_info () const
+const nano::container_info & nano::container_info_leaf::get_info () const
 {
 	return info;
 }
 
-void dump_crash_stacktrace ()
+void nano::dump_crash_stacktrace ()
 {
 	boost::stacktrace::safe_dump_to ("nano_node_backtrace.dump");
 }
 
-std::string generate_stacktrace ()
+std::string nano::generate_stacktrace ()
 {
 	auto stacktrace = boost::stacktrace::stacktrace ();
 	std::stringstream ss;
 	ss << stacktrace;
 	return ss.str ();
-}
 }
 
 void nano::remove_all_files_in_dir (boost::filesystem::path const & dir)

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -25,43 +25,43 @@ namespace nano
  * It makes use of the composite design pattern to collect information
  * from sequence containers and sequence containers inside member variables.
  */
-struct seq_con_info
+struct container_info
 {
 	std::string name;
 	size_t count;
 	size_t sizeof_element;
 };
 
-class seq_con_info_component
+class container_info_component
 {
 public:
-	virtual ~seq_con_info_component () = default;
+	virtual ~container_info_component () = default;
 	virtual bool is_composite () const = 0;
 };
 
-class seq_con_info_composite : public seq_con_info_component
+class container_info_composite : public container_info_component
 {
 public:
-	seq_con_info_composite (const std::string & name);
+	container_info_composite (const std::string & name);
 	bool is_composite () const override;
-	void add_component (std::unique_ptr<seq_con_info_component> child);
-	const std::vector<std::unique_ptr<seq_con_info_component>> & get_children () const;
+	void add_component (std::unique_ptr<container_info_component> child);
+	const std::vector<std::unique_ptr<container_info_component>> & get_children () const;
 	const std::string & get_name () const;
 
 private:
 	std::string name;
-	std::vector<std::unique_ptr<seq_con_info_component>> children;
+	std::vector<std::unique_ptr<container_info_component>> children;
 };
 
-class seq_con_info_leaf : public seq_con_info_component
+class container_info_leaf : public container_info_component
 {
 public:
-	seq_con_info_leaf (const seq_con_info & info);
+	container_info_leaf (container_info const & info);
 	bool is_composite () const override;
-	const seq_con_info & get_info () const;
+	const container_info & get_info () const;
 
 private:
-	seq_con_info info;
+	container_info info;
 };
 
 // Lower priority of calling work generating thread
@@ -131,7 +131,7 @@ public:
 };
 
 template <typename... T>
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (observer_set<T...> & observer_set, const std::string & name)
+std::unique_ptr<container_info_component> collect_container_info (observer_set<T...> & observer_set, const std::string & name)
 {
 	size_t count = 0;
 	{
@@ -140,8 +140,8 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (observer_set<T...>
 	}
 
 	auto sizeof_element = sizeof (typename decltype (observer_set.observers)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "observers", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "observers", count, sizeof_element }));
 	return composite;
 }
 

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -243,20 +243,16 @@ size_t nano::work_pool::size ()
 	return pending.size ();
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (work_pool & work_pool, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (work_pool & work_pool, const std::string & name)
-{
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-
-	size_t count = 0;
+	size_t count;
 	{
 		nano::lock_guard<std::mutex> guard (work_pool.mutex);
 		count = work_pool.pending.size ();
 	}
 	auto sizeof_element = sizeof (decltype (work_pool.pending)::value_type);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "pending", count, sizeof_element }));
-	composite->add_component (collect_seq_con_info (work_pool.work_observers, "work_observers"));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending", count, sizeof_element }));
+	composite->add_component (collect_container_info (work_pool.work_observers, "work_observers"));
 	return composite;
-}
 }

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -56,5 +56,5 @@ public:
 	nano::observer_set<bool> work_observers;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (work_pool & work_pool, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (work_pool & work_pool, const std::string & name);
 }

--- a/nano/lib/worker.cpp
+++ b/nano/lib/worker.cpp
@@ -64,16 +64,15 @@ void nano::worker::stop ()
 	}
 }
 
-std::unique_ptr<nano::seq_con_info_component> nano::collect_seq_con_info (nano::worker & worker, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::worker & worker, const std::string & name)
 {
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-
-	size_t count = 0;
+	size_t count;
 	{
 		nano::lock_guard<std::mutex> guard (worker.mutex);
 		count = worker.queue.size ();
 	}
 	auto sizeof_element = sizeof (decltype (worker.queue)::value_type);
-	composite->add_component (std::make_unique<nano::seq_con_info_leaf> (nano::seq_con_info{ "queue", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<nano::container_info_leaf> (nano::container_info{ "queue", count, sizeof_element }));
 	return composite;
 }

--- a/nano/lib/worker.hpp
+++ b/nano/lib/worker.hpp
@@ -26,8 +26,8 @@ private:
 	bool stopped{ false };
 	std::thread thread;
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (worker &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (worker &, const std::string &);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (worker & worker, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (worker & worker, const std::string & name);
 }

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1161,14 +1161,12 @@ account (account_a), blocks_uncemented (blocks_uncemented_a)
 {
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (active_transactions & active_transactions, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transactions & active_transactions, const std::string & name)
-{
-	size_t roots_count = 0;
-	size_t blocks_count = 0;
-	size_t confirmed_count = 0;
-	size_t pending_conf_height_count = 0;
+	size_t roots_count;
+	size_t blocks_count;
+	size_t confirmed_count;
+	size_t pending_conf_height_count;
 
 	{
 		nano::lock_guard<std::mutex> guard (active_transactions.mutex);
@@ -1178,15 +1176,14 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transaction
 		pending_conf_height_count = active_transactions.pending_conf_height.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "roots", roots_count, sizeof (decltype (active_transactions.roots)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", blocks_count, sizeof (decltype (active_transactions.blocks)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "pending_conf_height", pending_conf_height_count, sizeof (decltype (active_transactions.pending_conf_height)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "confirmed", confirmed_count, sizeof (decltype (active_transactions.confirmed)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "priority_wallet_cementable_frontiers_count", active_transactions.priority_wallet_cementable_frontiers_size (), sizeof (nano::cementable_account) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "priority_cementable_frontiers_count", active_transactions.priority_cementable_frontiers_size (), sizeof (nano::cementable_account) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "inactive_votes_cache_count", active_transactions.inactive_votes_cache_size (), sizeof (nano::gap_information) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "dropped_elections_count", active_transactions.dropped_elections_cache_size (), sizeof (nano::election_timepoint) }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "roots", roots_count, sizeof (decltype (active_transactions.roots)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", blocks_count, sizeof (decltype (active_transactions.blocks)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending_conf_height", pending_conf_height_count, sizeof (decltype (active_transactions.pending_conf_height)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "confirmed", confirmed_count, sizeof (decltype (active_transactions.confirmed)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "priority_wallet_cementable_frontiers_count", active_transactions.priority_wallet_cementable_frontiers_size (), sizeof (nano::cementable_account) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "priority_cementable_frontiers_count", active_transactions.priority_cementable_frontiers_size (), sizeof (nano::cementable_account) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "inactive_votes_cache_count", active_transactions.inactive_votes_cache_size (), sizeof (nano::gap_information) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "dropped_elections_count", active_transactions.dropped_elections_cache_size (), sizeof (nano::election_timepoint) }));
 	return composite;
-}
 }

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -220,5 +220,5 @@ private:
 	friend class confirmation_height_long_chains_Test;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (active_transactions & active_transactions, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (active_transactions & active_transactions, const std::string & name);
 }

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -79,6 +79,6 @@ private:
 	nano::write_database_queue & write_database_queue;
 	std::mutex mutex;
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (block_processor & block_processor, const std::string & name);
 };
 }

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -1500,13 +1500,11 @@ void nano::bootstrap_initiator::notify_listeners (bool in_progress_a)
 	}
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (bootstrap_initiator & bootstrap_initiator, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiator & bootstrap_initiator, const std::string & name)
-{
-	size_t count = 0;
-	size_t cache_count = 0;
-	size_t excluded_peers_count = 0;
+	size_t count;
+	size_t cache_count;
+	size_t excluded_peers_count;
 	{
 		nano::lock_guard<std::mutex> guard (bootstrap_initiator.observers_mutex);
 		count = bootstrap_initiator.observers.size ();
@@ -1523,12 +1521,11 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiato
 	auto sizeof_element = sizeof (decltype (bootstrap_initiator.observers)::value_type);
 	auto sizeof_cache_element = sizeof (decltype (bootstrap_initiator.cache.cache)::value_type);
 	auto sizeof_excluded_peers_element = sizeof (decltype (bootstrap_initiator.excluded_peers.peers)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "observers", count, sizeof_element }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "pulls_cache", cache_count, sizeof_cache_element }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "excluded_peers", excluded_peers_count, sizeof_excluded_peers_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "observers", count, sizeof_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pulls_cache", cache_count, sizeof_cache_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "excluded_peers", excluded_peers_count, sizeof_excluded_peers_element }));
 	return composite;
-}
 }
 
 void nano::pulls_cache::add (nano::pull_info const & pull_a)

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -271,10 +271,10 @@ private:
 	std::vector<std::function<void(bool)>> observers;
 	boost::thread thread;
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiator & bootstrap_initiator, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (bootstrap_initiator & bootstrap_initiator, const std::string & name);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_initiator & bootstrap_initiator, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (bootstrap_initiator & bootstrap_initiator, const std::string & name);
 class bootstrap_limits final
 {
 public:

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -73,15 +73,12 @@ boost::asio::ip::tcp::endpoint nano::bootstrap_listener::endpoint ()
 	return boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), listening_socket->listening_port ());
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_listener & bootstrap_listener, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (bootstrap_listener & bootstrap_listener, const std::string & name)
 {
 	auto sizeof_element = sizeof (decltype (bootstrap_listener.connections)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "connections", bootstrap_listener.connection_count (), sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "connections", bootstrap_listener.connection_count (), sizeof_element }));
 	return composite;
-}
 }
 
 nano::bootstrap_server::bootstrap_server (std::shared_ptr<nano::socket> socket_a, std::shared_ptr<nano::node> node_a) :

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -31,7 +31,7 @@ private:
 	uint16_t port;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (bootstrap_listener & bootstrap_listener, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (bootstrap_listener & bootstrap_listener, const std::string & name);
 
 class message;
 enum class bootstrap_server_type

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -431,9 +431,7 @@ void nano::confirmation_height_processor::collect_unconfirmed_receive_and_source
 	}
 }
 
-namespace nano
-{
-confirmation_height_processor::conf_height_details::conf_height_details (nano::account const & account_a, nano::block_hash const & hash_a, uint64_t height_a, uint64_t num_blocks_confirmed_a, std::vector<callback_data> const & block_callbacks_required_a) :
+nano::confirmation_height_processor::conf_height_details::conf_height_details (nano::account const & account_a, nano::block_hash const & hash_a, uint64_t height_a, uint64_t num_blocks_confirmed_a, std::vector<callback_data> const & block_callbacks_required_a) :
 account (account_a),
 hash (hash_a),
 height (height_a),
@@ -442,31 +440,30 @@ block_callbacks_required (block_callbacks_required_a)
 {
 }
 
-confirmation_height_processor::receive_source_pair::receive_source_pair (confirmation_height_processor::conf_height_details const & receive_details_a, const block_hash & source_a) :
+nano::confirmation_height_processor::receive_source_pair::receive_source_pair (confirmation_height_processor::conf_height_details const & receive_details_a, const block_hash & source_a) :
 receive_details (receive_details_a),
 source_hash (source_a)
 {
 }
 
-confirmation_height_processor::confirmed_iterated_pair::confirmed_iterated_pair (uint64_t confirmed_height_a, uint64_t iterated_height_a) :
+nano::confirmation_height_processor::confirmed_iterated_pair::confirmed_iterated_pair (uint64_t confirmed_height_a, uint64_t iterated_height_a) :
 confirmed_height (confirmed_height_a), iterated_height (iterated_height_a)
 {
 }
 
-confirmation_height_processor::callback_data::callback_data (std::shared_ptr<nano::block> const & block_a, nano::block_sideband const & sideband_a, nano::election_status_type election_status_type_a) :
+nano::confirmation_height_processor::callback_data::callback_data (std::shared_ptr<nano::block> const & block_a, nano::block_sideband const & sideband_a, nano::election_status_type election_status_type_a) :
 block (block_a),
 sideband (sideband_a),
 election_status_type (election_status_type_a)
 {
 }
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (confirmation_height_processor & confirmation_height_processor_a, const std::string & name_a)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (confirmation_height_processor & confirmation_height_processor_a, const std::string & name_a)
 {
 	size_t receive_source_pairs_count = confirmation_height_processor_a.receive_source_pairs_size;
-	auto composite = std::make_unique<seq_con_info_composite> (name_a);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "receive_source_pairs", receive_source_pairs_count, sizeof (decltype (confirmation_height_processor_a.receive_source_pairs)::value_type) }));
+	auto composite = std::make_unique<container_info_composite> (name_a);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "receive_source_pairs", receive_source_pairs_count, sizeof (decltype (confirmation_height_processor_a.receive_source_pairs)::value_type) }));
 	return composite;
-}
 }
 
 size_t nano::pending_confirmation_height::size ()
@@ -494,13 +491,10 @@ nano::block_hash nano::pending_confirmation_height::current ()
 	return current_hash;
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (pending_confirmation_height & pending_confirmation_height_a, const std::string & name_a)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (pending_confirmation_height & pending_confirmation_height_a, const std::string & name_a)
 {
 	size_t pending_count = pending_confirmation_height_a.size ();
-	auto composite = std::make_unique<seq_con_info_composite> (name_a);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "pending", pending_count, sizeof (nano::block_hash) }));
+	auto composite = std::make_unique<container_info_composite> (name_a);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending", pending_count, sizeof (nano::block_hash) }));
 	return composite;
-}
 }

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -36,7 +36,7 @@ private:
 	friend class confirmation_height_dependent_election_after_already_cemented_Test;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (pending_confirmation_height &, const std::string &);
+std::unique_ptr<container_info_component> collect_container_info (pending_confirmation_height &, const std::string &);
 
 class confirmation_height_processor final
 {
@@ -117,9 +117,9 @@ private:
 	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<callback_data> &);
 	bool write_pending (std::deque<conf_height_details> &);
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (confirmation_height_processor &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, const std::string &);
 	friend class confirmation_height_pending_observer_callbacks_Test;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (confirmation_height_processor &, const std::string &);
+std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, const std::string &);
 }

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -135,9 +135,7 @@ nano::error nano::daemon_config::deserialize_json (bool & upgraded_a, nano::json
 	return json.get_error ();
 }
 
-namespace nano
-{
-nano::error read_node_config_toml (boost::filesystem::path const & data_path_a, nano::daemon_config & config_a, std::vector<std::string> const & config_overrides)
+nano::error nano::read_node_config_toml (boost::filesystem::path const & data_path_a, nano::daemon_config & config_a, std::vector<std::string> const & config_overrides)
 {
 	nano::error error;
 	auto json_config_path = nano::get_config_path (data_path_a);
@@ -237,12 +235,11 @@ nano::error read_node_config_toml (boost::filesystem::path const & data_path_a, 
 	return error;
 }
 
-nano::error read_and_update_daemon_config (boost::filesystem::path const & data_path, nano::daemon_config & config_a, nano::jsonconfig & json_a)
+nano::error nano::read_and_update_daemon_config (boost::filesystem::path const & data_path, nano::daemon_config & config_a, nano::jsonconfig & json_a)
 {
 	boost::system::error_code error_chmod;
 	auto config_path = nano::get_config_path (data_path);
 	auto error (json_a.read_and_update (config_a, config_path));
 	nano::set_secure_perm_file (config_path, error_chmod);
 	return error;
-}
 }

--- a/nano/node/distributed_work_factory.cpp
+++ b/nano/node/distributed_work_factory.cpp
@@ -97,19 +97,16 @@ void nano::distributed_work_factory::stop ()
 	}
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (distributed_work_factory & distributed_work, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (distributed_work_factory & distributed_work, const std::string & name)
-{
-	size_t item_count = 0;
+	size_t item_count;
 	{
 		nano::lock_guard<std::mutex> guard (distributed_work.mutex);
 		item_count = distributed_work.items.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
 	auto sizeof_item_element = sizeof (decltype (distributed_work.items)::value_type);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "items", item_count, sizeof_item_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "items", item_count, sizeof_item_element }));
 	return composite;
-}
 }

--- a/nano/node/distributed_work_factory.hpp
+++ b/nano/node/distributed_work_factory.hpp
@@ -33,6 +33,6 @@ public:
 	std::atomic<bool> stopped{ false };
 };
 
-class seq_con_info_component;
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (distributed_work_factory & distributed_work, const std::string & name);
+class container_info_component;
+std::unique_ptr<container_info_component> collect_container_info (distributed_work_factory & distributed_work, const std::string & name);
 }

--- a/nano/node/gap_cache.cpp
+++ b/nano/node/gap_cache.cpp
@@ -123,14 +123,11 @@ size_t nano::gap_cache::size ()
 	return blocks.size ();
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (gap_cache & gap_cache, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (gap_cache & gap_cache, const std::string & name)
 {
 	auto count = gap_cache.size ();
 	auto sizeof_element = sizeof (decltype (gap_cache.blocks)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", count, sizeof_element }));
 	return composite;
-}
 }

--- a/nano/node/gap_cache.hpp
+++ b/nano/node/gap_cache.hpp
@@ -57,5 +57,5 @@ public:
 	nano::node & node;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (gap_cache & gap_cache, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (gap_cache & gap_cache, const std::string & name);
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -16,7 +16,7 @@
 
 namespace
 {
-void construct_json (nano::seq_con_info_component * component, boost::property_tree::ptree & parent);
+void construct_json (nano::container_info_component * component, boost::property_tree::ptree & parent);
 using ipc_json_handler_no_arg_func_map = std::unordered_map<std::string, std::function<void(nano::json_handler *)>>;
 ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ();
 auto ipc_json_handler_no_arg_funcs = create_ipc_json_handler_no_arg_func_map ();
@@ -3862,7 +3862,7 @@ void nano::json_handler::stats ()
 	}
 	else if (type == "objects")
 	{
-		construct_json (collect_seq_con_info (node, "node").get (), response_l);
+		construct_json (collect_container_info (node, "node").get (), response_l);
 	}
 	else if (type == "samples")
 	{
@@ -4942,12 +4942,12 @@ void nano::json_handler::work_peers_clear ()
 
 namespace
 {
-void construct_json (nano::seq_con_info_component * component, boost::property_tree::ptree & parent)
+void construct_json (nano::container_info_component * component, boost::property_tree::ptree & parent)
 {
 	// We are a leaf node, print name and exit
 	if (!component->is_composite ())
 	{
-		auto & leaf_info = static_cast<nano::seq_con_info_leaf *> (component)->get_info ();
+		auto & leaf_info = static_cast<nano::container_info_leaf *> (component)->get_info ();
 		boost::property_tree::ptree child;
 		child.put ("count", leaf_info.count);
 		child.put ("size", leaf_info.count * leaf_info.sizeof_element);
@@ -4955,7 +4955,7 @@ void construct_json (nano::seq_con_info_component * component, boost::property_t
 		return;
 	}
 
-	auto composite = static_cast<nano::seq_con_info_composite *> (component);
+	auto composite = static_cast<nano::container_info_composite *> (component);
 
 	boost::property_tree::ptree current;
 	for (auto & child : composite->get_children ())

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -967,17 +967,26 @@ void nano::syn_cookies::purge (std::chrono::steady_clock::time_point const & cut
 	}
 }
 
-std::unique_ptr<nano::seq_con_info_component> nano::syn_cookies::collect_seq_con_info (std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (network & network, const std::string & name)
 {
-	size_t syn_cookies_count = 0;
-	size_t syn_cookies_per_ip_count = 0;
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (network.tcp_channels.collect_container_info ("tcp_channels"));
+	composite->add_component (network.udp_channels.collect_container_info ("udp_channels"));
+	composite->add_component (network.syn_cookies.collect_container_info ("syn_cookies"));
+	return composite;
+}
+
+std::unique_ptr<nano::container_info_component> nano::syn_cookies::collect_container_info (std::string const & name)
+{
+	size_t syn_cookies_count;
+	size_t syn_cookies_per_ip_count;
 	{
 		nano::lock_guard<std::mutex> syn_cookie_guard (syn_cookie_mutex);
 		syn_cookies_count = cookies.size ();
 		syn_cookies_per_ip_count = cookies_per_ip.size ();
 	}
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "syn_cookies", syn_cookies_count, sizeof (decltype (cookies)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "syn_cookies_per_ip", syn_cookies_per_ip_count, sizeof (decltype (cookies_per_ip)::value_type) }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "syn_cookies", syn_cookies_count, sizeof (decltype (cookies)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "syn_cookies_per_ip", syn_cookies_per_ip_count, sizeof (decltype (cookies_per_ip)::value_type) }));
 	return composite;
 }

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -78,7 +78,7 @@ public:
 	// Returns false if valid, true if invalid (true on error convention)
 	// Also removes the syn cookie from the store if valid
 	bool validate (nano::endpoint const &, nano::account const &, nano::signature const &);
-	std::unique_ptr<seq_con_info_component> collect_seq_con_info (std::string const &);
+	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 
 private:
 	class syn_cookie_info final
@@ -166,4 +166,5 @@ public:
 	static size_t const buffer_size = 512;
 	static size_t const confirm_req_hashes_max = 7;
 };
+std::unique_ptr<container_info_component> collect_container_info (network & network, const std::string & name);
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -64,29 +64,27 @@ void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
 	});
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (rep_crawler & rep_crawler, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_crawler & rep_crawler, const std::string & name)
-{
-	size_t count = 0;
+	size_t count;
 	{
 		nano::lock_guard<std::mutex> guard (rep_crawler.active_mutex);
 		count = rep_crawler.active.size ();
 	}
 
 	auto sizeof_element = sizeof (decltype (rep_crawler.active)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "active", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "active", count, sizeof_element }));
 	return composite;
 }
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_processor & block_processor, const std::string & name)
 {
-	size_t state_blocks_count = 0;
-	size_t blocks_count = 0;
-	size_t blocks_filter_count = 0;
-	size_t forced_count = 0;
-	size_t rolled_back_count = 0;
+	size_t state_blocks_count;
+	size_t blocks_count;
+	size_t blocks_filter_count;
+	size_t forced_count;
+	size_t rolled_back_count;
 
 	{
 		nano::lock_guard<std::mutex> guard (block_processor.mutex);
@@ -97,15 +95,14 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & 
 		rolled_back_count = block_processor.rolled_back.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "state_blocks", state_blocks_count, sizeof (decltype (block_processor.state_blocks)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks", blocks_count, sizeof (decltype (block_processor.blocks)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "blocks_filter", blocks_filter_count, sizeof (decltype (block_processor.blocks_filter)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "forced", forced_count, sizeof (decltype (block_processor.forced)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "rolled_back", rolled_back_count, sizeof (decltype (block_processor.rolled_back)::value_type) }));
-	composite->add_component (collect_seq_con_info (block_processor.generator, "generator"));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "state_blocks", state_blocks_count, sizeof (decltype (block_processor.state_blocks)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", blocks_count, sizeof (decltype (block_processor.blocks)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks_filter", blocks_filter_count, sizeof (decltype (block_processor.blocks_filter)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "forced", forced_count, sizeof (decltype (block_processor.forced)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "rolled_back", rolled_back_count, sizeof (decltype (block_processor.rolled_back)::value_type) }));
+	composite->add_component (collect_container_info (block_processor.generator, "generator"));
 	return composite;
-}
 }
 
 nano::node::node (boost::asio::io_context & io_ctx_a, uint16_t peering_port_a, boost::filesystem::path const & application_path_a, nano::alarm & alarm_a, nano::logging const & logging_a, nano::work_pool & work_a, nano::node_flags flags_a) :
@@ -585,37 +582,32 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 	}
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (node & node, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name)
-{
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (collect_seq_con_info (node.alarm, "alarm"));
-	composite->add_component (collect_seq_con_info (node.work, "work"));
-	composite->add_component (collect_seq_con_info (node.gap_cache, "gap_cache"));
-	composite->add_component (collect_seq_con_info (node.ledger, "ledger"));
-	composite->add_component (collect_seq_con_info (node.active, "active"));
-	composite->add_component (collect_seq_con_info (node.bootstrap_initiator, "bootstrap_initiator"));
-	composite->add_component (collect_seq_con_info (node.bootstrap, "bootstrap"));
-	composite->add_component (node.network.tcp_channels.collect_seq_con_info ("tcp_channels"));
-	composite->add_component (node.network.udp_channels.collect_seq_con_info ("udp_channels"));
-	composite->add_component (node.network.syn_cookies.collect_seq_con_info ("syn_cookies"));
-	composite->add_component (collect_seq_con_info (node.observers, "observers"));
-	composite->add_component (collect_seq_con_info (node.wallets, "wallets"));
-	composite->add_component (collect_seq_con_info (node.vote_processor, "vote_processor"));
-	composite->add_component (collect_seq_con_info (node.rep_crawler, "rep_crawler"));
-	composite->add_component (collect_seq_con_info (node.block_processor, "block_processor"));
-	composite->add_component (collect_seq_con_info (node.block_arrival, "block_arrival"));
-	composite->add_component (collect_seq_con_info (node.online_reps, "online_reps"));
-	composite->add_component (collect_seq_con_info (node.votes_cache, "votes_cache"));
-	composite->add_component (collect_seq_con_info (node.block_uniquer, "block_uniquer"));
-	composite->add_component (collect_seq_con_info (node.vote_uniquer, "vote_uniquer"));
-	composite->add_component (collect_seq_con_info (node.confirmation_height_processor, "confirmation_height_processor"));
-	composite->add_component (collect_seq_con_info (node.pending_confirmation_height, "pending_confirmation_height"));
-	composite->add_component (collect_seq_con_info (node.worker, "worker"));
-	composite->add_component (collect_seq_con_info (node.distributed_work, "distributed_work"));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (collect_container_info (node.alarm, "alarm"));
+	composite->add_component (collect_container_info (node.work, "work"));
+	composite->add_component (collect_container_info (node.gap_cache, "gap_cache"));
+	composite->add_component (collect_container_info (node.ledger, "ledger"));
+	composite->add_component (collect_container_info (node.active, "active"));
+	composite->add_component (collect_container_info (node.bootstrap_initiator, "bootstrap_initiator"));
+	composite->add_component (collect_container_info (node.bootstrap, "bootstrap"));
+	composite->add_component (collect_container_info (node.network, "network"));  
+	composite->add_component (collect_container_info (node.observers, "observers"));
+	composite->add_component (collect_container_info (node.wallets, "wallets"));
+	composite->add_component (collect_container_info (node.vote_processor, "vote_processor"));
+	composite->add_component (collect_container_info (node.rep_crawler, "rep_crawler"));
+	composite->add_component (collect_container_info (node.block_processor, "block_processor"));
+	composite->add_component (collect_container_info (node.block_arrival, "block_arrival"));
+	composite->add_component (collect_container_info (node.online_reps, "online_reps"));
+	composite->add_component (collect_container_info (node.votes_cache, "votes_cache"));
+	composite->add_component (collect_container_info (node.block_uniquer, "block_uniquer"));
+	composite->add_component (collect_container_info (node.vote_uniquer, "vote_uniquer"));
+	composite->add_component (collect_container_info (node.confirmation_height_processor, "confirmation_height_processor"));
+	composite->add_component (collect_container_info (node.pending_confirmation_height, "pending_confirmation_height"));
+	composite->add_component (collect_container_info (node.worker, "worker"));
+	composite->add_component (collect_container_info (node.distributed_work, "distributed_work"));
 	return composite;
-}
 }
 
 void nano::node::process_active (std::shared_ptr<nano::block> incoming)
@@ -1257,9 +1249,7 @@ bool nano::block_arrival::recent (nano::block_hash const & hash_a)
 	return arrival.get<tag_hash> ().find (hash_a) != arrival.get<tag_hash> ().end ();
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_arrival & block_arrival, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_arrival & block_arrival, const std::string & name)
 {
 	size_t count = 0;
 	{
@@ -1268,10 +1258,9 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_arrival & bl
 	}
 
 	auto sizeof_element = sizeof (decltype (block_arrival.arrival)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "arrival", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "arrival", count, sizeof_element }));
 	return composite;
-}
 }
 
 std::shared_ptr<nano::node> nano::node::shared ()

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -77,10 +77,10 @@ public:
 	static std::chrono::seconds constexpr arrival_time_min = std::chrono::seconds (300);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_arrival & block_arrival, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (block_arrival & block_arrival, const std::string & name);
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_crawler & rep_crawler, const std::string & name);
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (block_processor & block_processor, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (rep_crawler & rep_crawler, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (block_processor & block_processor, const std::string & name);
 
 class node final : public std::enable_shared_from_this<nano::node>
 {
@@ -194,7 +194,7 @@ public:
 	static double constexpr free_cutoff = 1024.0;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (node & node, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (node & node, const std::string & name);
 
 nano::node_flags const & inactive_node_flag_defaults ();
 

--- a/nano/node/node_observers.cpp
+++ b/nano/node/node_observers.cpp
@@ -1,15 +1,15 @@
 #include <nano/node/node_observers.hpp>
 
-std::unique_ptr<nano::seq_con_info_component> nano::collect_seq_con_info (nano::node_observers & node_observers, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::node_observers & node_observers, const std::string & name)
 {
-	auto composite = std::make_unique<nano::seq_con_info_composite> (name);
-	composite->add_component (collect_seq_con_info (node_observers.blocks, "blocks"));
-	composite->add_component (collect_seq_con_info (node_observers.wallet, "wallet"));
-	composite->add_component (collect_seq_con_info (node_observers.vote, "vote"));
-	composite->add_component (collect_seq_con_info (node_observers.active_stopped, "active_stopped"));
-	composite->add_component (collect_seq_con_info (node_observers.account_balance, "account_balance"));
-	composite->add_component (collect_seq_con_info (node_observers.endpoint, "endpoint"));
-	composite->add_component (collect_seq_con_info (node_observers.disconnect, "disconnect"));
-	composite->add_component (collect_seq_con_info (node_observers.work_cancel, "work_cancel"));
+	auto composite = std::make_unique<nano::container_info_composite> (name);
+	composite->add_component (collect_container_info (node_observers.blocks, "blocks"));
+	composite->add_component (collect_container_info (node_observers.wallet, "wallet"));
+	composite->add_component (collect_container_info (node_observers.vote, "vote"));
+	composite->add_component (collect_container_info (node_observers.active_stopped, "active_stopped"));
+	composite->add_component (collect_container_info (node_observers.account_balance, "account_balance"));
+	composite->add_component (collect_container_info (node_observers.endpoint, "endpoint"));
+	composite->add_component (collect_container_info (node_observers.disconnect, "disconnect"));
+	composite->add_component (collect_container_info (node_observers.work_cancel, "work_cancel"));
 	return composite;
 }

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -22,5 +22,5 @@ public:
 	nano::observer_set<nano::root const &> work_cancel;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (node_observers & node_observers, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (node_observers & node_observers, const std::string & name);
 }

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -86,19 +86,16 @@ std::vector<nano::account> nano::online_reps::list ()
 	return result;
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (online_reps & online_reps, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (online_reps & online_reps, const std::string & name)
-{
-	size_t count = 0;
+	size_t count;
 	{
 		nano::lock_guard<std::mutex> guard (online_reps.mutex);
 		count = online_reps.reps.size ();
 	}
 
 	auto sizeof_element = sizeof (decltype (online_reps.reps)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "arrival", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "arrival", count, sizeof_element }));
 	return composite;
-}
 }

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -36,8 +36,8 @@ private:
 	nano::uint128_t online;
 	nano::uint128_t minimum;
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (online_reps & online_reps, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (online_reps & online_reps, const std::string & name);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (online_reps & online_reps, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (online_reps & online_reps, const std::string & name);
 }

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -52,7 +52,7 @@ public:
  */
 class rep_crawler
 {
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (rep_crawler & rep_crawler, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (rep_crawler & rep_crawler, const std::string & name);
 
 	// clang-format off
 	class tag_account {};

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -368,11 +368,11 @@ bool nano::transport::tcp_channels::reachout (nano::endpoint const & endpoint_a)
 	return error;
 }
 
-std::unique_ptr<nano::seq_con_info_component> nano::transport::tcp_channels::collect_seq_con_info (std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::transport::tcp_channels::collect_container_info (std::string const & name)
 {
-	size_t channels_count = 0;
-	size_t attemps_count = 0;
-	size_t node_id_handshake_sockets_count = 0;
+	size_t channels_count;
+	size_t attemps_count;
+	size_t node_id_handshake_sockets_count;
 	{
 		nano::lock_guard<std::mutex> guard (mutex);
 		channels_count = channels.size ();
@@ -380,10 +380,10 @@ std::unique_ptr<nano::seq_con_info_component> nano::transport::tcp_channels::col
 		node_id_handshake_sockets_count = node_id_handshake_sockets.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "channels", channels_count, sizeof (decltype (channels)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "attempts", attemps_count, sizeof (decltype (attempts)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "node_id_handshake_sockets", node_id_handshake_sockets_count, sizeof (decltype (node_id_handshake_sockets)::value_type) }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "channels", channels_count, sizeof (decltype (channels)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "attempts", attemps_count, sizeof (decltype (attempts)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "node_id_handshake_sockets", node_id_handshake_sockets_count, sizeof (decltype (node_id_handshake_sockets)::value_type) }));
 
 	return composite;
 }

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -96,7 +96,7 @@ namespace transport
 		bool max_ip_connections (nano::tcp_endpoint const &);
 		// Should we reach out to this endpoint with a keepalive message
 		bool reachout (nano::endpoint const &);
-		std::unique_ptr<seq_con_info_component> collect_seq_con_info (std::string const &);
+		std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 		void purge (std::chrono::steady_clock::time_point const &);
 		void ongoing_keepalive ();
 		void list (std::deque<std::shared_ptr<nano::transport::channel>> &);

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -605,19 +605,19 @@ bool nano::transport::udp_channels::reachout (nano::endpoint const & endpoint_a)
 	return error;
 }
 
-std::unique_ptr<nano::seq_con_info_component> nano::transport::udp_channels::collect_seq_con_info (std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::transport::udp_channels::collect_container_info (std::string const & name)
 {
-	size_t channels_count = 0;
-	size_t attemps_count = 0;
+	size_t channels_count;
+	size_t attemps_count;
 	{
 		nano::lock_guard<std::mutex> guard (mutex);
 		channels_count = channels.size ();
 		attemps_count = attempts.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "channels", channels_count, sizeof (decltype (channels)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "attempts", attemps_count, sizeof (decltype (attempts)::value_type) }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "channels", channels_count, sizeof (decltype (channels)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "attempts", attemps_count, sizeof (decltype (attempts)::value_type) }));
 
 	return composite;
 }

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -87,7 +87,7 @@ namespace transport
 		bool max_ip_connections (nano::endpoint const &);
 		// Should we reach out to this endpoint with a keepalive message
 		bool reachout (nano::endpoint const &);
-		std::unique_ptr<seq_con_info_component> collect_seq_con_info (std::string const &);
+		std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 		void purge (std::chrono::steady_clock::time_point const &);
 		void ongoing_keepalive ();
 		void list (std::deque<std::shared_ptr<nano::transport::channel>> &);

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -302,14 +302,12 @@ void nano::vote_processor::calculate_weights ()
 	}
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (vote_processor & vote_processor, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & vote_processor, const std::string & name)
-{
-	size_t votes_count = 0;
-	size_t representatives_1_count = 0;
-	size_t representatives_2_count = 0;
-	size_t representatives_3_count = 0;
+	size_t votes_count;
+	size_t representatives_1_count;
+	size_t representatives_2_count;
+	size_t representatives_3_count;
 
 	{
 		nano::lock_guard<std::mutex> guard (vote_processor.mutex);
@@ -319,11 +317,10 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & v
 		representatives_3_count = vote_processor.representatives_3.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "votes", votes_count, sizeof (decltype (vote_processor.votes)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "representatives_1", representatives_1_count, sizeof (decltype (vote_processor.representatives_1)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "representatives_2", representatives_2_count, sizeof (decltype (vote_processor.representatives_2)::value_type) }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "representatives_3", representatives_3_count, sizeof (decltype (vote_processor.representatives_3)::value_type) }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "votes", votes_count, sizeof (decltype (vote_processor.votes)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "representatives_1", representatives_1_count, sizeof (decltype (vote_processor.representatives_1)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "representatives_2", representatives_2_count, sizeof (decltype (vote_processor.representatives_2)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "representatives_3", representatives_3_count, sizeof (decltype (vote_processor.representatives_3)::value_type) }));
 	return composite;
-}
 }

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -67,8 +67,8 @@ private:
 	bool is_active;
 	std::thread thread;
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & vote_processor, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (vote_processor & vote_processor, const std::string & name);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_processor & vote_processor, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (vote_processor & vote_processor, const std::string & name);
 }

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -161,9 +161,7 @@ void nano::votes_cache::remove (nano::block_hash const & hash_a)
 	cache.get<tag_hash> ().erase (hash_a);
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (vote_generator & vote_generator, const std::string & name)
 {
 	size_t hashes_count = 0;
 
@@ -172,23 +170,22 @@ std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & v
 		hashes_count = vote_generator.hashes.size ();
 	}
 	auto sizeof_element = sizeof (decltype (vote_generator.hashes)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "state_blocks", hashes_count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "state_blocks", hashes_count, sizeof_element }));
 	return composite;
 }
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (votes_cache & votes_cache, const std::string & name)
 {
-	size_t cache_count = 0;
+	size_t cache_count;
 
 	{
 		nano::lock_guard<std::mutex> guard (votes_cache.cache_mutex);
 		cache_count = votes_cache.cache.size ();
 	}
 	auto sizeof_element = sizeof (decltype (votes_cache.cache)::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
+	auto composite = std::make_unique<container_info_composite> (name);
 	/* This does not currently loop over each element inside the cache to get the sizes of the votes inside cached_votes */
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "cache", cache_count, sizeof_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cache", cache_count, sizeof_element }));
 	return composite;
-}
 }

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -49,10 +49,10 @@ private:
 	bool started{ false };
 	std::thread thread;
 
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (vote_generator & vote_generator, const std::string & name);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_generator & vote_generator, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (vote_generator & vote_generator, const std::string & name);
 class cached_votes final
 {
 public:
@@ -79,8 +79,8 @@ private:
 	cache;
 	// clang-format on
 	nano::network_params network_params;
-	friend std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name);
+	friend std::unique_ptr<container_info_component> collect_container_info (votes_cache & votes_cache, const std::string & name);
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (votes_cache & votes_cache, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (votes_cache & votes_cache, const std::string & name);
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -2026,25 +2026,22 @@ MDB_txn * nano::wallet_store::tx (nano::transaction const & transaction_a) const
 	return static_cast<MDB_txn *> (transaction_a.get_handle ());
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (wallets & wallets, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (wallets & wallets, const std::string & name)
-{
-	size_t items_count = 0;
-	size_t actions_count = 0;
+	size_t items_count;
+	size_t actions_count;
 	{
 		nano::lock_guard<std::mutex> guard (wallets.mutex);
 		items_count = wallets.items.size ();
 		actions_count = wallets.actions.size ();
 	}
 
-	auto composite = std::make_unique<seq_con_info_composite> (name);
 	auto sizeof_item_element = sizeof (decltype (wallets.items)::value_type);
 	auto sizeof_actions_element = sizeof (decltype (wallets.actions)::value_type);
 	auto sizeof_watcher_element = sizeof (decltype (wallets.watcher->watched)::value_type);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "items", items_count, sizeof_item_element }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "actions", actions_count, sizeof_actions_element }));
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "work_watcher", wallets.watcher->size (), sizeof_watcher_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "items", items_count, sizeof_item_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "actions", actions_count, sizeof_actions_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "work_watcher", wallets.watcher->size (), sizeof_watcher_element }));
 	return composite;
-}
 }

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -242,7 +242,7 @@ private:
 	nano::wallet_representative_counts counts;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (wallets & wallets, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (wallets & wallets, const std::string & name);
 
 class wallets_store
 {

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -757,16 +757,13 @@ size_t nano::vote_uniquer::size ()
 	return votes.size ();
 }
 
-namespace nano
-{
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_uniquer & vote_uniquer, const std::string & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (vote_uniquer & vote_uniquer, const std::string & name)
 {
 	auto count = vote_uniquer.size ();
 	auto sizeof_element = sizeof (vote_uniquer::value_type);
-	auto composite = std::make_unique<seq_con_info_composite> (name);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "votes", count, sizeof_element }));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "votes", count, sizeof_element }));
 	return composite;
-}
 }
 
 nano::genesis::genesis ()

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -275,7 +275,7 @@ private:
 	static unsigned constexpr cleanup_count = 2;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (vote_uniquer & vote_uniquer, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (vote_uniquer & vote_uniquer, const std::string & name);
 
 enum class vote_code
 {

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1131,15 +1131,12 @@ bool nano::ledger::block_not_confirmed_or_not_exists (nano::block const & block_
 	return result;
 }
 
-namespace nano
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (ledger & ledger, const std::string & name)
 {
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (ledger & ledger, const std::string & name)
-{
-	auto composite = std::make_unique<seq_con_info_composite> (name);
 	auto count = ledger.bootstrap_weights_size.load ();
 	auto sizeof_element = sizeof (decltype (ledger.bootstrap_weights)::value_type);
-	composite->add_component (std::make_unique<seq_con_info_leaf> (seq_con_info{ "bootstrap_weights", count, sizeof_element }));
-	composite->add_component (collect_seq_con_info (ledger.rep_weights, "rep_weights"));
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "bootstrap_weights", count, sizeof_element }));
+	composite->add_component (collect_container_info (ledger.rep_weights, "rep_weights"));
 	return composite;
-}
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -60,5 +60,5 @@ public:
 	std::atomic<bool> check_bootstrap_weights;
 };
 
-std::unique_ptr<seq_con_info_component> collect_seq_con_info (ledger & ledger, const std::string & name);
+std::unique_ptr<container_info_component> collect_container_info (ledger & ledger, const std::string & name);
 }


### PR DESCRIPTION
`seq_con_info` is not fully accurate, because there are many containers that are used not just sequence (vector, list etc..), such as maps. Changed it to be `container_info`.

I started a trend of using `namespace nano` guards around the `collect_seq_con_info` functions. We don't do this anywhere else (and I think that should stay the case). So adding the nano namespace qualifier to these functions i.e `nano::...`. Also arranged the contents of those functions to be more consistent with each other and removed any `= 0` count initialises because they are always set later so it's redundant.

**config.hpp**
No need for static, as `const` variables implicitly have static linakge already (of course you need the "pointer to constant data" form too: `const char* const str`)

**core_test/rpc.cpp**
The `rpc.database_txn_tracker` test was not being run when building with rocksdb regardless of the TEST_USE_ROCKSDB env variable, it should only be disabled if actually using it.

Some tests were missing `ASSERT_NO_ERROR` around `system.poll ()` and some `system.deadline_set ()` calls before them too.

**core_test/locks.cpp**
I had built with a ridiculously high `NANO_TIMED_LOCKS` value, without even realising, then noticed the locks tests appearing to stall. This is just because they do a sleep for the `NANO_TIMED_LOCKS` length inside the test, so I'm now failing the test if it is greater than 10 seconds just so that they can finish at least.