### PR TITLE
Avoid replying to confirm_req with repeated votes

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -479,7 +479,7 @@ public:
 			{
 				auto transaction (node.store.tx_begin_read ());
 				std::vector<nano::block_hash> blocks_bundle;
-				std::vector<std::shared_ptr<nano::vote>> cached_votes;
+				std::unordered_set<std::shared_ptr<nano::vote>> cached_votes;
 				size_t cached_count (0);
 				for (auto & root_hash : message_a.roots_hashes)
 				{
@@ -487,7 +487,7 @@ public:
 					if (!find_votes.empty ())
 					{
 						++cached_count;
-						cached_votes.insert (cached_votes.end (), find_votes.begin (), find_votes.end ());
+						cached_votes.insert (find_votes.begin (), find_votes.end ());
 					}
 					if (!find_votes.empty () || (!root_hash.first.is_zero () && node.store.block_exists (transaction, root_hash.first)))
 					{
@@ -514,7 +514,7 @@ public:
 							if (!find_successor_votes.empty ())
 							{
 								++cached_count;
-								cached_votes.insert (cached_votes.end (), find_successor_votes.begin (), find_successor_votes.end ());
+								cached_votes.insert (find_successor_votes.begin (), find_successor_votes.end ());
 							}
 							blocks_bundle.push_back (successor);
 							auto successor_block (node.store.block_get (transaction, successor));

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -479,7 +479,7 @@ public:
 			{
 				auto transaction (node.store.tx_begin_read ());
 				std::vector<nano::block_hash> blocks_bundle;
-				std::unordered_set<std::shared_ptr<nano::vote>> cached_votes;
+				std::vector<std::shared_ptr<nano::vote>> cached_votes;
 				size_t cached_count (0);
 				for (auto & root_hash : message_a.roots_hashes)
 				{
@@ -487,7 +487,13 @@ public:
 					if (!find_votes.empty ())
 					{
 						++cached_count;
-						cached_votes.insert (find_votes.begin (), find_votes.end ());
+						for (auto const & vote : find_votes)
+						{
+							if (std::find (cached_votes.begin (), cached_votes.end (), vote) == cached_votes.end ())
+							{
+								cached_votes.push_back (vote);
+							}
+						}
 					}
 					if (!find_votes.empty () || (!root_hash.first.is_zero () && node.store.block_exists (transaction, root_hash.first)))
 					{
@@ -514,7 +520,13 @@ public:
 							if (!find_successor_votes.empty ())
 							{
 								++cached_count;
-								cached_votes.insert (find_successor_votes.begin (), find_successor_votes.end ());
+								for (auto const & vote : find_successor_votes)
+								{
+									if (std::find (cached_votes.begin (), cached_votes.end (), vote) == cached_votes.end ())
+									{
+										cached_votes.push_back (vote);
+									}
+								}
 							}
 							blocks_bundle.push_back (successor);
 							auto successor_block (node.store.block_get (transaction, successor));


### PR DESCRIPTION
The added test fails when `cached_votes` without checking for duplicates. Kept as a vector since it's a very small amount of items.

This should be free performance under saturation since nodes are getting the same vote repeatedly in response. Might result in lower write drops as well.