### PR TITLE
Checks before overwriting unchecked

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3290,23 +3290,23 @@ TEST (ledger, unchecked_upsert)
 	ASSERT_EQ (1, ledger.cache.unchecked_count);
 	// Higher work updates the table
 	block->block_work_set (*pool.generate (block->root ()));
-	ledger.unchecked_upsert (transaction, unchecked_key, info);
+	ASSERT_FALSE (ledger.unchecked_upsert (transaction, unchecked_key, info));
 	ASSERT_EQ (1, ledger.cache.unchecked_count);
 	ASSERT_TRUE (store->unchecked_exists (transaction, unchecked_key));
 	ASSERT_EQ (store->unchecked_get (transaction, unchecked_key)->block->block_work (), block->block_work ());
 	// Same work but valid signature (with existing invalid) updates
 	info.verified = nano::signature_verification::valid;
 	ASSERT_EQ (store->unchecked_get (transaction, unchecked_key)->verified, nano::signature_verification::unknown);
-	ledger.unchecked_upsert (transaction, unchecked_key, info);
+	ASSERT_FALSE (ledger.unchecked_upsert (transaction, unchecked_key, info));
 	ASSERT_EQ (store->unchecked_get (transaction, unchecked_key)->verified, nano::signature_verification::valid);
 	// Higher work but invalidating signature does not update
 	block->block_work_set (*pool.generate (block->root (), block->difficulty ()));
 	info.verified = nano::signature_verification::unknown;
-	ledger.unchecked_upsert (transaction, unchecked_key, info);
+	ASSERT_TRUE (ledger.unchecked_upsert (transaction, unchecked_key, info));
 	ASSERT_NE (store->unchecked_get (transaction, unchecked_key)->block->block_work (), block->block_work ());
-	// Lower work does not update the table
+	// Lower work does not update
 	block->block_work_set (0);
-	ledger.unchecked_upsert (transaction, unchecked_key, info);
+	ASSERT_TRUE (ledger.unchecked_upsert (transaction, unchecked_key, info));
 	ASSERT_TRUE (store->unchecked_exists (transaction, unchecked_key));
 	ASSERT_NE (store->unchecked_get (transaction, unchecked_key)->block->block_work (), block->block_work ());
 	ASSERT_EQ (1, ledger.cache.unchecked_count);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3286,7 +3286,7 @@ TEST (ledger, unchecked_upsert)
 	auto transaction (store->tx_begin_write ());
 	ASSERT_EQ (0, ledger.cache.unchecked_count);
 	// Inserting a new entry
-	ledger.unchecked_upsert (transaction, unchecked_key, info);
+	ASSERT_FALSE (ledger.unchecked_upsert (transaction, unchecked_key, info));
 	ASSERT_EQ (1, ledger.cache.unchecked_count);
 	// Higher work updates the table
 	block->block_work_set (*pool.generate (block->root ()));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4470,7 +4470,7 @@ TEST (node, gap_unchecked_replace)
 		auto const default_work = open->block_work ();
 		node.process_active (open);
 		node.block_processor.flush ();
-		nano::unchecked_key unchecked_key{ open->previous ().is_zero () ? open->link () : open->previous (), open->hash () };
+		nano::unchecked_key unchecked_key{ open->previous ().is_zero () ? static_cast<nano::block_hash> (open->link ()) : open->previous (), open->hash () };
 		ASSERT_TRUE (node.store.unchecked_exists (node.store.tx_begin_read (), unchecked_key));
 
 		ASSERT_LT (node.network_params.network.publish_thresholds.entry, node.default_difficulty (open->work_version ()));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4448,7 +4448,7 @@ TEST (node, deferred_dependent_elections)
 }
 }
 
-/** Ensure that blocks processed as gap_source and gap_previous only overwrite the existing entry if the work difficulty is higher */
+/** Ensure that blocks processed as gap_source and gap_previous only overwrite the existing entry if the work difficulty is higher. Other checks are done in test ledger.unchecked_upsert */
 TEST (node, gap_unchecked_replace)
 {
 	nano::system system (1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4448,11 +4448,13 @@ TEST (node, deferred_dependent_elections)
 }
 }
 
