### PR TITLE
Block work version

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -399,6 +399,15 @@ TEST (state_block, hashing)
 	ASSERT_EQ (hash, block.hash ());
 }
 
+TEST (blocks, work_version)
+{
+	ASSERT_EQ (nano::work_version::work_1, nano::send_block ().work_version ());
+	ASSERT_EQ (nano::work_version::work_1, nano::receive_block ().work_version ());
+	ASSERT_EQ (nano::work_version::work_1, nano::change_block ().work_version ());
+	ASSERT_EQ (nano::work_version::work_1, nano::open_block ().work_version ());
+	ASSERT_EQ (nano::work_version::work_1, nano::state_block ().work_version ());
+}
+
 TEST (block_uniquer, null)
 {
 	nano::block_uniquer uniquer;

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -31,7 +31,7 @@ TEST (distributed_work, no_peers)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_FALSE (nano::work_validate (hash, *work));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, *work));
 	// should only be removed after cleanup
 	ASSERT_EQ (1, node->distributed_work.items.size ());
 	while (!node->distributed_work.items.empty ())
@@ -177,7 +177,7 @@ TEST (distributed_work, peer)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_FALSE (nano::work_validate (hash, *work));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, *work));
 	ASSERT_EQ (1, work_peer->generations_good);
 	ASSERT_EQ (0, work_peer->generations_bad);
 	ASSERT_NO_ERROR (system.poll ());
@@ -207,7 +207,7 @@ TEST (distributed_work, peer_malicious)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_FALSE (nano::work_validate (hash, *work));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, *work));
 	system.deadline_set (5s);
 	while (malicious_peer->generations_bad < 1)
 	{
@@ -265,7 +265,7 @@ TEST (distributed_work, peer_multi)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_FALSE (nano::work_validate (hash, *work));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, *work));
 	system.deadline_set (5s);
 	while (slow_peer->cancels < 1)
 	{
@@ -304,5 +304,5 @@ TEST (distributed_work, fail_resolve)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_FALSE (nano::work_validate (hash, *work));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, *work));
 }

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -36,9 +36,10 @@ class work_peer_connection : public std::enable_shared_from_this<work_peer_conne
 	const std::string empty_response = "Empty response";
 
 public:
-	work_peer_connection (asio::io_context & ioc_a, work_peer_type const type_a, nano::work_pool & pool_a, std::function<void(bool const)> on_generation_a, std::function<void()> on_cancel_a) :
+	work_peer_connection (asio::io_context & ioc_a, work_peer_type const type_a, nano::work_version const version_a, nano::work_pool & pool_a, std::function<void(bool const)> on_generation_a, std::function<void()> on_cancel_a) :
 	socket (ioc_a),
 	type (type_a),
+	version (version_a),
 	work_pool (pool_a),
 	on_generation (on_generation_a),
 	on_cancel (on_cancel_a),
@@ -53,6 +54,7 @@ public:
 
 private:
 	work_peer_type type;
+	nano::work_version version;
 	nano::work_pool & work_pool;
 	beast::flat_buffer buffer{ 8192 };
 	http::request<http::string_body> request;
