### PR TITLE
Stuck uncemented blocks after heavy load

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -192,14 +192,19 @@ void nano::active_transactions::add_election_winner_details (nano::block_hash co
 	election_winner_details.emplace (hash_a, election_a);
 }
 
+void nano::active_transactions::remove_election_winner_details (nano::block_hash const & hash_a)
+{
+	nano::lock_guard<std::mutex> guard (election_winner_details_mutex);
+	election_winner_details.erase (hash_a);
+}
+
 void nano::active_transactions::block_already_cemented_callback (nano::block_hash const & hash_a)
 {
 	// Depending on timing there is a situation where the election_winner_details is not reset.
 	// This can happen when a block wins an election, and the block is confirmed + observer
 	// called before the block hash gets added to election_winner_details. If the block is confirmed
 	// callbacks have already been done, so we can safely just remove it.
-	nano::lock_guard<std::mutex> guard (election_winner_details_mutex);
-	election_winner_details.erase (hash_a);
+	remove_election_winner_details (hash_a);
 }
 
 void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> & lock_a)

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -188,6 +188,7 @@ public:
 	size_t inactive_votes_cache_size ();
 	size_t election_winner_details_size ();
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
+	void remove_election_winner_details (nano::block_hash const &);
 
 private:
 	std::mutex election_winner_details_mutex;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -56,6 +56,12 @@ nano::confirmation_height_bounded::top_and_next_hash nano::confirmation_height_b
 
 void nano::confirmation_height_bounded::process ()
 {
+	if (pending_empty ())
+	{
+		clear_process_vars ();
+		timer.restart ();
+	}
+
 	boost::optional<top_and_next_hash> next_in_receive_chain;
 	boost::circular_buffer_space_optimized<nano::block_hash> checkpoints{ max_items };
 	boost::circular_buffer_space_optimized<receive_source_pair> receive_source_pairs{ max_items };
@@ -531,6 +537,7 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 
 	debug_assert (pending_writes.empty ());
 	debug_assert (pending_writes_size == 0);
+	timer.restart ();
 }
 
 bool nano::confirmation_height_bounded::pending_empty () const
@@ -538,11 +545,10 @@ bool nano::confirmation_height_bounded::pending_empty () const
 	return pending_writes.empty ();
 }
 
-void nano::confirmation_height_bounded::reset ()
+void nano::confirmation_height_bounded::clear_process_vars ()
 {
 	accounts_confirmed_info.clear ();
 	accounts_confirmed_info_size = 0;
-	timer.restart ();
 }
 
 nano::confirmation_height_bounded::receive_chain_details::receive_chain_details (nano::account const & account_a, uint64_t height_a, nano::block_hash const & hash_a, nano::block_hash const & top_level_a, boost::optional<nano::block_hash> next_a, uint64_t bottom_height_a, nano::block_hash const & bottom_most_a) :

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -19,7 +19,7 @@ class confirmation_height_bounded final
 public:
 	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<bool> &, nano::block_hash const &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
-	void reset ();
+	void clear_process_vars ();
 	void process ();
 	void cement_blocks (nano::write_guard & scoped_write_guard_a);
 

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -71,20 +71,12 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 			if (force_unbounded || valid_unbounded)
 			{
 				debug_assert (bounded_processor.pending_empty ());
-				if (unbounded_processor.pending_empty ())
-				{
-					unbounded_processor.reset ();
-				}
 				unbounded_processor.process ();
 			}
 			else
 			{
 				debug_assert (mode_a == confirmation_height_mode::bounded || mode_a == confirmation_height_mode::automatic);
 				debug_assert (unbounded_processor.pending_empty ());
-				if (bounded_processor.pending_empty ())
-				{
-					bounded_processor.reset ();
-				}
 				bounded_processor.process ();
 			}
 
@@ -96,6 +88,8 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 				lk.lock ();
 				original_hash.clear ();
 				original_hashes_pending.clear ();
+				bounded_processor.clear_process_vars ();
+				unbounded_processor.clear_process_vars ();
 			};
 
 			if (!paused)
@@ -111,7 +105,6 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 						bounded_processor.cement_blocks (scoped_write_guard);
 					}
 					lock_and_cleanup ();
-					bounded_processor.reset ();
 				}
 				else if (!unbounded_processor.pending_empty ())
 				{
@@ -121,7 +114,6 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 						unbounded_processor.cement_blocks (scoped_write_guard);
 					}
 					lock_and_cleanup ();
