### PR TITLE
Websocket notification for RPC work_generate without peers

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4835,7 +4835,11 @@ void nano::json_handler::work_generate ()
 			{
 				if (node.local_work_generation_enabled ())
 				{
-					node.work.generate (work_version, hash, difficulty, callback);
+					auto error = node.distributed_work.make (work_version, hash, {}, difficulty, callback, {});
+					if (error)
+					{
+						ec = nano::error_common::failure_work_generation;
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Noticed I wasn't getting a websocket notification if `use_peers` is `false`. The easiest way of accomplishing this is just using distributed work without peers which fallsback to local work generation immediately.

Sample notification
```json
 {
    "success": "true",
    "reason": "",
    "duration": "690",
    "request": {
        "version": "work_1",
        "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2",
        "difficulty": "ffffffc000000000",
        "multiplier": "1.000000000000000"
    },
    "result": {
        "source": "local",
        "work": "1627ff6c0ddbcab4",
        "difficulty": "ffffffd7529945e2",
        "multiplier": "1.573357211876761"
    },
    "bad_peers": ""
}
```