### PR TITLE
Update tick count in timer::update

### DIFF
--- a/nano/core_test/timer.cpp
+++ b/nano/core_test/timer.cpp
@@ -42,6 +42,8 @@ TEST (timer, measure_and_compare)
 	ASSERT_LT (t1.since_start (), 200ms);
 	ASSERT_GT (t1.since_start (), 10ms);
 	ASSERT_GE (t1.stop (), 50ms);
+	std::this_thread::sleep_for (50ms);
+	ASSERT_GT (t1.restart (), 10ms);
 }
 
 TEST (timer, cummulative_child)

--- a/nano/lib/timer.cpp
+++ b/nano/lib/timer.cpp
@@ -97,12 +97,14 @@ void nano::timer<UNIT, CLOCK>::start ()
 }
 
 template <typename UNIT, typename CLOCK>
-void nano::timer<UNIT, CLOCK>::restart ()
+UNIT nano::timer<UNIT, CLOCK>::restart ()
 {
+	auto current = ticks;
 	state = nano::timer_state::started;
 	begin = CLOCK::now ();
 	ticks = UNIT::zero ();
 	measurements = 0;
+	return current;
 }
 
 template <typename UNIT, typename CLOCK>

--- a/nano/lib/timer.cpp
+++ b/nano/lib/timer.cpp
@@ -113,19 +113,26 @@ UNIT nano::timer<UNIT, CLOCK>::pause ()
 }
 
 template <typename UNIT, typename CLOCK>
+void nano::timer<UNIT, CLOCK>::update_ticks ()
+{
+	auto end = CLOCK::now ();
+	ticks += std::chrono::duration_cast<UNIT> (end - begin);
+}
+
+template <typename UNIT, typename CLOCK>
 UNIT nano::timer<UNIT, CLOCK>::stop ()
 {
 	debug_assert (state == nano::timer_state::started);
 	state = nano::timer_state::stopped;
 
-	auto end = CLOCK::now ();
-	ticks += std::chrono::duration_cast<UNIT> (end - begin);
+	update_ticks ();
 	return ticks;
 }
 
 template <typename UNIT, typename CLOCK>
-UNIT nano::timer<UNIT, CLOCK>::value () const
+UNIT nano::timer<UNIT, CLOCK>::value ()
 {
+	update_ticks ();
 	return ticks;
 }
 

--- a/nano/lib/timer.hpp
+++ b/nano/lib/timer.hpp
@@ -59,9 +59,9 @@ public:
 	UNIT stop ();
 
 	/**
-	 * Return current tick count.
+	 * Updates and returns current tick count.
 	 */
-	UNIT value () const;
+	UNIT value ();
 
 	/** Returns the duration in UNIT since the timer was last started. */
 	UNIT since_start () const;
@@ -94,5 +94,6 @@ private:
 	UNIT ticks{ 0 };
 	UNIT minimum{ UNIT::zero () };
 	unsigned measurements{ 0 };
+	void update_ticks ();
 };
 }

--- a/nano/lib/timer.hpp
+++ b/nano/lib/timer.hpp
@@ -42,8 +42,9 @@ public:
 	/**
 	 * Restarts the timer by setting start time to current time and resetting tick count.
 	 * This can be called in any timer state.
+	 * @return duration
 	 */
-	void restart ();
+	UNIT restart ();
 
 	/**
 	 * Stops the timer and increases the measurement count. A timer can be started and paused


### PR DESCRIPTION
Currently, tick count is updated only on timer pause/stop, but we have some code that assumes it's updated on `value()` as well. This PR makes it so. @guilhermelawless also suggested returning ticks from restart, useful in test.