### PR TITLE
tsan fix: rpc.wallet_destroy

### DIFF
--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -380,7 +380,9 @@ void nano::wallet_store::initialize (nano::transaction const & transaction_a, bo
 {
 	debug_assert (strlen (path_a.c_str ()) == path_a.size ());
 	auto error (0);
-	error |= mdb_dbi_open (tx (transaction_a), path_a.c_str (), MDB_CREATE, &handle);
+	MDB_dbi handle_l;
+	error |= mdb_dbi_open (tx (transaction_a), path_a.c_str (), MDB_CREATE, &handle_l);
+	handle = handle_l;
 	init_a = error != 0;
 }
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -110,7 +110,7 @@ public:
 	static size_t const seed_iv_index;
 	static int const special_count;
 	nano::kdf & kdf;
-	MDB_dbi handle{ 0 };
+	std::atomic<MDB_dbi> handle{ 0 };
 	std::recursive_mutex mutex;
 
 private:


### PR DESCRIPTION
Race on `handle` during teardown.