### PR TITLE
Ensure max_work_generate_difficulty is updated when changing the default difficulty

### DIFF
--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -55,7 +55,6 @@ TEST (distributed_work, no_peers_cancel)
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.max_work_generate_multiplier = 1e6;
-	node_config.max_work_generate_difficulty = nano::difficulty::from_multiplier (node_config.max_work_generate_multiplier, nano::network_constants ().publish_thresholds.base);
 	auto & node = *system.add_node (node_config);
 	nano::block_hash hash{ 1 };
 	bool done{ false };

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3727,6 +3727,22 @@ TEST (node, aggressive_flooding)
 	ASSERT_EQ (1 + 2 * nodes_wallets.size () + 2, node1.ledger.cache.block_count);
 }
 
+// Tests that upon changing the default difficulty, max generation difficulty changes proportionally
+TEST (node, max_work_generate_difficulty)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.max_work_generate_multiplier = 2.0;
+	auto & node = *system.add_node (node_config);
+	auto initial_difficulty = node.default_difficulty (nano::work_version::work_1);
+	ASSERT_EQ (node.max_work_generate_difficulty (nano::work_version::work_1), nano::difficulty::from_multiplier (node.config.max_work_generate_multiplier, initial_difficulty));
+	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_1));
+	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_2));
+	auto final_difficulty = node.default_difficulty (nano::work_version::work_1);
+	ASSERT_NE (final_difficulty, initial_difficulty);
+	ASSERT_EQ (node.max_work_generate_difficulty (nano::work_version::work_1), nano::difficulty::from_multiplier (node.config.max_work_generate_multiplier, final_difficulty));
+}
+
 TEST (active_difficulty, recalculate_work)
 {
 	nano::system system;

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1164,7 +1164,7 @@ TEST (wallet, work_watcher_update)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	node_config.work_watcher_period = 1s;
-	node_config.max_work_generate_difficulty = std::numeric_limits<uint64_t>::max ();
+	node_config.max_work_generate_multiplier = 1e6;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto & node = *system.add_node (node_config, node_flags);
@@ -1273,7 +1273,6 @@ TEST (wallet, work_watcher_cancel)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.work_watcher_period = 1s;
 	node_config.max_work_generate_multiplier = 1e6;
-	node_config.max_work_generate_difficulty = nano::difficulty::from_multiplier (node_config.max_work_generate_multiplier, nano::network_constants ().publish_thresholds.base);
 	node_config.enable_voting = false;
 	auto & node = *system.add_node (node_config);
 	auto & wallet (*system.wallet (0));
@@ -1323,7 +1322,7 @@ TEST (wallet, limited_difficulty)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
-	node_config.max_work_generate_difficulty = nano::network_constants ().publish_thresholds.base;
+	node_config.max_work_generate_multiplier = 1;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto & node = *system.add_node (node_config, node_flags);
@@ -1338,7 +1337,7 @@ TEST (wallet, limited_difficulty)
 		nano::lock_guard<std::mutex> guard (node.active.mutex);
 		node.active.trended_active_difficulty = std::numeric_limits<uint64_t>::max ();
 	}
-	ASSERT_EQ (node_config.max_work_generate_difficulty, node.active.limited_active_difficulty ());
+	ASSERT_EQ (node.max_work_generate_difficulty (nano::work_version::work_1), node.active.limited_active_difficulty ());
 	auto send = wallet.send_action (nano::test_genesis_key.pub, nano::keypair ().pub, 1, 1);
 	ASSERT_NE (nullptr, send);
 }

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -795,7 +795,7 @@ uint64_t nano::active_transactions::active_difficulty ()
 
 uint64_t nano::active_transactions::limited_active_difficulty ()
 {
-	return std::min (active_difficulty (), node.config.max_work_generate_difficulty);
+	return std::min (active_difficulty (), node.max_work_generate_difficulty (nano::work_version::work_1));
 }
 
 // List of active blocks in elections

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4953,7 +4953,7 @@ void nano::json_handler::work_generate ()
 		auto hash (hash_impl ());
 		auto difficulty (difficulty_optional_impl (work_version));
 		multiplier_optional_impl (work_version, difficulty);
-		if (!ec && (difficulty > node.config.max_work_generate_difficulty || difficulty < nano::work_threshold_entry (work_version)))
+		if (!ec && (difficulty > node.max_work_generate_difficulty (work_version) || difficulty < nano::work_threshold_entry (work_version)))
 		{
 			ec = nano::error_rpc::difficulty_limit;
 		}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1018,6 +1018,11 @@ uint64_t nano::node::default_difficulty (nano::work_version const version_a) con
 	return result;
 }
 
