### PR TITLE
UPnP basic logging messages are more frequent than intended

### DIFF
--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -173,7 +173,7 @@ void nano::port_mapping::check_mapping_loop ()
 	}
 	else
 	{
-		if (check_count++ < 10)
+		if (check_count < 10)
 		{
 			node.logger.always_log (boost::str (boost::format ("UPnP No IGD devices found")));
 		}
@@ -182,6 +182,7 @@ void nano::port_mapping::check_mapping_loop ()
 			node_l->port_mapping.check_mapping_loop ();
 		});
 	}
+	++check_count;
 }
 
 void nano::port_mapping::stop ()


### PR DESCRIPTION
Thanks @SergiySW for finding this, was changed by accident in https://github.com/nanocurrency/nano-node/pull/2837 .

UPnP device discovery basic logging from every ~1 minute to every ~15 minutes as before 2837.