### PR TITLE
Adjust request aggregator stats

### DIFF
--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -34,7 +34,7 @@ TEST (request_aggregator, one)
 	// In the ledger but no vote generated yet
 	// Generated votes are created after the pool is removed from the aggregator, so a simple check on empty () is not enough
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated) == 0)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -49,10 +49,9 @@ TEST (request_aggregator, one)
 	}
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_EQ (3, node.stats.count (nano::stat::type::requests, nano::stat::detail::all));
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
@@ -80,19 +79,18 @@ TEST (request_aggregator, one_update)
 	// In the ledger but no vote generated yet
 	// Generated votes are created after the pool is removed from the aggregator, so a simple check on empty () is not enough
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out) == 0)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_TRUE (node.aggregator.empty ());
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::in));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::out));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::in));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out));
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached));
+	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
@@ -118,12 +116,11 @@ TEST (request_aggregator, two)
 	// One vote should be generated for both blocks
 	// Generated votes are created after the pool is removed from the aggregator, so a simple check on empty () is not enough
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated) == 0)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	ASSERT_TRUE (node.aggregator.empty ());
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out));
 	// The same request should now send the cached vote
 	node.aggregator.add (channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
@@ -134,13 +131,11 @@ TEST (request_aggregator, two)
 	}
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_EQ (4, node.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::in));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::out));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::in));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached, nano::stat::dir::in));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached, nano::stat::dir::out));
+	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	// Make sure the cached vote is for both hashes
 	auto vote1 (node.votes_cache.find (send1->hash ()));
@@ -179,13 +174,11 @@ TEST (request_aggregator, two_endpoints)
 	}
 	ASSERT_EQ (2, node1.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_EQ (2, node1.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::in));
-	ASSERT_EQ (2, node1.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::out));
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::in));
-	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out));
-	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached, nano::stat::dir::in));
-	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached, nano::stat::dir::out));
+	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
+	ASSERT_EQ (1, node1.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
 }
 
 TEST (request_aggregator, split)
@@ -224,7 +217,7 @@ TEST (request_aggregator, split)
 	// In the ledger but no vote generated yet
 	// Generated votes are created after the pool is removed from the aggregator, so a simple check on empty () is not enough
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated) < 2)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) < 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -232,12 +225,10 @@ TEST (request_aggregator, split)
 	// Two votes were sent, the first one for 12 hashes and the second one for 1 hash
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_EQ (13, node.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::in));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::all, nano::stat::dir::out));
-	ASSERT_EQ (13, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::in));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out));
+	ASSERT_EQ (13, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_EQ (2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
@@ -260,7 +251,7 @@ TEST (request_aggregator, channel_lifetime)
 	}
 	ASSERT_EQ (1, node.aggregator.size ());
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated) == 0)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -292,7 +283,7 @@ TEST (request_aggregator, channel_update)
 	// channel1 is not being held anymore
 	ASSERT_EQ (nullptr, channel1_w.lock ());
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated) == 0)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -339,9 +330,9 @@ TEST (request_aggregator, unique)
 	node.aggregator.add (channel, request);
 	node.aggregator.add (channel, request);
 	system.deadline_set (3s);
-	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::out) < 1)
+	while (node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) < 1)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated, nano::stat::dir::in));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -150,9 +150,11 @@ TEST (request_aggregator, two_endpoints)
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	auto & node1 (*system.add_node (node_config));
+	nano::node_flags node_flags;
+	node_flags.disable_rep_crawler = true;
+	auto & node1 (*system.add_node (node_config, node_flags));
 	node_config.peering_port = nano::get_available_port ();
-	auto & node2 (*system.add_node (node_config));
+	auto & node2 (*system.add_node (node_config, node_flags));
 	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (genesis.hash ())));

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -652,11 +652,17 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::aggregator_dropped:
 			res = "aggregator_dropped";
 			break;
-		case nano::stat::detail::requests_cached:
-			res = "requests_cached";
+		case nano::stat::detail::requests_cached_hashes:
+			res = "requests_cached_hashes";
 			break;
-		case nano::stat::detail::requests_generated:
-			res = "requests_generated";
+		case nano::stat::detail::requests_generated_hashes:
+			res = "requests_generated_hashes";
+			break;
+		case nano::stat::detail::requests_cached_votes:
+			res = "requests_cached_votes";
+			break;
+		case nano::stat::detail::requests_generated_votes:
+			res = "requests_generated_votes";
 			break;
 		case nano::stat::detail::requests_unknown:
 			res = "requests_unknown";

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -438,6 +438,9 @@ std::string nano::stat::type_to_string (uint32_t key)
 		case nano::stat::type::drop:
 			res = "drop";
 			break;
+		case nano::stat::type::aggregator:
+			res = "aggregator";
+			break;
 		case nano::stat::type::requests:
 			res = "requests";
 			break;
@@ -643,17 +646,20 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::blocks_confirmed:
 			res = "blocks_confirmed";
 			break;
+		case nano::stat::detail::aggregator_accepted:
+			res = "aggregator_accepted";
+			break;
+		case nano::stat::detail::aggregator_dropped:
+			res = "aggregator_dropped";
+			break;
 		case nano::stat::detail::requests_cached:
