### PR TITLE
[RocksDB] Do not fill block cache from ranged iterators

### DIFF
--- a/nano/node/rocksdb/rocksdb_iterator.hpp
+++ b/nano/node/rocksdb/rocksdb_iterator.hpp
@@ -16,10 +16,10 @@ inline bool is_read (nano::transaction const & transaction_a)
 	return (dynamic_cast<const nano::read_transaction *> (&transaction_a) != nullptr);
 }
 
-inline rocksdb::ReadOptions const & snapshot_options (nano::transaction const & transaction_a)
+inline rocksdb::ReadOptions & snapshot_options (nano::transaction const & transaction_a)
 {
 	debug_assert (is_read (transaction_a));
-	return *static_cast<const rocksdb::ReadOptions *> (transaction_a.get_handle ());
+	return *static_cast<rocksdb::ReadOptions *> (transaction_a.get_handle ());
 }
 }
 
@@ -31,50 +31,33 @@ template <typename T, typename U>
 class rocksdb_iterator : public store_iterator_impl<T, U>
 {
 public:
-	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a)
+	rocksdb_iterator () = default;
+
+	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a, rocksdb_val const * val_a)
 	{
+		// Don't fill the block cache for any blocks read as a result of an iterator
 		rocksdb::Iterator * iter;
 		if (is_read (transaction_a))
 		{
-			iter = db->NewIterator (snapshot_options (transaction_a), handle_a);
+			auto & read_options = snapshot_options (transaction_a);
+			read_options.fill_cache = false;
+			cursor.reset (db->NewIterator (read_options, handle_a));
 		}
 		else
 		{
 			rocksdb::ReadOptions ropts;
 			ropts.fill_cache = false;
-			iter = tx (transaction_a)->GetIterator (ropts, handle_a);
+			cursor.reset (tx (transaction_a)->GetIterator (ropts, handle_a));
 		}
 
-		cursor.reset (iter);
-		cursor->SeekToFirst ();
-
-		if (cursor->Valid ())
+		if (val_a)
 		{
-			current.first.value = cursor->key ();
-			current.second.value = cursor->value ();
+			cursor->Seek (*val_a);
 		}
 		else
 		{
-			clear ();
+			cursor->SeekToFirst ();
 		}
-	}
-
-	rocksdb_iterator () = default;
-
-	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a, rocksdb_val const & val_a)
-	{
-		rocksdb::Iterator * iter;
-		if (is_read (transaction_a))
-		{
-			iter = db->NewIterator (snapshot_options (transaction_a), handle_a);
-		}
-		else
-		{
-			iter = tx (transaction_a)->GetIterator (rocksdb::ReadOptions (), handle_a);
-		}
-
-		cursor.reset (iter);
-		cursor->Seek (val_a);
 
 		if (cursor->Valid ())
 		{
@@ -85,6 +68,11 @@ public:
 		{
 			clear ();
 		}
+	}
+
+	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a) :
+	rocksdb_iterator (db, transaction_a, handle_a, nullptr)
+	{
 	}
 
 	rocksdb_iterator (nano::rocksdb_iterator<T, U> && other_a)

--- a/nano/node/rocksdb/rocksdb_txn.cpp
+++ b/nano/node/rocksdb/rocksdb_txn.cpp
@@ -3,7 +3,10 @@
 nano::read_rocksdb_txn::read_rocksdb_txn (rocksdb::DB * db_a) :
 db (db_a)
 {
-	options.snapshot = db_a->GetSnapshot ();
+	if (db_a)
+	{
+		options.snapshot = db_a->GetSnapshot ();
+	}
 }
 
 nano::read_rocksdb_txn::~read_rocksdb_txn ()
@@ -13,7 +16,10 @@ nano::read_rocksdb_txn::~read_rocksdb_txn ()
 
 void nano::read_rocksdb_txn::reset ()
 {
-	db->ReleaseSnapshot (options.snapshot);
+	if (db)
+	{
+		db->ReleaseSnapshot (options.snapshot);
+	}
 }
 
 void nano::read_rocksdb_txn::renew ()

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -400,7 +400,7 @@ public:
 		nano::db_val<Val> data;
 		auto status = get (transaction_a, tables::meta, nano::db_val<Val> (version_key), data);
 		int result (minimum_version);
-		if (!not_found (status))
+		if (success (status))
 		{
 			nano::uint256_union version_value (data);
 			debug_assert (version_value.qwords[2] == 0 && version_value.qwords[1] == 0 && version_value.qwords[0] == 0);


### PR DESCRIPTION
When reading a range of keys from iterators, we generally don't care about keys afterwards (such as frontiers confirmation or bulk reading at start). It can pollute the `block_cache` which is now prevented.

This also has some miscellaneous changes for various things I found working in this area, like using smart pointers instead of manual memory management.