### PR TITLE
Bisected election backtracking

### DIFF
--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -72,6 +72,7 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
 	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
+	send->sideband_set ({});
 	{
 		nano::lock_guard<std::mutex> guard (node2.active.mutex);
 		auto election (std::make_shared<nano::election> (node2, send, nullptr, false));

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -29,6 +29,7 @@ TEST (confirmation_solicitor, batches)
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
 	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
+	send->sideband_set ({});
 	{
 		nano::lock_guard<std::mutex> guard (node2.active.mutex);
 		for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -59,6 +59,14 @@ TEST (election, bisect_dependencies)
 		election->activate_dependencies ();
 		node.active.activate_dependencies (lock);
 	}
+	// The first dependency activation also starts an election for the first unconfirmed block
+	ASSERT_EQ (3, node.active.size ());
+	{
+		auto election = node.active.election (blocks[2]->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		ASSERT_EQ (2, election->blocks.begin ()->second->sideband ().height);
+	}
+
 	auto check_height_and_activate_next = [&node, &blocks](uint64_t height_a) {
 		auto election = node.active.election (blocks[height_a]->qualified_root ());
 		ASSERT_NE (nullptr, election);
@@ -67,23 +75,22 @@ TEST (election, bisect_dependencies)
 		election->activate_dependencies ();
 		node.active.activate_dependencies (lock);
 	};
-	ASSERT_EQ (2, node.active.size ());
 	check_height_and_activate_next (300 - 128); // ensure limited by 128 jumps
-	ASSERT_EQ (3, node.active.size ());
-	check_height_and_activate_next (87);
 	ASSERT_EQ (4, node.active.size ());
-	check_height_and_activate_next (44);
+	check_height_and_activate_next (87);
 	ASSERT_EQ (5, node.active.size ());
-	check_height_and_activate_next (23);
+	check_height_and_activate_next (44);
 	ASSERT_EQ (6, node.active.size ());
-	check_height_and_activate_next (12);
+	check_height_and_activate_next (23);
 	ASSERT_EQ (7, node.active.size ());
-	check_height_and_activate_next (7);
+	check_height_and_activate_next (12);
 	ASSERT_EQ (8, node.active.size ());
-	check_height_and_activate_next (4);
+	check_height_and_activate_next (7);
 	ASSERT_EQ (9, node.active.size ());
-	check_height_and_activate_next (3);
+	check_height_and_activate_next (4);
 	ASSERT_EQ (10, node.active.size ());
+	check_height_and_activate_next (3);
+	ASSERT_EQ (10, node.active.size ()); // height 2 already inserted initially, no more blocks to activate
 	check_height_and_activate_next (2);
 	ASSERT_EQ (10, node.active.size ()); // conf height is 1, no more blocks to activate
 	ASSERT_EQ (node.active.blocks.size (), node.active.roots.size ());

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -55,15 +55,17 @@ TEST (election, bisect_dependencies)
 		auto election = node.active.insert (blocks.back ()).election;
 		ASSERT_NE (nullptr, election);
 		ASSERT_EQ (300, election->blocks.begin ()->second->sideband ().height);
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
+		nano::unique_lock<std::mutex> lock (node.active.mutex);
 		election->activate_dependencies ();
+		node.active.activate_dependencies (lock);
 	}
 	auto check_height_and_activate_next = [&node, &blocks](uint64_t height_a) {
 		auto election = node.active.election (blocks[height_a]->qualified_root ());
 		ASSERT_NE (nullptr, election);
 		ASSERT_EQ (height_a, election->blocks.begin ()->second->sideband ().height);
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
+		nano::unique_lock<std::mutex> lock (node.active.mutex);
 		election->activate_dependencies ();
+		node.active.activate_dependencies (lock);
 	};
 	ASSERT_EQ (2, node.active.size ());
 	check_height_and_activate_next (300 - 128); // ensure limited by 128 jumps

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -35,7 +35,7 @@ TEST (election, bisect_dependencies)
 	blocks.push_back (genesis.open);
 	nano::block_builder builder;
 	auto amount = nano::genesis_amount;
-	for (int i = 0; i < 29; ++i)
+	for (int i = 0; i < 299; ++i)
 	{
 		auto latest = blocks.back ();
 		blocks.push_back (builder.state ()
@@ -49,12 +49,12 @@ TEST (election, bisect_dependencies)
 		                  .build ());
 		ASSERT_EQ (nano::process_result::progress, node.process (*blocks.back ()).code);
 	}
-	ASSERT_EQ (31, blocks.size ());
+	ASSERT_EQ (301, blocks.size ());
 	ASSERT_TRUE (node.active.empty ());
 	{
 		auto election = node.active.insert (blocks.back ()).election;
 		ASSERT_NE (nullptr, election);
-		ASSERT_EQ (30, election->blocks.begin ()->second->sideband ().height);
+		ASSERT_EQ (300, election->blocks.begin ()->second->sideband ().height);
 		nano::lock_guard<std::mutex> guard (node.active.mutex);
 		election->activate_dependencies ();
 	}
@@ -66,14 +66,24 @@ TEST (election, bisect_dependencies)
 		election->activate_dependencies ();
 	};
 	ASSERT_EQ (2, node.active.size ());
