### PR TITLE
Optimize vote post-processing operations

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -314,11 +314,19 @@ startup_time (std::chrono::steady_clock::now ())
 			}
 		});
 		observers.vote.add ([this](std::shared_ptr<nano::vote> vote_a, std::shared_ptr<nano::transport::channel> channel_a, nano::vote_code code_a) {
-			if (code_a == nano::vote_code::vote || code_a == nano::vote_code::indeterminate)
+			debug_assert (code_a != nano::vote_code::invalid);
+			if (code_a != nano::vote_code::replay)
+			{
+				auto active_in_rep_crawler (!this->rep_crawler.response (channel_a, vote_a));
+				if (active_in_rep_crawler || code_a == nano::vote_code::vote)
+				{
+					// Representative is defined as online if replying to live votes or rep_crawler queries
+					this->online_reps.observe (vote_a->account);
+				}
+			}
+			if (code_a == nano::vote_code::indeterminate)
 			{
 				this->gap_cache.vote (vote_a);
-				this->online_reps.observe (vote_a->account);
-				this->rep_crawler.response (channel_a, vote_a);
 			}
 		});
 		if (websocket_server)

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -194,17 +194,20 @@ bool nano::rep_crawler::is_pr (nano::transport::channel const & channel_a) const
 	return result;
 }
 
-void nano::rep_crawler::response (std::shared_ptr<nano::transport::channel> & channel_a, std::shared_ptr<nano::vote> & vote_a)
+bool nano::rep_crawler::response (std::shared_ptr<nano::transport::channel> & channel_a, std::shared_ptr<nano::vote> & vote_a)
 {
+	bool error = true;
 	nano::lock_guard<std::mutex> lock (active_mutex);
 	for (auto i = vote_a->begin (), n = vote_a->end (); i != n; ++i)
 	{
 		if (active.count (*i) != 0)
 		{
 			responses.emplace_back (channel_a, vote_a);
+			error = false;
 			break;
 		}
 	}
+	return error;
 }
 
 nano::uint128_t nano::rep_crawler::total_weight () const

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -95,9 +95,9 @@ public:
 	/**
 	 * Called when a non-replay vote on a block previously sent by query() is received. This indiciates
 	 * with high probability that the endpoint is a representative node.
-	 * @return True if the rep entry was updated with new information due to increase in weight.
+	 * @return false if the vote corresponded to any active hash.
 	 */
-	void response (std::shared_ptr<nano::transport::channel> &, std::shared_ptr<nano::vote> &);
+	bool response (std::shared_ptr<nano::transport::channel> &, std::shared_ptr<nano::vote> &);
 
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;


### PR DESCRIPTION
This can be done now that confirmed elections linger for 5 seconds in active roots after confirmation ( #2535 and follow up PRs ), such that there is little risk of a live vote being marked as indeterminate.

The rep crawler is always checked, but online weight only for live votes or rep crawler queries. Gap cache only for indeterminate votes.