### PR TITLE
Release write_guard lock when no longer required

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -802,7 +802,7 @@ void nano::active_transactions::update_active_multiplier (nano::unique_lock<std:
 	last_prioritized_multiplier.reset ();
 	double multiplier (1.);
 	// Heurestic to filter out non-saturated network and frontier confirmation
-	if (roots.size () > prioritized_cutoff / 2 || (node.network_params.network.is_test_network () && !roots.empty ()))
+	if (roots.size () >= prioritized_cutoff || (node.network_params.network.is_test_network () && !roots.empty ()))
 	{
 		auto & sorted_roots = roots.get<tag_difficulty> ();
 		std::vector<double> prioritized;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -275,7 +275,9 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
 	{
 		// Spend some time prioritizing accounts with the most uncemented blocks to reduce voting traffic
 		auto request_interval = std::chrono::milliseconds (node.network_params.network.request_interval_ms);
-		auto time_spent_prioritizing_ledger_accounts = request_interval / 100;
+		auto low_active = roots.size () < 1000;
+		// Spend longer searching ledger accounts when there is a low amount of elections going on
+		auto time_spent_prioritizing_ledger_accounts = request_interval / (low_active ? 20 : 100);
 		auto time_spent_prioritizing_wallet_accounts = request_interval / 250;
 		lock_a.unlock ();
 		auto transaction = node.store.tx_begin_read ();

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -275,8 +275,8 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
 	{
 		// Spend some time prioritizing accounts with the most uncemented blocks to reduce voting traffic
 		auto request_interval = std::chrono::milliseconds (node.network_params.network.request_interval_ms);
-		auto low_active = roots.size () < 1000;
 		// Spend longer searching ledger accounts when there is a low amount of elections going on
+		auto low_active = roots.size () < 1000;
 		auto time_spent_prioritizing_ledger_accounts = request_interval / (low_active ? 20 : 100);
 		auto time_spent_prioritizing_wallet_accounts = request_interval / 250;
 		lock_a.unlock ();

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -430,7 +430,8 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 							if (timer.since_start ().count () > maximum_batch_write_time)
 							{
 								// Reduce (unless we have hit a floor)
-								batch_write_size = std::min<uint64_t> (16384u, batch_write_size - amount_to_change);
+								auto const minimum_batch_size = 16384u;
+								batch_write_size = std::min<uint64_t> (minimum_batch_size, batch_write_size - amount_to_change);
 							}
 							else if (timer.since_start ().count () > maximum_batch_write_time + (maximum_batch_write_time / 5)) // 20% less
 							{

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -413,7 +413,7 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 					cemented_blocks.emplace_back (block);
 
 					// Flush these callbacks and continue as we write in batches (ideally maximum 250ms) to not hold write db transaction for too long.
-					// Include a 10% tolerance to save having to wait for  to save having
+					// Include a tolerance to save having to potentially wait on the block processor if the number of blocks to cement is only a bit higher than the max.
 					if (cemented_blocks.size () > batch_write_size + (batch_write_size / 10))
 					{
 						auto num_blocks_cemented = num_blocks_iterated - total_blocks_cemented + 1;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -424,17 +424,16 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 						// Update the maximum amount of blocks to write next time based on the time it took to cement this batch.
 						if (!network_params.network.is_test_network ())
 						{
-							auto const percentage_change = 10;
-							auto const amount_to_change = batch_write_size * percentage_change / 100.0;
+							auto const amount_to_change = batch_write_size / 10; // 10%
 							auto const maximum_batch_write_time = 250; // milliseconds
 							if (timer.since_start ().count () > maximum_batch_write_time)
 							{
-								// Reduce by 10% (unless we have hit a floor)
+								// Reduce (unless we have hit a floor)
 								batch_write_size = std::min<uint64_t> (16384u, batch_write_size - amount_to_change);
 							}
-							else
+							else if (timer.since_start ().count () > maximum_batch_write_time + (maximum_batch_write_time / 5)) // 20% less
 							{
-								// Increase by 10%
+								// Increase amount of blocks written for next batch if the time for writing this one is sufficiently lower than the max time to warrant changing
 								batch_write_size += amount_to_change;
 							}
 						}

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -483,8 +483,12 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 		}
 	}
 
-	scoped_write_guard_a.release ();
-	notify_observers_callback (cemented_blocks);
+	// Scope guard could have been released earlier (0 cemented_blocks would indicate that)
+	if (!cemented_blocks.empty ())
+	{
+		scoped_write_guard_a.release ();
+		notify_observers_callback (cemented_blocks);
+	}
 
 	debug_assert (pending_writes.empty ());
 	debug_assert (pending_writes_size == 0);

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -427,13 +427,14 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 						{
 							auto const amount_to_change = batch_write_size / 10; // 10%
 							auto const maximum_batch_write_time = 250; // milliseconds
+							auto const maximum_batch_write_time_increase_cutoff = maximum_batch_write_time - (maximum_batch_write_time / 5);
 							if (timer.since_start ().count () > maximum_batch_write_time)
 							{
 								// Reduce (unless we have hit a floor)
 								auto const minimum_batch_size = 16384u;
-								batch_write_size = std::min<uint64_t> (minimum_batch_size, batch_write_size - amount_to_change);
+								batch_write_size = std::max<uint64_t> (minimum_batch_size, batch_write_size - amount_to_change);
 							}
-							else if (timer.since_start ().count () > maximum_batch_write_time + (maximum_batch_write_time / 5)) // 20% less
+							else if (timer.since_start ().count () < maximum_batch_write_time_increase_cutoff)
 							{
 								// Increase amount of blocks written for next batch if the time for writing this one is sufficiently lower than the max time to warrant changing
 								batch_write_size += amount_to_change;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -486,7 +486,7 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 	}
 
 	// Scope guard could have been released earlier (0 cemented_blocks would indicate that)
-	if (!cemented_blocks.empty ())
+	if (scoped_write_guard_a.is_owned () && !cemented_blocks.empty ())
 	{
 		scoped_write_guard_a.release ();
 		notify_observers_callback (cemented_blocks);

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -17,7 +17,7 @@ class write_guard;
 class confirmation_height_bounded final
 {
 public:
-	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<bool> &, nano::block_hash const &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
+	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<bool> &, nano::block_hash const &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
 	void prepare_new ();
 	void process ();
@@ -55,9 +55,6 @@ private:
 
 	/** The maximum number of blocks to be read in while iterating over a long account chain */
 	uint64_t const batch_read_size = 65536;
-
-	/** The maximum amount of blocks to write at once. This can be increased if the system can process more blocks within a 200ms period. */
-	uint64_t batch_write_size{ 65536 };
 
 	/** The maximum number of various containers to keep the memory bounded */
 	uint32_t const max_items{ 131072 };
@@ -125,14 +122,12 @@ private:
 	nano::logger_mt & logger;
 	std::atomic<bool> & stopped;
 	nano::block_hash const & original_hash;
+	uint64_t & batch_write_size;
 	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;
 	std::function<uint64_t ()> awaiting_processing_size_callback;
 	nano::network_params network_params;
 
-	friend class confirmation_height_many_accounts_single_confirmation_Test;
-	friend class confirmation_height_many_accounts_many_confirmations_Test;
-	friend class confirmation_height_long_chains_Test;
 	friend std::unique_ptr<nano::container_info_component> collect_container_info (confirmation_height_bounded &, const std::string & name_a);
 };
 

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -54,9 +54,10 @@ private:
 	};
 
 	/** The maximum number of blocks to be read in while iterating over a long account chain */
-	static uint64_t constexpr batch_read_size = 4096;
+	static uint64_t constexpr batch_read_size = 65536;
 
-	static uint32_t constexpr max_items{ 65536 };
+	/** The maximum number of various containers to keep the memory bounded */
+	static uint32_t constexpr max_items{ 131072 };
 
 	// All of the atomic variables here just track the size for use in collect_container_info.
 	// This is so that no mutexes are needed during the algorithm itself, which would otherwise be needed

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -54,10 +54,13 @@ private:
 	};
 
 	/** The maximum number of blocks to be read in while iterating over a long account chain */
-	static uint64_t constexpr batch_read_size = 65536;
+	uint64_t const batch_read_size = 65536;
+
+	/** The maximum amount of blocks to write at once. This can be increased if the system can process more blocks within a 200ms period. */
+	uint64_t batch_write_size{ 65536 };
 
 	/** The maximum number of various containers to keep the memory bounded */
-	static uint32_t constexpr max_items{ 131072 };
+	uint32_t const max_items{ 131072 };
 
 	// All of the atomic variables here just track the size for use in collect_container_info.
 	// This is so that no mutexes are needed during the algorithm itself, which would otherwise be needed
@@ -66,7 +69,7 @@ private:
 	// This allows the load and stores to use relaxed atomic memory ordering.
 	std::deque<write_details> pending_writes;
 	nano::relaxed_atomic_integral<uint64_t> pending_writes_size{ 0 };
-	static uint32_t constexpr pending_writes_max_size{ max_items };
+	uint32_t const pending_writes_max_size{ max_items };
 	/* Holds confirmation height/cemented frontier in memory for accounts while iterating */
 	std::unordered_map<account, confirmed_info> accounts_confirmed_info;
 	nano::relaxed_atomic_integral<uint64_t> accounts_confirmed_info_size{ 0 };
@@ -125,7 +128,11 @@ private:
 	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;
 	std::function<uint64_t ()> awaiting_processing_size_callback;
+	nano::network_params network_params;
 
+	friend class confirmation_height_many_accounts_single_confirmation_Test;
+	friend class confirmation_height_many_accounts_many_confirmations_Test;
+	friend class confirmation_height_long_chains_Test;
 	friend std::unique_ptr<nano::container_info_component> collect_container_info (confirmation_height_bounded &, const std::string & name_a);
 };
 

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -12,6 +12,7 @@ class ledger;
 class read_transaction;
 class logger_mt;
 class write_database_queue;
+class write_guard;
 
 class confirmation_height_bounded final
 {
@@ -20,7 +21,7 @@ public:
 	bool pending_empty () const;
 	void prepare_new ();
 	void process ();
-	bool cement_blocks ();
+	bool cement_blocks (nano::write_guard & scoped_write_guard_a);
 
 private:
 	class top_and_next_hash final

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -106,15 +106,19 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 				if (!confirmation_height_bounded_processor.pending_empty ())
 				{
 					debug_assert (confirmation_height_unbounded_processor.pending_empty ());
-					auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
-					confirmation_height_bounded_processor.cement_blocks ();
+					{
+						auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
+						confirmation_height_bounded_processor.cement_blocks (scoped_write_guard);
+					}
 					lock_and_cleanup ();
 				}
 				else if (!confirmation_height_unbounded_processor.pending_empty ())
 				{
 					debug_assert (confirmation_height_bounded_processor.pending_empty ());
-					auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
-					confirmation_height_unbounded_processor.cement_blocks ();
+					{
+						auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
+						confirmation_height_unbounded_processor.cement_blocks (scoped_write_guard);
+					}
 					lock_and_cleanup ();
 				}
 				else

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -15,8 +15,8 @@ nano::confirmation_height_processor::confirmation_height_processor (nano::ledger
 ledger (ledger_a),
 write_database_queue (write_database_queue_a),
 // clang-format off
-confirmation_height_unbounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logger_a, stopped, original_hash, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
-confirmation_height_bounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logger_a, stopped, original_hash, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
+confirmation_height_unbounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logger_a, stopped, original_hash, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
+confirmation_height_bounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logger_a, stopped, original_hash, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
 // clang-format on
 thread ([this, &latch, mode_a]() {
 	nano::thread_role::set (nano::thread_role::name::confirmation_height_processing);

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -70,6 +70,9 @@ private:
 	friend class confirmation_height_dependent_election_Test;
 	friend class confirmation_height_dependent_election_after_already_cemented_Test;
 	friend class confirmation_height_dynamic_algorithm_no_transition_while_pending_Test;
+	friend class confirmation_height_many_accounts_many_confirmations_Test;
+	friend class confirmation_height_long_chains_Test;
+	friend class confirmation_height_many_accounts_single_confirmation_Test;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, const std::string &);

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -57,6 +57,9 @@ private:
 
 	nano::ledger & ledger;
 	nano::write_database_queue & write_database_queue;
+	/** The maximum amount of blocks to write at once. This is dynamically modified by the bounded processor based on previous write performance **/
+	uint64_t batch_write_size{ 65536 };
+
 	confirmation_height_unbounded confirmation_height_unbounded_processor;
 	confirmation_height_bounded confirmation_height_bounded_processor;
 	std::thread thread;

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -5,13 +5,14 @@
 
 #include <numeric>
 
-nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, nano::block_hash const & original_hash_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
+nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, nano::block_hash const & original_hash_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
 ledger (ledger_a),
 write_database_queue (write_database_queue_a),
 batch_separate_pending_min_time (batch_separate_pending_min_time_a),
 logger (logger_a),
 stopped (stopped_a),
 original_hash (original_hash_a),
+batch_write_size (batch_write_size_a),
 notify_observers_callback (notify_observers_callback_a),
 notify_block_already_cemented_observers_callback (notify_block_already_cemented_observers_callback_a),
 awaiting_processing_size_callback (awaiting_processing_size_callback_a)
@@ -135,17 +136,30 @@ void nano::confirmation_height_unbounded::process ()
 		auto no_pending = awaiting_processing_size_callback () == 0;
 		auto should_output = finished_iterating && (no_pending || min_time_exceeded);
 
-		if ((max_write_size_reached || should_output) && !pending_writes.empty ())
+		auto total_pending_write_block_count = std::accumulate (pending_writes.cbegin (), pending_writes.cend (), uint64_t (0), [](uint64_t total, conf_height_details const & receive_details_a) {
+			return total += receive_details_a.num_blocks_confirmed;
+		});
+		auto force_write = total_pending_write_block_count > batch_write_size;
+
+		if ((max_write_size_reached || should_output || force_write) && !pending_writes.empty ())
 		{
+			bool error = false;
 			if (write_database_queue.process (nano::writer::confirmation_height))
 			{
 				auto scoped_write_guard = write_database_queue.pop ();
-				auto error = cement_blocks (scoped_write_guard);
-				// Don't set any more blocks as confirmed from the original hash if an inconsistency is found
-				if (error)
-				{
-					break;
-				}
+				error = cement_blocks (scoped_write_guard);
+			}
+			else if (force_write)
+			{
+				// Unbounded processor has grown too large, force a write
+				auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
+				error = cement_blocks (scoped_write_guard);
+			}
+
+			// Don't set any more cemented blocks from the original hash if an inconsistency is found
+			if (error)
+			{
+				break;
 			}
 		}
 
@@ -317,10 +331,6 @@ void nano::confirmation_height_unbounded::prepare_iterated_blocks_for_cementing 
  */
 bool nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & scoped_write_guard_a)
 {
-	auto total_pending_write_block_count = std::accumulate (pending_writes.cbegin (), pending_writes.cend (), uint64_t (0), [](uint64_t total, conf_height_details const & receive_details_a) {
-		return total += receive_details_a.num_blocks_confirmed;
-	});
-
 	std::vector<std::shared_ptr<nano::block>> cemented_blocks;
 	{
 		auto transaction (ledger.store.tx_begin_write ({}, { nano::tables::confirmation_height }));
@@ -364,7 +374,6 @@ bool nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 					return block_cache.at (hash_a);
 				});
 			}
-			total_pending_write_block_count -= pending.num_blocks_confirmed;
 			pending_writes.erase (pending_writes.begin ());
 			--pending_writes_size;
 		}
@@ -372,7 +381,6 @@ bool nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 	scoped_write_guard_a.release ();
 	notify_observers_callback (cemented_blocks);
 
-	debug_assert (total_pending_write_block_count == 0);
 	debug_assert (pending_writes.empty ());
 	return false;
 }

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -127,7 +127,7 @@ void nano::confirmation_height_unbounded::process ()
 			}
 		}
 
