### PR TITLE
set timeout to 1hr to catch tests that hang

### DIFF
--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -1,0 +1,15 @@
+name: Static Analyzers
+
+on: [push, pull_request]
+
+jobs:
+  clang_format:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@50fbc62
+      - name: Get clang-format 8
+        env: 
+          DEBIAN_FRONTEND: noninteractive
+        run: sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 1000
+      - name: Clang Format
+        run: ci/check-commit-format.sh 

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -24,6 +24,7 @@ jobs:
 
   gcc_test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@722adc6
       - name: Checkout Submodules
@@ -35,6 +36,7 @@ jobs:
   
   clang_test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@722adc6
       - name: Checkout Submodules
@@ -46,6 +48,7 @@ jobs:
 
   windows_test:
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@722adc6
       - name: Checkout Submodules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,19 +20,9 @@ jobs:
       - name: Run Tests
         run: ci/build-travis.sh "/tmp/qt/lib/cmake/Qt5";
 
-  clang_format:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@50fbc62
-      - name: Get clang-format 8
-        env: 
-          DEBIAN_FRONTEND: noninteractive
-        run: sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 1000
-      - name: Clang Format
-        run: ci/check-commit-format.sh 
-
   gcc_test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@722adc6
       - name: Checkout Submodules
@@ -44,6 +34,7 @@ jobs:
   
   clang_test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@722adc6
       - name: Checkout Submodules
@@ -55,6 +46,7 @@ jobs:
 
   windows_test:
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@722adc6
       - name: Windows Defender


### PR DESCRIPTION
OSX excluded, setting appears to cause instability with test machines
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes