### PR TITLE
Update bootstrap tests to disable frontiers confirmation

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -189,13 +189,13 @@ TEST (bootstrap_processor, process_one)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.enable_voting = false;
-	auto node0 = system.add_node (node_config);
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 = system.add_node (node_config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 100));
 
 	node_config.peering_port = nano::get_available_port ();
-	nano::node_flags node_flags;
-	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_rep_crawler = true;
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), system.alarm, node_config, system.work, node_flags));
 	nano::block_hash hash1 (node0->latest (nano::test_genesis_key.pub));
@@ -214,22 +214,27 @@ TEST (bootstrap_processor, process_one)
 
 TEST (bootstrap_processor, process_two)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 (system.add_node (config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash hash1 (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::block_hash hash1 (node0->latest (nano::test_genesis_key.pub));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 50));
-	nano::block_hash hash2 (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::block_hash hash2 (node0->latest (nano::test_genesis_key.pub));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 50));
-	nano::block_hash hash3 (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::block_hash hash3 (node0->latest (nano::test_genesis_key.pub));
 	ASSERT_NE (hash1, hash2);
 	ASSERT_NE (hash1, hash3);
 	ASSERT_NE (hash2, hash3);
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
-	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
-	ASSERT_NE (node1->latest (nano::test_genesis_key.pub), system.nodes[0]->latest (nano::test_genesis_key.pub));
+	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
+	ASSERT_NE (node1->latest (nano::test_genesis_key.pub), node0->latest (nano::test_genesis_key.pub));
 	system.deadline_set (10s);
-	while (node1->latest (nano::test_genesis_key.pub) != system.nodes[0]->latest (nano::test_genesis_key.pub))
+	while (node1->latest (nano::test_genesis_key.pub) != node0->latest (nano::test_genesis_key.pub))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -239,10 +244,14 @@ TEST (bootstrap_processor, process_two)
 // Bootstrap can pull universal blocks
 TEST (bootstrap_processor, process_state)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 (system.add_node (config, node_flags));
 	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto node0 (system.nodes[0]);
 	auto block1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, node0->latest (nano::test_genesis_key.pub), nano::test_genesis_key.pub, nano::genesis_amount - 100, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	auto block2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, block1->hash (), nano::test_genesis_key.pub, nano::genesis_amount, block1->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node0->work_generate_blocking (*block1);
@@ -265,45 +274,57 @@ TEST (bootstrap_processor, process_state)
 
 TEST (bootstrap_processor, process_new)
 {
-	nano::system system (2);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node1 (system.add_node (config, node_flags));
+	config.peering_port = nano::get_available_port ();
+	auto node2 (system.add_node (config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node1->config.receive_minimum.number ()));
 	system.deadline_set (10s);
-	while (system.nodes[0]->balance (key2.pub).is_zero ())
+	while (node1->balance (key2.pub).is_zero ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	nano::uint128_t balance1 (system.nodes[0]->balance (nano::test_genesis_key.pub));
-	nano::uint128_t balance2 (system.nodes[0]->balance (key2.pub));
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
-	ASSERT_FALSE (node1->init_error ());
-	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
+	nano::uint128_t balance1 (node1->balance (nano::test_genesis_key.pub));
+	nano::uint128_t balance2 (node1->balance (key2.pub));
+	auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
+	ASSERT_FALSE (node3->init_error ());
+	node3->bootstrap_initiator.bootstrap (node1->network.endpoint ());
 	system.deadline_set (10s);
-	while (node1->balance (key2.pub) != balance2)
+	while (node3->balance (key2.pub) != balance2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (balance1, node1->balance (nano::test_genesis_key.pub));
-	node1->stop ();
+	ASSERT_EQ (balance1, node3->balance (nano::test_genesis_key.pub));
+	node3->stop ();
 }
 
 TEST (bootstrap_processor, pull_diamond)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 (system.add_node (config, node_flags));
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::send_block> (system.nodes[0]->latest (nano::test_genesis_key.pub), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (system.nodes[0]->latest (nano::test_genesis_key.pub))));
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*send1).code);
+	auto send1 (std::make_shared<nano::send_block> (node0->latest (nano::test_genesis_key.pub), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (node0->latest (nano::test_genesis_key.pub))));
+	ASSERT_EQ (nano::process_result::progress, node0->process (*send1).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), 1, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*open).code);
+	ASSERT_EQ (nano::process_result::progress, node0->process (*open).code);
 	auto send2 (std::make_shared<nano::send_block> (open->hash (), nano::test_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 100, key.prv, key.pub, *system.work.generate (open->hash ())));
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*send2).code);
+	ASSERT_EQ (nano::process_result::progress, node0->process (*send2).code);
 	auto receive (std::make_shared<nano::receive_block> (send1->hash (), send2->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*receive).code);
