### PR TITLE
Add ASSERT_TIMELY

### DIFF
--- a/nano/core_test/testutil.hpp
+++ b/nano/core_test/testutil.hpp
@@ -32,6 +32,14 @@
 	GTEST_TEST_ERROR_CODE ((condition.value () > 0), #condition, "An error was expected", "", \
 	GTEST_FATAL_FAILURE_)
 
+/** Asserts that the condition becomes true within the deadline */
+#define ASSERT_TIMELY(time, condition)    \
+	system.deadline_set (time);           \
+	while (!(condition))                  \
+	{                                     \
+		ASSERT_NO_ERROR (system.poll ()); \
+	}
+
 /* Convenience globals for core_test */
 namespace nano
 {

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -178,6 +178,17 @@ std::error_code nano::system::poll (std::chrono::nanoseconds const & wait_time)
 	return ec;
 }
 
+std::error_code nano::system::poll_until_true (std::chrono::nanoseconds deadline_a, std::function<bool()> predicate_a)
+{
+	std::error_code ec;
+	deadline_set (deadline_a);
+	while (!ec && !predicate_a ())
+	{
+		ec = poll ();
+	}
+	return ec;
+}
+
 namespace
 {
 class traffic_generator : public std::enable_shared_from_this<traffic_generator>

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -38,6 +38,7 @@ public:
 	 * @returns 0 or nano::deadline_expired
 	 */
 	std::error_code poll (const std::chrono::nanoseconds & sleep_time = std::chrono::milliseconds (50));
+	std::error_code poll_until_true (std::chrono::nanoseconds deadline, std::function<bool()>);
 	void stop ();
 	void deadline_set (const std::chrono::duration<double, std::nano> & delta);
 	std::shared_ptr<nano::node> add_node (nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);


### PR DESCRIPTION
We often have to check if an expression becomes true within a polling loop, which is quite verbose. 
Adding a testutil macro for this, so it becomes

```
ASSERT_TIMELY (5s, stats.count (stat::type::message, stat::detail::confirm_ack, stat::dir::out) == 2);
```

instead of

```
system.deadline_set (3s);
while (stats.count (stat::type::message, stat::detail::confirm_ack, stat::dir::out) != 2)
{
	ASSERT_NO_ERROR (system.poll ());
}
```

(edit: https://github.com/nanocurrency/nano-node/pull/2632 fixed the request_aggregator test, adjusted this PR to be macro-only)

@guilhermelawless suggested a lambda version for more complex checks, added to system in the form of `poll_until_true`