### PR TITLE
Block builders build_shared and use in more tests

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -18,7 +18,13 @@ TEST (active_transactions, confirm_active)
 	node_flags.disable_request_loop = true;
 	auto & node1 = *system.add_node (node_flags);
 	nano::genesis genesis;
-	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send = nano::send_block_builder ()
+	            .previous (genesis.hash ())
+	            .destination (nano::public_key ())
+	            .balance (nano::genesis_amount - 100)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send).code);
 	nano::node_config node_config2 (nano::get_available_port (), system.logging);
 	node_config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
@@ -65,7 +71,13 @@ TEST (active_transactions, confirm_frontier)
 	node_flags.disable_request_loop = true;
 	auto & node1 = *system.add_node (node_flags);
 	nano::genesis genesis;
-	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send = nano::send_block_builder ()
+	            .previous (genesis.hash ())
+	            .destination (nano::public_key ())
+	            .balance (nano::genesis_amount - 100)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send).code);
 	nano::node_flags node_flags2;
 	// The rep crawler would otherwise request confirmations in order to find representatives
@@ -107,10 +119,43 @@ TEST (active_transactions, adjusted_multiplier_priority)
 	auto & node1 = *system.add_node (node_config);
 	nano::keypair key1, key2, key3;
 
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - 10 * nano::xrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 20 * nano::xrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
-	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 10 * nano::xrb_ratio, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
-	auto open2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, 10 * nano::xrb_ratio, send2->hash (), key2.prv, key2.pub, *system.work.generate (key2.pub)));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (nano::genesis_hash)
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (nano::genesis_hash))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 20 * nano::xrb_ratio)
+	             .link (key2.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto open1 = builder.make_block ()
+	             .account (key1.pub)
+	             .previous (0)
+	             .representative (key1.pub)
+	             .balance (10 * nano::xrb_ratio)
+	             .link (send1->hash ())
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
+	auto open2 = builder.make_block ()
+	             .account (key2.pub)
+	             .previous (0)
+	             .representative (key2.pub)
+	             .balance (10 * nano::xrb_ratio)
+	             .link (send2->hash ())
+	             .sign (key2.prv, key2.pub)
+	             .work (*system.work.generate (key2.pub))
+	             .build_shared ();
 	node1.process_active (send1); // genesis
 	node1.process_active (send2); // genesis
 	node1.process_active (open1); // key1
@@ -150,12 +195,60 @@ TEST (active_transactions, adjusted_multiplier_priority)
 
 	//genesis and key1,key2 are opened
 	//start chain of 2 on each
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, 9 * nano::xrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2->hash (), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base))));
-	auto send4 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, 8 * nano::xrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3->hash (), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base))));
-	auto send5 (std::make_shared<nano::state_block> (key1.pub, open1->hash (), key1.pub, 9 * nano::xrb_ratio, key3.pub, key1.prv, key1.pub, system.work_generate_limited (open1->hash (), nano::difficulty::from_multiplier (10, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base))));
-	auto send6 (std::make_shared<nano::state_block> (key1.pub, send5->hash (), key1.pub, 8 * nano::xrb_ratio, key3.pub, key1.prv, key1.pub, system.work_generate_limited (send5->hash (), nano::difficulty::from_multiplier (10, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base))));
-	auto send7 (std::make_shared<nano::state_block> (key2.pub, open2->hash (), key2.pub, 9 * nano::xrb_ratio, key3.pub, key2.prv, key2.pub, system.work_generate_limited (open2->hash (), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base))));
-	auto send8 (std::make_shared<nano::state_block> (key2.pub, send7->hash (), key2.pub, 8 * nano::xrb_ratio, key3.pub, key2.prv, key2.pub, system.work_generate_limited (send7->hash (), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base))));
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (9 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send2->hash (), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base)))
+	             .build_shared ();
+	auto send4 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send3->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (8 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send3->hash (), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base)))
+	             .build_shared ();
+	auto send5 = builder.make_block ()
+	             .account (key1.pub)
+	             .previous (open1->hash ())
+	             .representative (key1.pub)
+	             .balance (9 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (system.work_generate_limited (open1->hash (), nano::difficulty::from_multiplier (10, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base)))
+	             .build_shared ();
+	auto send6 = builder.make_block ()
+	             .account (key1.pub)
+	             .previous (send5->hash ())
+	             .representative (key1.pub)
+	             .balance (8 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (system.work_generate_limited (send5->hash (), nano::difficulty::from_multiplier (10, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base)))
+	             .build_shared ();
+	auto send7 = builder.make_block ()
+	             .account (key2.pub)
+	             .previous (open2->hash ())
+	             .representative (key2.pub)
+	             .balance (9 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (key2.prv, key2.pub)
+	             .work (system.work_generate_limited (open2->hash (), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base)))
+	             .build_shared ();
+	auto send8 = builder.make_block ()
+	             .account (key2.pub)
+	             .previous (send7->hash ())
+	             .representative (key2.pub)
+	             .balance (8 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (key2.prv, key2.pub)
+	             .work (system.work_generate_limited (send7->hash (), nano::difficulty::from_multiplier (50, node1.network_params.network.publish_thresholds.base), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base)))
+	             .build_shared ();
 
 	node1.process_active (send3); // genesis
 	node1.process_active (send5); // key1
@@ -224,9 +317,34 @@ TEST (active_transactions, keep_local)
 			node.active.roots.begin ()->election->confirm_once ();
 		}
 	}
-	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, node.config.receive_minimum.number (), send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
-	auto open2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, node.config.receive_minimum.number (), send2->hash (), key2.prv, key2.pub, *system.work.generate (key2.pub)));
-	auto open3 (std::make_shared<nano::state_block> (key3.pub, 0, key3.pub, node.config.receive_minimum.number (), send3->hash (), key3.prv, key3.pub, *system.work.generate (key3.pub)));
+	nano::state_block_builder builder;
+	auto open1 = builder.make_block ()
+	             .account (key1.pub)
+	             .previous (0)
+	             .representative (key1.pub)
+	             .balance (node.config.receive_minimum.number ())
+	             .link (send1->hash ())
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
+	auto open2 = builder.make_block ()
+	             .account (key2.pub)
+	             .previous (0)
+	             .representative (key2.pub)
+	             .balance (node.config.receive_minimum.number ())
+	             .link (send2->hash ())
+	             .sign (key2.prv, key2.pub)
+	             .work (*system.work.generate (key2.pub))
+	             .build_shared ();
+	auto open3 = builder.make_block ()
+	             .account (key3.pub)
+	             .previous (0)
+	             .representative (key3.pub)
+	             .balance (node.config.receive_minimum.number ())
+	             .link (send3->hash ())
+	             .sign (key3.prv, key3.pub)
+	             .work (*system.work.generate (key3.pub))
+	             .build_shared ();
 	node.process_active (open1);
 	node.process_active (open2);
 	node.process_active (open3);
@@ -253,14 +371,74 @@ TEST (active_transactions, prioritize_chains)
 	nano::genesis genesis;
 	nano::keypair key1, key2, key3;
 
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 10 * nano::xrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 10 * nano::xrb_ratio, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key1.pub, open1->hash (), key1.pub, nano::xrb_ratio * 9, key2.pub, key1.prv, key1.pub, *system.work.generate (open1->hash ())));
-	auto send3 (std::make_shared<nano::state_block> (key1.pub, send2->hash (), key1.pub, nano::xrb_ratio * 8, key2.pub, key1.prv, key1.pub, *system.work.generate (send2->hash ())));
-	auto send4 (std::make_shared<nano::state_block> (key1.pub, send3->hash (), key1.pub, nano::xrb_ratio * 7, key2.pub, key1.prv, key1.pub, *system.work.generate (send3->hash ())));
-	auto send5 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 20 * nano::xrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
-	auto send6 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send5->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 30 * nano::xrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send5->hash ())));
-	auto open2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, 10 * nano::xrb_ratio, send5->hash (), key2.prv, key2.pub, *system.work.generate (key2.pub, nano::difficulty::from_multiplier (50., node1.network_params.network.publish_thresholds.base))));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto open1 = builder.make_block ()
+	             .account (key1.pub)
+	             .previous (0)
+	             .representative (key1.pub)
+	             .balance (10 * nano::xrb_ratio)
+	             .link (send1->hash ())
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (key1.pub)
+	             .previous (open1->hash ())
+	             .representative (key1.pub)
+	             .balance (9 * nano::xrb_ratio)
+	             .link (key2.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (open1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .from (*send2)
+	             .previous (send2->hash ())
+	             .balance (8 * nano::xrb_ratio)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (send2->hash ()))
+	             .build_shared ();
+	auto send4 = builder.make_block ()
+	             .from (*send3)
+	             .previous (send3->hash ())
+	             .balance (7 * nano::xrb_ratio)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (send3->hash ()))
+	             .build_shared ();
+	auto send5 = builder.make_block ()
+	             .from (*send1)
+	             .previous (send1->hash ())
+	             .balance (nano::genesis_amount - 20 * nano::xrb_ratio)
+	             .link (key2.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto send6 = builder.make_block ()
+	             .from (*send5)
+	             .previous (send5->hash ())
+	             .balance (nano::genesis_amount - 30 * nano::xrb_ratio)
+	             .link (key3.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send5->hash ()))
+	             .build_shared ();
+	auto open2 = builder.make_block ()
+	             .account (key2.pub)
+	             .previous (0)
+	             .representative (key2.pub)
+	             .balance (10 * nano::xrb_ratio)
+	             .link (send5->hash ())
+	             .sign (key2.prv, key2.pub)
+	             .work (*system.work.generate (key2.pub))
+	             .build_shared ();
+
 	auto multiplier1 (nano::normalized_multiplier (nano::difficulty::to_multiplier (open2->difficulty (), nano::work_threshold (open2->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false))), node1.network_params.network.publish_thresholds.epoch_1));
 	auto multiplier2 (nano::normalized_multiplier (nano::difficulty::to_multiplier (send6->difficulty (), nano::work_threshold (open2->work_version (), nano::block_details (nano::epoch::epoch_0, true, false, false))), node1.network_params.network.publish_thresholds.epoch_1));
 
@@ -323,7 +501,13 @@ TEST (active_transactions, inactive_votes_cache)
 	auto & node = *system.nodes[0];
 	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key;
-	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
+	auto send = nano::send_block_builder ()
+	            .previous (latest)
+	            .destination (key.pub)
+	            .balance (nano::genesis_amount - 100)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (latest))
+	            .build_shared ();
 	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send->hash ())));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	system.deadline_set (5s);