+	ASSERT_EQ (nano::process_result::progress, node0->process (*receive).code);
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
-	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
+	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
 	system.deadline_set (10s);
 	while (node1->balance (nano::test_genesis_key.pub) != 100)
 	{
@@ -315,9 +336,14 @@ TEST (bootstrap_processor, pull_diamond)
 
 TEST (bootstrap_processor, pull_requeue_network_error)
 {
-	nano::system system (2);
-	auto node1 = system.nodes[0];
-	auto node2 = system.nodes[1];
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node1 (system.add_node (config, node_flags));
+	config.peering_port = nano::get_available_port ();
+	auto node2 (system.add_node (config, node_flags));
 	nano::genesis genesis;
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
@@ -456,14 +482,17 @@ TEST (bootstrap_processor, frontiers_confirmed)
 
 TEST (bootstrap_processor, push_diamond)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto node0 (system.add_node (config));
 	nano::keypair key;
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	auto wallet1 (node1->wallets.create (100));
 	wallet1->insert_adhoc (nano::test_genesis_key.prv);
 	wallet1->insert_adhoc (key.prv);
-	auto send1 (std::make_shared<nano::send_block> (system.nodes[0]->latest (nano::test_genesis_key.pub), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (system.nodes[0]->latest (nano::test_genesis_key.pub))));
+	auto send1 (std::make_shared<nano::send_block> (node0->latest (nano::test_genesis_key.pub), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (node0->latest (nano::test_genesis_key.pub))));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), 1, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
@@ -471,19 +500,22 @@ TEST (bootstrap_processor, push_diamond)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	auto receive (std::make_shared<nano::receive_block> (send1->hash (), send2->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
-	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
+	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
 	system.deadline_set (10s);
-	while (system.nodes[0]->balance (nano::test_genesis_key.pub) != 100)
+	while (node0->balance (nano::test_genesis_key.pub) != 100)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (100, system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (100, node0->balance (nano::test_genesis_key.pub));
 	node1->stop ();
 }
 
 TEST (bootstrap_processor, push_one)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto node0 (system.add_node (config));
 	nano::keypair key1;
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
@@ -492,9 +524,9 @@ TEST (bootstrap_processor, push_one)
 	nano::uint128_t balance1 (node1->balance (nano::test_genesis_key.pub));
 	ASSERT_NE (nullptr, wallet->send_action (nano::test_genesis_key.pub, key1.pub, 100));
 	ASSERT_NE (balance1, node1->balance (nano::test_genesis_key.pub));
-	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint ());
+	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
 	system.deadline_set (10s);
-	while (system.nodes[0]->balance (nano::test_genesis_key.pub) == balance1)
+	while (node0->balance (nano::test_genesis_key.pub) == balance1)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -503,24 +535,29 @@ TEST (bootstrap_processor, push_one)
 
 TEST (bootstrap_processor, lazy_hash)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 (system.add_node (config, node_flags));
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (key2.pub)));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
+	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
 	// Processing test chain
