### PR TITLE
Move excluded_peers to network

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -423,8 +423,8 @@ TEST (bootstrap_processor, frontiers_unconfirmed)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	//Add single excluded peers record (2 records are required to drop peer)
-	node3->bootstrap_initiator.excluded_peers.add (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ()), 0);
-	ASSERT_FALSE (node3->bootstrap_initiator.excluded_peers.check (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ())));
+	node3->network.excluded_peers.add (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ()), 0);
+	ASSERT_FALSE (node3->network.excluded_peers.check (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ())));
 	node3->bootstrap_initiator.bootstrap (node1->network.endpoint ());
 	system.deadline_set (15s);
 	while (node3->bootstrap_initiator.in_progress ())
@@ -434,7 +434,7 @@ TEST (bootstrap_processor, frontiers_unconfirmed)
 	ASSERT_FALSE (node3->ledger.block_exists (send1->hash ()));
 	ASSERT_FALSE (node3->ledger.block_exists (open1->hash ()));
 	ASSERT_EQ (1, node3->stats.count (nano::stat::type::bootstrap, nano::stat::detail::frontier_confirmation_failed, nano::stat::dir::in)); // failed request from node1
-	ASSERT_TRUE (node3->bootstrap_initiator.excluded_peers.check (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ())));
+	ASSERT_TRUE (node3->network.excluded_peers.check (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ())));
 }
 
 TEST (bootstrap_processor, frontiers_confirmed)

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1052,3 +1052,44 @@ TEST (bandwidth_limiter, validate)
 	ASSERT_EQ (limiter_3.get_rate (), limiter_3.get_limit () + message_size);
 	ASSERT_LT (std::chrono::steady_clock::now () - 1s, start);
 }
