### PR TITLE
Force node exit if ledger inconsistency in the conf height processor is found

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -846,8 +846,10 @@ TEST (confirmation_heightDeathTest, modified_chain)
 
 		// Rollback the block and now try to write, the block no longer exists so should bail
 		ledger.rollback (store.tx_begin_write (), send->hash ());
-		auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
-		ASSERT_DEATH_IF_SUPPORTED (bounded_processor.cement_blocks (scoped_write_guard), "");
+		{
+			auto scoped_write_guard = write_database_queue.wait (nano::writer::confirmation_height);
+			ASSERT_DEATH_IF_SUPPORTED (bounded_processor.cement_blocks (scoped_write_guard), "");
+		}
 
 #ifndef NDEBUG
 		// Reset conditions and test with the unbounded processor if in debug mode.

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -773,7 +773,7 @@ TEST (confirmation_height, rollback_added_block)
 
 		// No blocks should be cemented
 		ASSERT_EQ (0, stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-		ASSERT_EQ (1, stats.count (nano::stat::type::confirmation_height, nano::stat::detail::read_ledger_mismatch, nano::stat::dir::in));
+		ASSERT_EQ (1, stats.count (nano::stat::type::confirmation_height, nano::stat::detail::invalid_block, nano::stat::dir::in));
 		ASSERT_EQ (1, ledger.cache.cemented_count);
 		ASSERT_EQ (1, ledger.cache.block_count);
 	};
@@ -872,7 +872,7 @@ TEST (confirmation_height, modified_chain)
 	test_mode (nano::confirmation_height_mode::unbounded);
 }
 
-// This tests when a read has been done, but the account no longer exists by the time a write is done
+// This tests when a read has been done, but the account no longer exists by the time a write is done that it is not cemented.
 TEST (confirmation_height, modified_chain_account_removed)
 {
 	auto test_mode = [](nano::confirmation_height_mode mode_a) {

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -23,7 +23,7 @@ TEST (system, work_generate_limited)
 	}
 }
 
-TEST (difficulty, multipliers)
+TEST (difficultyDeathTest, multipliers)
 {
 	// For ASSERT_DEATH_IF_SUPPORTED
 	testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -64,19 +64,15 @@ TEST (difficulty, multipliers)
 		ASSERT_EQ (difficulty, nano::difficulty::from_multiplier (expected_multiplier, base));
 	}
 
+	// Causes valgrind to be noisy
+	if (!nano::running_within_valgrind ())
 	{
-#ifndef NDEBUG
-		// Causes valgrind to be noisy
-		if (!nano::running_within_valgrind ())
-		{
-			uint64_t base = 0xffffffc000000000;
-			uint64_t difficulty_nil = 0;
-			double multiplier_nil = 0.;
+		uint64_t base = 0xffffffc000000000;
+		uint64_t difficulty_nil = 0;
+		double multiplier_nil = 0.;
 
-			ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::to_multiplier (difficulty_nil, base), "");
-			ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::from_multiplier (multiplier_nil, base), "");
-		}
-#endif
+		ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::to_multiplier (difficulty_nil, base), "");
+		ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::from_multiplier (multiplier_nil, base), "");
 	}
 }
 

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -64,6 +64,8 @@ TEST (difficultyDeathTest, multipliers)
 		ASSERT_EQ (difficulty, nano::difficulty::from_multiplier (expected_multiplier, base));
 	}
 
+	// The death checks don't fail on a release config, so guard against them
+#ifndef NDEBUG
 	// Causes valgrind to be noisy
 	if (!nano::running_within_valgrind ())
 	{
@@ -74,6 +76,7 @@ TEST (difficultyDeathTest, multipliers)
 		ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::to_multiplier (difficulty_nil, base), "");
 		ASSERT_DEATH_IF_SUPPORTED (nano::difficulty::from_multiplier (multiplier_nil, base), "");
 	}
+#endif
 }
 
 TEST (difficulty, overflow)

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -703,9 +703,6 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::invalid_block:
 			res = "invalid_block";
 			break;
-		case nano::stat::detail::read_ledger_mismatch:
-			res = "read_ledger_mismatch";
-			break;
 		case nano::stat::detail::aggregator_accepted:
 			res = "aggregator_accepted";
 			break;

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -700,9 +700,6 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::blocks_confirmed_bounded:
 			res = "blocks_confirmed_bounded";
 			break;
