### PR TITLE
Election refactor follow up

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -7,19 +7,23 @@
 
 using namespace std::chrono_literals;
 
+namespace nano
+{
 TEST (active_transactions, confirm_active)
 {
-	nano::system system (1);
-	auto & node1 = *system.nodes[0];
-	// Send and vote for a block before peering with node2
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node1.config.receive_minimum.number ()));
-	system.deadline_set (5s);
-	while (!node1.active.empty () || !node1.block_confirmed_or_being_confirmed (node1.store.tx_begin_read (), send->hash ()))
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
-	auto & node2 = *system.add_node (nano::node_config (nano::get_available_port (), system.logging));
+	nano::system system;
+	nano::node_flags node_flags;
+	node_flags.disable_request_loop = true;
+	auto & node1 = *system.add_node (node_flags);
+	nano::genesis genesis;
+	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send).code);
+	nano::node_config node_config2 (nano::get_available_port (), system.logging);
+	node_config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	nano::node_flags node_flags2;
+	// The rep crawler would otherwise request confirmations in order to find representatives
+	node_flags2.disable_rep_crawler = true;
+	auto & node2 = *system.add_node (node_config2, node_flags2);
 	system.deadline_set (5s);
 	// Let node2 know about the block
 	while (node2.active.empty ())
@@ -27,56 +31,69 @@ TEST (active_transactions, confirm_active)
 		node1.network.flood_block (send, nano::buffer_drop_policy::no_limiter_drop);
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	while (node2.ledger.cache.cemented_count < 2 || !node2.active.empty ())
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
-}
-
-TEST (active_transactions, confirm_frontier)
-{
-	nano::system system (1);
-	auto & node1 = *system.nodes[0];
-	// Send and vote for a block before peering with node2
+	// Save election to check request count afterwards
+	auto election = node2.active.election (send->qualified_root ());
+	ASSERT_NE (nullptr, election);
+	// Add key to node1
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node1.config.receive_minimum.number ()));
-	system.deadline_set (5s);
-	while (!node1.active.empty () || !node1.block_confirmed_or_being_confirmed (node1.store.tx_begin_read (), send->hash ()))
+	// Add representative to disabled rep crawler
+	auto peers (node2.network.random_set (1));
+	ASSERT_FALSE (peers.empty ());
 	{
-		ASSERT_NO_ERROR (system.poll ());
+		nano::lock_guard<std::mutex> guard (node2.rep_crawler.probable_reps_mutex);
+		node2.rep_crawler.probable_reps.emplace (nano::test_genesis_key.pub, nano::genesis_amount, *peers.begin ());
 	}
-	auto & node2 = *system.add_node (nano::node_config (nano::get_available_port (), system.logging));
-	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
-	system.deadline_set (5s);
 	while (node2.ledger.cache.cemented_count < 2 || !node2.active.empty ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
+	// At least one confirmation request
+	ASSERT_GT (election->confirmation_request_count, 0);
+	// Blocks were cleared (except for not_an_account)
+	ASSERT_EQ (1, election->blocks.size ());
+}
 }
 
-TEST (active_transactions, confirm_dependent)
+namespace nano
+{
+TEST (active_transactions, confirm_frontier)
 {
 	nano::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto & node1 = *system.add_node (node_flags);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node1.config.receive_minimum.number ()));
-	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node1.config.receive_minimum.number ()));
-	auto send3 (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node1.config.receive_minimum.number ()));
-	nano::node_config node_config;
-	node_config.peering_port = nano::get_available_port ();
-	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	auto & node2 = *system.add_node (node_config);
-	node2.process_local (send1);
-	node2.process_local (send2);
-	node2.process_active (send3);
+	nano::genesis genesis;
+	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send).code);
+	nano::node_flags node_flags2;
+	// The rep crawler would otherwise request confirmations in order to find representatives
+	node_flags2.disable_rep_crawler = true;
+	auto & node2 = *system.add_node (node_flags2);
+	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
 	system.deadline_set (5s);
