### PR TITLE
Remove unnecessary lock requirement in active_transactions::lock.

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -637,11 +637,13 @@ TEST (active_transactions, restart_dropped)
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	// Verify the block was updated in the ledger
+	std::shared_ptr<nano::block> block;
+	while (block == nullptr)
 	{
-		auto block (node.store.block_get (node.store.tx_begin_write (), send1->hash ()));
-		ASSERT_EQ (work2, block->block_work ());
+		ASSERT_NO_ERROR (system.poll ());
+		block = node.store.block_get (node.store.tx_begin_read (), send1->hash ());
 	}
+	ASSERT_EQ (work2, block->block_work ());
 	// Drop election
 	node.active.erase (*send2);
 	// Try to restart election with the lower difficulty block, should not work since the block as lower work

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -662,7 +662,7 @@ TEST (active_transactions, restart_dropped)
 	}
 	// Verify the block was updated in the ledger
 	{
-		auto block (node.store.block_get (node.store.tx_begin_read (), send1->hash ()));
+		auto block (node.store.block_get (node.store.tx_begin_write (), send1->hash ()));
 		ASSERT_EQ (work2, block->block_work ());
 	}
 	// Drop election

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -732,9 +732,11 @@ TEST (votes, check_signature)
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	node1.active.start (send1);
-	nano::lock_guard<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
-	ASSERT_EQ (1, votes1->last_votes.size ());
+	{
+		nano::lock_guard<std::mutex> lock (node1.active.mutex);
+		auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
+		ASSERT_EQ (1, votes1->last_votes.size ());
+	}
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
 	auto transaction (node1.store.tx_begin_read ());
@@ -867,8 +869,11 @@ TEST (votes, add_old)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
-	nano::lock_guard<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
+	std::shared_ptr<nano::election> votes1;
+	{
+		nano::lock_guard<std::mutex> lock (node1.active.mutex);
+		votes1 = node1.active.roots.find (send1->qualified_root ())->election;
+	}
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);
 	nano::keypair key2;
@@ -877,7 +882,7 @@ TEST (votes, add_old)
 	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send2));
 	votes1->last_votes[nano::test_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	node1.vote_processor.vote_blocking (transaction, vote2, channel);
-	ASSERT_EQ (2, votes1->last_votes.size ());
+	ASSERT_EQ (2, votes1->last_votes_size ());
 	ASSERT_NE (votes1->last_votes.end (), votes1->last_votes.find (nano::test_genesis_key.pub));
 	ASSERT_EQ (send1->hash (), votes1->last_votes[nano::test_genesis_key.pub].hash);
 	auto winner (*votes1->tally ().begin ());
@@ -900,11 +905,15 @@ TEST (votes, add_old_different_account)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send2).code);
 	node1.active.start (send1);
 	node1.active.start (send2);
-	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
-	auto votes2 (node1.active.roots.find (send2->qualified_root ())->election);
-	ASSERT_EQ (1, votes1->last_votes.size ());
-	ASSERT_EQ (1, votes2->last_votes.size ());
+	std::shared_ptr<nano::election> votes1;
+	std::shared_ptr<nano::election> votes2;
+	{
+		nano::unique_lock<std::mutex> lock (node1.active.mutex);
+		votes1 = node1.active.roots.find (send1->qualified_root ())->election;
+		votes2 = node1.active.roots.find (send2->qualified_root ())->election;
+	}
+	ASSERT_EQ (1, votes1->last_votes_size ());
+	ASSERT_EQ (1, votes2->last_votes_size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	auto vote_result1 (node1.vote_processor.vote_blocking (transaction, vote1, channel));
@@ -938,8 +947,11 @@ TEST (votes, add_cooldown)
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	node1.active.start (send1);
-	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	auto votes1 (node1.active.roots.find (send1->qualified_root ())->election);
+	std::shared_ptr<nano::election> votes1;
+	{
+		nano::unique_lock<std::mutex> lock (node1.active.mutex);
+		votes1 = node1.active.roots.find (send1->qualified_root ())->election;
+	}
 	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.vote_processor.vote_blocking (transaction, vote1, channel);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2747,7 +2747,6 @@ TEST (node, fork_invalid_block_signature_vote_by_hash)
 	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, vote_blocks));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
