### PR TITLE
Set boost min to 1.69

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ set(Boost_USE_MULTITHREADED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package (Boost 1.67.0 REQUIRED COMPONENTS filesystem log log_setup thread program_options system)
+find_package (Boost 1.69.0 REQUIRED COMPONENTS filesystem log log_setup thread program_options system)
 
 if (NANO_ROCKSDB)
 	find_package (RocksDB REQUIRED)

--- a/ci/actions/osx/install_deps.sh
+++ b/ci/actions/osx/install_deps.sh
@@ -8,5 +8,5 @@ if [[ ${TEST-0} -eq 1 ]]; then
 else
     util/build_prep/fetch_rocksdb.sh
 fi
-util/build_prep/bootstrap_boost.sh -m -c -B 1.70 && \
+util/build_prep/fetch_boost.sh && \
 util/build_prep/macosx/build_qt.sh

--- a/ci/actions/osx/install_deps.sh
+++ b/ci/actions/osx/install_deps.sh
@@ -8,5 +8,5 @@ if [[ ${TEST-0} -eq 1 ]]; then
 else
     util/build_prep/fetch_rocksdb.sh
 fi
-util/build_prep/fetch_boost.sh && \
+sudo util/build_prep/fetch_boost.sh 
 util/build_prep/macosx/build_qt.sh

--- a/docker/ci/Dockerfile-clang
+++ b/docker/ci/Dockerfile-clang
@@ -14,8 +14,8 @@ RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 ENV BOOST_ROOT=/tmp/boost
 
-ADD util/build_prep/bootstrap_boost.sh bootstrap_boost.sh
-RUN ./bootstrap_boost.sh -m -c -B 1.70
+ADD util/build_prep/fetch_boost.sh fetch_boost.sh
+RUN ./fetch_boost.sh
 
 # workaround to get a path that can be easily passed into cmake for
 # BOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE 

--- a/docker/ci/Dockerfile-clang-6
+++ b/docker/ci/Dockerfile-clang-6
@@ -17,6 +17,6 @@ RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 ENV BOOST_ROOT=/tmp/boost
 
-ADD util/build_prep/bootstrap_boost.sh bootstrap_boost.sh
+ADD util/build_prep/fetch_boost.sh fetch_boost.sh
 
-RUN ./bootstrap_boost.sh -m -c -B 1.70
+RUN COMPILER=clang-6 ./fetch_boost.sh

--- a/docker/ci/Dockerfile-gcc
+++ b/docker/ci/Dockerfile-gcc
@@ -9,4 +9,4 @@ ENV BOOST_ROOT=/tmp/boost
 
 ADD util/build_prep/fetch_boost.sh fetch_boost.sh
 
-RUN TRAVIS_COMPILER=gcc ./fetch_boost.sh
+RUN COMPILER=gcc ./fetch_boost.sh

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -11,7 +11,7 @@ buildThreads=1
 buildCArgs=()
 buildCXXArgs=()
 buildLDArgs=()
-boostVersion='1.67'
+boostVersion='1.69'
 while getopts 'hmscCkpvB:j:' OPT; do
 	case "${OPT}" in
 		h)
@@ -83,11 +83,6 @@ if [ "${useClang}" = 'true' ]; then
 fi
 
 case "${boostVersion}" in
-	1.67)
-		BOOST_BASENAME=boost_1_67_0
-		BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.67.0/${BOOST_BASENAME}.tar.bz2/download
-		BOOST_ARCHIVE_SHA256='2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba'
-		;;
 	1.69)
 		BOOST_BASENAME=boost_1_69_0
 		BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.69.0/${BOOST_BASENAME}.tar.bz2/download
@@ -97,6 +92,16 @@ case "${boostVersion}" in
 		BOOST_BASENAME=boost_1_70_0
 		BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.70.0/${BOOST_BASENAME}.tar.bz2/download
 		BOOST_ARCHIVE_SHA256='430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778'
