### PR TITLE
Add active difficulty to node telemetry

### DIFF
--- a/nano/core_test/testutil.hpp
+++ b/nano/core_test/testutil.hpp
@@ -239,7 +239,7 @@ inline uint16_t get_available_port ()
 }
 
 #ifndef IGNORE_GTEST_INCL
-inline void compare_default_telemetry_response_data_excluding_signature (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a)
+inline void compare_default_telemetry_response_data_excluding_signature (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a)
 {
 	ASSERT_EQ (telemetry_data_a.block_count, 1);
 	ASSERT_EQ (telemetry_data_a.cemented_count, 1);
@@ -256,9 +256,10 @@ inline void compare_default_telemetry_response_data_excluding_signature (nano::t
 	ASSERT_EQ (telemetry_data_a.pre_release_version, nano::get_pre_release_node_version ());
 	ASSERT_EQ (telemetry_data_a.maker, 0);
 	ASSERT_GT (telemetry_data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
+	ASSERT_EQ (telemetry_data_a.active_difficulty, active_difficulty_a);
 }
 
-inline void compare_default_telemetry_response_data (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, nano::keypair const & node_id_a)
+inline void compare_default_telemetry_response_data (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a)
 {
 	ASSERT_FALSE (telemetry_data_a.validate_signature (nano::telemetry_data::size));
 	nano::telemetry_data telemetry_data_l = telemetry_data_a;
@@ -266,7 +267,7 @@ inline void compare_default_telemetry_response_data (nano::telemetry_data const 
 	telemetry_data_l.sign (node_id_a);
 	// Signature should be different because uptime/timestamp will have changed.
 	ASSERT_NE (telemetry_data_a.signature, telemetry_data_l.signature);
-	compare_default_telemetry_response_data_excluding_signature (telemetry_data_a, network_params_a, bandwidth_limit_a);
+	compare_default_telemetry_response_data_excluding_signature (telemetry_data_a, network_params_a, bandwidth_limit_a, active_difficulty_a);
 	ASSERT_EQ (telemetry_data_a.node_id, node_id_a.pub);
 }
 #endif

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -906,7 +906,7 @@ TEST (websocket, telemetry)
 	nano::jsonconfig telemetry_contents (contents);
 	nano::telemetry_data telemetry_data;
 	telemetry_data.deserialize_json (telemetry_contents, false);
-	compare_default_telemetry_response_data (telemetry_data, node2->network_params, node2->config.bandwidth_limit, node2->node_id);
+	compare_default_telemetry_response_data (telemetry_data, node2->network_params, node2->config.bandwidth_limit, node2->active.active_difficulty (), node2->node_id);
 
 	ASSERT_EQ (contents.get<std::string> ("address"), node2->network.endpoint ().address ().to_string ());
 	ASSERT_EQ (contents.get<uint16_t> ("port"), node2->network.endpoint ().port ());

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1188,6 +1188,7 @@ void nano::telemetry_data::deserialize (nano::stream & stream_a, uint16_t payloa
 	uint64_t timestamp_l;
 	read (stream_a, timestamp_l);
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
+	read (stream_a, active_difficulty);
 }
 
 void nano::telemetry_data::serialize_without_signature (nano::stream & stream_a, uint16_t /* size_a */) const
@@ -1208,6 +1209,7 @@ void nano::telemetry_data::serialize_without_signature (nano::stream & stream_a,
 	write (stream_a, pre_release_version);
 	write (stream_a, maker);
 	write (stream_a, std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
+	write (stream_a, active_difficulty);
 }
 
 void nano::telemetry_data::serialize (nano::stream & stream_a) const
@@ -1218,11 +1220,6 @@ void nano::telemetry_data::serialize (nano::stream & stream_a) const
 
 nano::error nano::telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore_identification_metrics_a) const
 {
-	if (!ignore_identification_metrics_a)
-	{
-		json.put ("signature", signature.to_string ());
-		json.put ("node_id", node_id.to_string ());
-	}
 	json.put ("block_count", block_count);
 	json.put ("cemented_count", cemented_count);
 	json.put ("unchecked_count", unchecked_count);
@@ -1238,6 +1235,13 @@ nano::error nano::telemetry_data::serialize_json (nano::jsonconfig & json, bool 
 	json.put ("pre_release_version", pre_release_version);
 	json.put ("maker", maker);
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
+	json.put ("active_difficulty", active_difficulty);
+	// Keep these last for UI purposes
+	if (!ignore_identification_metrics_a)
+	{
+		json.put ("node_id", node_id.to_string ());
+		json.put ("signature", signature.to_string ());
+	}
 	return json.get_error ();
 }
 
@@ -1290,12 +1294,13 @@ nano::error nano::telemetry_data::deserialize_json (nano::jsonconfig & json, boo
 	json.get ("maker", maker);
 	auto timestamp_l = json.get<uint64_t> ("timestamp");
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
+	json.get ("active_difficulty", active_difficulty);
 	return json.get_error ();
 }
 
 bool nano::telemetry_data::operator== (nano::telemetry_data const & data_a) const
 {
-	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp);
+	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty);
 }
 
 bool nano::telemetry_data::operator!= (nano::telemetry_data const & data_a) const

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1235,7 +1235,7 @@ nano::error nano::telemetry_data::serialize_json (nano::jsonconfig & json, bool 
 	json.put ("pre_release_version", pre_release_version);
 	json.put ("maker", maker);
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
-	json.put ("active_difficulty", active_difficulty);
+	json.put ("active_difficulty", nano::to_string_hex (active_difficulty));
 	// Keep these last for UI purposes
 	if (!ignore_identification_metrics_a)
 	{
@@ -1294,7 +1294,9 @@ nano::error nano::telemetry_data::deserialize_json (nano::jsonconfig & json, boo
 	json.get ("maker", maker);
 	auto timestamp_l = json.get<uint64_t> ("timestamp");
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
-	json.get ("active_difficulty", active_difficulty);
+	auto current_active_difficulty_text = json.get<std::string> ("active_difficulty");
+	auto ec = nano::from_string_hex (current_active_difficulty_text, active_difficulty);
+	debug_assert (!ec);
 	return json.get_error ();
 }
 

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -357,11 +357,12 @@ public:
 	uint8_t protocol_version{ 0 };
 	nano::block_hash genesis_block{ 0 };
 	uint8_t major_version{ 0 };
-	uint8_t minor_version;
-	uint8_t patch_version;
-	uint8_t pre_release_version;
-	uint8_t maker; // 0 for NF node
+	uint8_t minor_version{ 0 };
+	uint8_t patch_version{ 0 };
+	uint8_t pre_release_version{ 0 };
+	uint8_t maker{ 0 }; // 0 for NF node
 	std::chrono::system_clock::time_point timestamp;
+	uint64_t active_difficulty{ 0 };
 
 	void serialize (nano::stream &) const;
 	void deserialize (nano::stream &, uint16_t);
@@ -372,7 +373,7 @@ public:
 	bool operator== (nano::telemetry_data const &) const;
 	bool operator!= (nano::telemetry_data const &) const;
 
-	static auto constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t);
+	static auto constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
 
 private:
 	void serialize_without_signature (nano::stream &, uint16_t) const;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3812,7 +3812,7 @@ void nano::json_handler::telemetry ()
 					if (address.is_loopback () && port == rpc_l->node.network.endpoint ().port ())
 					{
 						// Requesting telemetry metrics locally
-						auto telemetry_data = nano::local_telemetry_data (rpc_l->node.ledger.cache, rpc_l->node.network, rpc_l->node.config.bandwidth_limit, rpc_l->node.network_params, rpc_l->node.startup_time, rpc_l->node.node_id);
+						auto telemetry_data = nano::local_telemetry_data (rpc_l->node.ledger.cache, rpc_l->node.network, rpc_l->node.config.bandwidth_limit, rpc_l->node.network_params, rpc_l->node.startup_time, rpc_l->node.active.active_difficulty (), rpc_l->node.node_id);
 
 						nano::jsonconfig config_l;
 						auto const should_ignore_identification_metrics = false;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -519,7 +519,7 @@ public:
 		nano::telemetry_ack telemetry_ack;
 		if (!node.flags.disable_providing_telemetry_metrics)
 		{
-			auto telemetry_data = nano::local_telemetry_data (node.ledger.cache, node.network, node.config.bandwidth_limit, node.network_params, node.startup_time, node.node_id);
+			auto telemetry_data = nano::local_telemetry_data (node.ledger.cache, node.network, node.config.bandwidth_limit, node.network_params, node.startup_time, node.active.active_difficulty (), node.node_id);
 			telemetry_ack = nano::telemetry_ack (telemetry_data);
 		}
 		channel->send (telemetry_ack, nullptr, nano::buffer_drop_policy::no_socket_drop);

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -627,7 +627,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	return consolidated_data;
 }
 
-nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledger_cache_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a, uint64_t active_diffciulty_a, nano::keypair const & node_id_a)
+nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledger_cache_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a)
 {
 	nano::telemetry_data telemetry_data;
 	telemetry_data.node_id = node_id_a.pub;
@@ -646,7 +646,7 @@ nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledg
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
 	telemetry_data.maker = 0; // 0 Indicates it originated from the NF
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
-	telemetry_data.active_difficulty = active_diffciulty_a;
+	telemetry_data.active_difficulty = active_difficulty_a;
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id_a);
 	return telemetry_data;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -513,6 +513,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	std::multiset<uint64_t> uptimes;
 	std::multiset<uint64_t> bandwidths;
 	std::multiset<uint64_t> timestamps;
+	std::multiset<uint64_t> active_difficulties;
 
 	for (auto const & telemetry_data : telemetry_datas)
 	{
@@ -536,6 +537,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 
 		++bandwidth_caps[telemetry_data.bandwidth_cap];
 		++genesis_blocks[telemetry_data.genesis_block];
+		active_difficulties.insert (telemetry_data.active_difficulty);
 	}
 
 	// Remove 10% of the results from the lower and upper bounds to catch any outliers. Need at least 10 responses before any are removed.
@@ -556,6 +558,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	auto unchecked_sum = strip_outliers_and_sum (unchecked_counts);
 	auto uptime_sum = strip_outliers_and_sum (uptimes);
 	auto bandwidth_sum = strip_outliers_and_sum (bandwidths);
+	auto active_difficulty_sum = strip_outliers_and_sum (active_difficulties);
 
 	nano::telemetry_data consolidated_data;
 	auto size = telemetry_datas.size () - num_either_side_to_remove * 2;
@@ -565,6 +568,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	consolidated_data.peer_count = boost::numeric_cast<decltype (consolidated_data.peer_count)> (peer_sum / size);
 	consolidated_data.uptime = boost::numeric_cast<decltype (consolidated_data.uptime)> (uptime_sum / size);
 	consolidated_data.unchecked_count = boost::numeric_cast<decltype (consolidated_data.unchecked_count)> (unchecked_sum / size);
+	consolidated_data.active_difficulty = boost::numeric_cast<decltype (consolidated_data.unchecked_count)> (active_difficulty_sum / size);
 
 	if (!timestamps.empty ())
 	{
@@ -623,7 +627,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	return consolidated_data;
 }
 
-nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledger_cache_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a, nano::keypair const & node_id_a)
+nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledger_cache_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a, uint64_t active_diffciulty_a, nano::keypair const & node_id_a)
 {
 	nano::telemetry_data telemetry_data;
 	telemetry_data.node_id = node_id_a.pub;
@@ -642,6 +646,7 @@ nano::telemetry_data nano::local_telemetry_data (nano::ledger_cache const & ledg
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
 	telemetry_data.maker = 0; // 0 Indicates it originated from the NF
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
+	telemetry_data.active_difficulty = active_diffciulty_a;
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id_a);
 	return telemetry_data;

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -150,5 +150,5 @@ private:
 std::unique_ptr<nano::container_info_component> collect_container_info (telemetry & telemetry, const std::string & name);
 
 nano::telemetry_data consolidate_telemetry_data (std::vector<telemetry_data> const & telemetry_data);
-nano::telemetry_data local_telemetry_data (nano::ledger_cache const &, nano::network &, uint64_t, nano::network_params const &, std::chrono::steady_clock::time_point, nano::keypair const & node_id_a);
+nano::telemetry_data local_telemetry_data (nano::ledger_cache const &, nano::network &, uint64_t, nano::network_params const &, std::chrono::steady_clock::time_point, uint64_t, nano::keypair const &);
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -8537,7 +8537,7 @@ TEST (rpc, node_telemetry_single)
 		nano::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = false;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (telemetry_data, node->network_params, node->config.bandwidth_limit, node->node_id);
+		nano::compare_default_telemetry_response_data (telemetry_data, node->network_params, node->config.bandwidth_limit, node->active.active_difficulty (), node->node_id);
 	}
 }
 
