### PR TITLE
Prevent getting stuck in block processor flush

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3193,7 +3193,7 @@ TEST (node, block_processor_signatures)
 
 /*
  *  State blocks go through a different signature path, ensure invalidly signed state blocks are rejected
- *	This test can freeze if the wake conditions in block_processor::flush are off, for that reason this is done async here
+ *  This test can freeze if the wake conditions in block_processor::flush are off, for that reason this is done async here
  */
 TEST (node, block_processor_reject_state)
 {

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -21,6 +21,9 @@ state_block_signature_verification (node.checker, node.ledger.network_params.led
 	state_block_signature_verification.blocks_verified_callback = [this](std::deque<nano::unchecked_info> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures) {
 		this->process_verified_state_blocks (items, verifications, hashes, blocks_signatures);
 	};
+	state_block_signature_verification.transition_inactive_callback = [this]() {
+		this->condition.notify_all ();
+	};
 }
 
 nano::block_processor::~block_processor ()

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -25,6 +25,7 @@ state_block_signature_verification (node.checker, node.ledger.network_params.led
 		if (this->flushing)
 		{
 			{
+				// Prevent a race with condition.wait in block_processor::flush
 				nano::lock_guard<std::mutex> guard (this->mutex);
 			}
 			this->condition.notify_all ();

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -22,7 +22,13 @@ state_block_signature_verification (node.checker, node.ledger.network_params.led
 		this->process_verified_state_blocks (items, verifications, hashes, blocks_signatures);
 	};
 	state_block_signature_verification.transition_inactive_callback = [this]() {
-		this->condition.notify_all ();
+		if (this->flushing)
+		{
+			{
+				nano::lock_guard<std::mutex> guard (this->mutex);
+			}
+			this->condition.notify_all ();
+		}
 	};
 }
 

--- a/nano/node/state_block_signature_verification.cpp
+++ b/nano/node/state_block_signature_verification.cpp
@@ -56,7 +56,9 @@ void nano::state_block_signature_verification::run (uint64_t state_block_signatu
 				lk.lock ();
 			}
 			active = false;
+			lk.unlock ();
 			transition_inactive_callback ();
+			lk.lock ();
 		}
 		else
 		{

--- a/nano/node/state_block_signature_verification.cpp
+++ b/nano/node/state_block_signature_verification.cpp
@@ -56,6 +56,7 @@ void nano::state_block_signature_verification::run (uint64_t state_block_signatu
 				lk.lock ();
 			}
 			active = false;
+			transition_inactive_callback ();
 		}
 		else
 		{

--- a/nano/node/state_block_signature_verification.hpp
+++ b/nano/node/state_block_signature_verification.hpp
@@ -25,6 +25,7 @@ public:
 	bool is_active ();
 
 	std::function<void(std::deque<nano::unchecked_info> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &)> blocks_verified_callback;
+	std::function<void()> transition_inactive_callback;
 
 private:
 	nano::signature_checker & signature_checker;


### PR DESCRIPTION
I noticed `node.block_processor_reject_state` was often freezing on windows, this is due to the verification callback being called and notifying the block processor before transitioning into an inactive state, so the `block_processor::flush` ends up waiting for the condition forever. I've added a second callback to solve this.