### PR TITLE
Disable UDP by default

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -196,8 +196,10 @@ TEST (node, quick_confirm)
 
 TEST (node, node_receive_quorum)
 {
-	nano::system system (1);
-	auto & node1 (*system.nodes[0]);
+	nano::system system;
+	nano::node_flags node_flags;
+	node_flags.disable_udp = false;
+	auto & node1 = *system.add_node (node_flags);
 	nano::keypair key;
 	nano::block_hash previous (node1.latest (nano::test_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key.prv);
@@ -215,7 +217,9 @@ TEST (node, node_receive_quorum)
 		ASSERT_FALSE (info->election->confirmed);
 		ASSERT_EQ (1, info->election->last_votes.size ());
 	}
-	nano::system system2 (1);
+	nano::system system2;
+	system2.add_node (node_flags);
+
 	system2.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	ASSERT_TRUE (node1.balance (key.pub).is_zero ());
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, system2.nodes[0]->network.endpoint (), node1.network_params.protocol.protocol_version));
@@ -235,6 +239,7 @@ TEST (node, auto_bootstrap)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
+	node_flags.disable_udp = false;
 	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
@@ -246,7 +251,7 @@ TEST (node, auto_bootstrap)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.protocol.protocol_version));
 	node1->network.send_keepalive (channel);
@@ -295,11 +300,12 @@ TEST (node, auto_bootstrap_reverse)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
+	node_flags.disable_udp = false;
 	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node0->network_params.protocol.protocol_version));
@@ -479,9 +485,11 @@ TEST (node, unlock_search)
 
 TEST (node, connect_after_junk)
 {
-	nano::system system (1);
-	auto node0 (system.nodes[0]);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
+	nano::system system;
+	nano::node_flags node_flags;
+	node_flags.disable_udp = false;
+	auto node0 = system.add_node (node_flags);
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work, node_flags));
 	std::vector<uint8_t> junk_buffer;
 	junk_buffer.push_back (0);
 	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.protocol.protocol_version));
@@ -1104,11 +1112,12 @@ TEST (json, backup)
 
 TEST (node_flags, disable_tcp_realtime)
 {
-	nano::system system (1);
-	auto node1 = system.nodes[0];
+	nano::system system;
 	nano::node_flags node_flags;
+	node_flags.disable_udp = false;
+	auto node1 = system.add_node (node_flags);
 	node_flags.disable_tcp_realtime = true;
-	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node2 = system.add_node (node_flags);
 	ASSERT_EQ (1, node1->network.size ());
 	auto list1 (node1->network.list (2));
 	ASSERT_EQ (node2->network.endpoint (), list1[0]->get_endpoint ());
@@ -1121,12 +1130,13 @@ TEST (node_flags, disable_tcp_realtime)
 
 TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 {
-	nano::system system (1);
-	auto node1 = system.nodes[0];
+	nano::system system;
 	nano::node_flags node_flags;
+	node_flags.disable_udp = false;
+	auto node1 = system.add_node (node_flags);
 	node_flags.disable_tcp_realtime = true;
 	node_flags.disable_bootstrap_listener = true;
-	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node2 = system.add_node (node_flags);
 	ASSERT_EQ (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->bootstrap.endpoint ());
 	ASSERT_NE (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.endpoint ());
 	ASSERT_EQ (1, node1->network.size ());
@@ -1139,13 +1149,14 @@ TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 	ASSERT_EQ (nano::transport::transport_type::udp, list2[0]->get_type ());
 }
 
+// UDP is disabled by default
 TEST (node_flags, disable_udp)
 {
-	nano::system system (1);
-	auto node1 = system.nodes[0];
+	nano::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = true;
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), system.alarm, nano::node_config (nano::get_available_port (), system.logging), system.work, node_flags));
+	node_flags.disable_udp = false;
+	auto node1 = system.add_node (node_flags);
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), system.alarm, nano::node_config (nano::get_available_port (), system.logging), system.work));
 	system.nodes.push_back (node2);
 	node2->start ();
 	ASSERT_EQ (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.udp_channels.get_local_endpoint ());
@@ -1338,14 +1349,11 @@ TEST (node, fork_multi_flip)
 	for (auto & type : types)
 	{
 		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::tcp)
