### PR TITLE
[RocksDB] Only delete from unchecked when existence is guaranteed

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -552,11 +552,9 @@ void nano::block_processor::queue_unchecked (nano::write_transaction const & tra
 	{
 		if (!node.flags.disable_block_processor_unchecked_deletion)
 		{
-			if (!node.store.unchecked_del (transaction_a, nano::unchecked_key (hash_a, info.block->hash ())))
-			{
-				debug_assert (node.ledger.cache.unchecked_count > 0);
-				--node.ledger.cache.unchecked_count;
-			}
+			node.store.unchecked_del (transaction_a, nano::unchecked_key (hash_a, info.block->hash ()));
+			debug_assert (node.ledger.cache.unchecked_count > 0);
+			--node.ledger.cache.unchecked_count;
 		}
 		add (info);
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -955,8 +955,9 @@ void nano::node::unchecked_cleanup ()
 		{
 			auto key (cleaning_list.front ());
 			cleaning_list.pop_front ();
-			if (!store.unchecked_del (transaction, key))
+			if (store.unchecked_exists (transaction, key))
 			{
+				store.unchecked_del (transaction, key);
 				debug_assert (ledger.cache.unchecked_count > 0);
 				--ledger.cache.unchecked_count;
 			}

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -215,7 +215,7 @@ bool nano::rocksdb_store::exists (nano::transaction const & transaction_a, table
 int nano::rocksdb_store::del (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a)
 {
 	debug_assert (transaction_a.contains (table_a));
-	// RocksDB errors when trying to delete an entry which doesn't exist. It is a pre-condition that the key exists
+	// RocksDB does not report not_found status, it is a pre-condition that the key exists
 	debug_assert (exists (transaction_a, table_a, key_a));
 
 	// Removing an entry so counts may need adjusting

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -761,8 +761,7 @@ public:
 	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
 	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
-	/* Returns true if nothing was deleted because it was not found, false otherwise */
-	virtual bool unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
+	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
 	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -434,8 +434,8 @@ public:
 
 	void pending_del (nano::write_transaction const & transaction_a, nano::pending_key const & key_a) override
 	{
-		auto status1 = del (transaction_a, tables::pending, key_a);
-		release_assert (success (status1));
+		auto status = del (transaction_a, tables::pending, key_a);
+		release_assert (success (status));
 	}
 
 	bool pending_get (nano::transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info & pending_a) override
@@ -486,11 +486,10 @@ public:
 		release_assert (success (status));
 	}
 
-	bool unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
+	void unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
 	{
 		auto status (del (transaction_a, tables::unchecked, key_a));
-		release_assert (success (status) || not_found (status));
-		return not_found (status);
+		release_assert (success (status));
 	}
 
 	std::shared_ptr<nano::vote> vote_get (nano::transaction const & transaction_a, nano::account const & account_a) override
@@ -551,8 +550,8 @@ public:
 
 	void account_del (nano::write_transaction const & transaction_a, nano::account const & account_a) override
 	{
-		auto status1 = del (transaction_a, tables::accounts, account_a);
-		release_assert (success (status1));
+		auto status = del (transaction_a, tables::accounts, account_a);
+		release_assert (success (status));
 	}
 
 	bool account_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::account_info & info_a) override


### PR DESCRIPTION
`unchecked_del` is the only deleting function which checks for `not_found`. This is because in `unchecked_cleanup ()` we do a first pass where we do bulk reading then write afterwards separately, but before the write transaction it could be removed. RocksDB doesn't report not-found keys being deleted so we need to make sure that the key exists before deleting so that the cache can be updated correctly.