### PR TITLE
Slow test fixes

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -670,7 +670,6 @@ void nano::node::stop ()
 	if (!stopped.exchange (true))
 	{
 		logger.always_log ("Node stopping");
-		write_database_queue.stop ();
 		// Cancels ongoing work generation tasks, which may be blocking other threads
 		// No tasks may wait for work generation in I/O threads, or termination signal capturing will be unable to call node::stop()
 		distributed_work.stop ();

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -78,7 +78,7 @@ public:
 	nano::ipc::ipc_config ipc_config;
 	std::string external_address;
 	uint16_t external_port{ 0 };
-	std::chrono::milliseconds block_processor_batch_max_time{ std::chrono::milliseconds (5000) };
+	std::chrono::milliseconds block_processor_batch_max_time{ network_params.network.is_test_network () ? std::chrono::milliseconds (500) : std::chrono::milliseconds (5000) };
 	std::chrono::seconds unchecked_cutoff_time{ std::chrono::seconds (4 * 60 * 60) }; // 4 hours
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_test_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -70,7 +70,7 @@ nano::write_guard nano::write_database_queue::wait (nano::writer writer)
 		queue.push_back (writer);
 	}
 
-	while (!stopped && queue.front () != writer)
+	while (queue.front () != writer)
 	{
 		cv.wait (lk);
 	}
@@ -110,13 +110,4 @@ bool nano::write_database_queue::process (nano::writer writer)
 nano::write_guard nano::write_database_queue::pop ()
 {
 	return write_guard (guard_finish_callback);
-}
-
-void nano::write_database_queue::stop ()
-{
-	{
-		nano::lock_guard<std::mutex> guard (mutex);
-		stopped = true;
-	}
-	cv.notify_all ();
 }

--- a/nano/node/write_database_queue.hpp
+++ b/nano/node/write_database_queue.hpp
@@ -50,14 +50,10 @@ public:
 	/** Doesn't actually pop anything until the returned write_guard is out of scope */
 	write_guard pop ();
 
-	/** This will release anything which is being blocked by the wait function */
-	void stop ();
-
 private:
 	std::deque<nano::writer> queue;
 	std::mutex mutex;
 	nano::condition_variable cv;
 	std::function<void()> guard_finish_callback;
-	bool stopped{ false };
 };
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -931,7 +931,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 		node->process_active (receive_blocks[i]);
 	}
 
-	system.deadline_set (200s);
+	system.deadline_set (300s);
 	num_blocks_to_confirm = num_accounts * 4;
 	while (node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in) != num_blocks_to_confirm)
 	{

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1319,11 +1319,13 @@ TEST (node_telemetry, under_load)
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	auto node = system.add_node (node_config);
-	node_config.peering_port = nano::get_available_port ();
 	nano::node_flags node_flags;
-	node_flags.disable_ongoing_telemetry_requests = true;
+	node_flags.disable_initial_telemetry_requests = true;
+	auto node = system.add_node (node_config, node_flags);
+	node->confirmation_height_processor.pause ();
+	node_config.peering_port = nano::get_available_port ();
 	auto node1 = system.add_node (node_config, node_flags);
+	node1->confirmation_height_processor.pause ();
 	nano::genesis genesis;
 	nano::keypair key;
 	nano::keypair key1;
@@ -1351,7 +1353,7 @@ TEST (node_telemetry, under_load)
 	std::thread thread1 (thread_func, nano::test_genesis_key, latest_genesis, nano::genesis_amount - num_blocks);
 	std::thread thread2 (thread_func, key, latest_key, num_blocks);
 
-	ASSERT_TIMELY (200s, node1->ledger.cache.block_count == num_blocks * 2 + 3);
+	ASSERT_TIMELY (400s, node1->ledger.cache.block_count == num_blocks * 2 + 3);
 
 	thread1.join ();
 	thread2.join ();

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -889,7 +889,6 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 		{
 			nano::keypair key;
 			keys.emplace_back (key);
-			system.wallet (0)->insert_adhoc (key.prv);
 
 			nano::send_block send (latest_genesis, key.pub, nano::genesis_amount - 1 - i, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1322,10 +1322,8 @@ TEST (node_telemetry, under_load)
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node = system.add_node (node_config, node_flags);
-	node->confirmation_height_processor.pause ();
 	node_config.peering_port = nano::get_available_port ();
 	auto node1 = system.add_node (node_config, node_flags);
-	node1->confirmation_height_processor.pause ();
 	nano::genesis genesis;
 	nano::keypair key;
 	nano::keypair key1;
@@ -1353,7 +1351,7 @@ TEST (node_telemetry, under_load)
 	std::thread thread1 (thread_func, nano::test_genesis_key, latest_genesis, nano::genesis_amount - num_blocks);
 	std::thread thread2 (thread_func, key, latest_key, num_blocks);
 
-	ASSERT_TIMELY (400s, node1->ledger.cache.block_count == num_blocks * 2 + 3);
+	ASSERT_TIMELY (200s, node1->ledger.cache.block_count == num_blocks * 2 + 3);
 
 	thread1.join ();
 	thread2.join ();

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -960,7 +960,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	system.deadline_set (20s);
+	system.deadline_set (60s);
 	while (node->active.election_winner_details_size () > 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());


### PR DESCRIPTION
`node_telemetry.under_load` was failing. git bisected and found it was caused by https://github.com/nanocurrency/nano-node/pull/2782. It seems the increase in iterations on the test network (it's gone from 20 to 400!) was creating too much work. As the number of iterations is dependent on the block_processor_batch_max_time, I am changing default if using test network, which should scale with the `process_confirmed_interval` which is also changed from 500ms to 50ms on test network.

`many_accounts_send_receive_self` can time out after sequential voting PR, increase deadline timer.

Fixes a bug with popping from empty `write_database_queue` when stopping the node causing a hang.