### PR TITLE
unstable tests on actions for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/linux/install_deps.sh
       - name: Run Tests
-        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:clang /bin/bash -c "cd /workspace && RELEASE=0 ASAN=0 TSAN=0 ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:clang /bin/bash -c "cd /workspace && ./ci/build-travis.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 ${PWD}"
 
   windows_test:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ execute_process(
 )
 
 option (CI_BUILD false)
+set (CI_TEST 0 CACHE STRING "")
 
 set (CPACK_PACKAGE_VERSION_MAJOR "21")
 set (CPACK_PACKAGE_VERSION_MINOR "0")

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -25,7 +25,7 @@ if (${env:artifact} -eq 1) {
     }
     $env:NETWORK_CFG = "test"
     $env:NANO_TEST = "-DNANO_TEST=ON"
-    $env:CI = "-DCI_BUILD=OFF"
+    $env:CI = '-DCI_TEST="1"'
     $env:RUN = "test"
 }
 

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -48,7 +48,6 @@ else
     ROCKSDB=""
 fi
 
-
 cmake \
     -G'Unix Makefiles' \
     -DACTIVE_NETWORK=nano_test_network \
@@ -61,6 +60,7 @@ cmake \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DBOOST_ROOT=/tmp/boost/ \
     -DQt5_DIR=${qt_dir} \
+    -DCI_TEST="1" \
     ${SANITIZERS} \
     ..
 

--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -44,5 +44,7 @@ target_compile_definitions(core_test
 		PRIVATE
 			-DTAG_VERSION_STRING=${TAG_VERSION_STRING}
 			-DGIT_COMMIT_HASH=${GIT_COMMIT_HASH}
-			-DBOOST_PROCESS_SUPPORTED=${BOOST_PROCESS_SUPPORTED})
+			-DBOOST_PROCESS_SUPPORTED=${BOOST_PROCESS_SUPPORTED}
+			-DCI=${CI_TEST})
+
 target_link_libraries (core_test node secure gtest libminiupnpc-static Boost::log_setup Boost::log Boost::boost)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2952,7 +2952,12 @@ TEST (node, epoch_conflict_confirm)
 	}
 }
 
+// Test is unstable on github actions for windows, disable if CI detected and windows
+#if (defined(_WIN32) && CI)
+TEST (node, DISABLED_fork_invalid_block_signature)
+#else
 TEST (node, fork_invalid_block_signature)
+#endif
 {
 	nano::system system (2);
 	auto & node1 (*system.nodes[0]);
@@ -3392,7 +3397,12 @@ TEST (node, dont_write_lock_node)
 	finished_promise.set_value ();
 }
 
+// Test is unstable on github actions for windows, disable if CI detected
+#if (defined(_WIN32) && CI)
+TEST (node, DISABLED_bidirectional_tcp)
+#else
 TEST (node, bidirectional_tcp)
+#endif
 {
 	nano::system system;
 	nano::node_flags node_flags;


### PR DESCRIPTION
if `(defined(_WIN32) && CI)` to guard from them running
adds CI_TEST to CMakeFiles to define CI="1" if CI_TEST is true
disables node.fork_invalid_block_signature and node.bidirectional_tcp