### PR TITLE
Fix wrong number of representatives in confirmation solicitor

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -227,7 +227,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 
 	// Only representatives ready to receive batched confirm_req
 	nano::confirmation_solicitor solicitor (node.network, node.network_params.network);
-	solicitor.prepare (node.rep_crawler.representatives (node.network_params.protocol.tcp_realtime_protocol_version_min));
+	solicitor.prepare (node.rep_crawler.principal_representatives (std::numeric_limits<size_t>::max (), node.network_params.protocol.tcp_realtime_protocol_version_min));
 
 	auto election_ttl_cutoff_l (std::chrono::steady_clock::now () - election_time_to_live);
 	auto roots_size_l (roots.size ());

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -317,14 +317,14 @@ void nano::rep_crawler::update_weights ()
 	}
 }
 
-std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a)
+std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, nano::uint128_t const weight_a, boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a)
 {
 	auto version_min (opt_version_min_a.value_or (node.network_params.protocol.protocol_version_min));
 	std::vector<representative> result;
 	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
 	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)
 	{
-		if (!i->weight.is_zero () && i->channel->get_network_version () >= version_min)
+		if (i->weight > weight_a && i->channel->get_network_version () >= version_min)
 		{
 			result.push_back (*i);
 		}
@@ -332,19 +332,9 @@ std::vector<nano::representative> nano::rep_crawler::representatives (size_t cou
 	return result;
 }
 
-std::vector<nano::representative> nano::rep_crawler::principal_representatives (size_t count_a)
+std::vector<nano::representative> nano::rep_crawler::principal_representatives (size_t count_a, boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a)
 {
-	std::vector<representative> result;
-	auto minimum = node.minimum_principal_weight ();
-	nano::lock_guard<std::mutex> lock (probable_reps_mutex);
-	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)
-	{
-		if (i->weight > minimum)
-		{
-			result.push_back (*i);
-		}
-	}
-	return result;
+	return representatives (count_a, node.minimum_principal_weight (), opt_version_min_a);
 }
 
 std::vector<std::shared_ptr<nano::transport::channel>> nano::rep_crawler::representative_endpoints (size_t count_a)

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -102,11 +102,11 @@ public:
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;
 
-	/** Request a list of the top \p count_a known representatives in descending order of weight, optionally with a minimum version \p opt_version_min_a */
-	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max (), boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a = boost::none);
+	/** Request a list of the top \p count_a known representatives in descending order of weight, with at least \p weight_a voting weight, and optionally with a minimum version \p opt_version_min_a */
+	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max (), nano::uint128_t const weight_a = 0, boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a = boost::none);
 
-	/** Request a list of the top \p count_a known principal representatives in descending order of weight. */
-	std::vector<representative> principal_representatives (size_t count_a = std::numeric_limits<size_t>::max ());
+	/** Request a list of the top \p count_a known principal representatives in descending order of weight, optionally with a minimum version \p opt_version_min_a */
+	std::vector<representative> principal_representatives (size_t count_a = std::numeric_limits<size_t>::max (), boost::optional<decltype (nano::protocol_constants::protocol_version_min)> const & opt_version_min_a = boost::none);
 
 	/** Request a list of the top \p count_a known representative endpoints. */
 	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (size_t count_a);


### PR DESCRIPTION
Also cleans up redundant code in repcrawler, and makes it more clear confirmations are only solicited from principal representatives.