### PR TITLE
Invoke callbacks even during socket closures

### DIFF
--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -72,7 +72,7 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, s
 	}
 }
 
-void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a, nano::buffer_drop_policy drop_policy_a)
+void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
 	auto this_l (shared_from_this ());
 	if (!closed)
@@ -183,12 +183,9 @@ void nano::socket::write_queued_messages ()
 							this_l->start_timer (node->network_params.node.idle_timeout);
 						}
 					}
-					else
+					else if (msg.callback)
 					{
-						if (msg.callback)
-						{
-							msg.callback (ec, size_a);
-						}
+						msg.callback (ec, size_a);
 					}
 				}
 			}
@@ -280,7 +277,7 @@ void nano::socket::flush_send_queue_callbacks ()
 		{
 			if (auto node_l = node.lock ())
 			{
-				node_l->background ([callback = item.callback]() {
+				node_l->background ([callback = std::move (item.callback)]() {
 					callback (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 				});
 			}

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -102,6 +102,7 @@ protected:
 	void start_timer ();
 	void stop_timer ();
 	void checkup ();
+	void flush_send_queue_callbacks ();
 };
 
 /** Socket class for TCP servers */

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -55,7 +55,7 @@ public:
 	virtual ~socket ();
 	void async_connect (boost::asio::ip::tcp::endpoint const &, std::function<void(boost::system::error_code const &)>);
 	void async_read (std::shared_ptr<std::vector<uint8_t>>, size_t, std::function<void(boost::system::error_code const &, size_t)>);
-	void async_write (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
+	void async_write (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
 
 	void close ();
 	boost::asio::ip::tcp::endpoint remote_endpoint () const;

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -56,6 +56,15 @@ void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const 
 	{
 		socket_l->async_write (buffer_a, tcp_callback (detail_a, socket_l->remote_endpoint (), callback_a), drop_policy_a);
 	}
+	else
+	{
+		if (callback_a)
+		{
+			node.background ([callback_a]() {
+				callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
+			});
+		}
+	}
 }
 
 std::function<void(boost::system::error_code const &, size_t)> nano::transport::channel_tcp::callback (nano::stat::detail detail_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a) const

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -56,14 +56,11 @@ void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const 
 	{
 		socket_l->async_write (buffer_a, tcp_callback (detail_a, socket_l->remote_endpoint (), callback_a), drop_policy_a);
 	}
-	else
+	else if (callback_a)
 	{
-		if (callback_a)
-		{
-			node.background ([callback_a]() {
-				callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
-			});
-		}
+		node.background ([callback_a]() {
+			callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
+		});
 	}
 }
 

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -102,7 +102,9 @@ void nano::transport::channel::send (nano::message const & message_a, std::funct
 	{
 		if (callback_a)
 		{
-			callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
+			node.background ([callback_a]() {
+				callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
+			});
 		}
 
 		node.stats.inc (nano::stat::type::drop, detail, nano::stat::dir::out);


### PR DESCRIPTION
During socket writes, callbacks can be missed if the socket is closing or closed depending on timing. These callbacks should be called even on error.

Recommend turning whitespace changes off.