-			res = "requests_votes_cached";
+			res = "requests_cached";
 			break;
 		case nano::stat::detail::requests_generated:
-			res = "requests_votes_generated";
+			res = "requests_generated";
 			break;
-		case nano::stat::detail::requests_ignored:
-			res = "requests_votes_ignored";
-			break;
-		case nano::stat::detail::requests_dropped:
-			res = "requests_dropped";
+		case nano::stat::detail::requests_unknown:
+			res = "requests_unknown";
 			break;
 	}
 	return res;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -198,6 +198,7 @@ public:
 		observer,
 		confirmation_height,
 		drop,
+		aggregator,
 		requests
 	};
 
@@ -295,11 +296,14 @@ public:
 		blocks_confirmed,
 		invalid_block,
 
+		// [request] aggregator
+		aggregator_accepted,
+		aggregator_dropped,
+
 		// requests
 		requests_cached,
 		requests_generated,
-		requests_ignored,
-		requests_dropped
+		requests_unknown,
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -301,9 +301,11 @@ public:
 		aggregator_dropped,
 
 		// requests
-		requests_cached,
-		requests_generated,
-		requests_unknown,
+		requests_cached_hashes,
+		requests_generated_hashes,
+		requests_cached_votes,
+		requests_generated_votes,
+		requests_unknown
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -130,6 +130,16 @@ bool nano::request_aggregator::empty ()
 
 std::vector<nano::block_hash> nano::request_aggregator::aggregate (nano::transaction const & transaction_a, channel_pool & pool_a) const
 {
+	// Unique hashes
+	using pair = decltype (pool_a.hashes_roots)::value_type;
+	std::sort (pool_a.hashes_roots.begin (), pool_a.hashes_roots.end (), [](pair const & pair1, pair const & pair2) {
+		return pair1.first < pair2.first;
+	});
+	pool_a.hashes_roots.erase (std::unique (pool_a.hashes_roots.begin (), pool_a.hashes_roots.end (), [](pair const & pair1, pair const & pair2) {
+		return pair1.first == pair2.first;
+	}),
+	pool_a.hashes_roots.end ());
+
 	size_t cached_hashes = 0;
 	std::vector<nano::block_hash> to_generate;
 	std::vector<std::shared_ptr<nano::vote>> cached_votes;
@@ -197,10 +207,6 @@ std::vector<nano::block_hash> nano::request_aggregator::aggregate (nano::transac
 
 void nano::request_aggregator::generate (nano::transaction const & transaction_a, std::vector<nano::block_hash> hashes_a, std::shared_ptr<nano::transport::channel> & channel_a) const
 {
-	// Unique hashes
-	std::sort (hashes_a.begin (), hashes_a.end ());
-	hashes_a.erase (std::unique (hashes_a.begin (), hashes_a.end ()), hashes_a.end ());
-
 	size_t generated_l = 0;
 	auto i (hashes_a.begin ());
 	auto n (hashes_a.end ());

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -199,9 +199,8 @@ std::vector<nano::block_hash> nano::request_aggregator::aggregate (nano::transac
 		nano::confirm_ack confirm (vote);
 		pool_a.channel->send (confirm);
 	}
-	// #hashes in, #votes out
-	stats.add (nano::stat::type::requests, nano::stat::detail::requests_cached, stat::dir::in, cached_hashes);
-	stats.add (nano::stat::type::requests, nano::stat::detail::requests_cached, stat::dir::out, cached_votes.size ());
+	stats.add (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes, stat::dir::in, cached_hashes);
+	stats.add (nano::stat::type::requests, nano::stat::detail::requests_cached_votes, stat::dir::in, cached_votes.size ());
 	return to_generate;
 }
 
@@ -225,9 +224,8 @@ void nano::request_aggregator::generate (nano::transaction const & transaction_a
 			this->votes_cache.add (vote);
 		});
 	}
-	// #hashes in, #votes out
-	stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated, stat::dir::in, hashes_a.size ());
-	stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated, stat::dir::out, generated_l);
+	stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes, stat::dir::in, hashes_a.size ());
+	stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated_votes, stat::dir::in, generated_l);
 }
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::request_aggregator & aggregator, const std::string & name)

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -76,7 +76,7 @@ private:
 	/** Aggregate and send cached votes for \p pool_a, returning the leftovers that were not found in cached votes **/
 	std::vector<nano::block_hash> aggregate (nano::transaction const &, channel_pool & pool_a) const;
 	/** Generate and send votes from \p hashes_a to \p channel_a, does not need a lock on the mutex **/
-	void generate (nano::transaction const &, std::vector<nano::block_hash> const hashes_a, std::shared_ptr<nano::transport::channel> & channel_a) const;
+	void generate (nano::transaction const &, std::vector<nano::block_hash> hashes_a, std::shared_ptr<nano::transport::channel> & channel_a) const;
 
 	nano::stat & stats;
 	nano::votes_cache & votes_cache;


### PR DESCRIPTION
And ensures unique hashes before generating votes, by doing the same sort+unique as for votes.

Based on feedback from @Srayman , these adjusted stats are now useful to determine the ratio of votes-to-hashes and other interesting stats.

```cpp
aggregator_accepted
aggregator_dropped

requests_cached_hashes
requests_generated_hashes
requests_cached_votes
requests_generated_votes
requests_unknow
```