### PR TITLE
Using relaxed atomics for counts not involved in control flow in conf height processor

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1207,14 +1207,12 @@ TEST (confirmation_height, dependent_election)
 
 		add_callback_stats (*node);
 
-		// Start an election and vote, should confirm the block
-		node->block_confirm (send2);
-
 		{
 			// The write guard prevents the confirmation height processor doing any writes.
-			// Note: This test could still fail intermittently due to thread scheduling between active and confirmation height.
 			system.deadline_set (10s);
 			auto write_guard = node->write_database_queue.wait (nano::writer::testing);
+			// Start an election and vote, should confirm the block
+			node->block_confirm (send2);
 			while (!node->write_database_queue.contains (nano::writer::confirmation_height))
 			{
 				ASSERT_NO_ERROR (system.poll ());

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/optional_ptr.hpp>
+#include <nano/lib/threading.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/worker.hpp>
@@ -108,4 +109,71 @@ TEST (filesystem, move_all_files)
 	ASSERT_TRUE (boost::filesystem::exists (path / "my_file2.txt"));
 	ASSERT_FALSE (boost::filesystem::exists (dummy_file1));
 	ASSERT_FALSE (boost::filesystem::exists (dummy_file2));
+}
+
+TEST (relaxed_atomic_integral, basic)
+{
+	nano::relaxed_atomic_integral<uint32_t> atomic{ 0 };
+	ASSERT_EQ (0, atomic++);
+	ASSERT_EQ (1, atomic);
+	ASSERT_EQ (2, ++atomic);
+	ASSERT_EQ (2, atomic);
+	ASSERT_EQ (2, atomic.load ());
+	ASSERT_EQ (2, atomic--);
+	ASSERT_EQ (1, atomic);
+	ASSERT_EQ (0, --atomic);
+	ASSERT_EQ (0, atomic);
+	ASSERT_EQ (0, atomic.fetch_add (2));
+	ASSERT_EQ (2, atomic);
+	ASSERT_EQ (2, atomic.fetch_sub (1));
+	ASSERT_EQ (1, atomic);
+	atomic.store (3);
+	ASSERT_EQ (3, atomic);
+
+	uint32_t expected{ 2 };
+	ASSERT_FALSE (atomic.compare_exchange_strong (expected, 1));
+	ASSERT_EQ (3, expected);
+	ASSERT_EQ (3, atomic);
+	ASSERT_TRUE (atomic.compare_exchange_strong (expected, 1));
+	ASSERT_EQ (1, atomic);
+	ASSERT_EQ (3, expected);
+
+	// Weak can fail spuriously, try a few times
+	bool res{ false };
+	for (int i = 0; i < 1000; ++i)
+	{
+		res |= atomic.compare_exchange_weak (expected, 2);
+		expected = 1;
+	}
+	ASSERT_TRUE (res);
+	ASSERT_EQ (2, atomic);
+}
+
+TEST (relaxed_atomic_integral, many_threads)
+{
+	std::vector<std::thread> threads;
+	auto num = 4;
+	nano::relaxed_atomic_integral<uint32_t> atomic{ 0 };
+	for (int i = 0; i < num; ++i)
+	{
+		threads.emplace_back ([&atomic] {
+			for (int i = 0; i < 10000; ++i)
+			{
+				++atomic;
+				atomic--;
+				atomic++;
+				--atomic;
+				atomic.fetch_add (2);
+				atomic.fetch_sub (2);
+			}
+		});
+	}
+
+	for (auto & thread : threads)
+	{
+		thread.join ();
+	}
+
+	// Check values
+	ASSERT_EQ (0, atomic);
 }

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -79,7 +79,7 @@ public:
    a total global ordering of atomic operations are well as synchronization between threads. Weaker memory
    ordering can provide benefits in some circumstances, such like in dumb counters where no other data is
    dependent on the ordering of these operations. This assumes T is a type of integer, not bool or char. */
-template <typename T, typename = std::enable_if<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 class relaxed_atomic_integral
 {
 public:

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -74,4 +74,86 @@ public:
 	std::vector<boost::thread> threads;
 	boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_guard;
 };
+
+/* Default memory order of normal std::atomic operations is std::memory_order_seq_cst which provides
+   a total global ordering of atomic operations are well as synchronization between threads. Weaker memory
+   ordering can provide benefits in some circumstances, such like in dumb counters where no other data is
+   dependent on the ordering of these operations. */
+template <typename T>
+class relaxed_atomic_integral
+{
+public:
+	relaxed_atomic_integral () noexcept = default;
+	constexpr relaxed_atomic_integral (T desired) noexcept :
+	atomic (desired)
+	{
+	}
+
+	T operator= (T desired) noexcept
+	{
+		store (desired);
+		return atomic;
+	}
+
+	relaxed_atomic_integral (relaxed_atomic_integral const &) = delete;
+	relaxed_atomic_integral & operator= (relaxed_atomic_integral const &) = delete;
+
+	void store (T desired, std::memory_order order = std::memory_order_relaxed) noexcept
+	{
+		atomic.store (desired, order);
+	}
+
+	T load (std::memory_order order = std::memory_order_relaxed) const noexcept
+	{
+		return atomic.load (std::memory_order_relaxed);
+	}
+
+	operator T () const noexcept
+	{
+		return load ();
+	}
+
+	bool compare_exchange_weak (T & expected, T desired, std::memory_order order = std::memory_order_relaxed) noexcept
+	{
+		return atomic.compare_exchange_weak (expected, desired, order);
+	}
+
+	bool compare_exchange_strong (T & expected, T desired, std::memory_order order = std::memory_order_relaxed) noexcept
+	{
+		return atomic.compare_exchange_weak (expected, desired, order);
+	}
+
+	T fetch_add (T arg, std::memory_order order = std::memory_order_relaxed) noexcept
+	{
+		return atomic.fetch_add (arg, order);
+	}
+
+	T fetch_sub (T arg, std::memory_order order = std::memory_order_relaxed) noexcept
+	{
+		return atomic.fetch_sub (arg, order);
+	}
+
+	T operator++ () noexcept
+	{
+		return fetch_add (1) + 1;
+	}
+
+	T operator++ (int) noexcept
+	{
+		return fetch_add (1);
+	}
+
+	T operator-- () noexcept
+	{
+		return fetch_sub (1) - 1;
+	}
+
+	T operator-- (int) noexcept
+	{
+		return fetch_sub (1);
+	}
+
+private:
+	std::atomic<T> atomic;
+};
 }

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -120,7 +120,7 @@ public:
 
 	bool compare_exchange_strong (T & expected, T desired, std::memory_order order = std::memory_order_relaxed) noexcept
 	{
-		return atomic.compare_exchange_weak (expected, desired, order);
+		return atomic.compare_exchange_strong (expected, desired, order);
 	}
 
 	T fetch_add (T arg, std::memory_order order = std::memory_order_relaxed) noexcept

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -78,8 +78,8 @@ public:
 /* Default memory order of normal std::atomic operations is std::memory_order_seq_cst which provides
    a total global ordering of atomic operations are well as synchronization between threads. Weaker memory
    ordering can provide benefits in some circumstances, such like in dumb counters where no other data is
-   dependent on the ordering of these operations. */
-template <typename T>
+   dependent on the ordering of these operations. This assumes T is a type of integer, not bool or char. */
+template <typename T, typename = std::enable_if<std::is_integral<T>::value>>
 class relaxed_atomic_integral
 {
 public:

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -292,12 +292,12 @@ void nano::confirmation_height_bounded::prepare_iterated_blocks_for_cementing (p
 			else
 			{
 				accounts_confirmed_info.emplace (preparation_data_a.account, confirmed_info_l);
-				accounts_confirmed_info_size = accounts_confirmed_info.size ();
+				accounts_confirmed_info_size.fetch_add (1, std::memory_order_relaxed);
 			}
 
 			preparation_data_a.checkpoints.erase (std::remove (preparation_data_a.checkpoints.begin (), preparation_data_a.checkpoints.end (), preparation_data_a.top_most_non_receive_block_hash), preparation_data_a.checkpoints.end ());
 			pending_writes.emplace_back (preparation_data_a.account, preparation_data_a.bottom_height, preparation_data_a.bottom_most, block_height, preparation_data_a.top_most_non_receive_block_hash);
-			++pending_writes_size;
+			pending_writes_size.fetch_add (1, std::memory_order_relaxed);
 		}
 	}
 