+
+namespace nano
+{
+TEST (peer_exclusion, validate)
+{
+	nano::peer_exclusion excluded_peers;
+	size_t fake_peers_count = 10;
+	size_t max_size = fake_peers_count * excluded_peers.peers_percentage_limit;
+	auto address (boost::asio::ip::address_v6::loopback ());
+	for (auto i = 0; i < max_size + 2; ++i)
+	{
+		nano::tcp_endpoint endpoint (address, i);
+		ASSERT_FALSE (excluded_peers.check (endpoint));
+		ASSERT_EQ (1, excluded_peers.add (endpoint, fake_peers_count));
+		ASSERT_FALSE (excluded_peers.check (endpoint));
+	}
+	// The oldest one must have been removed
+	ASSERT_EQ (max_size + 1, excluded_peers.size ());
+	auto & peers_by_endpoint (excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ());
+	ASSERT_EQ (peers_by_endpoint.end (), peers_by_endpoint.find (nano::tcp_endpoint (address, 0)));
+
+	auto to_seconds = [](std::chrono::steady_clock::time_point const & timepoint) {
+		return std::chrono::duration_cast<std::chrono::seconds> (timepoint.time_since_epoch ()).count ();
+	};
+	nano::tcp_endpoint first (address, 1);
+	ASSERT_NE (peers_by_endpoint.end (), peers_by_endpoint.find (first));
+	nano::tcp_endpoint second (address, 2);
+	ASSERT_EQ (false, excluded_peers.check (second));
+	ASSERT_NEAR (to_seconds (std::chrono::steady_clock::now () + excluded_peers.exclude_time_hours), to_seconds (peers_by_endpoint.find (second)->exclude_until), 2);
+	ASSERT_EQ (2, excluded_peers.add (second, fake_peers_count));
+	ASSERT_EQ (peers_by_endpoint.end (), peers_by_endpoint.find (first));
+	ASSERT_NEAR (to_seconds (std::chrono::steady_clock::now () + excluded_peers.exclude_time_hours), to_seconds (peers_by_endpoint.find (second)->exclude_until), 2);
+	ASSERT_EQ (3, excluded_peers.add (second, fake_peers_count));
+	ASSERT_NEAR (to_seconds (std::chrono::steady_clock::now () + excluded_peers.exclude_time_hours * 3 * 2), to_seconds (peers_by_endpoint.find (second)->exclude_until), 2);
+	ASSERT_EQ (max_size, excluded_peers.size ());
+
+	// Clear many entries if there are a low number of peers
+	ASSERT_EQ (4, excluded_peers.add (second, 0));
+	ASSERT_EQ (1, excluded_peers.size ());
+}
+}

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1059,7 +1059,7 @@ TEST (peer_exclusion, validate)
 {
 	nano::peer_exclusion excluded_peers;
 	size_t fake_peers_count = 10;
-	size_t max_size = fake_peers_count * excluded_peers.peers_percentage_limit;
+	auto max_size = excluded_peers.limited_size (fake_peers_count);
 	auto address (boost::asio::ip::address_v6::loopback ());
 	for (auto i = 0; i < max_size + 2; ++i)
 	{

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1091,5 +1091,17 @@ TEST (peer_exclusion, validate)
 	// Clear many entries if there are a low number of peers
 	ASSERT_EQ (4, excluded_peers.add (second, 0));
 	ASSERT_EQ (1, excluded_peers.size ());
+
+	auto component (nano::collect_container_info (excluded_peers, ""));
+	auto composite (dynamic_cast<nano::container_info_composite *> (component.get ()));
+	ASSERT_NE (nullptr, component);
+	auto & children (composite->get_children ());
+	ASSERT_EQ (1, children.size ());
+	auto child_leaf (dynamic_cast<nano::container_info_leaf *> (children.front ().get ()));
+	ASSERT_NE (nullptr, child_leaf);
+	auto child_info (child_leaf->get_info ());
+	ASSERT_EQ ("peers", child_info.name);
+	ASSERT_EQ (1, child_info.count);
+	ASSERT_EQ (sizeof (decltype (excluded_peers.peers)::value_type), child_info.sizeof_element);
 }
 }

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -113,6 +113,8 @@ add_library (node
 	openclwork.cpp
 	payment_observer_processor.hpp
 	payment_observer_processor.cpp
+	peer_exclusion.hpp
+	peer_exclusion.cpp
 	portmapping.hpp
 	portmapping.cpp
 	node_pow_server_config.hpp

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -286,7 +286,6 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (bo
 {
 	size_t count;
 	size_t cache_count;
-	;
 	{
 		nano::lock_guard<std::mutex> guard (bootstrap_initiator.observers_mutex);
 		count = bootstrap_initiator.observers.size ();

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -64,38 +64,6 @@ public:
 	// clang-format on
 	constexpr static size_t cache_size_max = 10000;
 };
-class excluded_peers_item final
-{
-public:
-	std::chrono::steady_clock::time_point exclude_until;
-	nano::tcp_endpoint endpoint;
-	uint64_t score;
-};
-class bootstrap_excluded_peers final
-{
-public:
-	uint64_t add (nano::tcp_endpoint const &, size_t);
-	bool check (nano::tcp_endpoint const &);
-	void remove (nano::tcp_endpoint const &);
-	std::mutex excluded_peers_mutex;
-	class endpoint_tag
-	{
-	};
-	// clang-format off
-	boost::multi_index_container<nano::excluded_peers_item,
-	mi::indexed_by<
-		mi::ordered_non_unique<
-			mi::member<nano::excluded_peers_item, std::chrono::steady_clock::time_point, &nano::excluded_peers_item::exclude_until>>,
-		mi::hashed_unique<mi::tag<endpoint_tag>,
-			mi::member<nano::excluded_peers_item, nano::tcp_endpoint, &nano::excluded_peers_item::endpoint>>>>
-	peers;
-	// clang-format on
-	constexpr static size_t excluded_peers_size_max = 5000;
-	constexpr static double excluded_peers_percentage_limit = 0.5;
-	constexpr static uint64_t score_limit = 2;
-	constexpr static std::chrono::hours exclude_time_hours = std::chrono::hours (1);
-	constexpr static std::chrono::hours exclude_remove_hours = std::chrono::hours (24);
-};
 class bootstrap_attempts final
 {
 public:
@@ -130,7 +98,6 @@ public:
 	std::shared_ptr<nano::bootstrap_attempt> current_lazy_attempt ();
 	std::shared_ptr<nano::bootstrap_attempt> current_wallet_attempt ();
 	nano::pulls_cache cache;
-	nano::bootstrap_excluded_peers excluded_peers;
 	nano::bootstrap_attempts attempts;
 	void stop ();
 

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -317,8 +317,8 @@ void nano::bootstrap_attempt_legacy::attempt_restart_check (nano::unique_lock<st
 		if (!confirmed)
 		{
 			node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::frontier_confirmation_failed, nano::stat::dir::in);
-			auto score (node->bootstrap_initiator.excluded_peers.add (endpoint_frontier_request, node->network.size ()));
-			if (score >= nano::bootstrap_excluded_peers::score_limit)
+			auto score (node->network.excluded_peers.add (endpoint_frontier_request, node->network.size ()));
+			if (score >= nano::peer_exclusion::score_limit)
 			{
 				node->logger.always_log (boost::str (boost::format ("Adding peer %1% to excluded peers list with score %2% after %3% seconds bootstrap attempt") % endpoint_frontier_request % score % std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - attempt_start).count ()));
 			}

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<nano::bootstrap_client> nano::bootstrap_connections::connection 
 void nano::bootstrap_connections::pool_connection (std::shared_ptr<nano::bootstrap_client> client_a, bool new_client, bool push_front)
 {
 	nano::unique_lock<std::mutex> lock (mutex);
-	if (!stopped && !client_a->pending_stop && !node.bootstrap_initiator.excluded_peers.check (client_a->channel->get_tcp_endpoint ()))
+	if (!stopped && !client_a->pending_stop && !node.network.excluded_peers.check (client_a->channel->get_tcp_endpoint ()))
 	{
 		// Idle bootstrap client socket
 		if (auto socket_l = client_a->channel->socket.lock ())
@@ -284,7 +284,7 @@ void nano::bootstrap_connections::populate_connections (bool repeat)
 		for (auto i = 0u; i < delta; i++)
 		{
 			auto endpoint (node.network.bootstrap_peer (true));
-			if (endpoint != nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0) && (node.flags.allow_bootstrap_peers_duplicates || endpoints.find (endpoint) == endpoints.end ()) && !node.bootstrap_initiator.excluded_peers.check (endpoint))
+			if (endpoint != nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0) && (node.flags.allow_bootstrap_peers_duplicates || endpoints.find (endpoint) == endpoints.end ()) && !node.network.excluded_peers.check (endpoint))
 			{
 				connect_client (endpoint);
 				endpoints.insert (endpoint);

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -908,6 +908,11 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (ne
 	composite->add_component (network.tcp_channels.collect_container_info ("tcp_channels"));
 	composite->add_component (network.udp_channels.collect_container_info ("udp_channels"));
 	composite->add_component (network.syn_cookies.collect_container_info ("syn_cookies"));
+
+	size_t excluded_peers_count = network.excluded_peers.size ();
+	auto sizeof_excluded_peers_element = sizeof (nano::peer_exclusion::ordered_endpoints::value_type);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "excluded_peers", excluded_peers_count, sizeof_excluded_peers_element }));
+
 	return composite;
 }
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -908,11 +908,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (ne
 	composite->add_component (network.tcp_channels.collect_container_info ("tcp_channels"));
 	composite->add_component (network.udp_channels.collect_container_info ("udp_channels"));
 	composite->add_component (network.syn_cookies.collect_container_info ("syn_cookies"));
-
-	size_t excluded_peers_count = network.excluded_peers.size ();
-	auto sizeof_excluded_peers_element = sizeof (nano::peer_exclusion::ordered_endpoints::value_type);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "excluded_peers", excluded_peers_count, sizeof_excluded_peers_element }));
-
+	composite->add_component (collect_container_info (network.excluded_peers, "excluded_peers"));
 	return composite;
 }
 

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/node/common.hpp>
+#include <nano/node/peer_exclusion.hpp>
 #include <nano/node/transport/tcp.hpp>
 #include <nano/node/transport/udp.hpp>
 #include <nano/secure/network_filter.hpp>