-	while (!node2.active.empty ())
+	while (node2.active.empty ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
-	ASSERT_EQ (4, node2.ledger.cache.cemented_count);
+	// Save election to check request count afterwards
+	auto election = node2.active.election (send->qualified_root ());
+	ASSERT_NE (nullptr, election);
+	// Add key to node1
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	// Add representative to disabled rep crawler
+	auto peers (node2.network.random_set (1));
+	ASSERT_FALSE (peers.empty ());
+	{
+		nano::lock_guard<std::mutex> guard (node2.rep_crawler.probable_reps_mutex);
+		node2.rep_crawler.probable_reps.emplace (nano::test_genesis_key.pub, nano::genesis_amount, *peers.begin ());
+	}
+	system.deadline_set (5s);
+	while (node2.ledger.cache.cemented_count < 2 || !node2.active.empty ())
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_GT (election->confirmation_request_count, 0);
+}
 }
 
 TEST (active_transactions, adjusted_difficulty_priority)

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,5 +1,6 @@
 #include <nano/core_test/testutil.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/testing.hpp>
 
 #include <gtest/gtest.h>
@@ -9,51 +10,49 @@ using namespace std::chrono_literals;
 TEST (confirmation_solicitor, batches)
 {
 	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
-	node_config.enable_voting = false;
-	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto & node1 = *system.add_node (node_config, node_flags);
-	node_config.peering_port = nano::get_available_port ();
-	// To prevent races on the solicitor
 	node_flags.disable_request_loop = true;
-	auto & node2 = *system.add_node (node_config, node_flags);
+	node_flags.disable_udp = false;
+	auto & node1 = *system.add_node (node_flags);
+	// This tests instantiates a solicitor
+	node_flags.disable_request_loop = true;
+	auto & node2 = *system.add_node (node_flags);
 	// Solicitor will only solicit from this representative
 	auto channel1 (node2.network.udp_channels.create (node1.network.endpoint ()));
 	nano::representative representative (nano::test_genesis_key.pub, nano::genesis_amount, channel1);
-	// Lock active_transactions which uses the solicitor
+
+	std::vector<nano::representative> representatives{ representative };
+	nano::confirmation_solicitor solicitor (node2.network, node2.network_params.network);
+	solicitor.prepare (representatives);
+	// Ensure the representatives are correct
+	ASSERT_EQ (1, representatives.size ());
+	ASSERT_EQ (channel1, representatives.front ().channel);
+	ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
+	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
 	{
-		nano::lock_guard<std::mutex> active_guard (node2.active.mutex);
-		std::vector<nano::representative> representatives{ representative };
-		node2.active.solicitor.prepare (representatives);
-		// Ensure the representatives are correct
-		ASSERT_EQ (1, representatives.size ());
-		ASSERT_EQ (channel1, representatives.front ().channel);
-		ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
-		auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
+		nano::lock_guard<std::mutex> guard (node2.active.mutex);
 		for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)
 		{
 			auto election (std::make_shared<nano::election> (node2, send, nullptr));
-			ASSERT_FALSE (node2.active.solicitor.add (*election));
+			ASSERT_FALSE (solicitor.add (*election));
 		}
-		ASSERT_EQ (1, node2.active.solicitor.max_confirm_req_batches);
+		ASSERT_EQ (1, solicitor.max_confirm_req_batches);
 		// Reached the maximum amount of requests for the channel
 		auto election (std::make_shared<nano::election> (node2, send, nullptr));
-		ASSERT_TRUE (node2.active.solicitor.add (*election));
+		ASSERT_TRUE (solicitor.add (*election));
 		// Broadcasting should be immediate
 		ASSERT_EQ (0, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
-		ASSERT_FALSE (node2.active.solicitor.broadcast (*election));
-		system.deadline_set (5s);
-		while (node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out) < 1)
-		{
-			ASSERT_NO_ERROR (system.poll ());
-		}
+		ASSERT_FALSE (solicitor.broadcast (*election));
+	}
+	system.deadline_set (5s);
+	while (node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out) < 1)
+	{
+		ASSERT_NO_ERROR (system.poll ());
 	}
 	// From rep crawler
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 	system.deadline_set (5s);
-	node2.active.solicitor.flush ();
+	solicitor.flush ();
 	while (node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out) < 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -3,6 +3,8 @@
 #include <nano/node/confirmation_height_processor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/repcrawler.hpp>