@@ -347,8 +531,21 @@ TEST (active_transactions, inactive_votes_cache_fork)
 	auto & node = *system.nodes[0];
 	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
-	auto send2 (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 200, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (latest)
+	             .destination (key.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (latest))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .previous (latest)
+	             .destination (key.pub)
+	             .balance (nano::genesis_amount - 200)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (latest))
+	             .build_shared ();
 	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	auto channel1 (node.network.udp_channels.create (node.network.endpoint ()));
@@ -381,8 +578,23 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	auto & node = *system.add_node (node_config);
 	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key;
-	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100 * nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
-	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, 100 * nano::Gxrb_ratio, send->hash (), key.prv, key.pub, *system.work.generate (key.pub))); // Increase key weight
+	nano::block_builder builder;
+	auto send = builder.send ()
+	            .previous (latest)
+	            .destination (key.pub)
+	            .balance (nano::genesis_amount - 100 * nano::Gxrb_ratio)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (latest))
+	            .build_shared ();
+	auto open = builder.state ()
+	            .account (key.pub)
+	            .previous (0)
+	            .representative (key.pub)
+	            .balance (100 * nano::Gxrb_ratio)
+	            .link (send->hash ())
+	            .sign (key.prv, key.pub)
+	            .work (*system.work.generate (key.pub))
+	            .build_shared ();
 	node.process_active (send);
 	node.block_processor.add (open);
 	node.block_processor.flush ();
@@ -437,9 +649,30 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	auto & node = *system.add_node (node_config);
 	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - 100 * nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 100 * nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ()))); // Decrease genesis weight to prevent election confirmation
-	auto open (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 100 * nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub))); // Increase key1 weight
+	nano::block_builder builder;
+	auto send1 = builder.send ()
+	             .previous (latest)
+	             .destination (key1.pub)
+	             .balance (nano::genesis_amount - 100 * nano::Gxrb_ratio)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (latest))
+	             .build_shared ();
+	auto send2 = builder.send ()
+	             .previous (send1->hash ())
+	             .destination (key1.pub)
+	             .balance (100 * nano::Gxrb_ratio)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto open = builder.state ()
+	            .account (key1.pub)
+	            .previous (0)
+	            .representative (key1.pub)
+	            .balance (100 * nano::Gxrb_ratio)
+	            .link (send1->hash ())
+	            .sign (key1.prv, key1.pub)
+	            .work (*system.work.generate (key1.pub))
+	            .build_shared ();
 	node.block_processor.add (send1);
 	node.block_processor.add (send2);
 	node.block_processor.add (open);
@@ -481,10 +714,27 @@ TEST (active_transactions, update_difficulty)
 	nano::genesis genesis;
 	nano::keypair key1;
 	// Generate blocks & start elections
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 100, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	auto difficulty1 (send1->difficulty ());
 	auto multiplier1 (nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty1, nano::work_threshold (send1->work_version (), nano::block_details (nano::epoch::epoch_0, true, false, false))), node1.network_params.network.publish_thresholds.epoch_1));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 200, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 200)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
 	auto difficulty2 (send2->difficulty ());
 	auto multiplier2 (nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty2, nano::work_threshold (send2->work_version (), nano::block_details (nano::epoch::epoch_0, true, false, false))), node1.network_params.network.publish_thresholds.epoch_1));
 	node1.process_active (send1);
@@ -496,10 +746,8 @@ TEST (active_transactions, update_difficulty)
 	auto work2 = node1.work_generate_blocking (send2->root (), difficulty2 + 1);
 
 	std::error_code ec;
-	nano::state_block_builder builder;
-	send1 = builder.from (*send1).work (*work1).build_shared (ec);
-	nano::state_block_builder builder1;
-	send2 = builder1.from (*send2).work (*work2).build_shared (ec);
+	send1 = builder.make_block ().from (*send1).work (*work1).build_shared (ec);
+	send2 = builder.make_block ().from (*send2).work (*work2).build_shared (ec);
 	ASSERT_FALSE (ec);
 
 	node1.process_active (send1);
@@ -547,10 +795,26 @@ TEST (active_transactions, vote_replays)
 	auto & node = *system.add_node (node_config);
 	nano::genesis genesis;
 	nano::keypair key;
-	std::error_code ec;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	ASSERT_NE (nullptr, send1);
-	auto open1 (std::make_shared<nano::state_block> (key.pub, 0, key.pub, nano::Gxrb_ratio, send1->hash (), key.prv, key.pub, *system.work.generate (key.pub)));
+	auto open1 = builder.make_block ()
+	             .account (key.pub)
+	             .previous (0)
+	             .representative (key.pub)
+	             .balance (nano::Gxrb_ratio)
+	             .link (send1->hash ())
+	             .sign (key.prv, key.pub)
+	             .work (*system.work.generate (key.pub))
+	             .build_shared ();
 	ASSERT_NE (nullptr, open1);
 	node.process_active (send1);
 	node.process_active (open1);
@@ -573,7 +837,15 @@ TEST (active_transactions, vote_replays)
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_open1));
 	ASSERT_EQ (nano::Gxrb_ratio, node.ledger.weight (key.pub));
 
-	auto send2 (std::make_shared<nano::state_block> (key.pub, open1->hash (), key.pub, nano::Gxrb_ratio - 1, key.pub, key.prv, key.pub, *system.work.generate (open1->hash ())));
+	auto send2 = builder.make_block ()
+	             .account (key.pub)
+	             .previous (open1->hash ())
+	             .representative (key.pub)
+	             .balance (nano::Gxrb_ratio - 1)
+	             .link (key.pub)
+	             .sign (key.prv, key.pub)
+	             .work (*system.work.generate (open1->hash ()))
+	             .build_shared ();
 	ASSERT_NE (nullptr, send2);
 	node.process_active (send2);
 	nano::blocks_confirm (node, { send2 });
@@ -619,15 +891,15 @@ TEST (active_transactions, activate_dependencies)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::genesis genesis;
 	nano::block_builder builder;
-	std::shared_ptr<nano::block> block0 = builder.state ()
-	                                      .account (nano::test_genesis_key.pub)
-	                                      .previous (genesis.hash ())
-	                                      .representative (nano::test_genesis_key.pub)
-	                                      .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	                                      .link (0)
-	                                      .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                      .work (node1->work_generate_blocking (genesis.hash ()).value ())
-	                                      .build ();
+	auto block0 = builder.state ()
+	              .account (nano::test_genesis_key.pub)
+	              .previous (genesis.hash ())
+	              .representative (nano::test_genesis_key.pub)
+	              .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	              .link (0)
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (node1->work_generate_blocking (genesis.hash ()).value ())
+	              .build_shared ();
 	// Establish a representative
 	node2->process_active (block0);
 	node2->block_processor.flush ();
@@ -788,14 +1060,70 @@ TEST (active_transactions, insertion_prioritization)
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto & node = *system.add_node (node_config, node_flags);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - 10 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 20 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 30 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2->hash ())));
-	auto send4 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 40 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3->hash ())));
-	auto send5 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send4->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 50 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send4->hash ())));
-	auto send6 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send5->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 60 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send5->hash ())));
-	auto send7 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send6->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 70 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send6->hash ())));
-
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (nano::genesis_hash)
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (nano::genesis_hash))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 20 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 30 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send2->hash ()))
+	             .build_shared ();
+	auto send4 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send3->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 40 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send3->hash ()))
+	             .build_shared ();
+	auto send5 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send4->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 50 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send4->hash ()))
+	             .build_shared ();
+	auto send6 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send5->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 60 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send5->hash ()))
+	             .build_shared ();
+	auto send7 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send6->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 70 * nano::xrb_ratio)
+	             .link (nano::public_key ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send6->hash ()))
+	             .build_shared ();
 	// Sort by difficulty, descending
 	std::vector<std::shared_ptr<nano::block>> blocks{ send1, send2, send3, send4, send5, send6, send7 };
 	for (auto const & block : blocks)
@@ -950,8 +1278,17 @@ TEST (active_transactions, election_difficulty_update_old)
 	auto & node = *system.add_node (node_flags);
 	nano::genesis genesis;
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 10 * nano::xrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send1_copy (std::make_shared<nano::state_block> (*send1));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto send1_copy = builder.make_block ().from (*send1).build_shared ();
 	node.process_active (send1);
 	node.block_processor.flush ();
 	ASSERT_EQ (1, node.active.size ());
@@ -989,9 +1326,34 @@ TEST (active_transactions, election_difficulty_update_fork)
 	auto epoch2 = system.upgrade_genesis_epoch (node, nano::epoch::epoch_2);
 	ASSERT_NE (nullptr, epoch2);
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, epoch2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (epoch2->hash ())));
-	auto open1 (std::make_shared<nano::state_block> (key.pub, 0, key.pub, nano::Gxrb_ratio, send1->hash (), key.prv, key.pub, *system.work.generate (key.pub)));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (epoch2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (epoch2->hash ()))
+	             .build_shared ();
+	auto open1 = builder.make_block ()
+	             .account (key.pub)
+	             .previous (0)
+	             .representative (key.pub)
+	             .balance (nano::Gxrb_ratio)
+	             .link (send1->hash ())
+	             .sign (key.prv, key.pub)
+	             .work (*system.work.generate (key.pub))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*open1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
@@ -1011,9 +1373,33 @@ TEST (active_transactions, election_difficulty_update_fork)
 
 	// Verify an election with multiple blocks is correctly updated on arrival of another block
 	// Each subsequent block has difficulty at least higher than the previous one
