### PR TITLE
Confirmation solicitor revamp

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable (core_test
 	block_store.cpp
 	bootstrap.cpp
 	confirmation_height.cpp
+	confirmation_solicitor.cpp
 	conflicts.cpp
 	difficulty.cpp
 	distributed_work.cpp

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -19,7 +19,7 @@ TEST (confirmation_solicitor, batches)
 	node_config.peering_port = nano::get_available_port ();
 	nano::node_flags node_flags;
 	// To prevent races on the solicitor
-	node_flags.disable_active_transactions = true;
+	node_flags.disable_request_loop = true;
 	auto & node2 = *system.add_node (node_config, node_flags);
 	// Lock active_transactions which uses the solicitor
 	{

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,0 +1,53 @@
+#include <nano/core_test/testutil.hpp>
+#include <nano/lib/jsonconfig.hpp>
+#include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+TEST (confirmation_solicitor, batches)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.enable_voting = false;
+	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto & node1 = *system.add_node (node_config);
+	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
+	// Solicitor will only solicit from this representative
+	nano::representative representative (nano::test_genesis_key.pub, nano::genesis_amount, channel1);
+	node_config.peering_port = nano::get_available_port ();
+	nano::node_flags node_flags;
+	// To prevent races on the solicitor
+	node_flags.disable_active_transactions = true;
+	auto & node2 = *system.add_node (node_config, node_flags);
+	// Lock active_transactions which uses the solicitor
+	{
+		nano::lock_guard<std::mutex> active_guard (node2.active.mutex);
+		std::vector<nano::representative> representatives{ representative };
+		node2.active.solicitor.prepare (representatives);
+		// Ensure the representatives are correct
+		ASSERT_EQ (1, representatives.size ());
+		ASSERT_EQ (channel1, representatives.front ().channel);
+		ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
+		nano::genesis genesis;
+		auto send (std::make_shared<nano::send_block> (genesis.open->hash (), nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.open->hash ())));
+		for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)
+		{
+			auto election (std::make_shared<nano::election> (node2, send, false, nullptr));
+			ASSERT_FALSE (node2.active.solicitor.add (election));
+		}
+		ASSERT_EQ (1, node2.active.solicitor.max_confirm_req_batches);
+		// Reached the maximum amount of requests for the channel
+		auto election (std::make_shared<nano::election> (node2, send, false, nullptr));
+		ASSERT_TRUE (node2.active.solicitor.add (election));
+	}
+	// From rep crawler
+	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
+	system.deadline_set (5s);
+	node2.active.solicitor.flush ();
+	while (node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out) < 2)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -73,7 +73,7 @@ public:
 		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : 45000;
 		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : 46000;
 		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : 47000;
-		request_interval_ms = is_test_network () ? (is_sanitizer_build ? 100 : 20) : 500;
+		request_interval_ms = is_test_network () ? 20 : 500;
 	}
 
 	/** Network work thresholds. ~5 seconds of work for the live network */

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -285,7 +285,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 				election_l->last_broadcast = now;
 			}
 			// Rate-limited requests for confirmation