@@ -130,10 +132,10 @@ private:
 		{
 			auto hash = hash_a;
 			auto this_l (shared_from_this ());
-			work_pool.generate (hash, [this_l, hash](boost::optional<uint64_t> work_a) {
+			work_pool.generate (version, hash, [this_l, hash](boost::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
 				uint64_t difficulty;
-				nano::work_validate (hash, result, &difficulty);
+				nano::work_validate (this_l->version, hash, result, &difficulty);
 				static nano::network_params params;
 				ptree::ptree message_l;
 				message_l.put ("work", nano::to_string_hex (result));
@@ -188,12 +190,14 @@ private:
 class fake_work_peer : public std::enable_shared_from_this<fake_work_peer>
 {
 public:
-	fake_work_peer (nano::work_pool & pool_a, asio::io_context & ioc_a, unsigned short port_a, work_peer_type const type_a) :
+	fake_work_peer () = delete;
+	fake_work_peer (nano::work_pool & pool_a, asio::io_context & ioc_a, unsigned short port_a, work_peer_type const type_a, nano::work_version const version_a = nano::work_version::work_1) :
 	pool (pool_a),
 	endpoint (tcp::v4 (), port_a),
 	ioc (ioc_a),
 	acceptor (ioc_a, endpoint),
-	type (type_a)
+	type (type_a),
+	version (version_a)
 	{
 	}
 	void start ()
@@ -213,7 +217,7 @@ private:
 	{
 		std::weak_ptr<fake_work_peer> this_w (shared_from_this ());
 		auto connection (std::make_shared<work_peer_connection> (
-		ioc, type, pool,
+		ioc, type, version, pool,
 		[this_w](bool const good_generation) {
 			if (auto this_l = this_w.lock ())
 			{
@@ -249,5 +253,6 @@ private:
 	asio::io_context & ioc;
 	tcp::acceptor acceptor;
 	work_peer_type const type;
+	nano::work_version version;
 };
 }

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -649,7 +649,7 @@ TEST (wallet, work)
 		uint64_t work (0);
 		if (!wallet->store.work_get (transaction, nano::test_genesis_key.pub, work))
 		{
-			done = !nano::work_validate (genesis.hash (), work);
+			done = !nano::work_validate (genesis.open->work_version (), genesis.hash (), work);
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -669,7 +669,7 @@ TEST (wallet, work_generate)
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
-	wallet->send_action (nano::test_genesis_key.pub, key.pub, 100);
+	auto block (wallet->send_action (nano::test_genesis_key.pub, key.pub, 100));
 	system.deadline_set (10s);
 	auto transaction (node1.store.tx_begin_read ());
 	while (node1.ledger.account_balance (transaction, nano::test_genesis_key.pub) == amount1)
@@ -683,7 +683,7 @@ TEST (wallet, work_generate)
 		ASSERT_NO_ERROR (system.poll ());
 		auto block_transaction (node1.store.tx_begin_read ());
 		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		again = wallet->store.work_get (transaction, account1, work1) || nano::work_validate (node1.ledger.latest_root (block_transaction, account1), work1);
+		again = wallet->store.work_get (transaction, account1, work1) || nano::work_validate (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1);
 	}
 }
 
@@ -949,7 +949,7 @@ TEST (wallet, no_work)
 	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), false));
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
-	ASSERT_FALSE (nano::work_validate (block->root (), block->block_work ()));
+	ASSERT_FALSE (nano::work_validate (*block));
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	uint64_t cached_work (0);
 	system.wallet (0)->store.work_get (transaction, nano::test_genesis_key.pub, cached_work);
@@ -1190,7 +1190,7 @@ TEST (wallet, work_watcher_generation_disabled)
 	auto block (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Mxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ())));
 	uint64_t difficulty (0);
 	ASSERT_FALSE (nano::work_validate (*block, &difficulty));
-	node.wallets.watcher->add (block, nano::work_version::work_1);
+	node.wallets.watcher->add (block);
 	ASSERT_FALSE (node.process_local (block).code != nano::process_result::progress);
 	ASSERT_TRUE (node.wallets.watcher->is_watched (block->qualified_root ()));
 	auto multiplier = nano::difficulty::to_multiplier (difficulty, node.network_params.network.publish_threshold);

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -106,9 +106,9 @@ TEST (work, opencl)
 			for (auto i (0); i < 16; ++i)
 			{
 				nano::random_pool::generate_block (root.bytes.data (), root.bytes.size ());
-				auto result (*pool.generate (root, difficulty));
+				auto result (*pool.generate (nano::work_version::work_1, root, difficulty));
 				uint64_t result_difficulty (0);
-				ASSERT_FALSE (nano::work_validate (root, result, &result_difficulty));
+				ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, root, result, &result_difficulty));
 				ASSERT_GE (result_difficulty, difficulty);
 				difficulty += difficulty_add;
 			}
@@ -149,15 +149,15 @@ TEST (work, difficulty)
 	uint64_t nonce1 (0);
 	do
 	{
-		auto work1 = *pool.generate (root, difficulty1);
-		nano::work_validate (root, work1, &nonce1);
+		auto work1 = *pool.generate (nano::work_version::work_1, root, difficulty1);
+		nano::work_validate (nano::work_version::work_1, root, work1, &nonce1);
 	} while (nonce1 > difficulty2);
 	ASSERT_GT (nonce1, difficulty1);
 	uint64_t nonce2 (0);
 	do
 	{
-		auto work2 = *pool.generate (root, difficulty2);
-		nano::work_validate (root, work2, &nonce2);
+		auto work2 = *pool.generate (nano::work_version::work_1, root, difficulty2);
+		nano::work_validate (nano::work_version::work_1, root, work2, &nonce2);
 	} while (nonce2 > difficulty3);
 	ASSERT_GT (nonce2, difficulty2);
 }
