### PR TITLE
Sequential elections

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -154,6 +154,7 @@ TEST (confirmation_height, multiple_accounts)
 		auto receive3 = std::make_shared<nano::receive_block> (open3.hash (), send6.hash (), key3.prv, key3.pub, *system.work.generate (open3.hash ()));
 		node->process_active (receive3);
 		node->block_processor.flush ();
+		node->block_confirm (receive3);
 		{
 			auto election = node->active.election (receive3->qualified_root ());
 			ASSERT_NE (nullptr, election);
@@ -358,6 +359,7 @@ TEST (confirmation_height, gap_live)
 		// Now complete the chain where the block comes in on the live network
 		node->process_active (open1);
 		node->block_processor.flush ();
+		node->block_confirm (open1);
 		{
 			auto election = node->active.election (open1->qualified_root ());
 			ASSERT_NE (nullptr, election);
@@ -447,6 +449,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 
 		node->process_active (receive4);
 		node->block_processor.flush ();
+		node->block_confirm (receive4);
 		{
 			auto election = node->active.election (receive4->qualified_root ());
 			ASSERT_NE (nullptr, election);
@@ -1237,7 +1240,7 @@ TEST (confirmation_height, callback_confirmed_history)
 
 		node->process_active (send1);
 		node->block_processor.flush ();
-
+		node->block_confirm (send1);
 		{
 			node->process_active (send);
 			node->block_processor.flush ();

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -219,8 +219,10 @@ TEST (conflicts, dependency)
 
 TEST (conflicts, adjusted_multiplier)
 {
-	nano::system system (1);
-	auto & node1 (*system.nodes[0]);
+	nano::system system;
+	nano::node_flags flags;
+	flags.disable_request_loop = true;
+	auto & node1 (*system.add_node (flags));
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
@@ -250,7 +252,7 @@ TEST (conflicts, adjusted_multiplier)
 	nano::keypair key4;
 	auto send5 (std::make_shared<nano::state_block> (key3.pub, change1->hash (), nano::test_genesis_key.pub, 0, key4.pub, key3.prv, key3.pub, *system.work.generate (change1->hash ()))); // Pending for open epoch block
 	node1.process_active (send5);
-	node1.block_processor.flush ();
+	nano::blocks_confirm (node1, { send1, send2, receive1, open1, send3, send4, open_epoch1, receive2, open2, change1, send5 });
 	system.deadline_set (3s);
 	while (node1.active.size () != 11)
 	{
@@ -285,6 +287,7 @@ TEST (conflicts, adjusted_multiplier)
 	ASSERT_GT (open_epoch2->difficulty (), nano::difficulty::from_multiplier ((adjusted_multipliers.find (send1->hash ())->second), node1.network_params.network.publish_thresholds.base));
 	node1.process_active (open_epoch2);
 	node1.block_processor.flush ();
+	node1.block_confirm (open_epoch2);
 	system.deadline_set (3s);
 	while (node1.active.size () != 12)
 	{

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -63,38 +63,38 @@ TEST (gap_cache, comparison)
 	ASSERT_EQ (arrival, cache.blocks.get<1> ().begin ()->arrival);
 }
 
+// Upon receiving enough votes for a gapped block, a lazy bootstrap should be initiated
 TEST (gap_cache, gap_bootstrap)
 {
-	nano::system system (2);
+	nano::node_flags node_flags;
+	node_flags.disable_legacy_bootstrap = true;
+	node_flags.disable_request_loop = true; // to avoid fallback behavior of broadcasting blocks
+	nano::system system (2, nano::transport::transport_type::tcp, node_flags);
+
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	nano::block_hash latest (node1.latest (nano::test_genesis_key.pub));
 	nano::keypair key;
 	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
-	{
-		nano::block_post_events events;
-		auto transaction (node1.store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node1.block_processor.process_one (transaction, events, send).code);
-	}
+	node1.process (*send);
 	ASSERT_EQ (nano::genesis_amount - 100, node1.balance (nano::genesis_account));
 	ASSERT_EQ (nano::genesis_amount, node2.balance (nano::genesis_account));
+	// Confirm send block, allowing voting on the upcoming block
+	node1.block_confirm (send);
+	{
+		auto election = node1.active.election (send->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		nano::lock_guard<std::mutex> guard (node1.active.mutex);
+		election->confirm_once ();
+	}
+	ASSERT_TIMELY (2s, node1.block_confirmed (send->hash ()));
+	node1.active.erase (*send);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	system.wallet (0)->insert_adhoc (key.prv);
 	auto latest_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 100));
 	ASSERT_NE (nullptr, latest_block);
 	ASSERT_EQ (nano::genesis_amount - 200, node1.balance (nano::genesis_account));
 	ASSERT_EQ (nano::genesis_amount, node2.balance (nano::genesis_account));
-	system.deadline_set (10s);
-	{
-		// The separate publish and vote system doesn't work very well here because it's instantly confirmed.
-		// We help it get the block and vote out here.
-		auto transaction (node1.store.tx_begin_read ());
-		node1.network.flood_block (latest_block);
-	}
-	while (node2.balance (nano::genesis_account) != nano::genesis_amount - 200)
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
+	ASSERT_TIMELY (10s, node2.balance (nano::genesis_account) == nano::genesis_amount - 200);
 }
 
 TEST (gap_cache, two_dependencies)

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -930,8 +930,9 @@ TEST (votes, add_old_different_account)
 	node1.work_generate_blocking (*send1);
 	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (send1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (send2).code);
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
+	nano::blocks_confirm (node1, { send1, send2 });
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election1);
 	auto election2 = node1.active.election (send2->qualified_root ());
@@ -2662,10 +2663,11 @@ TEST (ledger, block_hash_account_conflict)
 	node1.work_generate_blocking (*receive1);
 	node1.work_generate_blocking (*send2);
 	node1.work_generate_blocking (*open_epoch1);
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (send1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (receive1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (send2).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (open_epoch1).code);
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
+	ASSERT_EQ (nano::process_result::progress, node1.process (*receive1).code);
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
+	ASSERT_EQ (nano::process_result::progress, node1.process (*open_epoch1).code);
+	nano::blocks_confirm (node1, { send1, receive1, send2, open_epoch1 });
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election1);
 	auto election2 = node1.active.election (receive1->qualified_root ());

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -242,6 +242,7 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_FALSE (ec);
 	ASSERT_EQ (nano::process_result::progress, node.process_local (send2).code);
 	ASSERT_EQ (node.config.vote_minimum, node.weight (nano::test_genesis_key.pub));
+	node.block_confirm (send2);
 	// Process a vote
 	auto vote2 (node.store.vote_generate (node.store.tx_begin_read (), nano::test_genesis_key.pub, nano::test_genesis_key.prv, { send2->hash () }));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote2));
@@ -269,6 +270,7 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_FALSE (ec);
 	ASSERT_EQ (nano::process_result::progress, node.process_local (open).code);
 	ASSERT_EQ (nano::genesis_amount - node.config.vote_minimum.number (), node.weight (nano::test_genesis_key.pub));
+	node.block_confirm (open);
 	// Insert account in wallet
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	node.wallets.compute_reps ();

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -278,6 +278,7 @@ private:
 	friend class active_transactions_confirmation_consistency_Test;
 	friend class active_transactions_vote_generator_session_Test;
 	friend class node_vote_by_hash_bundle_Test;
+	friend class node_deferred_dependent_elections_Test;
 	friend class election_bisect_dependencies_Test;
 	friend class election_dependencies_open_link_Test;
 };

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -295,14 +295,17 @@ void nano::block_processor::process_live (nano::block_hash const & hash_a, std::
 	}
 
 	// Start collecting quorum on block
-	auto election = node.active.insert (block_a, process_return_a.previous_balance.number ());
-	if (election.inserted)
+	if (watch_work_a || node.ledger.can_vote (node.store.tx_begin_read (), *block_a))
 	{
-		election.election->transition_passive ();
-	}
-	else if (election.election)
-	{
-		election.election->try_generate_votes (block_a->hash ());
+		auto election = node.active.insert (block_a, process_return_a.previous_balance.number ());
+		if (election.inserted)
+		{
+			election.election->transition_passive ();
+		}
+		else if (election.election)
+		{
+			election.election->try_generate_votes (block_a->hash ());
+		}
 	}
 
 	// Announce block contents to the network

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -525,7 +525,7 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 	if (!store.block_exists (transaction_a, block_a->type (), block_a->hash ()) && store.root_exists (transaction_a, block_a->root ()))
 	{
 		std::shared_ptr<nano::block> ledger_block (ledger.forked_block (transaction_a, *block_a));
-		if (ledger_block && !block_confirmed_or_being_confirmed (transaction_a, ledger_block->hash ()))
+		if (ledger_block && !block_confirmed_or_being_confirmed (transaction_a, ledger_block->hash ()) && ledger.can_vote (transaction_a, *ledger_block))
 		{
 			std::weak_ptr<nano::node> this_w (shared_from_this ());
 			auto election = active.insert (ledger_block, boost::none, [this_w, root](std::shared_ptr<nano::block>) {

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -201,6 +201,18 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 	return !error ? std::move (epoch) : nullptr;
 }
 
+void nano::blocks_confirm (nano::node & node_a, std::vector<std::shared_ptr<nano::block>> const & blocks_a)
+{
+	// Finish processing all blocks
+	node_a.block_processor.flush ();
+	for (auto const & block : blocks_a)
+	{
+		// A sideband is required to start an election
+		debug_assert (block->has_sideband ());
+		node_a.block_confirm (block);
+	}
+}
+
 std::unique_ptr<nano::state_block> nano::system::upgrade_genesis_epoch (nano::node & node_a, nano::epoch const epoch_a)
 {
 	return upgrade_epoch (work, node_a.ledger, epoch_a);

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -56,5 +56,6 @@ public:
 	unsigned node_sequence{ 0 };
 };
 std::unique_ptr<nano::state_block> upgrade_epoch (nano::work_pool &, nano::ledger &, nano::epoch);
+void blocks_confirm (nano::node &, std::vector<std::shared_ptr<nano::block>> const &);
 }
 REGISTER_ERROR_CODES (nano, error_system);


### PR DESCRIPTION
Building off the multi-level election controls added in https://github.com/nanocurrency/nano-node/pull/2785, this PR changes the block processing behavior to only start an election if the block's ancestors are confirmed.

- There is a superlinear usage of resources the more elections are active for the same chain, which is now prevented.
- On confirming an election, the successors (in the same chain and destination chain for sends) are activated (functionality from https://github.com/nanocurrency/nano-node/pull/2785).
- Frontier confirmation works as the fallback behavior, for bootstraps and nodes restarting after getting blocks. Backtracking (https://github.com/nanocurrency/nano-node/pull/2778) later starts the bottom-most election if unable to confirm the frontier.