-	auto fork_change (std::make_shared<nano::state_block> (key.pub, open1->hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key.prv, key.pub, *system.work.generate (open1->hash ())));
-	auto fork_send (std::make_shared<nano::state_block> (key.pub, open1->hash (), key.pub, 0, key.pub, key.prv, key.pub, *system.work.generate (open1->hash (), fork_change->difficulty ())));
-	auto fork_receive (std::make_shared<nano::state_block> (key.pub, open1->hash (), key.pub, 2 * nano::Gxrb_ratio, send2->hash (), key.prv, key.pub, *system.work.generate (open1->hash (), fork_send->difficulty ())));
+	auto fork_change = builder.make_block ()
+	                   .account (key.pub)
+	                   .previous (open1->hash ())
+	                   .representative (nano::test_genesis_key.pub)
+	                   .balance (nano::Gxrb_ratio)
+	                   .link (0)
+	                   .sign (key.prv, key.pub)
+	                   .work (*system.work.generate (open1->hash ()))
+	                   .build_shared ();
+	auto fork_send = builder.make_block ()
+	                 .account (key.pub)
+	                 .previous (open1->hash ())
+	                 .representative (key.pub)
+	                 .balance (0)
+	                 .link (key.pub)
+	                 .sign (key.prv, key.pub)
+	                 .work (*system.work.generate (open1->hash (), fork_change->difficulty ()))
+	                 .build_shared ();
+	auto fork_receive = builder.make_block ()
+	                    .account (key.pub)
+	                    .previous (open1->hash ())
+	                    .representative (key.pub)
+	                    .balance (2 * nano::Gxrb_ratio)
+	                    .link (send2->hash ())
+	                    .sign (key.prv, key.pub)
+	                    .work (*system.work.generate (open1->hash (), fork_send->difficulty ()))
+	                    .build_shared ();
 	ASSERT_GT (fork_send->difficulty (), fork_change->difficulty ());
 	ASSERT_GT (fork_receive->difficulty (), fork_send->difficulty ());
 
@@ -1058,7 +1444,13 @@ TEST (active_transactions, confirm_new)
 	nano::system system (1);
 	auto & node1 = *system.nodes[0];
 	nano::genesis genesis;
-	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send = nano::send_block_builder ()
+	            .previous (genesis.hash ())
+	            .destination (nano::public_key ())
+	            .balance (nano::genesis_amount - 100)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared ();
 	node1.process_active (send);
 	node1.block_processor.flush ();
 	ASSERT_EQ (1, node1.active.size ());
@@ -1086,8 +1478,15 @@ TEST (active_transactions, restart_dropped)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::genesis genesis;
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	// Process only in ledger and simulate dropping the election
+	auto send = nano::state_block_builder ()
+	            .account (nano::test_genesis_key.pub)
+	            .previous (genesis.hash ())
+	            .representative (nano::test_genesis_key.pub)
+	            .balance (nano::genesis_amount - nano::xrb_ratio)
+	            .link (nano::test_genesis_key.pub)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared (); // Process only in ledger and simulate dropping the election
 	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
 	node.active.recently_dropped.add (send->qualified_root ());
 	// Generate higher difficulty work
@@ -1138,8 +1537,25 @@ TEST (active_transactions, conflicting_block_vote_existing_election)
 	auto & node = *system.add_node (node_flags);
 	nano::genesis genesis;
 	nano::keypair key;
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 100, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto fork (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 200, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::state_block_builder builder;
+	auto send = builder.make_block ()
+	            .account (nano::test_genesis_key.pub)
+	            .previous (genesis.hash ())
+	            .representative (nano::test_genesis_key.pub)
+	            .balance (nano::genesis_amount - 100)
+	            .link (key.pub)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared ();
+	auto fork = builder.make_block ()
+	            .account (nano::test_genesis_key.pub)
+	            .previous (genesis.hash ())
+	            .representative (nano::test_genesis_key.pub)
+	            .balance (nano::genesis_amount - 200)
+	            .link (key.pub)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared ();
 	auto vote_fork (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, fork));
 
 	ASSERT_EQ (nano::process_result::progress, node.process_local (send).code);

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -497,9 +497,9 @@ TEST (active_transactions, update_difficulty)
 
 	std::error_code ec;
 	nano::state_block_builder builder;
-	send1 = std::shared_ptr<nano::state_block> (builder.from (*send1).work (*work1).build (ec));
+	send1 = builder.from (*send1).work (*work1).build_shared (ec);
 	nano::state_block_builder builder1;
-	send2 = std::shared_ptr<nano::state_block> (builder1.from (*send2).work (*work2).build (ec));
+	send2 = builder1.from (*send2).work (*work2).build_shared (ec);
 	ASSERT_FALSE (ec);
 
 	node1.process_active (send1);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2609,25 +2609,25 @@ TEST (ledger, block_hash_account_conflict)
 	 * Generate a send block whose destination is a block hash already
 	 * in the ledger and not an account
 	 */
-	std::shared_ptr<nano::state_block> send1 = builder.state ()
-	                                           .account (nano::genesis_account)
-	                                           .previous (genesis.hash ())
-	                                           .representative (nano::genesis_account)
-	                                           .balance (nano::genesis_amount - 100)
-	                                           .link (key1.pub)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*pool.generate (genesis.hash ()))
-	                                           .build ();
+	auto send1 = builder.state ()
+	             .account (nano::genesis_account)
+	             .previous (genesis.hash ())
+	             .representative (nano::genesis_account)
+	             .balance (nano::genesis_amount - 100)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*pool.generate (genesis.hash ()))
+	             .build_shared ();
 
-	std::shared_ptr<nano::state_block> receive1 = builder.state ()
-	                                              .account (key1.pub)
-	                                              .previous (0)
-	                                              .representative (nano::genesis_account)
-	                                              .balance (100)
-	                                              .link (send1->hash ())
-	                                              .sign (key1.prv, key1.pub)
-	                                              .work (*pool.generate (key1.pub))
-	                                              .build ();
+	auto receive1 = builder.state ()
+	                .account (key1.pub)
+	                .previous (0)
+	                .representative (nano::genesis_account)
+	                .balance (100)
+	                .link (send1->hash ())
+	                .sign (key1.prv, key1.pub)
+	                .work (*pool.generate (key1.pub))
+	                .build_shared ();
 
 	/*
 	 * Note that the below link is a block hash when this is intended
@@ -2635,29 +2635,29 @@ TEST (ledger, block_hash_account_conflict)
 	 * received , except by epoch blocks, which can sign an open block
 	 * for arbitrary accounts.
 	 */
-	std::shared_ptr<nano::state_block> send2 = builder.state ()
-	                                           .account (key1.pub)
-	                                           .previous (receive1->hash ())
-	                                           .representative (nano::genesis_account)
-	                                           .balance (90)
-	                                           .link (receive1->hash ())
-	                                           .sign (key1.prv, key1.pub)
-	                                           .work (*pool.generate (receive1->hash ()))
-	                                           .build ();
+	auto send2 = builder.state ()
+	             .account (key1.pub)
+	             .previous (receive1->hash ())
+	             .representative (nano::genesis_account)
+	             .balance (90)
+	             .link (receive1->hash ())
+	             .sign (key1.prv, key1.pub)
+	             .work (*pool.generate (receive1->hash ()))
+	             .build_shared ();
 
 	/*
 	 * Generate an epoch open for the account with the same value as the block hash
 	 */
 	auto receive1_hash = receive1->hash ();
-	std::shared_ptr<nano::state_block> open_epoch1 = builder.state ()
-	                                                 .account (reinterpret_cast<nano::account const &> (receive1_hash))
-	                                                 .previous (0)
-	                                                 .representative (0)
-	                                                 .balance (0)
-	                                                 .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
-	                                                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                                 .work (*pool.generate (receive1->hash ()))
-	                                                 .build ();
+	auto open_epoch1 = builder.state ()
+	                   .account (reinterpret_cast<nano::account const &> (receive1_hash))
+	                   .previous (0)
+	                   .representative (0)
+	                   .balance (0)
+	                   .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
+	                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                   .work (*pool.generate (receive1->hash ()))
+	                   .build_shared ();
 
 	node1.work_generate_blocking (*send1);
 	node1.work_generate_blocking (*receive1);
@@ -3149,37 +3149,37 @@ TEST (ledger, can_vote)
 	ASSERT_TRUE (ledger.can_vote (transaction, *genesis.open));
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	std::shared_ptr<nano::state_block> send1 = builder.state ()
-	                                           .account (nano::genesis_account)
-	                                           .previous (genesis.hash ())
-	                                           .representative (nano::genesis_account)
-	                                           .balance (nano::genesis_amount - 100)
-	                                           .link (key1.pub)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*pool.generate (genesis.hash ()))
-	                                           .build ();
+	auto send1 = builder.state ()
+	             .account (nano::genesis_account)
+	             .previous (genesis.hash ())
+	             .representative (nano::genesis_account)
+	             .balance (nano::genesis_amount - 100)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*pool.generate (genesis.hash ()))
+	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (ledger.can_vote (transaction, *send1));
-	std::shared_ptr<nano::state_block> send2 = builder.state ()
-	                                           .account (nano::genesis_account)
-	                                           .previous (send1->hash ())
-	                                           .representative (nano::genesis_account)
-	                                           .balance (nano::genesis_amount - 200)
-	                                           .link (key1.pub)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*pool.generate (send1->hash ()))
-	                                           .build ();
+	auto send2 = builder.state ()
+	             .account (nano::genesis_account)
+	             .previous (send1->hash ())
+	             .representative (nano::genesis_account)
+	             .balance (nano::genesis_amount - 200)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*pool.generate (send1->hash ()))
+	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_FALSE (ledger.can_vote (transaction, *send2));
-	std::shared_ptr<nano::state_block> receive1 = builder.state ()
-	                                              .account (key1.pub)
-	                                              .previous (0)
-	                                              .representative (nano::genesis_account)
-	                                              .balance (100)
-	                                              .link (send1->hash ())
-	                                              .sign (key1.prv, key1.pub)
-	                                              .work (*pool.generate (key1.pub))
-	                                              .build ();
+	auto receive1 = builder.state ()
+	                .account (key1.pub)
+	                .previous (0)
+	                .representative (nano::genesis_account)
+	                .balance (100)
+	                .link (send1->hash ())
+	                .sign (key1.prv, key1.pub)
+	                .work (*pool.generate (key1.pub))
+	                .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (ledger.can_vote (transaction, *receive1));
 	nano::confirmation_height_info height;
@@ -3187,15 +3187,15 @@ TEST (ledger, can_vote)
 	height.height += 1;
 	ledger.store.confirmation_height_put (transaction, nano::genesis_account, height);
 	ASSERT_TRUE (ledger.can_vote (transaction, *receive1));
-	std::shared_ptr<nano::state_block> receive2 = builder.state ()
-	                                              .account (key1.pub)
-	                                              .previous (receive1->hash ())
-	                                              .representative (nano::genesis_account)
-	                                              .balance (200)
-	                                              .link (send2->hash ())
-	                                              .sign (key1.prv, key1.pub)
-	                                              .work (*pool.generate (receive1->hash ()))
-	                                              .build ();
+	auto receive2 = builder.state ()
+	                .account (key1.pub)
+	                .previous (receive1->hash ())
+	                .representative (nano::genesis_account)
+	                .balance (200)
+	                .link (send2->hash ())
+	                .sign (key1.prv, key1.pub)
+	                .work (*pool.generate (receive1->hash ()))
+	                .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_FALSE (ledger.can_vote (transaction, *receive2));
 	ASSERT_FALSE (ledger.store.confirmation_height_get (transaction, key1.pub, height));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3845,37 +3845,37 @@ TEST (node, rollback_vote_self)
 	nano::state_block_builder builder;
 	nano::keypair key;
 	auto weight = node.config.online_weight_minimum.number ();
