### PR TITLE
Add time retrieval latency profile to CLI diagnostics

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -614,6 +614,14 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		nano::uint256_union junk2 (0);
 		nano::kdf kdf;
 		kdf.phs (junk1, "", junk2);
+		std::cout << "Testing time retrieval latency... " << std::flush;
+		nano::timer<std::chrono::nanoseconds> timer (nano::timer_state::started);
+		auto const iters = 2'000'000;
+		for (auto i (0); i < iters; ++i)
+		{
+			(void)std::chrono::steady_clock::now ();
+		}
+		std::cout << timer.stop ().count () / iters << " " << timer.unit () << std::endl;
 		std::cout << "Dumping OpenCL information" << std::endl;
 		bool error (false);
 		nano::opencl_environment environment (error);


### PR DESCRIPTION
A slower clocksource can have significant impact on the performance of the node. I was faced with this issue in a laptop with unstable TSC which falls back to the slower HPET (almost two orders of magnitude slower).

The cause wasn't immediately apparent, only after profiling, so this PR adds a quick loop to `--diagnostics` to measure the latency in retrieving the current system time. The loop isn't optimized away even in O3. Only takes ~100ms total with TSC.

For reference:
- System with TSC: 33 nanoseconds
- System with HPET: 1300 nanoseconds