-		auto max_write_size_reached = (pending_writes.size () >= confirmation_height::batch_write_size);
+		auto max_write_size_reached = (pending_writes.size () >= confirmation_height::unbounded_cutoff);
 		// When there are a lot of pending confirmation height blocks, it is more efficient to
 		// bulk some of them up to enable better write performance which becomes the bottleneck.
 		auto min_time_exceeded = (timer.since_start () >= batch_separate_pending_min_time);

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -13,6 +13,7 @@ class ledger;
 class read_transaction;
 class logger_mt;
 class write_database_queue;
+class write_guard;
 
 class confirmation_height_unbounded final
 {
@@ -21,7 +22,7 @@ public:
 	bool pending_empty () const;
 	void prepare_new ();
 	void process ();
-	bool cement_blocks ();
+	bool cement_blocks (nano::write_guard &);
 
 private:
 	class confirmed_iterated_pair

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -18,7 +18,7 @@ class write_guard;
 class confirmation_height_unbounded final
 {
 public:
-	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<bool> &, nano::block_hash const &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
+	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<bool> &, nano::block_hash const &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
 	void prepare_new ();
 	void process ();
@@ -97,6 +97,8 @@ private:
 	nano::logger_mt & logger;
 	std::atomic<bool> & stopped;
 	nano::block_hash const & original_hash;
+	uint64_t & batch_write_size;
+
 	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;
 	std::function<uint64_t ()> awaiting_processing_size_callback;

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -34,6 +34,11 @@ nano::write_guard::~write_guard ()
 	}
 }
 
