### PR TITLE
Add wallet-processed block to work watcher via the block processor

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -248,7 +248,7 @@ TEST (active_transactions, keep_local)
 	auto send4 (wallet.send_action (nano::test_genesis_key.pub, key4.pub, node.config.receive_minimum.number ()));
 	auto send5 (wallet.send_action (nano::test_genesis_key.pub, key5.pub, node.config.receive_minimum.number ()));
 	auto send6 (wallet.send_action (nano::test_genesis_key.pub, key6.pub, node.config.receive_minimum.number ()));
-	system.deadline_set (10s);
+	system.deadline_set (5s);
 	// should not drop wallet created transactions
 	while (node.active.size () != 6)
 	{
@@ -264,16 +264,14 @@ TEST (active_transactions, keep_local)
 		}
 	}
 	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, node.config.receive_minimum.number (), send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
-	node.process_active (open1);
-	node.active.start (open1);
 	auto open2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, node.config.receive_minimum.number (), send2->hash (), key2.prv, key2.pub, *system.work.generate (key2.pub)));
-	node.process_active (open2);
-	node.active.start (open2);
 	auto open3 (std::make_shared<nano::state_block> (key3.pub, 0, key3.pub, node.config.receive_minimum.number (), send3->hash (), key3.prv, key3.pub, *system.work.generate (key3.pub)));
+	node.process_active (open1);
+	node.process_active (open2);
 	node.process_active (open3);
-	node.active.start (open3);
+	node.block_processor.flush ();
 	ASSERT_EQ (3, node.active.size ());
-	system.deadline_set (10s);
+	system.deadline_set (5s);
 	// bound elections, should drop after one loop
 	while (node.active.size () != node_config.active_elections_size)
 	{

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -270,7 +270,6 @@ TEST (active_transactions, keep_local)
 	node.process_active (open2);
 	node.process_active (open3);
 	node.block_processor.flush ();
-	ASSERT_EQ (3, node.active.size ());
 	system.deadline_set (5s);
 	// bound elections, should drop after one loop
 	while (node.active.size () != node_config.active_elections_size)

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -360,13 +360,15 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 
 void nano::block_processor::process_live (nano::block_hash const & hash_a, std::shared_ptr<nano::block> block_a, const bool watch_work_a)
 {
-	// Start collecting quorum on block
-	node.active.start (block_a, false);
-	//add block to watcher if desired after block has been added to active
+	// Add to work watcher to prevent dropping the election
 	if (watch_work_a)
 	{
 		node.wallets.watcher->add (block_a);
 	}
+
+	// Start collecting quorum on block
+	node.active.start (block_a, false);
+
 	// Announce block contents to the network
 	node.network.flood_block (block_a, false);
 	if (node.config.enable_voting && node.wallets.rep_counts ().voting > 0)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1141,8 +1141,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 		}
 		if (!error)
 		{
-			wallets.watcher->add (block_a);
-			error = wallets.node.process_local (block_a).code != nano::process_result::progress;
+			error = wallets.node.process_local (block_a, true).code != nano::process_result::progress;
 		}
 		if (!error && generate_work_a)
 		{


### PR DESCRIPTION
Switched the order so the block is added to the watcher before starting the election, which could unluckily result in a drop.

Fixed an occasional failure in `active_transactions.keep_local` where one of the blocks would already have been dropped when checking the active roots.