### PR TITLE
Output ledger initialization message on start-up

### DIFF
--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -54,6 +54,11 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 		nano::alarm alarm (io_ctx);
 		try
 		{
+			// This avoid a blank prompt during any node initialization delays
+			auto initialization_text = "Starting up Nano node...";
+			std::cout << initialization_text << std::endl;
+			logger.always_log (initialization_text);
+
 			auto node (std::make_shared<nano::node> (io_ctx, data_path, alarm, config.node, opencl_work, flags));
 			if (!node->init_error ())
 			{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -749,12 +749,6 @@ epoch_2_started_cb (epoch_2_started_cb_a)
 {
 	if (!store.init_error ())
 	{
-		if (!network_params.network.is_test_network ())
-		{
-			// Setting up the ledger cache can take some time
-			std::cout << "Initializing ledger..." << std::endl;
-		}
-
 		auto transaction = store.tx_begin_read ();
 		if (generate_cache_a.reps || generate_cache_a.account_count || generate_cache_a.epoch_2)
 		{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -749,6 +749,12 @@ epoch_2_started_cb (epoch_2_started_cb_a)
 {
 	if (!store.init_error ())
 	{
+		if (!network_params.network.is_test_network ())
+		{
+			// Setting up the ledger cache can take some time
+			std::cout << "Initializing ledger..." << std::endl;
+		}
+
 		auto transaction = store.tx_begin_read ();
 		if (generate_cache_a.reps || generate_cache_a.account_count || generate_cache_a.epoch_2)
 		{


### PR DESCRIPTION
Some reports of node taking a minute or so to start up on fresh boot. Instead of having blank prompt, output something semi-reassuring