-TEST (node, unchecked_compare_work)
+/** Ensure that blocks processed as gap_source and gap_previous only overwrite the existing entry if the work difficulty is higher */
+TEST (node, gap_unchecked_replace)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::state_block_builder builder;
+	// With previous_a zero it's a gap_source, otherwise it's a gap_previous
 	auto test_unchecked = [&](nano::block_hash const & previous_a) {
 		nano::keypair key;
 		std::shared_ptr<nano::state_block> open = builder.make_block ()

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -360,7 +360,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (info_a.block->previous (), hash);
-			put_or_replace_unchecked (transaction_a, unchecked_key, info_a);
+			node.ledger.unchecked_upsert (transaction_a, unchecked_key, info_a);
 
 			node.gap_cache.add (hash);
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_previous);
@@ -379,7 +379,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (node.ledger.block_source (transaction_a, *(info_a.block)), hash);
-			put_or_replace_unchecked (transaction_a, unchecked_key, info_a);
+			node.ledger.unchecked_upsert (transaction_a, unchecked_key, info_a);
 
 			node.gap_cache.add (hash);
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
@@ -470,20 +470,6 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 		}
 	}
 	return result;
-}
-
-void nano::block_processor::put_or_replace_unchecked (const nano::write_transaction & transaction_a, nano::unchecked_key & unchecked_key, nano::unchecked_info & info_a)
-{
-	auto existing (node.store.unchecked_get (transaction_a, unchecked_key));
-	// Only overwrite if the new block's difficulty is higher
-	if (!existing || info_a.block->difficulty () > existing->block->difficulty ())
-	{
-		node.store.unchecked_put (transaction_a, unchecked_key, info_a);
-	}
-	if (!existing)
-	{
-		++node.ledger.cache.unchecked_count;
-	}
 }
 
 nano::process_return nano::block_processor::process_one (nano::write_transaction const & transaction_a, block_post_events & events_a, std::shared_ptr<nano::block> block_a, const bool watch_work_a)

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -56,6 +56,7 @@ public:
 	bool have_blocks ();
 	void process_blocks ();
 	nano::process_return process_one (nano::write_transaction const &, block_post_events &, nano::unchecked_info, const bool = false, nano::block_origin const = nano::block_origin::remote);
+	void put_or_replace_unchecked (const nano::write_transaction & transaction_a, nano::unchecked_key & unchecked_key, nano::unchecked_info & info_a);
 	nano::process_return process_one (nano::write_transaction const &, block_post_events &, std::shared_ptr<nano::block>, const bool = false);
 	std::atomic<bool> flushing{ false };
 	// Delay required for average network propagartion before requesting confirmation

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -56,7 +56,6 @@ public:
 	bool have_blocks ();
 	void process_blocks ();
 	nano::process_return process_one (nano::write_transaction const &, block_post_events &, nano::unchecked_info, const bool = false, nano::block_origin const = nano::block_origin::remote);
-	void put_or_replace_unchecked (const nano::write_transaction & transaction_a, nano::unchecked_key & unchecked_key, nano::unchecked_info & info_a);
 	nano::process_return process_one (nano::write_transaction const &, block_post_events &, std::shared_ptr<nano::block>, const bool = false);
 	std::atomic<bool> flushing{ false };
 	// Delay required for average network propagartion before requesting confirmation

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -162,7 +162,7 @@ nano::account nano::system::account (nano::transaction const & transaction_a, si
 	return nano::account (result);
 }
 