@@ -8591,7 +8591,7 @@ TEST (rpc, node_telemetry_all)
 		nano::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = true;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data_excluding_signature (telemetry_data, node->network_params, node->config.bandwidth_limit);
+		nano::compare_default_telemetry_response_data_excluding_signature (telemetry_data, node->network_params, node->config.bandwidth_limit, node->active.active_difficulty ());
 		ASSERT_FALSE (response.json.get_optional<std::string> ("node_id").is_initialized ());
 		ASSERT_FALSE (response.json.get_optional<std::string> ("signature").is_initialized ());
 	}
@@ -8614,7 +8614,7 @@ TEST (rpc, node_telemetry_all)
 	nano::telemetry_data data;
 	auto const should_ignore_identification_metrics = false;
 	ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-	nano::compare_default_telemetry_response_data (data, node->network_params, node->config.bandwidth_limit, node->node_id);
+	nano::compare_default_telemetry_response_data (data, node->network_params, node->config.bandwidth_limit, node->active.active_difficulty (), node->node_id);
 
 	ASSERT_EQ (node->network.endpoint ().address ().to_string (), metrics.get<std::string> ("address"));
 	ASSERT_EQ (node->network.endpoint ().port (), metrics.get<uint16_t> ("port"));
@@ -8653,7 +8653,7 @@ TEST (rpc, node_telemetry_self)
 		nano::telemetry_data data;
 		nano::jsonconfig config (response.json);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (data, node1.network_params, node1.config.bandwidth_limit, node1.node_id);