-			if (election_l->last_request < request_cutoff && !solicitor.add (*election_l))
+			else if (election_l->last_request < request_cutoff && !solicitor.add (*election_l))
 			{
 				++election_l->confirmation_request_count;
 				election_l->last_request = now;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -22,10 +22,12 @@ election_time_to_live (node_a.network_params.network.is_test_network () ? 0s : 1
 min_time_between_requests (node_a.network_params.network.is_test_network () ? 25ms : 3s),
 min_time_between_floods (node_a.network_params.network.is_test_network () ? 50ms : 6s),
 min_request_count_flood (node_a.network_params.network.is_test_network () ? 0 : 2),
+// clang-format off
 thread ([this]() {
 	nano::thread_role::set (nano::thread_role::name::request_loop);
 	request_loop ();
 })
+// clang-format on
 {
 	assert (min_time_between_requests > std::chrono::milliseconds (node.network_params.network.request_interval_ms));
 	assert (min_time_between_floods > std::chrono::milliseconds (node.network_params.network.request_interval_ms));

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -326,7 +326,7 @@ void nano::active_transactions::request_loop ()
 
 	lock.lock ();
 
-	while (!stopped && !node.flags.disable_active_transactions)
+	while (!stopped && !node.flags.disable_request_loop)
 	{
 		// Account for the time spent in request_confirm by defining the wakeup point beforehand
 		const auto wakeup_l (std::chrono::steady_clock::now () + std::chrono::milliseconds (node.network_params.network.request_interval_ms));

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -121,7 +121,6 @@ public:
 	std::chrono::milliseconds const election_request_delay;
 	// Maximum time an election can be kept active if it is extending the container
 	std::chrono::seconds const election_time_to_live;
-	static size_t constexpr max_confirm_representatives = 30;
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;
 	size_t priority_cementable_frontiers_size ();
@@ -133,6 +132,7 @@ public:
 	void add_dropped_elections_cache (nano::qualified_root const &);
 	std::chrono::steady_clock::time_point find_dropped_elections_cache (nano::qualified_root const &);
 	size_t dropped_elections_cache_size ();
+	nano::confirmation_solicitor solicitor;
 
 private:
 	// Call action with confirmed block, may be different than what we started with
@@ -181,7 +181,6 @@ private:
 		mi::hashed_unique<mi::tag<tag_root>,
 			mi::member<nano::election_timepoint, nano::qualified_root, &nano::election_timepoint::root>>>>
 	dropped_elections_cache;
-	nano::confirmation_solicitor solicitor;
 	// clang-format on
 	static size_t constexpr dropped_elections_cache_max{ 32 * 1024 };
 	boost::thread thread;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -116,11 +116,6 @@ public:
 	void erase_inactive_votes_cache (nano::block_hash const &);
 	nano::node & node;
 	std::mutex mutex;
-	std::chrono::seconds const long_election_threshold;
-	// Delay until requesting confirmation for an election
-	std::chrono::milliseconds const election_request_delay;
-	// Maximum time an election can be kept active if it is extending the container
-	std::chrono::seconds const election_time_to_live;
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;
 	size_t priority_cementable_frontiers_size ();
@@ -148,6 +143,20 @@ private:
 	nano::condition_variable condition;
 	bool started{ false };
 	std::atomic<bool> stopped{ false };
+
+	// Minimum time an election must be active before escalation
+	std::chrono::seconds const long_election_threshold;
+	// Delay until requesting confirmation for an election
+	std::chrono::milliseconds const election_request_delay;
+	// Maximum time an election can be kept active if it is extending the container
+	std::chrono::seconds const election_time_to_live;
+	// Minimum time between confirmation requests for an election
+	std::chrono::milliseconds const min_time_between_requests;
+	// Minimum time between broadcasts of the current winner of an election, as a backup to requesting confirmations
+	std::chrono::milliseconds const min_time_between_floods;
+	// Minimum election request count to start broadcasting blocks, as a backup to requesting confirmations
+	size_t const min_request_count_flood;
+
 	// clang-format off
 	boost::multi_index_container<nano::qualified_root,
 	mi::indexed_by<

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -2,12 +2,15 @@
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 
+using namespace std::chrono_literals;
+
 nano::confirmation_solicitor::confirmation_solicitor (nano::node & node_a) :
 node (node_a),
 max_confirm_req_batches (node_a.network_params.network.is_test_network () ? 1 : 20),
 max_block_broadcasts (node_a.network_params.network.is_test_network () ? 4 : 30),
-soliciting_alternating_factor (node_a.network_params.network.is_test_network () ? 2 : 4),
-block_flooding_alternating_factor (8)
+min_time_between_requests (node_a.network_params.network.is_test_network () ? 10ms : 3s),
+min_time_between_floods (node_a.network_params.network.is_test_network () ? 20ms : 6s),
+min_request_count_flood (node_a.network_params.network.is_test_network () ? 0 : 4)
 {
 }
 
@@ -24,13 +27,17 @@ void nano::confirmation_solicitor::prepare (std::vector<nano::representative> co
 bool nano::confirmation_solicitor::add (std::shared_ptr<nano::election> election_a)
 {
 	assert (prepared);
-	if (((election_a->confirmation_request_count > block_flooding_alternating_factor && election_a->confirmation_request_count % block_flooding_alternating_factor == 1) || node.network_params.network.is_test_network ()) && rebroadcasted++ < max_block_broadcasts)
+	auto now (std::chrono::steady_clock::now ());
+	auto flood_cutoff (now - min_time_between_floods);
+	if (election_a->confirmation_request_count >= min_request_count_flood && election_a->last_broadcast < flood_cutoff && rebroadcasted++ < max_block_broadcasts)
 	{
+		election_a->last_broadcast = now;
 		node.network.flood_block (election_a->status.winner);
 	}
 	static auto max_channel_requests (max_confirm_req_batches * nano::network::confirm_req_hashes_max);
+	auto request_cutoff (now - min_time_between_requests);
 	bool any_bundle{ false };
-	if (election_a->confirmation_request_count % soliciting_alternating_factor == 0)
+	if (election_a->last_request < request_cutoff)
 	{
 		for (auto const & rep : representatives)
 		{
@@ -52,13 +59,10 @@ bool nano::confirmation_solicitor::add (std::shared_ptr<nano::election> election
 				}
 			}
 		}
-		if (any_bundle)
-		{
-			++election_a->confirmation_request_count;
-		}
 	}
-	else if (election_a->confirmation_request_count > 0)
+	if (any_bundle)
 	{
+		election_a->last_request = now;
 		++election_a->confirmation_request_count;
 	}
 	return !any_bundle;

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -4,13 +4,13 @@
 
 using namespace std::chrono_literals;
 
-nano::confirmation_solicitor::confirmation_solicitor (nano::node & node_a) :
-node (node_a),
-max_confirm_req_batches (node_a.network_params.network.is_test_network () ? 1 : 20),
-max_block_broadcasts (node_a.network_params.network.is_test_network () ? 4 : 30),
-min_time_between_requests (node_a.network_params.network.is_test_network () ? 10ms : 3s),
-min_time_between_floods (node_a.network_params.network.is_test_network () ? 20ms : 6s),
-min_request_count_flood (node_a.network_params.network.is_test_network () ? 0 : 4)
+nano::confirmation_solicitor::confirmation_solicitor (nano::network & network_a, nano::network_constants const & params_a) :
+max_confirm_req_batches (params_a.is_test_network () ? 1 : 20),
+max_block_broadcasts (params_a.is_test_network () ? 4 : 30),
+network (network_a),
+min_time_between_requests (params_a.is_test_network () ? 10ms : 3s),
+min_time_between_floods (params_a.is_test_network () ? 20ms : 6s),
+min_request_count_flood (params_a.is_test_network () ? 0 : 4)
 {
 }
 
@@ -27,15 +27,15 @@ void nano::confirmation_solicitor::prepare (std::vector<nano::representative> co
 bool nano::confirmation_solicitor::add (std::shared_ptr<nano::election> election_a)
 {
 	assert (prepared);
-	auto now (std::chrono::steady_clock::now ());
-	auto flood_cutoff (now - min_time_between_floods);
+	auto const now (std::chrono::steady_clock::now ());
+	auto const flood_cutoff (now - min_time_between_floods);
 	if (election_a->confirmation_request_count >= min_request_count_flood && election_a->last_broadcast < flood_cutoff && rebroadcasted++ < max_block_broadcasts)
 	{
 		election_a->last_broadcast = now;
-		node.network.flood_block (election_a->status.winner);
+		network.flood_block (election_a->status.winner);
 	}
-	static auto max_channel_requests (max_confirm_req_batches * nano::network::confirm_req_hashes_max);
-	auto request_cutoff (now - min_time_between_requests);
+	auto const max_channel_requests (max_confirm_req_batches * nano::network::confirm_req_hashes_max);
+	auto const request_cutoff (now - min_time_between_requests);
 	bool any_bundle{ false };
 	if (election_a->last_request < request_cutoff)
 	{
@@ -48,7 +48,7 @@ bool nano::confirmation_solicitor::add (std::shared_ptr<nano::election> election
 				{
 					if (existing->second.size () < max_channel_requests)
 					{
-						existing->second.push_back ({ election_a->status.winner->hash (), election_a->status.winner->root () });
+						existing->second.emplace_back (election_a->status.winner->hash (), election_a->status.winner->root ());
 						any_bundle = true;
 					}
 				}
@@ -73,7 +73,7 @@ void nano::confirmation_solicitor::flush ()
 	assert (prepared);
 	for (auto const & request_queue : requests)
 	{
-		auto channel (request_queue.first);
+		auto const & channel (request_queue.first);
 		std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes_l;
 		for (auto const & root_hash : request_queue.second)
 		{

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -1,6 +1,5 @@
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
-#include <nano/node/node.hpp>
 
 using namespace std::chrono_literals;
 

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/node/network.hpp>
 #include <nano/node/repcrawler.hpp>
 
 #include <unordered_map>
@@ -12,7 +13,7 @@ class node;
 class confirmation_solicitor final
 {
 public:
-	confirmation_solicitor (nano::node &);
+	confirmation_solicitor (nano::network &, nano::network_constants const &);
 	/** Prepare object for batching election confirmation requests*/
 	void prepare (std::vector<nano::representative> const &);
 	/** Add an election that needs to be confirmed. Returns false if a request will be performed on flush() */
@@ -24,11 +25,12 @@ public:
 	size_t const max_block_broadcasts;
 
 private:
+	nano::network & network;
+
 	std::chrono::milliseconds const min_time_between_requests;
 	std::chrono::milliseconds const min_time_between_floods;
 	size_t const min_request_count_flood;
 	int rebroadcasted{ 0 };
-	nano::node & node;
 	std::vector<nano::representative> representatives;
 	using vector_root_hashes = std::vector<std::pair<nano::block_hash, nano::root>>;
 	std::unordered_map<std::shared_ptr<nano::transport::channel>, vector_root_hashes> requests;

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -11,41 +11,27 @@ class node;
 /** This class accepts elections that need further votes before they can be confirmed and bundles them in to single confirm_req packets */
 class confirmation_solicitor final
 {
-	class request
-	{
-	public:
-		std::shared_ptr<nano::transport::channel> channel;
-		std::shared_ptr<nano::election> election;
-		bool operator== (nano::confirmation_solicitor::request const & other_a) const
-		{
-			return *channel == *other_a.channel && election == other_a.election;
-		}
-	};
-	class request_hash
-	{
-	public:
-		size_t operator () (nano::confirmation_solicitor::request const & item_a) const
-		{
-			return std::hash<std::shared_ptr<nano::election>> ()(item_a.election) ^ std::hash<nano::transport::channel> ()(*item_a.channel);
-		}
-	};
 public:
 	confirmation_solicitor (nano::node &);
 	/** Prepare object for batching election confirmation requests*/
-	void prepare ();
-	/** Add an election that needs to be confirmed */
-	void add (std::shared_ptr<nano::election>);
-	/** Bundle hashes together for identical channels in to a single confirm_req by hash packet */
+	void prepare (std::vector<nano::representative> const &);
+	/** Add an election that needs to be confirmed. Returns false if a request will be performed on flush() */
+	bool add (std::shared_ptr<nano::election>);
+	/** Dispatch bundled requests to each channel*/
 	void flush ();
+	/** The maximum amount of confirmation requests (batches) to be sent to each channel */
+	size_t const max_confirm_req_batches;
+	size_t const max_block_broadcasts;
+
 private:
-	static size_t constexpr max_confirm_req_batches = 20;
-	static size_t constexpr max_confirm_req = 5;
-	static size_t constexpr max_block_broadcasts = 30;
-	int rebroadcasted { 0 };
+	/** Modulo factor to alternate between top elections when soliciting confirmations */
+	size_t const soliciting_alternating_factor;
+	size_t const block_flooding_alternating_factor;
+	int rebroadcasted{ 0 };
 	nano::node & node;
 	std::vector<nano::representative> representatives;
-	/** Unique channel/hash to be requested */
-	std::unordered_set<request, nano::confirmation_solicitor::request_hash> requests;
-	bool prepared { false };
+	using vector_root_hashes = std::vector<std::pair<nano::block_hash, nano::root>>;
+	std::unordered_map<std::shared_ptr<nano::transport::channel>, vector_root_hashes> requests;
+	bool prepared{ false };
 };
 }

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -16,20 +16,20 @@ public:
 	confirmation_solicitor (nano::network &, nano::network_constants const &);
 	/** Prepare object for batching election confirmation requests*/
 	void prepare (std::vector<nano::representative> const &);
-	/** Add an election that needs to be confirmed. Returns false if a request will be performed on flush() */
-	bool add (std::shared_ptr<nano::election>);
+	/** Broadcast the winner of an election if the broadcast limit has not been reached. Returns false if the broadcast was performed */
+	bool broadcast (nano::election const &);
+	/** Add an election that needs to be confirmed. Returns false if successfully added */
+	bool add (nano::election const &);
 	/** Dispatch bundled requests to each channel*/
 	void flush ();
 	/** The maximum amount of confirmation requests (batches) to be sent to each channel */
 	size_t const max_confirm_req_batches;
+	/** The global maximum amount of block broadcasts */
 	size_t const max_block_broadcasts;
 
 private:
 	nano::network & network;
 
-	std::chrono::milliseconds const min_time_between_requests;
-	std::chrono::milliseconds const min_time_between_floods;
-	size_t const min_request_count_flood;
 	int rebroadcasted{ 0 };
 	std::vector<nano::representative> representatives;
 	using vector_root_hashes = std::vector<std::pair<nano::block_hash, nano::root>>;

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -24,9 +24,9 @@ public:
 	size_t const max_block_broadcasts;
 
 private:
-	/** Modulo factor to alternate between top elections when soliciting confirmations */
-	size_t const soliciting_alternating_factor;
-	size_t const block_flooding_alternating_factor;
+	std::chrono::milliseconds const min_time_between_requests;
+	std::chrono::milliseconds const min_time_between_floods;
+	size_t const min_request_count_flood;
 	int rebroadcasted{ 0 };
 	nano::node & node;
 	std::vector<nano::representative> representatives;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -79,8 +79,8 @@ public:
 	bool stopped;
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 	unsigned confirmation_request_count{ 0 };
-	std::chrono::steady_clock::time_point last_broadcast {};
-	std::chrono::steady_clock::time_point last_request {};
+	std::chrono::steady_clock::time_point last_broadcast;
+	std::chrono::steady_clock::time_point last_request;
 	std::unordered_set<nano::block_hash> dependent_blocks;
 	std::chrono::seconds late_blocks_delay{ 5 };
 };

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -79,6 +79,8 @@ public:
 	bool stopped;
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 	unsigned confirmation_request_count{ 0 };
+	std::chrono::steady_clock::time_point last_broadcast {};
+	std::chrono::steady_clock::time_point last_request {};
 	std::unordered_set<nano::block_hash> dependent_blocks;
 	std::chrono::seconds late_blocks_delay{ 5 };
 };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -110,7 +110,6 @@ class node_flags final
 {
 public:
 	std::vector<std::string> config_overrides;
-	bool disable_active_transactions{ false };
 	bool disable_backup{ false };
 	bool disable_lazy_bootstrap{ false };
 	bool disable_legacy_bootstrap{ false };
@@ -119,6 +118,7 @@ public:
 	bool disable_bootstrap_bulk_pull_server{ false };
 	bool disable_bootstrap_bulk_push_client{ false };
 	bool disable_rep_crawler{ false };
+	bool disable_request_loop{ false };
 	bool disable_tcp_realtime{ false };
 	bool disable_udp{ false };
 	bool disable_unchecked_cleanup{ false };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -110,6 +110,7 @@ class node_flags final
 {
 public:
 	std::vector<std::string> config_overrides;
+	bool disable_active_transactions{ false };
 	bool disable_backup{ false };
 	bool disable_lazy_bootstrap{ false };
 	bool disable_legacy_bootstrap{ false };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -245,13 +245,14 @@ void nano::rep_crawler::update_weights ()
 	}
 }
 
-std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a)
+std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a)
 {
+	auto version_min (opt_version_min_a.value_or (node.network_params.protocol.protocol_version_min));
 	std::vector<representative> result;
 	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
 	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)
 	{
-		if (!i->weight.is_zero ())
+		if (!i->weight.is_zero () && i->channel->get_network_version () >= version_min)
 		{
 			result.push_back (*i);
 		}

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -9,6 +9,7 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
+#include <boost/optional.hpp>
 
 #include <chrono>
 #include <memory>
@@ -103,8 +104,8 @@ public:
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;
 
-	/** Request a list of the top \p count_a known representatives in descending order of weight. */
-	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max ());
+	/** Request a list of the top \p count_a known representatives in descending order of weight, optionally with a minimum version \p opt_version_min_a */
+	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max (), boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a = boost::none);
 
 	/** Request a list of the top \p count_a known representative endpoints. */
 	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (size_t count_a);


### PR DESCRIPTION
Being a revamp this is best reviewed in split mode. The changes are:

- Fix for getting stuck in the loop
- Requests ordering is now respected to ensure prioritization
- Batch count was global and not per-channel
- **confirmation_request_count no longer used to alternate between elections, instead now doing it time-based**. Using a counter + modulo was not great.
- Deleted all uses of single confirm_req since there is more than enough weight on TCP now. This can however be reverted.
- Added a flag to disable active_transactions to allow for testing the solicitor
- Added a basic test for the solicitor

Eventually, it seemed more efficient to get rid of the `request` class and do most of the logic in `::add()` and have `::flush()` only batch and dispatch the messages. Overall I think the solicitor has still simplified a lot of the logic, but I could not escape making it more complicated while still making sure the behavior is the same as before.

Rate-limiting logic is left in `active_transactions`