### PR TITLE
[RocksDB] Add store hint for cached counts

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -120,7 +120,7 @@ TEST (block_store, add_item)
 	auto latest1 (store->block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
 	ASSERT_FALSE (store->block_exists (transaction, hash1));
-	store->block_put (transaction, hash1, block);
+	store->block_put (transaction, hash1, block, nano::store_hint::key_not_exists);
 	auto latest2 (store->block_get (transaction, hash1));
 	ASSERT_NE (nullptr, latest2);
 	ASSERT_EQ (block, *latest2);
@@ -139,17 +139,17 @@ TEST (block_store, clear_successor)
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block1.sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block_put (transaction, block1.hash (), block1);
+	store->block_put (transaction, block1.hash (), block1, nano::store_hint::key_not_exists);
 	nano::open_block block2 (0, 2, 0, nano::keypair ().prv, 0, 0);
 	block2.sideband_set ({});
-	store->block_put (transaction, block2.hash (), block2);
+	store->block_put (transaction, block2.hash (), block2, nano::store_hint::key_not_exists);
 	auto block2_store (store->block_get (transaction, block1.hash ()));
 	ASSERT_NE (nullptr, block2_store);
 	ASSERT_EQ (0, block2_store->sideband ().successor.number ());
 	auto modified_sideband = block2_store->sideband ();
 	modified_sideband.successor = block2.hash ();
 	block1.sideband_set (modified_sideband);
-	store->block_put (transaction, block1.hash (), block1);
+	store->block_put (transaction, block1.hash (), block1, nano::store_hint::key_not_exists);
 	{
 		auto block1_store (store->block_get (transaction, block1.hash ()));
 		ASSERT_NE (nullptr, block1_store);
@@ -176,7 +176,7 @@ TEST (block_store, add_nonempty_block)
 	auto transaction (store->tx_begin_write ());
 	auto latest1 (store->block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
-	store->block_put (transaction, hash1, block);
+	store->block_put (transaction, hash1, block, nano::store_hint::key_not_exists);
 	auto latest2 (store->block_get (transaction, hash1));
 	ASSERT_NE (nullptr, latest2);
 	ASSERT_EQ (block, *latest2);
@@ -202,8 +202,8 @@ TEST (block_store, add_two_items)
 	block2.signature = nano::sign_message (key1.prv, key1.pub, hash2);
 	auto latest2 (store->block_get (transaction, hash2));
 	ASSERT_EQ (nullptr, latest2);
-	store->block_put (transaction, hash1, block);
-	store->block_put (transaction, hash2, block2);
+	store->block_put (transaction, hash1, block, nano::store_hint::key_not_exists);
+	store->block_put (transaction, hash2, block2, nano::store_hint::key_not_exists);
 	auto latest3 (store->block_get (transaction, hash1));
 	ASSERT_NE (nullptr, latest3);
 	ASSERT_EQ (block, *latest3);
@@ -223,13 +223,13 @@ TEST (block_store, add_receive)
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block1.sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block_put (transaction, block1.hash (), block1);
+	store->block_put (transaction, block1.hash (), block1, nano::store_hint::key_not_exists);
 	nano::receive_block block (block1.hash (), 1, nano::keypair ().prv, 2, 3);
 	block.sideband_set ({});
 	nano::block_hash hash1 (block.hash ());
 	auto latest1 (store->block_get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
-	store->block_put (transaction, hash1, block);
+	store->block_put (transaction, hash1, block, nano::store_hint::key_not_exists);
 	auto latest2 (store->block_get (transaction, hash1));
 	ASSERT_NE (nullptr, latest2);
 	ASSERT_EQ (block, *latest2);
@@ -471,7 +471,7 @@ TEST (block_store, one_block)
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block1.sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block_put (transaction, block1.hash (), block1);
+	store->block_put (transaction, block1.hash (), block1, nano::store_hint::key_not_exists);
 	ASSERT_TRUE (store->block_exists (transaction, block1.hash ()));
 }
 
@@ -573,12 +573,12 @@ TEST (block_store, two_block)
 	hashes.push_back (block1.hash ());
 	blocks.push_back (block1);
 	auto transaction (store->tx_begin_write ());
-	store->block_put (transaction, hashes[0], block1);
+	store->block_put (transaction, hashes[0], block1, nano::store_hint::key_not_exists);
 	nano::open_block block2 (0, 1, 2, nano::keypair ().prv, 0, 0);
 	block2.sideband_set ({});
 	hashes.push_back (block2.hash ());
 	blocks.push_back (block2);
-	store->block_put (transaction, hashes[1], block2);
+	store->block_put (transaction, hashes[1], block2, nano::store_hint::key_not_exists);
 	ASSERT_TRUE (store->block_exists (transaction, block1.hash ()));
 	ASSERT_TRUE (store->block_exists (transaction, block2.hash ()));
 }
@@ -809,8 +809,8 @@ TEST (block_store, block_replace)
 	nano::send_block send2 (0, 0, 0, nano::keypair ().prv, 0, 2);
 	send2.sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block_put (transaction, 0, send1);
-	store->block_put (transaction, 0, send2);
+	store->block_put (transaction, 0, send1, nano::store_hint::key_not_exists);
+	store->block_put (transaction, 0, send2, nano::store_hint::key_exists);
 	auto block3 (store->block_get (transaction, 0));
 	ASSERT_NE (nullptr, block3);
 	ASSERT_EQ (2, block3->block_work ());
@@ -827,7 +827,7 @@ TEST (block_store, block_count)
 		nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
 		block.sideband_set ({});
 		auto hash1 (block.hash ());
-		store->block_put (transaction, hash1, block);
+		store->block_put (transaction, hash1, block, nano::store_hint::key_not_exists);
 	}
 	auto transaction (store->tx_begin_read ());
 	ASSERT_EQ (1, store->block_count (transaction).sum ());
@@ -1003,7 +1003,7 @@ TEST (block_store, state_block)
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, genesis, ledger_cache);
 		ASSERT_EQ (nano::block_type::state, block1.type ());
