### PR TITLE
Optional randomized mode for local work generation

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -183,6 +183,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.vote_minimum, defaults.node.vote_minimum);
 	ASSERT_EQ (conf.node.work_peers, defaults.node.work_peers);
 	ASSERT_EQ (conf.node.work_threads, defaults.node.work_threads);
+	ASSERT_EQ (conf.node.work_shuffle_queue, defaults.node.work_shuffle_queue);
 	ASSERT_EQ (conf.node.max_queued_requests, defaults.node.max_queued_requests);
 
 	ASSERT_EQ (conf.node.logging.bulk_pull_logging_value, defaults.node.logging.bulk_pull_logging_value);
@@ -425,6 +426,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	vote_minimum = "999"
 	work_peers = ["test.org:999"]
 	work_threads = 999
+	work_shuffle_queue = true
 	work_watcher_period = 999
 	max_work_generate_multiplier = 1.0
 	max_queued_requests = 999
@@ -596,6 +598,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.vote_minimum, defaults.node.vote_minimum);
 	ASSERT_NE (conf.node.work_peers, defaults.node.work_peers);
 	ASSERT_NE (conf.node.work_threads, defaults.node.work_threads);
+	ASSERT_NE (conf.node.work_shuffle_queue, defaults.node.work_shuffle_queue);
 	ASSERT_NE (conf.node.max_queued_requests, defaults.node.max_queued_requests);
 
 	ASSERT_NE (conf.node.logging.bulk_pull_logging_value, defaults.node.logging.bulk_pull_logging_value);

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -370,7 +370,7 @@ void nano::work_pool::stop ()
 void nano::work_pool::generate (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::function<void(boost::optional<uint64_t> const &)> callback_a)
 {
 	debug_assert (!root_a.is_zero ());
-	if (!threads.empty ())
+	if (!done && !threads.empty ())
 	{
 		{
 			nano::lock_guard<std::mutex> lock (mutex);

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -50,7 +50,6 @@ public:
 	version (version_a), item (item_a), difficulty (difficulty_a), callback (callback_a)
 	{
 	}
-	work_item operator= (nano::work_item const &);
 	nano::work_version const version;
 	nano::root const item;
 	uint64_t const difficulty;
@@ -78,10 +77,10 @@ public:
 	size_t size ();
 	nano::network_constants network_constants;
 	std::atomic<int> ticket;
-	boost::optional<nano::work_item> current;
 	bool done;
 	std::vector<boost::thread> threads;
 	std::list<nano::work_item> pending;
+	std::list<nano::work_item>::iterator current{ pending.end () };
 	std::mutex mutex;
 	nano::condition_variable producer_condition;
 	nano::condition_variable next_item_condition;

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -47,10 +47,11 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 		nano::logger_mt logger{ config.node.logging.min_time_between_log_output };
 		boost::asio::io_context io_ctx;
 		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
-		nano::work_pool opencl_work (config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
+		nano::work_pool_order work_order (config.node.work_shuffle_queue ? nano::work_pool_order::random : nano::work_pool_order::sequenced);
+		nano::work_pool opencl_work (config.node.work_threads, work_order, config.node.pow_sleep_interval, opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
 			return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
 		}
-		                                                                                              : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+		                                                                                                          : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
 		nano::alarm alarm (io_ctx);
 		try
 		{

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -316,7 +316,7 @@ int main (int argc, char * const * argv)
 				pow_rate_limiter = std::chrono::nanoseconds (boost::lexical_cast<uint64_t> (pow_sleep_interval_it->second.as<std::string> ()));
 			}
 
-			nano::work_pool work (std::numeric_limits<unsigned>::max (), pow_rate_limiter);
+			nano::work_pool work (std::numeric_limits<unsigned>::max (), nano::work_pool_order::sequenced, pow_rate_limiter);
 			nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
 			std::cerr << "Starting generation profiling\n";
 			while (true)
@@ -421,10 +421,10 @@ int main (int argc, char * const * argv)
 							nano::logger_mt logger;
 							nano::opencl_config config (platform, device, threads);
 							auto opencl (nano::opencl_work::create (true, config, logger));
-							nano::work_pool work_pool (std::numeric_limits<unsigned>::max (), std::chrono::nanoseconds (0), opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
+							nano::work_pool work_pool (std::numeric_limits<unsigned>::max (), nano::work_pool_order::sequenced, std::chrono::nanoseconds (0), opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 								return opencl->generate_work (version_a, root_a, difficulty_a);
 							}
-							                                                                                                       : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+							                                                                                                                                         : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
 							nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
 							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x\n") % platform % device % threads % difficulty);
 							for (uint64_t i (0); true; ++i)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -108,10 +108,11 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 		std::shared_ptr<nano_qt::wallet> gui;
 		nano::set_application_icon (application);
 		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
-		nano::work_pool work (config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
+		nano::work_pool_order work_order (config.node.work_shuffle_queue ? nano::work_pool_order::random : nano::work_pool_order::sequenced);
+		nano::work_pool work (config.node.work_threads, work_order, config.node.pow_sleep_interval, opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 			return opencl->generate_work (version_a, root_a, difficulty_a);
 		}
-		                                                                                       : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+		                                                                                                   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
 		nano::alarm alarm (io_ctx);
 		node = std::make_shared<nano::node> (io_ctx, data_path, alarm, config.node, work, flags);
 		if (!node->init_error ())

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -102,6 +102,7 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("max_work_generate_multiplier", max_work_generate_multiplier, "Maximum allowed difficulty multiplier for work generation.\ntype:double,[1..]");
 	toml.put ("frontiers_confirmation", serialize_frontiers_confirmation (frontiers_confirmation), "Mode controlling frontier confirmation rate.\ntype:string,{auto,always,disabled}");
 	toml.put ("max_queued_requests", max_queued_requests, "Limit for number of queued confirmation requests for one channel, after which new requests are dropped until the queue drops below this value.\ntype:uint32");
+	toml.put ("work_shuffle_queue", work_shuffle_queue, "Enable or disable (default) shuffling the work generation queue.\ntype:bool");
 
 	auto work_peers_l (toml.create_array ("work_peers", "A list of \"address:port\" entries to identify work peers."));
 	for (auto i (work_peers.begin ()), n (work_peers.end ()); i != n; ++i)
@@ -362,6 +363,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get<double> ("max_work_generate_multiplier", max_work_generate_multiplier);
 
 		toml.get<uint32_t> ("max_queued_requests", max_queued_requests);
+		toml.get<bool> ("work_shuffle_queue", work_shuffle_queue);
 
 		if (toml.has_key ("frontiers_confirmation"))
 		{

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -99,6 +99,7 @@ public:
 	std::chrono::seconds work_watcher_period{ std::chrono::seconds (5) };
 	double max_work_generate_multiplier{ 64. };
 	uint32_t max_queued_requests{ 512 };
+	bool work_shuffle_queue{ false };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
 	nano::frontiers_confirmation_mode frontiers_confirmation{ nano::frontiers_confirmation_mode::automatic };


### PR DESCRIPTION
Currently work generation is done FIFO, but in cases where someone is doing requests in burst and using multiple work peers, having the peers pick the next item randomly can increase efficiency, especially due to latency.

While this can be done with a simple middleware, this PR provides the same functionality directly in the node doing local work generation.

This needs an additional synchronization process between the threads while one of them chooses the next item, but the impact is not measurable as work generation uses considerable resources. Retrieving the chosen element is also an O(n) operation vs O(1) in sequenced mode. Doesn't seem worth using a second container or boost multi index container.

Changed to use 2 threads (unless only one is available) in tests as to cover multi-thread behavior