### PR TITLE
Optionally disable data in responses to telemetry requests with CLI option

### DIFF
--- a/nano/core_test/node_telemetry.cpp
+++ b/nano/core_test/node_telemetry.cpp
@@ -11,7 +11,7 @@ using namespace std::chrono_literals;
 namespace
 {
 void wait_peer_connections (nano::system & system_a);
-void compare_default_test_result_data (nano::telemetry_data & telemetry_data_a, nano::node const & node_server_a);
+void compare_default_test_result_data (nano::telemetry_data const & telemetry_data_a, nano::node const & node_server_a);
 }
 
 TEST (node_telemetry, consolidate_data)
@@ -720,6 +720,89 @@ TEST (node_telemetry, disconnects)
 	}
 }
 
+TEST (node_telemetry, disable_metrics_single)
+{
+	nano::system system (1);
+	auto node_client = system.nodes.front ();
+	nano::node_flags node_flags;
+	node_flags.disable_providing_telemetry_metrics = true;
+	auto node_server = system.add_node (node_flags);
+
+	wait_peer_connections (system);
+
+	// Try and request metrics from a node which is turned off but a channel is not closed yet
+	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+	ASSERT_TRUE (channel);
+
+	std::atomic<bool> done{ false };
+	node_client->telemetry.get_metrics_single_peer_async (channel, [&done](nano::telemetry_data_response const & response_a) {
+		ASSERT_TRUE (response_a.error);
+		done = true;
+	});
+
+	system.deadline_set (10s);
+	while (!done)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	// It should still be able to receive metrics though
+	done = false;
+	auto channel1 = node_server->network.find_channel (node_client->network.endpoint ());
+	node_server->telemetry.get_metrics_single_peer_async (channel1, [&done, node_server](nano::telemetry_data_response const & response_a) {
+		ASSERT_FALSE (response_a.error);
+		compare_default_test_result_data (response_a.data, *node_server);
+		done = true;
+	});
+
+	system.deadline_set (10s);
+	while (!done)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
+TEST (node_telemetry, disable_metrics_batch)
+{
+	nano::system system (1);
+	auto node_client = system.nodes.front ();
+	nano::node_flags node_flags;
+	node_flags.disable_providing_telemetry_metrics = true;
+	auto node_server = system.add_node (node_flags);
+
+	wait_peer_connections (system);
+
+	// Try and request metrics from a node which is turned off but a channel is not closed yet
+	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+	ASSERT_TRUE (channel);
+
+	std::atomic<bool> done{ false };
+	node_client->telemetry.get_metrics_random_peers_async ([&done](nano::telemetry_data_responses const & responses_a) {
+		ASSERT_FALSE (responses_a.all_received);
+		done = true;
+	});
+
+	system.deadline_set (10s);
+	while (!done)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+
+	// It should still be able to receive metrics though
+	done = false;
+	node_server->telemetry.get_metrics_random_peers_async ([&done, node_server](nano::telemetry_data_responses const & responses_a) {
+		ASSERT_TRUE (responses_a.all_received);
+		compare_default_test_result_data (responses_a.data.front (), *node_server);
+		done = true;
+	});
+
+	system.deadline_set (10s);
+	while (!done)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
 namespace
 {
 void wait_peer_connections (nano::system & system_a)
@@ -737,7 +820,7 @@ void wait_peer_connections (nano::system & system_a)
 	}
 }
 
-void compare_default_test_result_data (nano::telemetry_data & telemetry_data_a, nano::node const & node_server_a)
+void compare_default_test_result_data (nano::telemetry_data const & telemetry_data_a, nano::node const & node_server_a)
 {
 	ASSERT_EQ (telemetry_data_a.block_count, 1);
 	ASSERT_EQ (telemetry_data_a.cemented_count, 1);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -91,6 +91,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_udp", "Disables UDP realtime network")
 		("disable_unchecked_cleanup", "Disables periodic cleanup of old records from unchecked table")
 		("disable_unchecked_drop", "Disables drop of unchecked table at startup")
+		("disable_providing_telemetry_metrics", "Disable using any node information in the telemetry_ack messages.")
 		("fast_bootstrap", "Increase bootstrap speed for high end nodes with higher limits")
 		("batch_size", boost::program_options::value<std::size_t>(), "Increase sideband batch size, default 512")
 		("block_processor_batch_size", boost::program_options::value<std::size_t>(), "Increase block processor transaction batch write size, default 0 (limited by config block_processor_batch_max_time), 256k for fast_bootstrap")
@@ -113,6 +114,7 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") > 0);
 	flags_a.disable_bootstrap_listener = (vm.count ("disable_bootstrap_listener") > 0);
 	flags_a.disable_tcp_realtime = (vm.count ("disable_tcp_realtime") > 0);
+	flags_a.disable_providing_telemetry_metrics = (vm.count ("disable_providing_telemetry_metrics") > 0);
 	flags_a.disable_udp = (vm.count ("disable_udp") > 0);
 	if (flags_a.disable_tcp_realtime && flags_a.disable_udp)
 	{

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1071,6 +1071,11 @@ void nano::telemetry_req::visit (nano::message_visitor & visitor_a) const
 	visitor_a.telemetry_req (*this);
 }
 
+nano::telemetry_ack::telemetry_ack () :
+message (nano::message_type::telemetry_ack)
+{
+}
+
 nano::telemetry_ack::telemetry_ack (bool & error_a, nano::stream & stream_a, nano::message_header const & message_header) :
 message (message_header)
 {
@@ -1090,33 +1095,40 @@ data (telemetry_data_a)
 void nano::telemetry_ack::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
-	write (stream_a, data.block_count);
-	write (stream_a, data.cemented_count);
-	write (stream_a, data.unchecked_count);
-	write (stream_a, data.account_count);
-	write (stream_a, data.bandwidth_cap);
-	write (stream_a, data.peer_count);
-	write (stream_a, data.protocol_version_number);
-	write (stream_a, data.vendor_version);
-	write (stream_a, data.uptime);
-	write (stream_a, data.genesis_block.bytes);
+	if (!is_empty_payload ())
+	{
+		write (stream_a, data.block_count);
+		write (stream_a, data.cemented_count);
+		write (stream_a, data.unchecked_count);
+		write (stream_a, data.account_count);
+		write (stream_a, data.bandwidth_cap);
+		write (stream_a, data.peer_count);
+		write (stream_a, data.protocol_version_number);
+		write (stream_a, data.vendor_version);
+		write (stream_a, data.uptime);
+		write (stream_a, data.genesis_block.bytes);
+	}
 }
 
 bool nano::telemetry_ack::deserialize (nano::stream & stream_a)
 {
 	auto error (false);
+	assert (header.type == nano::message_type::telemetry_ack);
 	try
 	{
-		read (stream_a, data.block_count);
-		read (stream_a, data.cemented_count);
-		read (stream_a, data.unchecked_count);
-		read (stream_a, data.account_count);
-		read (stream_a, data.bandwidth_cap);
-		read (stream_a, data.peer_count);
-		read (stream_a, data.protocol_version_number);
-		read (stream_a, data.vendor_version);
-		read (stream_a, data.uptime);
-		read (stream_a, data.genesis_block.bytes);
+		if (!is_empty_payload ())
+		{
+			read (stream_a, data.block_count);
+			read (stream_a, data.cemented_count);
+			read (stream_a, data.unchecked_count);
+			read (stream_a, data.account_count);
+			read (stream_a, data.bandwidth_cap);
+			read (stream_a, data.peer_count);
+			read (stream_a, data.protocol_version_number);
+			read (stream_a, data.vendor_version);
+			read (stream_a, data.uptime);
+			read (stream_a, data.genesis_block.bytes);
+		}
 	}
 	catch (std::runtime_error const &)
 	{
@@ -1131,9 +1143,19 @@ void nano::telemetry_ack::visit (nano::message_visitor & visitor_a) const
 	visitor_a.telemetry_ack (*this);
 }
 
+uint16_t nano::telemetry_ack::size () const
+{
+	return size (header);
+}
+
 uint16_t nano::telemetry_ack::size (nano::message_header const & message_header_a)
 {
 	return static_cast<uint16_t> (message_header_a.extensions.to_ulong ());
+}
+
+bool nano::telemetry_ack::is_empty_payload () const
+{
+	return size () == 0;
 }
 
 nano::telemetry_data nano::telemetry_data::consolidate (std::vector<nano::telemetry_data> const & telemetry_data_responses_a)

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -363,11 +363,14 @@ public:
 class telemetry_ack final : public message
 {
 public:
+	telemetry_ack ();
 	telemetry_ack (bool &, nano::stream &, nano::message_header const &);
 	explicit telemetry_ack (telemetry_data const &);
 	void serialize (nano::stream &) const override;
 	void visit (nano::message_visitor &) const override;
 	bool deserialize (nano::stream &);
+	uint16_t size () const;
+	bool is_empty_payload () const;
 	static uint16_t size (nano::message_header const &);
 	nano::telemetry_data data;
 };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -124,6 +124,7 @@ public:
 	bool disable_udp{ false };
 	bool disable_unchecked_cleanup{ false };
 	bool disable_unchecked_drop{ true };
+	bool disable_providing_telemetry_metrics{ false };
 	bool fast_bootstrap{ false };
 	bool read_only{ false };
 	nano::generate_cache generate_cache;

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -53,7 +53,7 @@ public:
 private:
 	// Class only available to the telemetry class
 	void get_metrics_async (std::unordered_set<std::shared_ptr<nano::transport::channel>> const & channels_a, std::function<void(telemetry_data_responses const &)> const & callback_a);
-	void add (nano::telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a);
+	void add (nano::telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a, bool is_empty_a);
 	size_t telemetry_data_size ();
 
 	nano::network_params network_params;
@@ -100,8 +100,9 @@ public:
 	/*
 	 * Add telemetry metrics received from this endpoint.
 	 * Should this be unsolicited, it will not be added.
+	 * Some peers may have disabled responding with telemetry data, need to account for this
 	 */
-	void add (nano::telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a);
+	void add (nano::telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a, bool is_empty_a);
 
 	/*
 	 * Collects metrics from square root number of peers and invokes the callback when complete.


### PR DESCRIPTION
Adds "-disable_providing_telemetry_metrics" CLI command for users who do not want to provide metrics to other peers for what ever reason (suggested by @SergiySW). Still sending `telemetry_ack` response messages, otherwise we have to wait for the alarm timeout (3s). `stats` counters remain unchanged, but the payload is 0 and it is not added to the response data set for further processing.