### PR TITLE
Buffer drop policies

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -24,7 +24,7 @@ TEST (active_transactions, confirm_one)
 	// Let node2 know about the block
 	while (node2.active.empty ())
 	{
-		node1.network.flood_block (send, false);
+		node1.network.flood_block (send, nano::buffer_drop_policy::no_limiter_drop);
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	while (node2.ledger.cache.cemented_count < 2)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3593,7 +3593,7 @@ TEST (node, bandwidth_limiter)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 	ASSERT_EQ (node.network.limiter.get_rate (), node.network.limiter.get_limit ());
 	// Non-droppable, increases the rate
-	channel2->send (message, nullptr, false);
+	channel2->send (message, nullptr, nano::buffer_drop_policy::no_limiter_drop);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 	system.deadline_set (300ms);
 	// Wait for the trended rate to catch up

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -7,6 +7,56 @@
 
 using namespace std::chrono_literals;
 
+TEST (socket, drop_policy)
+{
+	auto node_flags = nano::inactive_node_flag_defaults ();
+	node_flags.read_only = false;
+	nano::inactive_node inactivenode (nano::unique_path (), nano::get_available_port (), node_flags);
+	auto node = inactivenode.node;
+
+	nano::thread_runner runner (node->io_ctx, 1);
+	auto server_port (nano::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), server_port);
+
+	auto server_socket (std::make_shared<nano::server_socket> (node, endpoint, 1, nano::socket::concurrency::multi_writer));
+	boost::system::error_code ec;
+	server_socket->start (ec);
+	ASSERT_FALSE (ec);
+	std::vector<std::shared_ptr<nano::socket>> connections;
+
+	// Accept connection, but don't read so the writer will drop.
+	server_socket->on_connection ([&connections](std::shared_ptr<nano::socket> new_connection, boost::system::error_code const & ec_a) {
+		connections.push_back (new_connection);
+		return true;
+	});
+
+	auto client (std::make_shared<nano::socket> (node, boost::none, nano::socket::concurrency::multi_writer));
+
+	// We're going to write twice the queue size + 1, and the server isn't reading
+	// The total number of drops should thus be 1 (the socket allows doubling the queue size for no_socket_drop)
+	auto total_message_count (client->get_max_write_queue_size () * 2 + 1);
+	nano::util::counted_completion write_completion (total_message_count - 1);
+
+	client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), server_port),
+	[client, total_message_count, node, &write_completion](boost::system::error_code const & ec_a) {
+		for (int i = 0; i < total_message_count; i++)
+		{
+			std::vector<uint8_t> buff (1);
+			client->async_write (
+			nano::shared_const_buffer (std::move (buff)), [&write_completion](boost::system::error_code const & ec, size_t size_a) {
+				write_completion.increment ();
+			},
+			nano::buffer_drop_policy::no_socket_drop);
+		}
+	});
+	write_completion.await_count_for (std::chrono::seconds (5));
+	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out));
+
+	node->stop ();
+	runner.stop_event_processing ();
+	runner.join ();
+}
+
 TEST (socket, concurrent_writes)
 {
 	auto node_flags = nano::inactive_node_flag_defaults ();

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -382,7 +382,7 @@ void nano::block_processor::process_live (nano::block_hash const & hash_a, std::
 	node.active.insert (block_a, false);
 
 	// Announce block contents to the network
-	node.network.flood_block (block_a, false);
+	node.network.flood_block (block_a, nano::buffer_drop_policy::no_limiter_drop);
 	if (node.config.enable_voting && node.wallets.rep_counts ().voting > 0)
 	{
 		// Announce our weighted vote to the network

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -98,7 +98,7 @@ void nano::bulk_pull_client::request ()
 			this_l->connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_request_failure, nano::stat::dir::in);
 		}
 	},
-	false); // is bootstrap traffic is_droppable false
+	nano::buffer_drop_policy::no_limiter_drop);
 }
 
 void nano::bulk_pull_client::throttled_receive_block ()
@@ -332,7 +332,7 @@ void nano::bulk_pull_account_client::request ()
 			this_l->connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_error_starting_request, nano::stat::dir::in);
 		}
 	},
-	false); // is bootstrap traffic is_droppable false
+	nano::buffer_drop_policy::no_limiter_drop);
 }
 
 void nano::bulk_pull_account_client::receive_pending ()

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -32,7 +32,7 @@ void nano::bulk_push_client::start ()
 			}
 		}
 	},
-	false); // is bootstrap traffic is_droppable false
+	nano::buffer_drop_policy::no_limiter_drop);
 }
 
 void nano::bulk_push_client::push ()

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -33,7 +33,7 @@ void nano::frontier_req_client::run ()
 			}
 		}
 	},