-	std::shared_ptr<nano::state_block> send1 = builder.make_block ()
-	                                           .account (nano::test_genesis_key.pub)
-	                                           .previous (nano::genesis_hash)
-	                                           .representative (nano::test_genesis_key.pub)
-	                                           .link (key.pub)
-	                                           .balance (nano::genesis_amount - weight)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*system.work.generate (nano::genesis_hash))
-	                                           .build ();
-	std::shared_ptr<nano::state_block> open = builder.make_block ()
-	                                          .account (key.pub)
-	                                          .previous (0)
-	                                          .representative (key.pub)
-	                                          .link (send1->hash ())
-	                                          .balance (weight)
-	                                          .sign (key.prv, key.pub)
-	                                          .work (*system.work.generate (key.pub))
-	                                          .build ();
-	std::shared_ptr<nano::state_block> send2 = builder.make_block ()
-	                                           .from (*send1)
-	                                           .previous (send1->hash ())
-	                                           .balance (send1->balance ().number () - 1)
-	                                           .link (nano::test_genesis_key.pub)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*system.work.generate (send1->hash ()))
-	                                           .build ();
-	std::shared_ptr<nano::state_block> fork = builder.make_block ()
-	                                          .from (*send2)
-	                                          .balance (send2->balance ().number () - 2)
-	                                          .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                          .build ();
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (nano::genesis_hash)
+	             .representative (nano::test_genesis_key.pub)
+	             .link (key.pub)
+	             .balance (nano::genesis_amount - weight)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (nano::genesis_hash))
+	             .build_shared ();
+	auto open = builder.make_block ()
+	            .account (key.pub)
+	            .previous (0)
+	            .representative (key.pub)
+	            .link (send1->hash ())
+	            .balance (weight)
+	            .sign (key.prv, key.pub)
+	            .work (*system.work.generate (key.pub))
+	            .build_shared ();
+	auto send2 = builder.make_block ()
+	             .from (*send1)
+	             .previous (send1->hash ())
+	             .balance (send1->balance ().number () - 1)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto fork = builder.make_block ()
+	            .from (*send2)
+	            .balance (send2->balance ().number () - 2)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
 	// Confirm blocks to allow voting
@@ -3938,15 +3938,15 @@ TEST (node, dependency_graph)
 	nano::keypair key1, key2, key3;
 
 	// Send to key1
-	std::shared_ptr<nano::state_block> gen_send1 = builder.make_block ()
-	                                               .account (nano::test_genesis_key.pub)
-	                                               .previous (nano::genesis_hash)
-	                                               .representative (nano::test_genesis_key.pub)
-	                                               .link (key1.pub)
-	                                               .balance (nano::genesis_amount - 1)
-	                                               .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                               .work (*system.work.generate (nano::genesis_hash))
-	                                               .build ();
+	auto gen_send1 = builder.make_block ()
+	                 .account (nano::test_genesis_key.pub)
+	                 .previous (nano::genesis_hash)
+	                 .representative (nano::test_genesis_key.pub)
+	                 .link (key1.pub)
+	                 .balance (nano::genesis_amount - 1)
+	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .work (*system.work.generate (nano::genesis_hash))
+	                 .build_shared ();
 	// Receive from genesis
 	auto key1_open = builder.make_block ()
 	                 .account (key1.pub)
@@ -4138,15 +4138,15 @@ TEST (node, dependency_graph_frontier)
 	nano::keypair key1, key2, key3;
 
 	// Send to key1
-	std::shared_ptr<nano::state_block> gen_send1 = builder.make_block ()
-	                                               .account (nano::test_genesis_key.pub)
-	                                               .previous (nano::genesis_hash)
-	                                               .representative (nano::test_genesis_key.pub)
-	                                               .link (key1.pub)
-	                                               .balance (nano::genesis_amount - 1)
-	                                               .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                               .work (*system.work.generate (nano::genesis_hash))
-	                                               .build ();
+	auto gen_send1 = builder.make_block ()
+	                 .account (nano::test_genesis_key.pub)
+	                 .previous (nano::genesis_hash)
+	                 .representative (nano::test_genesis_key.pub)
+	                 .link (key1.pub)
+	                 .balance (nano::genesis_amount - 1)
+	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .work (*system.work.generate (nano::genesis_hash))
+	                 .build_shared ();
 	// Receive from genesis
 	auto key1_open = builder.make_block ()
 	                 .account (key1.pub)
@@ -4310,45 +4310,45 @@ TEST (node, deferred_dependent_elections)
 
 	nano::state_block_builder builder;
 	nano::keypair key;
-	std::shared_ptr<nano::state_block> send1 = builder.make_block ()
-	                                           .account (nano::test_genesis_key.pub)
-	                                           .previous (nano::genesis_hash)
-	                                           .representative (nano::test_genesis_key.pub)
-	                                           .link (key.pub)
-	                                           .balance (nano::genesis_amount - 1)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*system.work.generate (nano::genesis_hash))
-	                                           .build ();
-	std::shared_ptr<nano::state_block> open = builder.make_block ()
-	                                          .account (key.pub)
-	                                          .previous (0)
-	                                          .representative (key.pub)
-	                                          .link (send1->hash ())
-	                                          .balance (1)
-	                                          .sign (key.prv, key.pub)
-	                                          .work (*system.work.generate (key.pub))
-	                                          .build ();
-	std::shared_ptr<nano::state_block> send2 = builder.make_block ()
-	                                           .from (*send1)
-	                                           .previous (send1->hash ())
-	                                           .balance (send1->balance ().number () - 1)
-	                                           .link (key.pub)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*system.work.generate (send1->hash ()))
-	                                           .build ();
-	std::shared_ptr<nano::state_block> receive = builder.make_block ()
-	                                             .from (*open)
-	                                             .previous (open->hash ())
-	                                             .link (send2->hash ())
-	                                             .balance (2)
-	                                             .sign (key.prv, key.pub)
-	                                             .work (*system.work.generate (open->hash ()))
-	                                             .build ();
-	std::shared_ptr<nano::state_block> fork = builder.make_block ()
-	                                          .from (*receive)
-	                                          .representative (nano::test_genesis_key.pub)
-	                                          .sign (key.prv, key.pub)
-	                                          .build ();
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (nano::genesis_hash)
+	             .representative (nano::test_genesis_key.pub)
+	             .link (key.pub)
+	             .balance (nano::genesis_amount - 1)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (nano::genesis_hash))
+	             .build_shared ();
+	auto open = builder.make_block ()
+	            .account (key.pub)
+	            .previous (0)
+	            .representative (key.pub)
+	            .link (send1->hash ())
+	            .balance (1)
+	            .sign (key.prv, key.pub)
+	            .work (*system.work.generate (key.pub))
+	            .build_shared ();
+	auto send2 = builder.make_block ()
+	             .from (*send1)
+	             .previous (send1->hash ())
+	             .balance (send1->balance ().number () - 1)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto receive = builder.make_block ()
+	               .from (*open)
+	               .previous (open->hash ())
+	               .link (send2->hash ())
+	               .balance (2)
+	               .sign (key.prv, key.pub)
+	               .work (*system.work.generate (open->hash ()))
+	               .build_shared ();
+	auto fork = builder.make_block ()
+	            .from (*receive)
+	            .representative (nano::test_genesis_key.pub)
+	            .sign (key.prv, key.pub)
+	            .build_shared ();
 	node.process_active (send1);
 	node.block_processor.flush ();
 	auto election_send1 = node.active.election (send1->qualified_root ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -186,12 +186,31 @@ TEST (node, send_out_of_order)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key2;
 	nano::genesis genesis;
-	nano::send_block send1 (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ()));
-	nano::send_block send2 (send1.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
-	nano::send_block send3 (send2.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2.hash ()));
-	node1.process_active (std::make_shared<nano::send_block> (send3));
-	node1.process_active (std::make_shared<nano::send_block> (send2));
-	node1.process_active (std::make_shared<nano::send_block> (send1));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .previous (send1->hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - 2 * node1.config.receive_minimum.number ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .previous (send2->hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - 3 * node1.config.receive_minimum.number ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send2->hash ()))
+	             .build_shared ();
+	node1.process_active (send3);
+	node1.process_active (send2);
+	node1.process_active (send1);
 	system.deadline_set (10s);
 	while (std::any_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<nano::node> const & node_a) { return node_a->balance (nano::test_genesis_key.pub) != nano::genesis_amount - node1.config.receive_minimum.number () * 3; }))
 	{
@@ -208,7 +227,13 @@ TEST (node, quick_confirm)
 	auto genesis_start_balance (node1.balance (nano::test_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key.prv);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send (std::make_shared<nano::send_block> (previous, key.pub, node1.config.online_weight_minimum.number () + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+	auto send = nano::send_block_builder ()
+	            .previous (previous)
+	            .destination (key.pub)
+	            .balance (node1.config.online_weight_minimum.number () + 1)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (previous))
+	            .build_shared ();
 	node1.process_active (send);
 	system.deadline_set (10s);
 	while (node1.balance (key.pub).is_zero ())
@@ -228,7 +253,13 @@ TEST (node, node_receive_quorum)
 	nano::keypair key;
 	nano::block_hash previous (node1.latest (nano::test_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto send (std::make_shared<nano::send_block> (previous, key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+	auto send = nano::send_block_builder ()
+	            .previous (previous)
+	            .destination (key.pub)
+	            .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (previous))
+	            .build_shared ();
 	node1.process_active (send);
 	system.deadline_set (10s);
 	while (!node1.ledger.block_exists (send->hash ()))
@@ -350,7 +381,13 @@ TEST (node, receive_gap)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	ASSERT_EQ (0, node1.gap_cache.size ());
-	auto block (std::make_shared<nano::send_block> (5, 1, 2, nano::keypair ().prv, 4, 0));
+	auto block = nano::send_block_builder ()
+	             .previous (5)
+	             .destination (1)
+	             .balance (2)
+	             .sign (nano::keypair ().prv, 4)
+	             .work (0)
+	             .build_shared ();
 	node1.work_generate_blocking (*block);
 	nano::publish message (block);
 	node1.network.process_message (message, node1.network.udp_channels.create (node1.network.endpoint ()));
@@ -561,7 +598,13 @@ TEST (node, confirm_locked)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	system.wallet (0)->enter_password (transaction, "1");
-	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::keypair ().prv, 0, 0));
+	auto block = nano::send_block_builder ()
+	             .previous (0)
+	             .destination (0)
+	             .balance (0)
+	             .sign (nano::keypair ().prv, 0)
+	             .work (0)
+	             .build_shared ();
 	system.nodes[0]->network.flood_block (block);
 }
 
@@ -1221,10 +1264,23 @@ TEST (node, fork_publish)
 		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 		nano::keypair key1;
 		nano::genesis genesis;
-		auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		nano::send_block_builder builder;
+		auto send1 = builder.make_block ()
+		             .previous (genesis.hash ())
+		             .destination (key1.pub)
+		             .balance (nano::genesis_amount - 100)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (0)
+		             .build_shared ();
 		node1.work_generate_blocking (*send1);
 		nano::keypair key2;
-		auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send2 = builder.make_block ()
+		             .previous (genesis.hash ())
+		             .destination (key2.pub)
+		             .balance (nano::genesis_amount - 100)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (0)
+		             .build_shared ();
 		node1.work_generate_blocking (*send2);
 		node1.process_active (send1);
 		node1.block_processor.flush ();
@@ -1262,8 +1318,21 @@ TEST (node, fork_publish_inactive)
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, send1->block_work ()));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (send1->block_work ())
+	             .build_shared ();
 	auto & node (*system.nodes[0]);
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::fork, node.process_local (send2).code);
@@ -1288,9 +1357,22 @@ TEST (node, fork_keep)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::genesis genesis;
+	nano::send_block_builder builder;
 	// send1 and send2 fork to different accounts
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	node1.process_active (send1);
 	node1.block_processor.flush ();
 	node2.process_active (send1);
