### PR TITLE
Allow unescaped quoted strings with --config CLI

### DIFF
--- a/nano/core_test/cli.cpp
+++ b/nano/core_test/cli.cpp
@@ -46,26 +46,21 @@ TEST (cli, key_create)
 
 TEST (cli, config_override_parsing)
 {
-	auto error (false);
 	std::vector<nano::config_key_value_pair> key_value_pairs;
-	auto config_overrides = nano::config_overrides (key_value_pairs, error);
+	auto config_overrides = nano::config_overrides (key_value_pairs);
 	ASSERT_TRUE (config_overrides.empty ());
-	ASSERT_FALSE (error);
 	key_value_pairs.push_back ({ "key", "value" });
-	config_overrides = nano::config_overrides (key_value_pairs, error);
+	config_overrides = nano::config_overrides (key_value_pairs);
 	ASSERT_EQ (config_overrides[0], "key=\"value\"");
-	ASSERT_FALSE (error);
 	key_value_pairs.push_back ({ "node.online_weight_minimum", "40000000000000000000000000000000000000" });
-	config_overrides = nano::config_overrides (key_value_pairs, error);
+	config_overrides = nano::config_overrides (key_value_pairs);
 	ASSERT_EQ (config_overrides[1], "node.online_weight_minimum=\"40000000000000000000000000000000000000\"");
-	ASSERT_FALSE (error);
 
-	// Shouldn't add this as it contains escaped quotes
+	// Should add this as it contains escaped quotes, and make sure these are not escaped again
 	key_value_pairs.push_back ({ "key", "\"value\"" });
-	config_overrides = nano::config_overrides (key_value_pairs, error);
-	ASSERT_EQ (config_overrides[0], "key=\"value\"");
-	ASSERT_EQ (config_overrides.size (), 2);
-	ASSERT_TRUE (error);
+	config_overrides = nano::config_overrides (key_value_pairs);
+	ASSERT_EQ (config_overrides[2], "key=\"value\"");
+	ASSERT_EQ (config_overrides.size (), 3);
 }
 
 namespace

--- a/nano/core_test/cli.cpp
+++ b/nano/core_test/cli.cpp
@@ -63,7 +63,7 @@ TEST (cli, config_override_parsing)
 	ASSERT_EQ (config_overrides.size (), 3);
 
 	// Try it with arrays, with and without escaped quotes
-	key_value_pairs.push_back ({ "node.work_peers", "[127.0.0.1:7000,\"128.0.0.1:50000\"]"});
+	key_value_pairs.push_back ({ "node.work_peers", "[127.0.0.1:7000,\"128.0.0.1:50000\"]" });
 	config_overrides = nano::config_overrides (key_value_pairs);
 	ASSERT_EQ (config_overrides[3], "node.work_peers=[\"127.0.0.1:7000\",\"128.0.0.1:50000\"]");
 	ASSERT_EQ (config_overrides.size (), 4);

--- a/nano/core_test/cli.cpp
+++ b/nano/core_test/cli.cpp
@@ -61,6 +61,12 @@ TEST (cli, config_override_parsing)
 	config_overrides = nano::config_overrides (key_value_pairs);
 	ASSERT_EQ (config_overrides[2], "key=\"value\"");
 	ASSERT_EQ (config_overrides.size (), 3);
+
+	// Try it with arrays, with and without escaped quotes
+	key_value_pairs.push_back ({ "node.work_peers", "[127.0.0.1:7000,\"128.0.0.1:50000\"]"});
+	config_overrides = nano::config_overrides (key_value_pairs);
+	ASSERT_EQ (config_overrides[3], "node.work_peers=[\"127.0.0.1:7000\",\"128.0.0.1:50000\"]");
+	ASSERT_EQ (config_overrides.size (), 4);
 }
 
 namespace

--- a/nano/core_test/cli.cpp
+++ b/nano/core_test/cli.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/cli.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/secure/utility.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -41,6 +42,30 @@ TEST (cli, key_create)
 	auto public_key = nano::pub_key (private_key);
 	ASSERT_EQ (vals[1], public_key.to_string ());
 	ASSERT_EQ (vals[2], public_key.to_account ());
