### PR TITLE
Simplify RocksDB config options

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -255,15 +255,8 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.lmdb_config.map_size, defaults.node.lmdb_config.map_size);
 
 	ASSERT_EQ (conf.node.rocksdb_config.enable, defaults.node.rocksdb_config.enable);
-	ASSERT_EQ (conf.node.rocksdb_config.bloom_filter_bits, defaults.node.rocksdb_config.bloom_filter_bits);
-	ASSERT_EQ (conf.node.rocksdb_config.block_cache, defaults.node.rocksdb_config.block_cache);
+	ASSERT_EQ (conf.node.rocksdb_config.memory_multiplier, defaults.node.rocksdb_config.memory_multiplier);
 	ASSERT_EQ (conf.node.rocksdb_config.io_threads, defaults.node.rocksdb_config.io_threads);
-	ASSERT_EQ (conf.node.rocksdb_config.enable_pipelined_write, defaults.node.rocksdb_config.enable_pipelined_write);
-	ASSERT_EQ (conf.node.rocksdb_config.cache_index_and_filter_blocks, defaults.node.rocksdb_config.cache_index_and_filter_blocks);
-	ASSERT_EQ (conf.node.rocksdb_config.block_size, defaults.node.rocksdb_config.block_size);
-	ASSERT_EQ (conf.node.rocksdb_config.memtable_size, defaults.node.rocksdb_config.memtable_size);
-	ASSERT_EQ (conf.node.rocksdb_config.num_memtables, defaults.node.rocksdb_config.num_memtables);
-	ASSERT_EQ (conf.node.rocksdb_config.total_memtable_size, defaults.node.rocksdb_config.total_memtable_size);
 }
 
 TEST (toml, optional_child)
@@ -513,15 +506,8 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 
 	[node.rocksdb]
 	enable = true
-	bloom_filter_bits = 10
-	block_cache = 512
+	memory_multiplier = 3
 	io_threads = 99
-	enable_pipelined_write = true
-	cache_index_and_filter_blocks = true
-	block_size = 16
-	memtable_size = 128
-	num_memtables = 3
-	total_memtable_size = 0
 
 	[node.experimental]
 	secondary_work_peers = ["test.org:998"]
@@ -668,15 +654,8 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.lmdb_config.map_size, defaults.node.lmdb_config.map_size);
 
 	ASSERT_NE (conf.node.rocksdb_config.enable, defaults.node.rocksdb_config.enable);
-	ASSERT_NE (conf.node.rocksdb_config.bloom_filter_bits, defaults.node.rocksdb_config.bloom_filter_bits);
-	ASSERT_NE (conf.node.rocksdb_config.block_cache, defaults.node.rocksdb_config.block_cache);
+	ASSERT_NE (conf.node.rocksdb_config.memory_multiplier, defaults.node.rocksdb_config.memory_multiplier);
 	ASSERT_NE (conf.node.rocksdb_config.io_threads, defaults.node.rocksdb_config.io_threads);
-	ASSERT_NE (conf.node.rocksdb_config.enable_pipelined_write, defaults.node.rocksdb_config.enable_pipelined_write);
-	ASSERT_NE (conf.node.rocksdb_config.cache_index_and_filter_blocks, defaults.node.rocksdb_config.cache_index_and_filter_blocks);
-	ASSERT_NE (conf.node.rocksdb_config.block_size, defaults.node.rocksdb_config.block_size);
-	ASSERT_NE (conf.node.rocksdb_config.memtable_size, defaults.node.rocksdb_config.memtable_size);
-	ASSERT_NE (conf.node.rocksdb_config.num_memtables, defaults.node.rocksdb_config.num_memtables);
-	ASSERT_NE (conf.node.rocksdb_config.total_memtable_size, defaults.node.rocksdb_config.total_memtable_size);
 }
 
 /** There should be no required values **/

