### PR TITLE
Clear peers and online weight after 1 week of inactivity

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -783,11 +783,8 @@ void nano::node::long_inactivity_cleanup ()
 			++sample;
 		}
 		assert (sample != n);
-		auto one_week_ago = (std::chrono::system_clock::now () - std::chrono::hours (7 * 24)).time_since_epoch ().count ();
-		if (sample->first < one_week_ago)
-		{
-			perform_cleanup = true;
-		}
+		auto const one_week_ago = (std::chrono::system_clock::now () - std::chrono::hours (7 * 24)).time_since_epoch ().count ();
+		perform_cleanup = sample->first < one_week_ago;
 	}
 	if (perform_cleanup)
 	{

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -115,7 +115,6 @@ public:
 	nano::block_hash rep_block (nano::account const &);
 	nano::uint128_t minimum_principal_weight ();
 	nano::uint128_t minimum_principal_weight (nano::uint128_t const &);
-	void long_inactivity_cleanup ();
 	void ongoing_rep_calculation ();
 	void ongoing_bootstrap ();
 	void ongoing_store_flush ();
@@ -195,6 +194,9 @@ public:
 	std::atomic<bool> stopped{ false };
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
+
+private:
+	void long_inactivity_cleanup ();
 };
 
 std::unique_ptr<container_info_component> collect_container_info (node & node, const std::string & name);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -115,6 +115,7 @@ public:
 	nano::block_hash rep_block (nano::account const &);
 	nano::uint128_t minimum_principal_weight ();
 	nano::uint128_t minimum_principal_weight (nano::uint128_t const &);
+	void long_inactivity_cleanup ();
 	void ongoing_rep_calculation ();
 	void ongoing_bootstrap ();
 	void ongoing_store_flush ();


### PR DESCRIPTION
To test, add this after L775 in node.cpp

```cpp
store.online_weight_put (transaction, (std::chrono::system_clock::now () - std::chrono::hours (8 * 24)).time_since_epoch ().count (), nano::amount (1000));
```

Do we have any other way of reaching the last entry without using two iterators as I did?