### PR TITLE
Ensure propagation and removal for the work watcher

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1269,7 +1269,9 @@ TEST (work_watcher, removed_after_win)
 	auto & wallet (*system.wallet (0));
 	wallet.insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key;
+	ASSERT_EQ (0, wallet.wallets.watcher->size ());
 	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	ASSERT_EQ (1, wallet.wallets.watcher->size ());
 	system.deadline_set (5s);
 	while (node.wallets.watcher->is_watched (block1->qualified_root ()))
 	{
@@ -1345,27 +1347,6 @@ TEST (work_watcher, generation_disabled)
 	}
 	ASSERT_EQ (updated_multiplier, multiplier);
 	ASSERT_TRUE (node.distributed_work.items.empty ());
-}
-
-TEST (work_watcher, removed)
-{
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
-	node_config.work_watcher_period = 1s;
-	auto & node = *system.add_node (node_config);
-	(void)node;
-	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
-	nano::keypair key;
-	ASSERT_EQ (0, wallet.wallets.watcher->size ());
-	auto const block (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
-	ASSERT_EQ (1, wallet.wallets.watcher->size ());
-	auto transaction (wallet.wallets.tx_begin_write ());
-	system.deadline_set (3s);
-	while (0 == wallet.wallets.watcher->size ())
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
 }
 
 TEST (work_watcher, cancel)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1158,7 +1158,7 @@ TEST (wallet, deterministic_restore)
 	ASSERT_TRUE (wallet->exists (pub));
 }
 
-TEST (wallet, work_watcher_update)
+TEST (work_watcher, update)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
@@ -1206,7 +1206,106 @@ TEST (wallet, work_watcher_update)
 	ASSERT_GT (updated_multiplier2, multiplier2);
 }
 
-TEST (wallet, work_watcher_generation_disabled)
+TEST (work_watcher, propagate)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.enable_voting = false;
+	node_config.work_watcher_period = 1s;
+	nano::node_flags node_flags;
+	node_flags.disable_request_loop = true;
+	auto & node = *system.add_node (node_config, node_flags);
+	auto & wallet (*system.wallet (0));
+	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	node_config.peering_port = nano::get_available_port ();
+	auto & node_passive = *system.add_node (node_config);
+	nano::keypair key;
+	auto const block (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	system.deadline_set (5s);
+	while (!node_passive.ledger.block_exists (block->hash ()))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	auto const multiplier (nano::normalized_multiplier (nano::difficulty::to_multiplier (block->difficulty (), nano::work_threshold (block->work_version (), nano::block_details (nano::epoch::epoch_0, false, false, false))), node.network_params.network.publish_thresholds.epoch_1));
+	auto updated_multiplier{ multiplier };
+	auto propagated_multiplier{ multiplier };
+	{
+		nano::lock_guard<std::mutex> guard (node.active.mutex);
+		node.active.trended_active_multiplier = multiplier * 1.001;
+	}
+	bool updated{ false };
+	bool propagated{ false };
+	system.deadline_set (10s);
+	while (!(updated && propagated))
+	{
+		{
+			nano::lock_guard<std::mutex> guard (node.active.mutex);
+			{
+				auto const existing (node.active.roots.find (block->qualified_root ()));
+				ASSERT_NE (existing, node.active.roots.end ());
+				updated_multiplier = existing->multiplier;
+			}
+		}
+		{
+			nano::lock_guard<std::mutex> guard (node_passive.active.mutex);
+			{
+				auto const existing (node_passive.active.roots.find (block->qualified_root ()));
+				ASSERT_NE (existing, node_passive.active.roots.end ());
+				propagated_multiplier = existing->multiplier;
+			}
+		}
+		updated = updated_multiplier != multiplier;
+		propagated = propagated_multiplier != multiplier;
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_GT (updated_multiplier, multiplier);
+	ASSERT_EQ (propagated_multiplier, updated_multiplier);
+}
+
+TEST (work_watcher, removed_after_win)
+{
+	nano::system system (1);
+	auto & node (*system.nodes[0]);
+	auto & wallet (*system.wallet (0));
+	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	system.deadline_set (5s);
+	while (node.wallets.watcher->is_watched (block1->qualified_root ()))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (0, node.wallets.watcher->size ());
+}
+
+TEST (work_watcher, removed_after_lose)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.enable_voting = false;
+	node_config.work_watcher_period = 1s;
+	auto & node = *system.add_node (node_config);
+	auto & wallet (*system.wallet (0));
+	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	nano::keypair key;
+	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	ASSERT_TRUE (node.wallets.watcher->is_watched (block1->qualified_root ()));
+	nano::genesis genesis;
+	auto fork1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	node.process_active (fork1);
+	node.block_processor.flush ();
+	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, fork1));
+	nano::confirm_ack message (vote);
+	node.network.process_message (message, nullptr);
+	system.deadline_set (5s);
+	while (node.wallets.watcher->is_watched (block1->qualified_root ()))
+	{
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_EQ (0, node.wallets.watcher->size ());
+}
+
+TEST (work_watcher, generation_disabled)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
@@ -1248,7 +1347,7 @@ TEST (wallet, work_watcher_generation_disabled)
 	ASSERT_TRUE (node.distributed_work.items.empty ());
 }
 