@@ -178,8 +178,8 @@ TEST (work, eco_pow)
 			uint64_t nonce (0);
 			do
 			{
-				auto work = *pool.generate (root, difficulty1);
-				nano::work_validate (root, work, &nonce);
+				auto work = *pool.generate (nano::work_version::work_1, root, difficulty1);
+				nano::work_validate (nano::work_version::work_1, root, work, &nonce);
 			} while (nonce > difficulty2);
 			ASSERT_GT (nonce, difficulty1);
 		}

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -76,6 +76,11 @@ size_t nano::block::size (nano::block_type type_a)
 	return result;
 }
 
+nano::work_version nano::block::work_version () const
+{
+	return nano::work_version::work_1;
+}
+
 nano::block_hash nano::block::generate_hash () const
 {
 	nano::block_hash result;

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -5,6 +5,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/lib/utility.hpp>
+#include <nano/lib/work.hpp>
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
@@ -58,6 +59,7 @@ public:
 	virtual ~block () = default;
 	virtual bool valid_predecessor (nano::block const &) const = 0;
 	static size_t size (nano::block_type);
+	virtual nano::work_version work_version () const;
 	// If there are any changes to the hashables, call this to update the cached hash
 	void refresh ();
 

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -21,9 +21,9 @@ std::string nano::to_string (nano::work_version const version_a)
 	return result;
 }
 
-bool nano::work_validate (nano::work_version const version_a, nano::block const & block_a, uint64_t * difficulty_a)
+bool nano::work_validate (nano::block const & block_a, uint64_t * difficulty_a)
 {
-	return nano::work_validate (version_a, block_a.root (), block_a.block_work (), difficulty_a);
+	return nano::work_validate (block_a.work_version (), block_a.root (), block_a.block_work (), difficulty_a);
 }
 
 bool nano::work_validate (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a, uint64_t * difficulty_a)
@@ -38,18 +38,6 @@ bool nano::work_validate (nano::work_version const version_a, nano::root const &
 			debug_assert (false && "Invalid version specified to work_validate");
 	}
 	return invalid;
-}
-
-bool nano::work_validate (nano::block const & block_a, uint64_t * difficulty_a)
-{
-	return nano::work_validate (block_a.root (), block_a.block_work (), difficulty_a);
-}
-
-bool nano::work_validate (nano::root const & root_a, uint64_t const work_a, uint64_t * difficulty_a)
-{
-	static nano::network_constants network_constants;
-	debug_assert (network_constants.is_test_network ());
-	return nano::work_validate (nano::work_version::work_1, root_a, work_a, difficulty_a);
 }
 
 bool nano::work_v1::validate (nano::root const & root_a, uint64_t work_a, uint64_t * difficulty_a)

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -21,12 +21,8 @@ enum class work_version
 std::string to_string (nano::work_version const version_a);
 
 class block;
-bool work_validate (nano::work_version const, nano::block const &, uint64_t * = nullptr);
-bool work_validate (nano::work_version const, nano::root const &, uint64_t const, uint64_t * = nullptr);
-// For tests only
 bool work_validate (nano::block const &, uint64_t * = nullptr);
-// For tests only
-bool work_validate (nano::root const &, uint64_t const, uint64_t * = nullptr);
+bool work_validate (nano::work_version const, nano::root const &, uint64_t const, uint64_t * = nullptr);
 
 namespace work_v1
 {

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1104,7 +1104,7 @@ int main (int argc, char * const * argv)
 						std::cerr << boost::str (boost::format ("Incorrect sideband block details for block %1%\n") % hash.to_string ());
 					}
 					// Check if block work value is correct