-	check_height_and_activate_next (15);
+	check_height_and_activate_next (300 - 128); // ensure limited by 128 jumps
 	ASSERT_EQ (3, node.active.size ());
-	check_height_and_activate_next (8);
+	check_height_and_activate_next (87);
 	ASSERT_EQ (4, node.active.size ());
+	check_height_and_activate_next (44);
+	ASSERT_EQ (5, node.active.size ());
+	check_height_and_activate_next (23);
+	ASSERT_EQ (6, node.active.size ());
+	check_height_and_activate_next (12);
+	ASSERT_EQ (7, node.active.size ());
+	check_height_and_activate_next (7);
+	ASSERT_EQ (8, node.active.size ());
 	check_height_and_activate_next (4);
-	ASSERT_EQ (5, node.active.size ());
+	ASSERT_EQ (9, node.active.size ());
+	check_height_and_activate_next (3);
+	ASSERT_EQ (10, node.active.size ());
 	check_height_and_activate_next (2);
-	ASSERT_EQ (5, node.active.size ());
+	ASSERT_EQ (10, node.active.size ()); // conf height is 1, no more blocks to activate
 	ASSERT_EQ (node.active.blocks.size (), node.active.roots.size ());
 }
 }

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -17,3 +17,63 @@ TEST (election, construction)
 	election->transition_passive ();
 	ASSERT_FALSE (election->idle ());
 }
