### PR TITLE
Fix system.generate_send_new intermittent failures

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -597,6 +597,8 @@ TEST (system, generate_send_new)
 	ASSERT_GT (node1.balance (stake_preserver.pub), node1.balance (nano::genesis_account));
 	std::vector<nano::account> accounts;
 	accounts.push_back (nano::test_genesis_key.pub);
+	// This indirectly waits for online weight to stabilize, required to prevent intermittent failures
+	ASSERT_TIMELY (5s, node1.wallets.rep_counts ().voting > 0);
 	system.generate_send_new (node1, accounts);
 	nano::account new_account (0);
 	{


### PR DESCRIPTION
This is likely due to wallet rep counts not updating quick enough on CI due to online weight fluctuating very heavily in this test, causing votes to not be generated. Waiting for the online weight to stabilize by waiting on a voting rep should fix it.

Ran CI twice and didn't trigger whereas it would trigger often without this change.