### PR TITLE
Fix network.tcp_no_connect_excluded_peers test failure

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1121,6 +1121,9 @@ TEST (network, tcp_no_connect_excluded_peers)
 	node0->network.excluded_peers.remove (endpoint1_tcp);
 	ASSERT_FALSE (node0->network.excluded_peers.check (endpoint1_tcp));
 
+	// Wait until there is a syn_cookie
+	ASSERT_TIMELY (5s, node1->network.syn_cookies.cookies_size () != 0);
+
 	// Manually cleanup previous attempt
 	node1->network.cleanup (std::chrono::steady_clock::now ());
 	node1->network.syn_cookies.purge (std::chrono::steady_clock::now ());

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -1007,6 +1007,12 @@ void nano::syn_cookies::purge (std::chrono::steady_clock::time_point const & cut
 	}
 }
 
+size_t nano::syn_cookies::cookies_size ()
+{
+	nano::lock_guard<std::mutex> lock (syn_cookie_mutex);
+	return cookies.size ();
+}
+
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (network & network, const std::string & name)
 {
 	auto composite = std::make_unique<container_info_composite> (name);

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -99,6 +99,7 @@ public:
 	// Also removes the syn cookie from the store if valid
 	bool validate (nano::endpoint const &, nano::account const &, nano::signature const &);
 	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
+	size_t cookies_size ();
 
 private:
 	class syn_cookie_info final


### PR DESCRIPTION
Was only reproducible on MacOS (for what ever reason), the `socket::async_connect` completion handler had not been called yet, so the `syn_cookie` assignment may have come after the purging in the test which can mess up the node handshake, due to the `syn_cookie` already existing. Am now  checking that the `syn_cookie` is set before continuing.