+bool nano::write_guard::is_owned () const
+{
+	return owns;
+}
+
 void nano::write_guard::release ()
 {
 	debug_assert (owns);

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -16,7 +16,7 @@ guard_finish_callback (std::move (write_guard_a.guard_finish_callback))
 	write_guard_a.guard_finish_callback = nullptr;
 }
 
-nano::write_guard& nano::write_guard::operator= (nano::write_guard && write_guard_a) noexcept
+nano::write_guard & nano::write_guard::operator= (nano::write_guard && write_guard_a) noexcept
 {
 	owns = write_guard_a.owns;
 	guard_finish_callback = std::move (write_guard_a.guard_finish_callback);

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -37,7 +37,10 @@ nano::write_guard::~write_guard ()
 void nano::write_guard::release ()
 {
 	debug_assert (owns);
-	guard_finish_callback ();
+	if (owns)
+	{
+		guard_finish_callback ();
+	}
 	owns = false;
 }
 

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -23,6 +23,10 @@ public:
 	write_guard (std::function<void()> guard_finish_callback_a);
 	void release ();
 	~write_guard ();
+	write_guard (write_guard const&) = delete;
+	write_guard& operator= (write_guard const&) = delete;
+	write_guard (write_guard &&) noexcept;
+	write_guard& operator= (write_guard &&) noexcept;
 
 private:
 	std::function<void()> guard_finish_callback;

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -23,10 +23,10 @@ public:
 	write_guard (std::function<void()> guard_finish_callback_a);
 	void release ();
 	~write_guard ();
-	write_guard (write_guard const&) = delete;
-	write_guard& operator= (write_guard const&) = delete;
+	write_guard (write_guard const &) = delete;
+	write_guard & operator= (write_guard const &) = delete;
 	write_guard (write_guard &&) noexcept;
-	write_guard& operator= (write_guard &&) noexcept;
+	write_guard & operator= (write_guard &&) noexcept;
 
 private:
 	std::function<void()> guard_finish_callback;

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -20,12 +20,13 @@ enum class writer
 class write_guard final
 {
 public:
-	write_guard (nano::condition_variable & cv_a, std::function<void()> guard_finish_callback_a);
+	write_guard (std::function<void()> guard_finish_callback_a);
+	void release ();
 	~write_guard ();
 
 private:
-	nano::condition_variable & cv;
 	std::function<void()> guard_finish_callback;
+	bool owns{ true };
 };
 
 class write_database_queue final

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -27,6 +27,7 @@ public:
 	write_guard & operator= (write_guard const &) = delete;
 	write_guard (write_guard &&) noexcept;
 	write_guard & operator= (write_guard &&) noexcept;
+	bool is_owned () const;
 
 private:
 	std::function<void()> guard_finish_callback;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -232,8 +232,6 @@ public:
 
 namespace confirmation_height
 {
-	/** The maximum amount of blocks to write */
-	uint64_t const batch_write_size{ 65536 };
 	/** When the uncemented count (block count - cemented count) is less than this use the unbounded processor */
 	uint64_t const unbounded_cutoff{ 16384 };
 }

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -230,11 +230,12 @@ public:
 	nano::block_hash frontier;
 };
 
