### PR TITLE
Fix qt tests failing to click radio buttons

### DIFF
--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -420,7 +420,7 @@ TEST (wallet, create_open_receive)
 	ASSERT_EQ (nano::process_result::old, system.nodes[0]->process (open).code);
 	wallet->block_creation.block->clear ();
 	wallet->block_creation.source->clear ();
-	QTest::mouseClick (wallet->block_creation.receive, Qt::LeftButton);
+	wallet->block_creation.receive->click ();
 	QTest::keyClicks (wallet->block_creation.source, latest2.to_string ().c_str ());
 	QTest::mouseClick (wallet->block_creation.create, Qt::LeftButton);
 	std::string json2 (wallet->block_creation.block->toPlainText ().toStdString ());
@@ -447,10 +447,10 @@ TEST (wallet, create_change)
 	wallet->client_window->show ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	QTest::mouseClick (wallet->advanced.create_block, Qt::LeftButton);
-	QTest::mouseClick (wallet->block_creation.change, Qt::LeftButton);
+	wallet->block_creation.change->click ();
 	QTest::keyClicks (wallet->block_creation.account, nano::test_genesis_key.pub.to_account ().c_str ());
 	QTest::keyClicks (wallet->block_creation.representative, key.pub.to_account ().c_str ());
-	QTest::mouseClick (wallet->block_creation.create, Qt::LeftButton);
+	wallet->block_creation.create->click ();
 	std::string json (wallet->block_creation.block->toPlainText ().toStdString ());
 	ASSERT_FALSE (json.empty ());
 	boost::property_tree::ptree tree1;


### PR DESCRIPTION
Mouse clicks from the QTest library are not registering on radio buttons in more than one version of QT (confirmed by @argakiig), though they do work on CI. This change bypasses the testing library by calling the click action directly.