+		;;
+	1.72)
+		BOOST_BASENAME=boost_1_72_0
+		BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.72.0/${BOOST_BASENAME}.tar.bz2/download
+		BOOST_ARCHIVE_SHA256='59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722'
+		;;
+	1.73)
+		BOOST_BASENAME=boost_1_73_0
+		BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.73.0/${BOOST_BASENAME}.tar.bz2/download
+		BOOST_ARCHIVE_SHA256='4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402'
 		;;
 	*)
 		echo "Unsupported Boost version: ${boostVersion}" >&2

--- a/util/build_prep/centos/prep.sh.in
+++ b/util/build_prep/centos/prep.sh.in
@@ -28,8 +28,8 @@ yes | yum install -y llvm-toolset-7-cmake devtoolset-7-llvm|| exit 1
 		exit 1
 	fi
 
-	if ! version_min 'boost --version' 1.66.999; then
-		echo "boost version too low (1.67.0+ required)" >&2
+	if ! version_min 'boost --version' 1.68.999; then
+		echo "boost version too low (1.69.0+ required)" >&2
 	        exit 1
 	fi
 

--- a/util/build_prep/fetch_boost.sh
+++ b/util/build_prep/fetch_boost.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 OS=`uname`
 
-TRAVIS_COMPILER="${TRAVIS_COMPILER:-clang}"
+COMPILER="${COMPILER:-clang}"
 
 pushd /tmp
-wget -O boost-$OS-$TRAVIS_COMPILER-1.70.tgz https://s3.us-east-2.amazonaws.com/repo.nano.org/artifacts/boost-$OS-$TRAVIS_COMPILER-1.70.tgz
-tar -zxf boost-$OS-$TRAVIS_COMPILER-1.70.tgz
+wget -O boost-$OS-$COMPILER-1.70.tgz https://s3.us-east-2.amazonaws.com/repo.nano.org/artifacts/boost-$OS-$COMPILER-1.70.tgz
+tar -zxf boost-$OS-$COMPILER-1.70.tgz
 mv tmp/* .
 rm -fr tmp
 popd

--- a/util/build_prep/fetch_boost.sh
+++ b/util/build_prep/fetch_boost.sh
@@ -4,8 +4,8 @@ OS=`uname`
 TRAVIS_COMPILER="${TRAVIS_COMPILER:-clang}"
 
 pushd /tmp
-wget -O boost-$OS-$TRAVIS_COMPILER-latest.tgz https://s3.us-east-2.amazonaws.com/repo.nano.org/artifacts/boost-$OS-$TRAVIS_COMPILER-latest.tgz
-tar -zxf boost-$OS-$TRAVIS_COMPILER-latest.tgz
+wget -O boost-$OS-$TRAVIS_COMPILER-1.70.tgz https://s3.us-east-2.amazonaws.com/repo.nano.org/artifacts/boost-$OS-$TRAVIS_COMPILER-1.70.tgz
+tar -zxf boost-$OS-$TRAVIS_COMPILER-1.70.tgz
 mv tmp/* .
 rm -fr tmp
 popd

--- a/util/build_prep/macosx/prep.sh.in
+++ b/util/build_prep/macosx/prep.sh.in
@@ -50,8 +50,8 @@ if ! have boost; then
 	exit 1
 fi
 
-if ! version_min 'boost --version' 1.66.999; then
-	echo "boost version too low (1.67.0+ required)" >&2
+if ! version_min 'boost --version' 1.68.999; then
+	echo "boost version too low (1.69.0+ required)" >&2
 
 	exit 1
 fi

--- a/util/build_prep/ubuntu/prep.sh.in
+++ b/util/build_prep/ubuntu/prep.sh.in
@@ -29,8 +29,8 @@ if ! have boost; then
 	exit 1
 fi
 
-if ! version_min 'boost --version' 1.66.999; then
-	echo "boost version too low (1.67.0+ required)" >&2
+if ! version_min 'boost --version' 1.68.999; then
+	echo "boost version too low (1.69.0+ required)" >&2
 	exit 1
 fi
 boost_dir="$(boost --install-prefix)"


### PR DESCRIPTION
add 1.72 and 1.73 for convenience
* docs at https://github.com/nanocurrency/nano-docs/pull/297
* boost(1.70 static/shared) cache used again on nix and osx builds

Closes #2776 as it was a workaround, no longer necessary.