### PR TITLE
Update adjusted difficulty in batches

### DIFF
--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -255,6 +255,7 @@ TEST (conflicts, adjusted_difficulty)
 	std::unordered_map<nano::block_hash, uint64_t> adjusted_difficulties;
 	{
 		nano::lock_guard<std::mutex> guard (node1.active.mutex);
+		node1.active.update_adjusted_difficulty ();
 		ASSERT_EQ (node1.active.roots.get<1> ().begin ()->election->status.winner->hash (), send1->hash ());
 		for (auto i (node1.active.roots.get<1> ().begin ()), n (node1.active.roots.get<1> ().end ()); i != n; ++i)
 		{
@@ -289,6 +290,7 @@ TEST (conflicts, adjusted_difficulty)
 	}
 	{
 		nano::lock_guard<std::mutex> guard (node1.active.mutex);
+		node1.active.update_adjusted_difficulty ();
 		ASSERT_EQ (node1.active.roots.get<1> ().begin ()->election->status.winner->hash (), open_epoch2->hash ());
 	}
 }

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -98,7 +98,8 @@ public:
 	bool active (nano::block const &);
 	bool active (nano::qualified_root const &);
 	void update_difficulty (std::shared_ptr<nano::block>);
-	void adjust_difficulty (nano::block_hash const &);
+	void add_adjust_difficulty (nano::block_hash const &);
+	void update_adjusted_difficulty ();
 	void update_active_difficulty (nano::unique_lock<std::mutex> &);
 	uint64_t active_difficulty ();
 	uint64_t limited_active_difficulty ();
@@ -196,6 +197,7 @@ private:
 	void prioritize_account_for_confirmation (prioritize_num_uncemented &, size_t &, nano::account const &, nano::account_info const &, uint64_t);
 	static size_t constexpr max_priority_cementable_frontiers{ 100000 };
 	static size_t constexpr confirmed_frontiers_max_pending_cut_off{ 1000 };
+	std::deque<nano::block_hash> adjust_difficulty_list;
 	// clang-format off
 	using ordered_cache = boost::multi_index_container<nano::inactive_cache_information,
 	mi::indexed_by<

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -132,7 +132,7 @@ void nano::election::confirm_if_quorum ()
 		node.block_processor.force (block_l);
 		status.winner = block_l;
 		update_dependent ();
-		node.active.adjust_difficulty (winner_hash_l);
+		node.active.add_adjust_difficulty (winner_hash_l);
 	}
 	if (have_quorum (tally_l, sum))
 	{
@@ -290,7 +290,7 @@ void nano::election::clear_dependent ()
 {
 	for (auto & dependent_block : dependent_blocks)
 	{
-		node.active.adjust_difficulty (dependent_block);
+		node.active.add_adjust_difficulty (dependent_block);
 	}
 }
 


### PR DESCRIPTION
* Update adjusted difficulty in batches each request loop because ordered roots are used only in this loop

* Prevent extra item modification if adjusted difficulty remains the same (i.e. single block election without dependencies in roots container)