+		nano::compare_default_telemetry_response_data (data, node1.network_params, node1.config.bandwidth_limit, node1.active.active_difficulty (), node1.node_id);
 	}
 
 	request.put ("address", "[::1]");
@@ -8668,7 +8668,7 @@ TEST (rpc, node_telemetry_self)
 		nano::telemetry_data data;
 		nano::jsonconfig config (response.json);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (data, node1.network_params, node1.config.bandwidth_limit, node1.node_id);
+		nano::compare_default_telemetry_response_data (data, node1.network_params, node1.config.bandwidth_limit, node1.active.active_difficulty (), node1.node_id);
 	}
 
 	request.put ("address", "127.0.0.1");
@@ -8683,7 +8683,7 @@ TEST (rpc, node_telemetry_self)
 		nano::telemetry_data data;
 		nano::jsonconfig config (response.json);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (data, node1.network_params, node1.config.bandwidth_limit, node1.node_id);
+		nano::compare_default_telemetry_response_data (data, node1.network_params, node1.config.bandwidth_limit, node1.active.active_difficulty (), node1.node_id);
 	}
 
 	// Incorrect port should fail


### PR DESCRIPTION
This was suggested by @Inkeliz in https://github.com/nanocurrency/nano-node/issues/2726

Nodes now respond with the active difficulty in the telemetry response. Nodes on the beta network will need to upgrade to DB13 to receive telemetry from upgraded peers as this change is not backwards compatible.

Few unrelated changes:
- Moving signature/node_id to the bottom of the RPC as they are the least useful to people.
- Updated some variable names
- Timestamp didn't need to be checked in the `consolidate_data` section as it always uses average.