### PR TITLE
[ASAN] Access node through a weak_ptr on distributed_work dtor

### DIFF
--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -86,6 +86,7 @@ private:
 	void add_bad_peer (nano::tcp_endpoint const &);
 
 	nano::node & node;
+	// Only used in destructor, as the node reference can become invalid before distributed_work objects go out of scope
 	std::weak_ptr<nano::node> node_w;
 	nano::work_request request;
 

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -86,6 +86,7 @@ private:
 	void add_bad_peer (nano::tcp_endpoint const &);
 
 	nano::node & node;
+	std::weak_ptr<nano::node> node_w;
 	nano::work_request request;
 
 	std::chrono::seconds backoff;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3118,15 +3118,14 @@ TEST (rpc, work_peer_many)
 	node1.config.work_peers.push_back (std::make_pair (node3.network.endpoint ().address ().to_string (), rpc3.config.port));
 	node1.config.work_peers.push_back (std::make_pair (node4.network.endpoint ().address ().to_string (), rpc4.config.port));
 
-	for (auto i (0); i < 10; ++i)
+	std::array<std::atomic<uint64_t>, 10> works;
+	for (auto i (0); i < works.size (); ++i)
 	{
 		nano::keypair key1;
-		std::atomic<uint64_t> work (0);
-		node1.work_generate (key1.pub, [&work](boost::optional<uint64_t> work_a) {
-			ASSERT_TRUE (work_a.is_initialized ());
+		node1.work_generate (key1.pub, [& work = works[i]](boost::optional<uint64_t> work_a) {
 			work = *work_a;
 		});
-		while (nano::work_validate (key1.pub, work))
+		while (nano::work_validate (key1.pub, works[i]))
 		{
 			system1.poll ();
 			system2.poll ();


### PR DESCRIPTION
Since there is nothing to force a distributed_work to get destroyed before the node stops, this is a safer way to access the node on the destructor. Fixes some ASAN issues.