-/** The maximum amount of blocks to iterate over while writing */
 namespace confirmation_height
 {
-	uint64_t const batch_write_size{ 4096 };
-	uint64_t const unbounded_cutoff{ 4096 };
+	/** The maximum amount of blocks to write  */
+	uint64_t const batch_write_size{ 65536 };
+	/** When the uncemented count (block count - cemented count) is less than this use the unbounded processor */
+	uint64_t const unbounded_cutoff{ 16384 };
 }
 
 using vote_blocks_vec_iter = std::vector<boost::variant<std::shared_ptr<nano::block>, nano::block_hash>>::const_iterator;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -232,7 +232,7 @@ public:
 
 namespace confirmation_height
 {
-	/** The maximum amount of blocks to write  */
+	/** The maximum amount of blocks to write */
 	uint64_t const batch_write_size{ 65536 };
 	/** When the uncemented count (block count - cemented count) is less than this use the unbounded processor */
 	uint64_t const unbounded_cutoff{ 16384 };

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -589,7 +589,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 		cemented_count += i->second.height;
 	}
 
-	ASSERT_EQ (num_blocks_to_confirm, cemented_count);
+	ASSERT_EQ (num_blocks_to_confirm + 1, cemented_count);
 	ASSERT_EQ (cemented_count, node->ledger.cache.cemented_count);
 	ASSERT_EQ (node->active.election_winner_details_size (), 0);
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -841,7 +841,7 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 	}
 }
 
