### PR TITLE
Tally votes on conflicting block with no inactive votes

### DIFF
--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -84,7 +84,7 @@ public:
 	size_t last_votes_size ();
 	void update_dependent ();
 	void adjust_dependent_difficulty ();
-	void insert_inactive_votes_cache (nano::block_hash const &);
+	size_t insert_inactive_votes_cache (nano::block_hash const &);
 	bool prioritized () const;
 	void prioritize_election (nano::vote_generator_session &);
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters


### PR DESCRIPTION
Mostly applicable to tests, but consider this sequence of events:
- An election gets created for a processed block
- A vote arrives for a conflicting block; gets added to election, not inactive
- The conflicting block gets processed

Currently, `election::publish` calls `insert_inactive_votes_cache` but votes are not tallied since there was no inactive vote.

This fixes the above situation by calling `confirm_if_quorum` if no votes were cached when a new conflicting block is inserted.