### PR TITLE
Remove assert if a delayed work cache request is not found

### DIFF
--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1266,15 +1266,6 @@ void nano::wallet::work_ensure (nano::account const & account_a, nano::root cons
 				wallet_a.work_cache_blocking (account_a, root_a);
 			});
 		}
-		else if (existing == delayed_work->end ())
-		{
-			this_l->wallets.node.logger.always_log ("Error caching work for account ", account_a.to_account ());
-			debug_assert (false);
-		}
-		else
-		{
-			// Scheduled work was replaced by another root, no action to be done
-		}
 	});
 }
 


### PR DESCRIPTION
In https://github.com/nanocurrency/nano-node/pull/2680 I erased from `delayed_work` in `wallet::action_complete` to prevent queueing an outdated request, but this can make it assert when the request is not found later. Removing the assert is enough as the default action is to not do anything about it, which is correct.