-		{
-			node_flags.disable_udp = true;
-		}
-		else
+		if (type == nano::transport::transport_type::udp)
 		{
 			node_flags.disable_tcp_realtime = true;
 			node_flags.disable_bootstrap_listener = true;
+			node_flags.disable_udp = false;
 		}
 		nano::system system (2, type, node_flags);
 		auto & node1 (*system.nodes[0]);
@@ -1420,6 +1428,7 @@ TEST (node, fork_bootstrap_flip)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
+	node_flags.disable_udp = false;
 	auto & node1 (*system0.add_node (config0, node_flags));
 	nano::node_config config1 (nano::get_available_port (), system1.logging);
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
@@ -1711,14 +1720,11 @@ TEST (node, broadcast_elected)
 	for (auto & type : types)
 	{
 		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::tcp)
-		{
-			node_flags.disable_udp = true;
-		}
-		else
+		if (type == nano::transport::transport_type::udp)
 		{
 			node_flags.disable_tcp_realtime = true;
 			node_flags.disable_bootstrap_listener = true;
+			node_flags.disable_udp = false;
 		}
 		nano::system system;
 		nano::node_config node_config (nano::get_available_port (), system.logging);
@@ -2152,8 +2158,10 @@ TEST (node, rep_weight)
 
 TEST (node, rep_remove)
 {
-	nano::system system (1);
-	auto & node (*system.nodes[0]);
+	nano::system system;
+	nano::node_flags node_flags;
+	node_flags.disable_udp = false;
+	auto & node = *system.add_node (node_flags);
 	nano::genesis genesis;
 	nano::keypair keypair1;
 	nano::keypair keypair2;
@@ -2461,14 +2469,11 @@ TEST (node, block_confirm)
 	for (auto & type : types)
 	{
 		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::tcp)
-		{
-			node_flags.disable_udp = true;
-		}
-		else
+		if (type == nano::transport::transport_type::udp)
 		{
 			node_flags.disable_tcp_realtime = true;
 			node_flags.disable_bootstrap_listener = true;
+			node_flags.disable_udp = false;
 		}
 		nano::system system (2, type, node_flags);
 		auto & node1 (*system.nodes[0]);
@@ -2884,14 +2889,11 @@ TEST (node, vote_by_hash_republish)
 	for (auto & type : types)
 	{
 		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::tcp)
-		{
-			node_flags.disable_udp = true;
-		}
-		else
+		if (type == nano::transport::transport_type::udp)
 		{
 			node_flags.disable_tcp_realtime = true;
 			node_flags.disable_bootstrap_listener = true;
+			node_flags.disable_udp = false;
 		}
 		nano::system system (2, type, node_flags);
 		auto & node1 (*system.nodes[0]);
@@ -3220,7 +3222,7 @@ TEST (node, block_processor_full)
 	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node.work_generate_blocking (*send3);
 	// The write guard prevents block processor doing any writes
-	auto write_guard = node.write_database_queue.wait (nano::writer::confirmation_height);
+	auto write_guard = node.write_database_queue.wait (nano::writer::testing);
 	node.block_processor.add (send1);
 	ASSERT_FALSE (node.block_processor.full ());
 	node.block_processor.add (send2);
@@ -3248,7 +3250,7 @@ TEST (node, block_processor_half_full)
 	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node.work_generate_blocking (*send3);
 	// The write guard prevents block processor doing any writes
-	auto write_guard = node.write_database_queue.wait (nano::writer::confirmation_height);
+	auto write_guard = node.write_database_queue.wait (nano::writer::testing);
 	node.block_processor.add (send1);
 	ASSERT_FALSE (node.block_processor.half_full ());
 	node.block_processor.add (send2);
@@ -3476,7 +3478,6 @@ TEST (node, bidirectional_tcp)
 {
 	nano::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = true; // Disable UDP connections
 	// Disable bootstrap to start elections for new blocks
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_lazy_bootstrap = true;

--- a/nano/core_test/node_telemetry.cpp
+++ b/nano/core_test/node_telemetry.cpp
@@ -410,6 +410,7 @@ TEST (node_telemetry, over_udp)
 	nano::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_tcp_realtime = true;
+	node_flags.disable_udp = false;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -156,8 +156,10 @@ TEST (peer_container, list_fanout)
 // Test to make sure we don't repeatedly send keepalive messages to nodes that aren't responding
 TEST (peer_container, reachout)
 {
-	nano::system system (1);
-	auto & node1 (*system.nodes[0]);
+	nano::system system;
+	nano::node_flags node_flags;
+	node_flags.disable_udp = false;
+	auto & node1 = *system.add_node (node_flags);
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
 	// Make sure having been contacted by them already indicates we shouldn't reach out
 	node1.network.udp_channels.insert (endpoint0, node1.network_params.protocol.protocol_version);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -30,6 +30,8 @@ std::string nano::error_cli_messages::message (int ev) const
 			return "Config file read error";
 		case nano::error_cli::disable_all_network:
 			return "Flags --disable_tcp_realtime and --disable_udp cannot be used together";
+		case nano::error_cli::ambiguous_udp_options:
+			return "Flags --disable_udp and --enable_udp cannot be used together";
 	}
 
 	return "Invalid error code";
@@ -88,7 +90,8 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_wallet_bootstrap", "Disables wallet lazy bootstrap")
 		("disable_bootstrap_listener", "Disables bootstrap processing for TCP listener (not including realtime network TCP connections)")
 		("disable_tcp_realtime", "Disables TCP realtime network")
-		("disable_udp", "Disables UDP realtime network")
+		("disable_udp", "(Deprecated) UDP is disabled by default")
+		("enable_udp", "Enables UDP realtime network")
 		("disable_unchecked_cleanup", "Disables periodic cleanup of old records from unchecked table")
 		("disable_unchecked_drop", "Disables drop of unchecked table at startup")
 		("disable_providing_telemetry_metrics", "Disable using any node information in the telemetry_ack messages.")
@@ -115,7 +118,11 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	flags_a.disable_bootstrap_listener = (vm.count ("disable_bootstrap_listener") > 0);
 	flags_a.disable_tcp_realtime = (vm.count ("disable_tcp_realtime") > 0);
 	flags_a.disable_providing_telemetry_metrics = (vm.count ("disable_providing_telemetry_metrics") > 0);
-	flags_a.disable_udp = (vm.count ("disable_udp") > 0);
+	if ((vm.count ("disable_udp") > 0) && (vm.count ("enable_udp") > 0))
+	{
+		ec = nano::error_cli::ambiguous_udp_options;
+	}
+	flags_a.disable_udp = (vm.count ("enable_udp") == 0);
 	if (flags_a.disable_tcp_realtime && flags_a.disable_udp)
 	{
 		ec = nano::error_cli::disable_all_network;

--- a/nano/node/cli.hpp
+++ b/nano/node/cli.hpp
@@ -16,7 +16,8 @@ enum class error_cli
 	unknown_command = 4,
 	database_write_error = 5,
 	reading_config = 6,
-	disable_all_network = 7
+	disable_all_network = 7,
+	ambiguous_udp_options = 8
 };
 
 void add_node_options (boost::program_options::options_description &);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1339,7 +1339,6 @@ nano::node_flags const & nano::inactive_node_flag_defaults ()
 	node_flags.generate_cache.reps = false;
 	node_flags.generate_cache.cemented_count = false;
 	node_flags.generate_cache.unchecked_count = false;
-	node_flags.disable_udp = true;
 	node_flags.disable_bootstrap_listener = true;
 	node_flags.disable_tcp_realtime = true;
 	return node_flags;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -121,7 +121,7 @@ public:
 	bool disable_rep_crawler{ false };
 	bool disable_request_loop{ false };
 	bool disable_tcp_realtime{ false };
-	bool disable_udp{ false };
+	bool disable_udp{ true };
 	bool disable_unchecked_cleanup{ false };
 	bool disable_unchecked_drop{ true };
 	bool disable_providing_telemetry_metrics{ false };


### PR DESCRIPTION
Introduce `--enable_udp` CLI flag, keeping but deprecating `--disable_udp` as it is now an unnecessary option but kept for backwards compatibility. Warning if both are used together.

Most changes are updates to tests so the same functionality is tested.

Unrelated: using `nano::writer::testing` in a couple block_processor tests.