### PR TITLE
Bandwidth considerations following election refactor

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -152,7 +152,7 @@ bool nano::election::state_change (nano::election::state_t expected_a, nano::ele
 
 void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_a)
 {
-	if (last_req + std::chrono::seconds (15) < std::chrono::steady_clock::now ())
+	if (base_latency () * 5 < std::chrono::steady_clock::now () - last_req)
 	{
 		if (!solicitor_a.add (*this))
 		{
@@ -181,14 +181,7 @@ void nano::election::transition_active ()
 
 void nano::election::transition_active_impl ()
 {
-	if (!state_change (nano::election::state_t::idle, nano::election::state_t::active))
-	{
-		if (base_latency () * 5 < std::chrono::steady_clock::now () - last_block)
-		{
-			last_block = std::chrono::steady_clock::now ();
-			node.network.flood_block (status.winner);
-		}
-	}
+	state_change (nano::election::state_t::idle, nano::election::state_t::active);
 }
 
 bool nano::election::idle () const
@@ -247,7 +240,7 @@ void nano::election::activate_dependencies ()
 
 void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
 {
-	if (base_latency () * 5 < std::chrono::steady_clock::now () - last_block)
+	if (base_latency () * 20 < std::chrono::steady_clock::now () - last_block)
 	{
 		if (!solicitor_a.broadcast (*this))
 		{

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -47,7 +47,7 @@ private: // State management
 		expired_unconfirmed
 	};
 	static int constexpr passive_duration_factor = 5;
-	static int constexpr active_duration_factor = 20;
+	static int constexpr active_duration_factor = 30;
 	static int constexpr confirmed_duration_factor = 10;
 	static int constexpr confirmed_duration_factor_saturated = 1;
 	std::atomic<nano::election::state_t> state_m = { state_t::idle };
@@ -55,8 +55,7 @@ private: // State management
 	// Protects state_start, last_vote and last_block
 	std::mutex timepoints_mutex;
 	std::chrono::steady_clock::time_point state_start = { std::chrono::steady_clock::now () };
-	std::chrono::steady_clock::time_point last_vote = { std::chrono::steady_clock::time_point () };
-	std::chrono::steady_clock::time_point last_block = { std::chrono::steady_clock::time_point () };
+	std::chrono::steady_clock::time_point last_block = { std::chrono::steady_clock::now () };
 	std::chrono::steady_clock::time_point last_req = { std::chrono::steady_clock::time_point () };
 
 	bool valid_change (nano::election::state_t, nano::election::state_t) const;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1107,7 +1107,6 @@ void nano::node::block_confirm (std::shared_ptr<nano::block> block_a)
 	if (election.second)
 	{
 		election.first->transition_active ();
-		network.flood_block (block_a, nano::buffer_drop_policy::no_limiter_drop);
 	}
 	// Calculate votes for local representatives
 	if (config.enable_voting && wallets.rep_counts ().voting > 0 && active.active (*block_a))

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1107,6 +1107,7 @@ void nano::node::block_confirm (std::shared_ptr<nano::block> block_a)
 	if (election.second)
 	{
 		election.first->transition_active ();
+		network.flood_block (block_a, nano::buffer_drop_policy::no_limiter_drop);
 	}
 	// Calculate votes for local representatives
 	if (config.enable_voting && wallets.rep_counts ().voting > 0 && active.active (*block_a))


### PR DESCRIPTION
- Block broadcasting is used as a backup mechanism, now only done after and every 20 seconds
- Reduced send_confirm_req period from 15 to 5 seconds, as it is the primary mechanism and only targets representatives that haven't voted yet
- Increased time to activate dependencies ensuring at least one block broadcast is performed