+}
+
+TEST (cli, config_override_parsing)
+{
+	auto error (false);
+	std::vector<nano::config_key_value_pair> key_value_pairs;
+	auto config_overrides = nano::config_overrides (key_value_pairs, error);
+	ASSERT_TRUE (config_overrides.empty ());
+	ASSERT_FALSE (error);
+	key_value_pairs.push_back ({ "key", "value" });
+	config_overrides = nano::config_overrides (key_value_pairs, error);
+	ASSERT_EQ (config_overrides[0], "key=\"value\"");
+	ASSERT_FALSE (error);
+	key_value_pairs.push_back ({ "node.online_weight_minimum", "40000000000000000000000000000000000000" });
+	config_overrides = nano::config_overrides (key_value_pairs, error);
+	ASSERT_EQ (config_overrides[1], "node.online_weight_minimum=\"40000000000000000000000000000000000000\"");
+	ASSERT_FALSE (error);
+
+	// Shouldn't add this as it contains escaped quotes
+	key_value_pairs.push_back ({ "key", "\"value\"" });
+	config_overrides = nano::config_overrides (key_value_pairs, error);
+	ASSERT_EQ (config_overrides[0], "key=\"value\"");
+	ASSERT_EQ (config_overrides.size (), 2);
+	ASSERT_TRUE (error);
 }
 
 namespace

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library (nano_lib
 	blockbuilders.cpp
 	blocks.hpp
 	blocks.cpp
+	cli.hpp
+	cli.cpp
 	config.hpp
 	config.cpp
 	configbase.hpp

--- a/nano/lib/cli.cpp
+++ b/nano/lib/cli.cpp
@@ -1,6 +1,9 @@
 #include <nano/lib/cli.hpp>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+
+#include <sstream>
 
 std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a)
 {
@@ -9,10 +12,45 @@ std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pa
 	auto format_add_escaped_quotes (boost::format ("%1%=\"%2%\""));
 	for (auto pair : key_value_pairs_a)
 	{
-		// Should be equal number of escaped quotes if any are found.
-		auto already_escaped = pair.value.find ('\"') != std::string::npos;
-		// Make all values strings with escaped quotations so that they are handled correctly by toml parsing
-		overrides.push_back (((!already_escaped ? format_add_escaped_quotes : format) % pair.key % pair.value).str ());
+		auto start = pair.value.find ('[');
+
+		std::string value;
+		auto is_array = (start != std::string::npos);
+		if (is_array)
+		{
+			// Trim off the square brackets [] of the array
+			auto end = pair.value.find (']');
+			auto array_values = pair.value.substr (start + 1, end - start - 1);
+
+			// Split the string by comma
+			std::vector<std::string> split_elements;
+			boost::split (split_elements, array_values, boost::is_any_of (","));
+
+			auto format (boost::format ("%1%"));
+			auto format_add_escaped_quotes (boost::format ("\"%1%\""));
+
+			// Rebuild the array string adding escaped quotes if necessary
+			std::ostringstream ss;
+			ss << "[";
+			for (auto i = 0; i < split_elements.size (); ++i)
+			{
+				auto & elem = split_elements[i];
+				auto already_escaped = elem.find ('\"') != std::string::npos;
+				ss << ((!already_escaped ? format_add_escaped_quotes : format) % elem).str ();
+				if (i != split_elements.size () - 1)
+				{
+					ss << ",";
+				}
+			}
+			ss << "]";
+			value = ss.str ();
+		}
+		else
+		{
+			value = pair.value;
+		}
+		auto already_escaped = value.find ('\"') != std::string::npos;
+		overrides.push_back (((!already_escaped ? format_add_escaped_quotes : format) % pair.key % value).str ());
 	}
 	return overrides;
 }