@@ -315,7 +315,7 @@ void nano::confirmation_height_bounded::prepare_iterated_blocks_for_cementing (p
 		else
 		{
 			accounts_confirmed_info.emplace (std::piecewise_construct, std::forward_as_tuple (receive_details->account), std::forward_as_tuple (receive_details->height, receive_details->hash));
-			accounts_confirmed_info_size = accounts_confirmed_info.size ();
+			accounts_confirmed_info_size.fetch_add (1, std::memory_order_relaxed);
 		}
 
 		if (receive_details->next.is_initialized ())
@@ -443,7 +443,7 @@ bool nano::confirmation_height_bounded::cement_blocks ()
 			if (it != accounts_confirmed_info.cend () && it->second.confirmed_height == pending.top_height)
 			{
 				accounts_confirmed_info.erase (pending.account);
-				accounts_confirmed_info_size = accounts_confirmed_info.size ();
+				accounts_confirmed_info_size.fetch_sub (1, std::memory_order_relaxed);
 			}
 			pending_writes.pop_front ();
 			--pending_writes_size;
@@ -465,7 +465,7 @@ bool nano::confirmation_height_bounded::pending_empty () const
 void nano::confirmation_height_bounded::prepare_new ()
 {
 	accounts_confirmed_info.clear ();
-	accounts_confirmed_info_size = 0;
+	accounts_confirmed_info_size.store (0, std::memory_order_relaxed);
 	timer.restart ();
 }
 
@@ -504,7 +504,7 @@ iterated_frontier (iterated_frontier_a)
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (confirmation_height_bounded & confirmation_height_bounded, const std::string & name_a)
 {
 	auto composite = std::make_unique<container_info_composite> (name_a);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending_writes", confirmation_height_bounded.pending_writes_size, sizeof (decltype (confirmation_height_bounded.pending_writes)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "accounts_confirmed_info", confirmation_height_bounded.accounts_confirmed_info_size, sizeof (decltype (confirmation_height_bounded.accounts_confirmed_info)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending_writes", confirmation_height_bounded.pending_writes_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_bounded.pending_writes)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "accounts_confirmed_info", confirmation_height_bounded.accounts_confirmed_info_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_bounded.accounts_confirmed_info)::value_type) }));
 	return composite;
 }

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/threading.hpp>
 #include <nano/secure/blockstore.hpp>
 
 #include <boost/circular_buffer.hpp>
