### PR TITLE
Directed block broadcasting for long elections

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -590,8 +590,7 @@ TEST (active_transactions, update_difficulty)
 	node1.process_active (send1);
 	node1.process_active (send2);
 	node1.block_processor.flush ();
-	auto ec = system.poll_until_true (10s, [&node1, &node2] { return node1.active.size () == 2 && node2.active.size () == 2; });
-	ASSERT_NO_ERROR (ec);
+	ASSERT_NO_ERROR (system.poll_until_true (10s, [&node1, &node2] { return node1.active.size () == 2 && node2.active.size () == 2; }));
 	// Update work with higher difficulty
 	auto work1 = node1.work_generate_blocking (send1->root (), difficulty1 + 1);
 	auto work2 = node1.work_generate_blocking (send2->root (), difficulty2 + 1);

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -590,7 +590,8 @@ TEST (active_transactions, update_difficulty)
 	node1.process_active (send1);
 	node1.process_active (send2);
 	node1.block_processor.flush ();
-	system.poll_until_true (10s, [&node1, &node2] { return node1.active.size () == 2 && node2.active.size () == 2; });
+	auto ec = system.poll_until_true (10s, [&node1, &node2] { return node1.active.size () == 2 && node2.active.size () == 2; });
+	ASSERT_NO_ERROR (ec);
 	// Update work with higher difficulty
 	auto work1 = node1.work_generate_blocking (send1->root (), difficulty1 + 1);
 	auto work2 = node1.work_generate_blocking (send2->root (), difficulty2 + 1);

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -590,7 +590,7 @@ TEST (active_transactions, update_difficulty)
 	node1.process_active (send1);
 	node1.process_active (send2);
 	node1.block_processor.flush ();
-	system.poll_until_true (10s, [&node1, &node2] {return node1.active.size () == 2 && node2.active.size () == 2;});
+	system.poll_until_true (10s, [&node1, &node2] { return node1.active.size () == 2 && node2.active.size () == 2; });
 	// Update work with higher difficulty
 	auto work1 = node1.work_generate_blocking (send1->root (), difficulty1 + 1);
 	auto work2 = node1.work_generate_blocking (send2->root (), difficulty2 + 1);

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -7,6 +7,7 @@ nano::confirmation_solicitor::confirmation_solicitor (nano::network & network_a,
 max_confirm_req_batches (params_a.is_test_network () ? 1 : 20),
 max_block_broadcasts (params_a.is_test_network () ? 4 : 30),
 max_election_requests (30),
+max_election_broadcasts (network_a.fanout () / 2),
 network (network_a)
 {
 }
@@ -16,20 +17,32 @@ void nano::confirmation_solicitor::prepare (std::vector<nano::representative> co
 	debug_assert (!prepared);
 	requests.clear ();
 	rebroadcasted = 0;
-	representatives = representatives_a;
+	representatives_requests = representatives_broadcasts = representatives_a;
 	prepared = true;
 }
 
 bool nano::confirmation_solicitor::broadcast (nano::election const & election_a)
 {
 	debug_assert (prepared);
-	bool result (true);
+	bool error (true);
 	if (rebroadcasted++ < max_block_broadcasts)
 	{
-		network.flood_block (election_a.status.winner);
-		result = false;
+		nano::publish winner (election_a.status.winner);
+		unsigned count = 0;
+		// Directed broadcasting to principal representatives
+		for (auto i (representatives_broadcasts.begin ()), n (representatives_broadcasts.end ()); i != n && count < max_election_broadcasts; ++i)
+		{
+			if (election_a.last_votes.find (i->account) == election_a.last_votes.end ())
+			{
+				i->channel->send (winner);
+				++count;
+			}
+		}
+		// Random flood for block propagation
+		network.flood_message (winner, nano::buffer_drop_policy::limiter, 0.5f);
+		error = false;
 	}
-	return result;
+	return error;
 }
 
 bool nano::confirmation_solicitor::add (nano::election const & election_a)
@@ -37,7 +50,7 @@ bool nano::confirmation_solicitor::add (nano::election const & election_a)
 	debug_assert (prepared);
 	auto const max_channel_requests (max_confirm_req_batches * nano::network::confirm_req_hashes_max);
 	unsigned count = 0;
-	for (auto i (representatives.begin ()); i != representatives.end () && count < max_election_requests;)
+	for (auto i (representatives_requests.begin ()); i != representatives_requests.end () && count < max_election_requests;)
 	{
 		bool full_queue (false);
 		auto rep (*i);
@@ -54,7 +67,7 @@ bool nano::confirmation_solicitor::add (nano::election const & election_a)
 				full_queue = true;
 			}
 		}
-		i = !full_queue ? i + 1 : representatives.erase (i);
+		i = !full_queue ? i + 1 : representatives_requests.erase (i);
 	}
 	return count == 0;
 }

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -17,7 +17,9 @@ void nano::confirmation_solicitor::prepare (std::vector<nano::representative> co
 	debug_assert (!prepared);
 	requests.clear ();
 	rebroadcasted = 0;
-	representatives_requests = representatives_broadcasts = representatives_a;
+	/** Two copies are required as representatives can be erased from \p representatives_requests */
+	representatives_requests = representatives_a;
+	representatives_broadcasts = representatives_a;
 	prepared = true;
 }
 

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -28,12 +28,15 @@ public:
 	size_t const max_block_broadcasts;
 	/** Maximum amount of requests to be sent per election */
 	size_t const max_election_requests;
+	/** Maximum amount of directed broadcasts to be sent per election */
+	size_t const max_election_broadcasts;
 
 private:
 	nano::network & network;
 
 	unsigned rebroadcasted{ 0 };
-	std::vector<nano::representative> representatives;
+	std::vector<nano::representative> representatives_requests;
+	std::vector<nano::representative> representatives_broadcasts;
 	using vector_root_hashes = std::vector<std::pair<nano::block_hash, nano::root>>;
 	std::unordered_map<std::shared_ptr<nano::transport::channel>, vector_root_hashes> requests;
 	bool prepared{ false };

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -148,9 +148,9 @@ void nano::network::send_node_id_handshake (std::shared_ptr<nano::transport::cha
 	channel_a->send (message);
 }
 
-void nano::network::flood_message (nano::message const & message_a, nano::buffer_drop_policy drop_policy_a)
+void nano::network::flood_message (nano::message const & message_a, nano::buffer_drop_policy const drop_policy_a, float const scale_a)
 {
-	for (auto & i : list (fanout ()))
+	for (auto & i : list (fanout (scale_a)))
 	{
 		i->send (message_a, nullptr, drop_policy_a);
 	}

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -100,7 +100,7 @@ public:
 	~network ();
 	void start ();
 	void stop ();
-	void flood_message (nano::message const &, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
+	void flood_message (nano::message const &, nano::buffer_drop_policy const = nano::buffer_drop_policy::limiter, float const = 1.0f);
 	void flood_keepalive ()
 	{
 		nano::keepalive message;


### PR DESCRIPTION
If we're not getting votes from representatives after some time, it makes more sense to send them the election winner rather than a random flood, but the flood is still kept at half scale. The duplicate filter prevents this from being a large burden on representatives.

Therefore, with this PR, the behavior is: **for up to 30 elections per loop, send to top sqrt(peers)/2 representatives that haven't voted for that election, and to sqrt(peers)/2 random peers.**

A second copy of `representatives` is made in the solicitor since some representatives could be erased from the list afterr #2649 .

Note: the change on the `update_difficulty` test is not necessary but makes it faster since it does not wait for the election broadcasting (outside of tests, the node broadcasts a block with updated difficulty)