-		nano::unique_lock<std::mutex> lock (system.nodes[0]->active.mutex);
 		system.nodes[0]->vote_processor.vote_blocking (transaction, vote, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
 	}
 	while (system.nodes[0]->block (send1->hash ()))
@@ -2916,7 +2915,6 @@ TEST (node, confirm_back)
 	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, vote_blocks));
 	{
 		auto transaction (node.store.tx_begin_read ());
-		nano::unique_lock<std::mutex> lock (node.active.mutex);
 		node.vote_processor.vote_blocking (transaction, vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	}
 	system.deadline_set (10s);

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -530,7 +530,7 @@ bool nano::active_transactions::add (std::shared_ptr<nano::block> block_a, bool 
 }
 
 // Validate a vote and apply it to the current election if one exists
-nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a, bool single_lock)
+nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> vote_a)
 {
 	// If none of the hashes are active, it is unknown whether it's a replay
 	// In this case, votes are also not republished
@@ -538,11 +538,7 @@ nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> vot
 	bool replay (false);
 	bool processed (false);
 	{
-		nano::unique_lock<std::mutex> lock;
-		if (!single_lock)
-		{
-			lock = nano::unique_lock<std::mutex> (mutex);
-		}
+		nano::lock_guard<std::mutex> lock (mutex);
 		for (auto vote_block : vote_a->blocks)
 		{
 			nano::election_vote_result result;
@@ -797,14 +793,10 @@ uint64_t nano::active_transactions::limited_active_difficulty ()
 }
 
 // List of active blocks in elections
-std::deque<std::shared_ptr<nano::block>> nano::active_transactions::list_blocks (bool single_lock)
+std::deque<std::shared_ptr<nano::block>> nano::active_transactions::list_blocks ()
 {
 	std::deque<std::shared_ptr<nano::block>> result;
-	nano::unique_lock<std::mutex> lock;
-	if (!single_lock)
-	{
-		lock = nano::unique_lock<std::mutex> (mutex);
-	}
+	nano::lock_guard<std::mutex> lock (mutex);
 	for (auto & root : roots)
 	{
 		result.push_back (root.election->status.winner);

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -80,7 +80,7 @@ public:
 	bool start (std::shared_ptr<nano::block>, bool const = false, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
-	nano::vote_code vote (std::shared_ptr<nano::vote>, bool = false);
+	nano::vote_code vote (std::shared_ptr<nano::vote>);
 	// Is the root of this block in the roots container
 	bool active (nano::block const &);
 	bool active (nano::qualified_root const &);
@@ -89,7 +89,7 @@ public:
 	void update_active_difficulty (nano::unique_lock<std::mutex> &);
 	uint64_t active_difficulty ();
 	uint64_t limited_active_difficulty ();
-	std::deque<std::shared_ptr<nano::block>> list_blocks (bool = false);
+	std::deque<std::shared_ptr<nano::block>> list_blocks ();
 	void erase (nano::block const &);
 	bool empty ();
 	size_t size ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -330,7 +330,7 @@ startup_time (std::chrono::steady_clock::now ())
 						{
 							logger.try_log (boost::str (boost::format ("Found a representative at %1%") % channel_a->to_string ()));
 							// Rebroadcasting all active votes to new representative
-							auto blocks (this->active.list_blocks (true));
+							auto blocks (this->active.list_blocks ());
 							for (auto i (blocks.begin ()), n (blocks.end ()); i != n; ++i)
 							{
 								if (*i != nullptr)


### PR DESCRIPTION
This also removes some code-smell around passing in a bool to determine if the lock should actually be acquired.