+
+namespace nano
+{
+TEST (election, bisect_dependencies)
+{
+	nano::system system;
+	nano::node_flags flags;
+	flags.disable_request_loop = true;
+	auto & node = *system.add_node (flags);
+	nano::genesis genesis;
+	nano::confirmation_height_info conf_info;
+	ASSERT_FALSE (node.store.confirmation_height_get (node.store.tx_begin_read (), nano::test_genesis_key.pub, conf_info));
+	ASSERT_EQ (1, conf_info.height);
+	std::vector<std::shared_ptr<nano::block>> blocks;
+	blocks.push_back (nullptr); // idx == height
+	blocks.push_back (genesis.open);
+	nano::block_builder builder;
+	auto amount = nano::genesis_amount;
+	for (int i = 0; i < 29; ++i)
+	{
+		auto latest = blocks.back ();
+		blocks.push_back (builder.state ()
+		                  .previous (latest->hash ())
+		                  .account (nano::test_genesis_key.pub)
+		                  .representative (nano::test_genesis_key.pub)
+		                  .balance (--amount)
+		                  .link (nano::test_genesis_key.pub)
+		                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		                  .work (*system.work.generate (latest->hash ()))
+		                  .build ());
+		ASSERT_EQ (nano::process_result::progress, node.process (*blocks.back ()).code);
+	}
+	ASSERT_EQ (31, blocks.size ());
+	ASSERT_TRUE (node.active.empty ());
+	{
+		auto election = node.active.insert (blocks.back ()).election;
+		ASSERT_NE (nullptr, election);
+		ASSERT_EQ (30, election->blocks.begin ()->second->sideband ().height);
+		nano::lock_guard<std::mutex> guard (node.active.mutex);
+		election->activate_dependencies ();
+	}
+	auto check_height_and_activate_next = [&node, &blocks](uint64_t height_a) {
+		auto election = node.active.election (blocks[height_a]->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		ASSERT_EQ (height_a, election->blocks.begin ()->second->sideband ().height);
+		nano::lock_guard<std::mutex> guard (node.active.mutex);
+		election->activate_dependencies ();
+	};
+	ASSERT_EQ (2, node.active.size ());
+	check_height_and_activate_next (15);
+	ASSERT_EQ (3, node.active.size ());
+	check_height_and_activate_next (8);
+	ASSERT_EQ (4, node.active.size ());
+	check_height_and_activate_next (4);
+	ASSERT_EQ (5, node.active.size ());
+	check_height_and_activate_next (2);
+	ASSERT_EQ (5, node.active.size ());
+	ASSERT_EQ (node.active.blocks.size (), node.active.roots.size ());
+}
+}

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3185,4 +3185,8 @@ TEST (ledger, backtrack)
 	ASSERT_EQ (nullptr, ledger.backtrack (transaction, nullptr, 0));
 	ASSERT_EQ (nullptr, ledger.backtrack (transaction, nullptr, 10));
 	ASSERT_EQ (*blocks[1], *ledger.backtrack (transaction, blocks[1], 0));
+	auto block_228 = dynamic_cast<nano::state_block *> (blocks[228].get ());
+	std::shared_ptr<nano::block> block_228_no_sideband = nano::block_builder ().state ().from (*block_228).build ();
+	ASSERT_FALSE (block_228_no_sideband->has_sideband ());
+	ASSERT_EQ (*block_100, *ledger.backtrack (transaction, block_228_no_sideband, 100));
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3132,3 +3132,57 @@ TEST (ledger, epoch_2_upgrade_callback)
 	auto latest = upgrade_epoch (pool, ledger, nano::epoch::epoch_2);
 	ASSERT_TRUE (cb_hit);
 }
+
+TEST (ledger, backtrack)
+{
+	nano::genesis genesis;
+	nano::stat stats;
+	nano::logger_mt logger;
+	auto store = nano::make_store (logger, nano::unique_path ());
+	ASSERT_TRUE (!store->init_error ());
+	bool cb_hit = false;
+	nano::ledger ledger (*store, stats, nano::generate_cache (), [&cb_hit]() {
+		cb_hit = true;
+	});
+	{
+		auto transaction (store->tx_begin_write ());
+		store->initialize (transaction, genesis, ledger.cache);
+	}
+	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	std::vector<std::shared_ptr<nano::block>> blocks;
+	blocks.push_back (nullptr); // idx == height
+	blocks.push_back (genesis.open);
+	auto amount = nano::genesis_amount;
+	for (auto i = 0; i < 300; ++i)
+	{
+		nano::block_builder builder;
+		std::error_code ec;
+		auto latest = blocks.back ();
+		blocks.push_back (builder.state ()
+		                  .previous (latest->hash ())
+		                  .account (nano::test_genesis_key.pub)
+		                  .representative (nano::test_genesis_key.pub)
+		                  .balance (--amount)
+		                  .link (nano::test_genesis_key.pub)
+		                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		                  .work (*pool.generate (latest->hash ()))
+		                  .build (ec));
+		ASSERT_FALSE (ec);
+		ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), *blocks.back ()).code);
+	}
+	ASSERT_EQ (302, blocks.size ());
+	ASSERT_EQ (301, blocks[301]->sideband ().height);
+	auto transaction (store->tx_begin_read ());
+	auto block_100 = ledger.backtrack (transaction, blocks[228], 100);
+	ASSERT_NE (nullptr, block_100);
+	ASSERT_EQ (*block_100, *blocks[100]);
+	// Max backtracking
+	ASSERT_EQ (*block_100, *ledger.backtrack (transaction, blocks[228], 99));
+	ASSERT_EQ (*block_100, *ledger.backtrack (transaction, blocks[228], 0));
+	ASSERT_NE (nullptr, ledger.backtrack (transaction, blocks[10], 0));
+	ASSERT_NE (ledger.backtrack (transaction, blocks[10], 1), ledger.backtrack (transaction, blocks[10], 2));
+	ASSERT_NE (ledger.backtrack (transaction, blocks[10], 0), ledger.backtrack (transaction, blocks[10], 1));
+	ASSERT_EQ (nullptr, ledger.backtrack (transaction, nullptr, 0));
+	ASSERT_EQ (nullptr, ledger.backtrack (transaction, nullptr, 10));
+	ASSERT_EQ (*blocks[1], *ledger.backtrack (transaction, blocks[1], 0));
+}

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3173,20 +3173,13 @@ TEST (ledger, backtrack)
 	ASSERT_EQ (302, blocks.size ());
 	ASSERT_EQ (301, blocks[301]->sideband ().height);
 	auto transaction (store->tx_begin_read ());