@@ -1340,10 +1422,23 @@ TEST (node, fork_flip)
 	ASSERT_EQ (1, node1.network.size ());
 	nano::keypair key1;
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	nano::publish publish1 (send1);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send2 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (nano::genesis_amount - 100)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	nano::publish publish2 (send2);
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.network.process_message (publish1, channel1);
@@ -1412,12 +1507,31 @@ TEST (node, fork_multi_flip)
 		ASSERT_EQ (1, node1.network.size ());
 		nano::keypair key1;
 		nano::genesis genesis;
-		auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+		nano::send_block_builder builder;
+		auto send1 = builder.make_block ()
+		             .previous (genesis.hash ())
+		             .destination (key1.pub)
+		             .balance (nano::genesis_amount - 100)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*system.work.generate (genesis.hash ()))
+		             .build_shared ();
 		nano::publish publish1 (send1);
 		nano::keypair key2;
-		auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+		auto send2 = builder.make_block ()
+		             .previous (genesis.hash ())
+		             .destination (key2.pub)
+		             .balance (nano::genesis_amount - 100)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*system.work.generate (genesis.hash ()))
+		             .build_shared ();
 		nano::publish publish2 (send2);
-		auto send3 (std::make_shared<nano::send_block> (publish2.block->hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (publish2.block->hash ())));
+		auto send3 = builder.make_block ()
+		             .previous (publish2.block->hash ())
+		             .destination (key2.pub)
+		             .balance (nano::genesis_amount - 100)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*system.work.generate (publish2.block->hash ()))
+		             .build_shared ();
 		nano::publish publish3 (send3);
 		node1.network.process_message (publish1, node1.network.udp_channels.create (node1.network.endpoint ()));
 		node2.network.process_message (publish2, node2.network.udp_channels.create (node2.network.endpoint ()));
@@ -1487,9 +1601,22 @@ TEST (node, fork_bootstrap_flip)
 	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (node1.latest (nano::test_genesis_key.pub));
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system0.work.generate (latest)));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (latest)
+	             .destination (key1.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system0.work.generate (latest))
+	             .build_shared ();
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (latest, key2.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system0.work.generate (latest)));
+	auto send2 = builder.make_block ()
+	             .previous (latest)
+	             .destination (key2.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system0.work.generate (latest))
+	             .build_shared ();
 	// Insert but don't rebroadcast, simulating settled blocks
 	node1.block_processor.add (send1, nano::seconds_since_epoch ());
 	node1.block_processor.flush ();
@@ -1525,7 +1652,13 @@ TEST (node, fork_open)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 = nano::send_block_builder ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (0)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	nano::publish publish1 (send1);
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.network.process_message (publish1, channel1);
@@ -1536,12 +1669,25 @@ TEST (node, fork_open)
 		election->confirm_once ();
 	}
 	ASSERT_TIMELY (3s, node1.active.empty () && node1.block_confirmed (publish1.block->hash ()));
-	auto open1 (std::make_shared<nano::open_block> (publish1.block->hash (), 1, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub)));
+	nano::open_block_builder builder;
+	auto open1 = builder.make_block ()
+	             .source (publish1.block->hash ())
+	             .representative (1)
+	             .account (key1.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
 	nano::publish publish2 (open1);
 	node1.network.process_message (publish2, channel1);
 	node1.block_processor.flush ();
 	ASSERT_EQ (1, node1.active.size ());
-	auto open2 (std::make_shared<nano::open_block> (publish1.block->hash (), 2, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub)));
+	auto open2 = builder.make_block ()
+	             .source (publish1.block->hash ())
+	             .representative (2)
+	             .account (key1.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
 	nano::publish publish3 (open2);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	node1.network.process_message (publish3, channel1);
@@ -1567,15 +1713,34 @@ TEST (node, fork_open_flip)
 	nano::genesis genesis;
 	nano::keypair rep1;
 	nano::keypair rep2;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 = nano::send_block_builder ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (nano::genesis_amount - 1)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	// A copy is necessary to avoid data races during ledger processing, which sets the sideband
 	auto send1_copy (std::make_shared<nano::send_block> (*send1));
 	node1.process_active (send1);
 	node2.process_active (send1_copy);
 	// We should be keeping this block
-	auto open1 (std::make_shared<nano::open_block> (send1->hash (), rep1.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub)));
+	nano::open_block_builder builder;
+	auto open1 = builder.make_block ()
+	             .source (send1->hash ())
+	             .representative (rep1.pub)
+	             .account (key1.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
 	// This block should be evicted
-	auto open2 (std::make_shared<nano::open_block> (send1->hash (), rep2.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub)));
+	auto open2 = builder.make_block ()
+	             .source (send1->hash ())
+	             .representative (rep2.pub)
+	             .account (key1.pub)
+	             .sign (key1.prv, key1.pub)
+	             .work (*system.work.generate (key1.pub))
+	             .build_shared ();
 	ASSERT_FALSE (*open1 == *open2);
 	// node1 gets copy that will remain
 	node1.process_active (open1);
@@ -1662,7 +1827,13 @@ TEST (node, fork_no_vote_quorum)
 	ASSERT_EQ (nano::process_result::progress, node2.process (send1).code);
 	ASSERT_EQ (nano::process_result::progress, node3.process (send1).code);
 	auto key2 (system.wallet (2)->deterministic_insert ());
-	auto send2 (std::make_shared<nano::send_block> (block->hash (), key2, (nano::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (block->hash ())));
+	auto send2 = nano::send_block_builder ()
+	             .previous (block->hash ())
+	             .destination (key2)
+	             .balance ((nano::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2))
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (block->hash ()))
+	             .build_shared ();
 	nano::raw_key key3;
 	auto transaction (system.wallet (1)->wallets.tx_begin_read ());
 	ASSERT_FALSE (system.wallet (1)->store.fetch (transaction, key1, key3));
@@ -1720,8 +1891,25 @@ TEST (node, DISABLED_fork_pre_confirm)
 	}
 	nano::keypair key3;
 	nano::keypair key4;
-	auto block2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, node0.latest (nano::test_genesis_key.pub), key3.pub, node0.balance (nano::test_genesis_key.pub), 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	auto block3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, node0.latest (nano::test_genesis_key.pub), key4.pub, node0.balance (nano::test_genesis_key.pub), 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	nano::state_block_builder builder;
+	auto block2 = builder.make_block ()
+	              .account (nano::test_genesis_key.pub)
+	              .previous (node0.latest (nano::test_genesis_key.pub))
+	              .representative (key3.pub)
+	              .balance (node0.balance (nano::test_genesis_key.pub))
+	              .link (0)
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (0)
+	              .build_shared ();
+	auto block3 = builder.make_block ()
+	              .account (nano::test_genesis_key.pub)
+	              .previous (node0.latest (nano::test_genesis_key.pub))
+	              .representative (key4.pub)
+	              .balance (node0.balance (nano::test_genesis_key.pub))
+	              .link (0)
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (0)
+	              .build_shared ();
 	node0.work_generate_blocking (*block2);
 	node0.work_generate_blocking (*block3);
 	node0.process_active (block2);
@@ -1753,7 +1941,16 @@ TEST (node, DISABLED_fork_stale)
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Mxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	nano::state_block_builder builder;
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Mxrb_ratio)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (0)
+	             .build_shared ();
 	node1.work_generate_blocking (*send3);
 	node1.process_active (send3);
 	system2.deadline_set (10s);
@@ -1762,9 +1959,25 @@ TEST (node, DISABLED_fork_stale)
 		system1.poll ();
 		ASSERT_NO_ERROR (system2.poll ());
 	}
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Mxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send3->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Mxrb_ratio)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (0)
+	             .build_shared ();
 	node1.work_generate_blocking (*send1);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Mxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send3->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Mxrb_ratio)
