### PR TITLE
macro guards for unstable tests

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -7,6 +7,7 @@ on:
 env:
   RELEASE: 1
   artifact: 0
+  CI_TEST: 1
   
 jobs:
   osx_test:
@@ -31,7 +32,7 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/linux/install_deps.sh
       - name: Run Tests
-        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:gcc /bin/bash -c "cd /workspace && RELEASE=1 ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:gcc /bin/bash -c "cd /workspace && CI_TEST=${CI_TEST} RELEASE=1 ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
   
   clang_test:
     runs-on: ubuntu-18.04
@@ -42,7 +43,7 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/linux/install_deps.sh
       - name: Run Tests
-        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:clang /bin/bash -c "cd /workspace && RELEASE=1 ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:clang /bin/bash -c "cd /workspace && CI_TEST=${CI_TEST} RELEASE=1 ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
 
   windows_test:
     runs-on: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 env:
   RELEASE: 0
   artifact: 0
+  CI_TEST: 1
   
 jobs:
   osx_test:
@@ -45,7 +46,7 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/linux/install_deps.sh
       - name: Run Tests
-        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:gcc /bin/bash -c "cd /workspace && ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:gcc /bin/bash -c "cd /workspace && CI_TEST=${CI_TEST} ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
   
   clang_test:
     runs-on: ubuntu-18.04
@@ -56,7 +57,7 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/linux/install_deps.sh
       - name: Run Tests
-        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:clang /bin/bash -c "cd /workspace && RELEASE=0 ASAN=0 TSAN=0 ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:clang /bin/bash -c "cd /workspace && CI_TEST=${CI_TEST} ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
 
   windows_test:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ execute_process(
 )
 
 option (CI_BUILD false)
+set (CI_TEST false CACHE BOOL "")
 
 set (CPACK_PACKAGE_VERSION_MAJOR "21")
 set (CPACK_PACKAGE_VERSION_MINOR "0")

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -25,7 +25,7 @@ if (${env:artifact} -eq 1) {
     }
     $env:NETWORK_CFG = "test"
     $env:NANO_TEST = "-DNANO_TEST=ON"
-    $env:CI = "-DCI_BUILD=OFF"
+    $env:CI = "-DCI_TEST=ON"
     $env:RUN = "test"
 }
 

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -48,6 +48,7 @@ else
     ROCKSDB=""
 fi
 
+CI="${CI_TEST-false}"
 
 cmake \
     -G'Unix Makefiles' \
@@ -61,6 +62,7 @@ cmake \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DBOOST_ROOT=/tmp/boost/ \
     -DQt5_DIR=${qt_dir} \
+    -DCI_TEST=${CI} \
     ${SANITIZERS} \
     ..
 

--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -44,5 +44,7 @@ target_compile_definitions(core_test
 		PRIVATE
 			-DTAG_VERSION_STRING=${TAG_VERSION_STRING}
 			-DGIT_COMMIT_HASH=${GIT_COMMIT_HASH}
-			-DBOOST_PROCESS_SUPPORTED=${BOOST_PROCESS_SUPPORTED})
+			-DBOOST_PROCESS_SUPPORTED=${BOOST_PROCESS_SUPPORTED}
+			-DCI=${CI_TEST})
+
 target_link_libraries (core_test node secure gtest libminiupnpc-static Boost::log_setup Boost::log Boost::boost)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2952,6 +2952,8 @@ TEST (node, epoch_conflict_confirm)
 	}
 }
 
+// Test is unstable on github actions for windows, disable if CI detected
+#if (defined(_WIN32) && CI)
 TEST (node, fork_invalid_block_signature)
 {
 	nano::system system (2);
@@ -2984,6 +2986,7 @@ TEST (node, fork_invalid_block_signature)
 	}
 	ASSERT_EQ (node1.block (send2->hash ())->block_signature (), send2->block_signature ());
 }
+#endif
 
 TEST (node, fork_election_invalid_block_signature)
 {
@@ -3392,6 +3395,8 @@ TEST (node, dont_write_lock_node)
 	finished_promise.set_value ();
 }
 
+// Test is unstable on github actions for windows, disable if CI detected
+#if (defined(_WIN32) && CI)
 TEST (node, bidirectional_tcp)
 {
 	nano::system system;
@@ -3461,6 +3466,7 @@ TEST (node, bidirectional_tcp)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 }
+#endif
 
 // The test must be completed in less than 1 second
 TEST (node, bandwidth_limiter)


### PR DESCRIPTION
On actions node.fork_invalid_block_signature and node.bidirectional_tcp
intermittently fail for windows. 
#if !(defined(_WIN32) && CI) is used to guard these when running in actions if windows