-	auto block_100 = ledger.backtrack (transaction, blocks[228], 100);
+	auto block_100 = ledger.backtrack (transaction, blocks[300], 200);
 	ASSERT_NE (nullptr, block_100);
 	ASSERT_EQ (*block_100, *blocks[100]);
-	// Max backtracking
-	ASSERT_EQ (*block_100, *ledger.backtrack (transaction, blocks[228], 99));
-	ASSERT_EQ (*block_100, *ledger.backtrack (transaction, blocks[228], 0));
-	ASSERT_NE (nullptr, ledger.backtrack (transaction, blocks[10], 0));
-	ASSERT_NE (ledger.backtrack (transaction, blocks[10], 1), ledger.backtrack (transaction, blocks[10], 2));
-	ASSERT_NE (ledger.backtrack (transaction, blocks[10], 0), ledger.backtrack (transaction, blocks[10], 1));
+	ASSERT_NE (nullptr, ledger.backtrack (transaction, blocks[10], 10));
+	ASSERT_NE (ledger.backtrack (transaction, blocks[10], 1), ledger.backtrack (transaction, blocks[11], 2));
+	ASSERT_EQ (ledger.backtrack (transaction, blocks[1], 0), ledger.backtrack (transaction, blocks[1], 1));
+	ASSERT_NE (ledger.backtrack (transaction, blocks[2], 0), ledger.backtrack (transaction, blocks[2], 1));
 	ASSERT_EQ (nullptr, ledger.backtrack (transaction, nullptr, 0));
 	ASSERT_EQ (nullptr, ledger.backtrack (transaction, nullptr, 10));
-	ASSERT_EQ (*blocks[1], *ledger.backtrack (transaction, blocks[1], 0));
-	auto block_228 = dynamic_cast<nano::state_block *> (blocks[228].get ());
-	std::shared_ptr<nano::block> block_228_no_sideband = nano::block_builder ().state ().from (*block_228).build ();
-	ASSERT_FALSE (block_228_no_sideband->has_sideband ());
-	ASSERT_EQ (*block_100, *ledger.backtrack (transaction, block_228_no_sideband, 100));
 }

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -251,6 +251,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 	solicitor.flush ();
 	generator_session.flush ();
 	lock_a.lock ();
+	activate_dependencies (lock_a);
 
 	// This is updated after the loop to ensure slow machines don't do the full check often
 	if (check_all_elections_l)
@@ -286,6 +287,64 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
 		prioritize_frontiers_for_confirmation (transaction, node.network_params.network.is_test_network () ? std::chrono::milliseconds (50) : time_spent_prioritizing_ledger_accounts, time_spent_prioritizing_wallet_accounts);
 		confirm_prioritized_frontiers (transaction);
 		lock_a.lock ();
