### PR TITLE
[TSAN] start_time data race in bootstrap_client

### DIFF
--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -241,7 +241,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 			}
 			if (connection->block_count++ == 0)
 			{
-				connection->start_time = std::chrono::steady_clock::now ();
+				connection->set_start_time (std::chrono::steady_clock::now ());
 			}
 			attempt->total_blocks++;
 			bool stop_pull (attempt->process_block (block, known_account, pull_blocks, pull.count, block_expected, pull.retry_limit));

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -19,7 +19,7 @@ connections (connections_a),
 channel (channel_a),
 socket (socket_a),
 receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
-start_time (std::chrono::steady_clock::now ())
+start_time_m (std::chrono::steady_clock::now ())
 {
 	++connections->connections_count;
 	receive_buffer->resize (256);
@@ -36,9 +36,16 @@ double nano::bootstrap_client::block_rate () const
 	return static_cast<double> (block_count.load () / elapsed);
 }
 
+void nano::bootstrap_client::set_start_time (std::chrono::steady_clock::time_point start_time_a)
+{
+	nano::lock_guard<std::mutex> guard (start_time_mutex);
+	start_time_m = start_time_a;
+}
+
 double nano::bootstrap_client::elapsed_seconds () const
 {
-	return std::chrono::duration_cast<std::chrono::duration<double>> (std::chrono::steady_clock::now () - start_time).count ();
+	nano::lock_guard<std::mutex> guard (start_time_mutex);
+	return std::chrono::duration_cast<std::chrono::duration<double>> (std::chrono::steady_clock::now () - start_time_m).count ();
 }
 
 void nano::bootstrap_client::stop (bool force)

--- a/nano/node/bootstrap/bootstrap_connections.hpp
+++ b/nano/node/bootstrap/bootstrap_connections.hpp
@@ -26,15 +26,19 @@ public:
 	void stop (bool force);
 	double block_rate () const;
 	double elapsed_seconds () const;
+	void set_start_time (std::chrono::steady_clock::time_point start_time_a);
 	std::shared_ptr<nano::node> node;
 	std::shared_ptr<nano::bootstrap_connections> connections;
 	std::shared_ptr<nano::transport::channel_tcp> channel;
 	std::shared_ptr<nano::socket> socket;
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;
-	std::chrono::steady_clock::time_point start_time;
 	std::atomic<uint64_t> block_count{ 0 };
 	std::atomic<bool> pending_stop{ false };
 	std::atomic<bool> hard_stop{ false };
+
+private:
+	mutable std::mutex start_time_mutex;
+	std::chrono::steady_clock::time_point start_time_m;
 };
 
 class bootstrap_connections final : public std::enable_shared_from_this<bootstrap_connections>


### PR DESCRIPTION
Hit this TSAN error on a recent spam test on beta (clang/linux):
https://gist.github.com/wezrule/eaf9b7ffd5ad3c2958c7e64448af0e78

Seems like protecting `start_time` is the appropriate step (`time_point` can't be atomic, at least in C++14). Not sure if that provides enough granularity but everything else is `std::atomic` so it seems sufficient.