### PR TITLE
 Flood difficulty updates from RPC process

### DIFF
--- a/nano/core_test/node_telemetry.cpp
+++ b/nano/core_test/node_telemetry.cpp
@@ -746,9 +746,9 @@ TEST (node_telemetry, remove_peer_invalid_signature)
 	node->network.process_message (telemetry_ack, channel);
 
 	ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::telemetry, nano::stat::detail::invalid_signature) > 0);
-	system.poll_until_true (3s, [&node, address = channel->get_endpoint ().address ()]() -> bool {
+	ASSERT_NO_ERROR (system.poll_until_true (3s, [&node, address = channel->get_endpoint ().address ()]() -> bool {
 		nano::lock_guard<std::mutex> guard (node->network.excluded_peers.mutex);
 		return node->network.excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ().count (address);
-	});
+	}));
 }
 }

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -145,9 +145,10 @@ public:
 	bool active (nano::block const &);
 	bool active (nano::qualified_root const &);
 	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
-	// Returns true if this block was not active
+	// Returns false if the election difficulty was updated
 	bool update_difficulty (nano::block const &);
-	void restart (std::shared_ptr<nano::block> const &, nano::write_transaction const &);
+	// Returns false if the election was restarted
+	bool restart (std::shared_ptr<nano::block> const &, nano::write_transaction const &);
 	double normalized_multiplier (nano::block const &, boost::optional<roots_iterator> const & = boost::none) const;
 	void add_adjust_difficulty (nano::block_hash const &);
 	void update_adjusted_multiplier ();
@@ -197,7 +198,8 @@ private:
 	// clang-format off
 	nano::election_insertion_result insert_impl (std::shared_ptr<nano::block> const &, boost::optional<nano::uint128_t> const & = boost::none, std::function<void(std::shared_ptr<nano::block>)> const & = [](std::shared_ptr<nano::block>) {});
 	// clang-format on
-	void update_difficulty_impl (roots_iterator const &, nano::block const &);
+	// Returns false if the election difficulty was updated
+	bool update_difficulty_impl (roots_iterator const &, nano::block const &);
 	void request_loop ();
 	void confirm_prioritized_frontiers (nano::transaction const & transaction_a);
 	void request_confirm (nano::unique_lock<std::mutex> &);

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -21,6 +21,12 @@ class transaction;
 class write_transaction;
 class write_database_queue;
 
+enum class block_origin
+{
+	local,
+	remote
+};
+
 /**
  * Processing blocks is a potentially long IO operation.
  * This class isolates block insertion from other operations like servicing network operations
@@ -42,7 +48,7 @@ public:
 	bool should_log ();
 	bool have_blocks ();
 	void process_blocks ();
-	nano::process_return process_one (nano::write_transaction const &, nano::unchecked_info, const bool = false, const bool = false);
+	nano::process_return process_one (nano::write_transaction const &, nano::unchecked_info, const bool = false, nano::block_origin const = nano::block_origin::remote);
 	nano::process_return process_one (nano::write_transaction const &, std::shared_ptr<nano::block>, const bool = false);
 	std::atomic<bool> flushing{ false };
 	// Delay required for average network propagartion before requesting confirmation
@@ -51,7 +57,8 @@ public:
 private:
 	void queue_unchecked (nano::write_transaction const &, nano::block_hash const &);
 	void process_batch (nano::unique_lock<std::mutex> &);
-	void process_live (nano::block_hash const &, std::shared_ptr<nano::block>, nano::process_return const &, const bool = false, const bool = false);
+	void process_live (nano::block_hash const &, std::shared_ptr<nano::block>, nano::process_return const &, const bool = false, nano::block_origin const = nano::block_origin::remote);
+	void process_old (nano::write_transaction const &, std::shared_ptr<nano::block> const &, nano::block_origin const);
 	void requeue_invalid (nano::block_hash const &, nano::unchecked_info const &);
 	void process_verified_state_blocks (std::deque<nano::unchecked_info> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &);
 	bool stopped{ false };

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -612,7 +612,7 @@ nano::process_return nano::node::process_local (std::shared_ptr<nano::block> blo
 	block_processor.wait_write ();
 	// Process block
 	auto transaction (store.tx_begin_write ({ tables::accounts, tables::cached_counts, tables::change_blocks, tables::frontiers, tables::open_blocks, tables::pending, tables::receive_blocks, tables::representation, tables::send_blocks, tables::state_blocks }, { tables::confirmation_height }));
-	return block_processor.process_one (transaction, info, work_watcher_a, true);
+	return block_processor.process_one (transaction, info, work_watcher_a, nano::block_origin::local);
 }
 
 void nano::node::start ()


### PR DESCRIPTION
This is currently done from the work watcher which doesn't go through ledger processing.

Now, there is a new `process_old` which floods the block if it was locally produced and there was a work update.

Unrelated: one telemetry test didn't have `ASSERT_NO_ERROR` around `system.poll_until_true`. Still passing but should keep an eye on CI.