--- a/nano/lib/rocksdbconfig.cpp
+++ b/nano/lib/rocksdbconfig.cpp
@@ -4,55 +4,25 @@
 nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 {
 	toml.put ("enable", enable, "Whether to use the RocksDB backend for the ledger database.\ntype:bool");
-	toml.put ("enable_pipelined_write", enable_pipelined_write, "Whether to use 2 separate write queues for memtable/WAL, true is recommended.\ntype:bool");
-	toml.put ("cache_index_and_filter_blocks", cache_index_and_filter_blocks, "Whether index and filter blocks are stored in block_cache, true is recommended.\ntype:bool");
-	toml.put ("bloom_filter_bits", bloom_filter_bits, "Number of bits to use with a bloom filter. Helps with point reads but uses more memory. 0 disables the bloom filter, 10 is recommended.\ntype:uint32");
-	toml.put ("block_cache", block_cache, "Size (MB) of the block cache; A larger number will increase performance of read operations. At least 512MB is recommended.\ntype:uint64");
+	toml.put ("memory_multiplier", memory_multiplier, "This will modify how much memory is used represented by 1 (low), 2 (medium), 3 (high). Default is 2.\ntype:uint8");
 	toml.put ("io_threads", io_threads, "Number of threads to use with the background compaction and flushing. Number of hardware threads is recommended.\ntype:uint32");
-	toml.put ("block_size", block_size, "Uncompressed data (KBs) per block. Increasing block size decreases memory usage and space amplification, but increases read amplification. 16 is recommended.\ntype:uint32");
-	toml.put ("num_memtables", num_memtables, "Number of memtables to keep in memory per column family. 2 is the minimum, 3 is recommended.\ntype:uint32");
-	toml.put ("memtable_size", memtable_size, "Amount of memory (MB) to build up before flushing to disk for an individual column family. Large values increase performance. 64 or 128 is recommended.\ntype:uint32");
-	toml.put ("total_memtable_size", total_memtable_size, "Total memory (MB) which can be used across all memtables, set to 0 for unconstrained.\ntype:uint32");
 	return toml.get_error ();
 }
 
 nano::error nano::rocksdb_config::deserialize_toml (nano::tomlconfig & toml)
 {
 	toml.get_optional<bool> ("enable", enable);
-	toml.get_optional<bool> ("enable_pipelined_write", enable_pipelined_write);
-	toml.get_optional<bool> ("cache_index_and_filter_blocks", cache_index_and_filter_blocks);
-	toml.get_optional<unsigned> ("bloom_filter_bits", bloom_filter_bits);
-	toml.get_optional<uint64_t> ("block_cache", block_cache);
+	toml.get_optional<uint8_t> ("memory_multiplier", memory_multiplier);
 	toml.get_optional<unsigned> ("io_threads", io_threads);
-	toml.get_optional<unsigned> ("block_size", block_size);
-	toml.get_optional<unsigned> ("num_memtables", num_memtables);
-	toml.get_optional<unsigned> ("memtable_size", memtable_size);
-	toml.get_optional<unsigned> ("total_memtable_size", total_memtable_size);
 
 	// Validate ranges
-	if (bloom_filter_bits > 100)
-	{
-		toml.get_error ().set ("bloom_filter_bits is too high");
-	}
-	if (num_memtables < 2)
-	{
-		toml.get_error ().set ("num_memtables must be at least 2");
-	}
-	if (memtable_size == 0)
-	{
-		toml.get_error ().set ("memtable_size must be non-zero");
-	}
-	if ((total_memtable_size < memtable_size * 8) && (total_memtable_size != 0))
-	{
-		toml.get_error ().set ("total_memtable_size should be at least 8 times greater than memtable_size or be set to 0");
-	}
 	if (io_threads == 0)
 	{
 		toml.get_error ().set ("io_threads must be non-zero");
 	}
-	if (block_size == 0)
+	if (memory_multiplier < 1 || memory_multiplier > 3)
 	{
-		toml.get_error ().set ("block_size must be non-zero");
+		toml.get_error ().set ("memory_multiplier must be either 1, 2 or 3");
 	}
 
 	return toml.get_error ();

--- a/nano/lib/rocksdbconfig.hpp
+++ b/nano/lib/rocksdbconfig.hpp
@@ -16,14 +16,7 @@ public:
 	nano::error deserialize_toml (nano::tomlconfig & toml_a);
 
 	bool enable{ false };
-	unsigned bloom_filter_bits{ 0 };
-	uint64_t block_cache{ 64 }; // MB
+	uint8_t memory_multiplier{ 2 };
 	unsigned io_threads{ std::thread::hardware_concurrency () };
-	bool enable_pipelined_write{ false };
-	bool cache_index_and_filter_blocks{ false };
-	unsigned block_size{ 4 }; // KB
-	unsigned memtable_size{ 32 }; // MB
-	unsigned num_memtables{ 2 }; // Need a minimum of 2
-	unsigned total_memtable_size{ 512 }; // MB
 };
 }

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -102,6 +102,9 @@ private:
 	rocksdb::Options get_db_options () const;
 	rocksdb::BlockBasedTableOptions get_table_options () const;
 	nano::rocksdb_config rocksdb_config;
+
+	constexpr static int base_memtable_size = 16;
+	constexpr static int base_block_cache_size = 16;
 };
 
 extern template class block_store_partial<rocksdb::Slice, rocksdb_store>;


### PR DESCRIPTION
Toml config options have been simplified for the user. Now just have `io_thread` and `memory_multiplier`