-		store->block_put (transaction, block1.hash (), block1);
+		store->block_put (transaction, block1.hash (), block1, nano::store_hint::key_not_exists);
 		ASSERT_TRUE (store->block_exists (transaction, block1.hash ()));
 		auto block2 (store->block_get (transaction, block1.hash ()));
 		ASSERT_NE (nullptr, block2);
@@ -1716,7 +1716,7 @@ TEST (block_store, reset_renew_existing_transaction)
 	// Write the block
 	{
 		auto write_transaction (store->tx_begin_write ());
-		store->block_put (write_transaction, hash1, block);
+		store->block_put (write_transaction, hash1, block, nano::store_hint::key_not_exists);
 	}
 
 	read_transaction.renew ();

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -855,7 +855,7 @@ bool nano::active_transactions::restart (std::shared_ptr<nano::block> const & bl
 				ledger_block->block_work_set (block_a->block_work ());
 
 				auto block_count = node.ledger.cache.block_count.load ();
-				node.store.block_put (transaction_a, hash, *ledger_block);
+				node.store.block_put (transaction_a, hash, *ledger_block, nano::store_hint::key_exists);
 				debug_assert (node.ledger.cache.block_count.load () == block_count);
 
 				// Restart election for the upgraded block, previously dropped from elections

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -580,7 +580,7 @@ int nano::mdb_store::get (nano::transaction const & transaction_a, tables table_
 	return mdb_get (env.tx (transaction_a), table_to_dbi (table_a), key_a, value_a);
 }
 
-int nano::mdb_store::put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, const nano::mdb_val & value_a) const
+int nano::mdb_store::put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, const nano::mdb_val & value_a, nano::store_hint) const
 {
 	return (mdb_put (env.tx (transaction_a), table_to_dbi (table_a), key_a, value_a, 0));
 }

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -185,7 +185,7 @@ public:
 	bool exists (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 
 	int get (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, nano::mdb_val & value_a) const;
-	int put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, const nano::mdb_val & value_a) const;
+	int put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, const nano::mdb_val & value_a, nano::store_hint /* unused */) const;
 	int del (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 
 	bool copy_db (boost::filesystem::path const & destination_file) override;

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -38,7 +38,7 @@ public:
 
 	bool exists (nano::transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a) const;
 	int get (nano::transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a, nano::rocksdb_val & value_a) const;
-	int put (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a, nano::rocksdb_val const & value_a);
+	int put (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a, nano::rocksdb_val const & value_a, nano::store_hint store_hint_a);
 	int del (nano::write_transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a);
 
 	void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds) override

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -500,6 +500,13 @@ enum class tables
 	vote
 };
 
