### PR TITLE
Refresh mutex lock after some consecutive requests without generation

### DIFF
--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -78,6 +78,8 @@ private:
 	/** Generate and send votes from \p hashes_a to \p channel_a, does not need a lock on the mutex **/
 	void generate (nano::transaction const &, std::vector<nano::block_hash> const hashes_a, std::shared_ptr<nano::transport::channel> & channel_a) const;
 
+	unsigned const max_consecutive_requests;
+
 	nano::stat & stats;
 	nano::votes_cache & votes_cache;
 	nano::block_store & store;


### PR DESCRIPTION
Got a `Mutex held for: 1292ms` on `request_aggregator::run()`, which can happen if there are many requests being processed and no vote generation on any of them.

This adds a counter of consecutive requests being processed and refreshes the mutex lock when it hits a threshold (10).

Threshold is set to 1 on the test network to ensure testing.