### PR TITLE
Make RPC name consistent with stats, websocket & protocol naming for telemetry

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -28,12 +28,12 @@ add_executable (core_test
 	network.cpp
 	network_filter.cpp
 	node.cpp
-	node_telemetry.cpp
 	processor_service.cpp
 	peer_container.cpp
 	request_aggregator.cpp
 	signing.cpp
 	socket.cpp
+	telemetry.cpp
 	toml.cpp
 	timer.cpp
 	uint256_union.cpp

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -9,7 +9,7 @@
 
 using namespace std::chrono_literals;
 
-TEST (node_telemetry, consolidate_data)
+TEST (telemetry, consolidate_data)
 {
 	auto time = 1582117035109;
 
@@ -113,7 +113,7 @@ TEST (node_telemetry, consolidate_data)
 	ASSERT_EQ (consolidated_telemetry_data, consolidated_telemetry_data);
 }
 
-TEST (node_telemetry, consolidate_data_remove_outliers)
+TEST (telemetry, consolidate_data_remove_outliers)
 {
 	nano::telemetry_data data;
 	data.account_count = 2;
@@ -181,7 +181,7 @@ TEST (node_telemetry, consolidate_data_remove_outliers)
 	ASSERT_EQ (data, consolidated_telemetry_data);
 }
 
-TEST (node_telemetry, signatures)
+TEST (telemetry, signatures)
 {
 	nano::keypair node_id;
 	nano::telemetry_data data;
@@ -201,7 +201,7 @@ TEST (node_telemetry, signatures)
 	ASSERT_NE (data.signature, signature);
 }
 
-TEST (node_telemetry, no_peers)
+TEST (telemetry, no_peers)
 {
 	nano::system system (1);
 
@@ -209,7 +209,7 @@ TEST (node_telemetry, no_peers)
 	ASSERT_TRUE (responses.empty ());
 }
 
-TEST (node_telemetry, basic)
+TEST (telemetry, basic)
 {
 	nano::system system;
 	nano::node_flags node_flags;
@@ -276,7 +276,7 @@ TEST (node_telemetry, basic)
 	}
 }
 
-TEST (node_telemetry, receive_from_non_listening_channel)
+TEST (telemetry, receive_from_non_listening_channel)
 {
 	nano::system system;
 	auto node = system.add_node ();
@@ -286,7 +286,7 @@ TEST (node_telemetry, receive_from_non_listening_channel)
 	ASSERT_EQ (node->telemetry->telemetry_data_size (), 0);
 }
 
-TEST (node_telemetry, over_udp)
+TEST (telemetry, over_udp)
 {
 	nano::system system;
 	nano::node_flags node_flags;
@@ -322,7 +322,7 @@ TEST (node_telemetry, over_udp)
 	ASSERT_EQ (nano::transport::transport_type::udp, list2[0]->get_type ());
 }
 
-TEST (node_telemetry, invalid_channel)
+TEST (telemetry, invalid_channel)
 {
 	nano::system system (2);
 
@@ -342,7 +342,7 @@ TEST (node_telemetry, invalid_channel)
 	}
 }
 
-TEST (node_telemetry, blocking_request)
+TEST (telemetry, blocking_request)
 {
 	nano::system system (2);
 
@@ -380,7 +380,7 @@ TEST (node_telemetry, blocking_request)
 	promise.get_future ().wait ();
 }
 
-TEST (node_telemetry, disconnects)
+TEST (telemetry, disconnects)
 {
 	nano::system system;
 	nano::node_flags node_flags;
@@ -408,7 +408,7 @@ TEST (node_telemetry, disconnects)
 	}
 }
 
-TEST (node_telemetry, dos_tcp)
+TEST (telemetry, dos_tcp)
 {
 	// Confirm that telemetry_reqs are not processed
 	nano::system system;
@@ -457,7 +457,7 @@ TEST (node_telemetry, dos_tcp)
 	}
 }
 
