### PR TITLE
Fix intermittent send_node_id_handshake unit test failures

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -92,15 +92,21 @@ TEST (network, send_node_id_handshake)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (0, node0->network.size ());
-	ASSERT_EQ (1, node1->network.size ());
+	system.deadline_set (10s);
+	while (node0->network.size () != 0 && node1->network.size () != 1)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
 	system.deadline_set (10s);
 	while (node0->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in) < initial + 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (1, node0->network.size ());
-	ASSERT_EQ (1, node1->network.size ());
+	system.deadline_set (10s);
+	while (node0->network.size () != 1 && node1->network.size () != 1)
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
 	auto list1 (node0->network.list (1));
 	ASSERT_EQ (node1->network.endpoint (), list1[0]->get_endpoint ());
 	auto list2 (node1->network.list (1));


### PR DESCRIPTION
Reported in https://github.com/nanocurrency/nano-node/issues/1121#issuecomment-482037451 and confirmed locally; this is a timing issue in test (time between stat update and network container update) which only crops up under TSAN. Solved by checking stats and network sizes separately.