-		case nano::stat::detail::invalid_block:
-			res = "invalid_block";
-			break;
 		case nano::stat::detail::aggregator_accepted:
 			res = "aggregator_accepted";
 			break;

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -691,9 +691,6 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::outdated_version:
 			res = "outdated_version";
 			break;
-		case nano::stat::detail::invalid_block:
-			res = "invalid_block";
-			break;
 		case nano::stat::detail::blocks_confirmed:
 			res = "blocks_confirmed";
 			break;
@@ -702,6 +699,12 @@ std::string nano::stat::detail_to_string (uint32_t key)
 			break;
 		case nano::stat::detail::blocks_confirmed_bounded:
 			res = "blocks_confirmed_bounded";
+			break;
+		case nano::stat::detail::invalid_block:
+			res = "invalid_block";
+			break;
+		case nano::stat::detail::read_ledger_mismatch:
+			res = "read_ledger_mismatch";
 			break;
 		case nano::stat::detail::aggregator_accepted:
 			res = "aggregator_accepted";

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -314,7 +314,6 @@ public:
 		blocks_confirmed_unbounded,
 		blocks_confirmed_bounded,
 		invalid_block,
-		read_ledger_mismatch,
 
 		// [request] aggregator
 		aggregator_accepted,

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -314,6 +314,7 @@ public:
 		blocks_confirmed_unbounded,
 		blocks_confirmed_bounded,
 		invalid_block,
+		read_ledger_mismatch,
 
 		// [request] aggregator
 		aggregator_accepted,

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -313,7 +313,6 @@ public:
 		blocks_confirmed,
 		blocks_confirmed_unbounded,
 		blocks_confirmed_bounded,
-		invalid_block,
 
 		// [request] aggregator
 		aggregator_accepted,

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -359,7 +359,7 @@ bool nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 		cemented_batch_timer.start ();
 		// Cement all pending entries, each entry is specific to an account and contains the least amount
 		// of blocks to retain consistent cementing across all account chains to genesis.
