### PR TITLE
Use the sideband when available in ledger.is_send

### DIFF
--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -149,6 +149,11 @@ void nano::block::sideband_set (nano::block_sideband const & sideband_a)
 	sideband_m = sideband_a;
 }
 
+bool nano::block::has_sideband () const
+{
+	return sideband_m.is_initialized ();
+}
+
 nano::account const & nano::block::representative () const
 {
 	static nano::account rep{ 0 };

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -73,6 +73,7 @@ public:
 	nano::block_hash full_hash () const;
 	nano::block_sideband const & sideband () const;
 	void sideband_set (nano::block_sideband const &);
+	bool has_sideband () const;
 	std::string to_json () const;
 	virtual void hash (blake2b_state &) const = 0;
 	virtual uint64_t block_work () const = 0;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -807,12 +807,19 @@ std::string nano::ledger::block_text (nano::block_hash const & hash_a)
 bool nano::ledger::is_send (nano::transaction const & transaction_a, nano::state_block const & block_a) const
 {
 	bool result (false);
-	nano::block_hash previous (block_a.hashables.previous);
-	if (!previous.is_zero ())
+	if (block_a.has_sideband ())
 	{
-		if (block_a.hashables.balance < balance (transaction_a, previous))
+		result = block_a.sideband ().details.is_send;
+	}
+	else
+	{
+		nano::block_hash previous (block_a.hashables.previous);
+		if (!previous.is_zero ())
 		{
-			result = true;
+			if (block_a.hashables.balance < balance (transaction_a, previous))
+			{
+				result = true;
+			}
 		}
 	}
 	return result;


### PR DESCRIPTION
This is used in some "warm" code paths, now avoids grabbing the previous block when the sideband is set, which is usually the case.