### PR TITLE
correct rpath for libs in tar.bz2 archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 if (APPLE)
 	set (CMAKE_INSTALL_RPATH "@executable_path/../Frameworks;@executable_path/../boost/lib")
 else()
-	set (CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+	set (CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
 # Create all libraries and executables in the root binary dir


### PR DESCRIPTION
fixes
```
./nano_node: error while loading shared libraries: libboost_log.so.1.70.0: cannot open shared object file: No such file or directory
```