+	             .link (key2.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (0)
+	             .build_shared ();
 	node1.work_generate_blocking (*send2);
 	{
 		auto transaction1 (node1.store.tx_begin_write ());
@@ -1807,22 +2020,53 @@ TEST (node, broadcast_elected)
 		nano::keypair rep_big;
 		nano::keypair rep_small;
 		nano::keypair rep_other;
+		nano::block_builder builder;
 		{
 			auto transaction0 (node0->store.tx_begin_write ());
 			auto transaction1 (node1->store.tx_begin_write ());
 			auto transaction2 (node2->store.tx_begin_write ());
-			nano::send_block fund_big (node0->ledger.latest (transaction0, nano::test_genesis_key.pub), rep_big.pub, nano::Gxrb_ratio * 5, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-			nano::open_block open_big (fund_big.hash (), rep_big.pub, rep_big.pub, rep_big.prv, rep_big.pub, 0);
-			nano::send_block fund_small (fund_big.hash (), rep_small.pub, nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-			nano::open_block open_small (fund_small.hash (), rep_small.pub, rep_small.pub, rep_small.prv, rep_small.pub, 0);
-			nano::send_block fund_other (fund_small.hash (), rep_other.pub, nano::Gxrb_ratio * 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-			nano::open_block open_other (fund_other.hash (), rep_other.pub, rep_other.pub, rep_other.prv, rep_other.pub, 0);
-			node0->work_generate_blocking (fund_big);
-			node0->work_generate_blocking (open_big);
-			node0->work_generate_blocking (fund_small);
-			node0->work_generate_blocking (open_small);
-			node0->work_generate_blocking (fund_other);
-			node0->work_generate_blocking (open_other);
+			auto fund_big = *builder.send ()
+			                 .previous (nano::genesis_hash)
+			                 .destination (rep_big.pub)
+			                 .balance (nano::Gxrb_ratio * 5)
+			                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+			                 .work (*system.work.generate (nano::genesis_hash))
+			                 .build ();
+			auto open_big = *builder.open ()
+			                 .source (fund_big.hash ())
+			                 .representative (rep_big.pub)
+			                 .account (rep_big.pub)
+			                 .sign (rep_big.prv, rep_big.pub)
+			                 .work (*system.work.generate (rep_big.pub))
+			                 .build ();
+			auto fund_small = *builder.send ()
+			                   .previous (fund_big.hash ())
+			                   .destination (rep_small.pub)
+			                   .balance (nano::Gxrb_ratio * 2)
+			                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+			                   .work (*system.work.generate (fund_big.hash ()))
+			                   .build ();
+			auto open_small = *builder.open ()
+			                   .source (fund_small.hash ())
+			                   .representative (rep_small.pub)
+			                   .account (rep_small.pub)
+			                   .sign (rep_small.prv, rep_small.pub)
+			                   .work (*system.work.generate (rep_small.pub))
+			                   .build ();
+			auto fund_other = *builder.send ()
+			                   .previous (fund_small.hash ())
+			                   .destination (rep_other.pub)
+			                   .balance (nano::Gxrb_ratio)
+			                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+			                   .work (*system.work.generate (fund_small.hash ()))
+			                   .build ();
+			auto open_other = *builder.open ()
+			                   .source (fund_other.hash ())
+			                   .representative (rep_other.pub)
+			                   .account (rep_other.pub)
+			                   .sign (rep_other.prv, rep_other.pub)
+			                   .work (*system.work.generate (rep_other.pub))
+			                   .build ();
 			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_big).code);
 			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_big).code);
 			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_big).code);
@@ -1860,14 +2104,24 @@ TEST (node, broadcast_elected)
 		system.wallet (0)->insert_adhoc (rep_big.prv);
 		system.wallet (1)->insert_adhoc (rep_small.prv);
 		system.wallet (2)->insert_adhoc (rep_other.prv);
-		auto fork0 (std::make_shared<nano::send_block> (node2->latest (nano::test_genesis_key.pub), rep_small.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-		node0->work_generate_blocking (*fork0);
+		auto fork0 = builder.send ()
+		             .previous (node2->latest (nano::test_genesis_key.pub))
+		             .destination (rep_small.pub)
+		             .balance (0)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*node0->work_generate_blocking (node2->latest (nano::test_genesis_key.pub)))
+		             .build_shared ();
 		// A copy is necessary to avoid data races during ledger processing, which sets the sideband
 		auto fork0_copy (std::make_shared<nano::send_block> (*fork0));
 		node0->process_active (fork0);
 		node1->process_active (fork0_copy);
-		auto fork1 (std::make_shared<nano::send_block> (node2->latest (nano::test_genesis_key.pub), rep_big.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-		node0->work_generate_blocking (*fork1);
+		auto fork1 = builder.send ()
+		             .previous (node2->latest (nano::test_genesis_key.pub))
+		             .destination (rep_big.pub)
+		             .balance (0)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*node0->work_generate_blocking (node2->latest (nano::test_genesis_key.pub)))
+		             .build_shared ();
 		system.wallet (2)->insert_adhoc (rep_small.prv);
 		node2->process_active (fork1);
 		system.deadline_set (10s);
@@ -1899,10 +2153,21 @@ TEST (node, rep_self_vote)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (node_config);
 	nano::keypair rep_big;
-	nano::send_block fund_big (node0->ledger.latest (node0->store.tx_begin_read (), nano::test_genesis_key.pub), rep_big.pub, nano::uint128_t ("0xb0000000000000000000000000000000"), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-	nano::open_block open_big (fund_big.hash (), rep_big.pub, rep_big.pub, rep_big.prv, rep_big.pub, 0);
-	node0->work_generate_blocking (fund_big);
-	node0->work_generate_blocking (open_big);
+	nano::block_builder builder;
+	auto fund_big = *builder.send ()
+	                 .previous (nano::genesis_hash)
+	                 .destination (rep_big.pub)
+	                 .balance (nano::uint128_t{ "0xb0000000000000000000000000000000" })
+	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .work (*system.work.generate (nano::genesis_hash))
+	                 .build ();
+	auto open_big = *builder.open ()
+	                 .source (fund_big.hash ())
+	                 .representative (rep_big.pub)
+	                 .account (rep_big.pub)
+	                 .sign (rep_big.prv, rep_big.pub)
+	                 .work (*system.work.generate (rep_big.pub))
+	                 .build ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (fund_big).code);
 	ASSERT_EQ (nano::process_result::progress, node0->process (open_big).code);
 	// Confirm both blocks, allowing voting on the upcoming block
@@ -1917,8 +2182,13 @@ TEST (node, rep_self_vote)
 	system.wallet (0)->insert_adhoc (rep_big.prv);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	ASSERT_EQ (system.wallet (0)->wallets.reps ().voting, 2);
-	auto block0 (std::make_shared<nano::send_block> (node0->latest (nano::test_genesis_key.pub), rep_big.pub, nano::uint128_t ("0x60000000000000000000000000000000"), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node0->work_generate_blocking (*block0);
+	auto block0 = builder.send ()
+	              .previous (fund_big.hash ())
+	              .destination (rep_big.pub)
+	              .balance (nano::uint128_t ("0x60000000000000000000000000000000"))
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (*system.work.generate (fund_big.hash ()))
+	              .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block0).code);
 	auto & active (node0->active);
 	auto election1 = active.insert (block0);
@@ -1976,12 +2246,14 @@ TEST (node, bootstrap_bulk_push)
 	auto node1 (system1.add_node (config1));
 	nano::keypair key0;
 	// node0 knows about send0 but node1 doesn't.
-	nano::send_block send0 (node0->latest (nano::test_genesis_key.pub), key0.pub, 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-	node0->work_generate_blocking (send0);
-	{
-		auto transaction (node0->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, send0).code);
-	}
+	auto send0 = *nano::send_block_builder ()
+	              .previous (nano::genesis_hash)
+	              .destination (key0.pub)
+	              .balance (500)
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (*node0->work_generate_blocking (nano::genesis_hash))
+	              .build ();
+	ASSERT_EQ (nano::process_result::progress, node0->process (send0).code);
 	ASSERT_FALSE (node0->bootstrap_initiator.in_progress ());
 	ASSERT_FALSE (node1->bootstrap_initiator.in_progress ());
 	ASSERT_TRUE (node1->active.empty ());
@@ -2007,12 +2279,28 @@ TEST (node, bootstrap_fork_open)
 	auto node1 = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key0;
-	nano::send_block send0 (node0->latest (nano::test_genesis_key.pub), key0.pub, nano::genesis_amount - 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-	nano::open_block open0 (send0.hash (), 1, key0.pub, key0.prv, key0.pub, 0);
-	nano::open_block open1 (send0.hash (), 2, key0.pub, key0.prv, key0.pub, 0);
-	node0->work_generate_blocking (send0);
-	node0->work_generate_blocking (open0);
-	node0->work_generate_blocking (open1);
+	nano::block_builder builder;
+	auto send0 = *builder.send ()
+	              .previous (nano::genesis_hash)
+	              .destination (key0.pub)
+	              .balance (nano::genesis_amount - 500)
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (*system.work.generate (nano::genesis_hash))
+	              .build ();
+	auto open0 = *builder.open ()
+	              .source (send0.hash ())
+	              .representative (1)
+	              .account (key0.pub)
+	              .sign (key0.prv, key0.pub)
+	              .work (*system.work.generate (key0.pub))
+	              .build ();
+	auto open1 = *builder.open ()
+	              .source (send0.hash ())
+	              .representative (2)
+	              .account (key0.pub)
+	              .sign (key0.prv, key0.pub)
+	              .work (*system.work.generate (key0.pub))
+	              .build ();
 	// Both know about send0
 	ASSERT_EQ (nano::process_result::progress, node0->process (send0).code);
 	ASSERT_EQ (nano::process_result::progress, node1->process (send0).code);
@@ -2049,12 +2337,14 @@ TEST (node, bootstrap_confirm_frontiers)
 	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::keypair key0;
 	// node0 knows about send0 but node1 doesn't.
-	nano::send_block send0 (node0->latest (nano::test_genesis_key.pub), key0.pub, nano::genesis_amount - 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
-	node0->work_generate_blocking (send0);
-	{
-		auto transaction (node0->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, send0).code);
-	}
+	auto send0 = *nano::send_block_builder ()
+	              .previous (nano::genesis_hash)
+	              .destination (key0.pub)
+	              .balance (nano::genesis_amount - 500)
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (*node0->work_generate_blocking (nano::genesis_hash))
+	              .build ();
+	ASSERT_EQ (nano::process_result::progress, node0->process (send0).code);
 	ASSERT_FALSE (node0->bootstrap_initiator.in_progress ());
 	ASSERT_FALSE (node1->bootstrap_initiator.in_progress ());
 	ASSERT_TRUE (node1->active.empty ());
@@ -2573,9 +2863,20 @@ TEST (node, block_confirm)
 		nano::genesis genesis;
 		nano::keypair key;
 		system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
-		auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (genesis.hash ())));
+		nano::state_block_builder builder;
+		auto send1 = builder.make_block ()
+		             .account (nano::test_genesis_key.pub)
+		             .previous (genesis.hash ())
+		             .representative (nano::test_genesis_key.pub)
+		             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+		             .link (key.pub)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*node1.work_generate_blocking (genesis.hash ()))
+		             .build_shared ();
 		// A copy is necessary to avoid data races during ledger processing, which sets the sideband
