### PR TITLE
CLI commands incorrect ledger cache setup

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -171,8 +171,8 @@ int main (int argc, char * const * argv)
 				auto node_flags = nano::inactive_node_flag_defaults ();
 				nano::update_flags (node_flags, vm);
 				node_flags.generate_cache.reps = true;
-				auto inactive_node = nano::default_inactive_node (data_path, vm);
-				auto node = inactive_node->node;
+				nano::inactive_node inactive_node (data_path, node_flags);
+				auto node = inactive_node.node;
 
 				auto const hardcoded = node->get_bootstrap_weights ().second;
 				auto const ledger_unfiltered = node->ledger.cache.rep_weights.get_rep_amounts ();
@@ -395,8 +395,8 @@ int main (int argc, char * const * argv)
 			auto node_flags = nano::inactive_node_flag_defaults ();
 			nano::update_flags (node_flags, vm);
 			node_flags.generate_cache.reps = true;
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
+			nano::inactive_node inactive_node (data_path, node_flags);
+			auto node = inactive_node.node;
 			auto transaction (node->store.tx_begin_read ());
 			nano::uint128_t total;
 			auto rep_amounts = node->ledger.cache.rep_weights.get_rep_amounts ();
@@ -433,8 +433,11 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_account_count"))
 		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % inactive_node->node->ledger.cache.account_count);
+			auto node_flags = nano::inactive_node_flag_defaults ();
+			nano::update_flags (node_flags, vm);
+			node_flags.generate_cache.account_count = true;
+			nano::inactive_node inactive_node (data_path, node_flags);
+			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % inactive_node.node->ledger.cache.account_count);
 		}
 		else if (vm.count ("debug_mass_activity"))
 		{
@@ -1350,10 +1353,14 @@ int main (int argc, char * const * argv)
 				std::exit (0);
 			});
 
-			auto inactive_node_l = nano::default_inactive_node (data_path, vm);
+			auto node_flags = nano::inactive_node_flag_defaults ();
+			nano::update_flags (node_flags, vm);
+			node_flags.generate_cache.enable_all ();
+			nano::inactive_node inactive_node_l (data_path, node_flags);
+
 			nano::node_rpc_config config;
-			nano::ipc::ipc_server server (*inactive_node_l->node, config);
-			auto handler_l (std::make_shared<nano::json_handler> (*inactive_node_l->node, config, command_l.str (), response_handler_l));
+			nano::ipc::ipc_server server (*inactive_node_l.node, config);
+			auto handler_l (std::make_shared<nano::json_handler> (*inactive_node_l.node, config, command_l.str (), response_handler_l));
 			handler_l->process_request ();
 		}
 		else if (vm.count ("validate_blocks") || vm.count ("debug_validate_blocks"))
@@ -1743,7 +1750,7 @@ int main (int argc, char * const * argv)
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
 				auto node = inactive_node->node;
 				auto transaction (node->store.tx_begin_read ());
-				block_count = node->store.block_count (transaction).sum ();
+				block_count = node->ledger.cache.block_count;
 				std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
 				for (auto i (node->store.latest_begin (transaction)), n (node->store.latest_end ()); i != n; ++i)
 				{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1681,6 +1681,8 @@ nano::node_flags const & nano::inactive_node_flag_defaults ()
 	node_flags.generate_cache.reps = false;
 	node_flags.generate_cache.cemented_count = false;
 	node_flags.generate_cache.unchecked_count = false;
+	node_flags.generate_cache.account_count = false;
+	node_flags.generate_cache.epoch_2 = false;
 	node_flags.disable_bootstrap_listener = true;
 	node_flags.disable_tcp_realtime = true;
 	return node_flags;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -858,3 +858,12 @@ nano::block_hash const & nano::unchecked_key::key () const
 {
 	return previous;
 }
+
+void nano::generate_cache::enable_all ()
+{
+	reps = true;
+	cemented_count = true;
+	unchecked_count = true;
+	account_count = true;
+	epoch_2 = true;
+}

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -487,7 +487,7 @@ enum class confirmation_height_mode
 };
 
 /* Holds flags for various cacheable data. For most CLI operations caching is unnecessary
- * (e.g getting the checked block count) so it can be disabled for performance reasons. */
+ * (e.g getting the cemented block count) so it can be disabled for performance reasons. */
 class generate_cache
 {
 public:
@@ -496,6 +496,8 @@ public:
 	bool unchecked_count = true;
 	bool account_count = true;
 	bool epoch_2 = true;
+
+	void enable_all ();
 };
 
 /* Holds an in-memory cache of various counts */


### PR DESCRIPTION
Noticed that the `--debug_rpc` CLI command wasn't correctly reporting on some things like cemented block count. This is because `inactive_node_flag_defaults` disables generating the cache unless it needs to, however also wasn't doing it for all, which it now does.

`--compare_rep_weights` & `--debug_dump_representatives` were not actually using the `node_flags` variable they created. This worked by chance because any setting of rep/account/epoch2 will set them all as any 1 requires iterating over all accounts (account/epoch2 were not being set to 0 in `inactive_node_flag_defaults`.