-					if (nano::work_validate (nano::work_version::work_1, *block))
+					if (nano::work_validate (*block))
 					{
 						std::cerr << boost::str (boost::format ("Invalid work for block %1% value: %2%\n") % hash.to_string () % nano::to_string_hex (block->block_work ()));
 					}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -580,7 +580,7 @@ std::pair<std::shared_ptr<nano::election>, bool> nano::active_transactions::inse
 				auto hash (block_a->hash ());
 				result.first = nano::make_shared<nano::election> (node, block_a, skip_delay_a, confirmation_action_a);
 				uint64_t difficulty (0);
-				release_assert (!nano::work_validate (nano::work_version::work_1, *block_a, &difficulty));
+				release_assert (!nano::work_validate (*block_a, &difficulty));
 				roots.get<tag_root> ().emplace (nano::conflict_info{ root, difficulty, difficulty, result.first });
 				blocks.emplace (hash, result.first);
 				adjust_difficulty (hash);
@@ -678,7 +678,7 @@ void nano::active_transactions::update_difficulty (std::shared_ptr<nano::block> 
 	if (existing_election != roots.get<tag_root> ().end ())
 	{
 		uint64_t difficulty;
-		auto error (nano::work_validate (nano::work_version::work_1, *block_a, &difficulty));
+		auto error (nano::work_validate (*block_a, &difficulty));
 		(void)error;
 		debug_assert (!error);
 		if (difficulty > existing_election->difficulty)

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -67,7 +67,7 @@ void nano::block_processor::add (std::shared_ptr<nano::block> block_a, uint64_t 
 
 void nano::block_processor::add (nano::unchecked_info const & info_a)
 {
-	if (!nano::work_validate (nano::work_version::work_1, info_a.block->root (), info_a.block->block_work ()))
+	if (!nano::work_validate (*info_a.block))
 	{
 		{
 			auto hash (info_a.block->hash ());
@@ -373,7 +373,7 @@ void nano::block_processor::process_live (nano::block_hash const & hash_a, std::
 	// Add to work watcher to prevent dropping the election
 	if (watch_work_a)
 	{
-		node.wallets.watcher->add (block_a, nano::work_version::work_1);
+		node.wallets.watcher->add (block_a);
 	}
 
 	// Start collecting quorum on block

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -214,7 +214,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (connection->receive_buffer->data (), size_a);
 		std::shared_ptr<nano::block> block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !nano::work_validate (nano::work_version::work_1, *block))
+		if (block != nullptr && !nano::work_validate (*block))
 		{
 			auto hash (block->hash ());
 			if (connection->node->config.logging.bulk_pull_logging ())

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -240,7 +240,7 @@ void nano::bulk_push_server::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (receive_buffer->data (), size_a);
 		auto block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !nano::work_validate (nano::work_version::work_1, *block))
+		if (block != nullptr && !nano::work_validate (*block))
 		{
 			connection->node->process_active (std::move (block));
 			throttled_receive ();

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -418,7 +418,7 @@ void nano::message_parser::deserialize_publish (nano::stream & stream_a, nano::m
 	nano::publish incoming (error, stream_a, header_a, &block_uniquer);
 	if (!error && at_end (stream_a))
 	{
-		if (!nano::work_validate (nano::work_version::work_1, *incoming.block))
+		if (!nano::work_validate (*incoming.block))
 		{
 			visitor.publish (incoming);
 		}
@@ -439,7 +439,7 @@ void nano::message_parser::deserialize_confirm_req (nano::stream & stream_a, nan
 	nano::confirm_req incoming (error, stream_a, header_a, &block_uniquer);
 	if (!error && at_end (stream_a))
 	{
-		if (incoming.block == nullptr || !nano::work_validate (nano::work_version::work_1, *incoming.block))
+		if (incoming.block == nullptr || !nano::work_validate (*incoming.block))
 		{
 			visitor.confirm_req (incoming);
 		}
@@ -465,7 +465,7 @@ void nano::message_parser::deserialize_confirm_ack (nano::stream & stream_a, nan
 			if (!vote_block.which ())
 			{
 				auto block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-				if (nano::work_validate (nano::work_version::work_1, *block))
+				if (nano::work_validate (*block))
 				{
 					status = parse_status::insufficient_work;
 					break;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2126,7 +2126,7 @@ void epoch_upgrader (std::shared_ptr<nano::node> node_a, nano::private_key const
 					             .work (node_a->work_generate_blocking (nano::work_version::work_1, info.head).value_or (0))
 					             .build ();
 					bool valid_signature (!nano::validate_message (signer, epoch->hash (), epoch->block_signature ()));
-					bool valid_work (!nano::work_validate (nano::work_version::work_1, *epoch.get ()));
+					bool valid_work (!nano::work_validate (*epoch.get ()));
 					nano::process_result result (nano::process_result::old);
 					if (valid_signature && valid_work)
 					{
@@ -2185,7 +2185,7 @@ void epoch_upgrader (std::shared_ptr<nano::node> node_a, nano::private_key const
 						             .work (node_a->work_generate_blocking (nano::work_version::work_1, key.account).value_or (0))
 						             .build ();
 						bool valid_signature (!nano::validate_message (signer, epoch->hash (), epoch->block_signature ()));
-						bool valid_work (!nano::work_validate (nano::work_version::work_1, *epoch.get ()));
+						bool valid_work (!nano::work_validate (*epoch.get ()));
 						nano::process_result result (nano::process_result::old);
 						if (valid_signature && valid_work)
 						{
@@ -3252,7 +3252,7 @@ void nano::json_handler::process ()
 		}
 		if (!rpc_l->ec)
 		{
-			if (!nano::work_validate (nano::work_version::work_1, *block))
+			if (!nano::work_validate (*block))
 			{
 				auto result (rpc_l->node.process_local (block, watch_work_l));
 				switch (result.code)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1006,14 +1006,14 @@ bool nano::node::work_generation_enabled (std::vector<std::pair<std::string, uin
 	return !peers_a.empty () || local_work_generation_enabled ();
 }
 
-boost::optional<uint64_t> nano::node::work_generate_blocking (nano::work_version const version_a, nano::block & block_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a)
 {
-	return work_generate_blocking (version_a, block_a, network_params.network.publish_threshold);
+	return work_generate_blocking (block_a, network_params.network.publish_threshold);
 }
 
-boost::optional<uint64_t> nano::node::work_generate_blocking (nano::work_version const version_a, nano::block & block_a, uint64_t difficulty_a)
+boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a, uint64_t difficulty_a)
 {
-	auto opt_work_l (work_generate_blocking (version_a, block_a.root (), difficulty_a, block_a.account ()));
+	auto opt_work_l (work_generate_blocking (block_a.work_version (), block_a.root (), difficulty_a, block_a.account ()));
 	if (opt_work_l.is_initialized ())
 	{
 		block_a.block_work_set (*opt_work_l);
@@ -1050,18 +1050,6 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::work_version
 	},
 	difficulty_a, account_a);
 	return promise.get_future ().get ();
-}
-
-boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a)
-{
-	debug_assert (network_params.network.is_test_network ());
-	return work_generate_blocking (block_a, network_params.network.publish_threshold);
-}
-
-boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a, uint64_t difficulty_a)
-{
-	debug_assert (network_params.network.is_test_network ());
-	return work_generate_blocking (nano::work_version::work_1, block_a, difficulty_a);
 }
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -129,8 +129,8 @@ public:
 	bool local_work_generation_enabled () const;
 	bool work_generation_enabled () const;
 	bool work_generation_enabled (std::vector<std::pair<std::string, uint16_t>> const &) const;
-	boost::optional<uint64_t> work_generate_blocking (nano::work_version const, nano::block &, uint64_t);
-	boost::optional<uint64_t> work_generate_blocking (nano::work_version const, nano::block &);
+	boost::optional<uint64_t> work_generate_blocking (nano::block &, uint64_t);
+	boost::optional<uint64_t> work_generate_blocking (nano::block &);
 	boost::optional<uint64_t> work_generate_blocking (nano::work_version const, nano::root const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	boost::optional<uint64_t> work_generate_blocking (nano::work_version const, nano::root const &, boost::optional<nano::account> const & = boost::none);
 	void work_generate (nano::work_version const, nano::root const &, std::function<void(boost::optional<uint64_t>)>, uint64_t, boost::optional<nano::account> const & = boost::none, bool const = false);
@@ -194,11 +194,6 @@ public:
 	std::atomic<bool> stopped{ false };
 	static double constexpr price_max = 16.0;
 	static double constexpr free_cutoff = 1024.0;
-
-	// For tests only
-	boost::optional<uint64_t> work_generate_blocking (nano::block &, uint64_t);
-	// For tests only
-	boost::optional<uint64_t> work_generate_blocking (nano::block &);
 	// For tests only
 	boost::optional<uint64_t> work_generate_blocking (nano::root const &, uint64_t);
 	// For tests only

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1134,10 +1134,10 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 	bool error{ false };
 	if (block_a != nullptr)
 	{
-		if (nano::work_validate (nano::work_version::work_1, *block_a))
+		if (nano::work_validate (*block_a))
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));
-			error = !wallets.node.work_generate_blocking (nano::work_version::work_1, *block_a, wallets.node.active.limited_active_difficulty ()).is_initialized ();
+			error = !wallets.node.work_generate_blocking (*block_a, wallets.node.active.limited_active_difficulty ()).is_initialized ();
 		}
 		if (!error)
 		{
@@ -1401,7 +1401,7 @@ void nano::work_watcher::stop ()
 	stopped = true;
 }
 
-void nano::work_watcher::add (std::shared_ptr<nano::block> block_a, nano::work_version const work_version_a)
+void nano::work_watcher::add (std::shared_ptr<nano::block> block_a)
 {
 	auto block_l (std::dynamic_pointer_cast<nano::state_block> (block_a));
 	if (!stopped && block_l != nullptr)
@@ -1410,7 +1410,7 @@ void nano::work_watcher::add (std::shared_ptr<nano::block> block_a, nano::work_v
 		nano::unique_lock<std::mutex> lock (mutex);
 		watched[root_l] = block_l;
 		lock.unlock ();
-		watching (work_version_a, root_l, block_l);
+		watching (root_l, block_l);
 	}
 }
 
@@ -1420,10 +1420,10 @@ void nano::work_watcher::update (nano::qualified_root const & root_a, std::share
 	watched[root_a] = block_a;
 }
 
-void nano::work_watcher::watching (nano::work_version const version_a, nano::qualified_root const & root_a, std::shared_ptr<nano::state_block> block_a)
+void nano::work_watcher::watching (nano::qualified_root const & root_a, std::shared_ptr<nano::state_block> block_a)
 {
 	std::weak_ptr<nano::work_watcher> watcher_w (shared_from_this ());
-	node.alarm.add (std::chrono::steady_clock::now () + node.config.work_watcher_period, [block_a, version_a, root_a, watcher_w]() {
+	node.alarm.add (std::chrono::steady_clock::now () + node.config.work_watcher_period, [block_a, root_a, watcher_w]() {
 		auto watcher_l = watcher_w.lock ();
 		if (watcher_l && !watcher_l->stopped && block_a != nullptr)
 		{
@@ -1432,8 +1432,7 @@ void nano::work_watcher::watching (nano::work_version const version_a, nano::qua
 			{
 				lock.unlock ();
 				uint64_t difficulty (0);
-				auto root_l (block_a->root ());
-				nano::work_validate (version_a, root_l, block_a->block_work (), &difficulty);
+				nano::work_validate (*block_a, &difficulty);
 				auto active_difficulty (watcher_l->node.active.limited_active_difficulty ());
 				/*
 				 * Work watcher should still watch blocks even without work generation, although no rework is done
@@ -1442,7 +1441,7 @@ void nano::work_watcher::watching (nano::work_version const version_a, nano::qua
 				if (active_difficulty > difficulty && watcher_l->node.work_generation_enabled ())
 				{
 					watcher_l->node.work_generate (
-					version_a, root_l, [watcher_l, block_a, version_a, root_a](boost::optional<uint64_t> work_a) {
+					block_a->work_version (), block_a->root (), [watcher_l, block_a, root_a](boost::optional<uint64_t> work_a) {
 						if (block_a != nullptr && watcher_l != nullptr && !watcher_l->stopped)
 						{
 							bool updated_l{ false };
@@ -1457,12 +1456,12 @@ void nano::work_watcher::watching (nano::work_version const version_a, nano::qua
 									watcher_l->node.active.update_difficulty (block);
 									watcher_l->update (root_a, block);
 									updated_l = true;
-									watcher_l->watching (version_a, root_a, block);
+									watcher_l->watching (root_a, block);
 								}
 							}
 							if (!updated_l)
 							{
-								watcher_l->watching (version_a, root_a, block_a);
+								watcher_l->watching (root_a, block_a);
 							}
 						}
 					},
@@ -1470,7 +1469,7 @@ void nano::work_watcher::watching (nano::work_version const version_a, nano::qua
 				}
 				else
 				{
-					watcher_l->watching (version_a, root_a, block_a);
+					watcher_l->watching (root_a, block_a);
 				}
 			}
 		}

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -168,9 +168,9 @@ public:
 	work_watcher (nano::node &);
 	~work_watcher ();
 	void stop ();
-	void add (std::shared_ptr<nano::block>, nano::work_version const);
+	void add (std::shared_ptr<nano::block>);
 	void update (nano::qualified_root const &, std::shared_ptr<nano::state_block>);
-	void watching (work_version const, nano::qualified_root const &, std::shared_ptr<nano::state_block>);
+	void watching (nano::qualified_root const &, std::shared_ptr<nano::state_block>);
 	void remove (std::shared_ptr<nano::block>);
 	bool is_watched (nano::qualified_root const &);
 	size_t size ();

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2229,7 +2229,7 @@ void nano_qt::block_creation::create_send ()
 						(void)error;
 						debug_assert (!error);
 						nano::state_block send (account_l, info.head, info.representative, balance - amount_l.number (), destination_l, key, account_l, 0);
-						if (wallet.node.work_generate_blocking (nano::work_version::work_1, send).is_initialized ())
+						if (wallet.node.work_generate_blocking (send).is_initialized ())
 						{
 							std::string block_l;
 							send.serialize_json (block_l);
@@ -2308,7 +2308,7 @@ void nano_qt::block_creation::create_receive ()
 						if (!error)
 						{
 							nano::state_block receive (pending_key.account, info.head, info.representative, info.balance.number () + pending.amount.number (), source_l, key, pending_key.account, 0);
-							if (wallet.node.work_generate_blocking (nano::work_version::work_1, receive).is_initialized ())
+							if (wallet.node.work_generate_blocking (receive).is_initialized ())
 							{
 								std::string block_l;
 								receive.serialize_json (block_l);
@@ -2387,7 +2387,7 @@ void nano_qt::block_creation::create_change ()
 				if (!error)
 				{
 					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key, account_l, 0);
-					if (wallet.node.work_generate_blocking (nano::work_version::work_1, change).is_initialized ())
+					if (wallet.node.work_generate_blocking (change).is_initialized ())
 					{
 						std::string block_l;
 						change.serialize_json (block_l);
@@ -2464,7 +2464,7 @@ void nano_qt::block_creation::create_open ()
 							if (!error)
 							{
 								nano::state_block open (pending_key.account, 0, representative_l, pending.amount, source_l, key, pending_key.account, 0);
-								if (wallet.node.work_generate_blocking (nano::work_version::work_1, open).is_initialized ())
+								if (wallet.node.work_generate_blocking (open).is_initialized ())
 								{
 									std::string block_l;
 									open.serialize_json (block_l);

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -727,7 +727,7 @@ TEST (wallet, seed_work_generation)
 		ASSERT_NO_ERROR (ec);
 	}
 	auto transaction (system.nodes[0]->store.tx_begin_read ());
-	ASSERT_FALSE (nano::work_validate (system.nodes[0]->ledger.latest_root (transaction, pub), work));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work));
 }
 
 TEST (wallet, backup_seed)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2222,13 +2222,13 @@ TEST (rpc, payment_begin_end)
 		root1 = node1->ledger.latest_root (transaction, account);
 	}
 	uint64_t work (0);
-	while (!nano::work_validate (root1, work))
+	while (!nano::work_validate (nano::work_version::work_1, root1, work))
 	{
 		++work;
 		ASSERT_LT (work, 50);
 	}
 	system.deadline_set (10s);
-	while (nano::work_validate (root1, work))
+	while (nano::work_validate (nano::work_version::work_1, root1, work))
 	{
 		auto ec = system.poll ();
 		auto transaction (wallet->wallets.tx_begin_read ());
@@ -2832,7 +2832,7 @@ TEST (rpc, work_generate)
 		auto work_text (response.json.get<std::string> ("work"));
 		uint64_t work, result_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
+		ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, work, &result_difficulty));
 		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2877,7 +2877,7 @@ TEST (rpc, work_generate_difficulty)
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
 		uint64_t result_difficulty;
-		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
+		ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, work, &result_difficulty));
 		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2901,7 +2901,7 @@ TEST (rpc, work_generate_difficulty)
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
 		uint64_t result_difficulty;
-		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
+		ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, work, &result_difficulty));
 		ASSERT_GE (result_difficulty, difficulty);
 	}
 	{
@@ -2954,7 +2954,7 @@ TEST (rpc, work_generate_multiplier)
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
 		uint64_t result_difficulty;
-		ASSERT_FALSE (nano::work_validate (hash, work, &result_difficulty));
+		ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, work, &result_difficulty));
 		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -3050,7 +3050,7 @@ TEST (rpc, work_peer_bad)
 		work = *work_a;
 	});
 	system.deadline_set (5s);
-	while (nano::work_validate (hash1, work))
+	while (nano::work_validate (nano::work_version::work_1, hash1, work))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -3080,7 +3080,7 @@ TEST (rpc, work_peer_one)
 		work = *work_a;
 	});
 	system.deadline_set (5s);
-	while (nano::work_validate (key1.pub, work))
+	while (nano::work_validate (nano::work_version::work_1, key1.pub, work))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -3125,7 +3125,7 @@ TEST (rpc, work_peer_many)
 		node1.work_generate (nano::work_version::work_1, key1.pub, [& work = works[i]](boost::optional<uint64_t> work_a) {
 			work = *work_a;
 		});
-		while (nano::work_validate (key1.pub, works[i]))
+		while (nano::work_validate (nano::work_version::work_1, key1.pub, works[i]))
 		{
 			system1.poll ();
 			system2.poll ();
@@ -3842,7 +3842,7 @@ TEST (rpc, work_validate)
 		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, params.network.publish_threshold), 1e-6);
 	}
 	uint64_t result_difficulty;
-	ASSERT_FALSE (nano::work_validate (hash, work1, &result_difficulty));
+	ASSERT_FALSE (nano::work_validate (nano::work_version::work_1, hash, work1, &result_difficulty));
 	ASSERT_GE (result_difficulty, params.network.publish_threshold);
 	request.put ("work", nano::to_string_hex (work1));
 	request.put ("difficulty", nano::to_string_hex (result_difficulty));

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -754,7 +754,7 @@ nano::uint128_t nano::ledger::account_pending (nano::transaction const & transac
 
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block const & block_a, nano::signature_verification verification)
 {
-	debug_assert (!nano::work_validate (nano::work_version::work_1, block_a));
+	debug_assert (!nano::work_validate (block_a));
 	ledger_processor processor (*this, transaction_a, verification);
 	block_a.visit (processor);
 	if (processor.result.code == nano::process_result::progress)


### PR DESCRIPTION
As of this change, work version refers to different work algorithms. Each block type can unequivocally return its work version. It's a virtual method but defaults to `work_1`, and no type overrides it currently. A new algorithm will likely need a new state block definition, to avoid ambiguity, although it could be inferred by trying to validate with both algorithms and then setting the version to the one that was valid (if any).

This change allowed removing work_version as a parameter for some work_validate and work_generate overloads. The work watcher can also infer the version from the block it is watching.