-uint64_t nano::system::work_generate_limited (nano::block_hash const & root_a, uint64_t min_a, uint64_t max_a)
+uint64_t nano::system::work_generate_limited (nano::root const & root_a, uint64_t min_a, uint64_t max_a)
 {
 	debug_assert (min_a > 0);
 	uint64_t result = 0;

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -35,7 +35,7 @@ public:
 	std::shared_ptr<nano::wallet> wallet (size_t);
 	nano::account account (nano::transaction const &, size_t);
 	/** Generate work with difficulty between \p min_difficulty_a (inclusive) and \p max_difficulty_a (exclusive) */
-	uint64_t work_generate_limited (nano::block_hash const & root_a, uint64_t min_difficulty_a, uint64_t max_difficulty_a);
+	uint64_t work_generate_limited (nano::root const & root_a, uint64_t min_difficulty_a, uint64_t max_difficulty_a);
 	/**
 	 * Polls, sleep if there's no work to be done (default 50ms), then check the deadline
 	 * @returns 0 or nano::deadline_expired

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -11,6 +11,7 @@
 #include <nano/secure/versioning.hpp>
 
 #include <boost/endian/conversion.hpp>
+#include <boost/optional.hpp>
 #include <boost/polymorphic_cast.hpp>
 
 #include <stack>
@@ -711,6 +712,7 @@ public:
 	virtual void unchecked_clear (nano::write_transaction const &) = 0;
 	virtual void unchecked_put (nano::write_transaction const &, nano::unchecked_key const &, nano::unchecked_info const &) = 0;
 	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
+	virtual boost::optional<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::unchecked_key const &) = 0;
 	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
 	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -92,6 +92,13 @@ public:
 		return (success (status));
 	}
 
+	boost::optional<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override
+	{
+		db_val<Val> value;
+		auto status (get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
+		return success (status) ? static_cast<boost::optional<nano::unchecked_info>> (nano::unchecked_info (value)) : boost::none;
+	}
+
 	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
 		std::vector<nano::unchecked_info> result;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1168,7 +1168,7 @@ void nano::ledger::change_latest (nano::write_transaction const & transaction_a,
 	}
 }
 
-void nano::ledger::unchecked_upsert (const nano::write_transaction & transaction_a, nano::unchecked_key & key_a, nano::unchecked_info & info_a)
+void nano::ledger::unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a)
 {
 	auto existing (store.unchecked_get (transaction_a, key_a));
 	if (existing.is_initialized ())

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1168,8 +1168,9 @@ void nano::ledger::change_latest (nano::write_transaction const & transaction_a,
 	}
 }
 
-void nano::ledger::unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a)
+bool nano::ledger::unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a)
 {
+	bool result{ true };
 	auto existing (store.unchecked_get (transaction_a, key_a));
 	if (existing.is_initialized ())
 	{
@@ -1179,14 +1180,17 @@ void nano::ledger::unchecked_upsert (nano::write_transaction const & transaction
 		bool const validating = info_a.verified != nano::signature_verification::unknown && existing->verified == nano::signature_verification::unknown;
 		if ((new_difficulty >= existing_difficulty && !invalidating) || (new_difficulty == existing_difficulty && validating))
 		{
+			result = false;
 			store.unchecked_put (transaction_a, key_a, info_a);
 		}
 	}
 	else
 	{
+		result = false;
 		store.unchecked_put (transaction_a, key_a, info_a);
 		++cache.unchecked_count;
 	}
+	return result;
 }
 
 std::shared_ptr<nano::block> nano::ledger::successor (nano::transaction const & transaction_a, nano::qualified_root const & root_a)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1168,6 +1168,20 @@ void nano::ledger::change_latest (nano::write_transaction const & transaction_a,
 	}
 }
 
+void nano::ledger::unchecked_upsert (const nano::write_transaction & transaction_a, nano::unchecked_key & key_a, nano::unchecked_info & info_a)
+{
+	auto existing (store.unchecked_get (transaction_a, key_a));
+	// Only overwrite if the new block's difficulty is higher
+	if (!existing || info_a.block->difficulty () > existing->block->difficulty ())
+	{
+		store.unchecked_put (transaction_a, key_a, info_a);
+	}
+	if (!existing)
+	{
+		++cache.unchecked_count;
+	}
+}
+
 std::shared_ptr<nano::block> nano::ledger::successor (nano::transaction const & transaction_a, nano::qualified_root const & root_a)
 {
 	nano::block_hash successor (0);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -43,7 +43,7 @@ public:
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
 	void change_latest (nano::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
-	void unchecked_upsert (const nano::write_transaction &, nano::unchecked_key &, nano::unchecked_info &);
+	void unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a);
 	void dump_account_chain (nano::account const &, std::ostream & = std::cout);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool can_vote (nano::transaction const &, nano::block const &);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -43,7 +43,7 @@ public:
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
 	void change_latest (nano::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
-	void unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a);
+	bool unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a);
 	void dump_account_chain (nano::account const &, std::ostream & = std::cout);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool can_vote (nano::transaction const &, nano::block const &);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -43,6 +43,7 @@ public:
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
 	void change_latest (nano::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
+	void unchecked_upsert (const nano::write_transaction &, nano::unchecked_key &, nano::unchecked_info &);
 	void dump_account_chain (nano::account const &, std::ostream & = std::cout);
 	bool could_fit (nano::transaction const &, nano::block const &);
 	bool can_vote (nano::transaction const &, nano::block const &);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -43,6 +43,10 @@ public:
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
 	void change_latest (nano::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
+	/**
+	 * Insert or conditionally update an unchecked entry, based on signature and work difficulty of existing and \p info_a.
+	 * @return false if inserted or updated existing entry.
+	 */
 	bool unchecked_upsert (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a);
 	void dump_account_chain (nano::account const &, std::ostream & = std::cout);
 	bool could_fit (nano::transaction const &, nano::block const &);


### PR DESCRIPTION
**EDIT:** See comment below

As blocks can now enter the node although their work only passes the minimal validation, and not the full ledger work validation, this check prevents replacing unchecked with the same block with insufficient work.

Other checks (thanks @SergiySW) are made related to signatures.