### PR TITLE
State blocks sideband upgrade adding is_send/receive/epoch

### DIFF
--- a/nano/core_test/versioning.cpp
+++ b/nano/core_test/versioning.cpp
@@ -17,7 +17,7 @@ TEST (versioning, account_info_v1)
 		nano::mdb_store store (logger, file);
 		ASSERT_FALSE (store.init_error ());
 		auto transaction (store.tx_begin_write ());
-		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
+		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0, nano::epoch::epoch_0, false, false, false);
 		store.block_put (transaction, open.hash (), open, sideband);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (account), nano::mdb_val (sizeof (v1), &v1), 0));
 		ASSERT_EQ (0, status);
@@ -53,7 +53,7 @@ TEST (versioning, account_info_v5)
 		nano::mdb_store store (logger, file);
 		ASSERT_FALSE (store.init_error ());
 		auto transaction (store.tx_begin_write ());
-		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
+		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0, nano::epoch::epoch_0, false, false, false);
 		store.block_put (transaction, open.hash (), open, sideband);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (account), nano::mdb_val (sizeof (v5), &v5), 0));
 		ASSERT_EQ (0, status);
@@ -89,7 +89,7 @@ TEST (versioning, account_info_v13)
 		nano::mdb_store store (logger, file);
 		ASSERT_FALSE (store.init_error ());
 		auto transaction (store.tx_begin_write ());
-		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
+		nano::block_sideband sideband (nano::block_type::open, 0, 0, 0, 0, 0, nano::epoch::epoch_0, false, false, false);
 		store.block_put (transaction, open.hash (), open, sideband);
 		auto status (mdb_put (store.env.tx (transaction), store.accounts_v0, nano::mdb_val (account), nano::mdb_val (v13), 0));
 		ASSERT_EQ (0, status);

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -242,6 +242,7 @@ private:
 	void upgrade_v14_to_v15 (nano::write_transaction &);
 	void upgrade_v15_to_v16 (nano::write_transaction const &);
 	void upgrade_v16_to_v17 (nano::write_transaction const &);
+	void upgrade_v17_to_v18 (nano::write_transaction const &);
 
 	void open_databases (bool &, nano::transaction const &, unsigned);
 

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -31,7 +31,7 @@ public:
 	{
 		auto hash_l (genesis_a.hash ());
 		assert (latest_begin (transaction_a) == latest_end ());
-		nano::block_sideband sideband (nano::block_type::open, network_params.ledger.genesis_account, 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0);
+		nano::block_sideband sideband (nano::block_type::open, network_params.ledger.genesis_account, 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false);
 		block_put (transaction_a, hash_l, *genesis_a.open, sideband);
 		++ledger_cache_a.block_count;
 		confirmation_height_put (transaction_a, network_params.ledger.genesis_account, nano::confirmation_height_info{ 1, genesis_a.hash () });
@@ -411,7 +411,7 @@ public:
 		auto block = block_get (transaction_a, hash_a, &sideband);
 		if (sideband.type == nano::block_type::state)
 		{
-			return sideband.epoch;
+			return sideband.details.epoch;
 		}
 
 		return nano::epoch::epoch_0;
@@ -781,7 +781,7 @@ protected:
 	nano::network_params network_params;
 	std::unordered_map<nano::account, std::shared_ptr<nano::vote>> vote_cache_l1;
 	std::unordered_map<nano::account, std::shared_ptr<nano::vote>> vote_cache_l2;
-	static int constexpr version{ 17 };
+	static int constexpr version{ 18 };
 
 	template <typename T>
 	std::shared_ptr<nano::block> block_random (nano::transaction const & transaction_a, tables table_a)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -276,6 +276,7 @@ void ledger_processor::state_block_impl (nano::state_block const & block_a)
 				nano::account_info info;
 				result.amount = block_a.hashables.balance;
 				auto is_send (false);
+				auto is_receive (false);
 				auto account_error (ledger.store.account_get (transaction, block_a.hashables.account, info));
 				if (!account_error)
 				{
@@ -288,6 +289,7 @@ void ledger_processor::state_block_impl (nano::state_block const & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							is_send = block_a.hashables.balance < info.balance;
+							is_receive = !is_send && !block_a.hashables.link.is_zero ();
 							result.amount = is_send ? (info.balance.number () - result.amount.number ()) : (result.amount.number () - info.balance.number ());
 							result.code = block_a.hashables.previous == info.head ? nano::process_result::progress : nano::process_result::fork; // Is the previous block the account's head block? (Ambigious)
 						}
@@ -299,6 +301,7 @@ void ledger_processor::state_block_impl (nano::state_block const & block_a)
 					result.code = block_a.previous ().is_zero () ? nano::process_result::progress : nano::process_result::gap_previous; // Does the first block in an account yield 0 for previous() ? (Unambigious)
 					if (result.code == nano::process_result::progress)
 					{
+						is_receive = true;
 						result.code = !block_a.hashables.link.is_zero () ? nano::process_result::progress : nano::process_result::gap_source; // Is the first block receiving from a send ? (Unambigious)
 					}
 				}
@@ -332,7 +335,7 @@ void ledger_processor::state_block_impl (nano::state_block const & block_a)
 				{
 					ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
 					result.state_is_send = is_send;
-					nano::block_sideband sideband (nano::block_type::state, block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), epoch);
+					nano::block_sideband sideband (nano::block_type::state, block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), epoch, is_send, is_receive, false);
 					ledger.store.block_put (transaction, hash, block_a, sideband);
 
 					if (!info.head.is_zero ())
