### PR TITLE
Increase active elections capacity with periodic full checks

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -236,6 +236,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	bool const check_all_elections_l (std::chrono::steady_clock::now () - last_check_all_elections > check_all_elections_period);
 	size_t const this_loop_target_l (check_all_elections_l ? sorted_roots_l.size () : node.config.active_elections_size / 10);
 	size_t count_l (0);
+	nano::timer<std::chrono::milliseconds> elapsed (nano::timer_state::started);
 
 	/*
 	 * Loop through active elections in descending order of proof-of-work difficulty, requesting confirmation
@@ -267,6 +268,10 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	if (check_all_elections_l)
 	{
 		last_check_all_elections = std::chrono::steady_clock::now ();
+		if (node.config.logging.timing_logging () && this_loop_target_l > node.config.active_elections_size / 10)
+		{
+			node.logger.try_log (boost::str (boost::format ("Processed %1% elections (%2% were already confirmed) in %3% %4%") % this_loop_target_l % (this_loop_target_l - count_l) % elapsed.value ().count () % elapsed.unit ()));
+		}
 	}
 }
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -62,11 +62,11 @@ void nano::active_transactions::search_frontiers (nano::transaction const & tran
 	nano::unique_lock<std::mutex> lk (mutex);
 	auto check_time_exceeded = std::chrono::steady_clock::now () >= next_frontier_check;
 	lk.unlock ();
-	auto max_elections = (node.config.active_elections_size / 20);
+	auto max_elections = 1000;
 	auto low_active_elections = roots_size < max_elections;
 	bool wallets_check_required = (!skip_wallets || !priority_wallet_cementable_frontiers.empty ()) && !agressive_mode;
 	// Minimise dropping real-time transactions, set the number of frontiers added to a factor of the total number of active elections
-	auto max_active = node.config.active_elections_size / 5;
+	auto max_active = node.config.active_elections_size / 20;
 	if (roots_size <= max_active && (check_time_exceeded || wallets_check_required || (!is_test_network && low_active_elections && agressive_mode)))
 	{
 		// When the number of active elections is low increase max number of elections for setting confirmation height.

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -247,7 +247,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	{
 		auto & election_l (i->election);
 		bool const overflow_l (count_l >= node.config.active_elections_size && election_l->election_start < election_ttl_cutoff_l && !node.wallets.watcher->is_watched (i->root));
-		if (overflow_l || election_l->transition_time (solicitor, saturated_l))
+		if (overflow_l || election_l->transition_time (solicitor))
 		{
 			election_l->clear_blocks ();
 			i = sorted_roots_l.erase (i);

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -243,10 +243,11 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	 * Elections extending the soft config.active_elections_size limit are flushed after a certain time-to-live cutoff
 	 * Flushed elections are later re-activated via frontier confirmation
 	 */
