### PR TITLE
Utility: nano::optional_ptr

### DIFF
--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -21,16 +21,18 @@ TEST (optional_ptr, basic)
 	ASSERT_FALSE (opt);
 	ASSERT_FALSE (opt.is_initialized ());
 
-	auto val = valtype{};
-	opt = val;
+	{
+		auto val = valtype{};
+		opt = val;
+		ASSERT_LT (sizeof (opt), sizeof (val));
+		std::unique_ptr<valtype> uptr;
+		ASSERT_EQ (sizeof (opt), sizeof (uptr));
+	}
 	ASSERT_TRUE (opt);
 	ASSERT_TRUE (opt.is_initialized ());
-	ASSERT_EQ (opt->x, val.x);
-	ASSERT_EQ (opt->y, val.y);
-	ASSERT_EQ (opt->z, val.z);
-	ASSERT_LT (sizeof (opt), sizeof (val));
-	std::unique_ptr<valtype> uptr;
-	ASSERT_EQ (sizeof (opt), sizeof (uptr));
+	ASSERT_EQ (opt->x, 1);
+	ASSERT_EQ (opt->y, 2);
+	ASSERT_EQ (opt->z, 3);
 }
 
 TEST (thread, worker)

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/optional_ptr.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/worker.hpp>
@@ -6,6 +7,31 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
+
+TEST (optional_ptr, basic)
+{
+	struct valtype
+	{
+		int64_t x{ 1 };
+		int64_t y{ 2 };
+		int64_t z{ 3 };
+	};
+
+	nano::optional_ptr<valtype> opt;
+	ASSERT_FALSE (opt);
+	ASSERT_FALSE (opt.is_initialized ());
+
+	auto val = valtype{};
+	opt = val;
+	ASSERT_TRUE (opt);
+	ASSERT_TRUE (opt.is_initialized ());
+	ASSERT_EQ (opt->x, val.x);
+	ASSERT_EQ (opt->y, val.y);
+	ASSERT_EQ (opt->z, val.z);
+	ASSERT_LT (sizeof (opt), sizeof (val));
+	std::unique_ptr<valtype> uptr;
+	ASSERT_EQ (sizeof (opt), sizeof (uptr));
+}
 
 TEST (thread, worker)
 {

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library (nano_lib
 	memory.cpp
 	numbers.hpp
 	numbers.cpp
+	optional_ptr.hpp
 	rep_weights.hpp
 	rep_weights.cpp
 	rocksdbconfig.hpp

--- a/nano/lib/optional_ptr.hpp
+++ b/nano/lib/optional_ptr.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <nano/lib/utility.hpp>
+
+#include <cstddef>
+#include <memory>
+
+namespace nano
+{
+/**
+ * A space efficient optional which does heap allocation when needed.
+ * This is an alternative to boost/std::optional when the value type is
+ * large and often not present.
+ *
+ * optional_ptr is similar to using std::unique_ptr as an optional, with the
+ * main difference being that it's copyable.
+ */
+template <typename T>
+class optional_ptr
+{
+	static_assert (sizeof (T) > alignof (std::max_align_t), "Use [std|boost]::optional");
+
+public:
+	optional_ptr () :
+	ptr (nullptr)
+	{
+	}
+
+	optional_ptr (T const & value) :
+	ptr (new T{ value })
+	{
+	}
+
+	optional_ptr (optional_ptr const & other) :
+	ptr (nullptr)
+	{
+		if (other && other.ptr)
+		{
+			ptr = std::make_unique<T> (*other.ptr);
+		}
+	}
+
+	optional_ptr & operator= (optional_ptr const & other)
+	{
+		if (other && other.ptr)
+		{
+			ptr = std::make_unique<T> (*other.ptr);
+		}
+		return *this;
+	}
+
+	T & operator* ()
+	{
+		return *ptr;
+	}
+
+	T const & operator* () const
+	{
+		return *ptr;
+	}
+
+	T * const operator-> ()
+	{
+		return ptr.operator-> ();
+	}
+
+	T const * const operator-> () const
+	{
+		return ptr.operator-> ();
+	}
+
+	T const * const get () const
+	{
+		debug_assert (is_initialized ());
+		return ptr.get ();
+	}
+
+	T * const get ()
+	{
+		debug_assert (is_initialized ());
+		return ptr.get ();
+	}
+
+	explicit operator bool () const
+	{
+		return static_cast<bool> (ptr);
+	}
+
+	bool is_initialized () const
+	{
+		return static_cast<bool> (ptr);
+	}
+
+private:
+	std::unique_ptr<T> ptr;
+};
+}

--- a/nano/lib/optional_ptr.hpp
+++ b/nano/lib/optional_ptr.hpp
@@ -21,18 +21,14 @@ class optional_ptr
 	static_assert (sizeof (T) > alignof (std::max_align_t), "Use [std|boost]::optional");
 
 public:
-	optional_ptr () :
-	ptr (nullptr)
-	{
-	}
+	optional_ptr () = default;
 
 	optional_ptr (T const & value) :
 	ptr (new T{ value })
 	{
 	}
 
-	optional_ptr (optional_ptr const & other) :
-	ptr (nullptr)
+	optional_ptr (optional_ptr const & other)
 	{
 		if (other && other.ptr)
 		{
@@ -92,6 +88,6 @@ public:
 	}
 
 private:
-	std::unique_ptr<T> ptr;
+	std::unique_ptr<T> ptr{ nullptr };
 };
 }


### PR DESCRIPTION
`nano::optional_ptr` is a heap allocated optional, as opposed to the value-wrapper approach in boost/std::optional.

This idea was discussed in relation to #2596 where boost::optional causes some memory overhead in the value-not-present case, and using a bare unique_ptr is inconvenient as it's non-copyable.