--- a/nano/lib/cli.cpp
+++ b/nano/lib/cli.cpp
@@ -1,0 +1,31 @@
+#include <nano/lib/cli.hpp>
+
+#include <boost/format.hpp>
+
+std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a, bool & error_a)
+{
+	std::vector<std::string> overrides;
+	for (auto pair : key_value_pairs_a)
+	{
+		// Do not allow escaped quotations
+		if (pair.value.find ("\"") != std::string::npos)
+		{
+			error_a = true;
+			break;
+		}
+
+		// Make all values strings with escaped quotations so that they are handled correctly by toml parsing
+		overrides.push_back ((boost::format ("%1%=\"%2%\"") % pair.key % pair.value).str ());
+	}
+	return overrides;
+}
+
+std::istream & nano::operator>> (std::istream & is, nano::config_key_value_pair & into)
+{
+	char ch;
+	while (is >> ch && ch != '=')
+	{
+		into.key += ch;
+	}
+	return is >> into.value;
+}

--- a/nano/lib/cli.cpp
+++ b/nano/lib/cli.cpp
@@ -2,20 +2,17 @@
 
 #include <boost/format.hpp>
 
-std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a, bool & error_a)
+std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a)
 {
 	std::vector<std::string> overrides;
+	auto format (boost::format ("%1%=%2%"));
+	auto format_add_escaped_quotes (boost::format ("%1%=\"%2%\""));
 	for (auto pair : key_value_pairs_a)
 	{
-		// Do not allow escaped quotations
-		if (pair.value.find ("\"") != std::string::npos)
-		{
-			error_a = true;
-			break;
-		}
-
+		// Should be equal number of escaped quotes if any are found.
+		auto already_escaped = pair.value.find ('\"') != std::string::npos;
 		// Make all values strings with escaped quotations so that they are handled correctly by toml parsing
-		overrides.push_back ((boost::format ("%1%=\"%2%\"") % pair.key % pair.value).str ());
+		overrides.push_back (((!already_escaped ? format_add_escaped_quotes : format) % pair.key % pair.value).str ());
 	}
 	return overrides;
 }

--- a/nano/lib/cli.hpp
+++ b/nano/lib/cli.hpp
@@ -13,7 +13,7 @@ public:
 	std::string value;
 };
 
-std::vector<std::string> config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a, bool & error_a);
+std::vector<std::string> config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a);
 
 std::istream & operator>> (std::istream & is, nano::config_key_value_pair & into);
 }

--- a/nano/lib/cli.hpp
+++ b/nano/lib/cli.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace nano
+{
+class config_key_value_pair
+{
+public:
+	std::string key;
+	std::string value;
+};
+
+std::vector<std::string> config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a, bool & error_a);
+
+std::istream & operator>> (std::istream & is, nano::config_key_value_pair & into);
+}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/cli.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/nano_node/daemon.hpp>
 #include <nano/node/cli.hpp>
@@ -68,7 +69,7 @@ int main (int argc, char * const * argv)
 	description.add_options ()
 		("help", "Print out options")
 		("version", "Prints out version")
-		("config", boost::program_options::value<std::vector<std::string>>()->multitoken(), "Pass node configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
+		("config", boost::program_options::value<std::vector<nano::config_key_value_pair>>()->multitoken(), "Pass node configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
 		("daemon", "Start node daemon")
 		("compare_rep_weights", "Display a summarized comparison between the hardcoded bootstrap weights and representative weights from the ledger. Full comparison is output to logs")
 		("debug_block_count", "Display the number of block")

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -138,15 +138,9 @@ int main (int argc, char * const * argv)
 	{
 		std::vector<std::string> config_overrides;
 		auto config (vm.find ("config"));
-		auto err (false);
 		if (config != vm.end ())
 		{
-			config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> (), err);
-			if (err)
-			{
-				std::cerr << "Config override parse error" << std::endl;
-				return 1;
-			}
+			config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> ());
 		}
 		run (data_path, config_overrides);
 	}

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/cli.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
@@ -90,7 +91,7 @@ int main (int argc, char * const * argv)
 	// clang-format off
 	description.add_options ()
 		("help", "Print out options")
