### PR TITLE
Union std::hash coverage

### DIFF
--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -467,7 +467,7 @@ TEST (uint64_t, parse)
 TEST (uint256_union, hash)
 {
 	std::hash<nano::uint256_union> h{};
-	for (unsigned i (0), n (nano::uint256_union{}.bytes.size ()); i < n; ++i)
+	for (size_t i (0), n (nano::uint256_union{}.bytes.size ()); i < n; ++i)
 	{
 		nano::uint256_union x1{ 0 };
 		nano::uint256_union x2{ 0 };
@@ -479,7 +479,7 @@ TEST (uint256_union, hash)
 TEST (uint512_union, hash)
 {
 	std::hash<nano::uint512_union> h{};
-	for (unsigned i (0), n (nano::uint512_union{}.bytes.size ()); i < n; ++i)
+	for (size_t i (0), n (nano::uint512_union{}.bytes.size ()); i < n; ++i)
 	{
 		nano::uint512_union x1{ 0 };
 		nano::uint512_union x2{ 0 };
@@ -488,7 +488,7 @@ TEST (uint512_union, hash)
 	}
 	for (auto part (0); part < nano::uint512_union{}.uint256s.size (); ++part)
 	{
-		for (unsigned i (0), n (nano::uint512_union{}.uint256s[part].bytes.size ()); i < n; ++i)
+		for (size_t i (0), n (nano::uint512_union{}.uint256s[part].bytes.size ()); i < n; ++i)
 		{
 			nano::uint512_union x1{ 0 };
 			nano::uint512_union x2{ 0 };

--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -466,6 +466,7 @@ TEST (uint64_t, parse)
 
 TEST (uint256_union, hash)
 {
+	ASSERT_EQ (4, nano::uint256_union{}.qwords.size ());
 	std::hash<nano::uint256_union> h{};
 	for (size_t i (0), n (nano::uint256_union{}.bytes.size ()); i < n; ++i)
 	{
@@ -478,6 +479,7 @@ TEST (uint256_union, hash)
 
 TEST (uint512_union, hash)
 {
+	ASSERT_EQ (2, nano::uint512_union{}.uint256s.size ());
 	std::hash<nano::uint512_union> h{};
 	for (size_t i (0), n (nano::uint512_union{}.bytes.size ()); i < n; ++i)
 	{

--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -464,6 +464,40 @@ TEST (uint64_t, parse)
 	ASSERT_TRUE (nano::from_string_hex ("", value4));
 }
 
+TEST (uint256_union, hash)
+{
+	std::hash<nano::uint256_union> h{};
+	for (unsigned i (0), n (nano::uint256_union{}.bytes.size ()); i < n; ++i)
+	{
+		nano::uint256_union x1{ 0 };
+		nano::uint256_union x2{ 0 };
+		x2.bytes[i] = 1;
+		ASSERT_NE (h (x1), h (x2));
+	}
+}
+
+TEST (uint512_union, hash)
+{
+	std::hash<nano::uint512_union> h{};
+	for (unsigned i (0), n (nano::uint512_union{}.bytes.size ()); i < n; ++i)
+	{
+		nano::uint512_union x1{ 0 };
+		nano::uint512_union x2{ 0 };
+		x2.bytes[i] = 1;
+		ASSERT_NE (h (x1), h (x2));
+	}
+	for (auto part (0); part < nano::uint512_union{}.uint256s.size (); ++part)
+	{
+		for (unsigned i (0), n (nano::uint512_union{}.uint256s[part].bytes.size ()); i < n; ++i)
+		{
+			nano::uint512_union x1{ 0 };
+			nano::uint512_union x2{ 0 };
+			x2.uint256s[part].bytes[i] = 1;
+			ASSERT_NE (h (x1), h (x2));
+		}
+	}
+}
+
 namespace
 {
 template <typename Union, typename Bound>

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -274,7 +274,10 @@ struct hash<::nano::uint256_union>
 {
 	size_t operator() (::nano::uint256_union const & data_a) const
 	{
-		return *reinterpret_cast<size_t const *> (data_a.bytes.data ());
+		return *reinterpret_cast<size_t const *> (data_a.bytes.data ())
+		+ *reinterpret_cast<size_t const *> (data_a.bytes.data () + 8)
+		+ *reinterpret_cast<size_t const *> (data_a.bytes.data () + 16)
+		+ *reinterpret_cast<size_t const *> (data_a.bytes.data () + 24);
 	}
 };
 template <>
@@ -330,7 +333,7 @@ struct hash<::nano::uint512_union>
 {
 	size_t operator() (::nano::uint512_union const & data_a) const
 	{
-		return *reinterpret_cast<size_t const *> (data_a.bytes.data ());
+		return hash<::nano::uint256_union> () (data_a.uint256s[0]) + hash<::nano::uint256_union> () (data_a.uint256s[1]);
 	}
 };
 template <>
@@ -338,7 +341,7 @@ struct hash<::nano::qualified_root>
 {
 	size_t operator() (::nano::qualified_root const & data_a) const
 	{
-		return *reinterpret_cast<size_t const *> (data_a.bytes.data ());
+		return hash<::nano::uint512_union> () (data_a);
 	}
 };
 }

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -272,7 +272,6 @@ namespace std
 template <>
 struct hash<::nano::uint256_union>
 {
-	static_assert (::nano::uint256_union{}.qwords.size () == 4, "");
 	size_t operator() (::nano::uint256_union const & data_a) const
 	{
 		return data_a.qwords[0] + data_a.qwords[1] + data_a.qwords[2] + data_a.qwords[3];
@@ -329,7 +328,6 @@ struct hash<::nano::uint256_t>
 template <>
 struct hash<::nano::uint512_union>
 {
-	static_assert (::nano::uint512_union{}.uint256s.size () == 2, "");
 	size_t operator() (::nano::uint512_union const & data_a) const
 	{
 		return hash<::nano::uint256_union> () (data_a.uint256s[0]) + hash<::nano::uint256_union> () (data_a.uint256s[1]);

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -272,12 +272,10 @@ namespace std
 template <>
 struct hash<::nano::uint256_union>
 {
+	static_assert (::nano::uint256_union{}.qwords.size () == 4, "");
 	size_t operator() (::nano::uint256_union const & data_a) const
 	{
-		return *reinterpret_cast<size_t const *> (data_a.bytes.data ())
-		+ *reinterpret_cast<size_t const *> (data_a.bytes.data () + 8)
-		+ *reinterpret_cast<size_t const *> (data_a.bytes.data () + 16)
-		+ *reinterpret_cast<size_t const *> (data_a.bytes.data () + 24);
+		return data_a.qwords[0] + data_a.qwords[1] + data_a.qwords[2] + data_a.qwords[3];
 	}
 };
 template <>
@@ -331,6 +329,7 @@ struct hash<::nano::uint256_t>
 template <>
 struct hash<::nano::uint512_union>
 {
+	static_assert (::nano::uint512_union{}.uint256s.size () == 2, "");
 	size_t operator() (::nano::uint512_union const & data_a) const
 	{
 		return hash<::nano::uint256_union> () (data_a.uint256s[0]) + hash<::nano::uint256_union> () (data_a.uint256s[1]);


### PR DESCRIPTION
Extends the specialization of std::hash to cover all bytes of 256_union and 512_union. This affects how set-like containers store them internally.