### PR TITLE
Retrieve block when activating dependencies

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -674,6 +674,24 @@ TEST (active_transactions, activate_dependencies)
 
 namespace nano
 {
+TEST (active_transactions, activate_dependencies_invalid)
+{
+	nano::system system;
+	nano::node_flags flags;
+	flags.disable_request_loop = true;
+	auto & node (*system.add_node (flags));
+	node.active.pending_dependencies.emplace_back (nano::genesis ().open->hash (), 10);
+	node.active.pending_dependencies.emplace_back (1, 1);
+	node.active.pending_dependencies.emplace_back (0, -1);
+	node.active.pending_dependencies.emplace_back (-1, 0);
+	{
+		nano::unique_lock<std::mutex> lock (node.active.mutex);
+		node.active.activate_dependencies (lock);
+	}
+	ASSERT_TRUE (node.active.empty ());
+	ASSERT_EQ (0, node.active.pending_dependencies.size ());
+}
+
 // Tests that blocks are correctly cleared from the duplicate filter for unconfirmed elections
 TEST (active_transactions, dropped_cleanup)
 {

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -307,52 +307,55 @@ void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mu
 		auto transaction = node.store.tx_begin_read ();
 		for (auto const & entry_l : pending_l)
 		{
-			auto const & block_l (entry_l.first);
-			auto const height_l (entry_l.second);
-			bool escalated_l (false);
-			auto previous_hash_l (block_l->previous ());
-			if (!previous_hash_l.is_zero ())
+			auto const & hash_l (entry_l.first);
+			auto const block_l (node.store.block_get (transaction, hash_l));
+			if (block_l)
 			{
-				/* Insert first unconfirmed block (pessimistic) and bisect the chain (likelihood) */
-				auto account (node.ledger.account (transaction, block_l->hash ()));
-				nano::confirmation_height_info conf_info_l;
-				if (!node.store.confirmation_height_get (transaction, account, conf_info_l))
+				auto const height_l (entry_l.second);
+				auto const previous_hash_l (block_l->previous ());
+				if (!previous_hash_l.is_zero ())
 				{
-					if (height_l > conf_info_l.height + 1 && !conf_info_l.frontier.is_zero ())
+					/* Insert first unconfirmed block (pessimistic) and bisect the chain (likelihood) */
+					auto const account (node.store.block_account_calculated (*block_l));
+					nano::confirmation_height_info conf_info_l;
+					if (!node.store.confirmation_height_get (transaction, account, conf_info_l))
 					{
-						auto successor_hash_l = node.store.block_successor (transaction, conf_info_l.frontier);
-						if (!confirmation_height_processor.is_processing_block (successor_hash_l))
+						if (height_l > conf_info_l.height + 1 && !conf_info_l.frontier.is_zero ())
 						{
-							auto successor_l = node.store.block_get (transaction, successor_hash_l);
-							debug_assert (successor_l != nullptr);
-							if (successor_l != nullptr)
+							auto const successor_hash_l = node.store.block_successor (transaction, conf_info_l.frontier);
+							if (!confirmation_height_processor.is_processing_block (successor_hash_l))
 							{
-								activate_l.emplace_back (successor_l, block_l->hash ());
+								auto const successor_l = node.store.block_get (transaction, successor_hash_l);
+								debug_assert (successor_l != nullptr);
+								if (successor_l != nullptr)
+								{
+									activate_l.emplace_back (successor_l, hash_l);
+								}
+							}
+						}
+						if (height_l > conf_info_l.height + 2)
+						{
+							auto const jumps_l = std::min<uint64_t> (128, (height_l - conf_info_l.height) / 2);
+							auto const backtracked_l (node.ledger.backtrack (transaction, block_l, jumps_l));
+							if (backtracked_l != nullptr)
+							{
+								activate_l.emplace_back (backtracked_l, hash_l);
 							}
 						}
 					}
-					if (height_l > conf_info_l.height + 2)
-					{
-						auto const jumps_l = std::min<uint64_t> (128, (height_l - conf_info_l.height) / 2);
-						auto backtracked_l (node.ledger.backtrack (transaction, block_l, jumps_l));
-						if (backtracked_l != nullptr)
-						{
-							activate_l.emplace_back (backtracked_l, block_l->hash ());
-						}
-					}
 				}
-			}
-			/* If previous block not existing/not commited yet, block_source can cause segfault for state blocks
+				/* If previous block not existing/not commited yet, block_source can cause segfault for state blocks
 				So source check can be done only if previous != nullptr or previous is 0 (open account) */
-			if (previous_hash_l.is_zero () || node.ledger.block_exists (previous_hash_l))
-			{
-				auto source_hash_l (node.ledger.block_source (transaction, *block_l));
-				if (!source_hash_l.is_zero () && source_hash_l != previous_hash_l && blocks.find (source_hash_l) == blocks.end ())
+				if (previous_hash_l.is_zero () || node.ledger.block_exists (previous_hash_l))
 				{
-					auto source_l (node.store.block_get (transaction, source_hash_l));
-					if (source_l != nullptr && !node.block_confirmed_or_being_confirmed (transaction, source_hash_l))
+					auto source_hash_l (node.ledger.block_source (transaction, *block_l));
+					if (!source_hash_l.is_zero () && source_hash_l != previous_hash_l && blocks.find (source_hash_l) == blocks.end ())
 					{
-						activate_l.emplace_back (source_l, block_l->hash ());
+						auto source_l (node.store.block_get (transaction, source_hash_l));
+						if (source_l != nullptr && !node.block_confirmed_or_being_confirmed (transaction, source_hash_l))
+						{
+							activate_l.emplace_back (source_l, block_l->hash ());
+						}
 					}
 				}
 			}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -208,7 +208,7 @@ private:
 	nano::account next_frontier_account{ 0 };
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
 	void activate_dependencies (nano::unique_lock<std::mutex> &);
-	std::vector<std::pair<std::shared_ptr<nano::block>, uint64_t>> pending_dependencies;
+	std::vector<std::pair<nano::block_hash, uint64_t>> pending_dependencies;
 	nano::condition_variable condition;
 	bool started{ false };
 	std::atomic<bool> stopped{ false };
@@ -267,6 +267,7 @@ private:
 	friend class election;
 	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, const std::string &);
 
+	friend class active_transactions_activate_dependencies_invalid_Test;
 	friend class active_transactions_dropped_cleanup_Test;
 	friend class active_transactions_vote_replays_Test;
 	friend class confirmation_height_prioritize_frontiers_Test;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -212,7 +212,7 @@ bool nano::election::confirmed () const
 void nano::election::activate_dependencies ()
 {
 	debug_assert (!node.active.mutex.try_lock ());
-	node.active.pending_dependencies.emplace_back (status.winner, height);
+	node.active.pending_dependencies.emplace_back (status.winner->hash (), height);
 }
 
 void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -677,6 +677,7 @@ public:
 	virtual bool root_exists (nano::transaction const &, nano::root const &) = 0;
 	virtual bool source_exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual nano::account block_account (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::account block_account_calculated (nano::block const &) const = 0;
 
 	virtual void frontier_put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) = 0;
 	virtual nano::account frontier_get (nano::transaction const &, nano::block_hash const &) const = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -203,10 +203,17 @@ public:
 	nano::account block_account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
 		auto block (block_get (transaction_a, hash_a));
-		nano::account result (block->account ());
+		debug_assert (block != nullptr);
+		return block_account_calculated (*block);
+	}
+
+	nano::account block_account_calculated (nano::block const & block_a) const override
+	{
+		debug_assert (block_a.has_sideband ());
+		nano::account result (block_a.account ());
 		if (result.is_zero ())
 		{
-			result = block->sideband ().account;
+			result = block_a.sideband ().account;
 		}
 		debug_assert (!result.is_zero ());
 		return result;


### PR DESCRIPTION
@wezrule noticed a failure during a test related to a block not being found in the ledger when activating dependencies.

There are in fact two issues:
1. In between adding the dependency and activating, the block could be rolled back, so we need to check if it exists
2. Due to potential simultaneous sideband changes in ledger processing, we need to retrieve a new copy of the block instead of simply checking if it exists and using the election object.

Added `store::block_account_calculated` that is used when we already have a sideband-loaded block in memory.

----

For reviewing would recommend hiding whitespace changes