-	system.nodes[0]->block_processor.add (send1);
-	system.nodes[0]->block_processor.add (receive1);
-	system.nodes[0]->block_processor.add (send2);
-	system.nodes[0]->block_processor.add (receive2);
-	system.nodes[0]->block_processor.flush ();
+	node0->block_processor.add (send1);
+	node0->block_processor.add (receive1);
+	node0->block_processor.add (send2);
+	node0->block_processor.add (receive2);
+	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	{
 		auto attempt (node1->bootstrap_initiator.current_attempt ());
@@ -538,8 +575,12 @@ TEST (bootstrap_processor, lazy_hash)
 
 TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 {
-	nano::system system (1);
-	auto node0 (system.nodes[0]);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 (system.add_node (config, node_flags));
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
@@ -574,30 +615,35 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 
 TEST (bootstrap_processor, lazy_max_pull_count)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	auto node0 (system.add_node (config, node_flags));
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (key2.pub)));
-	auto change1 (std::make_shared<nano::state_block> (key2.pub, receive2->hash (), key1.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (receive2->hash ())));
-	auto change2 (std::make_shared<nano::state_block> (key2.pub, change1->hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (change1->hash ())));
-	auto change3 (std::make_shared<nano::state_block> (key2.pub, change2->hash (), key2.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (change2->hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
+	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
+	auto change1 (std::make_shared<nano::state_block> (key2.pub, receive2->hash (), key1.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (receive2->hash ())));
+	auto change2 (std::make_shared<nano::state_block> (key2.pub, change1->hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (change1->hash ())));
+	auto change3 (std::make_shared<nano::state_block> (key2.pub, change2->hash (), key2.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (change2->hash ())));
 	// Processing test chain
-	system.nodes[0]->block_processor.add (send1);
-	system.nodes[0]->block_processor.add (receive1);
-	system.nodes[0]->block_processor.add (send2);
-	system.nodes[0]->block_processor.add (receive2);
-	system.nodes[0]->block_processor.add (change1);
-	system.nodes[0]->block_processor.add (change2);
-	system.nodes[0]->block_processor.add (change3);
-	system.nodes[0]->block_processor.flush ();
+	node0->block_processor.add (send1);
+	node0->block_processor.add (receive1);
+	node0->block_processor.add (send2);
+	node0->block_processor.add (receive2);
+	node0->block_processor.add (change1);
+	node0->block_processor.add (change2);
+	node0->block_processor.add (change3);
+	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
 	system.deadline_set (10s);
@@ -614,9 +660,12 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 TEST (bootstrap_processor, lazy_unclear_state_link)
 {
 	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_legacy_bootstrap = true;
-	auto node1 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node1 = system.add_node (config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key;
 	// Generating test chain
@@ -649,9 +698,12 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 {
 	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_legacy_bootstrap = true;
-	auto node1 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node1 = system.add_node (config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key, key2;
 	// Generating test chain
@@ -684,9 +736,12 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 TEST (bootstrap_processor, lazy_destinations)
 {
 	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_legacy_bootstrap = true;
-	auto node1 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node1 = system.add_node (config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1, key2;
 	// Generating test chain
@@ -717,24 +772,30 @@ TEST (bootstrap_processor, lazy_destinations)
 
 TEST (bootstrap_processor, wallet_lazy_frontier)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_legacy_bootstrap = true;
+	auto node0 = system.add_node (config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.nodes[0]->work_generate_blocking (key2.pub)));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
+	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
 	// Processing test chain
-	system.nodes[0]->block_processor.add (send1);
-	system.nodes[0]->block_processor.add (receive1);
-	system.nodes[0]->block_processor.add (send2);
-	system.nodes[0]->block_processor.add (receive2);
-	system.nodes[0]->block_processor.flush ();
+	node0->block_processor.add (send1);
+	node0->block_processor.add (receive1);
+	node0->block_processor.add (send2);
+	node0->block_processor.add (receive2);
+	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -755,22 +816,28 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 
 TEST (bootstrap_processor, wallet_lazy_pending)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_legacy_bootstrap = true;
+	auto node0 = system.add_node (config, node_flags);
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.nodes[0]->work_generate_blocking (genesis.hash ())));
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *system.nodes[0]->work_generate_blocking (receive1->hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
+	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
 	// Processing test chain
-	system.nodes[0]->block_processor.add (send1);
-	system.nodes[0]->block_processor.add (receive1);
-	system.nodes[0]->block_processor.add (send2);
-	system.nodes[0]->block_processor.flush ();
+	node0->block_processor.add (send1);
+	node0->block_processor.add (receive1);
+	node0->block_processor.add (send2);
+	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
-	node1->network.udp_channels.insert (system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -904,9 +971,14 @@ TEST (frontier_req, time_cutoff)
 
 TEST (bulk, genesis)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_lazy_bootstrap = true;
+	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto node1 = system.nodes[0];
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node2->init_error ());
 	nano::block_hash latest1 (node1->latest (nano::test_genesis_key.pub));
@@ -928,9 +1000,14 @@ TEST (bulk, genesis)
 
 TEST (bulk, offline_send)
 {
-	nano::system system (1);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_lazy_bootstrap = true;
+	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto node1 = system.nodes[0];
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node2->init_error ());
 	node2->start ();

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -334,7 +334,7 @@ TEST (bootstrap_processor, pull_diamond)
 	node1->stop ();
 }
 
-TEST (bootstrap_processor, pull_requeue_network_error)
+TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 {
 	nano::system system;
 	nano::node_config config (nano::get_available_port (), system.logging);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -229,8 +229,13 @@ TEST (node, node_receive_quorum)
 
 TEST (node, auto_bootstrap)
 {
-	nano::system system (1);
-	auto node0 (system.nodes[0]);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_lazy_bootstrap = true;
+	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
@@ -284,8 +289,13 @@ TEST (node, auto_bootstrap)
 
 TEST (node, auto_bootstrap_reverse)
 {
-	nano::system system (1);
-	auto node0 (system.nodes[0]);
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_lazy_bootstrap = true;
+	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
@@ -1403,12 +1413,19 @@ TEST (node, fork_multi_flip)
 // This could happen if a fork wasn't resolved before the process previously shut down
 TEST (node, fork_bootstrap_flip)
 {
-	nano::system system0 (1);
-	nano::system system1 (1);
-	auto & node1 (*system0.nodes[0]);
-	auto & node2 (*system1.nodes[0]);
+	nano::system system0;
+	nano::system system1;
+	nano::node_config config0 (nano::get_available_port (), system0.logging);
+	config0.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags;
+	node_flags.disable_bootstrap_bulk_push_client = true;
+	node_flags.disable_lazy_bootstrap = true;
+	auto & node1 (*system0.add_node (config0, node_flags));
+	nano::node_config config1 (nano::get_available_port (), system1.logging);
+	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto & node2 (*system1.add_node (config1, node_flags));
 	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash latest (system0.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node1.latest (nano::test_genesis_key.pub));
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system0.work.generate (latest)));
 	nano::keypair key2;
@@ -1858,10 +1875,14 @@ TEST (node, DISABLED_bootstrap_no_publish)
 // Check that an outgoing bootstrap request can push blocks
 TEST (node, bootstrap_bulk_push)
 {
-	nano::system system0 (1);
-	nano::system system1 (1);
-	auto node0 (system0.nodes[0]);
-	auto node1 (system1.nodes[0]);
+	nano::system system0;
+	nano::system system1;
+	nano::node_config config0 (nano::get_available_port (), system0.logging);
+	config0.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto node0 (system0.add_node (config0));
+	nano::node_config config1 (nano::get_available_port (), system1.logging);
+	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto node1 (system1.add_node (config1));
 	nano::keypair key0;
 	// node0 knows about send0 but node1 doesn't.
 	nano::send_block send0 (node0->latest (nano::test_genesis_key.pub), key0.pub, 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -832,7 +832,7 @@ TEST (websocket, bootstrap)
 	}
 	ASSERT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::bootstrap));
 
-	// Start bootsrap attempt
+	// Start bootstrap attempt
 	node1->bootstrap_initiator.bootstrap (true, "123abc");
 	ASSERT_NE (nullptr, node1->bootstrap_initiator.current_attempt ());
 
@@ -865,7 +865,7 @@ TEST (websocket, bootstrap)
 	}
 }
 
-TEST (websocket, bootstrap_excited)
+TEST (websocket, bootstrap_exited)
 {
 	nano::system system;
 	nano::node_config config (nano::get_available_port (), system.logging);
@@ -878,15 +878,16 @@ TEST (websocket, bootstrap_excited)
 	// Start bootstrap, exit after subscription
 	std::atomic<bool> bootstrap_started{ false };
 	std::atomic<bool> subscribed{ false };
-	std::thread bootstrap_thread ([&system, node1, &bootstrap_started, &subscribed]() {
+	std::thread bootstrap_thread ([node1, &bootstrap_started, &subscribed]() {
 		node1->bootstrap_initiator.bootstrap (true, "123abc");
 		auto attempt (node1->bootstrap_initiator.current_attempt ());
 		ASSERT_NE (nullptr, attempt);
 		bootstrap_started = true;
-		system.deadline_set (5s);
+		nano::system system2;
+		system2.deadline_set (5s);
 		while (!subscribed)
 		{
-			ASSERT_NO_ERROR (system.poll ());
+			ASSERT_NO_ERROR (system2.poll ());
 		}
 	});
 


### PR DESCRIPTION
Additionally:
- Disable bulk pull for most tests
- Fix websocket.bootstrap_exited TSAN warnings
- Disable bootstrap_processor.pull_requeue_network_error test
- Improve bootstrap_processor.lazy_unclear_state_link_not_existing test