### PR TITLE
Unchecked cache not handling duplicate entries or unchecked_clear

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -605,6 +605,9 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+
+	auto transaction = node1->store.tx_begin_read ();
+	ASSERT_EQ (node1->ledger.cache.unchecked_count, node1->store.unchecked_count (transaction));
 	node1->stop ();
 }
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -276,6 +276,9 @@ TEST (node, auto_bootstrap)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
+	auto transaction = node1->store.tx_begin_read ();
+	ASSERT_EQ (node1->ledger.cache.unchecked_count, node1->store.unchecked_count (transaction));
+
 	node1->stop ();
 }
 
@@ -2867,6 +2870,7 @@ TEST (node, block_processor_signatures)
 	{
 		auto transaction (node1.store.tx_begin_write ());
 		node1.store.unchecked_put (transaction, send5->previous (), send5);
+		++node1.ledger.cache.unchecked_count;
 	}
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, 0));
 	node1.work_generate_blocking (*receive1);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3934,6 +3934,7 @@ void nano::json_handler::unchecked_clear ()
 	node.worker.push_task ([rpc_l]() {
 		auto transaction (rpc_l->node.store.tx_begin_write ());
 		rpc_l->node.store.unchecked_clear (transaction);
+		rpc_l->node.ledger.cache.unchecked_count = 0;
 		rpc_l->response_l.put ("success", "");
 		rpc_l->response_errors ();
 	});

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -457,6 +457,7 @@ startup_time (std::chrono::steady_clock::now ())
 			{
 				auto transaction (store.tx_begin_write ());
 				store.unchecked_clear (transaction);
+				ledger.cache.unchecked_count = 0;
 				logger.always_log ("Dropping unchecked blocks");
 			}
 		}
@@ -936,8 +937,11 @@ void nano::node::unchecked_cleanup ()
 		{
 			auto key (cleaning_list.front ());
 			cleaning_list.pop_front ();
-			store.unchecked_del (transaction, key);
-			--ledger.cache.unchecked_count;
+			if (!store.unchecked_del (transaction, key))
+			{
+				assert (ledger.cache.unchecked_count > 0);
+				--ledger.cache.unchecked_count;
+			}
 		}
 	}
 }

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -702,7 +702,8 @@ public:
 	virtual void unchecked_put (nano::write_transaction const &, nano::unchecked_key const &, nano::unchecked_info const &) = 0;
 	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
 	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
-	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
+	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
+	virtual bool unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -703,6 +703,7 @@ public:
 	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
 	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
+	/* Returns true if nothing was deleted because it was not found, false otherwise */
 	virtual bool unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -77,6 +77,14 @@ public:
 		return iterator != pending_end () && nano::pending_key (iterator->first) == key_a;
 	}
 
+	bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override
+	{
+		nano::db_val<Val> value;
+		auto status (get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
+		release_assert (success (status) || not_found (status));
+		return (success (status));
+	}
+
 	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
 		std::vector<nano::unchecked_info> result;
@@ -477,10 +485,11 @@ public:
 		release_assert (success (status));
 	}
 
-	void unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
+	bool unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
 	{
 		auto status (del (transaction_a, tables::unchecked, key_a));
 		release_assert (success (status) || not_found (status));
+		return not_found (status);
 	}
 
 	std::shared_ptr<nano::vote> vote_get (nano::transaction const & transaction_a, nano::account const & account_a) override


### PR DESCRIPTION
The `unchecked_count` cache was not being updated when the unchecked table was cleared, which happened in 2 places. There was no `unchecked_clear` RPC test, so I've added one, the other code block is called on node start-up and isn't entered during tests, so couldn't make a test for it.

Processing blocks also just `unchecked_put` without any check for existence already, this is now checked. Added checks for tests which were confirmed to hit this. The extra `unchecked_exists` call only took 0.08% of CPU time during a snapshot on a bootstrapping attempt (gathering unchecked) on beta with LMDB. Untested on RocksDB, but `unchecked_get` is already an issue with it during bootstrapping, so any negative effects should be sorted for free alongside that.


Did a beta bootstrap and had 0 unchecked blocks and all checked blocks.