### PR TITLE
tsan: race in telemetry::ongoing_single_request_cleanup

### DIFF
--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -153,10 +153,14 @@ void nano::telemetry::ongoing_single_request_cleanup (nano::endpoint const & end
 		if (auto telemetry_impl = telemetry_impl_w.lock ())
 		{
 			nano::lock_guard<std::mutex> guard (this->mutex);
+			nano::lock_guard<std::mutex> guard_telemetry_impl (telemetry_impl->mutex);
 			if (std::chrono::steady_clock::now () - telemetry_impl->cache_cutoff > single_request_data_a.last_updated && telemetry_impl->callbacks.empty ())
 			{
 				//  This will be picked up by the batch request next round
-				this->finished_single_requests[endpoint_a] = telemetry_impl->cached_telemetry_data.begin ()->second;
+				if (!telemetry_impl->cached_telemetry_data.empty ())
+				{
+					this->finished_single_requests[endpoint_a] = telemetry_impl->cached_telemetry_data.begin ()->second;
+				}
 				this->single_requests.erase (endpoint_a);
 			}
 			else


### PR DESCRIPTION
Came over this when running core_test under tsan (node_telemetry.disconnects). Caught it the debugger, so tried to make a fix. Addresses two issues, one is accessing telemetry_impl without locking (which tsan caught), the other is `telemetry_impl->cached_telemetry_data.begin ()` sometimes segfaultet because it was empty, so added a not-empty check. @wezrule Not sure if the mutex order is correct or if this is the best way to handle it. Unable to trigger this code path on beta with node_telemetry rpc, but the test seems happy now.