-// Can take up to 1 hour
+// Can take up to 1 hour (recommend modiying test work difficulty base level to speed this up)
 TEST (confirmation_height, prioritize_frontiers_overwrite)
 {
 	nano::system system;
@@ -850,7 +850,7 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
-	auto num_accounts = node->active.max_priority_cementable_frontiers * 2 + 50;
+	auto num_accounts = node->active.max_priority_cementable_frontiers * 2;
 	nano::keypair last_keypair = nano::test_genesis_key;
 	auto last_open_hash = node->latest (nano::test_genesis_key.pub);
 	// Clear confirmation height so that the genesis account has the same amount of uncemented blocks as the other frontiers

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -841,7 +841,7 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 	}
 }
 
-// Can take up to 1 hour (recommend modiying test work difficulty base level to speed this up)
+// Can take up to 1 hour (recommend modifying test work difficulty base level to speed this up)
 TEST (confirmation_height, prioritize_frontiers_overwrite)
 {
 	nano::system system;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -468,7 +468,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
 	// The number of frontiers should be more than the nano::confirmation_height::unbounded_cutoff to test the amount of blocks confirmed is correct.
-	node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size = 500;
+	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 	nano::keypair last_keypair = nano::test_genesis_key;
 	auto last_open_hash = node->latest (nano::test_genesis_key.pub);
@@ -543,7 +543,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
-	node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size = 500;
+	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
@@ -609,7 +609,7 @@ TEST (confirmation_height, long_chains)
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key1.prv);
 