-		auto send1_copy (std::make_shared<nano::state_block> (*send1));
+		auto send1_copy = builder.make_block ()
+		                  .from (*send1)
+		                  .build_shared ();
 		node1.block_processor.add (send1, nano::seconds_since_epoch ());
 		node2.block_processor.add (send1_copy, nano::seconds_since_epoch ());
 		system.deadline_set (std::chrono::seconds (5));
@@ -2659,11 +2960,16 @@ TEST (node, confirm_quorum)
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	// Put greater than online_weight_minimum in pending so quorum can't be reached
 	nano::amount new_balance (node1.config.online_weight_minimum.number () - nano::Gxrb_ratio);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, new_balance, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (genesis.hash ())));
-	{
-		auto transaction (node1.store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
-	}
+	auto send1 = nano::state_block_builder ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (new_balance)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, new_balance.number ());
 	system.deadline_set (10s);
 	while (node1.active.empty ())
@@ -2686,9 +2992,34 @@ TEST (node, local_votes_cache)
 	node_config.receive_minimum = nano::genesis_amount;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (send1->hash ())));
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (send2->hash ())));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (send1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (send2->hash ()))
+	             .build_shared ();
 	{
 		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send1).code);
@@ -2768,7 +3099,15 @@ TEST (node, local_votes_cache_batch)
 	ASSERT_GE (node.network_params.voting.max_cache, 2);
 	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	auto send1 = nano::state_block_builder ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
 	std::vector<std::shared_ptr<nano::block>> blocks{ genesis.open, send1 };
 	std::vector<std::pair<nano::block_hash, nano::root>> batch{ { genesis.open->hash (), genesis.open->root () }, { send1->hash (), send1->root () } };
 	{
@@ -2850,7 +3189,15 @@ TEST (node, local_votes_cache_generate_new_vote)
 		ASSERT_EQ (current_vote->sequence, 1);
 		ASSERT_EQ (current_vote, votes1[0]);
 	}
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	auto send1 = nano::state_block_builder ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	// One of the hashes is cached
 	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes{ std::make_pair (genesis.open->hash (), genesis.open->root ()), std::make_pair (send1->hash (), send1->root ()) };
@@ -2911,8 +3258,21 @@ TEST (node, vote_republish)
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	node1.process_active (send1);
 	system.deadline_set (5s);
 	while (!node2.block (send1->hash ()))
@@ -2996,8 +3356,21 @@ TEST (node, vote_by_hash_republish)
 		nano::keypair key2;
 		system.wallet (1)->insert_adhoc (key2.prv);
 		nano::genesis genesis;
-		auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-		auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+		nano::send_block_builder builder;
+		auto send1 = builder.make_block ()
+		             .previous (genesis.hash ())
+		             .destination (key2.pub)
+		             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*system.work.generate (genesis.hash ()))
+		             .build_shared ();
+		auto send2 = builder.make_block ()
+		             .previous (genesis.hash ())
+		             .destination (key2.pub)
+		             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2)
+		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .work (*system.work.generate (genesis.hash ()))
+		             .build_shared ();
 		node1.process_active (send1);
 		system.deadline_set (5s);
 		while (!node2.block (send1->hash ()))
@@ -3041,8 +3414,22 @@ TEST (node, vote_by_hash_epoch_block_republish)
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto epoch1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 = nano::send_block_builder ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto epoch1 = nano::state_block_builder ()
+	              .account (nano::genesis_account)
+	              .previous (genesis.hash ())
+	              .representative (nano::genesis_account)
+	              .balance (nano::genesis_amount)
+	              .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
+	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .work (*system.work.generate (genesis.hash ()))
+	              .build_shared ();
 	node1.process_active (send1);
 	system.deadline_set (5s);
 	while (!node2.block (send1->hash ()))
@@ -3079,11 +3466,52 @@ TEST (node, epoch_conflict_confirm)
 	nano::keypair key;
 	nano::genesis genesis;
 	nano::keypair epoch_signer (nano::test_genesis_key);
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 1, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, 1, send->hash (), key.prv, key.pub, *system.work.generate (key.pub)));
-	auto change (std::make_shared<nano::state_block> (key.pub, open->hash (), key.pub, 1, 0, key.prv, key.pub, *system.work.generate (open->hash ())));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2, open->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send->hash ())));
-	auto epoch_open (std::make_shared<nano::state_block> (change->root (), 0, 0, 0, node0->ledger.epoch_link (nano::epoch::epoch_1), epoch_signer.prv, epoch_signer.pub, *system.work.generate (open->hash ())));
+	nano::state_block_builder builder;
+	auto send = builder.make_block ()
+	            .account (nano::test_genesis_key.pub)
+	            .previous (genesis.hash ())
+	            .representative (nano::test_genesis_key.pub)
+	            .balance (nano::genesis_amount - 1)
+	            .link (key.pub)
+	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .work (*system.work.generate (genesis.hash ()))
+	            .build_shared ();
+	auto open = builder.make_block ()
+	            .account (key.pub)
+	            .previous (0)
+	            .representative (key.pub)
+	            .balance (1)
+	            .link (send->hash ())
+	            .sign (key.prv, key.pub)
+	            .work (*system.work.generate (key.pub))
+	            .build_shared ();
+	auto change = builder.make_block ()
+	              .account (key.pub)
+	              .previous (open->hash ())
+	              .representative (key.pub)
+	              .balance (1)
+	              .link (0)
+	              .sign (key.prv, key.pub)
+	              .work (*system.work.generate (open->hash ()))
+	              .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2)
+	             .link (open->hash ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send->hash ()))
+	             .build_shared ();
+	auto epoch_open = builder.make_block ()
+	                  .account (change->root ())
+	                  .previous (0)
+	                  .representative (0)
+	                  .balance (0)
+	                  .link (node0->ledger.epoch_link (nano::epoch::epoch_1))
+	                  .sign (epoch_signer.prv, epoch_signer.pub)
+	                  .work (*system.work.generate (open->hash ()))
+	                  .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
@@ -3144,8 +3572,21 @@ TEST (node, fork_invalid_block_signature)
 	auto & node2 (*system.add_node (node_flags));
 	nano::keypair key2;
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .previous (genesis.hash ())
+	             .destination (key2.pub)
+	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	auto send2_corrupt (std::make_shared<nano::send_block> (*send2));
 	send2_corrupt->signature = nano::signature (123);
 	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, send2));
@@ -3180,33 +3621,33 @@ TEST (node, fork_election_invalid_block_signature)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::block_builder builder;
-	std::shared_ptr<nano::block> send1 = builder.state ()
-	                                     .account (nano::test_genesis_key.pub)
-	                                     .previous (genesis.hash ())
-	                                     .representative (nano::test_genesis_key.pub)
-	                                     .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	                                     .link (nano::test_genesis_key.pub)
-	                                     .work (*system.work.generate (genesis.hash ()))
-	                                     .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                     .build ();
-	std::shared_ptr<nano::block> send2 = builder.state ()
-	                                     .account (nano::test_genesis_key.pub)
-	                                     .previous (genesis.hash ())
-	                                     .representative (nano::test_genesis_key.pub)
-	                                     .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	                                     .link (nano::test_genesis_key.pub)
-	                                     .work (*system.work.generate (genesis.hash ()))
-	                                     .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                     .build ();
-	std::shared_ptr<nano::block> send3 = builder.state ()
-	                                     .account (nano::test_genesis_key.pub)
-	                                     .previous (genesis.hash ())
-	                                     .representative (nano::test_genesis_key.pub)
-	                                     .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	                                     .link (nano::test_genesis_key.pub)
-	                                     .work (*system.work.generate (genesis.hash ()))
-	                                     .sign (nano::test_genesis_key.prv, 0) // Invalid signature
-	                                     .build ();
+	auto send1 = builder.state ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .build_shared ();
+	auto send2 = builder.state ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .build_shared ();
+	auto send3 = builder.state ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .sign (nano::test_genesis_key.prv, 0) // Invalid signature
+	             .build_shared ();
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.network.process_message (nano::publish (send1), channel1);
 	system.deadline_set (5s);
@@ -3242,22 +3683,58 @@ TEST (node, block_processor_signatures)
 	auto & node1 (*system0.nodes[0]);
 	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
 	nano::block_hash latest (system0.nodes[0]->latest (nano::test_genesis_key.pub));
+	nano::state_block_builder builder;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, latest, nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node1.work_generate_blocking (*send1);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node1.work_generate_blocking (*send2);
 	nano::keypair key3;
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node1.work_generate_blocking (*send3);
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (latest)
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (key1.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1.work_generate_blocking (latest))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (key2.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1.work_generate_blocking (send1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
+	             .link (key3.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1.work_generate_blocking (send2->hash ()))
+	             .build_shared ();
 	// Invalid signature bit
-	auto send4 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 4 * nano::Gxrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node1.work_generate_blocking (*send4);
+	auto send4 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send3->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 4 * nano::Gxrb_ratio)
+	             .link (key3.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1.work_generate_blocking (send3->hash ()))
+	             .build_shared ();
 	send4->signature.bytes[32] ^= 0x1;
 	// Invalid signature bit (force)
-	auto send5 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 5 * nano::Gxrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node1.work_generate_blocking (*send5);
+	auto send5 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send3->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 5 * nano::Gxrb_ratio)
+	             .link (key3.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1.work_generate_blocking (send3->hash ()))
+	             .build_shared ();
 	send5->signature.bytes[31] ^= 0x1;
 	// Invalid signature to unchecked
 	{
@@ -3265,13 +3742,34 @@ TEST (node, block_processor_signatures)
 		node1.store.unchecked_put (transaction, send5->previous (), send5);
 		++node1.ledger.cache.unchecked_count;
 	}
-	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, 0));
-	node1.work_generate_blocking (*receive1);
-	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, 0));
-	node1.work_generate_blocking (*receive2);
+	auto receive1 = builder.make_block ()
+	                .account (key1.pub)
+	                .previous (0)
+	                .representative (nano::test_genesis_key.pub)
+	                .balance (nano::Gxrb_ratio)
+	                .link (send1->hash ())
+	                .sign (key1.prv, key1.pub)
+	                .work (*node1.work_generate_blocking (key1.pub))
+	                .build_shared ();
+	auto receive2 = builder.make_block ()
+	                .account (key2.pub)
+	                .previous (0)
+	                .representative (nano::test_genesis_key.pub)
+	                .balance (nano::Gxrb_ratio)
+	                .link (send2->hash ())
+	                .sign (key2.prv, key2.pub)
+	                .work (*node1.work_generate_blocking (key2.pub))
+	                .build_shared ();
 	// Invalid private key
