### PR TITLE
Delay wallet work caching to allow using lower difficulty on demand

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -706,7 +706,7 @@ TEST (wallet, work_cache_delayed)
 	auto block2 (wallet->send_action (nano::test_genesis_key.pub, key.pub, 100));
 	ASSERT_EQ (block2->hash (), node1.latest (nano::test_genesis_key.pub));
 	ASSERT_EQ (block2->hash (), node1.wallets.delayed_work->operator[] (nano::test_genesis_key.pub));
-	auto threshold (node1.network_params.network.publish_thresholds.base);
+	auto threshold (node1.default_difficulty ());
 	auto again (true);
 	system.deadline_set (10s);
 	while (again)

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/lmdbconfig.hpp>
+#include <nano/lib/locks.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/wallet_value.hpp>
@@ -146,6 +147,7 @@ public:
 	void send_async (nano::account const &, nano::account const &, nano::uint128_t const &, std::function<void(std::shared_ptr<nano::block>)> const &, uint64_t = 0, bool = true, boost::optional<std::string> = {});
 	void work_cache_blocking (nano::account const &, nano::root const &);
 	void work_update (nano::transaction const &, nano::account const &, nano::root const &, uint64_t);
+	// Schedule work generation after a few seconds
 	void work_ensure (nano::account const &, nano::root const &);
 	bool search_pending ();
 	void init_free_accounts (nano::transaction const &);
@@ -223,6 +225,7 @@ public:
 	std::function<void(bool)> observer;
 	std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> items;
 	std::multimap<nano::uint128_t, std::pair<std::shared_ptr<nano::wallet>, std::function<void(nano::wallet &)>>, std::greater<nano::uint128_t>> actions;
+	nano::locked<std::unordered_map<nano::account, nano::root>> delayed_work;
 	std::mutex mutex;
 	std::mutex action_mutex;
 	nano::condition_variable condition;


### PR DESCRIPTION
This is done by using the node alarm to delay the work cache action by 10 seconds (1 second in tests). Since those can't be canceled, the wallet keeps a map state of each account, and when the alarm triggers, this is checked to only queue the action if the root is the same.

The map is wrapped in `nano::locked`.