### PR TITLE
[RocksDB] Limit write locks to necessary tables

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4100,7 +4100,7 @@ void nano::json_handler::unchecked_clear ()
 {
 	auto rpc_l (shared_from_this ());
 	node.worker.push_task ([rpc_l]() {
-		auto transaction (rpc_l->node.store.tx_begin_write ());
+		auto transaction (rpc_l->node.store.tx_begin_write ({ tables::unchecked }));
 		rpc_l->node.store.unchecked_clear (transaction);
 		rpc_l->node.ledger.cache.unchecked_count = 0;
 		rpc_l->response_l.put ("success", "");

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -28,7 +28,7 @@ void nano::online_reps::observe (nano::account const & rep_a)
 
 void nano::online_reps::sample ()
 {
-	auto transaction (ledger.store.tx_begin_write ());
+	auto transaction (ledger.store.tx_begin_write ({ tables::online_weight }));
 	// Discard oldest entries
 	while (ledger.store.online_weight_count (transaction) >= network_params.node.max_weight_samples)
 	{


### PR DESCRIPTION
Update various places where write locks are done to only the tables actually used as opposed to locking all tables. Didn't bother touching CLI commands as it's not possible to have 2 different processes write to a RocksDB database