### PR TITLE
Prevent more rare deadlocks due to races for condition variables

### DIFF
--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -146,7 +146,7 @@ void nano::bootstrap_initiator::run_bootstrap ()
 			}
 			lock.lock ();
 		}
-		else if (!stopped)
+		else
 		{
 			condition.wait (lock);
 		}

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -146,7 +146,7 @@ void nano::bootstrap_initiator::run_bootstrap ()
 			}
 			lock.lock ();
 		}
-		else
+		else if (!stopped)
 		{
 			condition.wait (lock);
 		}
@@ -257,8 +257,10 @@ void nano::bootstrap_initiator::stop_attempts ()
 
 void nano::bootstrap_initiator::stop ()
 {
+	nano::unique_lock<std::mutex> lock (mutex);
 	if (!stopped.exchange (true))
 	{
+		lock.unlock ();
 		stop_attempts ();
 		connections->stop ();
 		condition.notify_all ();

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -257,10 +257,8 @@ void nano::bootstrap_initiator::stop_attempts ()
 
 void nano::bootstrap_initiator::stop ()
 {
-	nano::unique_lock<std::mutex> lock (mutex);
 	if (!stopped.exchange (true))
 	{
-		lock.unlock ();
 		stop_attempts ();
 		connections->stop ();
 		condition.notify_all ();

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -70,7 +70,7 @@ bool nano::bootstrap_attempt::still_pulling ()
 	return running && still_pulling;
 }
 
-bool nano::bootstrap_attempt::pull_started ()
+void nano::bootstrap_attempt::pull_started ()
 {
 	{
 		nano::lock_guard<std::mutex> guard (mutex);
@@ -79,7 +79,7 @@ bool nano::bootstrap_attempt::pull_started ()
 	condition.notify_all ();
 }
 
-bool nano::bootstrap_attempt::pull_finished ()
+void nano::bootstrap_attempt::pull_finished ()
 {
 	{
 		nano::lock_guard<std::mutex> guard (mutex);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -70,6 +70,24 @@ bool nano::bootstrap_attempt::still_pulling ()
 	return running && still_pulling;
 }
 
+bool nano::bootstrap_attempt::pull_started ()
+{
+	{
+		nano::lock_guard<std::mutex> guard (mutex);
+		++pulling;
+	}
+	condition.notify_all ();
+}
+
+bool nano::bootstrap_attempt::pull_finished ()
+{
+	{
+		nano::lock_guard<std::mutex> guard (mutex);
+		--pulling;
+	}
+	condition.notify_all ();
+}
+
 void nano::bootstrap_attempt::stop ()
 {
 	{
@@ -517,8 +535,8 @@ bool nano::bootstrap_attempt_legacy::request_frontier (nano::unique_lock<std::mu
 				auto pull (frontier_pulls.front ());
 				lock_a.unlock ();
 				node->bootstrap_initiator.connections->add_pull (pull);
-				++pulling;
 				lock_a.lock ();
+				++pulling;
 				frontier_pulls.pop_front ();
 			}
 		}

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -20,6 +20,8 @@ public:
 	virtual void run () = 0;
 	virtual void stop ();
 	bool still_pulling ();
+	bool pull_started ();
+	bool pull_finished ();
 	bool should_log ();
 	std::string mode_text ();
 	virtual void restart_condition ();

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -20,8 +20,8 @@ public:
 	virtual void run () = 0;
 	virtual void stop ();
 	bool still_pulling ();
-	bool pull_started ();
-	bool pull_finished ();
+	void pull_started ();
+	void pull_finished ();
 	bool should_log ();
 	std::string mode_text ();
 	virtual void restart_condition ();

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -50,8 +50,7 @@ nano::bulk_pull_client::~bulk_pull_client ()
 	{
 		connection->node->bootstrap_initiator.cache.remove (pull);
 	}
-	--attempt->pulling;
-	attempt->condition.notify_all ();
+	attempt->pull_finished ();
 }
 
 void nano::bulk_pull_client::request ()
@@ -292,8 +291,7 @@ pull_blocks (0)
 
 nano::bulk_pull_account_client::~bulk_pull_account_client ()
 {
-	--attempt->pulling;
-	attempt->condition.notify_all ();
+	attempt->pull_finished ();
 }
 
 void nano::bulk_pull_account_client::request ()


### PR DESCRIPTION
`pulling` is checked before some `condition.wait` meaning it must be modified while holding the mutex. The same for `new_connections_empty`.

I took a look through all condition variables in the node (not tests) and these were the only remaining as far as I could grasp.