@@ -154,6 +155,7 @@ public:
 	boost::asio::ip::udp::resolver resolver;
 	std::vector<boost::thread> packet_processing_threads;
 	nano::bandwidth_limiter limiter;
+	nano::peer_exclusion excluded_peers;
 	nano::node & node;
 	nano::network_filter publish_filter;
 	nano::transport::udp_channels udp_channels;

--- a/nano/node/peer_exclusion.cpp
+++ b/nano/node/peer_exclusion.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (na
 
 	size_t excluded_peers_count = excluded_peers.size ();
 	auto sizeof_excluded_peers_element = sizeof (nano::peer_exclusion::ordered_endpoints::value_type);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "excluded_peers", excluded_peers_count, sizeof_excluded_peers_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "peers", excluded_peers_count, sizeof_excluded_peers_element }));
 
 	return composite;
 }

--- a/nano/node/peer_exclusion.cpp
+++ b/nano/node/peer_exclusion.cpp
@@ -1,0 +1,76 @@
+#include <nano/node/peer_exclusion.hpp>
+
+constexpr std::chrono::hours nano::peer_exclusion::exclude_time_hours;
+constexpr std::chrono::hours nano::peer_exclusion::exclude_remove_hours;
+constexpr size_t nano::peer_exclusion::size_max;
+
+uint64_t nano::peer_exclusion::add (nano::tcp_endpoint const & endpoint_a, size_t const network_peers_count_a)
+{
+	uint64_t result (0);
+	nano::lock_guard<std::mutex> guard (mutex);
+	// Clean old excluded peers
+	while (peers.size () > 1 && peers.size () > std::min<size_t> (size_max, network_peers_count_a * peers_percentage_limit))
+	{
+		peers.get<tag_exclusion> ().erase (peers.get<tag_exclusion> ().begin ());
+	}
+	debug_assert (peers.size () <= size_max);
+	auto & peers_by_endpoint (peers.get<tag_endpoint> ());
+	auto existing (peers_by_endpoint.find (endpoint_a));
+	if (existing == peers_by_endpoint.end ())
+	{
+		// Insert new endpoint
+		auto inserted (peers.emplace (peer_exclusion::item{ std::chrono::steady_clock::steady_clock::now () + exclude_time_hours, endpoint_a, 1 }));
+		(void)inserted;
+		debug_assert (inserted.second);
+		result = 1;
+	}
+	else
+	{
+		// Update existing endpoint
+		peers_by_endpoint.modify (existing, [&result](peer_exclusion::item & item_a) {
+			++item_a.score;
+			result = item_a.score;
+			if (item_a.score == peer_exclusion::score_limit)
+			{
+				item_a.exclude_until = std::chrono::steady_clock::now () + peer_exclusion::exclude_time_hours;
+			}
+			else if (item_a.score > peer_exclusion::score_limit)
+			{
+				item_a.exclude_until = std::chrono::steady_clock::now () + peer_exclusion::exclude_time_hours * item_a.score * 2;
+			}
+		});
+	}
+	return result;
+}
+
+bool nano::peer_exclusion::check (nano::tcp_endpoint const & endpoint_a)
+{
+	bool excluded (false);
+	nano::lock_guard<std::mutex> guard (mutex);
+	auto & peers_by_endpoint (peers.get<tag_endpoint> ());
+	auto existing (peers_by_endpoint.find (endpoint_a));
+	if (existing != peers_by_endpoint.end () && existing->score >= score_limit)
+	{
+		if (existing->exclude_until > std::chrono::steady_clock::now ())
+		{
+			excluded = true;
+		}
+		else if (existing->exclude_until + exclude_remove_hours * existing->score < std::chrono::steady_clock::now ())
+		{
+			peers_by_endpoint.erase (existing);
+		}
+	}
+	return excluded;
+}
+
+void nano::peer_exclusion::remove (nano::tcp_endpoint const & endpoint_a)
+{
+	nano::lock_guard<std::mutex> guard (mutex);
+	peers.get<tag_endpoint> ().erase (endpoint_a);
+}
+
+size_t nano::peer_exclusion::size () const
+{
+	nano::lock_guard<std::mutex> guard (mutex);
+	return peers.size ();
+}

