### PR TITLE
Republishing a vote to principal representatives

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -216,7 +216,7 @@ void nano::network::flood_block_initial (std::shared_ptr<nano::block> const & bl
 void nano::network::flood_vote (std::shared_ptr<nano::vote> const & vote_a, float scale)
 {
 	nano::confirm_ack message (vote_a);
-	for (auto & i : list_non_pr (fanout (scale)))
+	for (auto & i : list (fanout (scale)))
 	{
 		i->send (message, nullptr);
 	}


### PR DESCRIPTION
This behavior was recently changed as part of #2468 . This specific change has the least impact to bandwidth usage out of all changes in that commit.

The list of peers to which a new vote is republished now includes PRs. Fanout is unchanged at `.5 * sqrt(peers)`. The effective fanout change on the main network is from ~14 to ~17.

This change allows PRs that do not directly connect to other PRs to still see their votes. Ensuring PR connectivity is another approach that will be explored in the future.

Note that this change does not apply to PRs as they do not republish votes since #2468 .