@@ -62,11 +63,11 @@ private:
 	// upon in any way (does not synchronize with any other data).
 	// This allows the load and stores to use relaxed atomic memory ordering.
 	std::deque<write_details> pending_writes;
-	std::atomic<uint64_t> pending_writes_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> pending_writes_size{ 0 };
 	static uint32_t constexpr pending_writes_max_size{ max_items };
 	/* Holds confirmation height/cemented frontier in memory for accounts while iterating */
 	std::unordered_map<account, confirmed_info> accounts_confirmed_info;
-	std::atomic<uint64_t> accounts_confirmed_info_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> accounts_confirmed_info_size{ 0 };
 
 	class receive_chain_details final
 	{

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -51,6 +51,7 @@ private:
 
 	nano::condition_variable condition;
 	std::atomic<bool> stopped{ false };
+	// No mutex needed for the observers as these should be set up during initialization of the node
 	std::vector<std::function<void(std::shared_ptr<nano::block>)>> cemented_observers;
 	std::vector<std::function<void(nano::block_hash const &)>> block_already_cemented_observers;
 

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -123,6 +123,7 @@ void nano::confirmation_height_unbounded::process ()
 			else
 			{
 				confirmed_iterated_pairs.emplace (std::piecewise_construct, std::forward_as_tuple (account), std::forward_as_tuple (confirmation_height, block_height));
+				confirmed_iterated_pairs_size.fetch_add (1, std::memory_order_relaxed);
 			}
 		}
 
@@ -238,6 +239,7 @@ void nano::confirmation_height_unbounded::prepare_iterated_blocks_for_cementing 
 		else
 		{
 			confirmed_iterated_pairs.emplace (std::piecewise_construct, std::forward_as_tuple (preparation_data_a.account), std::forward_as_tuple (block_height, block_height));
+			confirmed_iterated_pairs_size.fetch_add (1, std::memory_order_relaxed);
 		}
 
 		auto num_blocks_confirmed = block_height - preparation_data_a.confirmation_height;
@@ -302,6 +304,7 @@ void nano::confirmation_height_unbounded::prepare_iterated_blocks_for_cementing 
 		else
 		{
 			confirmed_iterated_pairs.emplace (std::piecewise_construct, std::forward_as_tuple (receive_account), std::forward_as_tuple (receive_details->height, receive_details->height));
+			confirmed_iterated_pairs_size.fetch_add (1, std::memory_order_relaxed);
 		}
 
 		pending_writes.push_back (*receive_details);

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -23,6 +23,7 @@ void nano::confirmation_height_unbounded::process ()
 	std::shared_ptr<conf_height_details> receive_details;
 	auto current = original_hash;
 	orig_block_callback_data.clear ();
