### PR TITLE
Include requesting telemetry metrics from temporary channels

### DIFF
--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -51,7 +51,7 @@ private: // State management
 	static int constexpr confirmed_duration_factor = 5;
 	std::atomic<nano::election::state_t> state_m = { state_t::idle };
 
-	// Protects state_start, last_vote and last_block
+	// These time points must be protected by this mutex
 	std::mutex timepoints_mutex;
 	std::chrono::steady_clock::time_point state_start = { std::chrono::steady_clock::now () };
 	std::chrono::steady_clock::time_point last_block = { std::chrono::steady_clock::now () };

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1226,7 +1226,6 @@ void nano::json_handler::block_account ()
 
 void nano::json_handler::block_count ()
 {
-	auto transaction (node.store.tx_begin_read ());
 	response_l.put ("count", std::to_string (node.ledger.cache.block_count));
 	response_l.put ("unchecked", std::to_string (node.ledger.cache.unchecked_count));
 	response_l.put ("cemented", std::to_string (node.ledger.cache.cemented_count));

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1227,7 +1227,7 @@ void nano::json_handler::block_account ()
 void nano::json_handler::block_count ()
 {
 	auto transaction (node.store.tx_begin_read ());
-	response_l.put ("count", std::to_string (node.store.block_count (transaction).sum ()));
+	response_l.put ("count", std::to_string (node.ledger.cache.block_count));
 	response_l.put ("unchecked", std::to_string (node.ledger.cache.unchecked_count));
 	response_l.put ("cemented", std::to_string (node.ledger.cache.cemented_count));
 	response_errors ();

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -111,7 +111,7 @@ void nano::telemetry::ongoing_req_all_peers (std::chrono::milliseconds next_requ
 				peers;
 
 				{
-					auto temp_peers = this_l->network.list (std::numeric_limits<size_t>::max (), this_l->network_params.protocol.telemetry_protocol_version_min, false);
+					auto temp_peers = this_l->network.list (std::numeric_limits<size_t>::max (), this_l->network_params.protocol.telemetry_protocol_version_min);
 					peers.insert (temp_peers.begin (), temp_peers.end ());
 				}
 


### PR DESCRIPTION
@Srayman reported some nodes could not request metrics to some peers during the bulk request phase, but could if requested manually. Now including temporary channels, I don't recall why they were removed as it doesn't seem to cause any issues.

Unrelated: Out of date comment
Unrelated: `block_count` RPC could use ledger cache.