### PR TITLE
Output current function in assert diagnostics

### DIFF
--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -108,9 +108,11 @@ void nano::move_all_files_to_dir (boost::filesystem::path const & from, boost::f
 /*
  * Backing code for "release_assert" & "debug_assert", which are macros
  */
-void assert_internal (const char * check_expr, const char * file, unsigned int line, bool is_release_assert)
+void assert_internal (const char * check_expr, const char * func, const char * file, unsigned int line, bool is_release_assert)
 {
-	std::cerr << "Assertion (" << check_expr << ") failed " << file << ":" << line << "\n\n";
+	std::cerr << "Assertion (" << check_expr << ") failed\n"
+	          << func << "\n"
+	          << file << ":" << line << "\n\n";
 
 	// Output stack trace to cerr
 	auto backtrace_str = nano::generate_stacktrace ();

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/lib/locks.hpp>
 
+#include <boost/current_function.hpp>
+
 #include <cassert>
 #include <functional>
 #include <mutex>
@@ -20,13 +22,13 @@ namespace system
 }
 }
 
-void assert_internal (const char * check_expr, const char * file, unsigned int line, bool is_release_assert);
-#define release_assert(check) check ? (void)0 : assert_internal (#check, __FILE__, __LINE__, true)
+void assert_internal (const char * check_expr, const char * func, const char * file, unsigned int line, bool is_release_assert);
+#define release_assert(check) check ? (void)0 : assert_internal (#check, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, true)
 
 #ifdef NDEBUG
 #define debug_assert(check) (void)0
 #else
-#define debug_assert(check) check ? (void)0 : assert_internal (#check, __FILE__, __LINE__, false)
+#define debug_assert(check) check ? (void)0 : assert_internal (#check, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, false)
 #endif
 
 namespace nano


### PR DESCRIPTION
There exists a `__func__` standard variable/macro which provides an unqualified string of the current function. GCC has a `__PRETTY_FUNCTION__` macro and similar exists in MSVC. I found out that boost has a macro `BOOST_CURRENT_FUNCTION` which encapsulates all possible compiler extensions. Tested with MSVC & clang putting `debug_assert (false);` in the first active_transactions.cpp core_test:
MSVC:
```
Assertion (false) failed
void __cdecl nano::active_transactions_confirm_active_Test::TestBody(void)
C:\Users\Wesley\Documents\Nano\raiblocks\nano\core_test\active_transactions.cpp:14
```
Clang:
```
Assertion (false) failed
virtual void nano::active_transactions_confirm_active_Test::TestBody()
/home/wezrule/nano/raiblocks/nano/core_test/active_transactions.cpp:14
```
This is useful because by default addresses in the stacktrace may not provide file/source line information, for instance with clang I get this, and we have seen in the past that line numbers from the macros do not always match the `assert` itself.
```
0# 0x0000000000E0C1D1 in ./core_test
1# ...
```