+#include <nano/secure/blockstore.hpp>
 
 #include <boost/format.hpp>
 #include <boost/variant/get.hpp>

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -26,11 +26,9 @@ class node;
 class block;
 class block_sideband;
 class election;
-class election_status;
 class vote;
 class transaction;
 class confirmation_height_processor;
-enum class election_status_type : uint8_t;
 
 class conflict_info final
 {

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -2,11 +2,6 @@
 
 #include <nano/lib/numbers.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
-#include <nano/node/election.hpp>
-#include <nano/node/gap_cache.hpp>
-#include <nano/node/repcrawler.hpp>
-#include <nano/node/transport/transport.hpp>
-#include <nano/secure/blockstore.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/circular_buffer.hpp>
@@ -32,9 +27,11 @@ class node;
 class block;
 class block_sideband;
 class election;
+class election_status;
 class vote;
 class transaction;
 class confirmation_height_processor;
+enum class election_status_type : uint8_t;
 
 class conflict_info final
 {

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
-#include <nano/node/confirmation_solicitor.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/circular_buffer.hpp>
@@ -139,7 +138,6 @@ public:
 	size_t inactive_votes_cache_size ();
 	size_t election_winner_details_size ();
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
-	nano::confirmation_solicitor solicitor;
 
 private:
 	std::mutex election_winner_details_mutex;

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/timer.hpp>
 #include <nano/node/blockprocessor.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/secure/blockstore.hpp>
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -280,6 +280,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 				state_change (nano::election::state_t::active, nano::election::state_t::backtracking);
 				lock.unlock ();
 				activate_dependencies ();
+				lock.lock ();
 			}
 			break;
 		case nano::election::state_t::backtracking:
@@ -298,7 +299,6 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			debug_assert (false);
 			break;
 	}
-	// Note: lock (timepoints_mutex) is at an unknown state here - possibly unlocked before activate_dependencies
 	if (!confirmed () && std::chrono::minutes (5) < std::chrono::steady_clock::now () - election_start)
 	{
 		result = true;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -156,6 +156,7 @@ void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_
 		if (!solicitor_a.add (*this))
 		{
 			last_req = std::chrono::steady_clock::now ();
+			++confirmation_request_count;
 		}
 	}
 }

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -1,3 +1,4 @@
+#include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 
@@ -148,11 +149,11 @@ bool nano::election::state_change (nano::election::state_t expected_a, nano::ele
 	return result;
 }
 
-void nano::election::send_confirm_req ()
+void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_a)
 {
 	if (last_req + std::chrono::seconds (15) < std::chrono::steady_clock::now ())
 	{
-		if (!node.active.solicitor.add (*this))
+		if (!solicitor_a.add (*this))
 		{
 			last_req = std::chrono::steady_clock::now ();
 		}
@@ -242,18 +243,18 @@ void nano::election::activate_dependencies ()
 	}
 }
 
-void nano::election::broadcast_block ()
+void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
 {
 	if (base_latency () * 5 < std::chrono::steady_clock::now () - last_block)
 	{
-		if (!node.active.solicitor.broadcast (*this))
+		if (!solicitor_a.broadcast (*this))
 		{
 			last_block = std::chrono::steady_clock::now ();
 		}
 	}
 }
 
-bool nano::election::transition_time (bool const saturated_a)
+bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a, bool const saturated_a)
 {
 	debug_assert (!node.active.mutex.try_lock ());
 	nano::unique_lock<std::mutex> lock (timepoints_mutex);
@@ -271,8 +272,8 @@ bool nano::election::transition_time (bool const saturated_a)
 			break;
 		}
 		case nano::election::state_t::active:
