### PR TITLE
Add clang-format test back in

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,22 @@ jobs:
       - name: Run Tests
         run: ci/build-travis.sh "/tmp/qt/lib/cmake/Qt5";
 
+  clang_format:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@50fbc62
+      - name: Get Clang 9
+        env: 
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - 
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' -y
+          sudo apt-get update -y
+          sudo apt-get install clang-tools-9 clang-format-9
+          sudo ln -s /usr/bin/clang-format-9 /usr/bin/clang-format
+      - name: Clang Format
+        run: ci/check-commit-format.sh 
+
   gcc_test:
     runs-on: ubuntu-18.04
     steps:

--- a/ci/check-commit-format.sh
+++ b/ci/check-commit-format.sh
@@ -10,4 +10,7 @@ if [ "$RESULT" != "no modified files to format" ] && [ "$RESULT" != "clang-forma
     echo
     echo "Code formatting differs from expected - please run ci/clang-format-all.sh"
     exit 1
+else
+    echo "clang-format passed"
+    exit 0
 fi


### PR DESCRIPTION
add clang-format back into the tests to be run
update check-commit-format.sh to return all clear
forced push to split cleanup of codebase to #2480 