-		("config", boost::program_options::value<std::vector<std::string>>()->multitoken(), "Pass RPC configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
+		("config", boost::program_options::value<std::vector<nano::config_key_value_pair>>()->multitoken(), "Pass RPC configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
 		("daemon", "Start RPC daemon")
 		("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
 		("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or test)")
@@ -137,9 +138,15 @@ int main (int argc, char * const * argv)
 	{
 		std::vector<std::string> config_overrides;
 		auto config (vm.find ("config"));
+		auto err (false);
 		if (config != vm.end ())
 		{
-			config_overrides = config->second.as<std::vector<std::string>> ();
+			config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> (), err);
+			if (err)
+			{
+				std::cerr << "Config override parse error" << std::endl;
+				return 1;
+			}
 		}
 		run (data_path, config_overrides);
 	}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -33,8 +33,6 @@ std::string nano::error_cli_messages::message (int ev) const
 			return "Flags --disable_tcp_realtime and --disable_udp cannot be used together";
 		case nano::error_cli::ambiguous_udp_options:
 			return "Flags --disable_udp and --enable_udp cannot be used together";
-		case nano::error_cli::config_override_error:
-			return "Config override parse error";
 	}
 
 	return "Invalid error code";
@@ -173,12 +171,7 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	auto config (vm.find ("config"));
 	if (config != vm.end ())
 	{
-		auto err (false);
-		flags_a.config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> (), err);
-		if (err)
-		{
-			ec = nano::error_cli::config_override_error;
-		}
+		flags_a.config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> ());
 	}
 	return ec;
 }

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/cli.hpp>
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/common.hpp>
@@ -32,6 +33,8 @@ std::string nano::error_cli_messages::message (int ev) const
 			return "Flags --disable_tcp_realtime and --disable_udp cannot be used together";
 		case nano::error_cli::ambiguous_udp_options:
 			return "Flags --disable_udp and --enable_udp cannot be used together";
+		case nano::error_cli::config_override_error:
+			return "Config override parse error";
 	}
 
 	return "Invalid error code";
@@ -170,7 +173,12 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	auto config (vm.find ("config"));
 	if (config != vm.end ())
 	{
-		flags_a.config_overrides = config->second.as<std::vector<std::string>> ();
+		auto err (false);
+		flags_a.config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> (), err);
+		if (err)
+		{
+			ec = nano::error_cli::config_override_error;
+		}
 	}
 	return ec;
 }

--- a/nano/node/cli.hpp
+++ b/nano/node/cli.hpp
@@ -17,8 +17,7 @@ enum class error_cli
 	database_write_error = 5,
 	reading_config = 6,
 	disable_all_network = 7,
-	ambiguous_udp_options = 8,
-	config_override_error = 9
+	ambiguous_udp_options = 8
 };
 
 void add_node_options (boost::program_options::options_description &);

--- a/nano/node/cli.hpp
+++ b/nano/node/cli.hpp
@@ -17,7 +17,8 @@ enum class error_cli
 	database_write_error = 5,
 	reading_config = 6,
 	disable_all_network = 7,
-	ambiguous_udp_options = 8
+	ambiguous_udp_options = 8,
+	config_override_error = 9
 };
 
 void add_node_options (boost::program_options::options_description &);


### PR DESCRIPTION
This task was originally because of confusion around this error found by @guilhermelawless:
`./nano_node --network live --daemon --config node.online_weight_minimum="40000000000000000000000000000000000000"`
> Error deserializing config: Malformed number (out of range: stoll) at line 1

The [docs](https://docs.nano.org/running-a-node/configuration/#passing-config-values-on-the-command-line) state that strings should be escaped. Would be nice if non-escaped quotes could be done which is what this PR has added.

To solve this we are now separating the key and value, then appending them together with the value being surrounded in escaped quotations if they are not added by the command. Toml seems to be able to handle this fine based on various tests. Reviewers should test a variety of options with different types (bool/int/string for instance).