-TEST (node_telemetry, dos_udp)
+TEST (telemetry, dos_udp)
 {
 	// Confirm that telemetry_reqs are not processed
 	nano::system system;
@@ -509,7 +509,7 @@ TEST (node_telemetry, dos_udp)
 	}
 }
 
-TEST (node_telemetry, disable_metrics)
+TEST (telemetry, disable_metrics)
 {
 	nano::system system;
 	nano::node_flags node_flags;
@@ -554,7 +554,7 @@ TEST (node_telemetry, disable_metrics)
 
 namespace nano
 {
-TEST (node_telemetry, remove_peer_different_genesis)
+TEST (telemetry, remove_peer_different_genesis)
 {
 	nano::system system (1);
 	auto node0 (system.nodes[0]);
@@ -580,7 +580,7 @@ TEST (node_telemetry, remove_peer_different_genesis)
 }
 
 // Peer exclusion is only fully supported for TCP-only nodes; peers can still reconnect through UDP
-TEST (node_telemetry, remove_peer_different_genesis_udp)
+TEST (telemetry, remove_peer_different_genesis_udp)
 {
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
@@ -623,7 +623,7 @@ TEST (node_telemetry, remove_peer_different_genesis_udp)
 	ASSERT_EQ (1, node1->network.excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ().count (node0->network.endpoint ().address ()));
 }
 
-TEST (node_telemetry, remove_peer_invalid_signature)
+TEST (telemetry, remove_peer_invalid_signature)
 {
 	nano::system system;
 	nano::node_flags node_flags;

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -95,8 +95,6 @@ add_library (node
 	logging.cpp
 	network.hpp
 	network.cpp
-	telemetry.hpp
-	telemetry.cpp
 	nodeconfig.hpp
 	nodeconfig.cpp
 	node_observers.hpp
@@ -129,6 +127,8 @@ add_library (node
 	socket.cpp
 	state_block_signature_verification.hpp
 	state_block_signature_verification.cpp
+	telemetry.hpp
+	telemetry.cpp
 	testing.hpp
 	testing.cpp
 	transport/tcp.hpp

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5097,7 +5097,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("stats", &nano::json_handler::stats);
 	no_arg_funcs.emplace ("stats_clear", &nano::json_handler::stats_clear);
 	no_arg_funcs.emplace ("stop", &nano::json_handler::stop);
-	no_arg_funcs.emplace ("node_telemetry", &nano::json_handler::telemetry);
+	no_arg_funcs.emplace ("telemetry", &nano::json_handler::telemetry);
 	no_arg_funcs.emplace ("unchecked", &nano::json_handler::unchecked);
 	no_arg_funcs.emplace ("unchecked_clear", &nano::json_handler::unchecked_clear);
 	no_arg_funcs.emplace ("unchecked_get", &nano::json_handler::unchecked_get);

--- a/nano/node/peer_exclusion.hpp
+++ b/nano/node/peer_exclusion.hpp
@@ -52,9 +52,9 @@ public:
 	size_t limited_size (size_t const) const;
 	size_t size () const;
 
-	friend class node_telemetry_remove_peer_different_genesis_Test;
-	friend class node_telemetry_remove_peer_different_genesis_udp_Test;
-	friend class node_telemetry_remove_peer_invalid_signature_Test;
+	friend class telemetry_remove_peer_different_genesis_Test;
+	friend class telemetry_remove_peer_different_genesis_udp_Test;
+	friend class telemetry_remove_peer_invalid_signature_Test;
 	friend class peer_exclusion_validate_Test;
 };
 std::unique_ptr<container_info_component> collect_container_info (peer_exclusion const & excluded_peers, const std::string & name);

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -144,7 +144,7 @@ private:
 	bool within_cache_plus_buffer_cutoff (telemetry_info const &) const;
 	bool verify_message (nano::telemetry_ack const &, nano::transport::channel const &);
 	friend std::unique_ptr<nano::container_info_component> collect_container_info (telemetry &, const std::string &);
-	friend class node_telemetry_remove_peer_invalid_signature_Test;
+	friend class telemetry_remove_peer_invalid_signature_Test;
 };
 
 std::unique_ptr<nano::container_info_component> collect_container_info (telemetry & telemetry, const std::string & name);

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -87,7 +87,7 @@ namespace transport
 	class tcp_channels final
 	{
 		friend class nano::transport::channel_tcp;
-		friend class node_telemetry_simultaneous_requests_Test;
+		friend class telemetry_simultaneous_requests_Test;
 
 	public:
 		tcp_channels (nano::node &);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -8672,7 +8672,7 @@ TEST (rpc, receive_work_disabled)
 	}
 }
 
-TEST (rpc, node_telemetry_single)
+TEST (rpc, telemetry_single)
 {
 	nano::system system (1);
 	auto & node1 = *add_ipc_enabled_node (system);
@@ -8698,7 +8698,7 @@ TEST (rpc, node_telemetry_single)
 	// Missing port
 	boost::property_tree::ptree request;
 	auto node = system.nodes.front ();
-	request.put ("action", "node_telemetry");
+	request.put ("action", "telemetry");
 	request.put ("address", "not_a_valid_address");
 
 	{
@@ -8775,7 +8775,7 @@ TEST (rpc, node_telemetry_single)
 	}
 }
 
-TEST (rpc, node_telemetry_all)
+TEST (rpc, telemetry_all)
 {
 	nano::system system (1);
 	auto & node1 = *add_ipc_enabled_node (system);
@@ -8813,7 +8813,7 @@ TEST (rpc, node_telemetry_all)
 	}
 
 	boost::property_tree::ptree request;
-	request.put ("action", "node_telemetry");
+	request.put ("action", "telemetry");
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
 		system.deadline_set (10s);
@@ -8855,7 +8855,7 @@ TEST (rpc, node_telemetry_all)
 }
 
 // Also tests all forms of ipv4/ipv6
-TEST (rpc, node_telemetry_self)
+TEST (rpc, telemetry_self)
 {
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
@@ -8872,7 +8872,7 @@ TEST (rpc, node_telemetry_self)
 	node1.network.udp_channels.insert (nano::endpoint (boost::asio::ip::make_address_v6 ("::1"), nano::get_available_port ()), 0);
 
 	boost::property_tree::ptree request;
-	request.put ("action", "node_telemetry");
+	request.put ("action", "telemetry");
 	request.put ("address", "::1");
 	request.put ("port", node1.network.endpoint ().port ());
 	auto const should_ignore_identification_metrics = false;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1224,7 +1224,7 @@ void callback_process (shared_data & shared_data_a, data & data, T & all_node_da
 };
 }
 
-TEST (node_telemetry, ongoing_requests)
+TEST (telemetry, ongoing_requests)
 {
 	nano::system system;
 	nano::node_flags node_flags;
@@ -1264,7 +1264,7 @@ namespace nano
 {
 namespace transport
 {
-	TEST (node_telemetry, simultaneous_requests)
+	TEST (telemetry, simultaneous_requests)
 	{
 		nano::system system;
 		nano::node_flags node_flags;
@@ -1334,7 +1334,7 @@ namespace transport
 }
 }
 
-TEST (node_telemetry, under_load)
+TEST (telemetry, under_load)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
@@ -1385,7 +1385,7 @@ TEST (node_telemetry, under_load)
 	}
 }
 
-TEST (node_telemetry, all_peers_use_single_request_cache)
+TEST (telemetry, all_peers_use_single_request_cache)
 {
 	nano::system system;
 	nano::node_flags node_flags;
@@ -1456,7 +1456,7 @@ TEST (node_telemetry, all_peers_use_single_request_cache)
 	ASSERT_EQ (0, node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::out));
 }
 
-TEST (node_telemetry, many_nodes)
+TEST (telemetry, many_nodes)
 {
 	nano::system system;
 	nano::node_flags node_flags;


### PR DESCRIPTION
Also updated some other places to use `telemetry` instead of `node_telemetry`