### PR TITLE
Additional ledger stats

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -511,6 +511,15 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::fork:
 			res = "fork";
 			break;
+		case nano::stat::detail::old:
+			res = "old";
+			break;
+		case nano::stat::detail::gap_previous:
+			res = "gap_previous";
+			break;
+		case nano::stat::detail::gap_source:
+			res = "gap_source";
+			break;
 		case nano::stat::detail::frontier_confirmation_failed:
 			res = "frontier_confirmation_failed";
 			break;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -226,6 +226,9 @@ public:
 		state_block,
 		epoch_block,
 		fork,
+		old,
+		gap_previous,
+		gap_source,
 
 		// message specific
 		keepalive,

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -420,6 +420,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			node.gap_cache.add (hash);
+			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_previous);
 			break;
 		}
 		case nano::process_result::gap_source:
@@ -443,6 +444,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			node.gap_cache.add (hash);
+			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
 			break;
 		}
 		case nano::process_result::old:
@@ -456,6 +458,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 				queue_unchecked (transaction_a, hash);
 			}
 			node.active.update_difficulty (info_a.block, transaction_a);
+			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::old);
 			break;
 		}
 		case nano::process_result::bad_signature:
@@ -486,7 +489,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 		case nano::process_result::fork:
 		{
 			node.process_fork (transaction_a, info_a.block);
-			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::fork, nano::stat::dir::in);
+			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::fork);
 			if (node.config.logging.ledger_logging ())
 			{
 				node.logger.try_log (boost::str (boost::format ("Fork for: %1% root: %2%") % hash.to_string () % info_a.block->root ().to_string ()));


### PR DESCRIPTION
Stats have consistently been helpful and leading to many optimizations, these are intended to help grasp the efficacy of the duplicate filter and bottlenecks in single-account processing.

Adds detail stats when ledger processing from the block processor, for `old`, `gap_previous` and `gap_source` process codes.