### PR TITLE
Fix Xcode warnings

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -927,7 +927,6 @@ TEST (active_transactions, election_difficulty_update_old)
 	auto send1_copy (std::make_shared<nano::state_block> (*send1));
 	node.process_active (send1);
 	node.block_processor.flush ();
-	auto root (send1->qualified_root ());
 	ASSERT_EQ (1, node.active.size ());
 	auto multiplier = node.active.roots.begin ()->multiplier;
 	{

--- a/nano/core_test/node_telemetry.cpp
+++ b/nano/core_test/node_telemetry.cpp
@@ -205,7 +205,6 @@ TEST (node_telemetry, no_peers)
 {
 	nano::system system (1);
 
-	std::atomic<bool> done{ false };
 	auto responses = system.nodes[0]->telemetry->get_metrics ();
 	ASSERT_TRUE (responses.empty ());
 }

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -692,7 +692,6 @@ TEST (wallet, work_cache_delayed)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
-	nano::uint128_t amount1 (node1.balance (nano::test_genesis_key.pub));
 	uint64_t work1;
 	wallet->insert_adhoc (nano::test_genesis_key.prv);
 	nano::account account1;
@@ -1357,7 +1356,6 @@ TEST (work_watcher, cancel)
 	nano::keypair key;
 	auto work1 (node.work_generate_blocking (nano::test_genesis_key.pub));
 	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100, *work1, false));