+	}
+}
+
+void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mutex> & lock_a)
+{
+	debug_assert (!mutex.try_lock ());
+	decltype (pending_dependencies) pending_l;
+	pending_l.swap (pending_dependencies);
+	lock_a.unlock ();
+	// Store blocks to activate when the lock is re-acquired, adding the hash of the original election as a dependency
+	std::vector<std::pair<std::shared_ptr<nano::block>, nano::block_hash>> activate_l;
+	{
+		auto transaction = node.store.tx_begin_read ();
+		for (auto const & entry_l : pending_l)
+		{
+			auto const & block_l (entry_l.first);
+			auto const height_l (entry_l.second);
+			bool escalated_l (false);
+			auto previous_hash_l (block_l->previous ());
+			if (!previous_hash_l.is_zero ())
+			{
+				auto account (node.ledger.account (transaction, block_l->hash ()));
+				nano::confirmation_height_info conf_info_l;
+				if (!node.store.confirmation_height_get (transaction, account, conf_info_l) && height_l > conf_info_l.height + 1)
+				{
+					auto const jumps_l = std::min<uint8_t> (128, (height_l - conf_info_l.height) / 2);
+					auto backtracked_l (node.ledger.backtrack (transaction, block_l, jumps_l));
+					if (backtracked_l != nullptr)
+					{
+						activate_l.emplace_back (backtracked_l, block_l->hash ());
+					}
+				}
+			}
+			/* If previous block not existing/not commited yet, block_source can cause segfault for state blocks
+				So source check can be done only if previous != nullptr or previous is 0 (open account) */
+			if (previous_hash_l.is_zero () || node.ledger.block_exists (previous_hash_l))
+			{
+				auto source_hash_l (node.ledger.block_source (transaction, *block_l));
+				if (!source_hash_l.is_zero () && source_hash_l != previous_hash_l && node.active.blocks.find (source_hash_l) == node.active.blocks.end ())
+				{
+					auto source_l (node.store.block_get (transaction, source_hash_l));
+					if (source_l != nullptr && !node.block_confirmed_or_being_confirmed (transaction, source_hash_l))
+					{
+						activate_l.emplace_back (source_l, block_l->hash ());
+					}
+				}
+			}
+		}
+	}
+	lock_a.lock ();
+	for (auto const & entry_l : activate_l)
+	{
+		auto election = node.active.insert_impl (entry_l.first);
+		if (election.inserted)
+		{
+			election.election->transition_active ();
+			election.election->dependent_blocks.insert (entry_l.second);
+		}
 	}
 }
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -316,11 +316,14 @@ void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mu
 					if (height_l > conf_info_l.height + 1 && !conf_info_l.frontier.is_zero ())
 					{
 						auto successor_hash_l = node.store.block_successor (transaction, conf_info_l.frontier);
-						auto successor_l = node.store.block_get (transaction, successor_hash_l);
-						debug_assert (successor_l != nullptr);
-						if (successor_l != nullptr)
+						if (!confirmation_height_processor.is_processing_block (successor_hash_l))
 						{
-							activate_l.emplace_back (successor_l, block_l->hash ());
+							auto successor_l = node.store.block_get (transaction, successor_hash_l);
+							debug_assert (successor_l != nullptr);
+							if (successor_l != nullptr)
+							{
+								activate_l.emplace_back (successor_l, block_l->hash ());
+							}
 						}
 					}
 					if (height_l > conf_info_l.height + 2)

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -292,7 +292,7 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
 
 void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mutex> & lock_a)
 {
-	debug_assert (!mutex.try_lock ());
+	debug_assert (lock_a.owns_lock ());
 	decltype (pending_dependencies) pending_l;
 	pending_l.swap (pending_dependencies);
 	lock_a.unlock ();

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -342,7 +342,7 @@ void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mu
 			if (previous_hash_l.is_zero () || node.ledger.block_exists (previous_hash_l))
 			{
 				auto source_hash_l (node.ledger.block_source (transaction, *block_l));
-				if (!source_hash_l.is_zero () && source_hash_l != previous_hash_l && node.active.blocks.find (source_hash_l) == node.active.blocks.end ())
+				if (!source_hash_l.is_zero () && source_hash_l != previous_hash_l && blocks.find (source_hash_l) == blocks.end ())
 				{
 					auto source_l (node.store.block_get (transaction, source_hash_l));
 					if (source_l != nullptr && !node.block_confirmed_or_being_confirmed (transaction, source_hash_l))
@@ -356,7 +356,7 @@ void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mu
 	lock_a.lock ();
 	for (auto const & entry_l : activate_l)
 	{
-		auto election = node.active.insert_impl (entry_l.first);
+		auto election = insert_impl (entry_l.first);
 		if (election.inserted)
 		{
 			election.election->transition_active ();

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -328,7 +328,7 @@ void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mu
 					}
 					if (height_l > conf_info_l.height + 2)
 					{
-						auto const jumps_l = std::min<uint8_t> (128, (height_l - conf_info_l.height) / 2);
+						auto const jumps_l = std::min<uint64_t> (128, (height_l - conf_info_l.height) / 2);
 						auto backtracked_l (node.ledger.backtrack (transaction, block_l, jumps_l));
 						if (backtracked_l != nullptr)
 						{

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -206,6 +206,8 @@ private:
 	void frontiers_confirmation (nano::unique_lock<std::mutex> &);
 	nano::account next_frontier_account{ 0 };
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
+	void activate_dependencies (nano::unique_lock<std::mutex> &);
+	std::vector<std::pair<std::shared_ptr<nano::block>, uint64_t>> pending_dependencies;
 	nano::condition_variable condition;
 	bool started{ false };
 	std::atomic<bool> stopped{ false };
@@ -261,6 +263,9 @@ private:
 	bool inactive_votes_bootstrap_check (std::vector<nano::account> const &, nano::block_hash const &, bool &);
 	boost::thread thread;
 
+	friend class election;
+	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, const std::string &);
+
 	friend class active_transactions_dropped_cleanup_Test;
 	friend class active_transactions_vote_replays_Test;
 	friend class confirmation_height_prioritize_frontiers_Test;
@@ -268,7 +273,7 @@ private:
 	friend class active_transactions_confirmation_consistency_Test;
 	friend class active_transactions_vote_generator_session_Test;
 	friend class node_vote_by_hash_bundle_Test;
-	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, const std::string &);
+	friend class election_bisect_dependencies_Test;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (active_transactions & active_transactions, const std::string & name);

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -221,9 +221,8 @@ void nano::election::activate_dependencies ()
 		nano::confirmation_height_info conf_info_l;
 		if (!node.store.confirmation_height_get (transaction, account, conf_info_l) && height > conf_info_l.height + 1)
 		{
-			auto bisect_height_l = conf_info_l.height + (height - conf_info_l.height) / 2;
-			debug_assert (bisect_height_l > conf_info_l.height && bisect_height_l < height);
-			auto backtracked_l (node.ledger.backtrack (transaction, status.winner, bisect_height_l));
+			auto const jumps_l = std::min<uint8_t> (128, (height - conf_info_l.height) / 2);
+			auto backtracked_l (node.ledger.backtrack (transaction, status.winner, jumps_l));
 			if (backtracked_l != nullptr)
 			{
 				auto election = node.active.insert_impl (backtracked_l);

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -111,5 +111,8 @@ public:
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 	std::unordered_set<nano::block_hash> dependent_blocks;
 	std::chrono::seconds late_blocks_delay{ 5 };
+	uint64_t const height;
+
+	friend class election_bisect_dependencies_Test;
 };
 }

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1178,21 +1178,15 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 	return result;
 }
 
-std::shared_ptr<nano::block> nano::ledger::backtrack (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & start_a, uint64_t const height_a)
+std::shared_ptr<nano::block> nano::ledger::backtrack (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & start_a, uint64_t jumps_a)
 {
-	constexpr unsigned backtrack_max = 128;
-	unsigned backtrack = 0;
 	auto block = start_a;
-	auto height (block && block->has_sideband () ? block->sideband ().height : std::numeric_limits<uint64_t>::max ());
-	for (; block != nullptr && !block->previous ().is_zero () && backtrack < backtrack_max && height > height_a; ++backtrack)
+	while (jumps_a > 0 && block != nullptr && !block->previous ().is_zero ())
 	{
 		block = store.block_get (transaction_a, block->previous ());
-		if (block)
-		{
-			height = block->sideband ().height;
-		}
+		--jumps_a;
 	}
-	debug_assert (block == nullptr || block->previous ().is_zero () || height <= height_a || backtrack == backtrack_max);
+	debug_assert (block == nullptr || block->previous ().is_zero () || jumps_a == 0);
 	return block;
 }
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1181,13 +1181,18 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 std::shared_ptr<nano::block> nano::ledger::backtrack (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & start_a, uint64_t const height_a)
 {
 	constexpr unsigned backtrack_max = 128;
-	auto block = start_a;
 	unsigned backtrack = 0;
-	for (backtrack; block != nullptr && !block->previous ().is_zero () && backtrack < backtrack_max && block->sideband ().height != height_a; ++backtrack)
+	auto block = start_a;
+	auto height (block && block->has_sideband () ? block->sideband ().height : std::numeric_limits<uint64_t>::max ());
+	for (; block != nullptr && !block->previous ().is_zero () && backtrack < backtrack_max && height > height_a; ++backtrack)
 	{
 		block = store.block_get (transaction_a, block->previous ());
+		if (block)
+		{
+			height = block->sideband ().height;
+		}
 	}
-	debug_assert (block == nullptr || block->previous ().is_zero () || block->sideband ().height == height_a || backtrack == backtrack_max);
+	debug_assert (block == nullptr || block->previous ().is_zero () || height <= height_a || backtrack == backtrack_max);
 	return block;
 }
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1184,6 +1184,7 @@ std::shared_ptr<nano::block> nano::ledger::backtrack (nano::transaction const & 
 	while (jumps_a > 0 && block != nullptr && !block->previous ().is_zero ())
 	{
 		block = store.block_get (transaction_a, block->previous ());
+		debug_assert (block != nullptr);
 		--jumps_a;
 	}
 	debug_assert (block == nullptr || block->previous ().is_zero () || jumps_a == 0);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1178,6 +1178,19 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 	return result;
 }
 
+std::shared_ptr<nano::block> nano::ledger::backtrack (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & start_a, uint64_t const height_a)
+{
+	constexpr unsigned backtrack_max = 128;
+	auto block = start_a;
+	unsigned backtrack = 0;
+	for (backtrack; block != nullptr && !block->previous ().is_zero () && backtrack < backtrack_max && block->sideband ().height != height_a; ++backtrack)
+	{
+		block = store.block_get (transaction_a, block->previous ());
+	}
+	debug_assert (block == nullptr || block->previous ().is_zero () || block->sideband ().height == height_a || backtrack == backtrack_max);
+	return block;
+}
+
 bool nano::ledger::block_confirmed (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	auto confirmed (false);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -25,8 +25,7 @@ public:
 	nano::uint128_t weight (nano::account const &);
 	std::shared_ptr<nano::block> successor (nano::transaction const &, nano::qualified_root const &);
 	std::shared_ptr<nano::block> forked_block (nano::transaction const &, nano::block const &);
-	// Limited to 128 jumps
-	std::shared_ptr<nano::block> backtrack (nano::transaction const &, std::shared_ptr<nano::block> const &, uint64_t const);
+	std::shared_ptr<nano::block> backtrack (nano::transaction const &, std::shared_ptr<nano::block> const &, uint64_t);
 	bool block_confirmed (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 	bool block_not_confirmed_or_not_exists (nano::block const & block_a) const;
 	nano::block_hash latest (nano::transaction const &, nano::account const &);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -25,6 +25,8 @@ public:
 	nano::uint128_t weight (nano::account const &);
 	std::shared_ptr<nano::block> successor (nano::transaction const &, nano::qualified_root const &);
 	std::shared_ptr<nano::block> forked_block (nano::transaction const &, nano::block const &);
+	// Limited to 128 jumps
+	std::shared_ptr<nano::block> backtrack (nano::transaction const &, std::shared_ptr<nano::block> const &, uint64_t const);
 	bool block_confirmed (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 	bool block_not_confirmed_or_not_exists (nano::block const & block_a) const;
 	nano::block_hash latest (nano::transaction const &, nano::account const &);


### PR DESCRIPTION
When an election is backtracked (fallback behavior), its dependents are activated. When many blocks are unconfirmed in the same chain, it's more efficient to bisect it and activate the midpoint between the current election height and the current confirmation height. This should converge sufficiently fast.

For worst case scenarios, also added a pessimistic fallback that starts an election for the first unconfirmed block.