-			broadcast_block ();
-			send_confirm_req ();
+			broadcast_block (solicitor_a);
+			send_confirm_req (solicitor_a);
 			if (base_latency () * active_duration_factor < std::chrono::steady_clock::now () - state_start)
 			{
 				state_change (nano::election::state_t::active, nano::election::state_t::backtracking);
@@ -281,8 +282,8 @@ bool nano::election::transition_time (bool const saturated_a)
 			}
 			break;
 		case nano::election::state_t::backtracking:
-			broadcast_block ();
-			send_confirm_req ();
+			broadcast_block (solicitor_a);
+			send_confirm_req (solicitor_a);
 			break;
 		case nano::election::state_t::confirmed:
 			if (base_latency () * (saturated_a ? confirmed_duration_factor_saturated : confirmed_duration_factor) < std::chrono::steady_clock::now () - state_start)

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -14,26 +14,6 @@ namespace nano
 class channel;
 class confirmation_solicitor;
 class node;
-enum class election_status_type : uint8_t
-{
-	ongoing = 0,
-	active_confirmed_quorum = 1,
-	active_confirmation_height = 2,
-	inactive_confirmation_height = 3,
-	stopped = 5
-};
-class election_status final
-{
-public:
-	std::shared_ptr<nano::block> winner;
-	nano::amount tally;
-	std::chrono::milliseconds election_end;
-	std::chrono::milliseconds election_duration;
-	unsigned confirmation_request_count;
-	unsigned block_count;
-	unsigned voter_count;
-	election_status_type type;
-};
 class vote_info final
 {
 public:

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -12,6 +12,7 @@
 namespace nano
 {
 class channel;
+class confirmation_solicitor;
 class node;
 enum class election_status_type : uint8_t
 {
@@ -80,8 +81,8 @@ private: // State management
 
 	bool valid_change (nano::election::state_t, nano::election::state_t) const;
 	bool state_change (nano::election::state_t, nano::election::state_t);
-	void broadcast_block ();
-	void send_confirm_req ();
+	void broadcast_block (nano::confirmation_solicitor &);
+	void send_confirm_req (nano::confirmation_solicitor &);
 	void activate_dependencies ();
 
 public:
@@ -101,7 +102,7 @@ public:
 	void insert_inactive_votes_cache (nano::block_hash const &);
 
 public: // State transitions
-	bool transition_time (bool const saturated);
+	bool transition_time (nano::confirmation_solicitor &, bool const saturated);
 	void transition_passive ();
 	void transition_active ();
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1842,11 +1842,9 @@ void nano::json_handler::confirmation_info ()
 	nano::qualified_root root;
 	if (!root.decode_hex (root_text))
 	{
-		nano::lock_guard<std::mutex> lock (node.active.mutex);
-		auto conflict_info (node.active.roots.find (root));
-		if (conflict_info != node.active.roots.end ())
+		auto election (node.active.election (root));
+		if (election != nullptr && !election->confirmed ())
 		{
-			auto election (conflict_info->election);
 			response_l.put ("announcements", std::to_string (election->confirmation_request_count));
 			response_l.put ("voters", std::to_string (election->last_votes.size ()));
 			response_l.put ("last_winner", election->status.winner->hash ().to_string ());

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -11,6 +11,7 @@
 #include <nano/node/bootstrap/bootstrap_server.hpp>
 #include <nano/node/confirmation_height_processor.hpp>
 #include <nano/node/distributed_work_factory.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/gap_cache.hpp>
 #include <nano/node/logging.hpp>
 #include <nano/node/network.hpp>

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -147,6 +147,9 @@ private:
 	/** Probable representatives */
 	probably_rep_t probable_reps;
 
+	friend class active_transactions_confirm_active_Test;
+	friend class active_transactions_confirm_frontier_Test;
+
 	std::deque<std::pair<std::shared_ptr<nano::transport::channel>, std::shared_ptr<nano::vote>>> responses;
 };
 }

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -2,7 +2,8 @@
 #include <nano/boost/asio/dispatch.hpp>
 #include <nano/boost/asio/strand.hpp>
 #include <nano/lib/work.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/election.hpp>
+#include <nano/node/transport/transport.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/node/websocket.hpp>
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -8152,6 +8152,56 @@ TEST (rpc, node_telemetry_self)
 	}
 }
 
+TEST (rpc, confirmation_active)
+{
+	nano::system system;
+	nano::node_config node_config;
+	node_config.ipc_config.transport_tcp.enabled = true;
+	node_config.ipc_config.transport_tcp.port = nano::get_available_port ();
+	nano::node_flags node_flags;
+	node_flags.disable_request_loop = true;
+	auto & node1 (*system.add_node (node_config, node_flags));
+	scoped_io_thread_name_change scoped_thread_name_io;
+	nano::node_rpc_config node_rpc_config;
+	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
+	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	rpc_config.rpc_process.ipc_port = node1.config.ipc_config.transport_tcp.port;
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
+	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
+	rpc.start ();
+
+	nano::genesis genesis;
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send2 (std::make_shared<nano::send_block> (send1->hash (), nano::public_key (), nano::genesis_amount - 200, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	node1.process_active (send1);
+	node1.process_active (send2);
+	node1.block_processor.flush ();
+	ASSERT_EQ (2, node1.active.size ());
+	{
+		nano::lock_guard<std::mutex> guard (node1.active.mutex);
+		auto info (node1.active.roots.find (send1->qualified_root ()));
+		ASSERT_NE (node1.active.roots.end (), info);
+		info->election->confirm_once ();
+	}
+
+	boost::property_tree::ptree request;
+	request.put ("action", "confirmation_active");
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		system.deadline_set (5s);
+		while (response.status == 0)
+		{
+			ASSERT_NO_ERROR (system.poll ());
+		}
+		ASSERT_EQ (200, response.status);
+		auto & confirmations (response.json.get_child ("confirmations"));
+		ASSERT_EQ (1, confirmations.size ());
+		ASSERT_EQ (send2->qualified_root ().to_string (), confirmations.front ().second.get<std::string> (""));
+		ASSERT_EQ (1, response.json.get<unsigned> ("unconfirmed"));
+		ASSERT_EQ (1, response.json.get<unsigned> ("confirmed"));
+	}
+}
+
 TEST (rpc, confirmation_info)
 {
 	nano::system system;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -506,5 +506,29 @@ public:
 	std::atomic<uint64_t> account_count{ 0 };
 };
 
+/* Defines the possible states for an election to stop in */
+enum class election_status_type : uint8_t
+{
+	ongoing = 0,
+	active_confirmed_quorum = 1,
+	active_confirmation_height = 2,
+	inactive_confirmation_height = 3,
+	stopped = 5
+};
+
+/* Holds a summary of an election */
+class election_status final
+{
+public:
+	std::shared_ptr<nano::block> winner;
+	nano::amount tally;
+	std::chrono::milliseconds election_end;
+	std::chrono::milliseconds election_duration;
+	unsigned confirmation_request_count;
+	unsigned block_count;
+	unsigned voter_count;
+	election_status_type type;
+};
+
 nano::wallet_id random_wallet_id ();
 }


### PR DESCRIPTION
Each commit refers to a fix or enhancement.

- active_transactions had some unnecessary includes making it required to recompile very often (and thus the whole node code)
- Now allocating a new solicitor in every loop, in the future we can instance it with parameters based on the state of active_transactions
- `confirmation_request_count` was not getting incremented
- RPC confirmation_info would return confirmed elections, which was not the previous behavior
- Added unconfirmed and confirmed total to RPC confirmation_active, useful for keeping track in tests. Otherwise it could look like there are no active roots even though there could be several thousand confirmed.
- Fixed tests for active_transactions, the rep crawler was requesting confirmations instead so had to disable it.
- Added new tests for the touched RPCs