-					unbounded_processor.reset ();
 				}
 				else
 				{

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -23,6 +23,11 @@ awaiting_processing_size_callback (awaiting_processing_size_callback_a)
 
 void nano::confirmation_height_unbounded::process ()
 {
+	if (pending_empty ())
+	{
+		clear_process_vars ();
+		timer.restart ();
+	}
 	std::shared_ptr<conf_height_details> receive_details;
 	auto current = original_hash;
 	std::vector<nano::block_hash> orig_block_callback_data;
@@ -406,6 +411,7 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 	}
 	debug_assert (pending_writes.empty ());
 	debug_assert (pending_writes_size == 0);
+	timer.restart ();
 }
 
 std::shared_ptr<nano::block> nano::confirmation_height_unbounded::get_block_and_sideband (nano::block_hash const & hash_a, nano::transaction const & transaction_a)
@@ -429,7 +435,7 @@ bool nano::confirmation_height_unbounded::pending_empty () const
 	return pending_writes.empty ();
 }
 
-void nano::confirmation_height_unbounded::reset ()
+void nano::confirmation_height_unbounded::clear_process_vars ()
 {
 	// Separate blocks which are pending confirmation height can be batched by a minimum processing time (to improve lmdb disk write performance),
 	// so make sure the slate is clean when a new batch is starting.
@@ -439,7 +445,6 @@ void nano::confirmation_height_unbounded::reset ()
 	implicit_receive_cemented_mapping_size = 0;
 	block_cache.clear ();
 	block_cache_size = 0;
-	timer.restart ();
 }
 
 nano::confirmation_height_unbounded::conf_height_details::conf_height_details (nano::account const & account_a, nano::block_hash const & hash_a, uint64_t height_a, uint64_t num_blocks_confirmed_a, std::vector<nano::block_hash> const & block_callback_data_a) :

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -67,8 +67,6 @@ private:
 	std::shared_ptr<nano::block> get_block_and_sideband (nano::block_hash const &, nano::transaction const &);
 	std::deque<conf_height_details> pending_writes;
 	nano::relaxed_atomic_integral<uint64_t> pending_writes_size{ 0 };
-	std::vector<nano::block_hash> orig_block_callback_data;
-	nano::relaxed_atomic_integral<uint64_t> orig_block_callback_data_size{ 0 };
 	std::unordered_map<nano::block_hash, std::weak_ptr<conf_height_details>> implicit_receive_cemented_mapping;
 	nano::relaxed_atomic_integral<uint64_t> implicit_receive_cemented_mapping_size{ 0 };
 
@@ -86,9 +84,10 @@ private:
 		bool already_traversed;
 		nano::block_hash const & current;
 		std::vector<nano::block_hash> const & block_callback_data;
+		std::vector<nano::block_hash> const & orig_block_callback_data;
 	};
 
-	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &);
+	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &, std::vector<nano::block_hash> &);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 
 	nano::network_params network_params;

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -20,7 +20,7 @@ class confirmation_height_unbounded final
 public:
 	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logger_mt &, std::atomic<bool> &, nano::block_hash const &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
-	void reset ();
+	void clear_process_vars ();
 	void process ();
 	void cement_blocks (nano::write_guard &);
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -43,7 +43,7 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 	debug_assert (!node.active.mutex.try_lock ());
 	// This must be kept above the setting of election state, as dependent confirmed elections require up to date changes to election_winner_details
 	nano::unique_lock<std::mutex> election_winners_lk (node.active.election_winner_details_mutex);
