### PR TITLE
Enable WebSocket server by default in Docker image

### DIFF
--- a/docker/node/config/config-node.toml
+++ b/docker/node/config/config-node.toml
@@ -4,6 +4,7 @@
 # WebSocket server bind address
 # type:string,ip
 address = "::ffff:0.0.0.0"
+enable = true
 
 [rpc]
 

--- a/docker/node/config/config-node.toml
+++ b/docker/node/config/config-node.toml
@@ -1,13 +1,15 @@
 
 [node.websocket]
 
-# WebSocket server bind address
+# WebSocket server bind address.
 # type:string,ip
 address = "::ffff:0.0.0.0"
+# Enable or disable WebSocket server.
+# type:bool
 enable = true
 
 [rpc]
 
-# Enable or disable RPC
+# Enable or disable RPC.
 # type:bool
 enable = true


### PR DESCRIPTION
The rpc server is enabled by default and port mappings are provided for both the rpc server and the websocket server. Keeping the configuration and documentation consistent between the two will be clearer.