--- a/nano/node/peer_exclusion.cpp
+++ b/nano/node/peer_exclusion.cpp
@@ -81,3 +81,14 @@ size_t nano::peer_exclusion::size () const
 	nano::lock_guard<std::mutex> guard (mutex);
 	return peers.size ();
 }
+
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::peer_exclusion const & excluded_peers, const std::string & name)
+{
+	auto composite = std::make_unique<container_info_composite> (name);
+
+	size_t excluded_peers_count = excluded_peers.size ();
+	auto sizeof_excluded_peers_element = sizeof (nano::peer_exclusion::ordered_endpoints::value_type);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "excluded_peers", excluded_peers_count, sizeof_excluded_peers_element }));
+
+	return composite;
+}

--- a/nano/node/peer_exclusion.hpp
+++ b/nano/node/peer_exclusion.hpp
@@ -1,0 +1,56 @@
+#include <nano/node/common.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+namespace mi = boost::multi_index;
+
+namespace nano
+{
+class peer_exclusion final
+{
+	class item final
+	{
+	public:
+		item () = delete;
+		std::chrono::steady_clock::time_point exclude_until;
+		nano::tcp_endpoint endpoint;
+		uint64_t score;
+	};
+
+	// clang-format off
+	class tag_endpoint {};
+	class tag_exclusion {};
+	// clang-format on
+
+public:
+	// clang-format off
+	using ordered_endpoints = boost::multi_index_container<peer_exclusion::item,
+	mi::indexed_by<
+		mi::ordered_non_unique<mi::tag<tag_exclusion>,
+			mi::member<peer_exclusion::item, std::chrono::steady_clock::time_point, &peer_exclusion::item::exclude_until>>,
+		mi::hashed_unique<mi::tag<tag_endpoint>,
+			mi::member<peer_exclusion::item, nano::tcp_endpoint, &item::endpoint>>>>;
+	// clang-format on
+
+private:
+	ordered_endpoints peers;
+	mutable std::mutex mutex;
+
+public:
+	constexpr static size_t size_max = 5000;
+	constexpr static double peers_percentage_limit = 0.5;
+	constexpr static uint64_t score_limit = 2;
+	constexpr static std::chrono::hours exclude_time_hours = std::chrono::hours (1);
+	constexpr static std::chrono::hours exclude_remove_hours = std::chrono::hours (24);
+
+	uint64_t add (nano::tcp_endpoint const &, size_t const);
+	bool check (nano::tcp_endpoint const &);
+	void remove (nano::tcp_endpoint const &);
+	size_t size () const;
+
+	friend class peer_exclusion_validate_Test;
+};
+}

--- a/nano/node/peer_exclusion.hpp
+++ b/nano/node/peer_exclusion.hpp
@@ -54,4 +54,5 @@ public:
 
 	friend class peer_exclusion_validate_Test;
 };
+std::unique_ptr<container_info_component> collect_container_info (peer_exclusion const & excluded_peers, const std::string & name);
 }

--- a/nano/node/peer_exclusion.hpp
+++ b/nano/node/peer_exclusion.hpp
@@ -49,6 +49,7 @@ public:
 	uint64_t add (nano::tcp_endpoint const &, size_t const);
 	bool check (nano::tcp_endpoint const &);
 	void remove (nano::tcp_endpoint const &);
+	size_t limited_size (size_t const) const;
 	size_t size () const;
 
 	friend class peer_exclusion_validate_Test;


### PR DESCRIPTION
Moves peer exclusion code into its own headers, moves the object from bootstrap initiator to network, some general cleanup and adds a validation test.