+uint64_t nano::node::max_work_generate_difficulty (nano::work_version const version_a) const
+{
+	return nano::difficulty::from_multiplier (config.max_work_generate_multiplier, default_difficulty (version_a));
+}
+
 bool nano::node::local_work_generation_enabled () const
 {
 	return config.work_threads > 0 || work.opencl;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -128,6 +128,7 @@ public:
 	int price (nano::uint128_t const &, int);
 	// The default difficulty updates to base only when the first epoch_2 block is processed
 	uint64_t default_difficulty (nano::work_version const) const;
+	uint64_t max_work_generate_difficulty (nano::work_version const) const;
 	bool local_work_generation_enabled () const;
 	bool work_generation_enabled () const;
 	bool work_generation_enabled (std::vector<std::pair<std::string, uint16_t>> const &) const;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -35,7 +35,6 @@ external_address (boost::asio::ip::address_v6{}.to_string ())
 	{
 		peering_port = network_params.network.default_node_port;
 	}
-	max_work_generate_difficulty = nano::difficulty::from_multiplier (max_work_generate_multiplier, network_params.network.publish_thresholds.base);
 	switch (network_params.network.network ())
 	{
 		case nano::nano_networks::nano_test_network:
@@ -361,7 +360,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 
 		nano::network_constants network;
 		toml.get<double> ("max_work_generate_multiplier", max_work_generate_multiplier);
-		max_work_generate_difficulty = nano::difficulty::from_multiplier (max_work_generate_multiplier, network.publish_thresholds.base);
 
 		toml.get<uint32_t> ("max_queued_requests", max_queued_requests);
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -98,7 +98,6 @@ public:
 	bool backup_before_upgrade{ false };
 	std::chrono::seconds work_watcher_period{ std::chrono::seconds (5) };
 	double max_work_generate_multiplier{ 64. };
-	uint64_t max_work_generate_difficulty{ nano::network_constants ().publish_full.base };
 	uint32_t max_queued_requests{ 512 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1152,7 +1152,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 		if (block_a->difficulty () < required_difficulty)
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));
-			debug_assert (required_difficulty <= wallets.node.config.max_work_generate_difficulty);
+			debug_assert (required_difficulty <= wallets.node.max_work_generate_difficulty (block_a->work_version ()));
 			auto target_difficulty = std::max (required_difficulty, wallets.node.active.limited_active_difficulty ());
 			error = !wallets.node.work_generate_blocking (*block_a, target_difficulty).is_initialized ();
 		}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2953,9 +2953,7 @@ TEST (rpc, work_generate)
 TEST (rpc, work_generate_difficulty)
 {
 	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
-	node_config.max_work_generate_difficulty = 0xffff000000000000;
-	auto node = add_ipc_enabled_node (system, node_config);
+	auto node = add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -3008,7 +3006,7 @@ TEST (rpc, work_generate_difficulty)
 		ASSERT_GE (result_difficulty, difficulty);
 	}
 	{
-		uint64_t difficulty (node->config.max_work_generate_difficulty + 1);
+		uint64_t difficulty (node->max_work_generate_difficulty (nano::work_version::work_1) + 1);
 		request.put ("difficulty", nano::to_string_hex (difficulty));
 		test_response response (request, rpc.config.port, system.io_ctx);
 		system.deadline_set (5s);
@@ -3026,7 +3024,6 @@ TEST (rpc, work_generate_multiplier)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
-	node_config.max_work_generate_difficulty = 0xfffff00000000000;
 	auto node = add_ipc_enabled_node (system, node_config);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -3082,7 +3079,7 @@ TEST (rpc, work_generate_multiplier)
 		ASSERT_EQ (response.json.get<std::string> ("error"), ec.message ());
 	}
 	{
-		double max_multiplier (nano::difficulty::to_multiplier (node->config.max_work_generate_difficulty, node->default_difficulty (nano::work_version::work_1)));
+		double max_multiplier (nano::difficulty::to_multiplier (node->max_work_generate_difficulty (nano::work_version::work_1), node->default_difficulty (nano::work_version::work_1)));
 		request.put ("multiplier", max_multiplier + 1);
 		test_response response (request, rpc.config.port, system.io_ctx);
 		system.deadline_set (5s);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1856,6 +1856,7 @@ TEST (rpc, process_block_with_work_watcher)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	node_config.work_watcher_period = 1s;
+	node_config.max_work_generate_multiplier = 1e6;
 	auto & node1 = *add_ipc_enabled_node (system, node_config);
 	nano::keypair key;
 	auto latest (node1.latest (nano::test_genesis_key.pub));
@@ -2953,7 +2954,9 @@ TEST (rpc, work_generate)
 TEST (rpc, work_generate_difficulty)
 {
 	nano::system system;
-	auto node = add_ipc_enabled_node (system);
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.max_work_generate_multiplier = 1000;
+	auto node = add_ipc_enabled_node (system, node_config);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -3024,6 +3027,7 @@ TEST (rpc, work_generate_multiplier)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.max_work_generate_multiplier = 100;
 	auto node = add_ipc_enabled_node (system, node_config);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;


### PR DESCRIPTION
Moves `max_work_generate_difficulty` out of config and into the node class, now calculated on the fly since it's rarely used.

`limited_active_difficulty` must be updated once #2691 is in.