### PR TITLE
Fix qt test wallet.seed_work_generation

### DIFF
--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -727,7 +727,7 @@ TEST (wallet, seed_work_generation)
 		ASSERT_NO_ERROR (ec);
 	}
 	auto transaction (system.nodes[0]->store.tx_begin_read ());
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), nano::work_threshold_base (nano::work_version::work_1));
+	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), system.nodes[0]->default_difficulty (nano::work_version::work_1));
 }
 
 TEST (wallet, backup_seed)


### PR DESCRIPTION
Missed this test in recent updates, saw failing in CI due the node targetting internally a lower difficulty.