### PR TITLE
Fix open blocks not getting activated through dependencies

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -314,7 +314,7 @@ void nano::active_transactions::activate_dependencies (nano::unique_lock<std::mu
 	pending_l.swap (pending_dependencies);
 	lock_a.unlock ();
 
-	auto first_unconfirmed = [this](nano::read_transaction const & transaction_a, nano::account const & account_a, nano::block_hash const & confirmed_frontier_a) {
+	auto first_unconfirmed = [this](nano::transaction const & transaction_a, nano::account const & account_a, nano::block_hash const & confirmed_frontier_a) {
 		if (!confirmed_frontier_a.is_zero ())
 		{
 			return this->node.store.block_successor (transaction_a, confirmed_frontier_a);

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -279,6 +279,7 @@ private:
 	friend class active_transactions_vote_generator_session_Test;
 	friend class node_vote_by_hash_bundle_Test;
 	friend class election_bisect_dependencies_Test;
+	friend class election_dependencies_open_link_Test;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (active_transactions & active_transactions, const std::string & name);

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -118,5 +118,6 @@ public:
 	friend class active_transactions;
 
 	friend class election_bisect_dependencies_Test;
+	friend class election_dependencies_open_link_Test;
 };
 }


### PR DESCRIPTION
This was a regression introduced by https://github.com/nanocurrency/nano-node/pull/2778

Adds two tests to ensure proper behavior:
- `election.dependencies_open_link` which covers the fix by itself
- `node.dependency_graph_frontier`, a more complex test ensuring we can walk down a more complex graph before confirming it from the bottom up. This test is a bit long at 8 to 10 seconds (same with sanitizers though), but seems like a strong addition.