+	orig_block_callback_data_size.store (0, std::memory_order_relaxed);
 
 	std::vector<receive_source_pair> receive_source_pairs;
 	release_assert (receive_source_pairs.empty ());
@@ -191,6 +192,7 @@ void nano::confirmation_height_unbounded::collect_unconfirmed_receive_and_source
 			else if (is_original_block)
 			{
 				orig_block_callback_data.push_back (hash);
+				orig_block_callback_data_size.fetch_add (1, std::memory_order_relaxed);
 			}
 			else
 			{
@@ -207,6 +209,7 @@ void nano::confirmation_height_unbounded::collect_unconfirmed_receive_and_source
 					last_receive_details->block_callback_data.push_back (hash);
 
 					implicit_receive_cemented_mapping[hash] = std::weak_ptr<conf_height_details> (last_receive_details);
+					implicit_receive_cemented_mapping_size.store (implicit_receive_cemented_mapping.size (), std::memory_order_relaxed);
 				}
 			}
 
@@ -275,6 +278,7 @@ void nano::confirmation_height_unbounded::prepare_iterated_blocks_for_cementing 
 		}
 
 		pending_writes.emplace_back (preparation_data_a.account, preparation_data_a.current, block_height, num_blocks_confirmed, block_callback_data);
+		pending_writes_size.fetch_add (1, std::memory_order_relaxed);
 	}
 
 	if (receive_details)
@@ -301,6 +305,7 @@ void nano::confirmation_height_unbounded::prepare_iterated_blocks_for_cementing 
 		}
 
 		pending_writes.push_back (*receive_details);
+		pending_writes_size.fetch_add (1, std::memory_order_relaxed);
 	}
 }
 
@@ -335,6 +340,7 @@ bool nano::confirmation_height_unbounded::cement_blocks ()
 				logger.always_log ("Failed to write confirmation height for: ", pending.hash.to_string ());
 				ledger.stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::invalid_block);
 				pending_writes.clear ();
+				pending_writes_size.store (0, std::memory_order_relaxed);
 				return true;
 			}
 #endif
@@ -361,6 +367,7 @@ bool nano::confirmation_height_unbounded::cement_blocks ()
 		}
 		total_pending_write_block_count -= pending.num_blocks_confirmed;
 		pending_writes.erase (pending_writes.begin ());
+		pending_writes_size.fetch_sub (1, std::memory_order_relaxed);
 	}
 	debug_assert (total_pending_write_block_count == 0);
 	debug_assert (pending_writes.empty ());
@@ -378,7 +385,7 @@ std::shared_ptr<nano::block> nano::confirmation_height_unbounded::get_block_and_
 	{
 		auto block (ledger.store.block_get (transaction_a, hash_a));
 		block_cache.emplace (hash_a, block);
-		++block_cache_size;
+		block_cache_size.fetch_add (1, std::memory_order_relaxed);
 		return block;
 	}
 }
@@ -393,11 +400,11 @@ void nano::confirmation_height_unbounded::prepare_new ()
 	// Separate blocks which are pending confirmation height can be batched by a minimum processing time (to improve lmdb disk write performance),
 	// so make sure the slate is clean when a new batch is starting.
 	confirmed_iterated_pairs.clear ();
-	confirmed_iterated_pairs_size = 0;
+	confirmed_iterated_pairs_size.store (0, std::memory_order_relaxed);
 	implicit_receive_cemented_mapping.clear ();
-	implicit_receive_cemented_mapping_size = 0;
+	implicit_receive_cemented_mapping_size.store (0, std::memory_order_relaxed);
 	block_cache.clear ();
-	block_cache_size = 0;
+	block_cache_size.store (0, std::memory_order_relaxed);
 	timer.restart ();
 }
 
