### PR TITLE
Stats RPC to print out rocksdb memory stats

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3698,7 +3698,7 @@ void nano::json_handler::stats ()
 		node.stats.log_samples (*sink);
 		use_sink = true;
 	}
-	else if (type == "rocksdb")
+	else if (type == "database")
 	{
 		node.store.serialize_memory_stats (response_l);
 	}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3698,6 +3698,10 @@ void nano::json_handler::stats ()
 		node.stats.log_samples (*sink);
 		use_sink = true;
 	}
+	else if (type == "other")
+	{
+		node.store.serialize_memory_stats (response_l);
+	}
 	else
 	{
 		ec = nano::error_rpc::invalid_missing_type;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3698,7 +3698,7 @@ void nano::json_handler::stats ()
 		node.stats.log_samples (*sink);
 		use_sink = true;
 	}
-	else if (type == "other")
+	else if (type == "rocksdb")
 	{
 		node.store.serialize_memory_stats (response_l);
 	}

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -143,6 +143,19 @@ void nano::mdb_store::serialize_mdb_tracker (boost::property_tree::ptree & json,
 	mdb_txn_tracker.serialize_json (json, min_read_time, min_write_time);
 }
 
+void nano::mdb_store::serialize_memory_stats (boost::property_tree::ptree & json)
+{
+	MDB_stat stats;
+	auto status (mdb_env_stat (env.environment, &stats));
+	release_assert (status == 0);
+	json.put ("branch_pages", stats.ms_branch_pages);
+	json.put ("depth", stats.ms_depth);
+	json.put ("entries", stats.ms_entries);
+	json.put ("leaf_pages", stats.ms_leaf_pages);
+	json.put ("overflow_pages", stats.ms_overflow_pages);
+	json.put ("page_size", stats.ms_psize);
+}
+
 nano::write_transaction nano::mdb_store::tx_begin_write (std::vector<nano::tables> const &, std::vector<nano::tables> const &)
 {
 	return env.tx_begin_write (create_txn_callbacks ());

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -49,6 +49,8 @@ public:
 
 	static void create_backup_file (nano::mdb_env &, boost::filesystem::path const &, nano::logger_mt &);
 
+	void serialize_memory_stats (boost::property_tree::ptree &) override;
+
 private:
 	nano::logger_mt & logger;
 	bool error{ false };

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -627,45 +627,45 @@ void nano::rocksdb_store::serialize_memory_stats (boost::property_tree::ptree & 
 
 	// Approximate size of active and unflushed immutable memtables (bytes).
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kCurSizeAllMemTables, &val);
-	json.put ("rocksdb.cur-size-all-mem-tables", val);
+	json.put ("cur-size-all-mem-tables", val);
 
 	// Approximate size of active, unflushed immutable, and pinned immutable memtables (bytes).
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kSizeAllMemTables, &val);
-	json.put ("rocksdb.size-all-mem-tables", val);
+	json.put ("size-all-mem-tables", val);
 
 	// Estimated memory used for reading SST tables, excluding memory used in block cache (e.g. filter and index blocks).
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateTableReadersMem, &val);
-	json.put ("rocksdb.estimate-table-readers-mem", val);
+	json.put ("estimate-table-readers-mem", val);
 
 	//  An estimate of the amount of live data in bytes.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateLiveDataSize, &val);
-	json.put ("rocksdb.estimate-live-data-size", val);
+	json.put ("estimate-live-data-size", val);
 
 	//  Returns 1 if at least one compaction is pending; otherwise, returns 0.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kCompactionPending, &val);
-	json.put ("rocksdb.compaction-pending", val);
+	json.put ("compaction-pending", val);
 
 	// Estimated number of total keys in the active and unflushed immutable memtables and storage.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateNumKeys, &val);
-	json.put ("rocksdb.estimate-num-keys", val);
+	json.put ("estimate-num-keys", val);
 
 	// Estimated total number of bytes compaction needs to rewrite to get all levels down
 	// to under target size. Not valid for other compactions than level-based.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimatePendingCompactionBytes, &val);
-	json.put ("rocksdb.estimate-pending-compaction-bytes", val);
+	json.put ("estimate-pending-compaction-bytes", val);
 
 	//  Total size (bytes) of all SST files.
 	//  WARNING: may slow down online queries if there are too many files.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kTotalSstFilesSize, &val);
-	json.put ("rocksdb.total-sst-files-size", val);
+	json.put ("total-sst-files-size", val);
 
 	// Block cache capacity.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kBlockCacheCapacity, &val);
-	json.put ("rocksdb.block-cache-capacity", val);
+	json.put ("block-cache-capacity", val);
 
 	// Memory size for the entries residing in block cache.
 	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kBlockCacheUsage, &val);
-	json.put ("rocksdb.block-cache-usage", val);
+	json.put ("block-cache-usage", val);
 }
 
 // Explicitly instantiate

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -7,6 +7,7 @@
 #include <boost/endian/conversion.hpp>
 #include <boost/format.hpp>
 #include <boost/polymorphic_cast.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 #include <rocksdb/merge_operator.h>
 #include <rocksdb/slice.h>
@@ -619,5 +620,53 @@ bool nano::rocksdb_store::init_error () const
 {
 	return error;
 }
