### PR TITLE
Improve automatic frontiers confirmation

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1000,7 +1000,7 @@ TEST (confirmation_height, prioritize_frontiers)
 		transaction.refresh ();
 		node->active.prioritize_frontiers_for_confirmation (transaction, std::chrono::seconds (1), std::chrono::seconds (1));
 		ASSERT_TRUE (priority_orders_match (node->active.priority_wallet_cementable_frontiers, std::array<nano::account, num_accounts>{ key3.pub, nano::genesis_account, key4.pub, key1.pub, key2.pub }));
-		node->active.search_frontiers (transaction);
+		node->active.confirm_prioritized_frontiers (transaction);
 
 		// Check that the active transactions roots contains the frontiers
 		system.deadline_set (std::chrono::seconds (10));

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -283,7 +283,7 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
 	auto disabled_confirmation_mode = (node.config.frontiers_confirmation != nano::frontiers_confirmation_mode::disabled);
 	auto conf_height_capacity_reached = pending_confirmation_height_size < confirmed_frontiers_max_pending_size;
 	auto all_cemented = node.ledger.cache.block_count == node.ledger.cache.cemented_count;
-	if (!disabled_confirmation_mode && bootstrap_weight_reached && !conf_height_capacity_reached && !all_cemented);
+	if (!disabled_confirmation_mode && bootstrap_weight_reached && !conf_height_capacity_reached && !all_cemented)
 	{
 		// Spend some time prioritizing accounts with the most uncemented blocks to reduce voting traffic
 		auto request_interval = std::chrono::milliseconds (node.network_params.network.request_interval_ms);

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -280,8 +280,8 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
   	 */
 	auto pending_confirmation_height_size (confirmation_height_processor.awaiting_processing_size ());
 	auto bootstrap_weight_reached (node.ledger.cache.block_count >= node.ledger.bootstrap_weight_max_blocks);
-	auto disabled_confirmation_mode = (node.config.frontiers_confirmation != nano::frontiers_confirmation_mode::disabled);
-	auto conf_height_capacity_reached = pending_confirmation_height_size < confirmed_frontiers_max_pending_size;
+	auto disabled_confirmation_mode = (node.config.frontiers_confirmation == nano::frontiers_confirmation_mode::disabled);
+	auto conf_height_capacity_reached = pending_confirmation_height_size > confirmed_frontiers_max_pending_size;
 	auto all_cemented = node.ledger.cache.block_count == node.ledger.cache.cemented_count;
 	if (!disabled_confirmation_mode && bootstrap_weight_reached && !conf_height_capacity_reached && !all_cemented)
 	{

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -159,7 +159,7 @@ private:
 	nano::election_insertion_result insert_impl (std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
 	void request_loop ();
-	void search_frontiers (nano::transaction const &);
+	void confirm_prioritized_frontiers (nano::transaction const & transaction_a);
 	void request_confirm (nano::unique_lock<std::mutex> &);
 	nano::account next_frontier_account{ 0 };
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
@@ -204,7 +204,7 @@ private:
 	bool skip_wallets{ false };
 	void prioritize_account_for_confirmation (prioritize_num_uncemented &, size_t &, nano::account const &, nano::account_info const &, uint64_t);
 	static size_t constexpr max_priority_cementable_frontiers{ 100000 };
-	static size_t constexpr confirmed_frontiers_max_pending_cut_off{ 1000 };
+	static size_t constexpr confirmed_frontiers_max_pending_size{ 10000 };
 	std::deque<nano::block_hash> adjust_difficulty_list;
 	// clang-format off
 	using ordered_cache = boost::multi_index_container<nano::inactive_cache_information,

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -161,6 +161,7 @@ private:
 	void request_loop ();
 	void confirm_prioritized_frontiers (nano::transaction const & transaction_a);
 	void request_confirm (nano::unique_lock<std::mutex> &);
+	void frontiers_confirmation (nano::unique_lock<std::mutex> &);
 	nano::account next_frontier_account{ 0 };
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
 	nano::condition_variable condition;


### PR DESCRIPTION
- Time spent prioritising by uncemented blocks is done for a lower time (7ms in total by default) but more frequently (every request loop, once some constraints are met).
- Increased `confirmed_frontiers_max_pending_size` (previously named `confirmed_frontiers_max_pending_cut_off`) from 1000 to 10000. This allows buffer more in the conf height processor for processing.
- Separated an if statement in (the now named) `confirm_prioritized_frontiers` which can save a disk read in some circumstances.
- Renamed some functions/variables and added comments to better explain what is happening

During testing this in **automatic** frontiers confirmation mode on a non-pr node on the beta network using a `rel_time_next_frontier_check` of 10s a full cement took 2 hours (~20M blocks). using 30s it took 5 hours 20 minutes. This is what has been chosen as a good middle ground, on live this would translate to about 12 hours but isn't a linear transition so will likely take longer than that.