### PR TITLE
Check against op aborted on secure rpc acceptor shutdown

### DIFF
--- a/nano/rpc/rpc_secure.cpp
+++ b/nano/rpc/rpc_secure.cpp
@@ -113,7 +113,7 @@ void nano::rpc_secure::accept ()
 {
 	auto connection (std::make_shared<nano::rpc_connection_secure> (config, io_ctx, logger, rpc_handler_interface, this->ssl_context));
 	acceptor.async_accept (connection->socket, boost::asio::bind_executor (connection->strand, [this, connection](boost::system::error_code const & ec) {
-		if (acceptor.is_open ())
+		if (ec != boost::asio::error::operation_aborted && acceptor.is_open ())
 		{
 			accept ();
 		}


### PR DESCRIPTION
Same as #1681 but for tls acceptor