-	if (state_m.exchange (nano::election::state_t::confirmed) != nano::election::state_t::confirmed && node.active.election_winner_details.find (status.winner->hash ()) == node.active.election_winner_details.cend ())
+	if (state_m.exchange (nano::election::state_t::confirmed) != nano::election::state_t::confirmed && (node.active.election_winner_details.count (status.winner->hash ()) == 0))
 	{
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
@@ -54,11 +54,10 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 		auto status_l (status);
 		auto node_l (node.shared ());
 		auto confirmation_action_l (confirmation_action);
-		auto this_l = shared_from_this ();
-		node.active.election_winner_details.emplace (status.winner->hash (), this_l);
+		node.active.election_winner_details.emplace (status.winner->hash (), shared_from_this ());
 		node.active.add_recently_confirmed (status_l.winner->qualified_root (), status_l.winner->hash ());
-		node_l->process_confirmed (status_l, this_l);
-		node.background ([node_l, status_l, confirmation_action_l, this_l]() {
+		node_l->process_confirmed (status_l);
+		node.background ([node_l, status_l, confirmation_action_l]() {
 			confirmation_action_l (status_l.winner);
 		});
 		adjust_dependent_difficulty ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1253,25 +1253,30 @@ void nano::node::process_confirmed_data (nano::transaction const & transaction_a
 	}
 }
 
-void nano::node::process_confirmed (nano::election_status const & status_a, std::shared_ptr<nano::election> const & election_a, uint8_t iteration_a)
+void nano::node::process_confirmed (nano::election_status const & status_a, uint64_t iteration_a)
 {
 	auto block_a (status_a.winner);
 	auto hash (block_a->hash ());
+	const auto num_iters = (config.block_processor_batch_max_time / network_params.node.process_confirmed_interval) * 4;
 	if (ledger.block_exists (block_a->type (), hash))
 	{
 		confirmation_height_processor.add (hash);
 	}
-	// Limit to 0.5 * 20 = 10 seconds (more than max block_processor::process_batch finish time)
-	else if (iteration_a < 20)
+	else if (iteration_a < num_iters)
 	{
 		iteration_a++;
 		std::weak_ptr<nano::node> node_w (shared ());
-		alarm.add (std::chrono::steady_clock::now () + network_params.node.process_confirmed_interval, [node_w, status_a, iteration_a, election_a]() {
+		alarm.add (std::chrono::steady_clock::now () + network_params.node.process_confirmed_interval, [node_w, status_a, iteration_a]() {
 			if (auto node_l = node_w.lock ())
 			{
-				node_l->process_confirmed (status_a, election_a, iteration_a);
+				node_l->process_confirmed (status_a, iteration_a);
 			}
 		});
+	}
+	else
+	{
+		// Do some cleanup due to this block never being processed by confirmation height processor
+		active.remove_election_winner_details (hash);
 	}
 }
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -103,7 +103,7 @@ public:
 	int store_version ();
 	void receive_confirmed (nano::transaction const &, std::shared_ptr<nano::block>, nano::block_hash const &);
 	void process_confirmed_data (nano::transaction const &, std::shared_ptr<nano::block>, nano::block_hash const &, nano::account &, nano::uint128_t &, bool &, nano::account &);
-	void process_confirmed (nano::election_status const &, std::shared_ptr<nano::election> const &, uint8_t = 0);
+	void process_confirmed (nano::election_status const &, uint64_t = 0);
 	void process_active (std::shared_ptr<nano::block>);
 	nano::process_return process (nano::block &);
 	nano::process_return process_local (std::shared_ptr<nano::block>, bool const = false);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -382,6 +382,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		}
 
 		// Validate ranges
+		nano::network_params network_params;
 		if (online_weight_quorum > 100)
 		{
 			toml.get_error ().set ("online_weight_quorum must be less than 100");
@@ -417,6 +418,10 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		if (frontiers_confirmation == nano::frontiers_confirmation_mode::invalid)
 		{
 			toml.get_error ().set ("frontiers_confirmation value is invalid (available: always, auto, disabled)");
+		}
+		if (block_processor_batch_max_time < network_params.node.process_confirmed_interval)
+		{
+			toml.get_error ().set ((boost::format ("block_processor_batch_max_time value must be equal or larger than %1%ms") % network_params.node.process_confirmed_interval.count ()).str ());
 		}
 	}
 	catch (std::runtime_error const & ex)

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -91,6 +91,6 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (on
 
 	auto sizeof_element = sizeof (decltype (online_reps.reps)::value_type);
 	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "arrival", count, sizeof_element }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "reps", count, sizeof_element }));
 	return composite;
 }


### PR DESCRIPTION
The issue is that in `node::processed_confirmed` there was an assumption that x2 the max block processor time (default 5s), so 10s was enough for the block to be committed to the ledger after being confirmed. This was not always the case during high load (1000tps) on some nodes where it might have taken longer. That number has now been doubled but also it was hardcoded before and didn't respect config changes which has now been changed. Updated the validation for the max block processor time so that it is always greater than the process confirmed interval. In the event the block still doesn't exist, it will handle that case too and allow the block to be confirmed later rather than be stuck.

The tests added were used during the debugging of this issue. They use send/receive to self which is what the spam test on beta was using at the time. 

Unrelated:
- `orig_block_callback_data` doesn't need to be a member variable as it will be cleared after processing a block after to the conf height processor, so made it a local variable.
- In `node::processed_confirmed` the parameter `election_a` is not used, so has been removed
- Removed unused `initialized_latch` variable in conf height tests.
- Noticed `online_reps` key was incorrect in stats -> objects, corrected it.

Thanks to Nox/Json for beta spam and @Srayman assistance.