### PR TITLE
Lock before stopping when notifying other threads

### DIFF
--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -519,7 +519,7 @@ void nano::bootstrap_attempt_wallet::request_pending (nano::unique_lock<std::mut
 	lock_a.unlock ();
 	auto connection_l (node->bootstrap_initiator.connections->connection (shared_from_this ()));
 	lock_a.lock ();
-	if (connection_l)
+	if (connection_l && !stopped)
 	{
 		auto account (wallet_accounts.front ());
 		wallet_accounts.pop_front ();

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -34,7 +34,10 @@ nano::confirmation_height_processor::~confirmation_height_processor ()
 
 void nano::confirmation_height_processor::stop ()
 {
-	stopped = true;
+	{
+		nano::lock_guard<std::mutex> guard (mutex);
+		stopped = true;
+	}
 	condition.notify_one ();
 	if (thread.joinable ())
 	{

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -59,7 +59,7 @@ private:
 	boost::asio::ip::address_v4 address;
 	std::array<mapping_protocol, 2> protocols;
 	uint64_t check_count{ 0 };
-	bool on{ false };
+	std::atomic<bool> on{ false };
 	std::mutex mutex;
 };
 }

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -77,6 +77,9 @@ nano::write_guard nano::write_database_queue::pop ()
 
 void nano::write_database_queue::stop ()
 {
-	stopped = true;
+	{
+		nano::lock_guard<std::mutex> guard (mutex);
+		stopped = true;
+	}
 	cv.notify_all ();
 }

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -2,7 +2,6 @@
 
 #include <nano/lib/locks.hpp>
 
-#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -53,6 +52,6 @@ private:
 	std::mutex mutex;
 	nano::condition_variable cv;
 	std::function<void()> guard_finish_callback;
-	std::atomic<bool> stopped{ false };
+	bool stopped{ false };
 };
 }


### PR DESCRIPTION
This prevents having all threads waiting and the system freezing. Mostly important for tests, especially with sanitizers, but could happen on stopping the node normally.

Portmapping requires an atomic bool, and the database queue doesn't after this change.

Other small related bootstrap changes included in this PR per @SergiySW suggestion.

Ran 7 times all core_test and no TSAN issues.