### PR TITLE
Fix intermittent failure in active_transactions.confirmation_consistency

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -849,7 +849,7 @@ TEST (active_transactions, confirmation_consistency)
 		nano::lock_guard<std::mutex> guard (node.active.mutex);
 		ASSERT_EQ (i + 1, node.active.recently_confirmed.size ());
 		ASSERT_EQ (block->qualified_root (), node.active.recently_confirmed.back ().first);
-		ASSERT_EQ (i + 1, node.active.recently_cemented.size ());
+		ASSERT_TIMELY (1s, i + 1 == node.active.recently_cemented.size ()); // done after a callback
 	}
 }
 }


### PR DESCRIPTION
`recently_cemented` is only changed in the conf height observer callbacks, after cementing. This is the intended behavior, but the test was intermittently failing under TSAN.

No failures after 100 runs.