+
+void nano::rocksdb_store::serialize_memory_stats (boost::property_tree::ptree & json)
+{
+	uint64_t val;
+
+	// Approximate size of active and unflushed immutable memtables (bytes).
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kCurSizeAllMemTables, &val);
+	json.put ("rocksdb.cur-size-all-mem-tables", val);
+
+	// Approximate size of active, unflushed immutable, and pinned immutable memtables (bytes).
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kSizeAllMemTables, &val);
+	json.put ("rocksdb.size-all-mem-tables", val);
+
+	// Estimated memory used for reading SST tables, excluding memory used in block cache (e.g. filter and index blocks).
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateTableReadersMem, &val);
+	json.put ("rocksdb.estimate-table-readers-mem", val);
+
+	//  An estimate of the amount of live data in bytes.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateLiveDataSize, &val);
+	json.put ("rocksdb.estimate-live-data-size", val);
+
+	//  Returns 1 if at least one compaction is pending; otherwise, returns 0.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kCompactionPending, &val);
+	json.put ("rocksdb.compaction-pending", val);
+
+	// Estimated number of total keys in the active and unflushed immutable memtables and storage.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateNumKeys, &val);
+	json.put ("rocksdb.estimate-num-keys", val);
+
+	// Estimated total number of bytes compaction needs to rewrite to get all levels down
+	// to under target size. Not valid for other compactions than level-based.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimatePendingCompactionBytes, &val);
+	json.put ("rocksdb.estimate-pending-compaction-bytes", val);
+
+	//  Total size (bytes) of all SST files.
+	//  WARNING: may slow down online queries if there are too many files.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kTotalSstFilesSize, &val);
+	json.put ("rocksdb.total-sst-files-size", val);
+
+	// Block cache capacity.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kBlockCacheCapacity, &val);
+	json.put ("rocksdb.block-cache-capacity", val);
+
+	// Memory size for the entries residing in block cache.
+	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kBlockCacheUsage, &val);
+	json.put ("rocksdb.block-cache-usage", val);
+}
+
 // Explicitly instantiate
 template class nano::block_store_partial<rocksdb::Slice, nano::rocksdb_store>;

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -41,10 +41,7 @@ public:
 	int put (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a, nano::rocksdb_val const & value_a);
 	int del (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a);
 
-	void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds) override
-	{
-		// Do nothing
-	}
+	void serialize_memory_stats (boost::property_tree::ptree &) override;
 
 	std::shared_ptr<nano::block> block_get_v14 (nano::transaction const &, nano::block_hash const &, nano::block_sideband_v14 * = nullptr, bool * = nullptr) const override
 	{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6687,21 +6687,12 @@ TEST (rpc, memory_stats)
 		ASSERT_EQ (response.json.get_child ("node").get_child ("vote_uniquer").get_child ("votes").get<std::string> ("count"), "1");
 	}
 
-	request.put ("type", "rocksdb");
+	request.put ("type", "database");
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
 		ASSERT_TIMELY (5s, response.status != 0);
 		ASSERT_EQ (200, response.status);
-
-		auto use_rocksdb_str = std::getenv ("TEST_USE_ROCKSDB");
-		if (use_rocksdb_str && boost::lexical_cast<int> (use_rocksdb_str) == 1)
-		{
-			ASSERT_TRUE (!response.json.empty ());
-		}
-		else
-		{
-			ASSERT_EQ ("Empty response", response.json.get<std::string> ("error"));
-		}
+		ASSERT_TRUE (!response.json.empty ());
 	}
 }
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6679,11 +6679,30 @@ TEST (rpc, memory_stats)
 	boost::property_tree::ptree request;
 	request.put ("action", "stats");
 	request.put ("type", "objects");
-	test_response response (request, rpc.config.port, system.io_ctx);
-	ASSERT_TIMELY (5s, response.status != 0);
-	ASSERT_EQ (200, response.status);
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
 
-	ASSERT_EQ (response.json.get_child ("node").get_child ("vote_uniquer").get_child ("votes").get<std::string> ("count"), "1");
+		ASSERT_EQ (response.json.get_child ("node").get_child ("vote_uniquer").get_child ("votes").get<std::string> ("count"), "1");
+	}
+
+	request.put ("type", "rocksdb");
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+
+		auto use_rocksdb_str = std::getenv ("TEST_USE_ROCKSDB");
+		if (use_rocksdb_str && boost::lexical_cast<int> (use_rocksdb_str) == 1)
+		{
+			ASSERT_TRUE (!response.json.empty ());
+		}
+		else
+		{
+			ASSERT_EQ ("Empty response", response.json.get<std::string> ("error"));
+		}
+	}
 }
 
 TEST (rpc, block_confirmed)

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -675,7 +675,8 @@ public:
 	virtual void rebuild_db (nano::write_transaction const & transaction_a) = 0;
 
 	/** Not applicable to all sub-classes */
-	virtual void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds) = 0;
+	virtual void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds){};
+	virtual void serialize_memory_stats (boost::property_tree::ptree &){};
 
 	virtual bool init_error () const = 0;
 

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -676,7 +676,7 @@ public:
 
 	/** Not applicable to all sub-classes */
 	virtual void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds){};
-	virtual void serialize_memory_stats (boost::property_tree::ptree &){};
+	virtual void serialize_memory_stats (boost::property_tree::ptree &) = 0;
 
 	virtual bool init_error () const = 0;
 


### PR DESCRIPTION
This extends the `stats` RPC with another `type` called `rocksdb`

Example output is:
```
{
    "cur-size-all-mem-tables": "84208080",
    "size-all-mem-tables": "434238032",
    "estimate-table-readers-mem": "129269335",
    "estimate-live-data-size": "16350750564",
    "compaction-pending": "0",
    "estimate-num-keys": "70453544",
    "estimate-pending-compaction-bytes": "0",
    "total-sst-files-size": "18014738665",
    "block-cache-capacity": "260046848",
    "block-cache-usage": "132867094"
}
```