### PR TITLE
Log stable filename

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -202,6 +202,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.logging.network_telemetry_logging_value, defaults.node.logging.network_telemetry_logging_value);
 	ASSERT_EQ (conf.node.logging.rotation_size, defaults.node.logging.rotation_size);
 	ASSERT_EQ (conf.node.logging.single_line_record_value, defaults.node.logging.single_line_record_value);
+	ASSERT_EQ (conf.node.logging.stable_log_filename, defaults.node.logging.stable_log_filename);
 	ASSERT_EQ (conf.node.logging.timing_logging_value, defaults.node.logging.timing_logging_value);
 	ASSERT_EQ (conf.node.logging.active_update_value, defaults.node.logging.active_update_value);
 	ASSERT_EQ (conf.node.logging.upnp_details_logging_value, defaults.node.logging.upnp_details_logging_value);
@@ -461,6 +462,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	node_lifetime_tracing = true
 	rotation_size = 999
 	single_line_record = true
+	stable_log_filename = true
 	timing = true
 	active_update = true
 	upnp_details = true
@@ -592,6 +594,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.logging.node_lifetime_tracing_value, defaults.node.logging.node_lifetime_tracing_value);
 	ASSERT_NE (conf.node.logging.rotation_size, defaults.node.logging.rotation_size);
 	ASSERT_NE (conf.node.logging.single_line_record_value, defaults.node.logging.single_line_record_value);
+	ASSERT_NE (conf.node.logging.stable_log_filename, defaults.node.logging.stable_log_filename);
 	ASSERT_NE (conf.node.logging.timing_logging_value, defaults.node.logging.timing_logging_value);
 	ASSERT_NE (conf.node.logging.active_update_value, defaults.node.logging.active_update_value);
 	ASSERT_NE (conf.node.logging.upnp_details_logging_value, defaults.node.logging.upnp_details_logging_value);

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -89,6 +89,7 @@ public:
 	bool flush{ true };
 	uintmax_t max_size{ 128 * 1024 * 1024 };
 	uintmax_t rotation_size{ 4 * 1024 * 1024 };
+	bool stable_log_filename{ false };
 	std::chrono::milliseconds min_time_between_log_output{ 5 };
 	bool single_line_record_value{ false };
 	static void release_file_sink ();


### PR DESCRIPTION
Boost 1.70+ allows for a combination of target_file_name, open_mode and enable_final_rotation to mimic the usual log rotation approach of a fixed log filename. This can be activated with a new toml config option, which is off by default to not break existing monitors that services might use. If built with < 1.70, activating the option will emit a stderr message and fall back to the old behaviour.