### PR TITLE
Long alias parsing with boost 1.67

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -64,6 +64,16 @@ int main (int argc, char * const * argv)
 {
 	nano::set_umask ();
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
+
+	auto alias_parser = [](const std::string & pre_parsed_a) -> std::pair<std::string, std::string> {
+		std::unordered_map<std::string, std::string> const alias_map{
+			{ "debug_validate_blocks", "validate_blocks" }
+		};
+		auto option = pre_parsed_a.size () > 2 ? pre_parsed_a.substr (2) : pre_parsed_a;
+		auto existing (alias_map.find (option));
+		return { existing != alias_map.end () ? existing->second : "", "" };
+	};
+
 	boost::program_options::options_description description ("Command line options");
 	// clang-format off
 	description.add_options ()
@@ -99,7 +109,7 @@ int main (int argc, char * const * argv)
 		("debug_cemented_block_count", "Displays the number of cemented (confirmed) blocks")
 		("debug_stacktrace", "Display an example stacktrace")
 		("debug_account_versions", "Display the total counts of each version for all accounts (including unpocketed)")
-		("validate_blocks,debug_validate_blocks", "Check all blocks for correct hash, signature, work value")
+		("validate_blocks", "Check all blocks for correct hash, signature, work value")
 		("platform", boost::program_options::value<std::string> (), "Defines the <platform> for OpenCL commands")
 		("device", boost::program_options::value<std::string> (), "Defines <device> for OpenCL command")
 		("threads", boost::program_options::value<std::string> (), "Defines <threads> count for various commands")
@@ -115,7 +125,7 @@ int main (int argc, char * const * argv)
 	boost::program_options::variables_map vm;
 	try
 	{
-		boost::program_options::store (boost::program_options::parse_command_line (argc, argv, description), vm);
+		boost::program_options::store (boost::program_options::command_line_parser (argc, argv).options (description).extra_parser (alias_parser).run (), vm);
 	}
 	catch (boost::program_options::error const & err)
 	{

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -69,7 +69,7 @@ int main (int argc, char * const * argv)
 		std::unordered_map<std::string, std::string> const alias_map{
 			{ "debug_validate_blocks", "validate_blocks" }
 		};
-		auto option = pre_parsed_a.size () > 2 ? pre_parsed_a.substr (2) : pre_parsed_a;
+		auto option = pre_parsed_a.size () > 2 ? pre_parsed_a.substr (2) : pre_parsed_a; // remove "--" from commands
 		auto existing (alias_map.find (option));
 		return { existing != alias_map.end () ? existing->second : "", "" };
 	};


### PR DESCRIPTION
Support for multiple long names was only introduced in [1.68](https://www.boost.org/users/history/version_1_68_0.html), but the `extra_parser` can be used which calls a function on each element ([example](https://www.boost.org/doc/libs/1_67_0/libs/program_options/example/custom_syntax.cpp)). Each element is a command, values are not affected.

This simply translates `--debug_validate_blocks` into `validate_blocks`, everything else should be untouched.