### PR TITLE
Allow core_test retries until 7-1-2020 00:00(gmt)

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -44,7 +44,7 @@ run_tests() {
         TIMEOUT_TIME_ARG=""
     fi
 
-    if [ "$(date +%s)" -lt 1577836799 ]; then
+    if [ "$(date +%s)" -lt 1593561600 ]; then
         tries=(_initial_ 1 2 3 4 5 6 7 8 9)
     else
         tries=(_initial_)


### PR DESCRIPTION
There are times where core_test will spuriously fail tests intermittently.
We have a loop on core_test that allows it to retry up to 10 times in the event of a failure.
This needs to be moved from time to time to allow restarts to continue