-		while (!!error && !pending_writes.empty ())
+		while (!error && !pending_writes.empty ())
 		{
 			const auto & pending = pending_writes.front ();
 			const auto & account = pending.account;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -72,8 +72,9 @@ void nano::confirmation_height_bounded::process ()
 		auto block = ledger.store.block_get (transaction, current);
 		if (!block)
 		{
-			// Mismatch with ledger
-			logger.always_log ("Ledger mismatch trying to set confirmation height for block ", current.to_string (), " (Bounded processor)");
+			auto error_str = (boost::format ("Ledger mismatch trying to set confirmation height for block %1% (bounded processor)") % current.to_string ()).str ();
+			logger.always_log (error_str);
+			std::cerr << error_str << std::endl;
 		}
 		release_assert (block);
 		nano::account account (block->account ());
@@ -373,7 +374,9 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 			error = ledger.store.confirmation_height_get (transaction, pending.account, confirmation_height_info);
 			if (error)
 			{
-				logger.always_log ("Failed to read confirmation height for account ", pending.account.to_account (), " (Unbounded processor)");
+				auto error_str = (boost::format ("Failed to read confirmation height for account %1% (bounded processor)") % pending.account.to_account ()).str ();
+				logger.always_log (error_str);
+				std::cerr << error_str << std::endl;
 			}
 
 			// Some blocks need to be cemented at least
@@ -408,7 +411,9 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 				{
 					if (!block)
 					{
-						logger.always_log ("Failed to write confirmation height for: ", new_cemented_frontier.to_string (), " (Unbounded processor)");
+						auto error_str = (boost::format ("Failed to write confirmation height for block %1% (bounded processor)") % new_cemented_frontier.to_string ()).str ();
+						logger.always_log (error_str);
+						std::cerr << error_str << std::endl;
 						// Undo any blocks about to be cemented from this account for this pending write.
 						cemented_blocks.erase (cemented_blocks.end () - num_blocks_iterated, cemented_blocks.end ());
 						error = true;

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -21,7 +21,7 @@ public:
 	bool pending_empty () const;
 	void reset ();
 	void process ();
-	bool cement_blocks (nano::write_guard & scoped_write_guard_a);
+	void cement_blocks (nano::write_guard & scoped_write_guard_a);
 
 private:
 	class top_and_next_hash final

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -52,6 +52,14 @@ void nano::confirmation_height_unbounded::process ()
 		}
 
 		auto block (get_block_and_sideband (current, read_transaction));
+		if (!block)
+		{
+			// Mismatch with ledger
+			logger.always_log ("Ledger mismatch trying to set confirmation height for block ", current.to_string (), " (Unbounded processor)");
+			ledger.stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::read_ledger_mismatch);
+			return;
+		}
+
 		nano::account account (block->account ());
 		if (account.is_zero ())
 		{
@@ -352,7 +360,7 @@ bool nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 
 				if (!block)
 				{
-					logger.always_log ("Failed to write confirmation height for: ", pending.hash.to_string ());
+					logger.always_log ("Failed to write confirmation height for: ", pending.hash.to_string (), " (Unbounded processor)");
 					ledger.stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::invalid_block);
 					pending_writes.clear ();
 					pending_writes_size = 0;

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -56,8 +56,9 @@ void nano::confirmation_height_unbounded::process ()
 		auto block (get_block_and_sideband (current, read_transaction));
 		if (!block)
 		{
-			// Mismatch with ledger
-			logger.always_log ("Ledger mismatch trying to set confirmation height for block ", current.to_string (), " (Unbounded processor)");
+			auto error_str = (boost::format ("Ledger mismatch trying to set confirmation height for block %1% (unbounded processor)") % current.to_string ()).str ();
+			logger.always_log (error_str);
+			std::cerr << error_str << std::endl;
 		}
 		release_assert (block);
 
@@ -346,7 +347,9 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 			error = ledger.store.confirmation_height_get (transaction, pending.account, confirmation_height_info);
 			if (error)
 			{
-				logger.always_log ("Failed to read confirmation height for account ", pending.account.to_account (), " when writing block ", pending.hash.to_string (), " (Unbounded processor)");
+				auto error_str = (boost::format ("Failed to read confirmation height for account %1% when writing block %2% (unbounded processor)") % pending.account.to_account () % pending.hash.to_string ()).str ();
+				logger.always_log (error_str);
+				std::cerr << error_str << std::endl;
 			}
 			auto confirmation_height = confirmation_height_info.height;
 			if (!error && pending.height > confirmation_height)
@@ -359,7 +362,9 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 
 				if (!block)
 				{
-					logger.always_log ("Failed to write confirmation height for: ", pending.hash.to_string (), " (Unbounded processor)");
+					auto error_str = (boost::format ("Failed to write confirmation height for block %1% (unbounded processor)") % pending.hash.to_string ()).str ();
+					logger.always_log (error_str);
+					std::cerr << error_str << std::endl;
 					error = true;
 					break;
 				}

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -91,7 +91,6 @@ private:
 	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 
-	nano::network_params network_params;
 	nano::ledger & ledger;
 	nano::write_database_queue & write_database_queue;
 	std::chrono::milliseconds batch_separate_pending_min_time;

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -91,6 +91,7 @@ private:
 	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 
+	nano::network_params network_params;
 	nano::ledger & ledger;
 	nano::write_database_queue & write_database_queue;
 	std::chrono::milliseconds batch_separate_pending_min_time;
@@ -98,7 +99,6 @@ private:
 	std::atomic<bool> & stopped;
 	nano::block_hash const & original_hash;
 	uint64_t & batch_write_size;
-	nano::network_constants network_constants;
 
 	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -22,7 +22,7 @@ public:
 	bool pending_empty () const;
 	void reset ();
 	void process ();
-	bool cement_blocks (nano::write_guard &);
+	void cement_blocks (nano::write_guard &);
 
 private:
 	class confirmed_iterated_pair

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -99,6 +99,7 @@ private:
 	std::atomic<bool> & stopped;
 	nano::block_hash const & original_hash;
 	uint64_t & batch_write_size;
+	nano::network_constants network_constants;
 
 	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -45,6 +45,7 @@ public:
 	nano::uint128_t block_balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
 		auto block (block_get (transaction_a, hash_a));
+		release_assert (block);
 		nano::uint128_t result (block_balance_calculated (block));
 		return result;
 	}


### PR DESCRIPTION
`release_assert` if there is a problem found in the conf height processor as this should never happen. 
Will log to the console before this happens though and added/modified some tests to use the bounded/unbounded processors directly to allow death testing to ensure it is working correctly. Death tests named as recommended by https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-test-naming