### PR TITLE
Improve initial TCP server keepalive

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -105,6 +105,9 @@ void nano::network::send_keepalive (std::shared_ptr<nano::transport::channel> ch
 void nano::network::send_keepalive_self (std::shared_ptr<nano::transport::channel> channel_a)
 {
 	nano::keepalive message;
+	random_fill (message.peers);
+	// Replace part of message with node external address or listening port
+	message.peers[1] = nano::endpoint (boost::asio::ip::address_v6{}, 0); // For node v19 (response channels)
 	if (node.config.external_address != boost::asio::ip::address_v6{}.to_string () && node.config.external_port != 0)
 	{
 		message.peers[0] = nano::endpoint (boost::asio::ip::make_address_v6 (node.config.external_address), node.config.external_port);


### PR DESCRIPTION
Send additional random peers in `nano::network::send_keepalive_self ()` function