### PR TITLE
Process old does not need to queue unchecked

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -401,7 +401,6 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			{
 				node.logger.try_log (boost::str (boost::format ("Old for: %1%") % hash.to_string ()));
 			}
-			queue_unchecked (transaction_a, hash);
 			process_old (transaction_a, info_a.block, origin_a);
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::old);
 			break;


### PR DESCRIPTION
Since we drop the unchecked table and download blocks again after a node restart, this isn't necessary. It's creating a local loop when not dropping unchecked blocks (flag [`--disable_unchecked_drop`](https://docs.nano.org/commands/command-line-interface/#-disable_unchecked_drop) which is used by [`--fast_bootstrap`](https://docs.nano.org/commands/command-line-interface/#-fast_bootstrap)

Removing this saves a disk read for unchecked blocks and all tests are passing without further changes.

Thanks @Srayman for finding this one!