-	false); // is bootstrap traffic is_droppable false
+	nano::buffer_drop_policy::no_limiter_drop);
 }
 
 nano::frontier_req_client::frontier_req_client (std::shared_ptr<nano::bootstrap_client> connection_a) :

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -221,7 +221,7 @@ bool nano::election::publish (std::shared_ptr<nano::block> block_a)
 			blocks.emplace (std::make_pair (block_a->hash (), block_a));
 			insert_inactive_votes_cache (block_a->hash ());
 			confirm_if_quorum ();
-			node.network.flood_block (block_a, false);
+			node.network.flood_block (block_a, nano::buffer_drop_policy::no_limiter_drop);
 		}
 		else
 		{

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -146,11 +146,11 @@ void nano::network::send_node_id_handshake (std::shared_ptr<nano::transport::cha
 	channel_a->send (message);
 }
 
-void nano::network::flood_message (nano::message const & message_a, bool const is_droppable_a)
+void nano::network::flood_message (nano::message const & message_a, nano::buffer_drop_policy drop_policy_a)
 {
 	for (auto & i : list (fanout ()))
 	{
-		i->send (message_a, nullptr, is_droppable_a);
+		i->send (message_a, nullptr, drop_policy_a);
 	}
 }
 
@@ -168,7 +168,7 @@ void nano::network::flood_vote_pr (std::shared_ptr<nano::vote> const & vote_a)
 	nano::confirm_ack message (vote_a);
 	for (auto const & i : node.rep_crawler.principal_representatives ())
 	{
-		i.channel->send (message, nullptr, false);
+		i.channel->send (message, nullptr, nano::buffer_drop_policy::no_limiter_drop);
 	}
 }
 
@@ -476,7 +476,7 @@ public:
 
 			telemetry_ack = nano::telemetry_ack (telemetry_data);
 		}
-		channel->send (telemetry_ack, nullptr, false);
+		channel->send (telemetry_ack, nullptr, nano::buffer_drop_policy::no_socket_drop);
 	}
 	void telemetry_ack (nano::telemetry_ack const & message_a) override
 	{

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -98,7 +98,7 @@ public:
 	~network ();
 	void start ();
 	void stop ();
-	void flood_message (nano::message const &, bool const = true);
+	void flood_message (nano::message const &, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
 	void flood_keepalive ()
 	{
 		nano::keepalive message;
@@ -107,10 +107,10 @@ public:
 	}
 	void flood_vote (std::shared_ptr<nano::vote> const &, float scale);
 	void flood_vote_pr (std::shared_ptr<nano::vote> const &);
-	void flood_block (std::shared_ptr<nano::block> block_a, bool const is_droppable_a = true)
+	void flood_block (std::shared_ptr<nano::block> block_a, nano::buffer_drop_policy drop_policy_a = nano::buffer_drop_policy::limiter)
 	{
 		nano::publish publish (block_a);
-		flood_message (publish, is_droppable_a);
+		flood_message (publish, drop_policy_a);
 	}
 
 	void flood_block_many (std::deque<std::shared_ptr<nano::block>>, std::function<void()> = nullptr, unsigned = broadcast_interval_ms);

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -20,7 +20,7 @@ enum class buffer_drop_policy
 	limiter,
 	/** Should not be dropped by bandwidth limiter */
 	no_limiter_drop,
-	/** Should not be dropped by socket write queue limiter */
+	/** Should not be dropped by bandwidth limiter or socket write queue limiter */
 	no_socket_drop
 };
 

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -13,6 +13,17 @@
 
 namespace nano
 {
+/** Policy to affects at which stage a buffer can be dropped */
+enum class buffer_drop_policy
+{
+	/** Can be dropped by bandwidth limiter (default) */
+	limiter,
+	/** Should not be dropped by bandwidth limiter */
+	no_limiter_drop,
+	/** Should not be dropped by socket write queue limiter */
+	no_socket_drop
+};
+
 class node;
 class server_socket;
 
@@ -44,7 +55,7 @@ public:
 	virtual ~socket ();
 	void async_connect (boost::asio::ip::tcp::endpoint const &, std::function<void(boost::system::error_code const &)>);
 	void async_read (std::shared_ptr<std::vector<uint8_t>>, size_t, std::function<void(boost::system::error_code const &, size_t)>);
-	void async_write (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> = nullptr);
+	void async_write (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
 
 	void close ();
 	boost::asio::ip::tcp::endpoint remote_endpoint () const;
@@ -55,6 +66,8 @@ public:
 	void start_timer (std::chrono::seconds deadline_a);
 	/** Change write concurrent */
 	void set_writer_concurrency (concurrency writer_concurrency_a);
+	/** Returns the maximum number of buffers in the write queue */
+	size_t get_max_write_queue_size () const;
 
 protected:
 	/** Holds the buffer and callback for queued writes */

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -427,7 +427,7 @@ void nano::telemetry_impl::fire_request_messages (std::deque<std::shared_ptr<nan
 				}
 			}
 		},
-		false);
+		nano::buffer_drop_policy::no_socket_drop);
 		// clang-format on
 
 		// If no response is seen after a certain period of time, remove it from the list of expected responses. However, only if it is part of the same round.

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -50,11 +50,11 @@ bool nano::transport::channel_tcp::operator== (nano::transport::channel const & 
 	return result;
 }
 