-	auto receive3 (std::make_shared<nano::state_block> (key3.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send3->hash (), key2.prv, key3.pub, 0));
-	node1.work_generate_blocking (*receive3);
+	auto receive3 = builder.make_block ()
+	                .account (key3.pub)
+	                .previous (0)
+	                .representative (nano::test_genesis_key.pub)
+	                .balance (nano::Gxrb_ratio)
+	                .link (send3->hash ())
+	                .sign (key2.prv, key3.pub)
+	                .work (*node1.work_generate_blocking (key3.pub))
+	                .build_shared ();
 	node1.process_active (send1);
 	node1.process_active (send2);
 	node1.process_active (send3);
@@ -3302,16 +3800,31 @@ TEST (node, block_processor_reject_state)
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send1);
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
 	send1->signature.bytes[0] ^= 1;
 	ASSERT_FALSE (node.ledger.block_exists (send1->hash ()));
 	node.process_active (send1);
 	auto flushed = std::async (std::launch::async, [&node] { node.block_processor.flush (); });
 	ASSERT_NE (std::future_status::timeout, flushed.wait_for (5s));
 	ASSERT_FALSE (node.ledger.block_exists (send1->hash ()));
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send2);
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
 	node.process_active (send2);
 	auto flushed2 = std::async (std::launch::async, [&node] { node.block_processor.flush (); });
 	ASSERT_NE (std::future_status::timeout, flushed2.wait_for (5s));
@@ -3325,12 +3838,34 @@ TEST (node, block_processor_full)
 	node_flags.block_processor_full_size = 3;
 	auto & node = *system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send1);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send2);
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send3);
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (send1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (send2->hash ()))
+	             .build_shared ();
 	// The write guard prevents block processor doing any writes
 	auto write_guard = node.write_database_queue.wait (nano::writer::testing);
 	node.block_processor.add (send1);
@@ -3353,12 +3888,34 @@ TEST (node, block_processor_half_full)
 	node_flags.block_processor_full_size = 6;
 	auto & node = *system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send1);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send2);
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node.work_generate_blocking (*send3);
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (send1->hash ()))
+	             .build_shared ();
+	auto send3 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send2->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node.work_generate_blocking (send2->hash ()))
+	             .build_shared ();
 	// The write guard prevents block processor doing any writes
 	auto write_guard = node.write_database_queue.wait (nano::writer::testing);
 	node.block_processor.add (send1);
@@ -3382,9 +3939,32 @@ TEST (node, confirm_back)
 	auto & node (*system.nodes[0]);
 	nano::genesis genesis;
 	auto genesis_start_balance (node.balance (nano::test_genesis_key.pub));
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key.pub, genesis_start_balance - 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, 1, send1->hash (), key.prv, key.pub, *system.work.generate (key.pub)));
-	auto send2 (std::make_shared<nano::state_block> (key.pub, open->hash (), key.pub, 0, nano::test_genesis_key.pub, key.prv, key.pub, *system.work.generate (open->hash ())));
+	auto send1 = nano::send_block_builder ()
+	             .previous (genesis.hash ())
+	             .destination (key.pub)
+	             .balance (genesis_start_balance - 1)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	nano::state_block_builder builder;
+	auto open = builder.make_block ()
+	            .account (key.pub)
+	            .previous (0)
+	            .representative (key.pub)
+	            .balance (1)
+	            .link (send1->hash ())
+	            .sign (key.prv, key.pub)
+	            .work (*system.work.generate (key.pub))
+	            .build_shared ();
+	auto send2 = builder.make_block ()
+	             .account (key.pub)
+	             .previous (open->hash ())
+	             .representative (key.pub)
+	             .balance (0)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (key.prv, key.pub)
+	             .work (*system.work.generate (open->hash ()))
+	             .build_shared ();
 	node.process_active (send1);
 	node.process_active (open);
 	node.process_active (send2);
@@ -3525,7 +4105,15 @@ TEST (node, unchecked_cleanup)
 	nano::system system (1);
 	nano::keypair key;
 	auto & node (*system.nodes[0]);
-	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, 1, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
+	auto open = nano::state_block_builder ()
+	            .account (key.pub)
+	            .previous (0)
+	            .representative (key.pub)
+	            .balance (1)
+	            .link (key.pub)
+	            .sign (key.prv, key.pub)
+	            .work (*system.work.generate (key.pub))
+	            .build_shared ();
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -3622,7 +4210,16 @@ TEST (node, bidirectional_tcp)
 	// Test block propagation from node 1
 	nano::genesis genesis;
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1->work_generate_blocking (genesis.hash ())));
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (genesis.hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1->work_generate_blocking (genesis.hash ()))
+	             .build_shared ();
 	node1->process_active (send1);
 	node1->block_processor.flush ();
 	system.deadline_set (5s);
@@ -3656,7 +4253,15 @@ TEST (node, bidirectional_tcp)
 	}
 	/* Test block propagation from node 2
 	Node 2 has only ephemeral TCP port open. Node 1 cannot establish connection to node 2 listening port */
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1->work_generate_blocking (send1->hash ())));
+	auto send2 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (send1->hash ())
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
+	             .link (key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*node1->work_generate_blocking (send1->hash ()))
+	             .build_shared ();
 	node2->process_active (send2);
 	node2->block_processor.flush ();
 	system.deadline_set (5s);
@@ -3742,11 +4347,11 @@ TEST (node, aggressive_flooding)
 	ASSERT_TIMELY (!sanitizer_or_valgrind ? 10s : 40s, node1.rep_crawler.principal_representatives ().size () == nodes_wallets.size ());
 
 	// Generate blocks and ensure they are sent to all representatives
-	nano::block_builder builder;
+	nano::state_block_builder builder;
 	std::shared_ptr<nano::state_block> block{};
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		block = builder.state ()
+		block = builder.make_block ()
 		        .account (nano::test_genesis_key.pub)
 		        .representative (nano::test_genesis_key.pub)
 		        .previous (node1.ledger.latest (transaction, nano::test_genesis_key.pub))
@@ -3801,8 +4406,13 @@ TEST (active_difficulty, recalculate_work)
 	nano::genesis genesis;
 	nano::keypair key1;
 	ASSERT_EQ (node1.network_params.network.publish_thresholds.epoch_1, node1.active.active_difficulty ());
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	node1.work_generate_blocking (*send1);
+	auto send1 = nano::send_block_builder ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (0)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
 	auto multiplier1 = nano::difficulty::to_multiplier (send1->difficulty (), node1.network_params.network.publish_thresholds.epoch_1);
 	// Process as local block
 	node1.process_active (send1);

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -307,22 +307,22 @@ TEST (request_aggregator, cannot_vote)
 	auto & node (*system.add_node (flags));
 	nano::genesis genesis;
 	nano::state_block_builder builder;
-	std::shared_ptr<nano::state_block> send1 = builder.make_block ()
-	                                           .account (nano::test_genesis_key.pub)
-	                                           .previous (nano::genesis_hash)
-	                                           .representative (nano::test_genesis_key.pub)
-	                                           .balance (nano::genesis_amount - 1)
-	                                           .link (nano::test_genesis_key.pub)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*system.work.generate (nano::genesis_hash))
-	                                           .build ();
-	std::shared_ptr<nano::state_block> send2 = builder.make_block ()
-	                                           .from (*send1)
-	                                           .previous (send1->hash ())
-	                                           .balance (send1->balance ().number () - 1)
-	                                           .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-	                                           .work (*system.work.generate (send1->hash ()))
-	                                           .build ();
+	auto send1 = builder.make_block ()
+	             .account (nano::test_genesis_key.pub)
+	             .previous (nano::genesis_hash)
+	             .representative (nano::test_genesis_key.pub)
+	             .balance (nano::genesis_amount - 1)
+	             .link (nano::test_genesis_key.pub)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (nano::genesis_hash))
+	             .build_shared ();
+	auto send2 = builder.make_block ()
+	             .from (*send1)
+	             .previous (send1->hash ())
+	             .balance (send1->balance ().number () - 1)
+	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .work (*system.work.generate (send1->hash ()))
+	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
 	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);

--- a/nano/lib/blockbuilders.cpp
+++ b/nano/lib/blockbuilders.cpp
@@ -674,6 +674,18 @@ std::unique_ptr<BLOCKTYPE> nano::abstract_builder<BLOCKTYPE, BUILDER>::build (st
 }
 
 template <typename BLOCKTYPE, typename BUILDER>
+std::shared_ptr<BLOCKTYPE> nano::abstract_builder<BLOCKTYPE, BUILDER>::build_shared ()
+{
+	return std::move (build ());
+}
+
+template <typename BLOCKTYPE, typename BUILDER>
+std::shared_ptr<BLOCKTYPE> nano::abstract_builder<BLOCKTYPE, BUILDER>::build_shared (std::error_code & ec)
+{
+	return std::move (build (ec));
+}
+
+template <typename BLOCKTYPE, typename BUILDER>
 nano::abstract_builder<BLOCKTYPE, BUILDER> & nano::abstract_builder<BLOCKTYPE, BUILDER>::work (uint64_t work)
 {
 	block->work = work;

--- a/nano/lib/blockbuilders.hpp
+++ b/nano/lib/blockbuilders.hpp
@@ -48,6 +48,10 @@ public:
 	std::unique_ptr<BLOCKTYPE> build ();
 	/** Returns the built block as a unique_ptr. Any errors are placed in \p ec */
 	std::unique_ptr<BLOCKTYPE> build (std::error_code & ec);
+	/** Returns the built block as a shared_ptr */
+	std::shared_ptr<BLOCKTYPE> build_shared ();
+	/** Returns the built block as a shared_ptr. Any errors are placed in \p ec */
+	std::shared_ptr<BLOCKTYPE> build_shared (std::error_code & ec);
 	/** Set work value */
 	abstract_builder & work (uint64_t work);
 	/** Sign the block using the \p private_key and \p public_key */


### PR DESCRIPTION
- Adds `build_shared()` to the abstract builder, so that the caller doesn't have to specify `std::shared_ptr<nano::state_block> ...`,   using `auto` instead. Keeps tests formatting clean.
- Use block builders in all `active_transactions` and `node` tests from `core_test`

Used the following script used to convert (95% of cases work without modifications): https://gist.github.com/guilhermelawless/6424ea9199db7584e314381cbce5dc65
