### PR TITLE
 Perform wallet representative action without holding any mutex

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1565,6 +1565,13 @@ TEST (wallet, foreach_representative_deadlock)
 	node.wallets.compute_reps ();
 	ASSERT_EQ (1, node.wallets.rep_counts ().voting);
 	node.wallets.foreach_representative ([&node](nano::public_key const & pub, nano::raw_key const & prv) {
-		ASSERT_TRUE (node.wallets.mutex.try_lock ());
+		if (node.wallets.mutex.try_lock ())
+		{
+			node.wallets.mutex.unlock ();
+		}
+		else
+		{
+			ASSERT_FALSE (true);
+		}
 	});
 }

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1556,3 +1556,15 @@ TEST (wallet, epoch_2_receive_unopened)
 	}
 	ASSERT_LT (tries, max_tries);
 }
+
+TEST (wallet, foreach_representative_deadlock)
+{
+	nano::system system (1);
+	auto & node (*system.nodes[0]);
+	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	node.wallets.compute_reps ();
+	ASSERT_EQ (1, node.wallets.rep_counts ().voting);
+	node.wallets.foreach_representative ([&node](nano::public_key const & pub, nano::raw_key const & prv) {
+		ASSERT_TRUE (node.wallets.mutex.try_lock ());
+	});
+}

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -137,9 +137,12 @@ wallets (wallets_a)
 
 void nano::votes_cache::add (std::shared_ptr<nano::vote> const & vote_a)
 {
-	nano::lock_guard<std::mutex> lock (cache_mutex);
 	auto voting (wallets.rep_counts ().voting);
-	debug_assert (voting > 0);
+	if (voting == 0)
+	{
+		return;
+	}
+	nano::lock_guard<std::mutex> lock (cache_mutex);
 	auto const max_cache_size (network_params.voting.max_cache / std::max (voting, static_cast<decltype (voting)> (1)));
 	for (auto & block : vote_a->blocks)
 	{


### PR DESCRIPTION
 This relaxes restrictions on the action and avoids potential deadlocks through lock-order-inversion.

Best reviewed with hidden whitespace changes.