-void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const & buffer_a, nano::stat::detail detail_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a)
+void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const & buffer_a, nano::stat::detail detail_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
 	if (auto socket_l = socket.lock ())
 	{
-		socket_l->async_write (buffer_a, tcp_callback (detail_a, socket_l->remote_endpoint (), callback_a));
+		socket_l->async_write (buffer_a, tcp_callback (detail_a, socket_l->remote_endpoint (), callback_a), drop_policy_a);
 	}
 }
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -30,7 +30,7 @@ namespace transport
 		~channel_tcp ();
 		size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
-		void send_buffer (nano::shared_const_buffer const &, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) override;
+		void send_buffer (nano::shared_const_buffer const &, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::function<void(boost::system::error_code const &, size_t)> callback (nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) const override;
 		std::function<void(boost::system::error_code const &, size_t)> tcp_callback (nano::stat::detail, nano::tcp_endpoint const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) const;
 		std::string to_string () const override;

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -85,16 +85,17 @@ node (node_a)
 	set_network_version (node_a.network_params.protocol.protocol_version);
 }
 
-void nano::transport::channel::send (nano::message const & message_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, bool const is_droppable_a)
+void nano::transport::channel::send (nano::message const & message_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
 	callback_visitor visitor;
 	message_a.visit (visitor);
 	auto buffer (message_a.to_shared_const_buffer ());
 	auto detail (visitor.result);
-	node.network.limiter.add (buffer.size (), !is_droppable_a);
-	if (!is_droppable_a || !node.network.limiter.should_drop (buffer.size ()))
+	auto is_droppable_by_limiter = drop_policy_a == nano::buffer_drop_policy::limiter;
+	node.network.limiter.add (buffer.size (), !is_droppable_by_limiter);
+	if (!is_droppable_by_limiter || !node.network.limiter.should_drop (buffer.size ()))
 	{
-		send_buffer (buffer, detail, callback_a);
+		send_buffer (buffer, detail, callback_a, drop_policy_a);
 		node.stats.inc (nano::stat::type::message, detail, nano::stat::dir::out);
 	}
 	else

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -59,8 +59,8 @@ namespace transport
 		virtual ~channel () = default;
 		virtual size_t hash_code () const = 0;
 		virtual bool operator== (nano::transport::channel const &) const = 0;
-		void send (nano::message const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, bool const = true);
-		virtual void send_buffer (nano::shared_const_buffer const &, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) = 0;
+		void send (nano::message const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
+		virtual void send_buffer (nano::shared_const_buffer const &, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) = 0;
 		virtual std::function<void(boost::system::error_code const &, size_t)> callback (nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) const = 0;
 		virtual std::string to_string () const = 0;
 		virtual nano::endpoint get_endpoint () const = 0;

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -33,7 +33,7 @@ bool nano::transport::channel_udp::operator== (nano::transport::channel const & 
 	return result;
 }
 
-void nano::transport::channel_udp::send_buffer (nano::shared_const_buffer const & buffer_a, nano::stat::detail detail_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a)
+void nano::transport::channel_udp::send_buffer (nano::shared_const_buffer const & buffer_a, nano::stat::detail detail_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
 	set_last_packet_sent (std::chrono::steady_clock::now ());
 	channels.send (buffer_a, endpoint, callback (detail_a, callback_a));

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -29,7 +29,7 @@ namespace transport
 		channel_udp (nano::transport::udp_channels &, nano::endpoint const &, uint8_t protocol_version);
 		size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
-		void send_buffer (nano::shared_const_buffer const &, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) override;
+		void send_buffer (nano::shared_const_buffer const &, nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::function<void(boost::system::error_code const &, size_t)> callback (nano::stat::detail, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr) const override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_udp const & other_a) const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1054,7 +1054,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 				if (block != nullptr)
 				{
 					cached_block = true;
-					wallets.node.network.flood_block (block, false);
+					wallets.node.network.flood_block (block, nano::buffer_drop_policy::no_limiter_drop);
 				}
 			}
 			else if (status != MDB_NOTFOUND)


### PR DESCRIPTION
The socket can drop messages even when the bandwidth limiter is instructed not to, e.g. when the peer isn't keeping up. This PR proposes a buffer drop policy instead of the current droppable flag, so callers can request the socket not to drop as well. 

Policies:
- limiter: Can be dropped by bandwidth limiter (default, as before)
- no_limiter_drop: The limiter should not drop
- no_socket_drop: The limiter should not drop, nor should the socket if possible

The `no_socket_drop` policy is applied to telemetry, otherwise no changes in what is dropped and not. This policy is supposed to be used for low volume messages (the socket impl allows a doubling of the write queue at most, as a safety valve.)