-	node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size = 500;
+	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_blocks = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 
 	// First open the other account

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -467,9 +467,9 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
-	// The number of frontiers should be more than the batch_write_size to test the amount of blocks confirmed is correct.
-	auto const batch_write_size = node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size;
-	auto const num_accounts = batch_write_size * 2 + 50;
+	// The number of frontiers should be more than the nano::confirmation_height::unbounded_cutoff to test the amount of blocks confirmed is correct.
+	node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size = 500;
+	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 	nano::keypair last_keypair = nano::test_genesis_key;
 	auto last_open_hash = node->latest (nano::test_genesis_key.pub);
 	{
@@ -543,8 +543,8 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 
-	auto const batch_write_size = node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size;
-	auto const num_accounts = batch_write_size * 2 + 50;
+	node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size = 500;
+	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 	{
@@ -577,7 +577,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	}
 
 	auto num_confirmed_bounded = node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in);
-	ASSERT_GE (num_confirmed_bounded, batch_write_size);
+	ASSERT_GE (num_confirmed_bounded, nano::confirmation_height::unbounded_cutoff);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks_to_confirm - num_confirmed_bounded);
 
 	system.deadline_set (60s);
@@ -609,8 +609,8 @@ TEST (confirmation_height, long_chains)
 	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key1.prv);
 
-	auto const batch_write_size = node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size;
-	auto const num_blocks = batch_write_size * 2 + 50;
+	node->confirmation_height_processor.confirmation_height_bounded_processor.batch_write_size = 500;
+	auto const num_blocks = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 
 	// First open the other account
 	nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + num_blocks + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));


### PR DESCRIPTION
The confirmation height processor can halt the block processor longer than necessary by holding onto the write_database_queue lock even when it releases the lmdb write lock. This adds the ability to release it. Ideally tested by @Srayman who first noticed this and can confirm its effectiveness (in combination with #2714).

- Frontiers confirmation time spent prioritising ledger accounts is increase by x5 to 25ms per request loop when the number of active transactions is low. This is to help find the few uncemented frontiers when the number of frontiers is large if they are missed during a high tps event.

- The bounded processor can modify the batch_write_size is give an optimum max amount of blocks to cement while holding the db write transaction to keep interference low with the block processor.

- Increased maximum amount of accounts/pending_writes in the bounded confirmation height processor by x2, the unbounded cutoff has been modified from 4k to 16k to help with nodes which may fall a bit behind in uncemented count while not using up so much memory (< 100MB at worst case still)