### PR TITLE
Add logging section to rpc config to optionally disable logging

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -104,6 +104,8 @@ TEST (toml, rpc_config_deserialize_defaults)
 	ASSERT_EQ (conf.rpc_process.ipc_address, defaults.rpc_process.ipc_address);
 	ASSERT_EQ (conf.rpc_process.ipc_port, defaults.rpc_process.ipc_port);
 	ASSERT_EQ (conf.rpc_process.num_ipc_connections, defaults.rpc_process.num_ipc_connections);
+
+	ASSERT_EQ (conf.rpc_logging.log_rpc, defaults.rpc_logging.log_rpc);
 }
 
 /** Empty config file should match a default config object */
@@ -725,6 +727,8 @@ TEST (toml, rpc_config_deserialize_no_defaults)
 	ipc_address = "0:0:0:0:0:ffff:7f01:101"
 	ipc_port = 999
 	num_ipc_connections = 999
+	[logging]
+	log_rpc = false
 	)toml";
 
 	nano::tomlconfig toml;
@@ -745,6 +749,8 @@ TEST (toml, rpc_config_deserialize_no_defaults)
 	ASSERT_NE (conf.rpc_process.ipc_address, defaults.rpc_process.ipc_address);
 	ASSERT_NE (conf.rpc_process.ipc_port, defaults.rpc_process.ipc_port);
 	ASSERT_NE (conf.rpc_process.num_ipc_connections, defaults.rpc_process.num_ipc_connections);
+
+	ASSERT_NE (conf.rpc_logging.log_rpc, defaults.rpc_logging.log_rpc);
 }
 
 /** There should be no required values **/
@@ -756,6 +762,7 @@ TEST (toml, rpc_config_no_required)
 	ss << R"toml(
 	[version]
 	[process]
+	[logging]
 	[secure]
 	)toml";
 

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -165,6 +165,10 @@ nano::error nano::rpc_config::serialize_toml (nano::tomlconfig & toml) const
 	rpc_process_l.put ("ipc_port", rpc_process.ipc_port, "Listening port of IPC server.\ntype:uint16");
 	rpc_process_l.put ("num_ipc_connections", rpc_process.num_ipc_connections, "Number of IPC connections to establish.\ntype:uint32");
 	toml.put_child ("process", rpc_process_l);
+
+	nano::tomlconfig rpc_logging_l;
+	rpc_logging_l.put ("log_rpc", rpc_logging.log_rpc, "Whether to log RPC calls.\ntype:bool");
+	toml.put_child ("logging", rpc_logging_l);
 	return toml.get_error ();
 }
 
@@ -185,6 +189,12 @@ nano::error nano::rpc_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get_optional<bool> ("enable_control", enable_control);
 		toml.get_optional<uint8_t> ("max_json_depth", max_json_depth);
 		toml.get_optional<uint64_t> ("max_request_size", max_request_size);
+
+		auto rpc_logging_l (toml.get_optional_child ("logging"));
+		if (rpc_logging_l)
+		{
+			rpc_logging_l->get_optional<bool> ("log_rpc", rpc_logging.log_rpc);
+		}
 
 		auto rpc_process_l (toml.get_optional_child ("process"));
 		if (rpc_process_l)

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -60,6 +60,12 @@ public:
 	}
 };
 
+class rpc_logging_config final
+{
+public:
+	bool log_rpc{ true };
+};
+
 class rpc_config final
 {
 public:
@@ -77,6 +83,7 @@ public:
 	rpc_secure_config secure;
 	uint8_t max_json_depth{ 20 };
 	uint64_t max_request_size{ 32 * 1024 * 1024 };
+	nano::rpc_logging_config rpc_logging;
 	static unsigned json_version ()
 	{
 		return 1;

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -124,8 +124,11 @@ void nano::rpc_connection::parse_request (STREAM_TYPE & stream, std::shared_ptr<
 					}));
 
 					std::stringstream ss;
-					ss << "RPC request " << request_id << " completed in: " << std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - start).count () << " microseconds";
-					this_l->logger.always_log (ss.str ().c_str ());
+					if (this_l->rpc_config.rpc_logging.log_rpc)
+					{
+						ss << "RPC request " << request_id << " completed in: " << std::chrono::duration_cast<std::chrono::microseconds> (std::chrono::steady_clock::now () - start).count () << " microseconds";
+						this_l->logger.always_log (ss.str ().c_str ());
+					}
 				});
 
 				std::string api_path_l = "/api/v2";

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -60,10 +60,13 @@ void nano::rpc_handler::process_request (nano::rpc_handler_request_params const 
 				}
 
 				auto action = request.get<std::string> ("action");
-				// Creating same string via stringstream as using it directly is generating a TSAN warning
-				std::stringstream ss;
-				ss << request_id;
-				logger.always_log (ss.str (), " ", filter_request (request));
+				if (rpc_config.rpc_logging.log_rpc)
+				{
+					// Creating same string via stringstream as using it directly is generating a TSAN warning
+					std::stringstream ss;
+					ss << request_id;
+					logger.always_log (ss.str (), " ", filter_request (request));
+				}
 
 				// Check if this is a RPC command which requires RPC enabled control
 				std::error_code rpc_control_disabled_ec = nano::error_rpc::rpc_control_disabled;


### PR DESCRIPTION
@Json's ramdisk node is crashing when pumping out 2000BPS `process` RPC calls. There are some boost standard error outputs suggesting problems with rotating the files at this high logging output speed.
![image](https://user-images.githubusercontent.com/650038/83400527-e8bbe180-a3fa-11ea-95aa-e46785af6ebf.png)

However I cannot reproduce this even, even with spamming 50MB of log messages per second over a few threads. Seems to be something special about his set-up, removing the logging output manually fixed the issue for him, so am adding a logging section to the rpc config which allows these messages to be disabled (they are enabled by default). This can be extended in the future to change the rotation/max size size and maybe some other options, but right now this should be sufficient.