-	auto difficulty1 (block1->difficulty ());
 	{
 		nano::unique_lock<std::mutex> lock (node.active.mutex);
 		// Prevent active difficulty repopulating multipliers

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -214,7 +214,7 @@ int main (int argc, char * const * argv)
 
 				std::vector<mismatched_t> mismatched;
 				mismatched.reserve (hardcoded.size ());
-				std::transform (hardcoded.begin (), hardcoded.end (), std::back_inserter (mismatched), [&ledger, &node](auto const & rep) {
+				std::transform (hardcoded.begin (), hardcoded.end (), std::back_inserter (mismatched), [&ledger](auto const & rep) {
 					auto ledger_rep (ledger.find (rep.first));
 					nano::uint128_t ledger_weight = (ledger_rep == ledger.end () ? 0 : ledger_rep->second);
 					auto absolute = ledger_weight > rep.second ? ledger_weight - rep.second : rep.second - ledger_weight;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -510,7 +510,6 @@ nano::election_insertion_result nano::active_transactions::insert_impl (std::sha
 			{
 				result.inserted = true;
 				auto hash (block_a->hash ());
-				auto difficulty (block_a->difficulty ());
 				auto epoch (block_a->sideband ().details.epoch);
 				auto previous_balance = block_a->previous ().is_zero () ? 0 : previous_balance_a.value_or_eval ([& node = node, &block_a] {
 					return node.ledger.balance (node.store.tx_begin_read (), block_a->previous ());

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -20,9 +20,9 @@ constexpr unsigned nano::bootstrap_limits::requeued_pulls_limit_test;
 
 nano::bootstrap_attempt::bootstrap_attempt (std::shared_ptr<nano::node> node_a, nano::bootstrap_mode mode_a, uint64_t incremental_id_a, std::string id_a) :
 node (node_a),
-mode (mode_a),
 incremental_id (incremental_id_a),
-id (id_a)
+id (id_a),
+mode (mode_a)
 {
 	if (id.empty ())
 	{

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -25,10 +25,9 @@ nano::election_vote_result::election_vote_result (bool replay_a, bool processed_
 
 nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> block_a, std::function<void(std::shared_ptr<nano::block>)> const & confirmation_action_a, bool prioritized_a) :
 confirmation_action (confirmation_action_a),
-state_start (std::chrono::steady_clock::now ()),
+prioritized_m (prioritized_a),
 node (node_a),
-status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
-prioritized_m (prioritized_a)
+status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing })
 {
 	last_votes.emplace (node.network_params.random.not_an_account, nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () });
 	blocks.emplace (block_a->hash (), block_a);

--- a/nano/node/ipc/ipc_access_config.cpp
+++ b/nano/node/ipc/ipc_access_config.cpp
@@ -5,44 +5,6 @@
 
 namespace
 {
-/** Convert permission to strings. This is how permissions appears in config-access.toml */
-std::string to_string (nano::ipc::access_permission permission)
-{
-	switch (permission)
-	{
-		case nano::ipc::access_permission::invalid:
-			return "invalid";
-		case nano::ipc::access_permission::unrestricted:
-			return "unrestricted";
-		case nano::ipc::access_permission::api_service_register:
-			return "api_service_register";
-		case nano::ipc::access_permission::api_service_stop:
-			return "api_service_stop";
-		case nano::ipc::access_permission::api_account_weight:
-			return "api_account_weight";
-		case nano::ipc::access_permission::api_topic_confirmation:
-			return "api_topic_confirmation";
-		case nano::ipc::access_permission::api_topic_service_stop:
-			return "api_topic_service_stop";
-		case nano::ipc::access_permission::account_query:
-			return "account_query";
-		case nano::ipc::access_permission::epoch_upgrade:
-			return "epoch_upgrade";
-		case nano::ipc::access_permission::service:
-			return "service";
-		case nano::ipc::access_permission::wallet:
-			return "wallet";
-		case nano::ipc::access_permission::wallet_read:
-			return "wallet_read";
-		case nano::ipc::access_permission::wallet_write:
-			return "wallet_write";
-		case nano::ipc::access_permission::wallet_seed_change:
-			return "wallet_seed_change";
-	}
-
-	return "invalid";
-}
-
 /** Convert string to permission */
 nano::ipc::access_permission from_string (std::string permission)
 {

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -13,9 +13,9 @@
 nano::network::network (nano::node & node_a, uint16_t port_a) :
 syn_cookies (node_a.network_params.node.max_peers_per_ip),
 buffer_container (node_a.stats, nano::network::buffer_size, 4096), // 2Mb receive buffer
-tcp_message_manager (node_a.stats, node_a.config.tcp_incoming_connections_max),
 resolver (node_a.io_ctx),
 limiter (node_a.config.bandwidth_limit_burst_ratio, node_a.config.bandwidth_limit),
+tcp_message_manager (node_a.config.tcp_incoming_connections_max),
 node (node_a),
 publish_filter (256 * 1024),
 udp_channels (node_a, port_a),
@@ -881,8 +881,7 @@ void nano::message_buffer_manager::stop ()
 	condition.notify_all ();
 }
 
-nano::tcp_message_manager::tcp_message_manager (nano::stat & stats_a, unsigned incoming_connections_max_a) :
-stats (stats_a),
+nano::tcp_message_manager::tcp_message_manager (unsigned incoming_connections_max_a) :
 max_entries (incoming_connections_max_a * nano::tcp_message_manager::max_entries_per_connection + 1)
 {
 	debug_assert (max_entries > 0);

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -69,14 +69,13 @@ private:
 class tcp_message_manager final
 {
 public:
-	tcp_message_manager (nano::stat & stats_a, unsigned incoming_connections_max_a);
+	tcp_message_manager (unsigned incoming_connections_max_a);
 	void put_message (nano::tcp_message_item const & item_a);
 	nano::tcp_message_item get_message ();
 	// Stop container and notify waiting threads
 	void stop ();
 
 private:
-	nano::stat & stats;
 	std::mutex mutex;
 	nano::condition_variable condition;
 	std::deque<nano::tcp_message_item> entries;

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -9,8 +9,8 @@ guard_finish_callback (guard_finish_callback_a)
 }
 
 nano::write_guard::write_guard (nano::write_guard && write_guard_a) noexcept :
-owns (write_guard_a.owns),
-guard_finish_callback (std::move (write_guard_a.guard_finish_callback))
+guard_finish_callback (std::move (write_guard_a.guard_finish_callback)),
+owns (write_guard_a.owns)
 {
 	write_guard_a.owns = false;
 	write_guard_a.guard_finish_callback = nullptr;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2124,7 +2124,6 @@ TEST (rpc, process_subtype_open)
 	ASSERT_EQ (200, response3.status);
 	ASSERT_EQ (open.hash ().to_string (), response3.json.get<std::string> ("hash"));
 	system.deadline_set (10s);
-	auto now (std::chrono::steady_clock::now ());
 	while (node2.latest (key.pub) != open.hash ())
 	{
 		ASSERT_NO_ERROR (system.poll ());


### PR DESCRIPTION
The Xcode IDE gives various warnings in the Issue Navigator, mostly around unused variables and constructor initializer list differences with the class member variable order. The `std::string to_string (nano::ipc::access_permission permission)` function is probably still useful later, but currently it is dead code (there's a warning about it being unused). Can always be added later when necessary.