-TEST (wallet, work_watcher_removed)
+TEST (work_watcher, removed)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
@@ -1269,7 +1368,7 @@ TEST (wallet, work_watcher_removed)
 	}
 }
 
-TEST (wallet, work_watcher_cancel)
+TEST (work_watcher, cancel)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -242,7 +242,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 				for (auto & i : rollback_list)
 				{
 					node.votes_cache.remove (i->hash ());
-					node.wallets.watcher->remove (i);
+					node.wallets.watcher->remove (*i);
 					// Stop all rolled back active transactions except initial
 					if (i->hash () != successor->hash ())
 					{

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -292,7 +292,7 @@ void nano::system::generate_rollback (nano::node & node_a, std::vector<nano::acc
 			debug_assert (!error);
 			for (auto & i : rollback_list)
 			{
-				node_a.wallets.watcher->remove (i);
+				node_a.wallets.watcher->remove (*i);
 				node_a.active.erase (*i);
 			}
 		}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1471,20 +1471,23 @@ void nano::work_watcher::watching (nano::qualified_root const & root_a, std::sha
 			{
 				watcher_l->node.work_generate (
 				block_a->work_version (), block_a->root (), active_difficulty, [watcher_l, block_a, root_a](boost::optional<uint64_t> work_a) {
-					if (work_a.is_initialized ())
+					if (watcher_l->is_watched (root_a))
 					{
-						debug_assert (nano::work_difficulty (block_a->work_version (), block_a->root (), *work_a) > block_a->difficulty ());
-						nano::state_block_builder builder;
-						std::error_code ec;
-						std::shared_ptr<nano::state_block> block (builder.from (*block_a).work (*work_a).build (ec));
-						if (!ec)
+						if (work_a.is_initialized ())
 						{
-							watcher_l->node.network.flood_block_initial (block);
-							watcher_l->node.active.update_difficulty (block);
-							watcher_l->update (root_a, block);
+							debug_assert (nano::work_difficulty (block_a->work_version (), block_a->root (), *work_a) > block_a->difficulty ());
+							nano::state_block_builder builder;
+							std::error_code ec;
+							std::shared_ptr<nano::state_block> block (builder.from (*block_a).work (*work_a).build (ec));
+							if (!ec)
+							{
+								watcher_l->node.network.flood_block_initial (block);
+								watcher_l->node.active.update_difficulty (block);
+								watcher_l->update (root_a, block);
+							}
 						}
+						watcher_l->watching (root_a, block_a);
 					}
-					watcher_l->watching (root_a, block_a);
 				},
 				block_a->account ());
 			}

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -174,7 +174,7 @@ public:
 	void add (std::shared_ptr<nano::block>);
 	void update (nano::qualified_root const &, std::shared_ptr<nano::state_block>);
 	void watching (nano::qualified_root const &, std::shared_ptr<nano::state_block>);
-	void remove (std::shared_ptr<nano::block>);
+	void remove (nano::block const &);
 	bool is_watched (nano::qualified_root const &);
 	size_t size ();
 	std::mutex mutex;


### PR DESCRIPTION
- Allow removing a block by its root, even if the hash does not match
- Simplify (1 less indent level) `work_watcher::watching`
- Test suite ensuring removal and propagation of updated block in different conditions