@@ -425,10 +432,10 @@ iterated_height (iterated_height_a)
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (confirmation_height_unbounded & confirmation_height_unbounded, const std::string & name_a)
 {
 	auto composite = std::make_unique<container_info_composite> (name_a);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "confirmed_iterated_pairs", confirmation_height_unbounded.confirmed_iterated_pairs_size, sizeof (decltype (confirmation_height_unbounded.confirmed_iterated_pairs)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending_writes", confirmation_height_unbounded.pending_writes_size, sizeof (decltype (confirmation_height_unbounded.pending_writes)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "implicit_receive_cemented_mapping", confirmation_height_unbounded.implicit_receive_cemented_mapping_size, sizeof (decltype (confirmation_height_unbounded.implicit_receive_cemented_mapping)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "block_cache", confirmation_height_unbounded.block_cache_size, sizeof (decltype (confirmation_height_unbounded.block_cache)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "orig_block_callback_data", confirmation_height_unbounded.orig_block_callback_data_size, sizeof (decltype (confirmation_height_unbounded.orig_block_callback_data)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "confirmed_iterated_pairs", confirmation_height_unbounded.confirmed_iterated_pairs_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_unbounded.confirmed_iterated_pairs)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "pending_writes", confirmation_height_unbounded.pending_writes_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_unbounded.pending_writes)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "implicit_receive_cemented_mapping", confirmation_height_unbounded.implicit_receive_cemented_mapping_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_unbounded.implicit_receive_cemented_mapping)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "block_cache", confirmation_height_unbounded.block_cache_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_unbounded.block_cache)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "orig_block_callback_data", confirmation_height_unbounded.orig_block_callback_data_size.load (std::memory_order_relaxed), sizeof (decltype (confirmation_height_unbounded.orig_block_callback_data)::value_type) }));
 	return composite;
 }

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/threading.hpp>
 #include <nano/secure/blockstore.hpp>
 
 #include <chrono>
@@ -59,16 +60,16 @@ private:
 	// upon in any way (does not synchronize with any other data).
 	// This allows the load and stores to use relaxed atomic memory ordering.
 	std::unordered_map<account, confirmed_iterated_pair> confirmed_iterated_pairs;
-	std::atomic<uint64_t> confirmed_iterated_pairs_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> confirmed_iterated_pairs_size{ 0 };
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> block_cache;
-	std::atomic<uint64_t> block_cache_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> block_cache_size{ 0 };
 	std::shared_ptr<nano::block> get_block_and_sideband (nano::block_hash const &, nano::transaction const &);
 	std::deque<conf_height_details> pending_writes;
-	std::atomic<uint64_t> pending_writes_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> pending_writes_size{ 0 };
 	std::vector<nano::block_hash> orig_block_callback_data;
-	std::atomic<uint64_t> orig_block_callback_data_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> orig_block_callback_data_size{ 0 };
 	std::unordered_map<nano::block_hash, std::weak_ptr<conf_height_details>> implicit_receive_cemented_mapping;
-	std::atomic<uint64_t> implicit_receive_cemented_mapping_size{ 0 };
+	nano::relaxed_atomic_integral<uint64_t> implicit_receive_cemented_mapping_size{ 0 };
 
 	nano::timer<std::chrono::milliseconds> timer;
 

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -53,6 +53,11 @@ private:
 		nano::block_hash source_hash;
 	};
 
+	// All of the atomic variables here just track the size for use in collect_container_info.
+	// This is so that no mutexes are needed during the algorithm itself, which would otherwise be needed
+	// for the sake of a rarely used RPC call for debugging purposes. As such the sizes are not being acted
+	// upon in any way (does not synchronize with any other data).
+	// This allows the load and stores to use relaxed atomic memory ordering.
 	std::unordered_map<account, confirmed_iterated_pair> confirmed_iterated_pairs;
 	std::atomic<uint64_t> confirmed_iterated_pairs_size{ 0 };
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> block_cache;
@@ -62,9 +67,9 @@ private:
 	std::atomic<uint64_t> pending_writes_size{ 0 };
 	std::vector<nano::block_hash> orig_block_callback_data;
 	std::atomic<uint64_t> orig_block_callback_data_size{ 0 };
-
 	std::unordered_map<nano::block_hash, std::weak_ptr<conf_height_details>> implicit_receive_cemented_mapping;
 	std::atomic<uint64_t> implicit_receive_cemented_mapping_size{ 0 };
+
 	nano::timer<std::chrono::milliseconds> timer;
 
 	class preparation_data final


### PR DESCRIPTION
The atomic variables used do not have any synchronize-with relationships with any data across threads and all of the atomics involved are independent. One of the reasonable uses of relaxed atomics is dumb counters (not used for anything like control flow). It would allow more freedom for compiler/CPU optimizations due to removing the happens-before restrictions across the atomic boundary, especially as the algorithms used are single threaded. But I understand that it makes the code harder to read and reason about and the easiest way to shoot yourself in the foot generally, however I think in this case it is ok, especially as it isn't used for anything critical.

Bug: Some sizes were not being set in `confirmation_height_bounded` (again only affects the RPC stats -> objects).

Unrelated: `confirmation_height.dependent_election` still fails intermittently (as the comment suggests). Moving the `block_confirm` inside the `write_guard` should fix it.