### PR TITLE
Fix requeue pull for lazy bootstrap

### DIFF
--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -403,7 +403,7 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 		{
 			pull.count = attempt_l->lazy_batch_size ();
 		}
-		if (pull.attempts < pull.retry_limit + (pull.processed / nano::bootstrap_limits::requeued_pulls_processed_blocks_factor))
+		if (attempt_l->mode == nano::bootstrap_mode::legacy && (pull.attempts < pull.retry_limit + (pull.processed / nano::bootstrap_limits::requeued_pulls_processed_blocks_factor)))
 		{
 			{
 				nano::lock_guard<std::mutex> lock (mutex);


### PR DESCRIPTION
It should not allow unlimited requeue, instead always check if new pull head was already processed