### PR TITLE
Increase minimum time to log block processing

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -256,7 +256,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 	awaiting_write = false;
 	lock_a.unlock ();
 
-	if (node.config.logging.timing_logging () && number_of_blocks_processed != 0 && timer_l.stop () > std::chrono::milliseconds (10))
+	if (node.config.logging.timing_logging () && number_of_blocks_processed != 0 && timer_l.stop () > std::chrono::milliseconds (100))
 	{
 		node.logger.always_log (boost::str (boost::format ("Processed %1% blocks (%2% blocks were forced) in %3% %4%") % number_of_blocks_processed % number_of_forced_processed % timer_l.value ().count () % timer_l.unit ()));
 	}

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -77,7 +77,7 @@ void nano::vote_processor::process_loop ()
 			condition.notify_all ();
 			lock.lock ();
 
-			if (log_this_iteration && elapsed.stop () > std::chrono::milliseconds (10))
+			if (log_this_iteration && elapsed.stop () > std::chrono::milliseconds (100))
 			{
 				logger.try_log (boost::str (boost::format ("Processed %1% votes in %2% milliseconds (rate of %3% votes per second)") % votes_l.size () % elapsed.value ().count () % ((votes_l.size () * 1000ULL) / elapsed.value ().count ())));
 			}

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -77,7 +77,7 @@ void nano::vote_processor::process_loop ()
 			condition.notify_all ();
 			lock.lock ();
 
-			if (log_this_iteration && elapsed.stop () > std::chrono::milliseconds (100))
+			if (log_this_iteration && elapsed.stop () > std::chrono::milliseconds (10))
 			{
 				logger.try_log (boost::str (boost::format ("Processed %1% votes in %2% milliseconds (rate of %3% votes per second)") % votes_l.size () % elapsed.value ().count () % ((votes_l.size () * 1000ULL) / elapsed.value ().count ())));
 			}


### PR DESCRIPTION
To `100ms` , anything below is very noisy due to locking on the active mutex.