+enum class store_hint
+{
+	key_exists,
+	key_not_exists,
+	none
+};
+
 class transaction_impl
 {
 public:
@@ -573,7 +580,7 @@ class block_store
 public:
 	virtual ~block_store () = default;
 	virtual void initialize (nano::write_transaction const &, nano::genesis const &, nano::ledger_cache &) = 0;
-	virtual void block_put (nano::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;
+	virtual void block_put (nano::write_transaction const &, nano::block_hash const &, nano::block const &, nano::store_hint) = 0;
 	virtual nano::block_hash block_successor (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual void block_successor_clear (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual std::shared_ptr<nano::block> block_get (nano::transaction const &, nano::block_hash const &) const = 0;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -342,7 +342,7 @@ void ledger_processor::state_block_impl (nano::state_block & block_a)
 					{
 						ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
 						block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details));
-						ledger.store.block_put (transaction, hash, block_a);
+						ledger.store.block_put (transaction, hash, block_a, nano::store_hint::key_not_exists);
 
 						if (!info.head.is_zero ())
 						{
@@ -443,7 +443,7 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 								result.account = block_a.hashables.account;
 								result.amount = 0;
 								block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details));
-								ledger.store.block_put (transaction, hash, block_a);
+								ledger.store.block_put (transaction, hash, block_a, nano::store_hint::key_not_exists);
 								nano::account_info new_info (hash, block_a.representative (), info.open_block.is_zero () ? hash : info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count + 1, epoch);
 								ledger.change_latest (transaction, block_a.hashables.account, info, new_info);
 								if (!ledger.store.frontier_get (transaction, info.head).is_zero ())
@@ -507,7 +507,7 @@ void ledger_processor::change_block (nano::change_block & block_a)
 							debug_assert (!validate_message (account, hash, block_a.signature));
 							result.verified = nano::signature_verification::valid;
 							block_a.sideband_set (nano::block_sideband (account, 0, info.balance, info.block_count + 1, nano::seconds_since_epoch (), block_details));
-							ledger.store.block_put (transaction, hash, block_a);
+							ledger.store.block_put (transaction, hash, block_a, nano::store_hint::key_not_exists);
 							auto balance (ledger.balance (transaction, block_a.hashables.previous));
 							ledger.cache.rep_weights.representation_add (block_a.representative (), balance);
 							ledger.cache.rep_weights.representation_add (info.representative, 0 - balance);
@@ -569,7 +569,7 @@ void ledger_processor::send_block (nano::send_block & block_a)
 								auto amount (info.balance.number () - block_a.hashables.balance.number ());
 								ledger.cache.rep_weights.representation_add (info.representative, 0 - amount);
 								block_a.sideband_set (nano::block_sideband (account, 0, block_a.hashables.balance /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details));
-								ledger.store.block_put (transaction, hash, block_a);
+								ledger.store.block_put (transaction, hash, block_a, nano::store_hint::key_not_exists);
 								nano::account_info new_info (hash, info.representative, info.open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
 								ledger.change_latest (transaction, account, info, new_info);
 								ledger.store.pending_put (transaction, nano::pending_key (block_a.hashables.destination, hash), { account, amount, nano::epoch::epoch_0 });
@@ -643,7 +643,7 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 											debug_assert (!error);
 											ledger.store.pending_del (transaction, key);
 											block_a.sideband_set (nano::block_sideband (account, 0, new_balance, info.block_count + 1, nano::seconds_since_epoch (), block_details));
-											ledger.store.block_put (transaction, hash, block_a);
+											ledger.store.block_put (transaction, hash, block_a, nano::store_hint::key_not_exists);
 											nano::account_info new_info (hash, info.representative, info.open_block, new_balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
 											ledger.change_latest (transaction, account, info, new_info);
 											ledger.cache.rep_weights.representation_add (info.representative, pending.amount.number ());
@@ -713,7 +713,7 @@ void ledger_processor::open_block (nano::open_block & block_a)
 									debug_assert (!error);
 									ledger.store.pending_del (transaction, key);
 									block_a.sideband_set (nano::block_sideband (block_a.hashables.account, 0, pending.amount, 1, nano::seconds_since_epoch (), block_details));
-									ledger.store.block_put (transaction, hash, block_a);
+									ledger.store.block_put (transaction, hash, block_a, nano::store_hint::key_not_exists);
 									nano::account_info new_info (hash, block_a.representative (), hash, pending.amount.number (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0);
 									ledger.change_latest (transaction, block_a.hashables.account, info, new_info);
 									ledger.cache.rep_weights.representation_add (block_a.representative (), pending.amount.number ());


### PR DESCRIPTION
Inside `put()` we always check if the key exists before updating the `cached_counts` database value. The caller has more information about whether the key might already exist, so we can skip this read IO. Added a "store hint" for this purpose.