### PR TITLE
Request telemetry data for local node

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -458,22 +458,7 @@ public:
 		nano::telemetry_ack telemetry_ack;
 		if (!node.flags.disable_providing_telemetry_metrics)
 		{
-			nano::telemetry_data telemetry_data;
-			telemetry_data.block_count = node.ledger.cache.block_count;
-			telemetry_data.cemented_count = node.ledger.cache.cemented_count;
-			telemetry_data.bandwidth_cap = node.config.bandwidth_limit;
-			telemetry_data.protocol_version = node.network_params.protocol.protocol_version;
-			telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - node.startup_time).count ();
-			telemetry_data.unchecked_count = node.ledger.cache.unchecked_count;
-			telemetry_data.genesis_block = node.network_params.ledger.genesis_hash;
-			telemetry_data.peer_count = node.network.size ();
-			telemetry_data.account_count = node.ledger.cache.account_count;
-			telemetry_data.major_version = nano::get_major_node_version ();
-			telemetry_data.minor_version = nano::get_minor_node_version ();
-			telemetry_data.patch_version = nano::get_patch_node_version ();
-			telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
-			telemetry_data.maker = 0; // 0 Indicates it originated from the NF
-
+			auto telemetry_data = nano::local_telemetry_data (node.ledger.cache, node.network, node.config.bandwidth_limit, node.network_params, node.startup_time);
 			telemetry_ack = nano::telemetry_ack (telemetry_data);
 		}
 		channel->send (telemetry_ack, nullptr, false);

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -669,3 +669,23 @@ nano::telemetry_data_time_pair nano::consolidate_telemetry_data_time_pairs (std:
 
 	return telemetry_data_time_pair{ consolidated_data, std::chrono::steady_clock::time_point{}, std::chrono::system_clock::time_point (std::chrono::milliseconds (consolidated_timestamp)) };
 }
+
+nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledger_cache_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a)
+{
+	nano::telemetry_data telemetry_data;
+	telemetry_data.block_count = ledger_cache_a.block_count;
+	telemetry_data.cemented_count = ledger_cache_a.cemented_count;
+	telemetry_data.bandwidth_cap = bandwidth_limit_a;
+	telemetry_data.protocol_version = network_params_a.protocol.protocol_version;
+	telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - statup_time_a).count ();
+	telemetry_data.unchecked_count = ledger_cache_a.unchecked_count;
+	telemetry_data.genesis_block = network_params_a.ledger.genesis_hash;
+	telemetry_data.peer_count = network_a.size ();
+	telemetry_data.account_count = ledger_cache_a.account_count;
+	telemetry_data.major_version = nano::get_major_node_version ();
+	telemetry_data.minor_version = nano::get_minor_node_version ();
+	telemetry_data.patch_version = nano::get_patch_node_version ();
+	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
+	telemetry_data.maker = 0; // 0 Indicates it originated from the NF
+	return telemetry_data;
+}

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -195,4 +195,5 @@ std::unique_ptr<nano::container_info_component> collect_container_info (telemetr
 
 nano::telemetry_data consolidate_telemetry_data (std::vector<telemetry_data> const & telemetry_data);
 nano::telemetry_data_time_pair consolidate_telemetry_data_time_pairs (std::vector<telemetry_data_time_pair> const & telemetry_data_time_pairs);
+nano::telemetry_data local_telemetry_data (nano::ledger_cache const &, nano::network &, uint64_t, nano::network_params const &, std::chrono::steady_clock::time_point);
 }


### PR DESCRIPTION
Json requested being able to see the telemetry metrics of your own node. This can now be queried through the RPC with:
`{"action":"node_telemetry", "address":"::1", "port":"7075"}`

Where `port` is the peering port, (defaults are 7075 for live & 54000 for beta network).
`address` is any valid loopback address: `127.0.0.1`, `::1` or `[::1]`