### PR TITLE
Lower beta network work threshold to 1/64x base

### DIFF
--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -62,7 +62,7 @@ TEST (difficulty, multipliers)
 
 TEST (difficulty, network_constants)
 {
-	ASSERT_NEAR (16., nano::difficulty::to_multiplier (nano::network_constants::publish_full_threshold, nano::network_constants::publish_beta_threshold), 1e-10);
+	ASSERT_NEAR (64., nano::difficulty::to_multiplier (nano::network_constants::publish_full_threshold, nano::network_constants::publish_beta_threshold), 1e-10);
 }
 
 TEST (difficulty, overflow)

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -90,7 +90,7 @@ public:
 
 	/** Network work thresholds. ~5 seconds of work for the live network */
 	static uint64_t const publish_full_threshold{ 0xffffffc000000000 };
-	static uint64_t const publish_beta_threshold{ 0xfffffc0000000000 }; // 16x lower than full
+	static uint64_t const publish_beta_threshold{ 0xfffff00000000000 }; // 64x lower than full
 	static uint64_t const publish_test_threshold{ 0xff00000000000000 }; // very low for tests
 
 	/** Error message when an invalid network is specified */


### PR DESCRIPTION
Previously 1/16x

On merge also update https://github.com/nanocurrency/nano-work-server