### PR TITLE
Pre-sample block rate for bootstrap connections

### DIFF
--- a/nano/node/bootstrap/bootstrap_connections.hpp
+++ b/nano/node/bootstrap/bootstrap_connections.hpp
@@ -24,7 +24,7 @@ public:
 	~bootstrap_client ();
 	std::shared_ptr<nano::bootstrap_client> shared ();
 	void stop (bool force);
-	double block_rate () const;
+	double sample_block_rate ();
 	double elapsed_seconds () const;
 	void set_start_time (std::chrono::steady_clock::time_point start_time_a);
 	std::shared_ptr<nano::node> node;
@@ -33,6 +33,7 @@ public:
 	std::shared_ptr<nano::socket> socket;
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;
 	std::atomic<uint64_t> block_count{ 0 };
+	std::atomic<double> block_rate{ 0 };
 	std::atomic<bool> pending_stop{ false };
 	std::atomic<bool> hard_stop{ false };
 


### PR DESCRIPTION
This solves a Debug assert on msvc: strict weak ordering not being satisfied in `bootstrap_connections::populate_connections` due to `block_rate_cmp`

```cpp
// FUNCTION TEMPLATE _Debug_lt_pred
template <class _Pr, class _Ty1, class _Ty2,
    enable_if_t<is_same_v<_Remove_cvref_t<_Ty1>, _Remove_cvref_t<_Ty2>>, int> = 0>
constexpr bool _Debug_lt_pred(_Pr&& _Pred, _Ty1&& _Left, _Ty2&& _Right) noexcept(
    noexcept(_Pred(_Left, _Right)) && noexcept(_Pred(_Right, _Left))) {
    // test if _Pred(_Left, _Right) and _Pred is strict weak ordering, when the arguments are the cv-same-type
    const auto _Result = static_cast<bool>(_Pred(_Left, _Right));
    if (_Result) {
        _STL_VERIFY(!_Pred(_Right, _Left), "invalid comparator");
    }

    return _Result;
}
```