### PR TITLE
Log when voting and warn if voting with more than one account

### DIFF
--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -62,7 +62,11 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 				          << "Path: " << node->application_path.string () << "\n"
 				          << "Build Info: " << BUILD_INFO << "\n"
 				          << "Database backend: " << node->store.vendor_get () << std::endl;
-
+				auto voting (node->wallets.rep_counts ().voting);
+				if (voting > 1)
+				{
+					std::cout << "Voting with more than one representative (" << voting << "). This can limit performance" << std::endl;
+				}
 				node->start ();
 				nano::ipc::ipc_server ipc_server (*node, config.rpc);
 #if BOOST_PROCESS_SUPPORTED

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -65,7 +65,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 				auto voting (node->wallets.rep_counts ().voting);
 				if (voting > 1)
 				{
-					std::cout << "Voting with more than one representative (" << voting << "). This can limit performance" << std::endl;
+					std::cout << "Voting with more than one representative can limit performance: " << voting << " representatives are configured" << std::endl;
 				}
 				node->start ();
 				nano::ipc::ipc_server ipc_server (*node, config.rpc);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -419,11 +419,12 @@ startup_time (std::chrono::steady_clock::now ())
 
 		if (config.enable_voting)
 		{
-			std::ostringstream stream ("Voting is enabled, more system resources will be used");
+			std::ostringstream stream;
+			stream << "Voting is enabled, more system resources will be used";
 			auto voting (wallets.rep_counts ().voting);
 			if (voting > 0)
 			{
-				stream << ". " << voting << " representatives are configured";
+				stream << ". " << voting << " representative(s) are configured";
 				if (voting > 1)
 				{
 					stream << ". Voting with more than one representative can limit performance";

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -414,6 +414,21 @@ startup_time (std::chrono::steady_clock::now ())
 			std::exit (1);
 		}
 
+		if (config.enable_voting)
+		{
+			std::ostringstream stream ("Voting is enabled, more system resources will be used");
+			auto voting (wallets.rep_counts ().voting);
+			if (voting > 0)
+			{
+				stream << ". " << voting << " representatives are configured";
+				if (voting > 1)
+				{
+					stream << ". Voting with more than one representative can limit performance";
+				}
+			}
+			logger.always_log (stream.str ());
+		}
+
 		node_id = nano::keypair ();
 		logger.always_log ("Node ID: ", node_id.pub.to_node_id ());
 


### PR DESCRIPTION
This only warns on startup so it will not recognize representatives in a fresh node, but otherwise, it does the following:

If voting is enabled:
- log:
  - how many voting accounts are detected
  - warn about system resources if more than one voting account
- stdout
  - display a warning if more than one voting account

With #2432 the cache size is limited automatically if more accounts are voting, which motivated this PR.

**Examples**
1 representative:
- log: `Voting is enabled, more system resources will be used. 1 representative(s) are configured`

2 representatives:
- log: `Voting is enabled, more system resources will be used. 2 representative(s) are configured. Voting with more than one representative can limit performance`
- stdout: `Voting with more than one representative (2). This can limit performance`