### PR TITLE
Disable node.fork_open_flip test on Windows actions

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1482,7 +1482,11 @@ TEST (node, fork_open)
 	node1.block_processor.flush ();
 }
 
+#if (defined(_WIN32) && CI)
+TEST (node, DISABLED_fork_open_flip)
+#else
 TEST (node, fork_open_flip)
+#endif
 {
 	nano::system system (2);
 	auto & node1 (*system.nodes[0]);


### PR DESCRIPTION
Couldn't reproduce locally, but seems to happen on actions a lot. Disable test while investigating