### PR TITLE
[TSAN] vote_processor.flush test

### DIFF
--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -57,7 +57,8 @@ TEST (vote_processor, flush)
 	auto channel (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	for (unsigned i = 0; i < 2000; ++i)
 	{
-		node.vote_processor.vote (vote, channel);
+		auto new_vote (std::make_shared<nano::vote> (*vote));
+		node.vote_processor.vote (new_vote, channel);
 		++vote->sequence; // invalidates votes without signing again
 	}
 	node.vote_processor.flush ();


### PR DESCRIPTION
https://gist.github.com/SergiySW/23743c3c818ac3b9bdc63cdca6ffe9cb
`vote` was changed in while processed