### PR TITLE
Fix logic in active_transactions.prioritize_chains test

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -300,7 +300,7 @@ TEST (active_transactions, prioritize_chains)
 		auto it (node1.active.roots.get<1> ().begin ());
 		while (!node1.active.roots.empty () && it != node1.active.roots.get<1> ().end ())
 		{
-			if (it->multiplier == (multiplier1 || multiplier2))
+			if (it->multiplier == multiplier1 || it->multiplier == multiplier2)
 			{
 				seen++;
 			}


### PR DESCRIPTION
The if condition is comparing a double to a boolean, whereas it should be comparing the multipliers directly. Not essential for v21 as just a test and it's been like this since inception