### PR TITLE
Reduce memory used by callback data in confirmation height processor

### DIFF
--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -58,9 +58,8 @@ private:
 	class callback_data final
 	{
 	public:
-		callback_data (std::shared_ptr<nano::block> const &, nano::block_sideband const &, nano::election_status_type);
-		std::shared_ptr<nano::block> block;
-		nano::block_sideband sideband;
+		callback_data (nano::block_hash const &, nano::election_status_type);
+		nano::block_hash hash;
 		nano::election_status_type election_status_type;
 	};
 

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -589,7 +589,7 @@ TEST (confirmation_height, long_chains)
 		node->active.next_frontier_check = std::chrono::steady_clock::now () + 7200s;
 	}
 
-	constexpr auto num_blocks = 10000;
+	constexpr auto num_blocks = 50000;
 
 	// First open the other account
 	nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + num_blocks + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
@@ -635,7 +635,7 @@ TEST (confirmation_height, long_chains)
 	// Call block confirm on the existing receive block on the genesis account which will confirm everything underneath on both accounts
 	node->block_confirm (receive1);
 
-	system.deadline_set (10s);
+	system.deadline_set (60s);
 	while (true)
 	{
 		auto transaction = node->store.tx_begin_read ();


### PR DESCRIPTION
#2233 made the confirmation height processor use a lot more memory as it stored the whole block & sideband for each block it traversed. This has been changed to only store the block hash. An additional `store.block_get ()` is then required later to retrieve the contents but this didn't have any measurable performance hit from benchmarking and gave considerable memory reduction gains, as shown below:
![image](https://user-images.githubusercontent.com/650038/71640888-9c714780-2c8a-11ea-950a-194f043425bf.png)

It shows for the `confirmation_height.long_chains` test in the `slow_tests` a reduction from 82MB to 12MB (86% less memory) for the affected containers. The memory is still unbounded (as well as for `receive_source_pairs`) but it has been significantly reduced and a proper bounded solution is scheduled for a future release.

I increased the number of blocks used in the slow_test.