### PR TITLE
Add different epoch_2 thresholds for the beta and test networks

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -80,6 +80,10 @@ public:
 		// The minimum threshold to enter the node, does not guarantee a block is processed
 		publish_threshold = is_test_network () ? publish_test_threshold : is_beta_network () ? publish_beta_threshold : publish_full_threshold;
 
+		publish_epoch_1_threshold = is_test_network () ? publish_test_epoch_1_threshold : is_beta_network () ? publish_beta_epoch_1_threshold : publish_full_epoch_1_threshold;
+		publish_epoch_2_threshold = is_test_network () ? publish_test_epoch_2_threshold : is_beta_network () ? publish_beta_epoch_2_threshold : publish_full_epoch_2_threshold;
+		publish_epoch_2_receive_threshold = is_test_network () ? publish_test_epoch_2_receive_threshold : is_beta_network () ? publish_beta_epoch_2_receive_threshold : publish_full_epoch_2_receive_threshold;
+
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
 
@@ -97,8 +101,17 @@ public:
 	static uint64_t const publish_full_threshold{ std::min ({ publish_full_epoch_1_threshold, publish_full_epoch_2_threshold, publish_full_epoch_2_receive_threshold }) };
 	static_assert (publish_full_threshold == publish_full_epoch_2_receive_threshold, "publish_full_threshold is ill-defined");
 
-	static uint64_t const publish_beta_threshold{ 0xfffff00000000000 }; // 64x lower than epoch 1
-	static uint64_t const publish_test_threshold{ 0xff00000000000000 }; // very low for tests
+	static uint64_t const publish_beta_epoch_1_threshold{ 0xfffff00000000000 }; // 64x lower than epoch 1
+	static uint64_t const publish_beta_epoch_2_threshold{ 0xfffff80000000000 }; // 2x higher than epoch 1
+	static uint64_t const publish_beta_epoch_2_receive_threshold{ 0xffffe00000000000 }; // 2x lower than epoch 1
+	static uint64_t const publish_beta_threshold{ std::min ({ publish_beta_epoch_1_threshold, publish_beta_epoch_2_threshold, publish_beta_epoch_2_receive_threshold }) };
+	static_assert (publish_beta_threshold == publish_beta_epoch_2_receive_threshold, "publish_beta_threshold is ill-defined");
+
+	static uint64_t const publish_test_epoch_1_threshold{ 0xff00000000000000 }; // very low for tests
+	static uint64_t const publish_test_epoch_2_threshold{ 0xff80000000000000 }; // 2x higher than epoch 1
+	static uint64_t const publish_test_epoch_2_receive_threshold{ 0xfe00000000000000 }; // 2x lower than epoch 1
+	static uint64_t const publish_test_threshold{ std::min ({ publish_test_epoch_1_threshold, publish_test_epoch_2_threshold, publish_test_epoch_2_receive_threshold }) };
+	static_assert (publish_test_threshold == publish_test_epoch_2_receive_threshold, "publish_test_threshold is ill-defined");
 
 	/** Error message when an invalid network is specified */
 	static const char * active_network_err_msg;
@@ -106,6 +119,9 @@ public:
 	/** The network this param object represents. This may differ from the global active network; this is needed for certain --debug... commands */
 	nano_networks current_network{ nano::network_constants::active_network };
 	uint64_t publish_threshold;
+	uint64_t publish_epoch_1_threshold;
+	uint64_t publish_epoch_2_threshold;
+	uint64_t publish_epoch_2_receive_threshold;
 	unsigned principal_weight_factor;
 	uint16_t default_node_port;
 	uint16_t default_rpc_port;

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -1,5 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/lib/epoch.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/node/xorshift.hpp>
@@ -84,20 +85,15 @@ uint64_t nano::work_v1::threshold (nano::block_details const details_a)
 	static_assert (nano::epoch::max == nano::epoch::epoch_2, "work_v1::threshold is ill-defined");
 	static nano::network_constants network_constants;
 
-	if (!network_constants.is_live_network ())
-	{
-		return network_constants.publish_threshold;
-	}
-
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (details_a.epoch)
 	{
 		case nano::epoch::epoch_2:
-			result = (details_a.is_receive || details_a.is_epoch) ? nano::network_constants::publish_full_epoch_2_receive_threshold : nano::network_constants::publish_full_epoch_2_threshold;
+			result = (details_a.is_receive || details_a.is_epoch) ? network_constants.publish_epoch_2_receive_threshold : network_constants.publish_epoch_2_threshold;
 			break;
 		case nano::epoch::epoch_1:
 		case nano::epoch::epoch_0:
-			result = nano::network_constants::publish_full_epoch_1_threshold;
+			result = network_constants.publish_epoch_1_threshold;
 			break;
 		default:
 			debug_assert (false && "Invalid epoch specified to work_v1 ledger work_threshold");


### PR DESCRIPTION
Multipliers are 2x / 0.5x for these networks, but these changes allow testing the same functionality.

- Unifies all thresholds in lib/config.hpp similarly to what was done for `publish_threshold`
- Adjusts `nano::work_threshold` to return the appropriate threshold for all networks
- Improves unit tests