### PR TITLE
Add GSL-style narrow_cast

### DIFF
--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/locks.hpp>
 
+#include <cassert>
 #include <functional>
 #include <mutex>
 #include <vector>
@@ -160,6 +161,15 @@ void transform_if (InputIt first, InputIt last, OutputIt dest, Pred pred, Func t
 
 		++first;
 	}
+}
+
+/** Safe narrowing cast which silences warnings and asserts on data loss in debug builds. This is optimized away. */
+template <typename TARGET_TYPE, typename SOURCE_TYPE>
+constexpr TARGET_TYPE narrow_cast (SOURCE_TYPE const & val)
+{
+	auto res (static_cast<TARGET_TYPE> (val));
+	assert (val == static_cast<SOURCE_TYPE> (res));
+	return res;
 }
 }
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -31,8 +31,8 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		status.confirmation_request_count = confirmation_request_count;
-		status.block_count = blocks.size ();
-		status.voter_count = last_votes.size ();
+		status.block_count = nano::narrow_cast<decltype (status.block_count)> (blocks.size ());
+		status.voter_count = nano::narrow_cast<decltype (status.voter_count)> (last_votes.size ());
 		status.type = type_a;
 		auto status_l (status);
 		auto node_l (node.shared ());
@@ -57,8 +57,8 @@ void nano::election::stop ()
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		status.confirmation_request_count = confirmation_request_count;
-		status.block_count = blocks.size ();
-		status.voter_count = last_votes.size ();
+		status.block_count = nano::narrow_cast<decltype (status.block_count)> (blocks.size ());
+		status.voter_count = nano::narrow_cast<decltype (status.voter_count)> (last_votes.size ());
 		status.type = nano::election_status_type::stopped;
 	}
 }

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -466,7 +466,7 @@ public:
 			telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - node.startup_time).count ();
 			telemetry_data.unchecked_count = node.ledger.cache.unchecked_count;
 			telemetry_data.genesis_block = node.network_params.ledger.genesis_hash;
-			telemetry_data.peer_count = node.network.size ();
+			telemetry_data.peer_count = nano::narrow_cast<decltype (telemetry_data.peer_count)> (node.network.size ());
 			telemetry_data.account_count = node.ledger.cache.account_count;
 			telemetry_data.major_version = nano::get_major_node_version ();
 			telemetry_data.minor_version = nano::get_minor_node_version ();


### PR DESCRIPTION
We have a handful of "potential data loss" warnings due to narrowing casts. This silences the warnings through a quite visible cast, which also checks that the values are in range in debug. C++ Core Guidelines/GSL defines a narrow_cast, but it's throwing (same with Boost's, which @wezrule mentioned). I think a good middle ground for our current code base is to assert. Ran through godbolt, and it's optimized away.