### PR TITLE
Don't crash using read-only CLI command with no ledger

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -66,6 +66,15 @@ TEST (node, block_store_path_failure)
 	node->stop ();
 }
 
+TEST (node_DeathTest, readonly_block_store_not_exist)
+{
+	// For ASSERT_DEATH_IF_SUPPORTED
+	testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+	// This is a read-only node with no ledger file
+	ASSERT_EXIT (nano::inactive_node (nano::unique_path (), nano::inactive_node_flag_defaults ()), ::testing::ExitedWithCode (1), "");
+}
+
 TEST (node, password_fanout)
 {
 	auto service (boost::make_shared<boost::asio::io_context> ());

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -371,7 +371,8 @@ node_seq (seq)
 		if (!ledger.block_exists (genesis.hash ()))
 		{
 			std::stringstream ss;
-			ss << "Genesis block not found. Make sure the node network ID is correct.";
+			ss << "Genesis block not found. This commonly indicates a configuration issue, check that the --network or --data_path command line arguments are correct, "
+			      "and also the ledger backend node config option. If using a read-only CLI command a ledger must already exist, start the node with --daemon first.";
 			if (network_params.network.is_beta_network ())
 			{
 				ss << " Beta network may have reset, try clearing database files";

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -361,9 +361,8 @@ node_seq (seq)
 		}
 
 		nano::genesis genesis;
-		if (!is_initialized)
+		if (!is_initialized && !flags.read_only)
 		{
-			release_assert (!flags.read_only);
 			auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::cached_counts, tables::confirmation_height, tables::frontiers }));
 			// Store was empty meaning we just created it, add the genesis block
 			store.initialize (transaction, genesis, ledger.cache);


### PR DESCRIPTION
It now correctly outputs "Genesis block not found. Make sure the node network ID is correct." which indicates that the ledger either doesn't exist or the `data_path` is set incorrectly, when using read-only CLI commands like `--debug_block_count`