### PR TITLE
Consistently add conflicting block to election

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1236,10 +1236,10 @@ TEST (node, fork_publish_inactive)
 {
 	nano::system system (1);
 	nano::genesis genesis;
-	nano::public_key pub1;
-	nano::public_key pub2;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), pub1, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), pub2, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::keypair key1;
+	nano::keypair key2;
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, send1->block_work ()));
 	auto & node (*system.nodes[0]);
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::fork, node.process_local (send2).code);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -547,7 +547,6 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 	auto root (block_a->root ());
 	if (!store.block_exists (transaction_a, block_a->type (), block_a->hash ()) && store.root_exists (transaction_a, block_a->root ()))
 	{
-		active.publish (block_a);
 		std::shared_ptr<nano::block> ledger_block (ledger.forked_block (transaction_a, *block_a));
 		if (ledger_block && !block_confirmed_or_being_confirmed (transaction_a, ledger_block->hash ()))
 		{
@@ -577,6 +576,7 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 				election.first->transition_active ();
 			}
 		}
+		active.publish (block_a);
 	}
 }
 


### PR DESCRIPTION
Moves `active.publish` until after election creation, otherwise the block is only added if the election already existed. Important for #2643 .

Added test fails without this change (send2 does not exist in election).