### PR TITLE
use commit hash instead of tag for security

### DIFF
--- a/.github/workflows/beta_artifacts.yml
+++ b/.github/workflows/beta_artifacts.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       BOOST_ROOT: /tmp/boost
     steps:
-      - uses: actions/checkout@v1
-      - uses: chrislennon/action-aws-cli@v1.1
+      - uses: actions/checkout@722adc6
+      - uses: chrislennon/action-aws-cli@1347f1d
       - name: tag
         run: echo "::set-env name=TAG::`git describe --tags $GITHUB_SHA`"
       - name: Checkout Submodules
@@ -35,8 +35,8 @@ jobs:
   linux_job:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: chrislennon/action-aws-cli@v1.1
+      - uses: actions/checkout@722adc6
+      - uses: chrislennon/action-aws-cli@1347f1d
       - name: tag
         run: echo "::set-env name=TAG::`git describe --tags $GITHUB_SHA`"
       - name: Checkout Submodules
@@ -59,8 +59,8 @@ jobs:
   windows_job:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: chrislennon/action-aws-cli@v1.1
+      - uses: actions/checkout@722adc6
+      - uses: chrislennon/action-aws-cli@1347f1d
       - name: tag
         run: |
           $TRAVIS_TAG=git describe --tags $GITHUB_SHA

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,7 +8,7 @@ jobs:
   linux_job:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps

--- a/.github/workflows/live_artifacts.yml
+++ b/.github/workflows/live_artifacts.yml
@@ -14,8 +14,8 @@ jobs:
     env:
       BOOST_ROOT: /tmp/boost
     steps:
-      - uses: actions/checkout@v1
-      - uses: chrislennon/action-aws-cli@v1.1
+      - uses: actions/checkout@722adc6
+      - uses: chrislennon/action-aws-cli@1347f1d
       - name: tag
         run: echo "::set-env name=TAG::`git describe --tags $GITHUB_SHA`"
       - name: Checkout Submodules
@@ -34,8 +34,8 @@ jobs:
   linux_job:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: chrislennon/action-aws-cli@v1.1
+      - uses: actions/checkout@722adc6
+      - uses: chrislennon/action-aws-cli@1347f1d
       - name: tag
         run: echo "::set-env name=TAG::`git describe --tags $GITHUB_SHA`"
       - name: Checkout Submodules
@@ -58,8 +58,8 @@ jobs:
   windows_job:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: chrislennon/action-aws-cli@v1.1
+      - uses: actions/checkout@722adc6
+      - uses: chrislennon/action-aws-cli@1347f1d
       - name: tag
         run: |
           $TRAVIS_TAG=git describe --tags $GITHUB_SHA

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       BOOST_ROOT: /tmp/boost
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps
@@ -25,7 +25,7 @@ jobs:
   gcc_test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps
@@ -36,7 +36,7 @@ jobs:
   clang_test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps
@@ -47,7 +47,7 @@ jobs:
   windows_test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   RELEASE: 0
-  artifact: 1
+  artifact: 0
   
 jobs:
   osx_test:
@@ -12,7 +12,7 @@ jobs:
     env:
       BOOST_ROOT: /tmp/boost
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps
@@ -23,7 +23,7 @@ jobs:
   gcc_test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps
@@ -34,7 +34,7 @@ jobs:
   clang_test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Fetch Deps
@@ -45,7 +45,7 @@ jobs:
   windows_test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@722adc6
       - name: Windows Defender
         run: ci/actions/windows/disable_windows_defender.ps1
       - name: Checkout Submodules
@@ -53,6 +53,4 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/windows/install_deps.ps1
       - name: Run Tests
-        env:
-          artifact: 0
         run: ci/actions/windows/build.ps1


### PR DESCRIPTION
https://julienrenaux.fr/2019/12/20/github-actions-security-risk/ presents a good explanation as to why this could be problematic.

other change related to artifact being set improperly in Tests workflow and then shadowed in the build step. Changed to be set properly in workflow and removed build step reference