### PR TITLE
Separate election state for the broadcasting block fallback

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -297,7 +297,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			send_confirm_req (solicitor_a);
 			if (base_latency () * active_broadcasting_duration_factor < std::chrono::steady_clock::now () - state_start)
 			{
-				state_change (nano::election::state_t::active, nano::election::state_t::backtracking);
+				state_change (nano::election::state_t::broadcasting, nano::election::state_t::backtracking);
 				lock.unlock ();
 				activate_dependencies ();
 				lock.lock ();

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -259,7 +259,7 @@ void nano::election::activate_dependencies ()
 
 void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
 {
-	if (base_latency () * 10 < std::chrono::steady_clock::now () - last_block)
+	if (base_latency () * 15 < std::chrono::steady_clock::now () - last_block)
 	{
 		if (!solicitor_a.broadcast (*this))
 		{

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -8,7 +8,8 @@
 using namespace std::chrono;
 
 int constexpr nano::election::passive_duration_factor;
-int constexpr nano::election::active_duration_factor;
+int constexpr nano::election::active_request_count_min;
+int constexpr nano::election::active_broadcasting_duration_factor;
 int constexpr nano::election::confirmed_duration_factor;
 
 std::chrono::milliseconds nano::election::base_latency () const
@@ -98,6 +99,18 @@ bool nano::election::valid_change (nano::election::state_t expected_a, nano::ele
 			}
 			break;
 		case nano::election::state_t::active:
+			switch (desired_a)
+			{
+				case nano::election::state_t::idle:
+				case nano::election::state_t::broadcasting:
+				case nano::election::state_t::confirmed:
+				case nano::election::state_t::expired_unconfirmed:
+					result = true;
+					break;
+				default:
+					break;
+			}
+		case nano::election::state_t::broadcasting:
 			switch (desired_a)
 			{
 				case nano::election::state_t::idle:
@@ -246,7 +259,7 @@ void nano::election::activate_dependencies ()
 
 void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
 {
-	if (confirmation_request_count >= 2 && base_latency () * 20 < std::chrono::steady_clock::now () - last_block)
+	if (base_latency () * 10 < std::chrono::steady_clock::now () - last_block)
 	{
 		if (!solicitor_a.broadcast (*this))
 		{
@@ -273,9 +286,16 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			break;
 		}
 		case nano::election::state_t::active:
+			send_confirm_req (solicitor_a);
+			if (confirmation_request_count > active_request_count_min)
+			{
+				state_change (nano::election::state_t::active, nano::election::state_t::broadcasting);
+			}
+			break;
+		case nano::election::state_t::broadcasting:
 			broadcast_block (solicitor_a);
 			send_confirm_req (solicitor_a);
-			if (confirmation_request_count >= 2 && base_latency () * active_duration_factor < std::chrono::steady_clock::now () - state_start)
+			if (base_latency () * active_broadcasting_duration_factor < std::chrono::steady_clock::now () - state_start)
 			{
 				state_change (nano::election::state_t::active, nano::election::state_t::backtracking);
 				lock.unlock ();

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -246,7 +246,7 @@ void nano::election::activate_dependencies ()
 
 void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
 {
-	if (base_latency () * 20 < std::chrono::steady_clock::now () - last_block)
+	if (confirmation_request_count >= 2 && base_latency () * 20 < std::chrono::steady_clock::now () - last_block)
 	{
 		if (!solicitor_a.broadcast (*this))
 		{
@@ -275,7 +275,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 		case nano::election::state_t::active:
 			broadcast_block (solicitor_a);
 			send_confirm_req (solicitor_a);
-			if (base_latency () * active_duration_factor < std::chrono::steady_clock::now () - state_start)
+			if (confirmation_request_count >= 2 && base_latency () * active_duration_factor < std::chrono::steady_clock::now () - state_start)
 			{
 				state_change (nano::election::state_t::active, nano::election::state_t::backtracking);
 				lock.unlock ();

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -40,15 +40,17 @@ private: // State management
 	enum class state_t
 	{
 		idle,
-		passive,
-		active,
-		backtracking,
-		confirmed,
+		passive, // only listening for incoming votes
+		active, // actively request confirmations
+		broadcasting, // request confirmations and broadcast the winner
+		backtracking, // start an election for unconfirmed dependent blocks
+		confirmed, // confirmed but still listening for votes
 		expired_confirmed,
 		expired_unconfirmed
 	};
 	static int constexpr passive_duration_factor = 5;
-	static int constexpr active_duration_factor = 30;
+	static int constexpr active_request_count_min = 2;
+	static int constexpr active_broadcasting_duration_factor = 30;
 	static int constexpr confirmed_duration_factor = 5;
 	std::atomic<nano::election::state_t> state_m = { state_t::idle };
 


### PR DESCRIPTION
Noted by @Srayman when frontier confirmation inserts a few thousand blocks at once.

Instead of basing only on time, a hard limit on confirmation requests helps avoid resorting to fallback mechanisms (block broadcasting, escalating to dependents) too soon.

This is implemented with a new state `broadcasting` , and before moving to this state at least two confirmation requests must be done. This indirectly extends the time before moving to backtracking by 10 seconds.

Time between broadcasts reduced to 15 from 20 seconds.