### PR TITLE
Process RPC incorrect enable_control checking when using watch_work

### DIFF
--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -90,7 +90,7 @@ void nano::rpc_handler::process_request ()
 					auto is_forced = force.is_initialized () && *force;
 					// watch_work if uninitialized is defaulted to true.
 					auto watch_work = request.get_optional<bool> ("watch_work");
-					auto is_watching_work = (watch_work.is_initialized () && *watch_work) || !watch_work.is_initialized ();
+					auto is_watching_work = watch_work.get_value_or (true);
 					if ((is_forced || is_watching_work) && !rpc_config.enable_control)
 					{
 						json_error_response (response, rpc_control_disabled_ec.message ());

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -87,8 +87,11 @@ void nano::rpc_handler::process_request ()
 				else if (action == "process")
 				{
 					auto force = request.get_optional<bool> ("force");
+					auto is_forced = force.is_initialized () && *force;
+					// watch_work if uninitialized is defaulted to true.
 					auto watch_work = request.get_optional<bool> ("watch_work");
-					if (((force.is_initialized () && *force) || (watch_work.is_initialized () && !*watch_work)) && !rpc_config.enable_control)
+					auto is_watching_work = (watch_work.is_initialized () && *watch_work) || !watch_work.is_initialized ();
+					if ((is_forced || is_watching_work) && !rpc_config.enable_control)
 					{
 						json_error_response (response, rpc_control_disabled_ec.message ());
 						error = true;

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -86,12 +86,9 @@ void nano::rpc_handler::process_request ()
 				}
 				else if (action == "process")
 				{
-					auto force = request.get_optional<bool> ("force");
-					auto is_forced = force.is_initialized () && *force;
-					// watch_work if uninitialized is defaulted to true.
-					auto watch_work = request.get_optional<bool> ("watch_work");
-					auto is_watching_work = watch_work.get_value_or (true);
-					if ((is_forced || is_watching_work) && !rpc_config.enable_control)
+					auto force = request.get_optional<bool> ("force").value_or (false);
+					auto watch_work = request.get_optional<bool> ("watch_work").value_or (true);
+					if ((force || watch_work) && !rpc_config.enable_control)
 					{
 						json_error_response (response, rpc_control_disabled_ec.message ());
 						error = true;


### PR DESCRIPTION
Found by @Joohansson https://github.com/nanocurrency/nano-node/issues/2461

`enable_control` was incorrectly being checked when `watch_work` was set.

The test was using `work_watcher` too, which isn't valid, but `watch_work` is defaulted to true anyway so it wouldn't have been caught. I've updated the test to do some negative testing when enable_control is both enabled/disabled.