-	for (auto i = sorted_roots_l.begin (), n = sorted_roots_l.end (); i != n; ++count_l)
+	for (auto i = sorted_roots_l.begin (), n = sorted_roots_l.end (); i != n;)
 	{
 		auto & election_l (i->election);
-		bool const overflow_l (count_l >= node.config.active_elections_size && election_l->election_start < election_ttl_cutoff_l && !node.wallets.watcher->is_watched (i->root));
+		count_l += !election_l->confirmed ();
+		bool const overflow_l (count_l > node.config.active_elections_size && election_l->election_start < election_ttl_cutoff_l && !node.wallets.watcher->is_watched (i->root));
 		if (overflow_l || election_l->transition_time (solicitor))
 		{
 			election_l->clear_blocks ();

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -155,6 +155,10 @@ private:
 	bool started{ false };
 	std::atomic<bool> stopped{ false };
 
+	// Periodically check all elections
+	std::chrono::milliseconds const check_all_elections_period;
+	std::chrono::steady_clock::time_point last_check_all_elections{};
+
 	// Maximum time an election can be kept active if it is extending the container
 	std::chrono::seconds const election_time_to_live;
 

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -133,7 +133,7 @@ bool nano::block_processor::should_log ()
 	auto now (std::chrono::steady_clock::now ());
 	if (next_log < now)
 	{
-		next_log = now + std::chrono::seconds (2);
+		next_log = now + (node.config.logging.timing_logging () ? std::chrono::seconds (2) : std::chrono::seconds (15));
 		result = true;
 	}
 	return result;

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -39,7 +39,7 @@ public:
 	void add (std::shared_ptr<nano::block>, uint64_t = 0);
 	void force (std::shared_ptr<nano::block>);
 	void wait_write ();
-	bool should_log (bool);
+	bool should_log ();
 	bool have_blocks ();
 	void process_blocks ();
 	nano::process_return process_one (nano::write_transaction const &, nano::unchecked_info, const bool = false, const bool = false);

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -9,7 +9,6 @@ using namespace std::chrono;
 int constexpr nano::election::passive_duration_factor;
 int constexpr nano::election::active_duration_factor;
 int constexpr nano::election::confirmed_duration_factor;
-int constexpr nano::election::confirmed_duration_factor_saturated;
 
 std::chrono::milliseconds nano::election::base_latency () const
 {
@@ -256,7 +255,7 @@ void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a
 	}
 }
 
-bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a, bool const saturated_a)
+bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a)
 {
 	debug_assert (!node.active.mutex.try_lock ());
 	nano::unique_lock<std::mutex> lock (timepoints_mutex);
@@ -289,7 +288,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			send_confirm_req (solicitor_a);
 			break;
 		case nano::election::state_t::confirmed:
-			if (base_latency () * (saturated_a ? confirmed_duration_factor_saturated : confirmed_duration_factor) < std::chrono::steady_clock::now () - state_start)
+			if (base_latency () * confirmed_duration_factor < std::chrono::steady_clock::now () - state_start)
 			{
 				result = true;
 				state_change (nano::election::state_t::confirmed, nano::election::state_t::expired_confirmed);

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -48,8 +48,7 @@ private: // State management
 	};
 	static int constexpr passive_duration_factor = 5;
 	static int constexpr active_duration_factor = 20;
-	static int constexpr confirmed_duration_factor = 10;
-	static int constexpr confirmed_duration_factor_saturated = 1;
+	static int constexpr confirmed_duration_factor = 5;
 	std::atomic<nano::election::state_t> state_m = { state_t::idle };
 
 	// Protects state_start, last_vote and last_block
@@ -83,7 +82,7 @@ public:
 	void insert_inactive_votes_cache (nano::block_hash const &);
 
 public: // State transitions
-	bool transition_time (nano::confirmation_solicitor &, bool const saturated);
+	bool transition_time (nano::confirmation_solicitor &);
 	void transition_passive ();
 	void transition_active ();
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1851,6 +1851,7 @@ void nano::json_handler::confirmation_info ()
 	if (!root.decode_hex (root_text))
 	{
 		auto election (node.active.election (root));
+		nano::lock_guard<std::mutex> guard (node.active.mutex);
 		if (election != nullptr && !election->confirmed ())
 		{
 			response_l.put ("announcements", std::to_string (election->confirmation_request_count));

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -82,7 +82,7 @@ public:
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_test_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
-	size_t active_elections_size{ 10000 };
+	size_t active_elections_size{ 50000 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
 	unsigned tcp_incoming_connections_max{ 1024 };
 	bool use_memory_pools{ true };


### PR DESCRIPTION
This was previously explored in #2440 with good results, but is not necessarily part of those changes.

The goal is to be able to hold more elections even if those are already confirmed. However, looping through all elections every 500ms (our default loop period) is not necessary, so this is only done every ~5 seconds. List of changes:

- `active_elections_size` increased from 10k to 50k. As a side effect, this fixes the slow frontier confirmation issue caused by lingering confirmed elections. `search_frontiers` was adjusted to prevent adding too many.
- Normally check top 5k elections every 500ms, but all 50k every 5 seconds.
- To avoid a situation where most of the top elections are confirmed, the loop counter is only increased for unconfirmed elections.
- Fixed election `confirmed_duration_factor` at 5 (corresponds to 5 seconds), even if saturated (possible due to above changes).
- Added timing logging for large number of elections.
- Adjusted timing logging for the block processor as it too verbose.
- Fixed a bug in RPC confirmation_info, this was introduced by mistake in #2619 

I wasn't sure if we should rename and deprecate the config value. It's a meaningful change and many operators may have overridden the value (e.g., by copying all default values at some point). It's not done in this PR, but something to consider.