@@ -420,7 +423,7 @@ void ledger_processor::epoch_block_impl (nano::state_block const & block_a)
 							ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::epoch_block);
 							result.account = block_a.hashables.account;
 							result.amount = 0;
-							nano::block_sideband sideband (nano::block_type::state, block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), epoch);
+							nano::block_sideband sideband (nano::block_type::state, block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), epoch, false, false, true);
 							ledger.store.block_put (transaction, hash, block_a, sideband);
 							nano::account_info new_info (hash, block_a.representative (), info.open_block.is_zero () ? hash : info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count + 1, epoch);
 							ledger.change_latest (transaction, block_a.hashables.account, info, new_info);
@@ -468,7 +471,7 @@ void ledger_processor::change_block (nano::change_block const & block_a)
 					{
 						assert (!validate_message (account, hash, block_a.signature));
 						result.verified = nano::signature_verification::valid;
-						nano::block_sideband sideband (nano::block_type::change, account, 0, info.balance, info.block_count + 1, nano::seconds_since_epoch (), nano::epoch::epoch_0);
+						nano::block_sideband sideband (nano::block_type::change, account, 0, info.balance, info.block_count + 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false);
 						ledger.store.block_put (transaction, hash, block_a, sideband);
 						auto balance (ledger.balance (transaction, block_a.hashables.previous));
 						ledger.cache.rep_weights.representation_add (block_a.representative (), balance);
@@ -524,7 +527,7 @@ void ledger_processor::send_block (nano::send_block const & block_a)
 						{
 							auto amount (info.balance.number () - block_a.hashables.balance.number ());
 							ledger.cache.rep_weights.representation_add (info.representative, 0 - amount);
-							nano::block_sideband sideband (nano::block_type::send, account, 0, block_a.hashables.balance /* unused */, info.block_count + 1, nano::seconds_since_epoch (), nano::epoch::epoch_0);
+							nano::block_sideband sideband (nano::block_type::send, account, 0, block_a.hashables.balance /* unused */, info.block_count + 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
 							ledger.store.block_put (transaction, hash, block_a, sideband);
 							nano::account_info new_info (hash, info.representative, info.open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
 							ledger.change_latest (transaction, account, info, new_info);
@@ -592,7 +595,7 @@ void ledger_processor::receive_block (nano::receive_block const & block_a)
 										(void)error;
 										assert (!error);
 										ledger.store.pending_del (transaction, key);
-										nano::block_sideband sideband (nano::block_type::receive, account, 0, new_balance, info.block_count + 1, nano::seconds_since_epoch (), nano::epoch::epoch_0);
+										nano::block_sideband sideband (nano::block_type::receive, account, 0, new_balance, info.block_count + 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
 										ledger.store.block_put (transaction, hash, block_a, sideband);
 										nano::account_info new_info (hash, info.representative, info.open_block, new_balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
 										ledger.change_latest (transaction, account, info, new_info);
@@ -656,7 +659,7 @@ void ledger_processor::open_block (nano::open_block const & block_a)
 								(void)error;
 								assert (!error);
 								ledger.store.pending_del (transaction, key);
-								nano::block_sideband sideband (nano::block_type::open, block_a.hashables.account, 0, pending.amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0);
+								nano::block_sideband sideband (nano::block_type::open, block_a.hashables.account, 0, pending.amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
 								ledger.store.block_put (transaction, hash, block_a, sideband);
 								nano::account_info new_info (hash, block_a.representative (), hash, pending.amount.number (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0);
 								ledger.change_latest (transaction, block_a.hashables.account, info, new_info);


### PR DESCRIPTION
This changes how the epoch byte in the state block sideband is [de]serialized, to also store these flags in the 3 most significant bits: `[is_send | is_receive | is_epoch | epoch (5 bits)]`

The upgrade is done in-place but takes a long time due to having to a random read to retrieve the previous block. A vacuum is performed at the end.

The upgrade does the following:
- Iterate through the state_blocks table
- For each block grab the previous block to determine the subtype of the current block
- Serialize the new sideband
- `mdb_cursor_put` with `MDB_CURRENT`

I was expecting no size growth due to using [MDB_CURRENT](http://www.lmdb.tech/doc/group__mdb__put.html#ga92f7832a496213db0f03105e6fa9afae), but no such luck. [mdb_cursor_put](http://www.lmdb.tech/doc/group__mdb.html#ga1f83ccb40011837ff37cc32be01ad91e) docs say:
> MDB_CURRENT - replace the item at the current cursor position. The key parameter must still be provided, and must match it. If using sorted duplicates (MDB_DUPSORT) the data item must still sort into the same place. This is intended to be used when the new data is the same size as the old. Otherwise it will simply perform a delete of the old record followed by an insert.

Since the new sideband deserialization discards the MSBs when reading the epoch, the upgrade can safely be stopped and restarted (from the beginning), and no additional versioning was necessary. This behavior is tested in the upgrade test.

However, it was necessary to move up the `block_sideband` class definition in order to have `block_w_sideband` declared in the same file (declaring in `versioning.hpp` would require saving a copy of the `block_sideband` class in `versioning.cpp`).

Also added a validation step of these new fields in the `--debug_validate_blocks` CLI.

-----

**Best case scenario test** (on a SATA III SSD)
Tested with @SergiySW 's daily ledger (which is rebuilt with https://github.com/nanocurrency/nano-node/pull/2435):
- Initial size 17GB
- Initial v16->v17 upgrade takes 2 minutes, basically no growth
- v17->v18 upgrade takes 45 minutes, growing to 29GB
- Post-upgrade vacuum brings it back to 17GB

This means the total space necessary for the best-case scenario was 29+17 = 46GB.