### PR TITLE
nano_test_network => nano_dev_network, new nano_test_network

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ option(ENABLE_AES "Enable AES optimizations (enabled by default with NANO_SIMD_O
 option(ENABLE_AVX2 "Enable AVX2 optimizations" OFF)
 
 SET (ACTIVE_NETWORK nano_live_network CACHE STRING "Selects which network parameters are used")
-set_property (CACHE ACTIVE_NETWORK PROPERTY STRINGS nano_test_network nano_beta_network nano_live_network)
+set_property (CACHE ACTIVE_NETWORK PROPERTY STRINGS nano_dev_network nano_beta_network nano_live_network)
 
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ option(ENABLE_AES "Enable AES optimizations (enabled by default with NANO_SIMD_O
 option(ENABLE_AVX2 "Enable AVX2 optimizations" OFF)
 
 SET (ACTIVE_NETWORK nano_live_network CACHE STRING "Selects which network parameters are used")
-set_property (CACHE ACTIVE_NETWORK PROPERTY STRINGS nano_dev_network nano_beta_network nano_live_network)
+set_property (CACHE ACTIVE_NETWORK PROPERTY STRINGS nano_dev_network nano_beta_network nano_live_network nano_test_network)
 
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -27,7 +27,7 @@ else {
         $env:ROCKS_LIB = '-DROCKSDB_LIBRARIES="c:\vcpkg\installed\x64-windows-static\debug\lib\rocksdbd.lib"'
     }
     $env:NANO_SHARED_BOOST = "OFF"
-    $env:NETWORK_CFG = "test"
+    $env:NETWORK_CFG = "dev"
     $env:NANO_TEST = "-DNANO_TEST=ON"
     $env:CI = '-DCI_TEST="1"'
     $env:RUN = "test"

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -63,7 +63,7 @@ fi
 
 cmake \
     -G'Unix Makefiles' \
-    -DACTIVE_NETWORK=nano_test_network \
+    -DACTIVE_NETWORK=nano_dev_network \
     -DNANO_TEST=ON \
     -DNANO_GUI=ON \
     -DNANO_ROCKSDB=ON \

--- a/docker/node/build.sh
+++ b/docker/node/build.sh
@@ -3,7 +3,7 @@
 network='live'
 
 print_usage() {
-	echo 'build.sh [-h] [-n {live|beta|test}]'
+	echo 'build.sh [-h] [-n {live|beta|dev}]'
 }
 
 while getopts 'hn:' OPT; do
@@ -26,7 +26,7 @@ case "${network}" in
 	live)
 		network_tag=''
 		;;
-	test|beta)
+	dev|beta)
 		network_tag="-${network}"
 		;;
 	*)

--- a/docker/node/entry.sh
+++ b/docker/node/entry.sh
@@ -81,8 +81,8 @@ case "${network}" in
 	beta)
 	dirSuffix='Beta'
 	;;
-	test)
-	dirSuffix='Test'
+	dev)
+	dirSuffix='Dev'
 	;;
 esac
 

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -22,7 +22,7 @@ TEST (active_transactions, confirm_active)
 	            .previous (genesis.hash ())
 	            .destination (nano::public_key ())
 	            .balance (nano::genesis_amount - 100)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send).code);
@@ -43,13 +43,13 @@ TEST (active_transactions, confirm_active)
 	auto election = node2.active.election (send->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	// Add key to node1
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Add representative to disabled rep crawler
 	auto peers (node2.network.random_set (1));
 	ASSERT_FALSE (peers.empty ());
 	{
 		nano::lock_guard<std::mutex> guard (node2.rep_crawler.probable_reps_mutex);
-		node2.rep_crawler.probable_reps.emplace (nano::test_genesis_key.pub, nano::genesis_amount, *peers.begin ());
+		node2.rep_crawler.probable_reps.emplace (nano::dev_genesis_key.pub, nano::genesis_amount, *peers.begin ());
 	}
 	ASSERT_TIMELY (10s, node2.ledger.cache.cemented_count == 2 && node2.active.empty ());
 	// At least one confirmation request
@@ -72,7 +72,7 @@ TEST (active_transactions, confirm_frontier)
 	            .previous (genesis.hash ())
 	            .destination (nano::public_key ())
 	            .balance (nano::genesis_amount - 100)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send).code);
@@ -86,13 +86,13 @@ TEST (active_transactions, confirm_frontier)
 	auto election = node2.active.election (send->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	// Add key to node1
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Add representative to disabled rep crawler
 	auto peers (node2.network.random_set (1));
 	ASSERT_FALSE (peers.empty ());
 	{
 		nano::lock_guard<std::mutex> guard (node2.rep_crawler.probable_reps_mutex);
-		node2.rep_crawler.probable_reps.emplace (nano::test_genesis_key.pub, nano::genesis_amount, *peers.begin ());
+		node2.rep_crawler.probable_reps.emplace (nano::dev_genesis_key.pub, nano::genesis_amount, *peers.begin ());
 	}
 	ASSERT_TIMELY (5s, node2.ledger.cache.cemented_count == 2 && node2.active.empty ());
 	ASSERT_GT (election->confirmation_request_count, 0u);
@@ -110,21 +110,21 @@ TEST (active_transactions, adjusted_multiplier_priority)
 
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (nano::genesis_hash)
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (nano::genesis_hash))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 20 * nano::xrb_ratio)
 	             .link (key2.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto open1 = builder.make_block ()
@@ -177,21 +177,21 @@ TEST (active_transactions, adjusted_multiplier_priority)
 	//genesis and key1,key2 are opened
 	//start chain of 2 on each
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (9 * nano::xrb_ratio)
 	             .link (key3.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send2->hash (), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base)))
 	             .build_shared ();
 	auto send4 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send3->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (8 * nano::xrb_ratio)
 	             .link (key3.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send3->hash (), nano::difficulty::from_multiplier (150, node1.network_params.network.publish_thresholds.base)))
 	             .build_shared ();
 	auto send5 = builder.make_block ()
@@ -272,13 +272,13 @@ TEST (active_transactions, keep_local)
 	nano::genesis genesis;
 	//key 1/2 will be managed by the wallet
 	nano::keypair key1, key2, key3, key4, key5, key6;
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (wallet.send_action (nano::test_genesis_key.pub, key1.pub, node.config.receive_minimum.number ()));
-	auto send2 (wallet.send_action (nano::test_genesis_key.pub, key2.pub, node.config.receive_minimum.number ()));
-	auto send3 (wallet.send_action (nano::test_genesis_key.pub, key3.pub, node.config.receive_minimum.number ()));
-	auto send4 (wallet.send_action (nano::test_genesis_key.pub, key4.pub, node.config.receive_minimum.number ()));
-	auto send5 (wallet.send_action (nano::test_genesis_key.pub, key5.pub, node.config.receive_minimum.number ()));
-	auto send6 (wallet.send_action (nano::test_genesis_key.pub, key6.pub, node.config.receive_minimum.number ()));
+	wallet.insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (wallet.send_action (nano::dev_genesis_key.pub, key1.pub, node.config.receive_minimum.number ()));
+	auto send2 (wallet.send_action (nano::dev_genesis_key.pub, key2.pub, node.config.receive_minimum.number ()));
+	auto send3 (wallet.send_action (nano::dev_genesis_key.pub, key3.pub, node.config.receive_minimum.number ()));
+	auto send4 (wallet.send_action (nano::dev_genesis_key.pub, key4.pub, node.config.receive_minimum.number ()));
+	auto send5 (wallet.send_action (nano::dev_genesis_key.pub, key5.pub, node.config.receive_minimum.number ()));
+	auto send6 (wallet.send_action (nano::dev_genesis_key.pub, key6.pub, node.config.receive_minimum.number ()));
 	// should not drop wallet created transactions
 	ASSERT_TIMELY (5s, node.active.size () == 6);
 	ASSERT_EQ (0, node.active.recently_dropped.size ());
@@ -342,12 +342,12 @@ TEST (active_transactions, prioritize_chains)
 
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto open1 = builder.make_block ()
@@ -387,7 +387,7 @@ TEST (active_transactions, prioritize_chains)
 	             .previous (send1->hash ())
 	             .balance (nano::genesis_amount - 20 * nano::xrb_ratio)
 	             .link (key2.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto send6 = builder.make_block ()
@@ -395,7 +395,7 @@ TEST (active_transactions, prioritize_chains)
 	             .previous (send5->hash ())
 	             .balance (nano::genesis_amount - 30 * nano::xrb_ratio)
 	             .link (key3.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send5->hash ()))
 	             .build_shared ();
 	auto open2 = builder.make_block ()
@@ -455,16 +455,16 @@ TEST (active_transactions, inactive_votes_cache)
 {
 	nano::system system (1);
 	auto & node = *system.nodes[0];
-	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node.latest (nano::dev_genesis_key.pub));
 	nano::keypair key;
 	auto send = nano::send_block_builder ()
 	            .previous (latest)
 	            .destination (key.pub)
 	            .balance (nano::genesis_amount - 100)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (latest))
 	            .build_shared ();
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send->hash ())));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send->hash ())));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 1);
 	node.process_active (send);
@@ -477,24 +477,24 @@ TEST (active_transactions, inactive_votes_cache_fork)
 {
 	nano::system system (1);
 	auto & node = *system.nodes[0];
-	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node.latest (nano::dev_genesis_key.pub));
 	nano::keypair key;
 	nano::send_block_builder builder;
 	auto send1 = builder.make_block ()
 	             .previous (latest)
 	             .destination (key.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (latest))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .previous (latest)
 	             .destination (key.pub)
 	             .balance (nano::genesis_amount - 200)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (latest))
 	             .build_shared ();
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	auto channel1 (node.network.udp_channels.create (node.network.endpoint ()));
 	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 1);
@@ -520,14 +520,14 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
-	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node.latest (nano::dev_genesis_key.pub));
 	nano::keypair key;
 	nano::block_builder builder;
 	auto send = builder.send ()
 	            .previous (latest)
 	            .destination (key.pub)
 	            .balance (nano::genesis_amount - 100 * nano::Gxrb_ratio)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (latest))
 	            .build_shared ();
 	auto open = builder.state ()
@@ -587,21 +587,21 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
-	nano::block_hash latest (node.latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node.latest (nano::dev_genesis_key.pub));
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto send1 = builder.send ()
 	             .previous (latest)
 	             .destination (key1.pub)
 	             .balance (nano::genesis_amount - 100 * nano::Gxrb_ratio)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (latest))
 	             .build_shared ();
 	auto send2 = builder.send ()
 	             .previous (send1->hash ())
 	             .destination (key1.pub)
 	             .balance (100 * nano::Gxrb_ratio)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto open = builder.state ()
@@ -620,7 +620,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	// Process votes
 	auto vote1 (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
 	node.vote_processor.vote (vote1, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
-	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
+	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, std::vector<nano::block_hash> (1, send1->hash ())));
 	node.vote_processor.vote (vote2, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	system.deadline_set (5s);
 	while (true)
@@ -656,23 +656,23 @@ TEST (active_transactions, update_difficulty)
 	// Generate blocks & start elections
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 100)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto difficulty1 (send1->difficulty ());
 	auto multiplier1 (nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty1, nano::work_threshold (send1->work_version (), nano::block_details (nano::epoch::epoch_0, true, false, false))), node1.network_params.network.publish_thresholds.epoch_1));
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 200)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto difficulty2 (send2->difficulty ());
@@ -737,12 +737,12 @@ TEST (active_transactions, vote_replays)
 	nano::keypair key;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	ASSERT_NE (nullptr, send1);
@@ -761,7 +761,7 @@ TEST (active_transactions, vote_replays)
 	nano::blocks_confirm (node, { send1, open1 });
 	ASSERT_EQ (2, node.active.size ());
 	// First vote is not a replay and confirms the election, second vote should be a replay since the election has confirmed but not yet removed
-	auto vote_send1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, send1));
+	auto vote_send1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, send1));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote_send1));
 	ASSERT_EQ (2, node.active.size ());
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_send1));
@@ -769,7 +769,7 @@ TEST (active_transactions, vote_replays)
 	ASSERT_TIMELY (3s, node.active.size () == 1);
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_send1));
 	// Open new account
-	auto vote_open1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, open1));
+	auto vote_open1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, open1));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote_open1));
 	ASSERT_EQ (1, node.active.size ());
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_open1));
@@ -790,7 +790,7 @@ TEST (active_transactions, vote_replays)
 	node.process_active (send2);
 	nano::blocks_confirm (node, { send2 });
 	ASSERT_EQ (1, node.active.size ());
-	auto vote1_send2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, send2));
+	auto vote1_send2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, send2));
 	auto vote2_send2 (std::make_shared<nano::vote> (key.pub, key.prv, 0, send2));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote2_send2));
 	ASSERT_EQ (1, node.active.size ());
@@ -828,16 +828,16 @@ TEST (active_transactions, activate_dependencies)
 	auto node1 (system.add_node (config, flags));
 	config.peering_port = nano::get_available_port ();
 	auto node2 (system.add_node (config, flags));
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::genesis genesis;
 	nano::block_builder builder;
 	auto block0 = builder.state ()
-	              .account (nano::test_genesis_key.pub)
+	              .account (nano::dev_genesis_key.pub)
 	              .previous (genesis.hash ())
-	              .representative (nano::test_genesis_key.pub)
+	              .representative (nano::dev_genesis_key.pub)
 	              .balance (nano::genesis_amount - nano::Gxrb_ratio)
 	              .link (0)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (node1->work_generate_blocking (genesis.hash ()).value ())
 	              .build_shared ();
 	// Establish a representative
@@ -845,12 +845,12 @@ TEST (active_transactions, activate_dependencies)
 	node2->block_processor.flush ();
 	ASSERT_TIMELY (10s, node1->block (block0->hash ()));
 	auto block1 = builder.state ()
-	              .account (nano::test_genesis_key.pub)
+	              .account (nano::dev_genesis_key.pub)
 	              .previous (block0->hash ())
-	              .representative (nano::test_genesis_key.pub)
+	              .representative (nano::dev_genesis_key.pub)
 	              .balance (nano::genesis_amount - nano::Gxrb_ratio)
 	              .link (0)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (node1->work_generate_blocking (block0->hash ()).value ())
 	              .build ();
 	// Wait for confirmation of the previous block, which tries to activate the successor
@@ -861,12 +861,12 @@ TEST (active_transactions, activate_dependencies)
 		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction, *block1).code);
 	}
 	std::shared_ptr<nano::block> block2 = builder.state ()
-	                                      .account (nano::test_genesis_key.pub)
+	                                      .account (nano::dev_genesis_key.pub)
 	                                      .previous (block1->hash ())
-	                                      .representative (nano::test_genesis_key.pub)
+	                                      .representative (nano::dev_genesis_key.pub)
 	                                      .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
 	                                      .link (0)
-	                                      .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                      .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                      .work (node1->work_generate_blocking (block1->hash ()).value ())
 	                                      .build ();
 	node2->process_active (block2);
@@ -954,10 +954,10 @@ TEST (active_transactions, confirmation_consistency)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	for (unsigned i = 0; i < 10; ++i)
 	{
-		auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::public_key (), node.config.receive_minimum.number ()));
+		auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::public_key (), node.config.receive_minimum.number ()));
 		ASSERT_NE (nullptr, block);
 		system.deadline_set (5s);
 		while (!node.ledger.block_confirmed (node.store.tx_begin_read (), block->hash ()))
@@ -986,66 +986,66 @@ TEST (active_transactions, insertion_prioritization)
 	auto & node = *system.add_node (node_config, node_flags);
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (nano::genesis_hash)
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (nano::genesis_hash))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 20 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 30 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send2->hash ()))
 	             .build_shared ();
 	auto send4 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send3->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 40 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send3->hash ()))
 	             .build_shared ();
 	auto send5 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send4->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 50 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send4->hash ()))
 	             .build_shared ();
 	auto send6 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send5->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 60 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send5->hash ()))
 	             .build_shared ();
 	auto send7 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send6->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 70 * nano::xrb_ratio)
 	             .link (nano::public_key ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send6->hash ()))
 	             .build_shared ();
 	// Sort by difficulty, descending
@@ -1178,12 +1178,12 @@ TEST (active_transactions, election_difficulty_update_old)
 	nano::keypair key;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 10 * nano::xrb_ratio)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send1_copy = builder.make_block ().from (*send1).build_shared ();
@@ -1226,12 +1226,12 @@ TEST (active_transactions, election_difficulty_update_fork)
 	nano::keypair key;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (epoch2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (epoch2->hash ()))
 	             .build_shared ();
 	auto open1 = builder.make_block ()
@@ -1244,12 +1244,12 @@ TEST (active_transactions, election_difficulty_update_fork)
 	             .work (*system.work.generate (key.pub))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
@@ -1274,7 +1274,7 @@ TEST (active_transactions, election_difficulty_update_fork)
 	auto fork_change = builder.make_block ()
 	                   .account (key.pub)
 	                   .previous (open1->hash ())
-	                   .representative (nano::test_genesis_key.pub)
+	                   .representative (nano::dev_genesis_key.pub)
 	                   .balance (nano::Gxrb_ratio)
 	                   .link (0)
 	                   .sign (key.prv, key.pub)
@@ -1346,7 +1346,7 @@ TEST (active_transactions, confirm_new)
 	            .previous (genesis.hash ())
 	            .destination (nano::public_key ())
 	            .balance (nano::genesis_amount - 100)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared ();
 	node1.process_active (send);
@@ -1354,7 +1354,7 @@ TEST (active_transactions, confirm_new)
 	ASSERT_EQ (1, node1.active.size ());
 	auto & node2 = *system.add_node ();
 	// Add key to node2
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Let node2 know about the block
 	ASSERT_TIMELY (5s, node2.block (send->hash ()));
 	// Wait confirmation
@@ -1369,12 +1369,12 @@ TEST (active_transactions, restart_dropped)
 	auto & node = *system.add_node (node_config);
 	nano::genesis genesis;
 	auto send = nano::state_block_builder ()
-	            .account (nano::test_genesis_key.pub)
+	            .account (nano::dev_genesis_key.pub)
 	            .previous (genesis.hash ())
-	            .representative (nano::test_genesis_key.pub)
+	            .representative (nano::dev_genesis_key.pub)
 	            .balance (nano::genesis_amount - nano::xrb_ratio)
-	            .link (nano::test_genesis_key.pub)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .link (nano::dev_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared (); // Process only in ledger and simulate dropping the election
 	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
@@ -1406,7 +1406,7 @@ TEST (active_transactions, restart_dropped)
 	// Generate even higher difficulty work
 	ASSERT_TRUE (node.work_generate_blocking (*send, send->difficulty () + 1).is_initialized ());
 	// Add voting
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Process the same block with updated work
 	ASSERT_EQ (0, node.active.size ());
 	node.process_active (send);
@@ -1429,24 +1429,24 @@ TEST (active_transactions, conflicting_block_vote_existing_election)
 	nano::keypair key;
 	nano::state_block_builder builder;
 	auto send = builder.make_block ()
-	            .account (nano::test_genesis_key.pub)
+	            .account (nano::dev_genesis_key.pub)
 	            .previous (genesis.hash ())
-	            .representative (nano::test_genesis_key.pub)
+	            .representative (nano::dev_genesis_key.pub)
 	            .balance (nano::genesis_amount - 100)
 	            .link (key.pub)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared ();
 	auto fork = builder.make_block ()
-	            .account (nano::test_genesis_key.pub)
+	            .account (nano::dev_genesis_key.pub)
 	            .previous (genesis.hash ())
-	            .representative (nano::test_genesis_key.pub)
+	            .representative (nano::dev_genesis_key.pub)
 	            .balance (nano::genesis_amount - 200)
 	            .link (key.pub)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared ();
-	auto vote_fork (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, fork));
+	auto vote_fork (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, fork));
 
 	ASSERT_EQ (nano::process_result::progress, node.process_local (send).code);
 	ASSERT_EQ (1, node.active.size ());
@@ -1474,30 +1474,30 @@ TEST (active_transactions, activate_account_chain)
 	nano::keypair key;
 	nano::state_block_builder builder;
 	auto send = builder.make_block ()
-	            .account (nano::test_genesis_key.pub)
+	            .account (nano::dev_genesis_key.pub)
 	            .previous (nano::genesis_hash)
-	            .representative (nano::test_genesis_key.pub)
-	            .link (nano::test_genesis_key.pub)
+	            .representative (nano::dev_genesis_key.pub)
+	            .link (nano::dev_genesis_key.pub)
 	            .balance (nano::genesis_amount - 1)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (nano::genesis_hash))
 	            .build ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .link (key.pub)
 	             .balance (nano::genesis_amount - 2)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send->hash ()))
 	             .build ();
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .link (key.pub)
 	             .balance (nano::genesis_amount - 3)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send2->hash ()))
 	             .build ();
 	auto open = builder.make_block ()
@@ -1524,11 +1524,11 @@ TEST (active_transactions, activate_account_chain)
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive).code);
 
-	auto result = node.active.activate (nano::test_genesis_key.pub);
+	auto result = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_TRUE (result.inserted);
 	ASSERT_EQ (1, node.active.size ());
 	ASSERT_EQ (1, result.election->blocks.count (send->hash ()));
-	auto result2 = node.active.activate (nano::test_genesis_key.pub);
+	auto result2 = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_FALSE (result2.inserted);
 	ASSERT_EQ (result2.election, result.election);
 	{
@@ -1538,7 +1538,7 @@ TEST (active_transactions, activate_account_chain)
 	ASSERT_TIMELY (3s, node.block_confirmed (send->hash ()));
 	// On cementing, the next election is started
 	ASSERT_TIMELY (3s, node.active.active (send2->qualified_root ()));
-	auto result3 = node.active.activate (nano::test_genesis_key.pub);
+	auto result3 = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_FALSE (result3.inserted);
 	ASSERT_NE (nullptr, result3.election);
 	ASSERT_EQ (1, result3.election->blocks.count (send2->hash ()));
@@ -1550,7 +1550,7 @@ TEST (active_transactions, activate_account_chain)
 	// On cementing, the next election is started
 	ASSERT_TIMELY (3s, node.active.active (open->qualified_root ()));
 	ASSERT_TIMELY (3s, node.active.active (send3->qualified_root ()));
-	auto result4 = node.active.activate (nano::test_genesis_key.pub);
+	auto result4 = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_FALSE (result4.inserted);
 	ASSERT_NE (nullptr, result4.election);
 	ASSERT_EQ (1, result4.election->blocks.count (send3->hash ()));

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -346,10 +346,10 @@ TEST (block_store, genesis)
 	ASSERT_FALSE (store->confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 1);
 	ASSERT_EQ (confirmation_height_info.frontier, hash);
-	auto test_pub_text (nano::test_genesis_key.pub.to_string ());
-	auto test_pub_account (nano::test_genesis_key.pub.to_account ());
-	auto test_prv_text (nano::test_genesis_key.prv.data.to_string ());
-	ASSERT_EQ (nano::genesis_account, nano::test_genesis_key.pub);
+	auto dev_pub_text (nano::dev_genesis_key.pub.to_string ());
+	auto dev_pub_account (nano::dev_genesis_key.pub.to_account ());
+	auto dev_prv_text (nano::dev_genesis_key.prv.data.to_string ());
+	ASSERT_EQ (nano::genesis_account, nano::dev_genesis_key.pub);
 }
 
 TEST (bootstrap, simple)
@@ -919,8 +919,8 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked, 1));
 	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked));
-	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	auto send2 (std::make_shared<nano::send_block> (1, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (1, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	ASSERT_NE (send1->hash (), send2->hash ());
 	store.unchecked_put (transaction, send1->hash (), send1);
 	store.unchecked_put (transaction, send1->hash (), send2);
@@ -963,7 +963,7 @@ TEST (block_store, sequence_flush)
 	ASSERT_FALSE (store->init_error ());
 	auto transaction (store->tx_begin_write ());
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	auto vote1 (store->vote_generate (transaction, key1.pub, key1.prv, send1));
 	auto seq2 (store->vote_get (transaction, vote1->account));
 	ASSERT_EQ (nullptr, seq2);
@@ -1038,29 +1038,29 @@ TEST (mdb_block_store, sideband_height)
 	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send (genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send (genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	nano::receive_block receive (send.hash (), send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send.hash ()));
+	nano::receive_block receive (send.hash (), send.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-	nano::change_block change (receive.hash (), 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (receive.hash ()));
+	nano::change_block change (receive.hash (), 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (receive.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
-	nano::state_block state_send1 (nano::test_genesis_key.pub, change.hash (), 0, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (change.hash ()));
+	nano::state_block state_send1 (nano::dev_genesis_key.pub, change.hash (), 0, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (change.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send1).code);
-	nano::state_block state_send2 (nano::test_genesis_key.pub, state_send1.hash (), 0, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_send1.hash ()));
+	nano::state_block state_send2 (nano::dev_genesis_key.pub, state_send1.hash (), 0, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send2).code);
-	nano::state_block state_send3 (nano::test_genesis_key.pub, state_send2.hash (), 0, nano::genesis_amount - 3 * nano::Gxrb_ratio, key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_send2.hash ()));
+	nano::state_block state_send3 (nano::dev_genesis_key.pub, state_send2.hash (), 0, nano::genesis_amount - 3 * nano::Gxrb_ratio, key3.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_send2.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send3).code);
 	nano::state_block state_open (key1.pub, 0, 0, nano::Gxrb_ratio, state_send1.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_open).code);
-	nano::state_block epoch (key1.pub, state_open.hash (), 0, nano::Gxrb_ratio, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_open.hash ()));
+	nano::state_block epoch (key1.pub, state_open.hash (), 0, nano::Gxrb_ratio, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_open.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch).code);
 	ASSERT_EQ (nano::epoch::epoch_1, store.block_version (transaction, epoch.hash ()));
-	nano::state_block epoch_open (key2.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (key2.pub));
+	nano::state_block epoch_open (key2.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch_open).code);
 	ASSERT_EQ (nano::epoch::epoch_1, store.block_version (transaction, epoch_open.hash ()));
 	nano::state_block state_receive (key2.pub, epoch_open.hash (), 0, nano::Gxrb_ratio, state_send2.hash (), key2.prv, key2.pub, *pool.generate (epoch_open.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive).code);
-	nano::open_block open (state_send3.hash (), nano::test_genesis_key.pub, key3.pub, key3.prv, key3.pub, *pool.generate (key3.pub));
+	nano::open_block open (state_send3.hash (), nano::dev_genesis_key.pub, key3.pub, key3.prv, key3.pub, *pool.generate (key3.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
 	auto block1 (store.block_get (transaction, genesis.hash ()));
 	ASSERT_EQ (block1->sideband ().height, 1);
@@ -1218,9 +1218,9 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	nano::genesis genesis;
 	nano::network_params network_params;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send (genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
-	nano::state_block epoch (nano::test_genesis_key.pub, send.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send.hash ()));
-	nano::state_block state_send (nano::test_genesis_key.pub, epoch.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch.hash ()));
+	nano::send_block send (genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block epoch (nano::dev_genesis_key.pub, send.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send.hash ()));
+	nano::state_block state_send (nano::dev_genesis_key.pub, epoch.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch.hash ()));
 	{
 		nano::logger_mt logger;
 		nano::mdb_store store (logger, path);
@@ -1261,8 +1261,8 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		store.block_del (transaction, epoch.hash ());
 
 		// Turn pending into v14
-		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v0, nano::mdb_val (nano::pending_key (nano::test_genesis_key.pub, send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_0)), 0));
-		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v1, nano::mdb_val (nano::pending_key (nano::test_genesis_key.pub, state_send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_1)), 0));
+		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v0, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_0)), 0));
+		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v1, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_1)), 0));
 
 		// This should fail as sizes are no longer correct for account_info
 		nano::mdb_val value;
@@ -1296,7 +1296,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	// accounts_v1, state_blocks_v1 & pending_v1 tables should be deleted
 	auto error_get_accounts_v1 (mdb_get (store.env.tx (transaction), store.accounts_v1, nano::mdb_val (nano::genesis_account), value));
 	ASSERT_NE (error_get_accounts_v1, MDB_SUCCESS);
-	auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_v1, nano::mdb_val (nano::pending_key (nano::test_genesis_key.pub, state_send.hash ())), value));
+	auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_v1, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ())), value));
 	ASSERT_NE (error_get_pending_v1, MDB_SUCCESS);
 	auto error_get_state_v1 (mdb_get (store.env.tx (transaction), store.state_blocks_v1, nano::mdb_val (state_send.hash ()), value));
 	ASSERT_NE (error_get_state_v1, MDB_SUCCESS);
@@ -1310,9 +1310,9 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_0);
 	ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);
 	nano::pending_info pending_info;
-	store.pending_get (transaction, nano::pending_key (nano::test_genesis_key.pub, send.hash ()), pending_info);
+	store.pending_get (transaction, nano::pending_key (nano::dev_genesis_key.pub, send.hash ()), pending_info);
 	ASSERT_EQ (pending_info.epoch, nano::epoch::epoch_0);
-	store.pending_get (transaction, nano::pending_key (nano::test_genesis_key.pub, state_send.hash ()), pending_info);
+	store.pending_get (transaction, nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ()), pending_info);
 	ASSERT_EQ (pending_info.epoch, nano::epoch::epoch_1);
 
 	// Version should be correct
@@ -1364,9 +1364,9 @@ TEST (mdb_block_store, upgrade_v16_v17)
 {
 	nano::genesis genesis;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block block1 (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
-	nano::state_block block2 (nano::test_genesis_key.pub, block1.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio - 1, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
-	nano::state_block block3 (nano::test_genesis_key.pub, block2.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio - 2, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block2.hash ()));
+	nano::state_block block1 (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block block2 (nano::dev_genesis_key.pub, block1.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio - 1, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::state_block block3 (nano::dev_genesis_key.pub, block2.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio - 2, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block2.hash ()));
 
 	auto code = [&block1, &block2, &block3](auto confirmation_height, nano::block_hash const & expected_cemented_frontier) {
 		auto path (nano::unique_path ());
@@ -1428,16 +1428,16 @@ TEST (mdb_block_store, upgrade_v17_v18)
 	nano::keypair key3;
 	nano::network_params network_params;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send_zero (genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
-	nano::state_block state_receive_zero (nano::test_genesis_key.pub, send_zero.hash (), nano::test_genesis_key.pub, nano::genesis_amount, send_zero.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send_zero.hash ()));
-	nano::state_block epoch (nano::test_genesis_key.pub, state_receive_zero.hash (), nano::test_genesis_key.pub, nano::genesis_amount, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_receive_zero.hash ()));
-	nano::state_block state_send (nano::test_genesis_key.pub, epoch.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch.hash ()));
-	nano::state_block state_receive (nano::test_genesis_key.pub, state_send.hash (), nano::test_genesis_key.pub, nano::genesis_amount, state_send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_send.hash ()));
-	nano::state_block state_change (nano::test_genesis_key.pub, state_receive.hash (), nano::test_genesis_key.pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_receive.hash ()));
-	nano::state_block state_send_change (nano::test_genesis_key.pub, state_change.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_change.hash ()));
-	nano::state_block epoch_first (key1.pub, 0, 0, 0, network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (key1.pub));
+	nano::send_block send_zero (genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block state_receive_zero (nano::dev_genesis_key.pub, send_zero.hash (), nano::dev_genesis_key.pub, nano::genesis_amount, send_zero.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send_zero.hash ()));
+	nano::state_block epoch (nano::dev_genesis_key.pub, state_receive_zero.hash (), nano::dev_genesis_key.pub, nano::genesis_amount, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_receive_zero.hash ()));
+	nano::state_block state_send (nano::dev_genesis_key.pub, epoch.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch.hash ()));
+	nano::state_block state_receive (nano::dev_genesis_key.pub, state_send.hash (), nano::dev_genesis_key.pub, nano::genesis_amount, state_send.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_send.hash ()));
+	nano::state_block state_change (nano::dev_genesis_key.pub, state_receive.hash (), nano::dev_genesis_key.pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_receive.hash ()));
+	nano::state_block state_send_change (nano::dev_genesis_key.pub, state_change.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_change.hash ()));
+	nano::state_block epoch_first (key1.pub, 0, 0, 0, network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (key1.pub));
 	nano::state_block state_receive2 (key1.pub, epoch_first.hash (), key1.pub, nano::Gxrb_ratio, state_send_change.hash (), key1.prv, key1.pub, *pool.generate (epoch_first.hash ()));
-	nano::state_block state_send2 (nano::test_genesis_key.pub, state_send_change.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (state_send_change.hash ()));
+	nano::state_block state_send2 (nano::dev_genesis_key.pub, state_send_change.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (state_send_change.hash ()));
 	nano::state_block state_open (key2.pub, 0, key2.pub, nano::Gxrb_ratio, state_send2.hash (), key2.prv, key2.pub, *pool.generate (key2.pub));
 	nano::state_block state_send_epoch_link (key2.pub, state_open.hash (), key2.pub, 0, network_params.ledger.epochs.link (nano::epoch::epoch_2), key2.prv, key2.pub, *pool.generate (state_open.hash ()));
 	{
@@ -1623,10 +1623,10 @@ TEST (mdb_block_store, upgrade_v18_v19)
 	auto path (nano::unique_path ());
 	nano::keypair key1;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send (nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (nano::genesis_hash));
-	nano::receive_block receive (send.hash (), send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send.hash ()));
-	nano::change_block change (receive.hash (), 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (receive.hash ()));
-	nano::state_block state (nano::test_genesis_key.pub, change.hash (), 0, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (change.hash ()));
+	nano::send_block send (nano::genesis_hash, nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
+	nano::receive_block receive (send.hash (), send.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send.hash ()));
+	nano::change_block change (receive.hash (), 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (receive.hash ()));
+	nano::state_block state (nano::dev_genesis_key.pub, change.hash (), 0, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (change.hash ()));
 
 	{
 		nano::genesis genesis;

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -26,11 +26,11 @@ TEST (bulk_pull, genesis_to_end)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
-	req->start = nano::test_genesis_key.pub;
+	req->start = nano::dev_genesis_key.pub;
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::bulk_pull_server> (connection, std::move (req)));
-	ASSERT_EQ (system.nodes[0]->latest (nano::test_genesis_key.pub), request->current);
+	ASSERT_EQ (system.nodes[0]->latest (nano::dev_genesis_key.pub), request->current);
 	ASSERT_EQ (request->request->end, request->request->end);
 }
 
@@ -40,11 +40,11 @@ TEST (bulk_pull, no_end)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
-	req->start = nano::test_genesis_key.pub;
+	req->start = nano::dev_genesis_key.pub;
 	req->end = 1;
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::bulk_pull_server> (connection, std::move (req)));
-	ASSERT_EQ (system.nodes[0]->latest (nano::test_genesis_key.pub), request->current);
+	ASSERT_EQ (system.nodes[0]->latest (nano::dev_genesis_key.pub), request->current);
 	ASSERT_TRUE (request->request->end.is_zero ());
 }
 
@@ -52,9 +52,9 @@ TEST (bulk_pull, end_not_owned)
 {
 	nano::system system (1);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, 100));
-	nano::block_hash latest (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, 100));
+	nano::block_hash latest (system.nodes[0]->latest (nano::dev_genesis_key.pub));
 	nano::open_block open (0, 1, 2, nano::keypair ().prv, 4, 5);
 	open.hashables.account = key2.pub;
 	open.hashables.representative = key2.pub;
@@ -79,7 +79,7 @@ TEST (bulk_pull, none)
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	nano::genesis genesis;
 	auto req = std::make_unique<nano::bulk_pull> ();
-	req->start = nano::test_genesis_key.pub;
+	req->start = nano::dev_genesis_key.pub;
 	req->end = genesis.hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::bulk_pull_server> (connection, std::move (req)));
@@ -92,7 +92,7 @@ TEST (bulk_pull, get_next_on_open)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
-	req->start = nano::test_genesis_key.pub;
+	req->start = nano::dev_genesis_key.pub;
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::bulk_pull_server> (connection, std::move (req)));
@@ -144,9 +144,9 @@ TEST (bulk_pull, count_limit)
 	nano::system system (1);
 	nano::genesis genesis;
 
-	auto send1 (std::make_shared<nano::send_block> (system.nodes[0]->latest (nano::test_genesis_key.pub), nano::test_genesis_key.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (system.nodes[0]->latest (nano::test_genesis_key.pub))));
+	auto send1 (std::make_shared<nano::send_block> (system.nodes[0]->latest (nano::dev_genesis_key.pub), nano::dev_genesis_key.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (system.nodes[0]->latest (nano::dev_genesis_key.pub))));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*send1).code);
-	auto receive1 (std::make_shared<nano::receive_block> (send1->hash (), send1->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto receive1 (std::make_shared<nano::receive_block> (send1->hash (), send1->hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*receive1).code);
 
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
@@ -194,18 +194,18 @@ TEST (bootstrap_processor, process_one)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node0 = system.add_node (node_config, node_flags);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 100));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, 100));
 
 	node_config.peering_port = nano::get_available_port ();
 	node_flags.disable_rep_crawler = true;
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), system.alarm, node_config, system.work, node_flags));
-	nano::block_hash hash1 (node0->latest (nano::test_genesis_key.pub));
-	nano::block_hash hash2 (node1->latest (nano::test_genesis_key.pub));
+	nano::block_hash hash1 (node0->latest (nano::dev_genesis_key.pub));
+	nano::block_hash hash2 (node1->latest (nano::dev_genesis_key.pub));
 	ASSERT_NE (hash1, hash2);
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	ASSERT_NE (node1->latest (nano::test_genesis_key.pub), node0->latest (nano::test_genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::test_genesis_key.pub) == node0->latest (nano::test_genesis_key.pub));
+	ASSERT_NE (node1->latest (nano::dev_genesis_key.pub), node0->latest (nano::dev_genesis_key.pub));
+	ASSERT_TIMELY (10s, node1->latest (nano::dev_genesis_key.pub) == node0->latest (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, node1->active.size ());
 	node1->stop ();
 }
@@ -218,20 +218,20 @@ TEST (bootstrap_processor, process_two)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node0 (system.add_node (config, node_flags));
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash hash1 (node0->latest (nano::test_genesis_key.pub));
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 50));
-	nano::block_hash hash2 (node0->latest (nano::test_genesis_key.pub));
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 50));
-	nano::block_hash hash3 (node0->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	nano::block_hash hash1 (node0->latest (nano::dev_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, 50));
+	nano::block_hash hash2 (node0->latest (nano::dev_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, 50));
+	nano::block_hash hash3 (node0->latest (nano::dev_genesis_key.pub));
 	ASSERT_NE (hash1, hash2);
 	ASSERT_NE (hash1, hash3);
 	ASSERT_NE (hash2, hash3);
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	ASSERT_NE (node1->latest (nano::test_genesis_key.pub), node0->latest (nano::test_genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::test_genesis_key.pub) == node0->latest (nano::test_genesis_key.pub));
+	ASSERT_NE (node1->latest (nano::dev_genesis_key.pub), node0->latest (nano::dev_genesis_key.pub));
+	ASSERT_TIMELY (10s, node1->latest (nano::dev_genesis_key.pub) == node0->latest (nano::dev_genesis_key.pub));
 	node1->stop ();
 }
 
@@ -245,19 +245,19 @@ TEST (bootstrap_processor, process_state)
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node0 (system.add_node (config, node_flags));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto block1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, node0->latest (nano::test_genesis_key.pub), nano::test_genesis_key.pub, nano::genesis_amount - 100, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
-	auto block2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, block1->hash (), nano::test_genesis_key.pub, nano::genesis_amount, block1->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto block1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, node0->latest (nano::dev_genesis_key.pub), nano::dev_genesis_key.pub, nano::genesis_amount - 100, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
+	auto block2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, block1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount, block1->hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node0->work_generate_blocking (*block1);
 	node0->work_generate_blocking (*block2);
 	node0->process (*block1);
 	node0->process (*block2);
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
-	ASSERT_EQ (node0->latest (nano::test_genesis_key.pub), block2->hash ());
-	ASSERT_NE (node1->latest (nano::test_genesis_key.pub), block2->hash ());
+	ASSERT_EQ (node0->latest (nano::dev_genesis_key.pub), block2->hash ());
+	ASSERT_NE (node1->latest (nano::dev_genesis_key.pub), block2->hash ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	ASSERT_NE (node1->latest (nano::test_genesis_key.pub), node0->latest (nano::test_genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::test_genesis_key.pub) == node0->latest (nano::test_genesis_key.pub));
+	ASSERT_NE (node1->latest (nano::dev_genesis_key.pub), node0->latest (nano::dev_genesis_key.pub));
+	ASSERT_TIMELY (10s, node1->latest (nano::dev_genesis_key.pub) == node0->latest (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, node1->active.size ());
 	node1->stop ();
 }
@@ -272,18 +272,18 @@ TEST (bootstrap_processor, process_new)
 	auto node1 (system.add_node (config, node_flags));
 	config.peering_port = nano::get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node1->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node1->config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, !node1->balance (key2.pub).is_zero ());
-	nano::uint128_t balance1 (node1->balance (nano::test_genesis_key.pub));
+	nano::uint128_t balance1 (node1->balance (nano::dev_genesis_key.pub));
 	nano::uint128_t balance2 (node1->balance (key2.pub));
 	auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node3->init_error ());
 	node3->bootstrap_initiator.bootstrap (node1->network.endpoint ());
 	ASSERT_TIMELY (10s, node3->balance (key2.pub) == balance2);
-	ASSERT_EQ (balance1, node3->balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (balance1, node3->balance (nano::dev_genesis_key.pub));
 	node3->stop ();
 }
 
@@ -296,19 +296,19 @@ TEST (bootstrap_processor, pull_diamond)
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node0 (system.add_node (config, node_flags));
 	nano::keypair key;
-	auto send1 (std::make_shared<nano::send_block> (node0->latest (nano::test_genesis_key.pub), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (node0->latest (nano::test_genesis_key.pub))));
+	auto send1 (std::make_shared<nano::send_block> (node0->latest (nano::dev_genesis_key.pub), key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (node0->latest (nano::dev_genesis_key.pub))));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*send1).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), 1, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*open).code);
-	auto send2 (std::make_shared<nano::send_block> (open->hash (), nano::test_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 100, key.prv, key.pub, *system.work.generate (open->hash ())));
+	auto send2 (std::make_shared<nano::send_block> (open->hash (), nano::dev_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 100, key.prv, key.pub, *system.work.generate (open->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*send2).code);
-	auto receive (std::make_shared<nano::receive_block> (send1->hash (), send2->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto receive (std::make_shared<nano::receive_block> (send1->hash (), send2->hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive).code);
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	ASSERT_TIMELY (10s, node1->balance (nano::test_genesis_key.pub) == 100);
-	ASSERT_EQ (100, node1->balance (nano::test_genesis_key.pub));
+	ASSERT_TIMELY (10s, node1->balance (nano::dev_genesis_key.pub) == 100);
+	ASSERT_EQ (100, node1->balance (nano::dev_genesis_key.pub));
 	node1->stop ();
 }
 
@@ -325,7 +325,7 @@ TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 	auto node2 (system.add_node (config, node_flags));
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 
 	node1->bootstrap_initiator.bootstrap (node2->network.endpoint ());
 	auto attempt (node1->bootstrap_initiator.current_attempt ());
@@ -336,7 +336,7 @@ TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 		nano::unique_lock<std::mutex> lock (node1->bootstrap_initiator.connections->mutex);
 		ASSERT_FALSE (attempt->stopped);
 		++attempt->pulling;
-		node1->bootstrap_initiator.connections->pulls.push_back (nano::pull_info (nano::test_genesis_key.pub, send1->hash (), genesis.hash (), attempt->incremental_id));
+		node1->bootstrap_initiator.connections->pulls.push_back (nano::pull_info (nano::dev_genesis_key.pub, send1->hash (), genesis.hash (), attempt->incremental_id));
 		node1->bootstrap_initiator.connections->request_pull (lock);
 		node2->stop ();
 	}
@@ -361,9 +361,9 @@ TEST (bootstrap_processor, frontiers_unconfirmed)
 	nano::genesis genesis;
 	nano::keypair key1, key2;
 	// Generating invalid chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open1).code);
@@ -375,11 +375,11 @@ TEST (bootstrap_processor, frontiers_unconfirmed)
 	node_flags.disable_rep_crawler = false;
 	auto node2 = system.add_node (node_config, node_flags);
 	// Generating valid chain
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send3 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node2->process (*send3).code);
 	auto open3 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::xrb_ratio, send3->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node2->process (*open3).code);
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	// Ensure node2 can generate votes
 	node2->block_confirm (send3);
@@ -418,15 +418,15 @@ TEST (bootstrap_processor, frontiers_confirmed)
 	nano::genesis genesis;
 	nano::keypair key1, key2;
 	// Generating valid chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open1).code);
 	auto open2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *system.work.generate (key2.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open2).code);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	// Confirm all blocks so node1 is free to generate votes
 	node1->block_confirm (send1);
@@ -464,9 +464,9 @@ TEST (bootstrap_processor, frontiers_unconfirmed_threshold)
 	// Generating invalid chain
 	auto threshold (node1->gap_cache.bootstrap_threshold () + 1);
 	ASSERT_LT (threshold, node1->config.online_weight_minimum.number ());
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - threshold, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - threshold, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - threshold - nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - threshold - nano::Gxrb_ratio, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, threshold, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open1).code);
@@ -477,7 +477,7 @@ TEST (bootstrap_processor, frontiers_unconfirmed_threshold)
 	// Test node with large representative
 	node_config.peering_port = nano::get_available_port ();
 	auto node2 = system.add_node (node_config, node_flags);
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	// Test node to bootstrap
 	node_config.peering_port = nano::get_available_port ();
@@ -505,19 +505,19 @@ TEST (bootstrap_processor, push_diamond)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	auto wallet1 (node1->wallets.create (100));
-	wallet1->insert_adhoc (nano::test_genesis_key.prv);
+	wallet1->insert_adhoc (nano::dev_genesis_key.prv);
 	wallet1->insert_adhoc (key.prv);
-	auto send1 (std::make_shared<nano::send_block> (node0->latest (nano::test_genesis_key.pub), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (node0->latest (nano::test_genesis_key.pub))));
+	auto send1 (std::make_shared<nano::send_block> (node0->latest (nano::dev_genesis_key.pub), key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (node0->latest (nano::dev_genesis_key.pub))));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), 1, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
-	auto send2 (std::make_shared<nano::send_block> (open->hash (), nano::test_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 100, key.prv, key.pub, *system.work.generate (open->hash ())));
+	auto send2 (std::make_shared<nano::send_block> (open->hash (), nano::dev_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 100, key.prv, key.pub, *system.work.generate (open->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
-	auto receive (std::make_shared<nano::receive_block> (send1->hash (), send2->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto receive (std::make_shared<nano::receive_block> (send1->hash (), send2->hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	ASSERT_TIMELY (10s, node0->balance (nano::test_genesis_key.pub) == 100);
-	ASSERT_EQ (100, node0->balance (nano::test_genesis_key.pub));
+	ASSERT_TIMELY (10s, node0->balance (nano::dev_genesis_key.pub) == 100);
+	ASSERT_EQ (100, node0->balance (nano::dev_genesis_key.pub));
 	node1->stop ();
 }
 
@@ -531,12 +531,12 @@ TEST (bootstrap_processor, push_one)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
-	nano::uint128_t balance1 (node1->balance (nano::test_genesis_key.pub));
-	ASSERT_NE (nullptr, wallet->send_action (nano::test_genesis_key.pub, key1.pub, 100));
-	ASSERT_NE (balance1, node1->balance (nano::test_genesis_key.pub));
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
+	nano::uint128_t balance1 (node1->balance (nano::dev_genesis_key.pub));
+	ASSERT_NE (nullptr, wallet->send_action (nano::dev_genesis_key.pub, key1.pub, 100));
+	ASSERT_NE (balance1, node1->balance (nano::dev_genesis_key.pub));
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
-	ASSERT_TIMELY (10s, node0->balance (nano::test_genesis_key.pub) != balance1);
+	ASSERT_TIMELY (10s, node0->balance (nano::dev_genesis_key.pub) != balance1);
 	node1->stop ();
 }
 
@@ -552,7 +552,7 @@ TEST (bootstrap_processor, lazy_hash)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
 	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
@@ -588,7 +588,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
 	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
@@ -624,12 +624,12 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
 	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
 	auto change1 (std::make_shared<nano::state_block> (key2.pub, receive2->hash (), key1.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (receive2->hash ())));
-	auto change2 (std::make_shared<nano::state_block> (key2.pub, change1->hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (change1->hash ())));
+	auto change2 (std::make_shared<nano::state_block> (key2.pub, change1->hash (), nano::dev_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (change1->hash ())));
 	auto change3 (std::make_shared<nano::state_block> (key2.pub, change2->hash (), key2.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *node0->work_generate_blocking (change2->hash ())));
 	// Processing test chain
 	node0->block_processor.add (send1);
@@ -664,9 +664,9 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 	nano::genesis genesis;
 	nano::keypair key;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
@@ -698,7 +698,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 	nano::genesis genesis;
 	nano::keypair key, key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
@@ -729,9 +729,9 @@ TEST (bootstrap_processor, lazy_destinations)
 	nano::genesis genesis;
 	nano::keypair key1, key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), key1.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
@@ -763,7 +763,7 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
 	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node0->work_generate_blocking (key2.pub)));
@@ -803,7 +803,7 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (genesis.hash ())));
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node0->work_generate_blocking (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node0->work_generate_blocking (receive1->hash ())));
 	// Processing test chain
@@ -835,7 +835,7 @@ TEST (bootstrap_processor, multiple_attempts)
 	nano::keypair key1;
 	nano::keypair key2;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1->work_generate_blocking (genesis.hash ())));
 	auto receive1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, nano::Gxrb_ratio, send1->hash (), key1.prv, key1.pub, *node1->work_generate_blocking (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, receive1->hash (), key1.pub, 0, key2.pub, key1.prv, key1.pub, *node1->work_generate_blocking (receive1->hash ())));
 	auto receive2 (std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, nano::Gxrb_ratio, send2->hash (), key2.prv, key2.pub, *node1->work_generate_blocking (key2.pub)));
@@ -877,7 +877,7 @@ TEST (bootstrap_processor, bootstrap_fork)
 	node_flags.disable_legacy_bootstrap = true;
 	auto node0 (system.add_node (config, node_flags));
 	nano::keypair key;
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, node0->latest (nano::test_genesis_key.pub), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (node0->latest (nano::test_genesis_key.pub))));
+	auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, node0->latest (nano::dev_genesis_key.pub), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (node0->latest (nano::dev_genesis_key.pub))));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*send).code);
 	// Confirm send block to vote later
 	node0->block_confirm (send);
@@ -892,13 +892,13 @@ TEST (bootstrap_processor, bootstrap_fork)
 	auto open_work (*system.work.generate (key.pub));
 	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, nano::Gxrb_ratio, send->hash (), key.prv, key.pub, open_work));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*open).code);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Create forked node
 	config.peering_port = nano::get_available_port ();
 	node_flags.disable_legacy_bootstrap = false;
 	auto node1 (system.add_node (config, node_flags));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
-	auto open_fork (std::make_shared<nano::state_block> (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send->hash (), key.prv, key.pub, open_work));
+	auto open_fork (std::make_shared<nano::state_block> (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, send->hash (), key.prv, key.pub, open_work));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open_fork).code);
 	// Resolve fork
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint ());
@@ -935,7 +935,7 @@ TEST (frontier_req, begin)
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::frontier_req_server> (connection, std::move (req)));
-	ASSERT_EQ (nano::test_genesis_key.pub, request->current);
+	ASSERT_EQ (nano::dev_genesis_key.pub, request->current);
 	nano::genesis genesis;
 	ASSERT_EQ (genesis.hash (), request->frontier);
 }
@@ -945,7 +945,7 @@ TEST (frontier_req, end)
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> ();
-	req->start = nano::test_genesis_key.pub.number () + 1;
+	req->start = nano::dev_genesis_key.pub.number () + 1;
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -960,10 +960,10 @@ TEST (frontier_req, count)
 	nano::genesis genesis;
 	// Public key FB93... after genesis in accounts table
 	nano::keypair key1 ("ED5AE0A6505B14B67435C29FD9FEEBC26F597D147BC92F6D795FFAD7AFD3D967");
-	nano::state_block send1 (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block send1 (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 	node1->work_generate_blocking (send1);
 	ASSERT_EQ (nano::process_result::progress, node1->process (send1).code);
-	nano::state_block receive1 (key1.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send1.hash (), key1.prv, key1.pub, 0);
+	nano::state_block receive1 (key1.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, send1.hash (), key1.prv, key1.pub, 0);
 	node1->work_generate_blocking (receive1);
 	ASSERT_EQ (nano::process_result::progress, node1->process (receive1).code);
 	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, node1));
@@ -973,7 +973,7 @@ TEST (frontier_req, count)
 	req->count = 1;
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::frontier_req_server> (connection, std::move (req)));
-	ASSERT_EQ (nano::test_genesis_key.pub, request->current);
+	ASSERT_EQ (nano::dev_genesis_key.pub, request->current);
 	ASSERT_EQ (send1.hash (), request->frontier);
 }
 
@@ -987,7 +987,7 @@ TEST (frontier_req, time_bound)
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::frontier_req_server> (connection, std::move (req)));
-	ASSERT_EQ (nano::test_genesis_key.pub, request->current);
+	ASSERT_EQ (nano::dev_genesis_key.pub, request->current);
 	// Wait 2 seconds until age of account will be > 1 seconds
 	std::this_thread::sleep_for (std::chrono::milliseconds (2100));
 	auto req2 (std::make_unique<nano::frontier_req> ());
@@ -1010,7 +1010,7 @@ TEST (frontier_req, time_cutoff)
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
 	auto request (std::make_shared<nano::frontier_req_server> (connection, std::move (req)));
-	ASSERT_EQ (nano::test_genesis_key.pub, request->current);
+	ASSERT_EQ (nano::dev_genesis_key.pub, request->current);
 	nano::genesis genesis;
 	ASSERT_EQ (genesis.hash (), request->frontier);
 	// Wait 4 seconds until age of account will be > 3 seconds
@@ -1034,19 +1034,19 @@ TEST (bulk, genesis)
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto node1 = system.add_node (config, node_flags);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node2->init_error ());
-	nano::block_hash latest1 (node1->latest (nano::test_genesis_key.pub));
-	nano::block_hash latest2 (node2->latest (nano::test_genesis_key.pub));
+	nano::block_hash latest1 (node1->latest (nano::dev_genesis_key.pub));
+	nano::block_hash latest2 (node2->latest (nano::dev_genesis_key.pub));
 	ASSERT_EQ (latest1, latest2);
 	nano::keypair key2;
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, 100));
-	nano::block_hash latest3 (node1->latest (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, 100));
+	nano::block_hash latest3 (node1->latest (nano::dev_genesis_key.pub));
 	ASSERT_NE (latest1, latest3);
 	node2->bootstrap_initiator.bootstrap (node1->network.endpoint ());
-	ASSERT_TIMELY (10s, node2->latest (nano::test_genesis_key.pub) == node1->latest (nano::test_genesis_key.pub));
-	ASSERT_EQ (node2->latest (nano::test_genesis_key.pub), node1->latest (nano::test_genesis_key.pub));
+	ASSERT_TIMELY (10s, node2->latest (nano::dev_genesis_key.pub) == node1->latest (nano::dev_genesis_key.pub));
+	ASSERT_EQ (node2->latest (nano::dev_genesis_key.pub), node1->latest (nano::dev_genesis_key.pub));
 	node2->stop ();
 }
 
@@ -1059,7 +1059,7 @@ TEST (bulk, offline_send)
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto node1 = system.add_node (config, node_flags);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work));
 	ASSERT_FALSE (node2->init_error ());
 	node2->start ();
@@ -1067,8 +1067,8 @@ TEST (bulk, offline_send)
 	nano::keypair key2;
 	auto wallet (node2->wallets.create (nano::random_wallet_id ()));
 	wallet->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node1->config.receive_minimum.number ()));
-	ASSERT_NE (std::numeric_limits<nano::uint256_t>::max (), node1->balance (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node1->config.receive_minimum.number ()));
+	ASSERT_NE (std::numeric_limits<nano::uint256_t>::max (), node1->balance (nano::dev_genesis_key.pub));
 	// Wait to finish election background tasks
 	ASSERT_TIMELY (10s, node1->active.empty ());
 	// Initiate bootstrap
@@ -1080,7 +1080,7 @@ TEST (bulk, offline_send)
 		ASSERT_NO_ERROR (system.poll ());
 	} while (node1->network.empty () || node2->network.empty ());
 	// Send block arrival via bootstrap
-	ASSERT_TIMELY (10s, node2->balance (nano::test_genesis_key.pub) != std::numeric_limits<nano::uint256_t>::max ());
+	ASSERT_TIMELY (10s, node2->balance (nano::dev_genesis_key.pub) != std::numeric_limits<nano::uint256_t>::max ());
 	// Receiving send block
 	ASSERT_TIMELY (20s, node2->balance (key2.pub) == node1->config.receive_minimum.number ());
 	node2->stop ();
@@ -1091,7 +1091,7 @@ TEST (bulk_pull_account, basics)
 	nano::system system (1);
 	system.nodes[0]->config.receive_minimum = 20;
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key1.prv);
 	auto send1 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 25));
 	auto send2 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 10));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -38,15 +38,15 @@ TEST (confirmation_height, single)
 		node_flags.confirmation_height_processor_mode = mode_a;
 		auto node = system.add_node (node_flags);
 		nano::keypair key1;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-		nano::block_hash latest1 (node->latest (nano::test_genesis_key.pub));
-		auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, latest1, nano::test_genesis_key.pub, amount - 100, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1)));
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+		nano::block_hash latest1 (node->latest (nano::dev_genesis_key.pub));
+		auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, latest1, nano::dev_genesis_key.pub, amount - 100, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1)));
 
 		// Check confirmation heights before, should be uninitialized (1 for genesis).
 		nano::confirmation_height_info confirmation_height_info;
 		add_callback_stats (*node);
 		auto transaction = node->store.tx_begin_read ();
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (1, confirmation_height_info.height);
 		ASSERT_EQ (nano::genesis_hash, confirmation_height_info.frontier);
 
@@ -58,7 +58,7 @@ TEST (confirmation_height, single)
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_TRUE (node->ledger.block_confirmed (transaction, send1->hash ()));
-			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (2, confirmation_height_info.height);
 			ASSERT_EQ (send1->hash (), confirmation_height_info.frontier);
 
@@ -90,12 +90,12 @@ TEST (confirmation_height, multiple_accounts)
 		nano::keypair key1;
 		nano::keypair key2;
 		nano::keypair key3;
-		nano::block_hash latest1 (system.nodes[0]->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest1 (system.nodes[0]->latest (nano::dev_genesis_key.pub));
 
 		// Send to all accounts
-		nano::send_block send1 (latest1, key1.pub, system.nodes.front ()->config.online_weight_minimum.number () + 300, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1));
-		nano::send_block send2 (send1.hash (), key2.pub, system.nodes.front ()->config.online_weight_minimum.number () + 200, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::send_block send3 (send2.hash (), key3.pub, system.nodes.front ()->config.online_weight_minimum.number () + 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2.hash ()));
+		nano::send_block send1 (latest1, key1.pub, system.nodes.front ()->config.online_weight_minimum.number () + 300, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1));
+		nano::send_block send2 (send1.hash (), key2.pub, system.nodes.front ()->config.online_weight_minimum.number () + 200, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::send_block send3 (send2.hash (), key3.pub, system.nodes.front ()->config.online_weight_minimum.number () + 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send2.hash ()));
 
 		// Open all accounts
 		nano::open_block open1 (send1.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
@@ -132,7 +132,7 @@ TEST (confirmation_height, multiple_accounts)
 			// Check confirmation heights of all the accounts are uninitialized (0),
 			// as we have any just added them to the ledger and not processed any live transactions yet.
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (nano::genesis_hash, confirmation_height_info.frontier);
 			ASSERT_FALSE (node->store.confirmation_height_get (transaction, key1.pub, confirmation_height_info));
@@ -165,8 +165,8 @@ TEST (confirmation_height, multiple_accounts)
 		auto & store = node->store;
 		auto transaction = node->store.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
-		ASSERT_FALSE (store.account_get (transaction, nano::test_genesis_key.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
+		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (4, confirmation_height_info.height);
 		ASSERT_EQ (send3.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (4, account_info.block_count);
@@ -201,7 +201,7 @@ TEST (confirmation_height, multiple_accounts)
 
 			// Confirm the other latest can't be rolled back either
 			ASSERT_TRUE (node->ledger.rollback (transaction, node->latest (key3.pub)));
-			ASSERT_TRUE (node->ledger.rollback (transaction, node->latest (nano::test_genesis_key.pub)));
+			ASSERT_TRUE (node->ledger.rollback (transaction, node->latest (nano::dev_genesis_key.pub)));
 
 			// Attempt some others which have been cemented
 			ASSERT_TRUE (node->ledger.rollback (transaction, open1.hash ()));
@@ -228,11 +228,11 @@ TEST (confirmation_height, gap_bootstrap)
 		auto & node1 = *system.add_node (node_flags);
 		nano::genesis genesis;
 		nano::keypair destination;
-		auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 		node1.work_generate_blocking (*send1);
-		auto send2 (std::make_shared<nano::state_block> (nano::genesis_account, send1->hash (), nano::genesis_account, nano::genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send2 (std::make_shared<nano::state_block> (nano::genesis_account, send1->hash (), nano::genesis_account, nano::genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 		node1.work_generate_blocking (*send2);
-		auto send3 (std::make_shared<nano::state_block> (nano::genesis_account, send2->hash (), nano::genesis_account, nano::genesis_amount - 3 * nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send3 (std::make_shared<nano::state_block> (nano::genesis_account, send2->hash (), nano::genesis_account, nano::genesis_amount - 3 * nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 		node1.work_generate_blocking (*send3);
 		auto open1 (std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0));
 		node1.work_generate_blocking (*open1);
@@ -262,7 +262,7 @@ TEST (confirmation_height, gap_bootstrap)
 			ASSERT_EQ (unchecked_count, 2);
 
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (genesis.hash (), confirmation_height_info.frontier);
 		}
@@ -278,7 +278,7 @@ TEST (confirmation_height, gap_bootstrap)
 			ASSERT_EQ (unchecked_count, 0);
 
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (genesis.hash (), confirmation_height_info.frontier);
 			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, destination.pub, confirmation_height_info));
@@ -309,15 +309,15 @@ TEST (confirmation_height, gap_live)
 		node_config.peering_port = nano::get_available_port ();
 		system.add_node (node_config, node_flags);
 		nano::keypair destination;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		system.wallet (1)->insert_adhoc (destination.prv);
 
 		nano::genesis genesis;
-		auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 		node->work_generate_blocking (*send1);
-		auto send2 (std::make_shared<nano::state_block> (nano::genesis_account, send1->hash (), nano::genesis_account, nano::genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send2 (std::make_shared<nano::state_block> (nano::genesis_account, send1->hash (), nano::genesis_account, nano::genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 		node->work_generate_blocking (*send2);
-		auto send3 (std::make_shared<nano::state_block> (nano::genesis_account, send2->hash (), nano::genesis_account, nano::genesis_amount - 3 * nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto send3 (std::make_shared<nano::state_block> (nano::genesis_account, send2->hash (), nano::genesis_account, nano::genesis_amount - 3 * nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 		node->work_generate_blocking (*send3);
 
 		auto open1 (std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0));
@@ -343,7 +343,7 @@ TEST (confirmation_height, gap_live)
 		{
 			auto transaction = node->store.tx_begin_read ();
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (nano::genesis_hash, confirmation_height_info.frontier);
 		}
@@ -368,7 +368,7 @@ TEST (confirmation_height, gap_live)
 
 		nano::confirmation_height_info confirmation_height_info;
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive2->hash ()));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (4, confirmation_height_info.height);
 		ASSERT_EQ (send3->hash (), confirmation_height_info.frontier);
 		ASSERT_FALSE (node->store.confirmation_height_get (transaction, destination.pub, confirmation_height_info));
@@ -397,24 +397,24 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::keypair key1;
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
-		nano::send_block send1 (latest, key1.pub, node->config.online_weight_minimum.number () + 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+		nano::send_block send1 (latest, key1.pub, node->config.online_weight_minimum.number () + 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 
 		nano::open_block open1 (send1.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
 		nano::send_block send2 (open1.hash (), nano::genesis_account, 1000, key1.prv, key1.pub, *system.work.generate (open1.hash ()));
 		nano::send_block send3 (send2.hash (), nano::genesis_account, 900, key1.prv, key1.pub, *system.work.generate (send2.hash ()));
 		nano::send_block send4 (send3.hash (), nano::genesis_account, 500, key1.prv, key1.pub, *system.work.generate (send3.hash ()));
 
-		nano::receive_block receive1 (send1.hash (), send2.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::receive_block receive2 (receive1.hash (), send3.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive1.hash ()));
-		nano::receive_block receive3 (receive2.hash (), send4.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive2.hash ()));
+		nano::receive_block receive1 (send1.hash (), send2.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::receive_block receive2 (receive1.hash (), send3.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive1.hash ()));
+		nano::receive_block receive3 (receive2.hash (), send4.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive2.hash ()));
 
-		nano::send_block send5 (receive3.hash (), key1.pub, node->config.online_weight_minimum.number () + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive3.hash ()));
+		nano::send_block send5 (receive3.hash (), key1.pub, node->config.online_weight_minimum.number () + 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive3.hash ()));
 		auto receive4 = std::make_shared<nano::receive_block> (send4.hash (), send5.hash (), key1.prv, key1.pub, *system.work.generate (send4.hash ()));
 		// Unpocketed send
 		nano::keypair key2;
-		nano::send_block send6 (send5.hash (), key2.pub, node->config.online_weight_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send5.hash ()));
+		nano::send_block send6 (send5.hash (), key2.pub, node->config.online_weight_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send5.hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
@@ -451,8 +451,8 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive4->hash ()));
 		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
+		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (6, confirmation_height_info.height);
 		ASSERT_EQ (send5.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (7, account_info.block_count);
@@ -484,19 +484,19 @@ TEST (confirmation_height, send_receive_self)
 		nano::node_config node_config (nano::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
-		nano::send_block send1 (latest, nano::test_genesis_key.pub, nano::genesis_amount - 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		nano::receive_block receive1 (send1.hash (), send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::send_block send2 (receive1.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive1.hash ()));
-		nano::send_block send3 (send2.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2.hash ()));
+		nano::send_block send1 (latest, nano::dev_genesis_key.pub, nano::genesis_amount - 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		nano::receive_block receive1 (send1.hash (), send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::send_block send2 (receive1.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive1.hash ()));
+		nano::send_block send3 (send2.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send2.hash ()));
 
-		nano::receive_block receive2 (send3.hash (), send2.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3.hash ()));
-		auto receive3 = std::make_shared<nano::receive_block> (receive2.hash (), send3.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive2.hash ()));
+		nano::receive_block receive2 (send3.hash (), send2.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send3.hash ()));
+		auto receive3 = std::make_shared<nano::receive_block> (receive2.hash (), send3.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive2.hash ()));
 
 		// Send to another account to prevent automatic receiving on the genesis account
 		nano::keypair key1;
-		nano::send_block send4 (receive3->hash (), key1.pub, node->config.online_weight_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive3->hash ()));
+		nano::send_block send4 (receive3->hash (), key1.pub, node->config.online_weight_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive3->hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
@@ -524,9 +524,9 @@ TEST (confirmation_height, send_receive_self)
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
 		nano::account_info account_info;
-		ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
+		ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (7, confirmation_height_info.height);
 		ASSERT_EQ (receive3->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (8, account_info.block_count);
@@ -550,14 +550,14 @@ TEST (confirmation_height, all_block_types)
 		nano::node_config node_config (nano::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 		nano::keypair key1;
 		nano::keypair key2;
 		auto & store = node->store;
-		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		nano::send_block send1 (send.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		nano::send_block send1 (send.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send.hash ()));
 
-		nano::open_block open (send.hash (), nano::test_genesis_key.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
+		nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
 		nano::state_block state_open (key2.pub, 0, 0, nano::Gxrb_ratio, send1.hash (), key2.prv, key2.pub, *system.work.generate (key2.pub));
 
 		nano::send_block send2 (open.hash (), key2.pub, 0, key1.prv, key1.pub, *system.work.generate (open.hash ()));
@@ -568,19 +568,19 @@ TEST (confirmation_height, all_block_types)
 
 		nano::change_block change (receive.hash (), key2.pub, key1.prv, key1.pub, *system.work.generate (receive.hash ()));
 
-		nano::state_block state_change (key2.pub, state_send.hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.work.generate (state_send.hash ()));
+		nano::state_block state_change (key2.pub, state_send.hash (), nano::dev_genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.work.generate (state_send.hash ()));
 
-		nano::state_block epoch (key2.pub, state_change.hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, node->ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (state_change.hash ()));
+		nano::state_block epoch (key2.pub, state_change.hash (), nano::dev_genesis_key.pub, nano::Gxrb_ratio, node->ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (state_change.hash ()));
 
-		nano::state_block epoch1 (key1.pub, change.hash (), key2.pub, nano::Gxrb_ratio, node->ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (change.hash ()));
+		nano::state_block epoch1 (key1.pub, change.hash (), key2.pub, nano::Gxrb_ratio, node->ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (change.hash ()));
 		nano::state_block state_send1 (key1.pub, epoch1.hash (), 0, nano::Gxrb_ratio - 1, key2.pub, key1.prv, key1.pub, *system.work.generate (epoch1.hash ()));
 		nano::state_block state_receive2 (key2.pub, epoch.hash (), 0, nano::Gxrb_ratio + 1, state_send1.hash (), key2.prv, key2.pub, *system.work.generate (epoch.hash ()));
 
 		auto state_send2 = std::make_shared<nano::state_block> (key2.pub, state_receive2.hash (), 0, nano::Gxrb_ratio, key1.pub, key2.prv, key2.pub, *system.work.generate (state_receive2.hash ()));
 		nano::state_block state_send3 (key2.pub, state_send2->hash (), 0, nano::Gxrb_ratio - 1, key1.pub, key2.prv, key2.pub, *system.work.generate (state_send2->hash ()));
 
-		nano::state_block state_send4 (key1.pub, state_send1.hash (), 0, nano::Gxrb_ratio - 2, nano::test_genesis_key.pub, key1.prv, key1.pub, *system.work.generate (state_send1.hash ()));
-		nano::state_block state_receive3 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 2 + 1, state_send4.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::state_block state_send4 (key1.pub, state_send1.hash (), 0, nano::Gxrb_ratio - 2, nano::dev_genesis_key.pub, key1.prv, key1.pub, *system.work.generate (state_send1.hash ()));
+		nano::state_block state_receive3 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 2 + 1, state_send4.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
 
 		{
 			auto transaction (store.tx_begin_write ());
@@ -625,8 +625,8 @@ TEST (confirmation_height, all_block_types)
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, state_send2->hash ()));
 		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
+		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
 		ASSERT_EQ (send1.hash (), confirmation_height_info.frontier);
 		ASSERT_LE (4, account_info.block_count);
@@ -670,10 +670,10 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		ASSERT_EQ (1, node1->network.size ());
 		nano::keypair key1;
 		nano::genesis genesis;
-		auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+		auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 		nano::publish publish1 (send1);
 		nano::keypair key2;
-		auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+		auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 		nano::publish publish2 (send2);
 		auto channel1 (node1->network.udp_channels.create (node1->network.endpoint ()));
 		node1->network.process_message (publish1, channel1);
@@ -683,7 +683,7 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		node2->block_processor.flush ();
 		ASSERT_EQ (1, node1->active.size ());
 		ASSERT_EQ (1, node2->active.size ());
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		node1->network.process_message (publish2, channel1);
 		node1->block_processor.flush ();
 		node2->network.process_message (publish1, channel2);
@@ -748,7 +748,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		nano::write_database_queue write_database_queue;
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+		auto send = std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 		{
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, genesis, ledger.cache);
@@ -779,9 +779,9 @@ TEST (confirmation_height, observers)
 		node_flags.confirmation_height_processor_mode = mode_a;
 		auto node1 = system.add_node (node_flags);
 		nano::keypair key1;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-		nano::block_hash latest1 (node1->latest (nano::test_genesis_key.pub));
-		auto send1 (std::make_shared<nano::send_block> (latest1, key1.pub, amount - node1->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1)));
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+		nano::block_hash latest1 (node1->latest (nano::dev_genesis_key.pub));
+		auto send1 (std::make_shared<nano::send_block> (latest1, key1.pub, amount - node1->config.receive_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1)));
 
 		add_callback_stats (*node1);
 
@@ -820,7 +820,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::write_database_queue write_database_queue;
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (nano::genesis_hash));
+		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
 		{
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, genesis, ledger.cache);
@@ -886,7 +886,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::write_database_queue write_database_queue;
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (nano::genesis_hash));
+		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
 		auto open = std::make_shared<nano::state_block> (key1.pub, 0, 0, nano::Gxrb_ratio, send->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 		{
 			auto transaction (store.tx_begin_write ());
@@ -946,12 +946,12 @@ TEST (confirmation_height, pending_observer_callbacks)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
 		nano::keypair key1;
-		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		auto send1 = std::make_shared<nano::send_block> (send.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		auto send1 = std::make_shared<nano::send_block> (send.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send.hash ()));
 
 		{
 			auto transaction = node->store.tx_begin_write ();
@@ -989,29 +989,29 @@ TEST (confirmation_height, prioritize_frontiers)
 		nano::keypair key2;
 		nano::keypair key3;
 		nano::keypair key4;
-		nano::block_hash latest1 (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest1 (node->latest (nano::dev_genesis_key.pub));
 
 		// Send different numbers of blocks all accounts
-		nano::send_block send1 (latest1, key1.pub, node->config.online_weight_minimum.number () + 10000, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1));
-		nano::send_block send2 (send1.hash (), key1.pub, node->config.online_weight_minimum.number () + 8500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::send_block send3 (send2.hash (), key1.pub, node->config.online_weight_minimum.number () + 8000, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2.hash ()));
-		nano::send_block send4 (send3.hash (), key2.pub, node->config.online_weight_minimum.number () + 7500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3.hash ()));
-		nano::send_block send5 (send4.hash (), key3.pub, node->config.online_weight_minimum.number () + 6500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send4.hash ()));
-		nano::send_block send6 (send5.hash (), key4.pub, node->config.online_weight_minimum.number () + 6000, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send5.hash ()));
+		nano::send_block send1 (latest1, key1.pub, node->config.online_weight_minimum.number () + 10000, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1));
+		nano::send_block send2 (send1.hash (), key1.pub, node->config.online_weight_minimum.number () + 8500, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::send_block send3 (send2.hash (), key1.pub, node->config.online_weight_minimum.number () + 8000, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send2.hash ()));
+		nano::send_block send4 (send3.hash (), key2.pub, node->config.online_weight_minimum.number () + 7500, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send3.hash ()));
+		nano::send_block send5 (send4.hash (), key3.pub, node->config.online_weight_minimum.number () + 6500, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send4.hash ()));
+		nano::send_block send6 (send5.hash (), key4.pub, node->config.online_weight_minimum.number () + 6000, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send5.hash ()));
 
 		// Open all accounts and add other sends to get different uncemented counts (as well as some which are the same)
 		nano::open_block open1 (send1.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-		nano::send_block send7 (open1.hash (), nano::test_genesis_key.pub, 500, key1.prv, key1.pub, *system.work.generate (open1.hash ()));
+		nano::send_block send7 (open1.hash (), nano::dev_genesis_key.pub, 500, key1.prv, key1.pub, *system.work.generate (open1.hash ()));
 
 		nano::open_block open2 (send4.hash (), nano::genesis_account, key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
 
 		nano::open_block open3 (send5.hash (), nano::genesis_account, key3.pub, key3.prv, key3.pub, *system.work.generate (key3.pub));
-		nano::send_block send8 (open3.hash (), nano::test_genesis_key.pub, 500, key3.prv, key3.pub, *system.work.generate (open3.hash ()));
-		nano::send_block send9 (send8.hash (), nano::test_genesis_key.pub, 200, key3.prv, key3.pub, *system.work.generate (send8.hash ()));
+		nano::send_block send8 (open3.hash (), nano::dev_genesis_key.pub, 500, key3.prv, key3.pub, *system.work.generate (open3.hash ()));
+		nano::send_block send9 (send8.hash (), nano::dev_genesis_key.pub, 200, key3.prv, key3.pub, *system.work.generate (send8.hash ()));
 
 		nano::open_block open4 (send6.hash (), nano::genesis_account, key4.pub, key4.prv, key4.pub, *system.work.generate (key4.pub));
-		nano::send_block send10 (open4.hash (), nano::test_genesis_key.pub, 500, key4.prv, key4.pub, *system.work.generate (open4.hash ()));
-		nano::send_block send11 (send10.hash (), nano::test_genesis_key.pub, 200, key4.prv, key4.pub, *system.work.generate (send10.hash ()));
+		nano::send_block send10 (open4.hash (), nano::dev_genesis_key.pub, 500, key4.prv, key4.pub, *system.work.generate (open4.hash ()));
+		nano::send_block send11 (send10.hash (), nano::dev_genesis_key.pub, 200, key4.prv, key4.pub, *system.work.generate (send10.hash ()));
 
 		{
 			auto transaction = node->store.tx_begin_write ();
@@ -1054,7 +1054,7 @@ TEST (confirmation_height, prioritize_frontiers)
 
 		{
 			// Add some to the local node wallets and check ordering of both containers
-			system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+			system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 			system.wallet (0)->insert_adhoc (key1.prv);
 			system.wallet (0)->insert_adhoc (key2.prv);
 			node->active.prioritize_frontiers_for_confirmation (transaction, std::chrono::seconds (1), std::chrono::seconds (1));
@@ -1080,12 +1080,12 @@ TEST (confirmation_height, prioritize_frontiers)
 		}
 
 		// Check that accounts which already exist have their order modified when the uncemented count changes.
-		nano::send_block send12 (send9.hash (), nano::test_genesis_key.pub, 100, key3.prv, key3.pub, *system.work.generate (send9.hash ()));
-		nano::send_block send13 (send12.hash (), nano::test_genesis_key.pub, 90, key3.prv, key3.pub, *system.work.generate (send12.hash ()));
-		nano::send_block send14 (send13.hash (), nano::test_genesis_key.pub, 80, key3.prv, key3.pub, *system.work.generate (send13.hash ()));
-		nano::send_block send15 (send14.hash (), nano::test_genesis_key.pub, 70, key3.prv, key3.pub, *system.work.generate (send14.hash ()));
-		nano::send_block send16 (send15.hash (), nano::test_genesis_key.pub, 60, key3.prv, key3.pub, *system.work.generate (send15.hash ()));
-		nano::send_block send17 (send16.hash (), nano::test_genesis_key.pub, 50, key3.prv, key3.pub, *system.work.generate (send16.hash ()));
+		nano::send_block send12 (send9.hash (), nano::dev_genesis_key.pub, 100, key3.prv, key3.pub, *system.work.generate (send9.hash ()));
+		nano::send_block send13 (send12.hash (), nano::dev_genesis_key.pub, 90, key3.prv, key3.pub, *system.work.generate (send12.hash ()));
+		nano::send_block send14 (send13.hash (), nano::dev_genesis_key.pub, 80, key3.prv, key3.pub, *system.work.generate (send13.hash ()));
+		nano::send_block send15 (send14.hash (), nano::dev_genesis_key.pub, 70, key3.prv, key3.pub, *system.work.generate (send14.hash ()));
+		nano::send_block send16 (send15.hash (), nano::dev_genesis_key.pub, 60, key3.prv, key3.pub, *system.work.generate (send15.hash ()));
+		nano::send_block send17 (send16.hash (), nano::dev_genesis_key.pub, 50, key3.prv, key3.pub, *system.work.generate (send16.hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send12).code);
@@ -1129,7 +1129,7 @@ TEST (confirmation_height, frontiers_confirmation_mode)
 			nano::node_config node_config (nano::get_available_port (), system.logging);
 			node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 			auto node = system.add_node (node_config, node_flags);
-			nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
+			nano::state_block send (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
 			{
 				auto transaction = node->store.tx_begin_write ();
 				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
@@ -1142,7 +1142,7 @@ TEST (confirmation_height, frontiers_confirmation_mode)
 			nano::node_config node_config (nano::get_available_port (), system.logging);
 			node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::automatic;
 			auto node = system.add_node (node_config, node_flags);
-			nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
+			nano::state_block send (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
 			{
 				auto transaction = node->store.tx_begin_write ();
 				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
@@ -1155,12 +1155,12 @@ TEST (confirmation_height, frontiers_confirmation_mode)
 			nano::node_config node_config (nano::get_available_port (), system.logging);
 			node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 			auto node = system.add_node (node_config, node_flags);
-			nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
+			nano::state_block send (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node->work_generate_blocking (genesis.hash ()));
 			{
 				auto transaction = node->store.tx_begin_write ();
 				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
 			}
-			system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+			system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 			std::this_thread::sleep_for (std::chrono::seconds (1));
 			ASSERT_EQ (0, node->active.size ());
 		}
@@ -1181,16 +1181,16 @@ TEST (confirmation_height, callback_confirmed_history)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
 
-		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send->hash ()));
+		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send->hash ()));
 
 		add_callback_stats (*node);
 
@@ -1264,12 +1264,12 @@ TEST (confirmation_height, dependent_election)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send->hash ()));
-		auto send2 = std::make_shared<nano::send_block> (send1->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ()));
+		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send->hash ()));
+		auto send2 = std::make_shared<nano::send_block> (send1->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ()));
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
@@ -1317,27 +1317,27 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
 		nano::keypair key1;
 		system.wallet (0)->insert_adhoc (key1.prv);
 
-		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		nano::send_block send1 (send.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		nano::send_block send1 (send.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send.hash ()));
 		nano::keypair dummy_key;
-		nano::send_block dummy_send (send1.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::send_block dummy_send (send1.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
 
 		nano::open_block open (send.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
 		nano::receive_block receive1 (open.hash (), send1.hash (), key1.prv, key1.pub, *system.work.generate (open.hash ()));
-		nano::send_block send2 (receive1.hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, key1.prv, key1.pub, *system.work.generate (receive1.hash ()));
+		nano::send_block send2 (receive1.hash (), nano::dev_genesis_key.pub, nano::Gxrb_ratio, key1.prv, key1.pub, *system.work.generate (receive1.hash ()));
 
-		nano::receive_block receive2 (dummy_send.hash (), send2.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (dummy_send.hash ()));
-		nano::send_block dummy_send1 (receive2.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive2.hash ()));
+		nano::receive_block receive2 (dummy_send.hash (), send2.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (dummy_send.hash ()));
+		nano::send_block dummy_send1 (receive2.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive2.hash ()));
 
 		nano::keypair key2;
 		system.wallet (0)->insert_adhoc (key2.prv);
-		nano::send_block send3 (dummy_send1.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio * 4, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (dummy_send1.hash ()));
-		nano::send_block dummy_send2 (send3.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 5, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3.hash ()));
+		nano::send_block send3 (dummy_send1.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio * 4, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (dummy_send1.hash ()));
+		nano::send_block dummy_send2 (send3.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 5, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send3.hash ()));
 
 		auto open1 = std::make_shared<nano::open_block> (send3.hash (), nano::genesis_account, key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
 
@@ -1405,27 +1405,27 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
 		nano::keypair key1;
 		system.wallet (0)->insert_adhoc (key1.prv);
 
-		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		nano::send_block send1 (send.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		nano::send_block send1 (send.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send.hash ()));
 		nano::keypair dummy_key;
-		nano::send_block dummy_send (send1.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
+		nano::send_block dummy_send (send1.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
 
 		nano::open_block open (send.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
 		nano::receive_block receive1 (open.hash (), send1.hash (), key1.prv, key1.pub, *system.work.generate (open.hash ()));
-		nano::send_block send2 (receive1.hash (), nano::test_genesis_key.pub, nano::Gxrb_ratio, key1.prv, key1.pub, *system.work.generate (receive1.hash ()));
+		nano::send_block send2 (receive1.hash (), nano::dev_genesis_key.pub, nano::Gxrb_ratio, key1.prv, key1.pub, *system.work.generate (receive1.hash ()));
 
-		nano::receive_block receive2 (dummy_send.hash (), send2.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (dummy_send.hash ()));
-		nano::send_block dummy_send1 (receive2.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive2.hash ()));
+		nano::receive_block receive2 (dummy_send.hash (), send2.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (dummy_send.hash ()));
+		nano::send_block dummy_send1 (receive2.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive2.hash ()));
 
 		nano::keypair key2;
 		system.wallet (0)->insert_adhoc (key2.prv);
-		nano::send_block send3 (dummy_send1.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio * 4, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (dummy_send1.hash ()));
-		nano::send_block dummy_send2 (send3.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 5, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3.hash ()));
+		nano::send_block send3 (dummy_send1.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio * 4, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (dummy_send1.hash ()));
+		nano::send_block dummy_send2 (send3.hash (), dummy_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 5, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send3.hash ()));
 
 		auto open1 = std::make_shared<nano::open_block> (send3.hash (), nano::genesis_account, key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
 
@@ -1491,12 +1491,12 @@ TEST (confirmation_height, election_winner_details_clearing)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
-		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send->hash ()));
-		auto send2 = std::make_shared<nano::send_block> (send1->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ()));
+		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send->hash ()));
+		auto send2 = std::make_shared<nano::send_block> (send1->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 3, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ()));
 
 		{
 			auto transaction = node->store.tx_begin_write ();
@@ -1566,7 +1566,7 @@ TEST (confirmation_height, election_winner_details_clearing_node_process_confirm
 	nano::system system (1);
 	auto node = system.nodes.front ();
 
-	auto send = std::make_shared<nano::send_block> (nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash));
+	auto send = std::make_shared<nano::send_block> (nano::genesis_hash, nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash));
 	// Add to election_winner_details. Use an unrealistic iteration so that it should fall into the else case and do a cleanup
 	node->active.add_election_winner_details (send->hash (), nullptr);
 	nano::election_status election;
@@ -1588,8 +1588,8 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	boost::latch initialized_latch{ 0 };
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	auto send = std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
-	auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send->hash ()));
+	auto send = std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
+	auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send->hash ()));
 	{
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, genesis, ledger.cache);

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -19,16 +19,16 @@ TEST (confirmation_solicitor, batches)
 	auto & node2 = *system.add_node (node_flags);
 	auto channel1 (node2.network.udp_channels.create (node1.network.endpoint ()));
 	// Solicitor will only solicit from this representative
-	nano::representative representative (nano::test_genesis_key.pub, nano::genesis_amount, channel1);
+	nano::representative representative (nano::dev_genesis_key.pub, nano::genesis_amount, channel1);
 	std::vector<nano::representative> representatives{ representative };
 	nano::confirmation_solicitor solicitor (node2.network, node2.network_params.network);
 	solicitor.prepare (representatives);
 	// Ensure the representatives are correct
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (channel1, representatives.front ().channel);
-	ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
+	ASSERT_EQ (nano::dev_genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
-	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
+	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
 	send->sideband_set ({});
 	{
 		nano::lock_guard<std::mutex> guard (node2.active.mutex);
@@ -62,16 +62,16 @@ TEST (confirmation_solicitor, different_hash)
 	auto & node2 = *system.add_node (node_flags);
 	auto channel1 (node2.network.udp_channels.create (node1.network.endpoint ()));
 	// Solicitor will only solicit from this representative
-	nano::representative representative (nano::test_genesis_key.pub, nano::genesis_amount, channel1);
+	nano::representative representative (nano::dev_genesis_key.pub, nano::genesis_amount, channel1);
 	std::vector<nano::representative> representatives{ representative };
 	nano::confirmation_solicitor solicitor (node2.network, node2.network_params.network);
 	solicitor.prepare (representatives);
 	// Ensure the representatives are correct
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (channel1, representatives.front ().channel);
-	ASSERT_EQ (nano::test_genesis_key.pub, representatives.front ().account);
+	ASSERT_EQ (nano::dev_genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
-	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
+	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
 	send->sideband_set ({});
 	{
 		nano::lock_guard<std::mutex> guard (node2.active.mutex);

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -14,7 +14,7 @@ TEST (conflicts, start_stop)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (0, node1.active.size ());
@@ -33,12 +33,12 @@ TEST (conflicts, add_existing)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	node1.active.insert (send1);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	send2->sideband_set ({});
 	auto election1 = node1.active.insert (send2);
 	ASSERT_EQ (1, node1.active.size ());
@@ -59,12 +59,12 @@ TEST (conflicts, add_two)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	node1.active.insert (send1);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
 	node1.active.insert (send2);
@@ -164,7 +164,7 @@ TEST (conflicts, reprioritize)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto difficulty1 (send1->difficulty ());
 	auto multiplier1 (nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty1, nano::work_threshold (send1->work_version (), nano::block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */))), node1.network_params.network.publish_thresholds.epoch_1));
@@ -198,9 +198,9 @@ TEST (conflicts, dependency)
 	auto node1 = system.add_node (node_config);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::xrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::xrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1->work_generate_blocking (*send1);
-	auto state_open1 (std::make_shared<nano::state_block> (key1.pub, 0, nano::test_genesis_key.pub, nano::xrb_ratio, send1->hash (), key1.prv, key1.pub, 0));
+	auto state_open1 (std::make_shared<nano::state_block> (key1.pub, 0, nano::dev_genesis_key.pub, nano::xrb_ratio, send1->hash (), key1.prv, key1.pub, 0));
 	node1->work_generate_blocking (*state_open1);
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node1->process (*state_open1).code);
@@ -228,11 +228,11 @@ TEST (conflicts, adjusted_multiplier)
 	nano::keypair key2;
 	nano::keypair key3;
 	ASSERT_EQ (0, node1.active.size ());
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 2 * nano::xrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 2 * nano::xrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	node1.process_active (send1);
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3 * nano::xrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send2 (std::make_shared<nano::send_block> (send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 3 * nano::xrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	node1.process_active (send2);
-	auto receive1 (std::make_shared<nano::receive_block> (send2->hash (), send2->hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2->hash ())));
+	auto receive1 (std::make_shared<nano::receive_block> (send2->hash (), send2->hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send2->hash ())));
 	node1.process_active (receive1);
 	auto open1 (std::make_shared<nano::open_block> (send1->hash (), key1.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	node1.process_active (open1);
@@ -240,17 +240,17 @@ TEST (conflicts, adjusted_multiplier)
 	node1.process_active (send3);
 	auto send4 (std::make_shared<nano::state_block> (key1.pub, send3->hash (), key1.pub, 0, key3.pub, key1.prv, key1.pub, *system.work.generate (send3->hash ())));
 	node1.process_active (send4);
-	ASSERT_EQ (node1.ledger.epoch_signer (node1.ledger.epoch_link (nano::epoch::epoch_1)), nano::test_genesis_key.pub);
-	auto open_epoch1 (std::make_shared<nano::state_block> (key2.pub, 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (key2.pub)));
+	ASSERT_EQ (node1.ledger.epoch_signer (node1.ledger.epoch_link (nano::epoch::epoch_1)), nano::dev_genesis_key.pub);
+	auto open_epoch1 (std::make_shared<nano::state_block> (key2.pub, 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (key2.pub)));
 	node1.process_active (open_epoch1);
 	auto receive2 (std::make_shared<nano::state_block> (key2.pub, open_epoch1->hash (), 0, nano::xrb_ratio, send3->hash (), key2.prv, key2.pub, *system.work.generate (open_epoch1->hash ())));
 	node1.process_active (receive2);
 	auto open2 (std::make_shared<nano::state_block> (key3.pub, 0, key3.pub, nano::xrb_ratio, send4->hash (), key3.prv, key3.pub, *system.work.generate (key3.pub)));
 	node1.process_active (open2);
-	auto change1 (std::make_shared<nano::state_block> (key3.pub, open2->hash (), nano::test_genesis_key.pub, nano::xrb_ratio, 0, key3.prv, key3.pub, *system.work.generate (open2->hash ())));
+	auto change1 (std::make_shared<nano::state_block> (key3.pub, open2->hash (), nano::dev_genesis_key.pub, nano::xrb_ratio, 0, key3.prv, key3.pub, *system.work.generate (open2->hash ())));
 	node1.process_active (change1);
 	nano::keypair key4;
-	auto send5 (std::make_shared<nano::state_block> (key3.pub, change1->hash (), nano::test_genesis_key.pub, 0, key4.pub, key3.prv, key3.pub, *system.work.generate (change1->hash ()))); // Pending for open epoch block
+	auto send5 (std::make_shared<nano::state_block> (key3.pub, change1->hash (), nano::dev_genesis_key.pub, 0, key4.pub, key3.prv, key3.pub, *system.work.generate (change1->hash ()))); // Pending for open epoch block
 	node1.process_active (send5);
 	nano::blocks_confirm (node1, { send1, send2, receive1, open1, send3, send4, open_epoch1, receive2, open2, change1, send5 });
 	ASSERT_TIMELY (3s, node1.active.size () == 11);
@@ -279,7 +279,7 @@ TEST (conflicts, adjusted_multiplier)
 	ASSERT_GT (adjusted_multipliers.find (open2->hash ())->second, adjusted_multipliers.find (change1->hash ())->second);
 	ASSERT_GT (adjusted_multipliers.find (change1->hash ())->second, adjusted_multipliers.find (send5->hash ())->second);
 	// Independent elections can have higher difficulty than adjusted tree
-	auto open_epoch2 (std::make_shared<nano::state_block> (key4.pub, 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (key4.pub, nano::difficulty::from_multiplier ((adjusted_multipliers.find (send1->hash ())->second), node1.network_params.network.publish_thresholds.base))));
+	auto open_epoch2 (std::make_shared<nano::state_block> (key4.pub, 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (key4.pub, nano::difficulty::from_multiplier ((adjusted_multipliers.find (send1->hash ())->second), node1.network_params.network.publish_thresholds.base))));
 	ASSERT_GT (open_epoch2->difficulty (), nano::difficulty::from_multiplier ((adjusted_multipliers.find (send1->hash ())->second), node1.network_params.network.publish_thresholds.base));
 	node1.process_active (open_epoch2);
 	node1.block_processor.flush ();

--- a/nano/core_test/core_test_main.cc
+++ b/nano/core_test/core_test_main.cc
@@ -7,21 +7,21 @@
 
 namespace nano
 {
-void cleanup_test_directories_on_exit ();
-void force_nano_test_network ();
+void cleanup_dev_directories_on_exit ();
+void force_nano_dev_network ();
 boost::filesystem::path unique_path ();
 }
 
 GTEST_API_ int main (int argc, char ** argv)
 {
 	printf ("Running main() from core_test_main.cc\n");
-	nano::force_nano_test_network ();
+	nano::force_nano_dev_network ();
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
 	// Setting up logging so that there aren't any piped to standard output.
 	nano::logging logging;
 	logging.init (nano::unique_path ());
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_test_directories_on_exit ();
+	nano::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -126,7 +126,7 @@ TEST (difficulty, network_constants)
 	nano::network_constants constants;
 	auto & full_thresholds = constants.publish_full;
 	auto & beta_thresholds = constants.publish_beta;
-	auto & test_thresholds = constants.publish_test;
+	auto & dev_thresholds = constants.publish_dev;
 
 	ASSERT_NEAR (8., nano::difficulty::to_multiplier (full_thresholds.epoch_2, full_thresholds.epoch_1), 1e-10);
 	ASSERT_NEAR (1 / 8., nano::difficulty::to_multiplier (full_thresholds.epoch_2_receive, full_thresholds.epoch_1), 1e-10);
@@ -139,10 +139,10 @@ TEST (difficulty, network_constants)
 	ASSERT_NEAR (1., nano::difficulty::to_multiplier (beta_thresholds.epoch_2_receive, beta_thresholds.entry), 1e-10);
 	ASSERT_NEAR (1., nano::difficulty::to_multiplier (beta_thresholds.epoch_2, beta_thresholds.base), 1e-10);
 
-	ASSERT_NEAR (8., nano::difficulty::to_multiplier (test_thresholds.epoch_2, test_thresholds.epoch_1), 1e-10);
-	ASSERT_NEAR (1 / 8., nano::difficulty::to_multiplier (test_thresholds.epoch_2_receive, test_thresholds.epoch_1), 1e-10);
-	ASSERT_NEAR (1., nano::difficulty::to_multiplier (test_thresholds.epoch_2_receive, test_thresholds.entry), 1e-10);
-	ASSERT_NEAR (1., nano::difficulty::to_multiplier (test_thresholds.epoch_2, test_thresholds.base), 1e-10);
+	ASSERT_NEAR (8., nano::difficulty::to_multiplier (dev_thresholds.epoch_2, dev_thresholds.epoch_1), 1e-10);
+	ASSERT_NEAR (1 / 8., nano::difficulty::to_multiplier (dev_thresholds.epoch_2_receive, dev_thresholds.epoch_1), 1e-10);
+	ASSERT_NEAR (1., nano::difficulty::to_multiplier (dev_thresholds.epoch_2_receive, dev_thresholds.entry), 1e-10);
+	ASSERT_NEAR (1., nano::difficulty::to_multiplier (dev_thresholds.epoch_2, dev_thresholds.base), 1e-10);
 
 	nano::work_version version{ nano::work_version::work_1 };
 	ASSERT_EQ (constants.publish_thresholds.base, constants.publish_thresholds.epoch_2);

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -28,7 +28,7 @@ TEST (election, bisect_dependencies)
 	auto & node = *system.add_node (flags);
 	nano::genesis genesis;
 	nano::confirmation_height_info conf_info;
-	ASSERT_FALSE (node.store.confirmation_height_get (node.store.tx_begin_read (), nano::test_genesis_key.pub, conf_info));
+	ASSERT_FALSE (node.store.confirmation_height_get (node.store.tx_begin_read (), nano::dev_genesis_key.pub, conf_info));
 	ASSERT_EQ (1, conf_info.height);
 	std::vector<std::shared_ptr<nano::block>> blocks;
 	blocks.push_back (nullptr); // idx == height
@@ -40,11 +40,11 @@ TEST (election, bisect_dependencies)
 		auto latest = blocks.back ();
 		blocks.push_back (builder.state ()
 		                  .previous (latest->hash ())
-		                  .account (nano::test_genesis_key.pub)
-		                  .representative (nano::test_genesis_key.pub)
+		                  .account (nano::dev_genesis_key.pub)
+		                  .representative (nano::dev_genesis_key.pub)
 		                  .balance (--amount)
-		                  .link (nano::test_genesis_key.pub)
-		                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		                  .link (nano::dev_genesis_key.pub)
+		                  .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		                  .work (*system.work.generate (latest->hash ()))
 		                  .build ());
 		ASSERT_EQ (nano::process_result::progress, node.process (*blocks.back ()).code);
@@ -109,12 +109,12 @@ TEST (election, dependencies_open_link)
 
 	// Send to key
 	auto gen_send = builder.make_block ()
-	                .account (nano::test_genesis_key.pub)
+	                .account (nano::dev_genesis_key.pub)
 	                .previous (nano::genesis_hash)
-	                .representative (nano::test_genesis_key.pub)
+	                .representative (nano::dev_genesis_key.pub)
 	                .link (key.pub)
 	                .balance (nano::genesis_amount - 1)
-	                .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                .work (*system.work.generate (nano::genesis_hash))
 	                .build ();
 	// Receive from genesis

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -65,9 +65,9 @@ TEST (gap_cache, gap_bootstrap)
 
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
-	nano::block_hash latest (node1.latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node1.latest (nano::dev_genesis_key.pub));
 	nano::keypair key;
-	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
+	auto send (std::make_shared<nano::send_block> (latest, key.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest)));
 	node1.process (*send);
 	ASSERT_EQ (nano::genesis_amount - 100, node1.balance (nano::genesis_account));
 	ASSERT_EQ (nano::genesis_amount, node2.balance (nano::genesis_account));
@@ -81,8 +81,8 @@ TEST (gap_cache, gap_bootstrap)
 	}
 	ASSERT_TIMELY (2s, node1.block_confirmed (send->hash ()));
 	node1.active.erase (*send);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto latest_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 100));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto latest_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 100));
 	ASSERT_NE (nullptr, latest_block);
 	ASSERT_EQ (nano::genesis_amount - 200, node1.balance (nano::genesis_account));
 	ASSERT_EQ (nano::genesis_amount, node2.balance (nano::genesis_account));
@@ -95,8 +95,8 @@ TEST (gap_cache, two_dependencies)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key;
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	auto open (std::make_shared<nano::open_block> (send1->hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (0, node1.gap_cache.size ());
 	node1.block_processor.add (send2, nano::seconds_since_epoch ());

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -81,7 +81,7 @@ TEST (ledger, process_modifies_sideband)
 	nano::genesis genesis;
 	store->initialize (store->tx_begin_write (), genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), send1).code);
 	ASSERT_EQ (send1.sideband ().timestamp, store->block_get (store->tx_begin_read (), send1.hash ())->sideband ().timestamp);
 }
@@ -99,25 +99,25 @@ TEST (ledger, process_send)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block send (info1.head, key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	nano::block_hash hash1 (send.hash ());
-	ASSERT_EQ (nano::test_genesis_key.pub, store->frontier_get (transaction, info1.head));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->frontier_get (transaction, info1.head));
 	ASSERT_EQ (1, info1.block_count);
 	// This was a valid block, it should progress.
 	auto return1 (ledger.process (transaction, send));
-	ASSERT_EQ (nano::test_genesis_key.pub, send.sideband ().account);
+	ASSERT_EQ (nano::dev_genesis_key.pub, send.sideband ().account);
 	ASSERT_EQ (2, send.sideband ().height);
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.amount (transaction, hash1));
 	ASSERT_TRUE (store->frontier_get (transaction, info1.head).is_zero ());
-	ASSERT_EQ (nano::test_genesis_key.pub, store->frontier_get (transaction, hash1));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->frontier_get (transaction, hash1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::test_genesis_key.pub, store->block_account_calculated (send));
-	ASSERT_EQ (50, ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->block_account_calculated (send));
+	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.account_pending (transaction, key2.pub));
 	nano::account_info info2;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info2));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info2));
 	ASSERT_EQ (2, info2.block_count);
 	auto latest6 (store->block_get (transaction, info2.head));
 	ASSERT_NE (nullptr, latest6);
@@ -140,10 +140,10 @@ TEST (ledger, process_send)
 	ASSERT_EQ (key2.pub, store->frontier_get (transaction, hash2));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
 	ASSERT_EQ (0, ledger.account_pending (transaction, key2.pub));
-	ASSERT_EQ (50, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (50, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (key2.pub));
 	nano::account_info info3;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info3));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info3));
 	auto latest2 (store->block_get (transaction, info3.head));
 	ASSERT_NE (nullptr, latest2);
 	auto latest3 (dynamic_cast<nano::send_block *> (latest2.get ()));
@@ -162,27 +162,27 @@ TEST (ledger, process_send)
 	ASSERT_TRUE (ledger.store.account_get (transaction, key2.pub, info5));
 	nano::pending_info pending1;
 	ASSERT_FALSE (ledger.store.pending_get (transaction, nano::pending_key (key2.pub, hash1), pending1));
-	ASSERT_EQ (nano::test_genesis_key.pub, pending1.source);
+	ASSERT_EQ (nano::dev_genesis_key.pub, pending1.source);
 	ASSERT_EQ (nano::genesis_amount - 50, pending1.amount.number ());
 	ASSERT_EQ (0, ledger.account_balance (transaction, key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.account_pending (transaction, key2.pub));
-	ASSERT_EQ (50, ledger.account_balance (transaction, nano::test_genesis_key.pub));
-	ASSERT_EQ (50, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
+	ASSERT_EQ (50, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	nano::account_info info6;
-	ASSERT_FALSE (ledger.store.account_get (transaction, nano::test_genesis_key.pub, info6));
+	ASSERT_FALSE (ledger.store.account_get (transaction, nano::dev_genesis_key.pub, info6));
 	ASSERT_EQ (hash1, info6.head);
 	ASSERT_FALSE (ledger.rollback (transaction, info6.head));
-	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::test_genesis_key.pub));
-	ASSERT_EQ (nano::test_genesis_key.pub, store->frontier_get (transaction, info1.head));
+	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->frontier_get (transaction, info1.head));
 	ASSERT_TRUE (store->frontier_get (transaction, hash1).is_zero ());
 	nano::account_info info7;
-	ASSERT_FALSE (ledger.store.account_get (transaction, nano::test_genesis_key.pub, info7));
+	ASSERT_FALSE (ledger.store.account_get (transaction, nano::dev_genesis_key.pub, info7));
 	ASSERT_EQ (1, info7.block_count);
 	ASSERT_EQ (info1.head, info7.head);
 	nano::pending_info pending2;
 	ASSERT_TRUE (ledger.store.pending_get (transaction, nano::pending_key (key2.pub, hash1), pending2));
-	ASSERT_EQ (nano::genesis_amount, ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_pending (transaction, key2.pub));
 	ASSERT_EQ (store->account_count (transaction), ledger.cache.account_count);
 }
@@ -199,9 +199,9 @@ TEST (ledger, process_receive)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block send (info1.head, key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	nano::block_hash hash1 (send.hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	nano::keypair key3;
@@ -215,7 +215,7 @@ TEST (ledger, process_receive)
 	ASSERT_EQ (1, open.sideband ().height);
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (key3.pub));
-	nano::send_block send2 (hash1, key2.pub, 25, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (hash1));
+	nano::send_block send2 (hash1, key2.pub, 25, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (hash1));
 	nano::block_hash hash3 (send2.hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
 	nano::receive_block receive (hash2, hash3, key2.prv, key2.pub, *pool.generate (hash2));
@@ -231,7 +231,7 @@ TEST (ledger, process_receive)
 	ASSERT_EQ (nano::process_result::progress, return2.code);
 	ASSERT_EQ (key2.pub, store->block_account_calculated (receive));
 	ASSERT_EQ (hash4, ledger.latest (transaction, key2.pub));
-	ASSERT_EQ (25, ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_pending (transaction, key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 25, ledger.account_balance (transaction, key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 25, ledger.weight (key3.pub));
@@ -239,14 +239,14 @@ TEST (ledger, process_receive)
 	ASSERT_TRUE (store->block_successor (transaction, hash2).is_zero ());
 	ASSERT_EQ (key2.pub, store->frontier_get (transaction, hash2));
 	ASSERT_TRUE (store->frontier_get (transaction, hash4).is_zero ());
-	ASSERT_EQ (25, ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 	ASSERT_EQ (25, ledger.account_pending (transaction, key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (key3.pub));
 	ASSERT_EQ (hash2, ledger.latest (transaction, key2.pub));
 	nano::pending_info pending1;
 	ASSERT_FALSE (ledger.store.pending_get (transaction, nano::pending_key (key2.pub, hash3), pending1));
-	ASSERT_EQ (nano::test_genesis_key.pub, pending1.source);
+	ASSERT_EQ (nano::dev_genesis_key.pub, pending1.source);
 	ASSERT_EQ (25, pending1.amount.number ());
 	ASSERT_EQ (store->account_count (transaction), ledger.cache.account_count);
 }
@@ -263,9 +263,9 @@ TEST (ledger, rollback_receiver)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block send (info1.head, key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	nano::block_hash hash1 (send.hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	nano::keypair key3;
@@ -273,15 +273,15 @@ TEST (ledger, rollback_receiver)
 	nano::block_hash hash2 (open.hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
 	ASSERT_EQ (hash2, ledger.latest (transaction, key2.pub));
-	ASSERT_EQ (50, ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
-	ASSERT_EQ (50, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (50, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, hash1));
-	ASSERT_EQ (nano::genesis_amount, ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_balance (transaction, key2.pub));
-	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
 	nano::account_info info2;
@@ -303,18 +303,18 @@ TEST (ledger, rollback_representation)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key5;
-	nano::change_block change1 (genesis.hash (), key5.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::change_block change1 (genesis.hash (), key5.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
 	nano::keypair key3;
-	nano::change_block change2 (change1.hash (), key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (change1.hash ()));
+	nano::change_block change2 (change1.hash (), key3.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (change1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change2).code);
 	nano::keypair key2;
-	nano::send_block send1 (change2.hash (), key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (change2.hash ()));
+	nano::send_block send1 (change2.hash (), key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (change2.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair key4;
 	nano::open_block open (send1.hash (), key4.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
-	nano::send_block send2 (send1.hash (), key2.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::send_block send2 (send1.hash (), key2.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
 	nano::receive_block receive1 (open.hash (), send2.hash (), key2.prv, key2.pub, *pool.generate (open.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
@@ -335,11 +335,11 @@ TEST (ledger, rollback_representation)
 	ledger.rollback (transaction, send1.hash ());
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (key3.pub));
 	nano::account_info info3;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info3));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info3));
 	ASSERT_EQ (key3.pub, info3.representative);
 	ASSERT_FALSE (ledger.rollback (transaction, change2.hash ()));
 	nano::account_info info4;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info4));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info4));
 	ASSERT_EQ (key5.pub, info4.representative);
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (key5.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
@@ -356,9 +356,9 @@ TEST (ledger, receive_rollback)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send (genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send (genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	nano::receive_block receive (send.hash (), send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send.hash ()));
+	nano::receive_block receive (send.hash (), send.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
 	ASSERT_FALSE (ledger.rollback (transaction, receive.hash ()));
 }
@@ -375,9 +375,9 @@ TEST (ledger, process_duplicate)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block send (info1.head, key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	nano::block_hash hash1 (send.hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, send).code);
@@ -396,7 +396,7 @@ TEST (ledger, representative_genesis)
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
-	auto latest (ledger.latest (transaction, nano::test_genesis_key.pub));
+	auto latest (ledger.latest (transaction, nano::dev_genesis_key.pub));
 	ASSERT_FALSE (latest.is_zero ());
 	ASSERT_EQ (genesis.open->hash (), ledger.representative (transaction, latest));
 }
@@ -426,30 +426,30 @@ TEST (ledger, representative_change)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-	nano::change_block block (info1.head, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
-	ASSERT_EQ (nano::test_genesis_key.pub, store->frontier_get (transaction, info1.head));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+	nano::change_block block (info1.head, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->frontier_get (transaction, info1.head));
 	auto return1 (ledger.process (transaction, block));
 	ASSERT_EQ (0, ledger.amount (transaction, block.hash ()));
 	ASSERT_TRUE (store->frontier_get (transaction, info1.head).is_zero ());
-	ASSERT_EQ (nano::test_genesis_key.pub, store->frontier_get (transaction, block.hash ()));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->frontier_get (transaction, block.hash ()));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::test_genesis_key.pub, store->block_account_calculated (block));
-	ASSERT_EQ (0, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->block_account_calculated (block));
+	ASSERT_EQ (0, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (key2.pub));
 	nano::account_info info2;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info2));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info2));
 	ASSERT_EQ (block.hash (), info2.head);
 	ASSERT_FALSE (ledger.rollback (transaction, info2.head));
-	ASSERT_EQ (nano::test_genesis_key.pub, store->frontier_get (transaction, info1.head));
+	ASSERT_EQ (nano::dev_genesis_key.pub, store->frontier_get (transaction, info1.head));
 	ASSERT_TRUE (store->frontier_get (transaction, block.hash ()).is_zero ());
 	nano::account_info info3;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info3));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info3));
 	ASSERT_EQ (info1.head, info3.head);
-	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 }
 
@@ -467,10 +467,10 @@ TEST (ledger, send_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-	nano::send_block block (info1.head, key2.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+	nano::send_block block (info1.head, key2.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
-	nano::send_block block2 (info1.head, key3.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block block2 (info1.head, key3.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block2).code);
 }
 
@@ -488,14 +488,14 @@ TEST (ledger, receive_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-	nano::send_block block (info1.head, key2.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+	nano::send_block block (info1.head, key2.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
 	nano::open_block block2 (block.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
 	nano::change_block block3 (block2.hash (), key3.pub, key2.prv, key2.pub, *pool.generate (block2.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
-	nano::send_block block4 (block.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block.hash ()));
+	nano::send_block block4 (block.hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block4).code);
 	nano::receive_block block5 (block2.hash (), block4.hash (), key2.prv, key2.pub, *pool.generate (block2.hash ()));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block5).code);
@@ -515,8 +515,8 @@ TEST (ledger, open_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-	nano::send_block block (info1.head, key2.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+	nano::send_block block (info1.head, key2.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
 	nano::open_block block2 (block.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
@@ -529,16 +529,16 @@ TEST (system, DISABLED_generate_send_existing)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::thread_runner runner (system.io_ctx, node1.config.io_threads);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair stake_preserver;
 	auto send_block (system.wallet (0)->send_action (nano::genesis_account, stake_preserver.pub, nano::genesis_amount / 3 * 2, true));
 	nano::account_info info1;
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		ASSERT_FALSE (node1.store.account_get (transaction, nano::test_genesis_key.pub, info1));
+		ASSERT_FALSE (node1.store.account_get (transaction, nano::dev_genesis_key.pub, info1));
 	}
 	std::vector<nano::account> accounts;
-	accounts.push_back (nano::test_genesis_key.pub);
+	accounts.push_back (nano::dev_genesis_key.pub);
 	system.generate_send_existing (node1, accounts);
 	// Have stake_preserver receive funds after generate_send_existing so it isn't chosen as the destination
 	{
@@ -551,7 +551,7 @@ TEST (system, DISABLED_generate_send_existing)
 	nano::account_info info2;
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		ASSERT_FALSE (node1.store.account_get (transaction, nano::test_genesis_key.pub, info2));
+		ASSERT_FALSE (node1.store.account_get (transaction, nano::dev_genesis_key.pub, info2));
 	}
 	ASSERT_NE (info1.head, info2.head);
 	system.deadline_set (15s);
@@ -559,7 +559,7 @@ TEST (system, DISABLED_generate_send_existing)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 		auto transaction (node1.store.tx_begin_read ());
-		ASSERT_FALSE (node1.store.account_get (transaction, nano::test_genesis_key.pub, info2));
+		ASSERT_FALSE (node1.store.account_get (transaction, nano::dev_genesis_key.pub, info2));
 	}
 	ASSERT_EQ (info1.block_count + 2, info2.block_count);
 	ASSERT_EQ (info2.balance, nano::genesis_amount / 3);
@@ -576,7 +576,7 @@ TEST (system, DISABLED_generate_send_new)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::thread_runner runner (system.io_ctx, node1.config.io_threads);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		auto iterator1 (node1.store.latest_begin (transaction));
@@ -594,7 +594,7 @@ TEST (system, DISABLED_generate_send_new)
 	}
 	ASSERT_GT (node1.balance (stake_preserver.pub), node1.balance (nano::genesis_account));
 	std::vector<nano::account> accounts;
-	accounts.push_back (nano::test_genesis_key.pub);
+	accounts.push_back (nano::dev_genesis_key.pub);
 	// This indirectly waits for online weight to stabilize, required to prevent intermittent failures
 	ASSERT_TIMELY (5s, node1.wallets.reps ().voting > 0);
 	system.generate_send_new (node1, accounts);
@@ -602,13 +602,13 @@ TEST (system, DISABLED_generate_send_new)
 	{
 		auto transaction (node1.wallets.tx_begin_read ());
 		auto iterator2 (system.wallet (0)->store.begin (transaction));
-		if (iterator2->first != nano::test_genesis_key.pub)
+		if (iterator2->first != nano::dev_genesis_key.pub)
 		{
 			new_account = iterator2->first;
 		}
 		++iterator2;
 		ASSERT_NE (system.wallet (0)->store.end (), iterator2);
-		if (iterator2->first != nano::test_genesis_key.pub)
+		if (iterator2->first != nano::dev_genesis_key.pub)
 		{
 			new_account = iterator2->first;
 		}
@@ -644,38 +644,38 @@ TEST (ledger, representation)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	ASSERT_EQ (nano::genesis_amount, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	nano::keypair key2;
-	nano::send_block block1 (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key2.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	ASSERT_EQ (nano::genesis_amount - 100, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 100, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	nano::keypair key3;
 	nano::open_block block2 (block1.hash (), key3.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	ASSERT_EQ (nano::genesis_amount - 100, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 100, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key3.pub));
-	nano::send_block block3 (block1.hash (), key2.pub, nano::genesis_amount - 200, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block3 (block1.hash (), key2.pub, nano::genesis_amount - 200, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key3.pub));
 	nano::receive_block block4 (block2.hash (), block3.hash (), key2.prv, key2.pub, *pool.generate (block2.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block4).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (200, rep_weights.representation_get (key3.pub));
 	nano::keypair key4;
 	nano::change_block block5 (block4.hash (), key4.pub, key2.prv, key2.pub, *pool.generate (block4.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block5).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (200, rep_weights.representation_get (key4.pub));
 	nano::keypair key5;
 	nano::send_block block6 (block5.hash (), key5.pub, 100, key2.prv, key2.pub, *pool.generate (block5.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block6).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key4.pub));
@@ -683,7 +683,7 @@ TEST (ledger, representation)
 	nano::keypair key6;
 	nano::open_block block7 (block6.hash (), key6.pub, key5.pub, key5.prv, key5.pub, *pool.generate (key5.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block7).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key4.pub));
@@ -691,7 +691,7 @@ TEST (ledger, representation)
 	ASSERT_EQ (100, rep_weights.representation_get (key6.pub));
 	nano::send_block block8 (block6.hash (), key5.pub, 0, key2.prv, key2.pub, *pool.generate (block6.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block8).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key4.pub));
@@ -699,7 +699,7 @@ TEST (ledger, representation)
 	ASSERT_EQ (100, rep_weights.representation_get (key6.pub));
 	nano::receive_block block9 (block7.hash (), block8.hash (), key5.prv, key5.pub, *pool.generate (block7.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block9).code);
-	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 200, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key4.pub));
@@ -719,11 +719,11 @@ TEST (ledger, double_open)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key2;
-	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::open_block open1 (send1.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::open_block open2 (send1.hash (), nano::test_genesis_key.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
+	nano::open_block open2 (send1.hash (), nano::dev_genesis_key.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, open2).code);
 }
 
@@ -739,7 +739,7 @@ TEST (ledger, double_receive)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key2;
-	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::open_block open1 (send1.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -755,7 +755,7 @@ TEST (votes, check_signature)
 	auto & node1 = *system.add_node (node_config);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	{
 		auto transaction (node1.store.tx_begin_write ());
@@ -766,7 +766,7 @@ TEST (votes, check_signature)
 		nano::lock_guard<std::mutex> lock (node1.active.mutex);
 		ASSERT_EQ (1, election1.election->last_votes.size ());
 	}
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
 	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0), node1.network_params.protocol.protocol_version)));
 	vote1->signature.bytes[0] ^= 1;
@@ -780,7 +780,7 @@ TEST (votes, add_one)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -788,13 +788,13 @@ TEST (votes, add_one)
 	nano::unique_lock<std::mutex> lock (node1.active.mutex);
 	ASSERT_EQ (1, election1.election->last_votes.size ());
 	lock.unlock ();
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
-	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
+	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2));
 	lock.lock ();
 	ASSERT_EQ (2, election1.election->last_votes.size ());
-	auto existing1 (election1.election->last_votes.find (nano::test_genesis_key.pub));
+	auto existing1 (election1.election->last_votes.find (nano::dev_genesis_key.pub));
 	ASSERT_NE (election1.election->last_votes.end (), existing1);
 	ASSERT_EQ (send1->hash (), existing1->second.hash);
 	auto winner (*election1.election->tally ().begin ());
@@ -808,7 +808,7 @@ TEST (votes, add_two)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -816,15 +816,15 @@ TEST (votes, add_two)
 	nano::unique_lock<std::mutex> lock (node1.active.mutex);
 	lock.unlock ();
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	auto vote2 (std::make_shared<nano::vote> (key2.pub, key2.prv, 1, send2));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2));
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	lock.lock ();
 	ASSERT_EQ (3, election1.election->last_votes.size ());
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::test_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::test_genesis_key.pub].hash);
+	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
 	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (key2.pub));
 	ASSERT_EQ (send2->hash (), election1.election->last_votes[key2.pub].hash);
 	auto winner (*election1.election->tally ().begin ());
@@ -841,39 +841,39 @@ TEST (votes, add_existing)
 	auto & node1 = *system.add_node (node_config);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	{
 		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto election1 = node1.active.insert (send1);
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	// Block is already processed from vote
 	ASSERT_TRUE (node1.active.publish (send1));
 	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	ASSERT_EQ (1, election1.election->last_votes[nano::test_genesis_key.pub].sequence);
+	ASSERT_EQ (1, election1.election->last_votes[nano::dev_genesis_key.pub].sequence);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
-	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send2));
+	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send2));
 	// Pretend we've waited the timeout
-	election1.election->last_votes[nano::test_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
+	election1.election->last_votes[nano::dev_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	lock.unlock ();
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2));
 	ASSERT_FALSE (node1.active.publish (send2));
 	lock.lock ();
-	ASSERT_EQ (2, election1.election->last_votes[nano::test_genesis_key.pub].sequence);
+	ASSERT_EQ (2, election1.election->last_votes[nano::dev_genesis_key.pub].sequence);
 	// Also resend the old vote, and see if we respect the sequence number
-	election1.election->last_votes[nano::test_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
+	election1.election->last_votes[nano::dev_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	lock.unlock ();
 	ASSERT_EQ (nano::vote_code::replay, node1.active.vote (vote1));
 	lock.lock ();
-	ASSERT_EQ (2, election1.election->last_votes[nano::test_genesis_key.pub].sequence);
+	ASSERT_EQ (2, election1.election->last_votes[nano::dev_genesis_key.pub].sequence);
 	ASSERT_EQ (2, election1.election->last_votes.size ());
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::test_genesis_key.pub));
-	ASSERT_EQ (send2->hash (), election1.election->last_votes[nano::test_genesis_key.pub].hash);
+	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send2->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		auto winner (*election1.election->tally ().begin ());
@@ -888,27 +888,27 @@ TEST (votes, add_old)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	auto election1 = node1.active.insert (send1);
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.vote_processor.vote_blocking (vote1, channel);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
-	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send2));
+	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send2));
 	{
 		nano::lock_guard<std::mutex> lock (node1.active.mutex);
-		election1.election->last_votes[nano::test_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
+		election1.election->last_votes[nano::dev_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	}
 	node1.vote_processor.vote_blocking (vote2, channel);
 	ASSERT_EQ (2, election1.election->last_votes_size ());
 	nano::lock_guard<std::mutex> lock (node1.active.mutex);
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::test_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::test_genesis_key.pub].hash);
+	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
 	auto winner (*election1.election->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
 }
@@ -920,9 +920,9 @@ TEST (votes, add_old_different_account)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
@@ -933,22 +933,22 @@ TEST (votes, add_old_different_account)
 	ASSERT_NE (nullptr, election2);
 	ASSERT_EQ (1, election1->last_votes_size ());
 	ASSERT_EQ (1, election2->last_votes_size ());
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	auto vote_result1 (node1.vote_processor.vote_blocking (vote1, channel));
 	ASSERT_EQ (nano::vote_code::vote, vote_result1);
 	ASSERT_EQ (2, election1->last_votes_size ());
 	ASSERT_EQ (1, election2->last_votes_size ());
-	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send2));
+	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send2));
 	auto vote_result2 (node1.vote_processor.vote_blocking (vote2, channel));
 	ASSERT_EQ (nano::vote_code::vote, vote_result2);
 	ASSERT_EQ (2, election1->last_votes_size ());
 	ASSERT_EQ (2, election2->last_votes_size ());
 	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	ASSERT_NE (election1->last_votes.end (), election1->last_votes.find (nano::test_genesis_key.pub));
-	ASSERT_NE (election2->last_votes.end (), election2->last_votes.find (nano::test_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1->last_votes[nano::test_genesis_key.pub].hash);
-	ASSERT_EQ (send2->hash (), election2->last_votes[nano::test_genesis_key.pub].hash);
+	ASSERT_NE (election1->last_votes.end (), election1->last_votes.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (election2->last_votes.end (), election2->last_votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), election1->last_votes[nano::dev_genesis_key.pub].hash);
+	ASSERT_EQ (send2->hash (), election2->last_votes[nano::dev_genesis_key.pub].hash);
 	auto winner1 (*election1->tally ().begin ());
 	ASSERT_EQ (*send1, *winner1.second);
 	auto winner2 (*election2->tally ().begin ());
@@ -962,23 +962,23 @@ TEST (votes, add_cooldown)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	auto election1 = node1.active.insert (send1);
-	auto vote1 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.vote_processor.vote_blocking (vote1, channel);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
-	auto vote2 (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 2, send2));
+	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send2));
 	node1.vote_processor.vote_blocking (vote2, channel);
 	nano::unique_lock<std::mutex> lock (node1.active.mutex);
 	ASSERT_EQ (2, election1.election->last_votes.size ());
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::test_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::test_genesis_key.pub].hash);
+	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
 	auto winner (*election1.election->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
 }
@@ -990,7 +990,7 @@ TEST (ledger, successor)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::genesis genesis;
-	nano::send_block send1 (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::send_block send1 (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 	node1.work_generate_blocking (send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send1).code);
@@ -1011,7 +1011,7 @@ TEST (ledger, fail_change_old)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::change_block block (genesis.hash (), key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::change_block block (genesis.hash (), key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
 	auto result2 (ledger.process (transaction, block));
@@ -1030,7 +1030,7 @@ TEST (ledger, fail_change_gap_previous)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::change_block block (1, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (nano::root (1)));
+	nano::change_block block (1, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::root (1)));
 	auto result1 (ledger.process (transaction, block));
 	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
 }
@@ -1064,11 +1064,11 @@ TEST (ledger, fail_change_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::change_block block1 (genesis.hash (), key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::change_block block1 (genesis.hash (), key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
 	nano::keypair key2;
-	nano::change_block block2 (genesis.hash (), key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::change_block block2 (genesis.hash (), key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::fork, result2.code);
 }
@@ -1085,7 +1085,7 @@ TEST (ledger, fail_send_old)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
 	auto result2 (ledger.process (transaction, block));
@@ -1104,7 +1104,7 @@ TEST (ledger, fail_send_gap_previous)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block (1, key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (nano::root (1)));
+	nano::send_block block (1, key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::root (1)));
 	auto result1 (ledger.process (transaction, block));
 	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
 }
@@ -1138,10 +1138,10 @@ TEST (ledger, fail_send_negative_spend)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 	nano::keypair key2;
-	nano::send_block block2 (block1.hash (), key2.pub, 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key2.pub, 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	ASSERT_EQ (nano::process_result::negative_spend, ledger.process (transaction, block2).code);
 }
 
@@ -1157,10 +1157,10 @@ TEST (ledger, fail_send_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 	nano::keypair key2;
-	nano::send_block block2 (genesis.hash (), key2.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block2 (genesis.hash (), key2.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block2).code);
 }
 
@@ -1176,7 +1176,7 @@ TEST (ledger, fail_open_old)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 	nano::open_block block2 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
@@ -1212,7 +1212,7 @@ TEST (ledger, fail_open_bad_signature)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 	nano::open_block block2 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
 	block2.signature.clear ();
@@ -1231,9 +1231,9 @@ TEST (ledger, fail_open_fork_previous)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
@@ -1254,7 +1254,7 @@ TEST (ledger, fail_open_account_mismatch)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 	nano::keypair badkey;
 	nano::open_block block2 (block1.hash (), 1, badkey.pub, badkey.prv, badkey.pub, *pool.generate (badkey.pub));
@@ -1274,9 +1274,9 @@ TEST (ledger, fail_receive_old)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
@@ -1297,10 +1297,10 @@ TEST (ledger, fail_receive_gap_source)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1323,7 +1323,7 @@ TEST (ledger, fail_receive_overreceive)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
 	nano::open_block block2 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1346,10 +1346,10 @@ TEST (ledger, fail_receive_bad_signature)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1372,10 +1372,10 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1398,10 +1398,10 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
 	nano::receive_block block3 (1, block2.hash (), key1.prv, key1.pub, *pool.generate (nano::root (1)));
@@ -1421,10 +1421,10 @@ TEST (ledger, fail_receive_fork_previous)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1451,13 +1451,13 @@ TEST (ledger, fail_receive_received_source)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::send_block block1 (genesis.hash (), key1.pub, 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), key1.pub, 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	auto result1 (ledger.process (transaction, block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	auto result2 (ledger.process (transaction, block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::send_block block6 (block2.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block2.hash ()));
+	nano::send_block block6 (block2.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block2.hash ()));
 	auto result6 (ledger.process (transaction, block6));
 	ASSERT_EQ (nano::process_result::progress, result6.code);
 	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1501,10 +1501,10 @@ TEST (ledger, latest_root)
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub));
-	auto hash1 (ledger.latest (transaction, nano::test_genesis_key.pub));
-	nano::send_block send (hash1, 0, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (hash1));
+	auto hash1 (ledger.latest (transaction, nano::dev_genesis_key.pub));
+	nano::send_block send (hash1, 0, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (hash1));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	ASSERT_EQ (send.hash (), ledger.latest_root (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (send.hash (), ledger.latest_root (transaction, nano::dev_genesis_key.pub));
 }
 
 TEST (ledger, change_representative_move_representation)
@@ -1520,12 +1520,12 @@ TEST (ledger, change_representative_move_representation)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	auto hash1 (genesis.hash ());
-	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::test_genesis_key.pub));
-	nano::send_block send (hash1, key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (hash1));
+	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
+	nano::send_block send (hash1, key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (hash1));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	ASSERT_EQ (0, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, ledger.weight (nano::dev_genesis_key.pub));
 	nano::keypair key2;
-	nano::change_block change (send.hash (), key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send.hash ()));
+	nano::change_block change (send.hash (), key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
 	nano::keypair key3;
 	nano::open_block open (send.hash (), key3.pub, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1545,12 +1545,12 @@ TEST (ledger, send_open_receive_rollback)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
 	nano::keypair key1;
-	nano::send_block send1 (info1.head, key1.pub, nano::genesis_amount - 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block send1 (info1.head, key1.pub, nano::genesis_amount - 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	auto return1 (ledger.process (transaction, send1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	nano::send_block send2 (send1.hash (), key1.pub, nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::send_block send2 (send1.hash (), key1.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	auto return2 (ledger.process (transaction, send2));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
 	nano::keypair key2;
@@ -1562,34 +1562,34 @@ TEST (ledger, send_open_receive_rollback)
 	ASSERT_EQ (nano::process_result::progress, return5.code);
 	nano::keypair key3;
 	ASSERT_EQ (100, ledger.weight (key2.pub));
-	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
-	nano::change_block change1 (send2.hash (), key3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send2.hash ()));
+	nano::change_block change1 (send2.hash (), key3.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send2.hash ()));
 	auto return6 (ledger.process (transaction, change1));
 	ASSERT_EQ (nano::process_result::progress, return6.code);
 	ASSERT_EQ (100, ledger.weight (key2.pub));
-	ASSERT_EQ (0, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, receive.hash ()));
 	ASSERT_EQ (50, ledger.weight (key2.pub));
-	ASSERT_EQ (0, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, open.hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
-	ASSERT_EQ (0, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, change1.hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
-	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 100, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, send2.hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
-	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 50, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, send1.hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
-	ASSERT_EQ (nano::genesis_amount - 0, ledger.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - 0, ledger.weight (nano::dev_genesis_key.pub));
 }
 
 TEST (ledger, bootstrap_rep_weight)
@@ -1606,8 +1606,8 @@ TEST (ledger, bootstrap_rep_weight)
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, genesis, ledger.cache);
-		ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+		ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	}
 	ASSERT_EQ (2, ledger.cache.block_count);
@@ -1618,8 +1618,8 @@ TEST (ledger, bootstrap_rep_weight)
 	}
 	{
 		auto transaction (store->tx_begin_write ());
-		ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+		ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	}
 	ASSERT_EQ (3, ledger.cache.block_count);
@@ -1643,17 +1643,17 @@ TEST (ledger, block_destination_source)
 	nano::keypair dest;
 	nano::uint128_t balance (nano::genesis_amount);
 	balance -= nano::Gxrb_ratio;
-	nano::send_block block1 (genesis.hash (), dest.pub, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block block1 (genesis.hash (), dest.pub, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	balance -= nano::Gxrb_ratio;
-	nano::send_block block2 (block1.hash (), nano::genesis_account, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block1.hash ()));
+	nano::send_block block2 (block1.hash (), nano::genesis_account, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block1.hash ()));
 	balance += nano::Gxrb_ratio;
-	nano::receive_block block3 (block2.hash (), block2.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block2.hash ()));
+	nano::receive_block block3 (block2.hash (), block2.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block2.hash ()));
 	balance -= nano::Gxrb_ratio;
-	nano::state_block block4 (nano::genesis_account, block3.hash (), nano::genesis_account, balance, dest.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block3.hash ()));
+	nano::state_block block4 (nano::genesis_account, block3.hash (), nano::genesis_account, balance, dest.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block3.hash ()));
 	balance -= nano::Gxrb_ratio;
-	nano::state_block block5 (nano::genesis_account, block4.hash (), nano::genesis_account, balance, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block4.hash ()));
+	nano::state_block block5 (nano::genesis_account, block4.hash (), nano::genesis_account, balance, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block4.hash ()));
 	balance += nano::Gxrb_ratio;
-	nano::state_block block6 (nano::genesis_account, block5.hash (), nano::genesis_account, balance, block5.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (block5.hash ()));
+	nano::state_block block6 (nano::genesis_account, block5.hash (), nano::genesis_account, balance, block5.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (block5.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
@@ -1686,7 +1686,7 @@ TEST (ledger, state_account)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_EQ (nano::genesis_account, ledger.account (transaction, send1.hash ()));
 }
@@ -1702,7 +1702,7 @@ TEST (ledger, state_send_receive)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -1716,7 +1716,7 @@ TEST (ledger, state_send_receive)
 	ASSERT_TRUE (send2->sideband ().details.is_send);
 	ASSERT_FALSE (send2->sideband ().details.is_receive);
 	ASSERT_FALSE (send2->sideband ().details.is_epoch);
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
 	ASSERT_TRUE (store->block_exists (transaction, receive1.hash ()));
 	auto receive2 (store->block_get (transaction, receive1.hash ()));
@@ -1744,7 +1744,7 @@ TEST (ledger, state_receive)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -1753,7 +1753,7 @@ TEST (ledger, state_receive)
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::genesis_account));
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
 	ASSERT_TRUE (store->block_exists (transaction, receive1.hash ()));
 	auto receive2 (store->block_get (transaction, receive1.hash ()));
@@ -1780,7 +1780,7 @@ TEST (ledger, state_rep_change)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
-	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
 	ASSERT_TRUE (store->block_exists (transaction, change1.hash ()));
 	auto change2 (store->block_get (transaction, change1.hash ()));
@@ -1808,7 +1808,7 @@ TEST (ledger, state_open)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -1847,9 +1847,9 @@ TEST (ledger, send_after_state_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::send_block send2 (send1.hash (), nano::genesis_account, nano::genesis_amount - (2 * nano::Gxrb_ratio), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::send_block send2 (send1.hash (), nano::genesis_account, nano::genesis_amount - (2 * nano::Gxrb_ratio), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, send2).code);
 }
 
@@ -1865,9 +1865,9 @@ TEST (ledger, receive_after_state_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::receive_block receive1 (send1.hash (), send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::receive_block receive1 (send1.hash (), send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, receive1).code);
 }
 
@@ -1883,10 +1883,10 @@ TEST (ledger, change_after_state_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair rep;
-	nano::change_block change1 (send1.hash (), rep.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::change_block change1 (send1.hash (), rep.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, change1).code);
 }
 
@@ -1901,7 +1901,7 @@ TEST (ledger, state_unreceivable_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -1910,7 +1910,7 @@ TEST (ledger, state_unreceivable_fail)
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::genesis_account));
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, receive1).code);
 }
 
@@ -1925,7 +1925,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -1934,7 +1934,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::genesis_account));
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, receive1).code);
 }
 
@@ -1949,10 +1949,10 @@ TEST (ledger, state_no_link_amount_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair rep;
-	nano::state_block change1 (nano::genesis_account, send1.hash (), rep.pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block change1 (nano::genesis_account, send1.hash (), rep.pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, change1).code);
 }
 
@@ -1967,7 +1967,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -1993,7 +1993,7 @@ TEST (ledger, state_open_state_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::state_block open1 (destination.pub, 0, nano::genesis_account, nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -2014,7 +2014,7 @@ TEST (ledger, state_state_open_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::open_block open1 (send1.hash (), nano::genesis_account, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -2036,7 +2036,7 @@ TEST (ledger, state_open_previous_fail)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::state_block open1 (destination.pub, 1, nano::genesis_account, nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (1));
 	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, open1).code);
@@ -2054,7 +2054,7 @@ TEST (ledger, state_open_source_fail)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::state_block open1 (destination.pub, 0, nano::genesis_account, 0, 0, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, open1).code);
@@ -2072,7 +2072,7 @@ TEST (ledger, state_send_change)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -2099,7 +2099,7 @@ TEST (ledger, state_receive_change)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -2109,7 +2109,7 @@ TEST (ledger, state_receive_change)
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
 	ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::genesis_account));
 	nano::keypair rep;
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), rep.pub, nano::genesis_amount, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), rep.pub, nano::genesis_amount, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
 	ASSERT_TRUE (store->block_exists (transaction, receive1.hash ()));
 	auto receive2 (store->block_get (transaction, receive1.hash ()));
@@ -2137,7 +2137,7 @@ TEST (ledger, state_open_old)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::open_block open1 (send1.hash (), nano::genesis_account, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -2158,9 +2158,9 @@ TEST (ledger, state_receive_old)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block send2 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - (2 * nano::Gxrb_ratio), destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block send2 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - (2 * nano::Gxrb_ratio), destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
 	nano::open_block open1 (send1.hash (), nano::genesis_account, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -2182,7 +2182,7 @@ TEST (ledger, state_rollback_send)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block_exists (transaction, send1.hash ()));
 	auto send2 (store->block_get (transaction, send1.hash ()));
@@ -2214,9 +2214,9 @@ TEST (ledger, state_rollback_receive)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
 	ASSERT_FALSE (store->pending_exists (transaction, nano::pending_key (nano::genesis_account, receive1.hash ())));
 	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
@@ -2242,7 +2242,7 @@ TEST (ledger, state_rollback_received_send)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::state_block receive1 (key.pub, 0, key.pub, nano::Gxrb_ratio, send1.hash (), key.prv, key.pub, *pool.generate (key.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
@@ -2270,7 +2270,7 @@ TEST (ledger, state_rep_change_rollback)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
-	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, change1.hash ()));
 	ASSERT_FALSE (store->block_exists (transaction, change1.hash ()));
@@ -2291,7 +2291,7 @@ TEST (ledger, state_open_rollback)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::state_block open1 (destination.pub, 0, nano::genesis_account, nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -2318,7 +2318,7 @@ TEST (ledger, state_send_change_rollback)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, send1.hash ()));
 	ASSERT_FALSE (store->block_exists (transaction, send1.hash ()));
@@ -2339,10 +2339,10 @@ TEST (ledger, state_receive_change_rollback)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair rep;
-	nano::state_block receive1 (nano::genesis_account, send1.hash (), rep.pub, nano::genesis_amount, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block receive1 (nano::genesis_account, send1.hash (), rep.pub, nano::genesis_amount, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
 	ASSERT_FALSE (store->block_exists (transaction, receive1.hash ()));
@@ -2364,12 +2364,12 @@ TEST (ledger, epoch_blocks_v1_general)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
 	ASSERT_FALSE (epoch1.sideband ().details.is_send);
 	ASSERT_FALSE (epoch1.sideband ().details.is_receive);
 	ASSERT_TRUE (epoch1.sideband ().details.is_epoch);
-	nano::state_block epoch2 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::state_block epoch2 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, epoch2).code);
 	nano::account_info genesis_info;
 	ASSERT_FALSE (ledger.store.account_get (transaction, nano::genesis_account, genesis_info));
@@ -2383,18 +2383,18 @@ TEST (ledger, epoch_blocks_v1_general)
 	ASSERT_FALSE (epoch1.sideband ().details.is_send);
 	ASSERT_FALSE (epoch1.sideband ().details.is_receive);
 	ASSERT_TRUE (epoch1.sideband ().details.is_epoch);
-	nano::change_block change1 (epoch1.hash (), nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::change_block change1 (epoch1.hash (), nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, change1).code);
-	nano::state_block send1 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::state_block send1 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (send1.sideband ().details.is_send);
 	ASSERT_FALSE (send1.sideband ().details.is_receive);
 	ASSERT_FALSE (send1.sideband ().details.is_epoch);
 	nano::open_block open1 (send1.hash (), nano::genesis_account, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open1).code);
-	nano::state_block epoch3 (destination.pub, 0, nano::genesis_account, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (destination.pub));
+	nano::state_block epoch3 (destination.pub, 0, nano::genesis_account, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, epoch3).code);
-	nano::state_block epoch4 (destination.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (destination.pub));
+	nano::state_block epoch4 (destination.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch4).code);
 	ASSERT_FALSE (epoch4.sideband ().details.is_send);
 	ASSERT_FALSE (epoch4.sideband ().details.is_receive);
@@ -2425,15 +2425,15 @@ TEST (ledger, epoch_blocks_v2_general)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	// Trying to upgrade from epoch 0 to epoch 2. It is a requirement epoch upgrades are sequential unless the account is unopened
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, epoch1).code);
 	// Set it to the first epoch and it should now succeed
-	epoch1 = nano::state_block (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, epoch1.work);
+	epoch1 = nano::state_block (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, epoch1.work);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	nano::state_block epoch2 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::state_block epoch2 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch2).code);
-	nano::state_block epoch3 (nano::genesis_account, epoch2.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch2.hash ()));
+	nano::state_block epoch3 (nano::genesis_account, epoch2.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch2.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, epoch3).code);
 	nano::account_info genesis_info;
 	ASSERT_FALSE (ledger.store.account_get (transaction, nano::genesis_account, genesis_info));
@@ -2444,17 +2444,17 @@ TEST (ledger, epoch_blocks_v2_general)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
 	ASSERT_FALSE (ledger.store.account_get (transaction, nano::genesis_account, genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
-	nano::change_block change1 (epoch1.hash (), nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::change_block change1 (epoch1.hash (), nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, change1).code);
-	nano::state_block send1 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::state_block send1 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::open_block open1 (send1.hash (), nano::genesis_account, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open1).code);
-	nano::state_block epoch4 (destination.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (destination.pub));
+	nano::state_block epoch4 (destination.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch4).code);
-	nano::state_block epoch5 (destination.pub, epoch4.hash (), nano::genesis_account, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch4.hash ()));
+	nano::state_block epoch5 (destination.pub, epoch4.hash (), nano::genesis_account, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch4.hash ()));
 	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, epoch5).code);
-	nano::state_block epoch6 (destination.pub, epoch4.hash (), 0, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch4.hash ()));
+	nano::state_block epoch6 (destination.pub, epoch4.hash (), 0, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch4.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch6).code);
 	nano::receive_block receive1 (epoch6.hash (), send1.hash (), destination.prv, destination.pub, *pool.generate (epoch6.hash ()));
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, receive1).code);
@@ -2479,11 +2479,11 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block epoch1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block epoch1 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	nano::state_block send2 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 2, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch1.hash ()));
+	nano::state_block send2 (nano::genesis_account, epoch1.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 2, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
 	nano::open_block open1 (send1.hash (), destination.pub, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
@@ -2507,14 +2507,14 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open2).code);
 	// Upgrade to epoch 2 and send to destination. Try to create an open block from an epoch 2 source block.
 	nano::keypair destination3;
-	nano::state_block epoch2 (nano::genesis_account, send2.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 2, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send2.hash ()));
+	nano::state_block epoch2 (nano::genesis_account, send2.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 2, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send2.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch2).code);
-	nano::state_block send4 (nano::genesis_account, epoch2.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 3, destination3.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (epoch2.hash ()));
+	nano::state_block send4 (nano::genesis_account, epoch2.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 3, destination3.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (epoch2.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send4).code);
 	nano::open_block open3 (send4.hash (), destination3.pub, destination3.pub, destination3.prv, destination3.pub, *pool.generate (destination3.pub));
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open3).code);
 	// Send it to an epoch 1 account
-	nano::state_block send5 (nano::genesis_account, send4.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 4, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send4.hash ()));
+	nano::state_block send5 (nano::genesis_account, send4.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 4, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send4.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send5).code);
 	ASSERT_FALSE (ledger.store.account_get (transaction, destination.pub, destination_info));
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
@@ -2524,9 +2524,9 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_2);
 	// Upgrade an unopened account straight to epoch 2
 	nano::keypair destination4;
-	nano::state_block send6 (nano::genesis_account, send5.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 5, destination4.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send5.hash ()));
+	nano::state_block send6 (nano::genesis_account, send5.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio * 5, destination4.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send5.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send6).code);
-	nano::state_block epoch4 (destination4.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (destination4.pub));
+	nano::state_block epoch4 (destination4.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (destination4.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch4).code);
 	ASSERT_EQ (store->account_count (transaction), ledger.cache.account_count);
 }
@@ -2543,15 +2543,15 @@ TEST (ledger, epoch_blocks_fork)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
-	nano::send_block send1 (genesis.hash (), nano::account (0), nano::genesis_amount, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), nano::account (0), nano::genesis_amount, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, epoch1).code);
-	nano::state_block epoch2 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block epoch2 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, epoch2).code);
-	nano::state_block epoch3 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block epoch3 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch3).code);
-	nano::state_block epoch4 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block epoch4 (nano::genesis_account, send1.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, epoch2).code);
 }
 
@@ -2562,12 +2562,12 @@ TEST (ledger, successor_epoch)
 	nano::keypair key1;
 	nano::genesis genesis;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::send_block send1 (genesis.hash (), key1.pub, nano::genesis_amount - 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send1 (genesis.hash (), key1.pub, nano::genesis_amount - 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	nano::state_block open (key1.pub, 0, key1.pub, 1, send1.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 	nano::state_block change (key1.pub, open.hash (), key1.pub, 1, 0, key1.prv, key1.pub, *pool.generate (open.hash ()));
 	auto open_hash = open.hash ();
-	nano::send_block send2 (send1.hash (), reinterpret_cast<nano::account const &> (open_hash), nano::genesis_amount - 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send1.hash ()));
-	nano::state_block epoch_open (reinterpret_cast<nano::account const &> (open_hash), 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (open.hash ()));
+	nano::send_block send2 (send1.hash (), reinterpret_cast<nano::account const &> (open_hash), nano::genesis_amount - 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send1.hash ()));
+	nano::state_block epoch_open (reinterpret_cast<nano::account const &> (open_hash), 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (open.hash ()));
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send1).code);
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, open).code);
@@ -2584,7 +2584,7 @@ TEST (ledger, epoch_open_pending)
 	auto & node1 (*system.nodes[0]);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
-	nano::state_block epoch_open (key1.pub, 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (key1.pub));
+	nano::state_block epoch_open (key1.pub, 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (key1.pub));
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::block_position, node1.ledger.process (transaction, epoch_open).code);
 }
@@ -2609,7 +2609,7 @@ TEST (ledger, block_hash_account_conflict)
 	             .representative (nano::genesis_account)
 	             .balance (nano::genesis_amount - 100)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*pool.generate (genesis.hash ()))
 	             .build_shared ();
 
@@ -2649,7 +2649,7 @@ TEST (ledger, block_hash_account_conflict)
 	                   .representative (0)
 	                   .balance (0)
 	                   .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
-	                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                   .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                   .work (*pool.generate (receive1->hash ()))
 	                   .build_shared ();
 
@@ -2694,14 +2694,14 @@ TEST (ledger, could_fit)
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	// Test legacy and state change blocks could_fit
-	nano::change_block change1 (genesis.hash (), nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
-	nano::state_block change2 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::change_block change1 (genesis.hash (), nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::state_block change2 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_TRUE (ledger.could_fit (transaction, change1));
 	ASSERT_TRUE (ledger.could_fit (transaction, change2));
 	// Test legacy and state send
 	nano::keypair key1;
-	nano::send_block send1 (change1.hash (), key1.pub, nano::genesis_amount - 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (change1.hash ()));
-	nano::state_block send2 (nano::genesis_account, change1.hash (), nano::genesis_account, nano::genesis_amount - 1, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (change1.hash ()));
+	nano::send_block send1 (change1.hash (), key1.pub, nano::genesis_amount - 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (change1.hash ()));
+	nano::state_block send2 (nano::genesis_account, change1.hash (), nano::genesis_account, nano::genesis_amount - 1, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (change1.hash ()));
 	ASSERT_FALSE (ledger.could_fit (transaction, send1));
 	ASSERT_FALSE (ledger.could_fit (transaction, send2));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
@@ -2723,7 +2723,7 @@ TEST (ledger, could_fit)
 	ASSERT_TRUE (ledger.could_fit (transaction, open1));
 	ASSERT_TRUE (ledger.could_fit (transaction, open2));
 	// Create another send to receive
-	nano::state_block send3 (nano::genesis_account, send2.hash (), nano::genesis_account, nano::genesis_amount - 2, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (send2.hash ()));
+	nano::state_block send3 (nano::genesis_account, send2.hash (), nano::genesis_account, nano::genesis_amount - 2, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send2.hash ()));
 	// Test legacy and state receive
 	nano::receive_block receive1 (open1.hash (), send3.hash (), key1.prv, key1.pub, *pool.generate (open1.hash ()));
 	nano::state_block receive2 (key1.pub, open1.hash (), nano::genesis_account, 2, send3.hash (), key1.prv, key1.pub, *pool.generate (open1.hash ()));
@@ -2733,7 +2733,7 @@ TEST (ledger, could_fit)
 	ASSERT_TRUE (ledger.could_fit (transaction, receive1));
 	ASSERT_TRUE (ledger.could_fit (transaction, receive2));
 	// Test epoch (state)
-	nano::state_block epoch1 (key1.pub, receive1.hash (), nano::genesis_account, 2, ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (receive1.hash ()));
+	nano::state_block epoch1 (key1.pub, receive1.hash (), nano::genesis_account, 2, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (receive1.hash ()));
 	ASSERT_FALSE (ledger.could_fit (transaction, epoch1));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
 	ASSERT_TRUE (ledger.could_fit (transaction, receive1));
@@ -2749,11 +2749,11 @@ TEST (ledger, unchecked_epoch)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto open1 (std::make_shared<nano::state_block> (destination.pub, 0, destination.pub, nano::Gxrb_ratio, send1->hash (), destination.prv, destination.pub, 0));
 	node1.work_generate_blocking (*open1);
-	auto epoch1 (std::make_shared<nano::state_block> (destination.pub, open1->hash (), destination.pub, nano::Gxrb_ratio, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto epoch1 (std::make_shared<nano::state_block> (destination.pub, open1->hash (), destination.pub, nano::Gxrb_ratio, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*epoch1);
 	node1.block_processor.add (epoch1);
 	node1.block_processor.flush ();
@@ -2789,7 +2789,7 @@ TEST (ledger, unchecked_epoch_invalid)
 	auto & node1 (*system.add_node (node_config));
 	nano::genesis genesis;
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto open1 (std::make_shared<nano::state_block> (destination.pub, 0, destination.pub, nano::Gxrb_ratio, send1->hash (), destination.prv, destination.pub, 0));
 	node1.work_generate_blocking (*open1);
@@ -2841,12 +2841,12 @@ TEST (ledger, unchecked_open)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
 	auto open1 (std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0));
 	node1.work_generate_blocking (*open1);
 	// Invalid signature for open block
-	auto open2 (std::make_shared<nano::open_block> (send1->hash (), nano::test_genesis_key.pub, destination.pub, destination.prv, destination.pub, 0));
+	auto open2 (std::make_shared<nano::open_block> (send1->hash (), nano::dev_genesis_key.pub, destination.pub, destination.prv, destination.pub, 0));
 	node1.work_generate_blocking (*open2);
 	open2->signature.bytes[0] ^= 1;
 	node1.block_processor.add (open1);
@@ -2878,9 +2878,9 @@ TEST (ledger, unchecked_receive)
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send1);
-	auto send2 (std::make_shared<nano::state_block> (nano::genesis_account, send1->hash (), nano::genesis_account, nano::genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto send2 (std::make_shared<nano::state_block> (nano::genesis_account, send1->hash (), nano::genesis_account, nano::genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*send2);
 	auto open1 (std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0));
 	node1.work_generate_blocking (*open1);
@@ -2934,9 +2934,9 @@ TEST (ledger, confirmation_height_not_updated)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info account_info;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, account_info));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, account_info));
 	nano::keypair key;
-	nano::send_block send1 (account_info.head, key.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (account_info.head));
+	nano::send_block send1 (account_info.head, key.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (account_info.head));
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_FALSE (store->confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
@@ -2959,29 +2959,29 @@ TEST (ledger, zero_rep)
 	nano::genesis genesis;
 	nano::block_builder builder;
 	auto block1 = builder.state ()
-	              .account (nano::test_genesis_key.pub)
+	              .account (nano::dev_genesis_key.pub)
 	              .previous (genesis.hash ())
 	              .representative (0)
 	              .balance (nano::genesis_amount)
 	              .link (0)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*system.work.generate (genesis.hash ()))
 	              .build ();
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *block1).code);
-	ASSERT_EQ (0, node1.ledger.cache.rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, node1.ledger.cache.rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (nano::genesis_amount, node1.ledger.cache.rep_weights.representation_get (0));
 	auto block2 = builder.state ()
-	              .account (nano::test_genesis_key.pub)
+	              .account (nano::dev_genesis_key.pub)
 	              .previous (block1->hash ())
-	              .representative (nano::test_genesis_key.pub)
+	              .representative (nano::dev_genesis_key.pub)
 	              .balance (nano::genesis_amount)
 	              .link (0)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*system.work.generate (block1->hash ()))
 	              .build ();
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *block2).code);
-	ASSERT_EQ (nano::genesis_amount, node1.ledger.cache.rep_weights.representation_get (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount, node1.ledger.cache.rep_weights.representation_get (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, node1.ledger.cache.rep_weights.representation_get (0));
 }
 
@@ -2996,7 +2996,7 @@ TEST (ledger, work_validation)
 	store->initialize (store->tx_begin_write (), genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::block_builder builder;
-	auto gen = nano::test_genesis_key;
+	auto gen = nano::dev_genesis_key;
 	nano::keypair key;
 
 	// With random work the block doesn't pass, then modifies the block with sufficient work and ensures a correct result
@@ -3094,10 +3094,10 @@ TEST (ledger, epoch_2_started_flag)
 	auto epoch1 = system.upgrade_genesis_epoch (node2, nano::epoch::epoch_1);
 	ASSERT_NE (nullptr, epoch1);
 	ASSERT_FALSE (node2.ledger.cache.epoch_2_started.load ());
-	nano::state_block send (nano::test_genesis_key.pub, epoch1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 1, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (epoch1->hash ()));
+	nano::state_block send (nano::dev_genesis_key.pub, epoch1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 1, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (epoch1->hash ()));
 	ASSERT_EQ (nano::process_result::progress, node2.process (send).code);
 	ASSERT_FALSE (node2.ledger.cache.epoch_2_started.load ());
-	nano::state_block epoch2 (key.pub, 0, 0, 0, node2.ledger.epoch_link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (key.pub));
+	nano::state_block epoch2 (key.pub, 0, 0, 0, node2.ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node2.process (epoch2).code);
 	ASSERT_TRUE (node2.ledger.cache.epoch_2_started.load ());
 
@@ -3149,7 +3149,7 @@ TEST (ledger, can_vote)
 	             .representative (nano::genesis_account)
 	             .balance (nano::genesis_amount - 100)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*pool.generate (genesis.hash ()))
 	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
@@ -3160,7 +3160,7 @@ TEST (ledger, can_vote)
 	             .representative (nano::genesis_account)
 	             .balance (nano::genesis_amount - 200)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*pool.generate (send1->hash ()))
 	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
@@ -3229,11 +3229,11 @@ TEST (ledger, backtrack)
 		auto latest = blocks.back ();
 		blocks.push_back (builder.state ()
 		                  .previous (latest->hash ())
-		                  .account (nano::test_genesis_key.pub)
-		                  .representative (nano::test_genesis_key.pub)
+		                  .account (nano::dev_genesis_key.pub)
+		                  .representative (nano::dev_genesis_key.pub)
 		                  .balance (--amount)
-		                  .link (nano::test_genesis_key.pub)
-		                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		                  .link (nano::dev_genesis_key.pub)
+		                  .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		                  .work (*pool.generate (latest->hash ()))
 		                  .build (ec));
 		ASSERT_FALSE (ec);

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -5,7 +5,7 @@
 
 namespace
 {
-class test_visitor : public nano::message_visitor
+class dev_visitor : public nano::message_visitor
 {
 public:
 	void keepalive (nano::keepalive const &) override
@@ -63,7 +63,7 @@ public:
 TEST (message_parser, exact_confirm_ack_size)
 {
 	nano::system system (1);
-	test_visitor visitor;
+	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
@@ -97,7 +97,7 @@ TEST (message_parser, exact_confirm_ack_size)
 TEST (message_parser, exact_confirm_req_size)
 {
 	nano::system system (1);
-	test_visitor visitor;
+	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
@@ -130,7 +130,7 @@ TEST (message_parser, exact_confirm_req_size)
 TEST (message_parser, exact_confirm_req_hash_size)
 {
 	nano::system system (1);
-	test_visitor visitor;
+	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
@@ -163,7 +163,7 @@ TEST (message_parser, exact_confirm_req_hash_size)
 TEST (message_parser, exact_publish_size)
 {
 	nano::system system (1);
-	test_visitor visitor;
+	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
@@ -196,7 +196,7 @@ TEST (message_parser, exact_publish_size)
 TEST (message_parser, exact_keepalive_size)
 {
 	nano::system system (1);
-	test_visitor visitor;
+	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -200,13 +200,13 @@ TEST (network, send_discarded_publish)
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		node1.network.flood_block (block);
-		ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::test_genesis_key.pub));
-		ASSERT_EQ (genesis.hash (), node2.latest (nano::test_genesis_key.pub));
+		ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::dev_genesis_key.pub));
+		ASSERT_EQ (genesis.hash (), node2.latest (nano::dev_genesis_key.pub));
 	}
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
 	auto transaction (node1.store.tx_begin_read ());
-	ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::test_genesis_key.pub));
-	ASSERT_EQ (genesis.hash (), node2.latest (nano::test_genesis_key.pub));
+	ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::dev_genesis_key.pub));
+	ASSERT_EQ (genesis.hash (), node2.latest (nano::dev_genesis_key.pub));
 }
 
 TEST (network, send_invalid_publish)
@@ -215,17 +215,17 @@ TEST (network, send_invalid_publish)
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	nano::genesis genesis;
-	auto block (std::make_shared<nano::send_block> (1, 1, 20, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::root (1))));
+	auto block (std::make_shared<nano::send_block> (1, 1, 20, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::root (1))));
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		node1.network.flood_block (block);
-		ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::test_genesis_key.pub));
-		ASSERT_EQ (genesis.hash (), node2.latest (nano::test_genesis_key.pub));
+		ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::dev_genesis_key.pub));
+		ASSERT_EQ (genesis.hash (), node2.latest (nano::dev_genesis_key.pub));
 	}
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
 	auto transaction (node1.store.tx_begin_read ());
-	ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::test_genesis_key.pub));
-	ASSERT_EQ (genesis.hash (), node2.latest (nano::test_genesis_key.pub));
+	ASSERT_EQ (genesis.hash (), node1.ledger.latest (transaction, nano::dev_genesis_key.pub));
+	ASSERT_EQ (genesis.hash (), node2.latest (nano::dev_genesis_key.pub));
 }
 
 TEST (network, send_valid_confirm_ack)
@@ -244,16 +244,16 @@ TEST (network, send_valid_confirm_ack)
 		auto & node1 (*system.nodes[0]);
 		auto & node2 (*system.nodes[1]);
 		nano::keypair key2;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		system.wallet (1)->insert_adhoc (key2.prv);
-		nano::block_hash latest1 (node1.latest (nano::test_genesis_key.pub));
-		nano::send_block block2 (latest1, key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1));
-		nano::block_hash latest2 (node2.latest (nano::test_genesis_key.pub));
+		nano::block_hash latest1 (node1.latest (nano::dev_genesis_key.pub));
+		nano::send_block block2 (latest1, key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1));
+		nano::block_hash latest2 (node2.latest (nano::dev_genesis_key.pub));
 		node1.process_active (std::make_shared<nano::send_block> (block2));
 		// Keep polling until latest block changes
-		ASSERT_TIMELY (10s, node2.latest (nano::test_genesis_key.pub) != latest2);
+		ASSERT_TIMELY (10s, node2.latest (nano::dev_genesis_key.pub) != latest2);
 		// Make sure the balance has decreased after processing the block.
-		ASSERT_EQ (50, node2.balance (nano::test_genesis_key.pub));
+		ASSERT_EQ (50, node2.balance (nano::dev_genesis_key.pub));
 	}
 }
 
@@ -274,18 +274,18 @@ TEST (network, send_valid_publish)
 		auto & node2 (*system.nodes[1]);
 		node1.bootstrap_initiator.stop ();
 		node2.bootstrap_initiator.stop ();
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		nano::keypair key2;
 		system.wallet (1)->insert_adhoc (key2.prv);
-		nano::block_hash latest1 (node1.latest (nano::test_genesis_key.pub));
-		nano::send_block block2 (latest1, key2.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1));
+		nano::block_hash latest1 (node1.latest (nano::dev_genesis_key.pub));
+		nano::send_block block2 (latest1, key2.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1));
 		auto hash2 (block2.hash ());
-		nano::block_hash latest2 (node2.latest (nano::test_genesis_key.pub));
+		nano::block_hash latest2 (node2.latest (nano::dev_genesis_key.pub));
 		node2.process_active (std::make_shared<nano::send_block> (block2));
 		ASSERT_TIMELY (10s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
 		ASSERT_NE (hash2, latest2);
-		ASSERT_TIMELY (10s, node2.latest (nano::test_genesis_key.pub) != latest2);
-		ASSERT_EQ (50, node2.balance (nano::test_genesis_key.pub));
+		ASSERT_TIMELY (10s, node2.latest (nano::dev_genesis_key.pub) != latest2);
+		ASSERT_EQ (50, node2.balance (nano::dev_genesis_key.pub));
 	}
 }
 
@@ -296,7 +296,7 @@ TEST (network, send_insufficient_work)
 	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
 	auto & node2 = *system.add_node (node_flags);
-	auto block (std::make_shared<nano::send_block> (0, 1, 20, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto block (std::make_shared<nano::send_block> (0, 1, 20, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	nano::publish publish (block);
 	nano::transport::channel_udp channel (node1.network.udp_channels, node2.network.endpoint (), node1.network_params.protocol.protocol_version);
 	channel.send (publish, [](boost::system::error_code const & ec, size_t size) {});
@@ -310,7 +310,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
-	auto block1 (std::make_shared<nano::send_block> (genesis.hash (), 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto block1 (std::make_shared<nano::send_block> (genesis.hash (), 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
 	node1.active.insert (block1);
@@ -325,11 +325,11 @@ TEST (receivable_processor, confirm_sufficient_pos)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
-	auto block1 (std::make_shared<nano::send_block> (genesis.hash (), 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto block1 (std::make_shared<nano::send_block> (genesis.hash (), 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
 	node1.active.insert (block1);
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, block1));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, block1));
 	nano::confirm_ack con1 (vote);
 	node1.network.process_message (con1, node1.network.udp_channels.create (node1.network.endpoint ()));
 }
@@ -351,26 +351,26 @@ TEST (receivable_processor, send_with_receive)
 		auto & node2 (*system.nodes[1]);
 		auto amount (std::numeric_limits<nano::uint128_t>::max ());
 		nano::keypair key2;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-		nano::block_hash latest1 (node1.latest (nano::test_genesis_key.pub));
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+		nano::block_hash latest1 (node1.latest (nano::dev_genesis_key.pub));
 		system.wallet (1)->insert_adhoc (key2.prv);
-		auto block1 (std::make_shared<nano::send_block> (latest1, key2.pub, amount - node1.config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest1)));
-		ASSERT_EQ (amount, node1.balance (nano::test_genesis_key.pub));
+		auto block1 (std::make_shared<nano::send_block> (latest1, key2.pub, amount - node1.config.receive_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest1)));
+		ASSERT_EQ (amount, node1.balance (nano::dev_genesis_key.pub));
 		ASSERT_EQ (0, node1.balance (key2.pub));
-		ASSERT_EQ (amount, node2.balance (nano::test_genesis_key.pub));
+		ASSERT_EQ (amount, node2.balance (nano::dev_genesis_key.pub));
 		ASSERT_EQ (0, node2.balance (key2.pub));
 		node1.process_active (block1);
 		node1.block_processor.flush ();
 		node2.process_active (block1);
 		node2.block_processor.flush ();
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::test_genesis_key.pub));
+		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev_genesis_key.pub));
 		ASSERT_EQ (0, node1.balance (key2.pub));
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::test_genesis_key.pub));
+		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev_genesis_key.pub));
 		ASSERT_EQ (0, node2.balance (key2.pub));
 		ASSERT_TIMELY (10s, node1.balance (key2.pub) == node1.config.receive_minimum.number () && node2.balance (key2.pub) == node1.config.receive_minimum.number ());
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::test_genesis_key.pub));
+		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev_genesis_key.pub));
 		ASSERT_EQ (node1.config.receive_minimum.number (), node1.balance (key2.pub));
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::test_genesis_key.pub));
+		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev_genesis_key.pub));
 		ASSERT_EQ (node1.config.receive_minimum.number (), node2.balance (key2.pub));
 	}
 }
@@ -378,14 +378,14 @@ TEST (receivable_processor, send_with_receive)
 TEST (network, receive_weight_change)
 {
 	nano::system system (2);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
 	{
 		auto transaction (system.nodes[1]->wallets.tx_begin_write ());
 		system.wallet (1)->store.representative_set (transaction, key2.pub);
 	}
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, std::all_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<nano::node> const & node_a) { return node_a->weight (key2.pub) == system.nodes[0]->config.receive_minimum.number (); }));
 }
 

--- a/nano/core_test/network_filter.cpp
+++ b/nano/core_test/network_filter.cpp
@@ -37,7 +37,7 @@ TEST (network_filter, unit)
 	{
 		one_block (genesis.open, true);
 	}
-	auto new_block (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.open->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 10 * nano::xrb_ratio, nano::public_key (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto new_block (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.open->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 10 * nano::xrb_ratio, nano::public_key (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	one_block (new_block, false);
 	for (int i = 0; i < 10; ++i)
 	{
@@ -57,7 +57,7 @@ TEST (network_filter, many)
 	nano::keypair key1;
 	for (int i = 0; i < 100; ++i)
 	{
-		auto block (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.open->hash (), nano::test_genesis_key.pub, nano::genesis_amount - i * 10 * nano::xrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+		auto block (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.open->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - i * 10 * nano::xrb_ratio, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 
 		nano::publish message (block);
 		auto bytes (message.to_bytes (false));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -94,15 +94,15 @@ TEST (node, password_fanout)
 TEST (node, balance)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto transaction (system.nodes[0]->store.tx_begin_write ());
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max (), system.nodes[0]->ledger.account_balance (transaction, nano::test_genesis_key.pub));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max (), system.nodes[0]->ledger.account_balance (transaction, nano::dev_genesis_key.pub));
 }
 
 TEST (node, representative)
 {
 	nano::system system (1);
-	auto block1 (system.nodes[0]->rep_block (nano::test_genesis_key.pub));
+	auto block1 (system.nodes[0]->rep_block (nano::dev_genesis_key.pub));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		ASSERT_TRUE (system.nodes[0]->ledger.store.block_exists (transaction, block1));
@@ -115,30 +115,30 @@ TEST (node, send_unkeyed)
 {
 	nano::system system (1);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->store.password.value_set (nano::keypair ().prv);
-	ASSERT_EQ (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_EQ (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 }
 
 TEST (node, send_self)
 {
 	nano::system system (1);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, !system.nodes[0]->balance (key2.pub).is_zero ());
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::dev_genesis_key.pub));
 }
 
 TEST (node, send_single)
 {
 	nano::system system (2);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::dev_genesis_key.pub));
 	ASSERT_TRUE (system.nodes[0]->balance (key2.pub).is_zero ());
 	ASSERT_TIMELY (10s, !system.nodes[0]->balance (key2.pub).is_zero ());
 }
@@ -147,10 +147,10 @@ TEST (node, send_single_observing_peer)
 {
 	nano::system system (3);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::dev_genesis_key.pub));
 	ASSERT_TRUE (system.nodes[0]->balance (key2.pub).is_zero ());
 	ASSERT_TIMELY (10s, std::all_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<nano::node> const & node_a) { return !node_a->balance (key2.pub).is_zero (); }));
 }
@@ -159,10 +159,10 @@ TEST (node, send_single_many_peers)
 {
 	nano::system system (10);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - system.nodes[0]->config.receive_minimum.number (), system.nodes[0]->balance (nano::dev_genesis_key.pub));
 	ASSERT_TRUE (system.nodes[0]->balance (key2.pub).is_zero ());
 	ASSERT_TIMELY (3.5min, std::all_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<nano::node> const & node_a) { return !node_a->balance (key2.pub).is_zero (); }));
 	system.stop ();
@@ -184,27 +184,27 @@ TEST (node, send_out_of_order)
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .previous (send1->hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - 2 * node1.config.receive_minimum.number ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto send3 = builder.make_block ()
 	             .previous (send2->hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - 3 * node1.config.receive_minimum.number ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send2->hash ()))
 	             .build_shared ();
 	node1.process_active (send3);
 	node1.process_active (send2);
 	node1.process_active (send1);
-	ASSERT_TIMELY (10s, std::all_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<nano::node> const & node_a) { return node_a->balance (nano::test_genesis_key.pub) == nano::genesis_amount - node1.config.receive_minimum.number () * 3; }));
+	ASSERT_TIMELY (10s, std::all_of (system.nodes.begin (), system.nodes.end (), [&](std::shared_ptr<nano::node> const & node_a) { return node_a->balance (nano::dev_genesis_key.pub) == nano::genesis_amount - node1.config.receive_minimum.number () * 3; }));
 }
 
 TEST (node, quick_confirm)
@@ -212,20 +212,20 @@ TEST (node, quick_confirm)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key;
-	nano::block_hash previous (node1.latest (nano::test_genesis_key.pub));
-	auto genesis_start_balance (node1.balance (nano::test_genesis_key.pub));
+	nano::block_hash previous (node1.latest (nano::dev_genesis_key.pub));
+	auto genesis_start_balance (node1.balance (nano::dev_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key.prv);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto send = nano::send_block_builder ()
 	            .previous (previous)
 	            .destination (key.pub)
 	            .balance (node1.config.online_weight_minimum.number () + 1)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (previous))
 	            .build_shared ();
 	node1.process_active (send);
 	ASSERT_TIMELY (10s, !node1.balance (key.pub).is_zero ());
-	ASSERT_EQ (node1.balance (nano::test_genesis_key.pub), node1.config.online_weight_minimum.number () + 1);
+	ASSERT_EQ (node1.balance (nano::dev_genesis_key.pub), node1.config.online_weight_minimum.number () + 1);
 	ASSERT_EQ (node1.balance (key.pub), genesis_start_balance - (node1.config.online_weight_minimum.number () + 1));
 }
 
@@ -236,13 +236,13 @@ TEST (node, node_receive_quorum)
 	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
 	nano::keypair key;
-	nano::block_hash previous (node1.latest (nano::test_genesis_key.pub));
+	nano::block_hash previous (node1.latest (nano::dev_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto send = nano::send_block_builder ()
 	            .previous (previous)
 	            .destination (key.pub)
 	            .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (previous))
 	            .build_shared ();
 	node1.process_active (send);
@@ -257,7 +257,7 @@ TEST (node, node_receive_quorum)
 	nano::system system2;
 	system2.add_node (node_flags);
 
-	system2.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system2.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_TRUE (node1.balance (key.pub).is_zero ());
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, system2.nodes[0]->network.endpoint (), node1.network_params.protocol.protocol_version));
 	node1.network.send_keepalive (channel);
@@ -279,9 +279,9 @@ TEST (node, auto_bootstrap)
 	node_flags.disable_udp = false;
 	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
-	auto send1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
+	auto send1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send1);
 	ASSERT_TIMELY (10s, node0->balance (key2.pub) == node0->config.receive_minimum.number ());
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work, node_flags));
@@ -316,11 +316,11 @@ TEST (node, auto_bootstrap_reverse)
 	node_flags.disable_udp = false;
 	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.alarm, system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node0->network_params.protocol.protocol_version));
 	node0->network.send_keepalive (channel);
 	node1->start ();
@@ -363,8 +363,8 @@ TEST (node, search_pending)
 	nano::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_pending ());
 	ASSERT_TIMELY (10s, !node->balance (key2.pub).is_zero ());
@@ -375,9 +375,9 @@ TEST (node, search_pending_same)
 	nano::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_pending ());
 	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
@@ -389,11 +389,11 @@ TEST (node, search_pending_multiple)
 	auto node (system.nodes[0]);
 	nano::keypair key2;
 	nano::keypair key3;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key3.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key3.pub, node->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key3.pub, node->config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, !node->balance (key3.pub).is_zero ());
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (key3.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_pending ());
@@ -407,10 +407,10 @@ TEST (node, search_pending_confirmed)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send1);
-	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send2);
 	ASSERT_TIMELY (10s, node->active.empty ());
 	bool confirmed (false);
@@ -423,7 +423,7 @@ TEST (node, search_pending_confirmed)
 	}
 	{
 		auto transaction (node->wallets.tx_begin_write ());
-		system.wallet (0)->store.erase (transaction, nano::test_genesis_key.pub);
+		system.wallet (0)->store.erase (transaction, nano::dev_genesis_key.pub);
 	}
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_pending ());
@@ -442,14 +442,14 @@ TEST (node, unlock_search)
 	nano::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
-	nano::uint128_t balance (node->balance (nano::test_genesis_key.pub));
+	nano::uint128_t balance (node->balance (nano::dev_genesis_key.pub));
 	{
 		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
 		system.wallet (0)->store.rekey (transaction, "");
 	}
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
-	ASSERT_TIMELY (10s, node->balance (nano::test_genesis_key.pub) != balance);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
+	ASSERT_TIMELY (10s, node->balance (nano::dev_genesis_key.pub) != balance);
 	ASSERT_TIMELY (10s, node->active.empty ());
 	system.wallet (0)->insert_adhoc (key2.prv);
 	{
@@ -505,7 +505,7 @@ TEST (node, price)
 TEST (node, confirm_locked)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	system.wallet (0)->enter_password (transaction, "1");
 	auto block = nano::send_block_builder ()
@@ -530,9 +530,9 @@ TEST (node_config, serialization)
 	config1.online_weight_quorum = 10;
 	config1.password_fanout = 20;
 	config1.enable_voting = false;
-	config1.callback_address = "test";
+	config1.callback_address = "dev";
 	config1.callback_port = 10;
-	config1.callback_target = "test";
+	config1.callback_target = "dev";
 	config1.deprecated_lmdb_max_dbs = 256;
 	nano::jsonconfig tree;
 	config1.serialize_json (tree);
@@ -993,7 +993,7 @@ TEST (node, fork_publish)
 		nano::system system (1);
 		node0 = system.nodes[0];
 		auto & node1 (*system.nodes[0]);
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		nano::keypair key1;
 		nano::genesis genesis;
 		nano::send_block_builder builder;
@@ -1001,7 +1001,7 @@ TEST (node, fork_publish)
 		             .previous (genesis.hash ())
 		             .destination (key1.pub)
 		             .balance (nano::genesis_amount - 100)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (0)
 		             .build_shared ();
 		node1.work_generate_blocking (*send1);
@@ -1010,7 +1010,7 @@ TEST (node, fork_publish)
 		             .previous (genesis.hash ())
 		             .destination (key2.pub)
 		             .balance (nano::genesis_amount - 100)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (0)
 		             .build_shared ();
 		node1.work_generate_blocking (*send2);
@@ -1032,7 +1032,7 @@ TEST (node, fork_publish)
 		node1.process_active (send2);
 		node1.block_processor.flush ();
 		lock.lock ();
-		auto existing1 (election->last_votes.find (nano::test_genesis_key.pub));
+		auto existing1 (election->last_votes.find (nano::dev_genesis_key.pub));
 		ASSERT_NE (election->last_votes.end (), existing1);
 		ASSERT_EQ (send1->hash (), existing1->second.hash);
 		auto transaction (node1.store.tx_begin_read ());
@@ -1055,14 +1055,14 @@ TEST (node, fork_publish_inactive)
 	             .previous (genesis.hash ())
 	             .destination (key1.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (send1->block_work ())
 	             .build_shared ();
 	auto & node (*system.nodes[0]);
@@ -1095,14 +1095,14 @@ TEST (node, fork_keep)
 	             .previous (genesis.hash ())
 	             .destination (key1.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	node1.process_active (send1);
@@ -1111,7 +1111,7 @@ TEST (node, fork_keep)
 	node2.block_processor.flush ();
 	ASSERT_EQ (1, node1.active.size ());
 	ASSERT_EQ (1, node2.active.size ());
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node1.process_active (send2);
 	node1.block_processor.flush ();
 	node2.process_active (send2);
@@ -1155,7 +1155,7 @@ TEST (node, fork_flip)
 	             .previous (genesis.hash ())
 	             .destination (key1.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	nano::publish publish1 (send1);
@@ -1164,7 +1164,7 @@ TEST (node, fork_flip)
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (nano::genesis_amount - 100)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	nano::publish publish2 (send2);
@@ -1176,7 +1176,7 @@ TEST (node, fork_flip)
 	node2.block_processor.flush ();
 	ASSERT_EQ (1, node1.active.size ());
 	ASSERT_EQ (1, node2.active.size ());
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node1.network.process_message (publish2, channel1);
 	node1.block_processor.flush ();
 	node2.network.process_message (publish1, channel2);
@@ -1240,7 +1240,7 @@ TEST (node, fork_multi_flip)
 		             .previous (genesis.hash ())
 		             .destination (key1.pub)
 		             .balance (nano::genesis_amount - 100)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (*system.work.generate (genesis.hash ()))
 		             .build_shared ();
 		nano::publish publish1 (send1);
@@ -1249,7 +1249,7 @@ TEST (node, fork_multi_flip)
 		             .previous (genesis.hash ())
 		             .destination (key2.pub)
 		             .balance (nano::genesis_amount - 100)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (*system.work.generate (genesis.hash ()))
 		             .build_shared ();
 		nano::publish publish2 (send2);
@@ -1257,7 +1257,7 @@ TEST (node, fork_multi_flip)
 		             .previous (publish2.block->hash ())
 		             .destination (key2.pub)
 		             .balance (nano::genesis_amount - 100)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (*system.work.generate (publish2.block->hash ()))
 		             .build_shared ();
 		nano::publish publish3 (send3);
@@ -1268,7 +1268,7 @@ TEST (node, fork_multi_flip)
 		node2.block_processor.flush ();
 		ASSERT_EQ (1, node1.active.size ());
 		ASSERT_EQ (1, node2.active.size ());
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		node1.network.process_message (publish2, node1.network.udp_channels.create (node1.network.endpoint ()));
 		node1.network.process_message (publish3, node1.network.udp_channels.create (node1.network.endpoint ()));
 		node1.block_processor.flush ();
@@ -1326,15 +1326,15 @@ TEST (node, fork_bootstrap_flip)
 	nano::node_config config1 (nano::get_available_port (), system1.logging);
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node2 (*system1.add_node (config1, node_flags));
-	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash latest (node1.latest (nano::test_genesis_key.pub));
+	system0.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	nano::block_hash latest (node1.latest (nano::dev_genesis_key.pub));
 	nano::keypair key1;
 	nano::send_block_builder builder;
 	auto send1 = builder.make_block ()
 	             .previous (latest)
 	             .destination (key1.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system0.work.generate (latest))
 	             .build_shared ();
 	nano::keypair key2;
@@ -1342,7 +1342,7 @@ TEST (node, fork_bootstrap_flip)
 	             .previous (latest)
 	             .destination (key2.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system0.work.generate (latest))
 	             .build_shared ();
 	// Insert but don't rebroadcast, simulating settled blocks
@@ -1384,7 +1384,7 @@ TEST (node, fork_open)
 	             .previous (genesis.hash ())
 	             .destination (key1.pub)
 	             .balance (0)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	nano::publish publish1 (send1);
@@ -1417,7 +1417,7 @@ TEST (node, fork_open)
 	             .work (*system.work.generate (key1.pub))
 	             .build_shared ();
 	nano::publish publish3 (open2);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node1.network.process_message (publish3, channel1);
 	node1.block_processor.flush ();
 	{
@@ -1445,7 +1445,7 @@ TEST (node, fork_open_flip)
 	             .previous (genesis.hash ())
 	             .destination (key1.pub)
 	             .balance (nano::genesis_amount - 1)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	// A copy is necessary to avoid data races during ledger processing, which sets the sideband
@@ -1480,7 +1480,7 @@ TEST (node, fork_open_flip)
 	node2.block_confirm (open2);
 	ASSERT_EQ (2, node1.active.size ());
 	ASSERT_EQ (2, node2.active.size ());
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Notify both nodes that a fork exists
 	node1.process_active (open2);
 	node1.block_processor.flush ();
@@ -1517,9 +1517,9 @@ TEST (node, coherent_observer)
 		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, status_a.winner->hash ()));
 	});
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1);
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1);
 }
 
 TEST (node, fork_no_vote_quorum)
@@ -1528,21 +1528,21 @@ TEST (node, fork_no_vote_quorum)
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	auto & node3 (*system.nodes[2]);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto key4 (system.wallet (0)->deterministic_insert ());
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, key4, nano::genesis_amount / 4);
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, key4, nano::genesis_amount / 4);
 	auto key1 (system.wallet (1)->deterministic_insert ());
 	{
 		auto transaction (system.wallet (1)->wallets.tx_begin_write ());
 		system.wallet (1)->store.representative_set (transaction, key1);
 	}
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1, node1.config.receive_minimum.number ()));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1, node1.config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, block);
 	ASSERT_TIMELY (30s, node3.balance (key1) == node1.config.receive_minimum.number () && node2.balance (key1) == node1.config.receive_minimum.number () && node1.balance (key1) == node1.config.receive_minimum.number ());
 	ASSERT_EQ (node1.config.receive_minimum.number (), node1.weight (key1));
 	ASSERT_EQ (node1.config.receive_minimum.number (), node2.weight (key1));
 	ASSERT_EQ (node1.config.receive_minimum.number (), node3.weight (key1));
-	nano::state_block send1 (nano::test_genesis_key.pub, block->hash (), nano::test_genesis_key.pub, (nano::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2), key1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (block->hash ()));
+	nano::state_block send1 (nano::dev_genesis_key.pub, block->hash (), nano::dev_genesis_key.pub, (nano::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2), key1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (block->hash ()));
 	ASSERT_EQ (nano::process_result::progress, node1.process (send1).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (send1).code);
 	ASSERT_EQ (nano::process_result::progress, node3.process (send1).code);
@@ -1551,7 +1551,7 @@ TEST (node, fork_no_vote_quorum)
 	             .previous (block->hash ())
 	             .destination (key2)
 	             .balance ((nano::genesis_amount / 4) - (node1.config.receive_minimum.number () * 2))
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (block->hash ()))
 	             .build_shared ();
 	nano::raw_key key3;
@@ -1567,9 +1567,9 @@ TEST (node, fork_no_vote_quorum)
 	nano::transport::channel_udp channel (node2.network.udp_channels, node3.network.endpoint (), node1.network_params.protocol.protocol_version);
 	channel.send_buffer (nano::shared_const_buffer (std::move (buffer)), nano::stat::detail::confirm_ack);
 	ASSERT_TIMELY (10s, node3.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::in) >= 3);
-	ASSERT_TRUE (node1.latest (nano::test_genesis_key.pub) == send1.hash ());
-	ASSERT_TRUE (node2.latest (nano::test_genesis_key.pub) == send1.hash ());
-	ASSERT_TRUE (node3.latest (nano::test_genesis_key.pub) == send1.hash ());
+	ASSERT_TRUE (node1.latest (nano::dev_genesis_key.pub) == send1.hash ());
+	ASSERT_TRUE (node2.latest (nano::dev_genesis_key.pub) == send1.hash ());
+	ASSERT_TRUE (node3.latest (nano::dev_genesis_key.pub) == send1.hash ());
 }
 
 // Disabled because it sometimes takes way too long (but still eventually finishes)
@@ -1580,7 +1580,7 @@ TEST (node, DISABLED_fork_pre_confirm)
 	auto & node1 (*system.nodes[1]);
 	auto & node2 (*system.nodes[2]);
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	system.wallet (1)->insert_adhoc (key1.prv);
 	{
@@ -1593,31 +1593,31 @@ TEST (node, DISABLED_fork_pre_confirm)
 		auto transaction (system.wallet (2)->wallets.tx_begin_write ());
 		system.wallet (2)->store.representative_set (transaction, key2.pub);
 	}
-	auto block0 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, nano::genesis_amount / 3));
+	auto block0 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, nano::genesis_amount / 3));
 	ASSERT_NE (nullptr, block0);
 	ASSERT_TIMELY (30s, node0.balance (key1.pub) != 0);
-	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, nano::genesis_amount / 3));
+	auto block1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, nano::genesis_amount / 3));
 	ASSERT_NE (nullptr, block1);
 	ASSERT_TIMELY (30s, node0.balance (key2.pub) != 0);
 	nano::keypair key3;
 	nano::keypair key4;
 	nano::state_block_builder builder;
 	auto block2 = builder.make_block ()
-	              .account (nano::test_genesis_key.pub)
-	              .previous (node0.latest (nano::test_genesis_key.pub))
+	              .account (nano::dev_genesis_key.pub)
+	              .previous (node0.latest (nano::dev_genesis_key.pub))
 	              .representative (key3.pub)
-	              .balance (node0.balance (nano::test_genesis_key.pub))
+	              .balance (node0.balance (nano::dev_genesis_key.pub))
 	              .link (0)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (0)
 	              .build_shared ();
 	auto block3 = builder.make_block ()
-	              .account (nano::test_genesis_key.pub)
-	              .previous (node0.latest (nano::test_genesis_key.pub))
+	              .account (nano::dev_genesis_key.pub)
+	              .previous (node0.latest (nano::dev_genesis_key.pub))
 	              .representative (key4.pub)
-	              .balance (node0.balance (nano::test_genesis_key.pub))
+	              .balance (node0.balance (nano::dev_genesis_key.pub))
 	              .link (0)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (0)
 	              .build_shared ();
 	node0.work_generate_blocking (*block2);
@@ -1630,8 +1630,8 @@ TEST (node, DISABLED_fork_pre_confirm)
 	system.deadline_set (70s);
 	while (!done)
 	{
-		done |= node0.latest (nano::test_genesis_key.pub) == block2->hash () && node1.latest (nano::test_genesis_key.pub) == block2->hash () && node2.latest (nano::test_genesis_key.pub) == block2->hash ();
-		done |= node0.latest (nano::test_genesis_key.pub) == block3->hash () && node1.latest (nano::test_genesis_key.pub) == block3->hash () && node2.latest (nano::test_genesis_key.pub) == block3->hash ();
+		done |= node0.latest (nano::dev_genesis_key.pub) == block2->hash () && node1.latest (nano::dev_genesis_key.pub) == block2->hash () && node2.latest (nano::dev_genesis_key.pub) == block2->hash ();
+		done |= node0.latest (nano::dev_genesis_key.pub) == block3->hash () && node1.latest (nano::dev_genesis_key.pub) == block3->hash () && node2.latest (nano::dev_genesis_key.pub) == block3->hash ();
 		ASSERT_NO_ERROR (system.poll ());
 	}
 }
@@ -1640,25 +1640,25 @@ TEST (node, DISABLED_fork_pre_confirm)
 TEST (node, DISABLED_fork_stale)
 {
 	nano::system system1 (1);
-	system1.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system1.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::system system2 (1);
 	auto & node1 (*system1.nodes[0]);
 	auto & node2 (*system2.nodes[0]);
 	node2.bootstrap_initiator.bootstrap (node1.network.endpoint ());
 	std::shared_ptr<nano::transport::channel> channel (std::make_shared<nano::transport::channel_udp> (node2.network.udp_channels, node1.network.endpoint (), node2.network_params.protocol.protocol_version));
-	auto vote = std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, std::vector<nano::block_hash> ());
+	auto vote = std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, std::vector<nano::block_hash> ());
 	node2.rep_crawler.response (channel, vote);
 	nano::genesis genesis;
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::state_block_builder builder;
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Mxrb_ratio)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (0)
 	             .build_shared ();
 	node1.work_generate_blocking (*send3);
@@ -1670,22 +1670,22 @@ TEST (node, DISABLED_fork_stale)
 		ASSERT_NO_ERROR (system2.poll ());
 	}
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send3->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Mxrb_ratio)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (0)
 	             .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send3->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Mxrb_ratio)
 	             .link (key2.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (0)
 	             .build_shared ();
 	node1.work_generate_blocking (*send2);
@@ -1739,7 +1739,7 @@ TEST (node, broadcast_elected)
 			                 .previous (nano::genesis_hash)
 			                 .destination (rep_big.pub)
 			                 .balance (nano::Gxrb_ratio * 5)
-			                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+			                 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 			                 .work (*system.work.generate (nano::genesis_hash))
 			                 .build ();
 			auto open_big = *builder.open ()
@@ -1753,7 +1753,7 @@ TEST (node, broadcast_elected)
 			                   .previous (fund_big.hash ())
 			                   .destination (rep_small.pub)
 			                   .balance (nano::Gxrb_ratio * 2)
-			                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+			                   .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 			                   .work (*system.work.generate (fund_big.hash ()))
 			                   .build ();
 			auto open_small = *builder.open ()
@@ -1767,7 +1767,7 @@ TEST (node, broadcast_elected)
 			                   .previous (fund_small.hash ())
 			                   .destination (rep_other.pub)
 			                   .balance (nano::Gxrb_ratio)
-			                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+			                   .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 			                   .work (*system.work.generate (fund_small.hash ()))
 			                   .build ();
 			auto open_other = *builder.open ()
@@ -1799,7 +1799,7 @@ TEST (node, broadcast_elected)
 		// Confirm blocks to allow voting
 		for (auto & node : system.nodes)
 		{
-			auto block (node->block (node->latest (nano::test_genesis_key.pub)));
+			auto block (node->block (node->latest (nano::dev_genesis_key.pub)));
 			ASSERT_NE (nullptr, block);
 			node->block_confirm (block);
 			auto election (node->active.election (block->qualified_root ()));
@@ -1815,22 +1815,22 @@ TEST (node, broadcast_elected)
 		system.wallet (1)->insert_adhoc (rep_small.prv);
 		system.wallet (2)->insert_adhoc (rep_other.prv);
 		auto fork0 = builder.send ()
-		             .previous (node2->latest (nano::test_genesis_key.pub))
+		             .previous (node2->latest (nano::dev_genesis_key.pub))
 		             .destination (rep_small.pub)
 		             .balance (0)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-		             .work (*node0->work_generate_blocking (node2->latest (nano::test_genesis_key.pub)))
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+		             .work (*node0->work_generate_blocking (node2->latest (nano::dev_genesis_key.pub)))
 		             .build_shared ();
 		// A copy is necessary to avoid data races during ledger processing, which sets the sideband
 		auto fork0_copy (std::make_shared<nano::send_block> (*fork0));
 		node0->process_active (fork0);
 		node1->process_active (fork0_copy);
 		auto fork1 = builder.send ()
-		             .previous (node2->latest (nano::test_genesis_key.pub))
+		             .previous (node2->latest (nano::dev_genesis_key.pub))
 		             .destination (rep_big.pub)
 		             .balance (0)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-		             .work (*node0->work_generate_blocking (node2->latest (nano::test_genesis_key.pub)))
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+		             .work (*node0->work_generate_blocking (node2->latest (nano::dev_genesis_key.pub)))
 		             .build_shared ();
 		system.wallet (2)->insert_adhoc (rep_small.prv);
 		node2->process_active (fork1);
@@ -1860,7 +1860,7 @@ TEST (node, rep_self_vote)
 	                 .previous (nano::genesis_hash)
 	                 .destination (rep_big.pub)
 	                 .balance (nano::uint128_t{ "0xb0000000000000000000000000000000" })
-	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                 .work (*system.work.generate (nano::genesis_hash))
 	                 .build ();
 	auto open_big = *builder.open ()
@@ -1882,13 +1882,13 @@ TEST (node, rep_self_vote)
 	}
 
 	system.wallet (0)->insert_adhoc (rep_big.prv);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_EQ (system.wallet (0)->wallets.reps ().voting, 2);
 	auto block0 = builder.send ()
 	              .previous (fund_big.hash ())
 	              .destination (rep_big.pub)
 	              .balance (nano::uint128_t ("0x60000000000000000000000000000000"))
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*system.work.generate (fund_big.hash ()))
 	              .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block0).code);
@@ -1898,7 +1898,7 @@ TEST (node, rep_self_vote)
 	ASSERT_TIMELY (1s, election1.election->last_votes_size () == 3);
 	nano::unique_lock<std::mutex> lock (active.mutex);
 	auto & rep_votes (election1.election->last_votes);
-	ASSERT_NE (rep_votes.end (), rep_votes.find (nano::test_genesis_key.pub));
+	ASSERT_NE (rep_votes.end (), rep_votes.find (nano::dev_genesis_key.pub));
 	ASSERT_NE (rep_votes.end (), rep_votes.find (rep_big.pub));
 }
 
@@ -1911,7 +1911,7 @@ TEST (node, DISABLED_bootstrap_no_publish)
 	auto node1 (system1.nodes[0]);
 	nano::keypair key0;
 	// node0 knows about send0 but node1 doesn't.
-	nano::send_block send0 (node0->latest (nano::test_genesis_key.pub), key0.pub, 500, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::send_block send0 (node0->latest (nano::dev_genesis_key.pub), key0.pub, 500, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 	{
 		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, send0).code);
@@ -1948,7 +1948,7 @@ TEST (node, bootstrap_bulk_push)
 	              .previous (nano::genesis_hash)
 	              .destination (key0.pub)
 	              .balance (500)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*node0->work_generate_blocking (nano::genesis_hash))
 	              .build ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (send0).code);
@@ -1975,14 +1975,14 @@ TEST (node, bootstrap_fork_open)
 	auto node0 = system.add_node (node_config);
 	node_config.peering_port = nano::get_available_port ();
 	auto node1 = system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key0;
 	nano::block_builder builder;
 	auto send0 = *builder.send ()
 	              .previous (nano::genesis_hash)
 	              .destination (key0.pub)
 	              .balance (nano::genesis_amount - 500)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*system.work.generate (nano::genesis_hash))
 	              .build ();
 	auto open0 = *builder.open ()
@@ -2005,7 +2005,7 @@ TEST (node, bootstrap_fork_open)
 	// Confirm send0 to allow starting and voting on the following blocks
 	for (auto node : system.nodes)
 	{
-		node->block_confirm (node->block (node->latest (nano::test_genesis_key.pub)));
+		node->block_confirm (node->block (node->latest (nano::dev_genesis_key.pub)));
 		{
 			auto election = node->active.election (send0.qualified_root ());
 			ASSERT_NE (nullptr, election);
@@ -2032,14 +2032,14 @@ TEST (node, bootstrap_confirm_frontiers)
 	nano::system system1 (1);
 	auto node0 (system0.nodes[0]);
 	auto node1 (system0.nodes[0]);
-	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system0.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key0;
 	// node0 knows about send0 but node1 doesn't.
 	auto send0 = *nano::send_block_builder ()
 	              .previous (nano::genesis_hash)
 	              .destination (key0.pub)
 	              .balance (nano::genesis_amount - 500)
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*node0->work_generate_blocking (nano::genesis_hash))
 	              .build ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (send0).code);
@@ -2089,7 +2089,7 @@ TEST (node, DISABLED_unconfirmed_send)
 	auto wallet1 (system.wallet (1));
 	nano::keypair key0;
 	wallet1->insert_adhoc (key0.prv);
-	wallet0->insert_adhoc (nano::test_genesis_key.prv);
+	wallet0->insert_adhoc (nano::dev_genesis_key.prv);
 	auto send1 (wallet0->send_action (nano::genesis_account, key0.pub, 2 * nano::Mxrb_ratio));
 	ASSERT_TIMELY (10s, node1.balance (key0.pub) == 2 * nano::Mxrb_ratio && !node1.bootstrap_initiator.in_progress ());
 	auto latest (node1.latest (key0.pub));
@@ -2110,10 +2110,10 @@ TEST (node, rep_list)
 	auto wallet0 (system.wallet (0));
 	auto wallet1 (system.wallet (1));
 	// Node0 has a rep
-	wallet0->insert_adhoc (nano::test_genesis_key.prv);
+	wallet0->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	// Broadcast a confirm so others should know this is a rep node
-	wallet0->send_action (nano::test_genesis_key.pub, key1.pub, nano::Mxrb_ratio);
+	wallet0->send_action (nano::dev_genesis_key.pub, key1.pub, nano::Mxrb_ratio);
 	ASSERT_EQ (0, node1.rep_crawler.representatives (1).size ());
 	system.deadline_set (10s);
 	auto done (false);
@@ -2143,12 +2143,12 @@ TEST (node, rep_weight)
 	auto amount_not_pr (node.minimum_principal_weight () - 100);
 	std::shared_ptr<nano::block> block1 = builder
 	                                      .state ()
-	                                      .account (nano::test_genesis_key.pub)
+	                                      .account (nano::dev_genesis_key.pub)
 	                                      .previous (genesis.hash ())
-	                                      .representative (nano::test_genesis_key.pub)
+	                                      .representative (nano::dev_genesis_key.pub)
 	                                      .balance (nano::genesis_amount - amount_not_pr)
 	                                      .link (keypair1.pub)
-	                                      .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                      .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                      .work (*system.work.generate (genesis.hash ()))
 	                                      .build ();
 	std::shared_ptr<nano::block> block2 = builder
@@ -2163,12 +2163,12 @@ TEST (node, rep_weight)
 	                                      .build ();
 	std::shared_ptr<nano::block> block3 = builder
 	                                      .state ()
-	                                      .account (nano::test_genesis_key.pub)
+	                                      .account (nano::dev_genesis_key.pub)
 	                                      .previous (block1->hash ())
-	                                      .representative (nano::test_genesis_key.pub)
+	                                      .representative (nano::dev_genesis_key.pub)
 	                                      .balance (nano::genesis_amount - amount_not_pr - amount_pr)
 	                                      .link (keypair2.pub)
-	                                      .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                      .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                      .work (*system.work.generate (block1->hash ()))
 	                                      .build ();
 	std::shared_ptr<nano::block> block4 = builder
@@ -2199,7 +2199,7 @@ TEST (node, rep_weight)
 	node.network.udp_channels.insert (endpoint0, node.network_params.protocol.protocol_version);
 	node.network.udp_channels.insert (endpoint1, node.network_params.protocol.protocol_version);
 	node.network.udp_channels.insert (endpoint2, node.network_params.protocol.protocol_version);
-	auto vote0 = std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, genesis.open);
+	auto vote0 = std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, genesis.open);
 	auto vote1 = std::make_shared<nano::vote> (keypair1.pub, keypair1.prv, 0, genesis.open);
 	auto vote2 = std::make_shared<nano::vote> (keypair2.pub, keypair2.prv, 0, genesis.open);
 	node.rep_crawler.response (channel0, vote0);
@@ -2209,8 +2209,8 @@ TEST (node, rep_weight)
 	// Make sure we get the rep with the most weight first
 	auto reps (node.rep_crawler.representatives (1));
 	ASSERT_EQ (1, reps.size ());
-	ASSERT_EQ (node.balance (nano::test_genesis_key.pub), reps[0].weight.number ());
-	ASSERT_EQ (nano::test_genesis_key.pub, reps[0].account);
+	ASSERT_EQ (node.balance (nano::dev_genesis_key.pub), reps[0].weight.number ());
+	ASSERT_EQ (nano::dev_genesis_key.pub, reps[0].account);
 	ASSERT_EQ (*channel0, reps[0].channel_ref ());
 	ASSERT_TRUE (node.rep_crawler.is_pr (*channel0));
 	ASSERT_FALSE (node.rep_crawler.is_pr (*channel1));
@@ -2229,12 +2229,12 @@ TEST (node, rep_remove)
 	nano::block_builder builder;
 	std::shared_ptr<nano::block> block1 = builder
 	                                      .state ()
-	                                      .account (nano::test_genesis_key.pub)
+	                                      .account (nano::dev_genesis_key.pub)
 	                                      .previous (genesis.hash ())
-	                                      .representative (nano::test_genesis_key.pub)
+	                                      .representative (nano::dev_genesis_key.pub)
 	                                      .balance (nano::genesis_amount - node.minimum_principal_weight () * 2)
 	                                      .link (keypair1.pub)
-	                                      .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                      .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                      .work (*system.work.generate (genesis.hash ()))
 	                                      .build ();
 	std::shared_ptr<nano::block> block2 = builder
@@ -2249,12 +2249,12 @@ TEST (node, rep_remove)
 	                                      .build ();
 	std::shared_ptr<nano::block> block3 = builder
 	                                      .state ()
-	                                      .account (nano::test_genesis_key.pub)
+	                                      .account (nano::dev_genesis_key.pub)
 	                                      .previous (block1->hash ())
-	                                      .representative (nano::test_genesis_key.pub)
+	                                      .representative (nano::dev_genesis_key.pub)
 	                                      .balance (nano::genesis_amount - node.minimum_principal_weight () * 4)
 	                                      .link (keypair2.pub)
-	                                      .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                      .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                      .work (*system.work.generate (block1->hash ()))
 	                                      .build ();
 	std::shared_ptr<nano::block> block4 = builder
@@ -2291,10 +2291,10 @@ TEST (node, rep_remove)
 	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 0);
 	// Add working representative
 	auto node1 = system.add_node (nano::node_config (nano::get_available_port (), system.logging));
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto channel1 (node.network.find_channel (node1->network.endpoint ()));
 	ASSERT_NE (nullptr, channel1);
-	auto vote2 = std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, genesis.open);
+	auto vote2 = std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, genesis.open);
 	node.rep_crawler.response (channel1, vote2);
 	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 1);
 	// Add inactive TCP representative channel
@@ -2315,7 +2315,7 @@ TEST (node, rep_remove)
 	// Remove inactive representatives
 	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 1);
 	reps = node.rep_crawler.representatives (1);
-	ASSERT_EQ (nano::test_genesis_key.pub, reps[0].account);
+	ASSERT_EQ (nano::dev_genesis_key.pub, reps[0].account);
 	ASSERT_EQ (1, node.network.size ());
 	auto list (node.network.list (1));
 	ASSERT_EQ (node1->network.endpoint (), list[0]->get_endpoint ());
@@ -2327,7 +2327,7 @@ TEST (node, rep_connection_close)
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	// Add working representative (node 2)
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_TIMELY (10s, node1.rep_crawler.representative_count () == 1);
 	node2.stop ();
 	// Remove representative with closed channel
@@ -2346,11 +2346,11 @@ TEST (node, no_voting)
 	auto wallet0 (system.wallet (0));
 	auto wallet1 (system.wallet (1));
 	// Node1 has a rep
-	wallet1->insert_adhoc (nano::test_genesis_key.prv);
+	wallet1->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	wallet1->insert_adhoc (key1.prv);
 	// Broadcast a confirm so others should know this is a rep node
-	wallet1->send_action (nano::test_genesis_key.pub, key1.pub, nano::Mxrb_ratio);
+	wallet1->send_action (nano::dev_genesis_key.pub, key1.pub, nano::Mxrb_ratio);
 	ASSERT_TIMELY (10s, node0.active.empty ());
 	ASSERT_EQ (0, node0.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::in));
 }
@@ -2360,14 +2360,14 @@ TEST (node, send_callback)
 	nano::system system (1);
 	auto & node0 (*system.nodes[0]);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
 	node0.config.callback_address = "localhost";
 	node0.config.callback_port = 8010;
 	node0.config.callback_target = "/";
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, node0.config.receive_minimum.number ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node0.config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, node0.balance (key2.pub).is_zero ());
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - node0.config.receive_minimum.number (), node0.balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - node0.config.receive_minimum.number (), node0.balance (nano::dev_genesis_key.pub));
 }
 
 // Check that votes get replayed back to nodes if they sent an old sequence number.
@@ -2381,16 +2381,16 @@ TEST (node, vote_replay)
 	for (auto i (0); i < 11000; ++i)
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		auto vote (node1.store.vote_generate (transaction, nano::test_genesis_key.pub, nano::test_genesis_key.prv, genesis.open));
+		auto vote (node1.store.vote_generate (transaction, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, genesis.open));
 	}
 	auto node2 = system.add_node ();
 	{
 		auto transaction (node2->store.tx_begin_read ());
 		nano::lock_guard<std::mutex> lock (node2->store.get_cache_mutex ());
-		auto vote (node2->store.vote_current (transaction, nano::test_genesis_key.pub));
+		auto vote (node2->store.vote_current (transaction, nano::dev_genesis_key.pub));
 		ASSERT_EQ (nullptr, vote);
 	}
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto done (false);
 	system.deadline_set (20s);
 	while (!done)
@@ -2398,7 +2398,7 @@ TEST (node, vote_replay)
 		auto ec = system.poll ();
 		auto transaction (node2->store.tx_begin_read ());
 		nano::lock_guard<std::mutex> lock (node2->store.get_cache_mutex ());
-		auto vote (node2->store.vote_current (transaction, nano::test_genesis_key.pub));
+		auto vote (node2->store.vote_current (transaction, nano::dev_genesis_key.pub));
 		done = vote && (vote->sequence >= 10000);
 		ASSERT_NO_ERROR (ec);
 	}
@@ -2415,13 +2415,13 @@ TEST (node, balance_observer)
 		{
 			balances++;
 		}
-		else if (nano::test_genesis_key.pub == account_a && !is_pending)
+		else if (nano::dev_genesis_key.pub == account_a && !is_pending)
 		{
 			balances++;
 		}
 	});
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1);
 	system.deadline_set (10s);
 	auto done (false);
 	while (!done)
@@ -2486,7 +2486,7 @@ TEST (node, online_reps)
 	// 1 sample of minimum weight
 	ASSERT_EQ (node1.config.online_weight_minimum, node1.online_reps.online_stake ());
 	auto vote (std::make_shared<nano::vote> ());
-	node1.online_reps.observe (nano::test_genesis_key.pub);
+	node1.online_reps.observe (nano::dev_genesis_key.pub);
 	// 1 minimum, 1 maximum
 	node1.online_reps.sample ();
 	ASSERT_EQ (nano::genesis_amount, node1.online_reps.online_stake ());
@@ -2512,15 +2512,15 @@ TEST (node, block_confirm)
 		auto & node2 (*system.nodes[1]);
 		nano::genesis genesis;
 		nano::keypair key;
-		system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 		nano::state_block_builder builder;
 		auto send1 = builder.make_block ()
-		             .account (nano::test_genesis_key.pub)
+		             .account (nano::dev_genesis_key.pub)
 		             .previous (genesis.hash ())
-		             .representative (nano::test_genesis_key.pub)
+		             .representative (nano::dev_genesis_key.pub)
 		             .balance (nano::genesis_amount - nano::Gxrb_ratio)
 		             .link (key.pub)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (*node1.work_generate_blocking (genesis.hash ()))
 		             .build_shared ();
 		// A copy is necessary to avoid data races during ledger processing, which sets the sideband
@@ -2532,7 +2532,7 @@ TEST (node, block_confirm)
 		ASSERT_TIMELY (5s, node1.ledger.block_exists (send1->hash ()) && node2.ledger.block_exists (send1_copy->hash ()));
 		ASSERT_TRUE (node1.ledger.block_exists (send1->hash ()));
 		ASSERT_TRUE (node2.ledger.block_exists (send1_copy->hash ()));
-		auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send1->hash ())));
+		auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (send1->hash ())));
 		{
 			auto transaction (node1.store.tx_begin_write ());
 			ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send2).code);
@@ -2599,27 +2599,27 @@ TEST (node, confirm_quorum)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Put greater than online_weight_minimum in pending so quorum can't be reached
 	nano::amount new_balance (node1.config.online_weight_minimum.number () - nano::Gxrb_ratio);
 	auto send1 = nano::state_block_builder ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (new_balance)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, new_balance.number ());
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, new_balance.number ());
 	ASSERT_TIMELY (10s, !node1.active.empty ());
 	nano::lock_guard<std::mutex> guard (node1.active.mutex);
 	auto info (node1.active.roots.find (nano::qualified_root (send1->hash (), send1->hash ())));
 	ASSERT_NE (node1.active.roots.end (), info);
 	ASSERT_FALSE (info->election->confirmed ());
 	ASSERT_EQ (1, info->election->last_votes.size ());
-	ASSERT_EQ (0, node1.balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, node1.balance (nano::dev_genesis_key.pub));
 }
 
 TEST (node, local_votes_cache)
@@ -2632,30 +2632,30 @@ TEST (node, local_votes_cache)
 	nano::genesis genesis;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (send1->hash ()))
 	             .build_shared ();
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (send2->hash ()))
 	             .build_shared ();
 	{
@@ -2672,7 +2672,7 @@ TEST (node, local_votes_cache)
 		election->confirm_once ();
 	}
 	ASSERT_TIMELY (3s, node.ledger.cache.cemented_count == 3);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::confirm_req message1 (send1);
 	nano::confirm_req message2 (send2);
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
@@ -2685,7 +2685,7 @@ TEST (node, local_votes_cache)
 			{
 				nano::lock_guard<std::mutex> lock (node.store.get_cache_mutex ());
 				auto transaction (node.store.tx_begin_read ());
-				current_vote = node.store.vote_current (transaction, nano::test_genesis_key.pub);
+				current_vote = node.store.vote_current (transaction, nano::dev_genesis_key.pub);
 			}
 			ASSERT_NO_ERROR (system.poll ());
 		}
@@ -2706,7 +2706,7 @@ TEST (node, local_votes_cache)
 	// Make sure a new vote was not generated
 	{
 		nano::lock_guard<std::mutex> lock (node.store.get_cache_mutex ());
-		ASSERT_EQ (2, node.store.vote_current (node.store.tx_begin_read (), nano::test_genesis_key.pub)->sequence);
+		ASSERT_EQ (2, node.store.vote_current (node.store.tx_begin_read (), nano::dev_genesis_key.pub)->sequence);
 	}
 	// Max cache
 	{
@@ -2736,14 +2736,14 @@ TEST (node, local_votes_cache_batch)
 	auto & node (*system.add_node (node_config));
 	ASSERT_GE (node.network_params.voting.max_cache, 2);
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto send1 = nano::state_block_builder ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	std::vector<std::pair<nano::block_hash, nano::root>> batch{ { genesis.open->hash (), genesis.open->root () }, { send1->hash (), send1->root () } };
@@ -2785,7 +2785,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Repsond with cached vote
 	nano::confirm_req message1 (genesis.open);
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
@@ -2798,17 +2798,17 @@ TEST (node, local_votes_cache_generate_new_vote)
 	{
 		nano::lock_guard<std::mutex> lock (node.store.get_cache_mutex ());
 		auto transaction (node.store.tx_begin_read ());
-		auto current_vote (node.store.vote_current (transaction, nano::test_genesis_key.pub));
+		auto current_vote (node.store.vote_current (transaction, nano::dev_genesis_key.pub));
 		ASSERT_EQ (current_vote->sequence, 1);
 		ASSERT_EQ (current_vote, votes1[0]);
 	}
 	auto send1 = nano::state_block_builder ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
@@ -2823,7 +2823,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 	{
 		nano::lock_guard<std::mutex> lock (node.store.get_cache_mutex ());
 		auto transaction (node.store.tx_begin_read ());
-		auto current_vote (node.store.vote_current (transaction, nano::test_genesis_key.pub));
+		auto current_vote (node.store.vote_current (transaction, nano::dev_genesis_key.pub));
 		ASSERT_EQ (current_vote->sequence, 2);
 		ASSERT_EQ (current_vote, votes2[0]);
 	}
@@ -2846,20 +2846,20 @@ TEST (node, vote_republish)
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	node1.process_active (send1);
 	ASSERT_TIMELY (5s, node2.block (send1->hash ()));
 	node1.active.publish (send2);
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, send2));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, send2));
 	ASSERT_TRUE (node1.active.active (*send1));
 	ASSERT_TRUE (node2.active.active (*send1));
 	node1.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
@@ -2876,7 +2876,7 @@ TEST (node, vote_by_hash_bundle)
 	// Keep max_hashes above system to ensure it is kept in scope as votes can be added during system destruction
 	std::atomic<size_t> max_hashes{ 0 };
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (key1.prv);
 
@@ -2920,14 +2920,14 @@ TEST (node, vote_by_hash_republish)
 		             .previous (genesis.hash ())
 		             .destination (key2.pub)
 		             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (*system.work.generate (genesis.hash ()))
 		             .build_shared ();
 		auto send2 = builder.make_block ()
 		             .previous (genesis.hash ())
 		             .destination (key2.pub)
 		             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2)
-		             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		             .work (*system.work.generate (genesis.hash ()))
 		             .build_shared ();
 		node1.process_active (send1);
@@ -2935,7 +2935,7 @@ TEST (node, vote_by_hash_republish)
 		node1.active.publish (send2);
 		std::vector<nano::block_hash> vote_blocks;
 		vote_blocks.push_back (send2->hash ());
-		auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, vote_blocks));
+		auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, vote_blocks));
 		ASSERT_TRUE (node1.active.active (*send1));
 		ASSERT_TRUE (node2.active.active (*send1));
 		node1.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
@@ -2960,7 +2960,7 @@ TEST (node, vote_by_hash_epoch_block_republish)
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto epoch1 = nano::state_block_builder ()
@@ -2969,7 +2969,7 @@ TEST (node, vote_by_hash_epoch_block_republish)
 	              .representative (nano::genesis_account)
 	              .balance (nano::genesis_amount)
 	              .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
-	              .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	              .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	              .work (*system.work.generate (genesis.hash ()))
 	              .build_shared ();
 	node1.process_active (send1);
@@ -2977,7 +2977,7 @@ TEST (node, vote_by_hash_epoch_block_republish)
 	node1.active.publish (epoch1);
 	std::vector<nano::block_hash> vote_blocks;
 	vote_blocks.push_back (epoch1->hash ());
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, vote_blocks));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, vote_blocks));
 	ASSERT_TRUE (node1.active.active (*send1));
 	ASSERT_TRUE (node2.active.active (*send1));
 	node1.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
@@ -2997,15 +2997,15 @@ TEST (node, epoch_conflict_confirm)
 	auto node1 = system.add_node (node_config);
 	nano::keypair key;
 	nano::genesis genesis;
-	nano::keypair epoch_signer (nano::test_genesis_key);
+	nano::keypair epoch_signer (nano::dev_genesis_key);
 	nano::state_block_builder builder;
 	auto send = builder.make_block ()
-	            .account (nano::test_genesis_key.pub)
+	            .account (nano::dev_genesis_key.pub)
 	            .previous (genesis.hash ())
-	            .representative (nano::test_genesis_key.pub)
+	            .representative (nano::dev_genesis_key.pub)
 	            .balance (nano::genesis_amount - 1)
 	            .link (key.pub)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .work (*system.work.generate (genesis.hash ()))
 	            .build_shared ();
 	auto open = builder.make_block ()
@@ -3027,12 +3027,12 @@ TEST (node, epoch_conflict_confirm)
 	              .work (*system.work.generate (open->hash ()))
 	              .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2)
 	             .link (open->hash ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send->hash ()))
 	             .build_shared ();
 	auto epoch_open = builder.make_block ()
@@ -3073,7 +3073,7 @@ TEST (node, epoch_conflict_confirm)
 		ASSERT_TRUE (node0->active.blocks.find (change->hash ()) != node0->active.blocks.end ());
 		ASSERT_TRUE (node0->active.blocks.find (epoch_open->hash ()) != node0->active.blocks.end ());
 	}
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_TIMELY (5s, node0->active.empty ());
 	{
 		auto transaction (node0->store.tx_begin_read ());
@@ -3101,20 +3101,20 @@ TEST (node, fork_invalid_block_signature)
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number ())
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .previous (genesis.hash ())
 	             .destination (key2.pub)
 	             .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.receive_minimum.number () * 2)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto send2_corrupt (std::make_shared<nano::send_block> (*send2));
 	send2_corrupt->signature = nano::signature (123);
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, send2));
-	auto vote_corrupt (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, send2_corrupt));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, send2));
+	auto vote_corrupt (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, send2_corrupt));
 
 	node1.process_active (send1);
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
@@ -3136,31 +3136,31 @@ TEST (node, fork_election_invalid_block_signature)
 	nano::genesis genesis;
 	nano::block_builder builder;
 	auto send1 = builder.state ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .build_shared ();
 	auto send2 = builder.state ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .build_shared ();
 	auto send3 = builder.state ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
-	             .sign (nano::test_genesis_key.prv, 0) // Invalid signature
+	             .sign (nano::dev_genesis_key.prv, 0) // Invalid signature
 	             .build_shared ();
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.network.process_message (nano::publish (send1), channel1);
@@ -3195,58 +3195,58 @@ TEST (node, block_processor_signatures)
 {
 	nano::system system0 (1);
 	auto & node1 (*system0.nodes[0]);
-	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash latest (system0.nodes[0]->latest (nano::test_genesis_key.pub));
+	system0.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	nano::block_hash latest (system0.nodes[0]->latest (nano::dev_genesis_key.pub));
 	nano::state_block_builder builder;
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::keypair key3;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (latest)
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
 	             .link (key1.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1.work_generate_blocking (latest))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
 	             .link (key2.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1.work_generate_blocking (send1->hash ()))
 	             .build_shared ();
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
 	             .link (key3.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1.work_generate_blocking (send2->hash ()))
 	             .build_shared ();
 	// Invalid signature bit
 	auto send4 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send3->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 4 * nano::Gxrb_ratio)
 	             .link (key3.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1.work_generate_blocking (send3->hash ()))
 	             .build_shared ();
 	send4->signature.bytes[32] ^= 0x1;
 	// Invalid signature bit (force)
 	auto send5 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send3->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 5 * nano::Gxrb_ratio)
 	             .link (key3.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1.work_generate_blocking (send3->hash ()))
 	             .build_shared ();
 	send5->signature.bytes[31] ^= 0x1;
@@ -3259,7 +3259,7 @@ TEST (node, block_processor_signatures)
 	auto receive1 = builder.make_block ()
 	                .account (key1.pub)
 	                .previous (0)
-	                .representative (nano::test_genesis_key.pub)
+	                .representative (nano::dev_genesis_key.pub)
 	                .balance (nano::Gxrb_ratio)
 	                .link (send1->hash ())
 	                .sign (key1.prv, key1.pub)
@@ -3268,7 +3268,7 @@ TEST (node, block_processor_signatures)
 	auto receive2 = builder.make_block ()
 	                .account (key2.pub)
 	                .previous (0)
-	                .representative (nano::test_genesis_key.pub)
+	                .representative (nano::dev_genesis_key.pub)
 	                .balance (nano::Gxrb_ratio)
 	                .link (send2->hash ())
 	                .sign (key2.prv, key2.pub)
@@ -3278,7 +3278,7 @@ TEST (node, block_processor_signatures)
 	auto receive3 = builder.make_block ()
 	                .account (key3.pub)
 	                .previous (0)
-	                .representative (nano::test_genesis_key.pub)
+	                .representative (nano::dev_genesis_key.pub)
 	                .balance (nano::Gxrb_ratio)
 	                .link (send3->hash ())
 	                .sign (key2.prv, key3.pub)
@@ -3316,12 +3316,12 @@ TEST (node, block_processor_reject_state)
 	nano::genesis genesis;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	send1->signature.bytes[0] ^= 1;
@@ -3331,12 +3331,12 @@ TEST (node, block_processor_reject_state)
 	ASSERT_NE (std::future_status::timeout, flushed.wait_for (5s));
 	ASSERT_FALSE (node.ledger.block_exists (send1->hash ()));
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	node.process_active (send2);
@@ -3354,30 +3354,30 @@ TEST (node, block_processor_full)
 	nano::genesis genesis;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (send1->hash ()))
 	             .build_shared ();
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (send2->hash ()))
 	             .build_shared ();
 	// The write guard prevents block processor doing any writes
@@ -3400,30 +3400,30 @@ TEST (node, block_processor_half_full)
 	nano::genesis genesis;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (send1->hash ()))
 	             .build_shared ();
 	auto send3 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send2->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 3 * nano::Gxrb_ratio)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node.work_generate_blocking (send2->hash ()))
 	             .build_shared ();
 	// The write guard prevents block processor doing any writes
@@ -3444,12 +3444,12 @@ TEST (node, confirm_back)
 	nano::keypair key;
 	auto & node (*system.nodes[0]);
 	nano::genesis genesis;
-	auto genesis_start_balance (node.balance (nano::test_genesis_key.pub));
+	auto genesis_start_balance (node.balance (nano::dev_genesis_key.pub));
 	auto send1 = nano::send_block_builder ()
 	             .previous (genesis.hash ())
 	             .destination (key.pub)
 	             .balance (genesis_start_balance - 1)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	nano::state_block_builder builder;
@@ -3467,7 +3467,7 @@ TEST (node, confirm_back)
 	             .previous (open->hash ())
 	             .representative (key.pub)
 	             .balance (0)
-	             .link (nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
 	             .sign (key.prv, key.pub)
 	             .work (*system.work.generate (open->hash ()))
 	             .build_shared ();
@@ -3478,7 +3478,7 @@ TEST (node, confirm_back)
 	ASSERT_EQ (3, node.active.size ());
 	std::vector<nano::block_hash> vote_blocks;
 	vote_blocks.push_back (send2->hash ());
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, vote_blocks));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, vote_blocks));
 	node.vote_processor.vote_blocking (vote, std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	ASSERT_TIMELY (10s, node.active.empty ());
 }
@@ -3694,19 +3694,19 @@ TEST (node, bidirectional_tcp)
 	nano::keypair key;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (genesis.hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - nano::Gxrb_ratio)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1->work_generate_blocking (genesis.hash ()))
 	             .build_shared ();
 	node1->process_active (send1);
 	node1->block_processor.flush ();
 	ASSERT_TIMELY (10s, node1->ledger.block_exists (send1->hash ()) && node2->ledger.block_exists (send1->hash ()));
 	// Test block confirmation from node 1 (add representative to node 1)
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Wait to find new reresentative
 	ASSERT_TIMELY (10s, node2->rep_crawler.representative_count () != 0);
 	/* Wait for confirmation
@@ -3723,24 +3723,24 @@ TEST (node, bidirectional_tcp)
 	// Test block propagation & confirmation from node 2 (remove representative from node 1)
 	{
 		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->store.erase (transaction, nano::test_genesis_key.pub);
+		system.wallet (0)->store.erase (transaction, nano::dev_genesis_key.pub);
 	}
 	/* Test block propagation from node 2
 	Node 2 has only ephemeral TCP port open. Node 1 cannot establish connection to node 2 listening port */
 	auto send2 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (send1->hash ())
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 2 * nano::Gxrb_ratio)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*node1->work_generate_blocking (send1->hash ()))
 	             .build_shared ();
 	node2->process_active (send2);
 	node2->block_processor.flush ();
 	ASSERT_TIMELY (10s, node1->ledger.block_exists (send2->hash ()) && node2->ledger.block_exists (send2->hash ()));
 	// Test block confirmation from node 2 (add representative to node 2)
-	system.wallet (1)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (1)->insert_adhoc (nano::dev_genesis_key.prv);
 	// Wait to find changed reresentative
 	ASSERT_TIMELY (10s, node1->rep_crawler.representative_count () != 0);
 	/* Wait for confirmation
@@ -3772,7 +3772,7 @@ TEST (node, aggressive_flooding)
 	node_flags.disable_wallet_bootstrap = true;
 	auto & node1 (*system.add_node (node_flags));
 	auto & wallet1 (*system.wallet (0));
-	wallet1.insert_adhoc (nano::test_genesis_key.prv);
+	wallet1.insert_adhoc (nano::dev_genesis_key.prv);
 	std::vector<std::pair<std::shared_ptr<nano::node>, std::shared_ptr<nano::wallet>>> nodes_wallets;
 	bool const sanitizer_or_valgrind (is_sanitizer_build || nano::running_within_valgrind ());
 	nodes_wallets.resize (!sanitizer_or_valgrind ? 5 : 3);
@@ -3795,7 +3795,7 @@ TEST (node, aggressive_flooding)
 		nano::keypair keypair;
 		node_wallet.second->store.representative_set (node_wallet.first->wallets.tx_begin_write (), keypair.pub);
 		node_wallet.second->insert_adhoc (keypair.prv);
-		auto block (wallet1.send_action (nano::test_genesis_key.pub, keypair.pub, large_amount));
+		auto block (wallet1.send_action (nano::dev_genesis_key.pub, keypair.pub, large_amount));
 		genesis_blocks.push_back (block);
 	}
 
@@ -3806,7 +3806,7 @@ TEST (node, aggressive_flooding)
 		{
 			node_wallet.first->process (*block);
 		}
-		ASSERT_EQ (node1.latest (nano::test_genesis_key.pub), node_wallet.first->latest (nano::test_genesis_key.pub));
+		ASSERT_EQ (node1.latest (nano::dev_genesis_key.pub), node_wallet.first->latest (nano::dev_genesis_key.pub));
 	}
 
 	// Wait until the main node sees all representatives
@@ -3818,13 +3818,13 @@ TEST (node, aggressive_flooding)
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		block = builder.make_block ()
-		        .account (nano::test_genesis_key.pub)
-		        .representative (nano::test_genesis_key.pub)
-		        .previous (node1.ledger.latest (transaction, nano::test_genesis_key.pub))
-		        .balance (node1.ledger.account_balance (transaction, nano::test_genesis_key.pub) - 1)
-		        .link (nano::test_genesis_key.pub)
-		        .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-		        .work (*node1.work_generate_blocking (node1.ledger.latest (transaction, nano::test_genesis_key.pub)))
+		        .account (nano::dev_genesis_key.pub)
+		        .representative (nano::dev_genesis_key.pub)
+		        .previous (node1.ledger.latest (transaction, nano::dev_genesis_key.pub))
+		        .balance (node1.ledger.account_balance (transaction, nano::dev_genesis_key.pub) - 1)
+		        .link (nano::dev_genesis_key.pub)
+		        .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+		        .work (*node1.work_generate_blocking (node1.ledger.latest (transaction, nano::dev_genesis_key.pub)))
 		        .build ();
 	}
 	// Processing locally goes through the aggressive block flooding path
@@ -3839,7 +3839,7 @@ TEST (node, aggressive_flooding)
 	ASSERT_TIMELY (!sanitizer_or_valgrind ? 5s : 25s, all_have_block (block->hash ()));
 
 	// Do the same for a wallet block
-	auto wallet_block = wallet1.send_sync (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 10);
+	auto wallet_block = wallet1.send_sync (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, 10);
 	ASSERT_TIMELY (!sanitizer_or_valgrind ? 5s : 25s, all_have_block (wallet_block));
 
 	// All blocks: genesis + (send+open) for each representative + 2 local blocks
@@ -3876,7 +3876,7 @@ TEST (active_difficulty, recalculate_work)
 	             .previous (genesis.hash ())
 	             .destination (key1.pub)
 	             .balance (0)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (genesis.hash ()))
 	             .build_shared ();
 	auto multiplier1 = nano::difficulty::to_multiplier (send1->difficulty (), node1.network_params.network.publish_thresholds.epoch_1);
@@ -3918,12 +3918,12 @@ TEST (node, rollback_vote_self)
 	nano::keypair key;
 	auto weight = node.config.online_weight_minimum.number ();
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (nano::genesis_hash)
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .link (key.pub)
 	             .balance (nano::genesis_amount - weight)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (nano::genesis_hash))
 	             .build_shared ();
 	auto open = builder.make_block ()
@@ -3939,14 +3939,14 @@ TEST (node, rollback_vote_self)
 	             .from (*send1)
 	             .previous (send1->hash ())
 	             .balance (send1->balance ().number () - 1)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto fork = builder.make_block ()
 	            .from (*send2)
 	            .balance (send2->balance ().number () - 2)
-	            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	            .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
@@ -3967,7 +3967,7 @@ TEST (node, rollback_vote_self)
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (2, election->blocks.size ());
 	// Insert genesis key in the wallet
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	{
 		// The write guard prevents the block processor from performing the rollback
 		auto write_guard = node.write_database_queue.wait (nano::writer::testing);
@@ -3993,7 +3993,7 @@ TEST (node, rollback_vote_self)
 	}
 	// A vote is eventually generated from the local representative
 	ASSERT_TIMELY (5s, 3 == election->last_votes_size ());
-	auto vote (election->last_votes.find (nano::test_genesis_key.pub));
+	auto vote (election->last_votes.find (nano::dev_genesis_key.pub));
 	ASSERT_NE (election->last_votes.end (), vote);
 	ASSERT_EQ (fork->hash (), vote->second.hash);
 }
@@ -4011,12 +4011,12 @@ TEST (node, dependency_graph)
 
 	// Send to key1
 	auto gen_send1 = builder.make_block ()
-	                 .account (nano::test_genesis_key.pub)
+	                 .account (nano::dev_genesis_key.pub)
 	                 .previous (nano::genesis_hash)
-	                 .representative (nano::test_genesis_key.pub)
+	                 .representative (nano::dev_genesis_key.pub)
 	                 .link (key1.pub)
 	                 .balance (nano::genesis_amount - 1)
-	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                 .work (*system.work.generate (nano::genesis_hash))
 	                 .build_shared ();
 	// Receive from genesis
@@ -4034,7 +4034,7 @@ TEST (node, dependency_graph)
 	                  .account (key1.pub)
 	                  .previous (key1_open->hash ())
 	                  .representative (key1.pub)
-	                  .link (nano::test_genesis_key.pub)
+	                  .link (nano::dev_genesis_key.pub)
 	                  .balance (0)
 	                  .sign (key1.prv, key1.pub)
 	                  .work (*system.work.generate (key1_open->hash ()))
@@ -4045,7 +4045,7 @@ TEST (node, dependency_graph)
 	                   .previous (gen_send1->hash ())
 	                   .link (key1_send1->hash ())
 	                   .balance (nano::genesis_amount)
-	                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                   .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                   .work (*system.work.generate (gen_send1->hash ()))
 	                   .build ();
 	// Send to key2
@@ -4054,7 +4054,7 @@ TEST (node, dependency_graph)
 	                 .previous (gen_receive->hash ())
 	                 .link (key2.pub)
 	                 .balance (gen_receive->balance ().number () - 2)
-	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                 .work (*system.work.generate (gen_receive->hash ()))
 	                 .build ();
 	// Receive from genesis
@@ -4129,7 +4129,7 @@ TEST (node, dependency_graph)
 	                  .previous (key3_receive->hash ())
 	                  .link (node.ledger.epoch_link (nano::epoch::epoch_1))
 	                  .balance (key3_receive->balance ())
-	                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                  .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                  .work (*system.work.generate (key3_receive->hash ()))
 	                  .build ();
 
@@ -4166,7 +4166,7 @@ TEST (node, dependency_graph)
 	ASSERT_EQ (node.ledger.cache.block_count - 2, dependency_graph.size ());
 
 	// Start an election for the first block of the dependency graph, and ensure all blocks are eventually confirmed
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node.block_confirm (gen_send1);
 
 	ASSERT_NO_ERROR (system.poll_until_true (15s, [&] {
@@ -4211,12 +4211,12 @@ TEST (node, dependency_graph_frontier)
 
 	// Send to key1
 	auto gen_send1 = builder.make_block ()
-	                 .account (nano::test_genesis_key.pub)
+	                 .account (nano::dev_genesis_key.pub)
 	                 .previous (nano::genesis_hash)
-	                 .representative (nano::test_genesis_key.pub)
+	                 .representative (nano::dev_genesis_key.pub)
 	                 .link (key1.pub)
 	                 .balance (nano::genesis_amount - 1)
-	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                 .work (*system.work.generate (nano::genesis_hash))
 	                 .build_shared ();
 	// Receive from genesis
@@ -4234,7 +4234,7 @@ TEST (node, dependency_graph_frontier)
 	                  .account (key1.pub)
 	                  .previous (key1_open->hash ())
 	                  .representative (key1.pub)
-	                  .link (nano::test_genesis_key.pub)
+	                  .link (nano::dev_genesis_key.pub)
 	                  .balance (0)
 	                  .sign (key1.prv, key1.pub)
 	                  .work (*system.work.generate (key1_open->hash ()))
@@ -4245,7 +4245,7 @@ TEST (node, dependency_graph_frontier)
 	                   .previous (gen_send1->hash ())
 	                   .link (key1_send1->hash ())
 	                   .balance (nano::genesis_amount)
-	                   .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                   .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                   .work (*system.work.generate (gen_send1->hash ()))
 	                   .build ();
 	// Send to key2
@@ -4254,7 +4254,7 @@ TEST (node, dependency_graph_frontier)
 	                 .previous (gen_receive->hash ())
 	                 .link (key2.pub)
 	                 .balance (gen_receive->balance ().number () - 2)
-	                 .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                 .work (*system.work.generate (gen_receive->hash ()))
 	                 .build ();
 	// Receive from genesis
@@ -4329,7 +4329,7 @@ TEST (node, dependency_graph_frontier)
 	                  .previous (key3_receive->hash ())
 	                  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
 	                  .balance (key3_receive->balance ())
-	                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                  .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                  .work (*system.work.generate (key3_receive->hash ()))
 	                  .build ();
 
@@ -4354,7 +4354,7 @@ TEST (node, dependency_graph_frontier)
 	ASSERT_TRUE (node1.active.empty () && node2.active.empty ());
 
 	// node1 can vote, but only on the first block
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	// activate the graph frontier
 	// node2 activates dependencies in sequence until it reaches the first block
@@ -4383,12 +4383,12 @@ TEST (node, deferred_dependent_elections)
 	nano::state_block_builder builder;
 	nano::keypair key;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (nano::genesis_hash)
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .link (key.pub)
 	             .balance (nano::genesis_amount - 1)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (nano::genesis_hash))
 	             .build_shared ();
 	auto open = builder.make_block ()
@@ -4405,7 +4405,7 @@ TEST (node, deferred_dependent_elections)
 	             .previous (send1->hash ())
 	             .balance (send1->balance ().number () - 1)
 	             .link (key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	auto receive = builder.make_block ()
@@ -4418,7 +4418,7 @@ TEST (node, deferred_dependent_elections)
 	               .build_shared ();
 	auto fork = builder.make_block ()
 	            .from (*receive)
-	            .representative (nano::test_genesis_key.pub)
+	            .representative (nano::dev_genesis_key.pub)
 	            .sign (key.prv, key.pub)
 	            .build_shared ();
 	node.process_active (send1);

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -25,9 +25,9 @@ TEST (processor_service, bad_send_signature)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, nano::test_genesis_key.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	nano::send_block send (info1.head, nano::dev_genesis_key.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	send.signature.bytes[32] ^= 0x1;
 	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, send).code);
 }
@@ -44,13 +44,13 @@ TEST (processor_service, bad_receive_signature)
 	store->initialize (transaction, genesis, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info1));
-	nano::send_block send (info1.head, nano::test_genesis_key.pub, 50, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (info1.head));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info1));
+	nano::send_block send (info1.head, nano::dev_genesis_key.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 	nano::block_hash hash1 (send.hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	nano::account_info info2;
-	ASSERT_FALSE (store->account_get (transaction, nano::test_genesis_key.pub, info2));
-	nano::receive_block receive (hash1, hash1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (hash1));
+	ASSERT_FALSE (store->account_get (transaction, nano::dev_genesis_key.pub, info2));
+	nano::receive_block receive (hash1, hash1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (hash1));
 	receive.signature.bytes[32] ^= 0x1;
 	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, receive).code);
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -14,8 +14,8 @@ TEST (request_aggregator, one)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
@@ -50,8 +50,8 @@ TEST (request_aggregator, one_update)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (genesis.hash (), genesis.open->root ());
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
@@ -83,8 +83,8 @@ TEST (request_aggregator, two)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (genesis.hash (), genesis.open->root ());
 	request.emplace_back (send1->hash (), send1->root ());
@@ -128,8 +128,8 @@ TEST (request_aggregator, two_endpoints)
 	node_config.peering_port = nano::get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (genesis.hash ())));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
@@ -160,7 +160,7 @@ TEST (request_aggregator, split)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	std::vector<std::shared_ptr<nano::block>> blocks;
 	auto previous = genesis.hash ();
@@ -170,12 +170,12 @@ TEST (request_aggregator, split)
 		nano::block_builder builder;
 		blocks.push_back (builder
 		                  .state ()
-		                  .account (nano::test_genesis_key.pub)
+		                  .account (nano::dev_genesis_key.pub)
 		                  .previous (previous)
-		                  .representative (nano::test_genesis_key.pub)
+		                  .representative (nano::dev_genesis_key.pub)
 		                  .balance (nano::genesis_amount - (i + 1))
-		                  .link (nano::test_genesis_key.pub)
-		                  .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+		                  .link (nano::dev_genesis_key.pub)
+		                  .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 		                  .work (*system.work.generate (previous))
 		                  .build ());
 		auto const & block = blocks.back ();
@@ -217,8 +217,8 @@ TEST (request_aggregator, channel_lifetime)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -238,8 +238,8 @@ TEST (request_aggregator, channel_update)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -267,8 +267,8 @@ TEST (request_aggregator, channel_max_queue)
 	node_config.max_queued_requests = 1;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -285,8 +285,8 @@ TEST (request_aggregator, unique)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -308,24 +308,24 @@ TEST (request_aggregator, cannot_vote)
 	nano::genesis genesis;
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
-	             .account (nano::test_genesis_key.pub)
+	             .account (nano::dev_genesis_key.pub)
 	             .previous (nano::genesis_hash)
-	             .representative (nano::test_genesis_key.pub)
+	             .representative (nano::dev_genesis_key.pub)
 	             .balance (nano::genesis_amount - 1)
-	             .link (nano::test_genesis_key.pub)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .link (nano::dev_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (nano::genesis_hash))
 	             .build_shared ();
 	auto send2 = builder.make_block ()
 	             .from (*send1)
 	             .previous (send1->hash ())
 	             .balance (send1->balance ().number () - 1)
-	             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	             .work (*system.work.generate (send1->hash ()))
 	             .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_FALSE (node.ledger.can_vote (node.store.tx_begin_read (), *send2));
 
 	std::vector<std::pair<nano::block_hash, nano::root>> request;

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -252,7 +252,7 @@ TEST (telemetry, basic)
 	}
 
 	// Wait the cache period and check cache is not used
-	std::this_thread::sleep_for (nano::telemetry_cache_cutoffs::test);
+	std::this_thread::sleep_for (nano::telemetry_cache_cutoffs::dev);
 
 	std::atomic<bool> done{ false };
 	node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &telemetry_data](nano::telemetry_data_response const & response_a) {
@@ -412,7 +412,7 @@ TEST (telemetry, dos_tcp)
 		});
 	}
 
-	ASSERT_TIMELY (10s, (nano::telemetry_cache_cutoffs::test + orig) <= std::chrono::steady_clock::now ());
+	ASSERT_TIMELY (10s, (nano::telemetry_cache_cutoffs::dev + orig) <= std::chrono::steady_clock::now ());
 
 	// Should process no more telemetry_req messages
 	ASSERT_EQ (1, node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in));
@@ -455,7 +455,7 @@ TEST (telemetry, dos_udp)
 		});
 	}
 
-	ASSERT_TIMELY (20s, (nano::telemetry_cache_cutoffs::test + orig) <= std::chrono::steady_clock::now ());
+	ASSERT_TIMELY (20s, (nano::telemetry_cache_cutoffs::dev + orig) <= std::chrono::steady_clock::now ());
 
 	// Should process no more telemetry_req messages
 	ASSERT_EQ (1, node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in));

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -70,10 +70,10 @@ TEST (toml, daemon_config_update_array)
 	nano::tomlconfig t;
 	boost::filesystem::path data_path (".");
 	nano::daemon_config c (data_path);
-	c.node.preconfigured_peers.push_back ("test-peer.org");
+	c.node.preconfigured_peers.push_back ("dev-peer.org");
 	c.serialize_toml (t);
 	c.deserialize_toml (t);
-	ASSERT_EQ (c.node.preconfigured_peers[0], "test-peer.org");
+	ASSERT_EQ (c.node.preconfigured_peers[0], "dev-peer.org");
 }
 
 /** Empty rpc config file should match a default config object */
@@ -81,7 +81,7 @@ TEST (toml, rpc_config_deserialize_defaults)
 {
 	std::stringstream ss;
 
-	// A config file with values that differs from test-net defaults
+	// A config file with values that differs from devnet defaults
 	ss << R"toml(
 	[process]
 	)toml";
@@ -407,7 +407,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	password_fanout = 999
 	peering_port = 999
 	pow_sleep_interval= 999
-	preconfigured_peers = ["test.org"]
+	preconfigured_peers = ["dev.org"]
 	preconfigured_representatives = ["nano_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4"]
 	receive_minimum = "999"
 	signature_checker_threads = 999
@@ -418,7 +418,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	vote_generator_delay = 999
 	vote_generator_threshold = 9
 	vote_minimum = "999"
-	work_peers = ["test.org:999"]
+	work_peers = ["dev.org:999"]
 	work_threads = 999
 	work_watcher_period = 999
 	max_work_generate_multiplier = 1.0
@@ -431,16 +431,16 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	min_write_txn_time = 999
 
 	[node.httpcallback]
-	address = "test.org"
+	address = "dev.org"
 	port = 999
-	target = "/test"
+	target = "/dev"
 
 	[node.ipc.local]
 	allow_unsafe = true
 	enable = true
 	io_timeout = 999
 	io_threads = 999
-	path = "/tmp/test"
+	path = "/tmp/dev"
 
 	[node.ipc.tcp]
 	enable = true
@@ -482,8 +482,8 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	work_generation_time = false
 
 	[node.statistics.log]
-	filename_counters = "testcounters.stat"
-	filename_samples = "testsamples.stat"
+	filename_counters = "devcounters.stat"
+	filename_samples = "devsamples.stat"
 	headers = false
 	interval_counters = 999
 	interval_samples = 999
@@ -510,7 +510,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	io_threads = 99
 
 	[node.experimental]
-	secondary_work_peers = ["test.org:998"]
+	secondary_work_peers = ["dev.org:998"]
 
 	[opencl]
 	device = 999
@@ -524,7 +524,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 
 	[rpc.child_process]
 	enable = true
-	rpc_path = "/test/nano_rpc"
+	rpc_path = "/dev/nano_rpc"
 	)toml";
 
 	nano::tomlconfig toml;
@@ -694,7 +694,7 @@ TEST (toml, rpc_config_deserialize_no_defaults)
 {
 	std::stringstream ss;
 
-	// A config file with values that differs from test-net defaults
+	// A config file with values that differs from devnet defaults
 	ss << R"toml(
 	address = "0:0:0:0:0:ffff:7f01:101"
 	enable_control = true

--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -375,9 +375,9 @@ TEST (uint256_union, decode_nano_variant)
 TEST (uint256_union, account_transcode)
 {
 	nano::account value;
-	auto text (nano::test_genesis_key.pub.to_account ());
+	auto text (nano::dev_genesis_key.pub.to_account ());
 	ASSERT_FALSE (value.decode_account (text));
-	ASSERT_EQ (nano::test_genesis_key.pub, value);
+	ASSERT_EQ (nano::dev_genesis_key.pub, value);
 
 	/*
 	 * Handle different offsets for the underscore separator

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -54,7 +54,7 @@ TEST (vote_processor, flush)
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::genesis genesis;
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 1, std::vector<nano::block_hash>{ genesis.open->hash () }));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, std::vector<nano::block_hash>{ genesis.open->hash () }));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, node.network.endpoint (), node.network_params.protocol.protocol_version));
 	for (unsigned i = 0; i < 2000; ++i)
 	{
@@ -146,16 +146,16 @@ TEST (vote_processor, weights)
 	nano::keypair key1;
 	nano::keypair key2;
 
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key0.prv);
 	system.wallet (2)->insert_adhoc (key1.prv);
 	system.wallet (3)->insert_adhoc (key2.prv);
 	system.wallet (1)->store.representative_set (system.nodes[1]->wallets.tx_begin_write (), key0.pub);
 	system.wallet (2)->store.representative_set (system.nodes[2]->wallets.tx_begin_write (), key1.pub);
 	system.wallet (3)->store.representative_set (system.nodes[3]->wallets.tx_begin_write (), key2.pub);
-	system.wallet (0)->send_sync (nano::test_genesis_key.pub, key0.pub, level0);
-	system.wallet (0)->send_sync (nano::test_genesis_key.pub, key1.pub, level1);
-	system.wallet (0)->send_sync (nano::test_genesis_key.pub, key2.pub, level2);
+	system.wallet (0)->send_sync (nano::dev_genesis_key.pub, key0.pub, level0);
+	system.wallet (0)->send_sync (nano::dev_genesis_key.pub, key1.pub, level1);
+	system.wallet (0)->send_sync (nano::dev_genesis_key.pub, key2.pub, level2);
 
 	// Wait for representatives
 	ASSERT_TIMELY (10s, node.ledger.cache.rep_weights.get_rep_amounts ().size () == 4);
@@ -173,9 +173,9 @@ TEST (vote_processor, weights)
 	ASSERT_NE (node.vote_processor.representatives_2.end (), node.vote_processor.representatives_2.find (key2.pub));
 	ASSERT_EQ (node.vote_processor.representatives_3.end (), node.vote_processor.representatives_3.find (key2.pub));
 
-	ASSERT_NE (node.vote_processor.representatives_1.end (), node.vote_processor.representatives_1.find (nano::test_genesis_key.pub));
-	ASSERT_NE (node.vote_processor.representatives_2.end (), node.vote_processor.representatives_2.find (nano::test_genesis_key.pub));
-	ASSERT_NE (node.vote_processor.representatives_3.end (), node.vote_processor.representatives_3.find (nano::test_genesis_key.pub));
+	ASSERT_NE (node.vote_processor.representatives_1.end (), node.vote_processor.representatives_1.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (node.vote_processor.representatives_2.end (), node.vote_processor.representatives_2.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (node.vote_processor.representatives_3.end (), node.vote_processor.representatives_3.find (nano::dev_genesis_key.pub));
 }
 }
 
@@ -191,29 +191,29 @@ TEST (vote_processor, no_broadcast_local)
 	// Reduce the weight of genesis to 2x default min voting weight
 	nano::keypair key;
 	std::shared_ptr<nano::block> send = builder.state ()
-	                                    .account (nano::test_genesis_key.pub)
-	                                    .representative (nano::test_genesis_key.pub)
+	                                    .account (nano::dev_genesis_key.pub)
+	                                    .representative (nano::dev_genesis_key.pub)
 	                                    .previous (nano::genesis_hash)
 	                                    .balance (2 * node.config.vote_minimum.number ())
 	                                    .link (key.pub)
-	                                    .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                    .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                    .work (*system.work.generate (nano::genesis_hash))
 	                                    .build (ec);
 	ASSERT_FALSE (ec);
 	ASSERT_EQ (nano::process_result::progress, node.process_local (send).code);
-	ASSERT_EQ (2 * node.config.vote_minimum.number (), node.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (2 * node.config.vote_minimum.number (), node.weight (nano::dev_genesis_key.pub));
 	// Insert account in wallet
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node.wallets.compute_reps ();
-	ASSERT_TRUE (node.wallets.reps ().exists (nano::test_genesis_key.pub));
+	ASSERT_TRUE (node.wallets.reps ().exists (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (node.wallets.reps ().have_half_rep ());
 	// Process a vote
-	auto vote (node.store.vote_generate (node.store.tx_begin_read (), nano::test_genesis_key.pub, nano::test_genesis_key.prv, { send->hash () }));
+	auto vote (node.store.vote_generate (node.store.tx_begin_read (), nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, { send->hash () }));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote));
 	// Make sure the vote was processed
 	auto election (node.active.election (send->qualified_root ()));
 	ASSERT_NE (nullptr, election);
-	auto existing (election->last_votes.find (nano::test_genesis_key.pub));
+	auto existing (election->last_votes.find (nano::dev_genesis_key.pub));
 	ASSERT_NE (election->last_votes.end (), existing);
 	ASSERT_EQ (vote->sequence, existing->second.sequence);
 	// Ensure the vote, from a local representative, was not broadcast on processing - it should be flooded on generation instead
@@ -222,30 +222,30 @@ TEST (vote_processor, no_broadcast_local)
 
 	// Repeat test with no representative
 	// Erase account from the wallet
-	system.wallet (0)->store.erase (node.wallets.tx_begin_write (), nano::test_genesis_key.pub);
+	system.wallet (0)->store.erase (node.wallets.tx_begin_write (), nano::dev_genesis_key.pub);
 	node.wallets.compute_reps ();
-	ASSERT_FALSE (node.wallets.reps ().exists (nano::test_genesis_key.pub));
+	ASSERT_FALSE (node.wallets.reps ().exists (nano::dev_genesis_key.pub));
 
 	std::shared_ptr<nano::block> send2 = builder.state ()
-	                                     .account (nano::test_genesis_key.pub)
-	                                     .representative (nano::test_genesis_key.pub)
+	                                     .account (nano::dev_genesis_key.pub)
+	                                     .representative (nano::dev_genesis_key.pub)
 	                                     .previous (send->hash ())
 	                                     .balance (node.config.vote_minimum)
 	                                     .link (key.pub)
-	                                     .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+	                                     .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 	                                     .work (*system.work.generate (send->hash ()))
 	                                     .build (ec);
 	ASSERT_FALSE (ec);
 	ASSERT_EQ (nano::process_result::progress, node.process_local (send2).code);
-	ASSERT_EQ (node.config.vote_minimum, node.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (node.config.vote_minimum, node.weight (nano::dev_genesis_key.pub));
 	node.block_confirm (send2);
 	// Process a vote
-	auto vote2 (node.store.vote_generate (node.store.tx_begin_read (), nano::test_genesis_key.pub, nano::test_genesis_key.prv, { send2->hash () }));
+	auto vote2 (node.store.vote_generate (node.store.tx_begin_read (), nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, { send2->hash () }));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote2));
 	// Make sure the vote was processed
 	auto election2 (node.active.election (send2->qualified_root ()));
 	ASSERT_NE (nullptr, election2);
-	auto existing2 (election2->last_votes.find (nano::test_genesis_key.pub));
+	auto existing2 (election2->last_votes.find (nano::dev_genesis_key.pub));
 	ASSERT_NE (election2->last_votes.end (), existing2);
 	ASSERT_EQ (vote2->sequence, existing2->second.sequence);
 	// Ensure the vote was broadcast
@@ -256,7 +256,7 @@ TEST (vote_processor, no_broadcast_local)
 	// Increase the genesis weight again
 	std::shared_ptr<nano::block> open = builder.state ()
 	                                    .account (key.pub)
-	                                    .representative (nano::test_genesis_key.pub)
+	                                    .representative (nano::dev_genesis_key.pub)
 	                                    .previous (0)
 	                                    .balance (nano::genesis_amount - 2 * node.config.vote_minimum.number ())
 	                                    .link (send->hash ())
@@ -265,20 +265,20 @@ TEST (vote_processor, no_broadcast_local)
 	                                    .build (ec);
 	ASSERT_FALSE (ec);
 	ASSERT_EQ (nano::process_result::progress, node.process_local (open).code);
-	ASSERT_EQ (nano::genesis_amount - node.config.vote_minimum.number (), node.weight (nano::test_genesis_key.pub));
+	ASSERT_EQ (nano::genesis_amount - node.config.vote_minimum.number (), node.weight (nano::dev_genesis_key.pub));
 	node.block_confirm (open);
 	// Insert account in wallet
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node.wallets.compute_reps ();
-	ASSERT_TRUE (node.wallets.reps ().exists (nano::test_genesis_key.pub));
+	ASSERT_TRUE (node.wallets.reps ().exists (nano::dev_genesis_key.pub));
 	ASSERT_TRUE (node.wallets.reps ().have_half_rep ());
 	// Process a vote
-	auto vote3 (node.store.vote_generate (node.store.tx_begin_read (), nano::test_genesis_key.pub, nano::test_genesis_key.prv, { open->hash () }));
+	auto vote3 (node.store.vote_generate (node.store.tx_begin_read (), nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, { open->hash () }));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote3));
 	// Make sure the vote was processed
 	auto election3 (node.active.election (open->qualified_root ()));
 	ASSERT_NE (nullptr, election3);
-	auto existing3 (election3->last_votes.find (nano::test_genesis_key.pub));
+	auto existing3 (election3->last_votes.find (nano::dev_genesis_key.pub));
 	ASSERT_NE (election3->last_votes.end (), existing3);
 	ASSERT_EQ (vote3->sequence, existing3->second.sequence);
 	// Ensure the vote wass not broadcasst

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -52,7 +52,7 @@ TEST (vote_generator, cache)
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
 	auto epoch1 = system.upgrade_genesis_epoch (node, nano::epoch::epoch_1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node.active.generator.add (epoch1->root (), epoch1->hash ());
 	ASSERT_TIMELY (1s, !node.history.votes (epoch1->root (), epoch1->hash ()).empty ());
 	auto votes (node.history.votes (epoch1->root (), epoch1->hash ()));
@@ -66,14 +66,14 @@ TEST (vote_generator, multiple_representatives)
 	auto & node (*system.nodes[0]);
 	nano::keypair key1, key2, key3;
 	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv);
 	wallet.insert_adhoc (key1.prv);
 	wallet.insert_adhoc (key2.prv);
 	wallet.insert_adhoc (key3.prv);
 	auto const amount = 100 * nano::Gxrb_ratio;
-	wallet.send_sync (nano::test_genesis_key.pub, key1.pub, amount);
-	wallet.send_sync (nano::test_genesis_key.pub, key2.pub, amount);
-	wallet.send_sync (nano::test_genesis_key.pub, key3.pub, amount);
+	wallet.send_sync (nano::dev_genesis_key.pub, key1.pub, amount);
+	wallet.send_sync (nano::dev_genesis_key.pub, key2.pub, amount);
+	wallet.send_sync (nano::dev_genesis_key.pub, key3.pub, amount);
 	ASSERT_TIMELY (3s, node.balance (key1.pub) == amount && node.balance (key2.pub) == amount && node.balance (key3.pub) == amount);
 	wallet.change_sync (key1.pub, key1.pub);
 	wallet.change_sync (key2.pub, key2.pub);
@@ -81,12 +81,12 @@ TEST (vote_generator, multiple_representatives)
 	ASSERT_TRUE (node.weight (key1.pub) == amount && node.weight (key2.pub) == amount && node.weight (key3.pub) == amount);
 	node.wallets.compute_reps ();
 	ASSERT_EQ (4, node.wallets.reps ().voting);
-	auto hash = wallet.send_sync (nano::test_genesis_key.pub, nano::test_genesis_key.pub, 1);
+	auto hash = wallet.send_sync (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, 1);
 	auto send = node.block (hash);
 	ASSERT_NE (nullptr, send);
 	ASSERT_TIMELY (5s, node.history.votes (send->root (), send->hash ()).size () == 4);
 	auto votes (node.history.votes (send->root (), send->hash ()));
-	for (auto const & account : { key1.pub, key2.pub, key3.pub, nano::test_genesis_key.pub })
+	for (auto const & account : { key1.pub, key2.pub, key3.pub, nano::dev_genesis_key.pub })
 	{
 		auto existing (std::find_if (votes.begin (), votes.end (), [&account](std::shared_ptr<nano::vote> const & vote_a) -> bool {
 			return vote_a->account == account;
@@ -99,7 +99,7 @@ TEST (vote_generator, session)
 {
 	nano::system system (1);
 	auto node (system.nodes[0]);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::vote_generator_session generator_session (node->active.generator);
 	boost::thread thread ([node, &generator_session]() {
 		nano::thread_role::set (nano::thread_role::name::request_loop);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -166,43 +166,43 @@ TEST (wallet, insufficient_spend_one)
 {
 	nano::system system (1);
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 500));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 500));
 	ASSERT_NE (nullptr, block);
-	ASSERT_EQ (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, nano::genesis_amount));
+	ASSERT_EQ (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, nano::genesis_amount));
 }
 
 TEST (wallet, spend_all_one)
 {
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
-	nano::block_hash latest1 (node1.latest (nano::test_genesis_key.pub));
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::block_hash latest1 (node1.latest (nano::dev_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
 	nano::account_info info2;
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		node1.store.account_get (transaction, nano::test_genesis_key.pub, info2);
+		node1.store.account_get (transaction, nano::dev_genesis_key.pub, info2);
 		ASSERT_NE (latest1, info2.head);
 		auto block (node1.store.block_get (transaction, info2.head));
 		ASSERT_NE (nullptr, block);
 		ASSERT_EQ (latest1, block->previous ());
 	}
 	ASSERT_TRUE (info2.balance.is_zero ());
-	ASSERT_EQ (0, node1.balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, node1.balance (nano::dev_genesis_key.pub));
 }
 
 TEST (wallet, send_async)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
 	std::thread thread ([&system]() {
-		ASSERT_TIMELY (10s, system.nodes[0]->balance (nano::test_genesis_key.pub).is_zero ());
+		ASSERT_TIMELY (10s, system.nodes[0]->balance (nano::dev_genesis_key.pub).is_zero ());
 	});
 	std::atomic<bool> success (false);
-	system.wallet (0)->send_async (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), [&success](std::shared_ptr<nano::block> block_a) { ASSERT_NE (nullptr, block_a); success = true; });
+	system.wallet (0)->send_async (nano::dev_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), [&success](std::shared_ptr<nano::block> block_a) { ASSERT_NE (nullptr, block_a); success = true; });
 	thread.join ();
 	ASSERT_TIMELY (2s, success);
 }
@@ -211,34 +211,34 @@ TEST (wallet, spend)
 {
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
-	nano::block_hash latest1 (node1.latest (nano::test_genesis_key.pub));
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	nano::block_hash latest1 (node1.latest (nano::dev_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
 	// Sending from empty accounts should always be an error.  Accounts need to be opened with an open block, not a send block.
 	ASSERT_EQ (nullptr, system.wallet (0)->send_action (0, key2.pub, 0));
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
 	nano::account_info info2;
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		node1.store.account_get (transaction, nano::test_genesis_key.pub, info2);
+		node1.store.account_get (transaction, nano::dev_genesis_key.pub, info2);
 		ASSERT_NE (latest1, info2.head);
 		auto block (node1.store.block_get (transaction, info2.head));
 		ASSERT_NE (nullptr, block);
 		ASSERT_EQ (latest1, block->previous ());
 	}
 	ASSERT_TRUE (info2.balance.is_zero ());
-	ASSERT_EQ (0, node1.balance (nano::test_genesis_key.pub));
+	ASSERT_EQ (0, node1.balance (nano::dev_genesis_key.pub));
 }
 
 TEST (wallet, change)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
-	auto block1 (system.nodes[0]->rep_block (nano::test_genesis_key.pub));
+	auto block1 (system.nodes[0]->rep_block (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (block1.is_zero ());
-	ASSERT_NE (nullptr, system.wallet (0)->change_action (nano::test_genesis_key.pub, key2.pub));
-	auto block2 (system.nodes[0]->rep_block (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->change_action (nano::dev_genesis_key.pub, key2.pub));
+	auto block2 (system.nodes[0]->rep_block (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (block2.is_zero ());
 	ASSERT_NE (block1, block2);
 }
@@ -246,20 +246,20 @@ TEST (wallet, change)
 TEST (wallet, partial_spend)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, 500));
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - 500, system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, 500));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - 500, system.nodes[0]->balance (nano::dev_genesis_key.pub));
 }
 
 TEST (wallet, spend_no_previous)
 {
 	nano::system system (1);
 	{
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
 		nano::account_info info1;
-		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::test_genesis_key.pub, info1));
+		ASSERT_FALSE (system.nodes[0]->store.account_get (transaction, nano::dev_genesis_key.pub, info1));
 		for (auto i (0); i < 50; ++i)
 		{
 			nano::keypair key;
@@ -267,8 +267,8 @@ TEST (wallet, spend_no_previous)
 		}
 	}
 	nano::keypair key2;
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, 500));
-	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - 500, system.nodes[0]->balance (nano::test_genesis_key.pub));
+	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, 500));
+	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max () - 500, system.nodes[0]->balance (nano::dev_genesis_key.pub));
 }
 
 TEST (wallet, find_none)
@@ -635,7 +635,7 @@ TEST (wallet, work)
 {
 	nano::system system (1);
 	auto wallet (system.wallet (0));
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::genesis genesis;
 	auto done (false);
 	system.deadline_set (20s);
@@ -643,7 +643,7 @@ TEST (wallet, work)
 	{
 		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 		uint64_t work (0);
-		if (!wallet->store.work_get (transaction, nano::test_genesis_key.pub, work))
+		if (!wallet->store.work_get (transaction, nano::dev_genesis_key.pub, work))
 		{
 			done = nano::work_difficulty (genesis.open->work_version (), genesis.hash (), work) >= system.nodes[0]->default_difficulty (genesis.open->work_version ());
 		}
@@ -656,18 +656,18 @@ TEST (wallet, work_generate)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
-	nano::uint128_t amount1 (node1.balance (nano::test_genesis_key.pub));
+	nano::uint128_t amount1 (node1.balance (nano::dev_genesis_key.pub));
 	uint64_t work1;
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::account account1;
 	{
 		auto transaction (node1.wallets.tx_begin_read ());
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
-	auto block (wallet->send_action (nano::test_genesis_key.pub, key.pub, 100));
+	auto block (wallet->send_action (nano::dev_genesis_key.pub, key.pub, 100));
 	auto transaction (node1.store.tx_begin_read ());
-	ASSERT_TIMELY (10s, node1.ledger.account_balance (transaction, nano::test_genesis_key.pub) != amount1);
+	ASSERT_TIMELY (10s, node1.ledger.account_balance (transaction, nano::dev_genesis_key.pub) != amount1);
 	system.deadline_set (10s);
 	auto again (true);
 	while (again)
@@ -685,18 +685,18 @@ TEST (wallet, work_cache_delayed)
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
 	uint64_t work1;
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::account account1;
 	{
 		auto transaction (node1.wallets.tx_begin_read ());
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
-	auto block1 (wallet->send_action (nano::test_genesis_key.pub, key.pub, 100));
-	ASSERT_EQ (block1->hash (), node1.latest (nano::test_genesis_key.pub));
-	auto block2 (wallet->send_action (nano::test_genesis_key.pub, key.pub, 100));
-	ASSERT_EQ (block2->hash (), node1.latest (nano::test_genesis_key.pub));
-	ASSERT_EQ (block2->hash (), node1.wallets.delayed_work->operator[] (nano::test_genesis_key.pub));
+	auto block1 (wallet->send_action (nano::dev_genesis_key.pub, key.pub, 100));
+	ASSERT_EQ (block1->hash (), node1.latest (nano::dev_genesis_key.pub));
+	auto block2 (wallet->send_action (nano::dev_genesis_key.pub, key.pub, 100));
+	ASSERT_EQ (block2->hash (), node1.latest (nano::dev_genesis_key.pub));
+	ASSERT_EQ (block2->hash (), node1.wallets.delayed_work->operator[] (nano::dev_genesis_key.pub));
 	auto threshold (node1.default_difficulty (nano::work_version::work_1));
 	auto again (true);
 	system.deadline_set (10s);
@@ -817,27 +817,27 @@ TEST (wallet, insert_deterministic_locked)
 TEST (wallet, no_work)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv, false);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv, false);
 	nano::keypair key2;
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), false));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), false));
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
 	ASSERT_GE (block->difficulty (), nano::work_threshold (block->work_version (), block->sideband ().details));
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	uint64_t cached_work (0);
-	system.wallet (0)->store.work_get (transaction, nano::test_genesis_key.pub, cached_work);
+	system.wallet (0)->store.work_get (transaction, nano::dev_genesis_key.pub, cached_work);
 	ASSERT_EQ (0, cached_work);
 }
 
 TEST (wallet, send_race)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key2;
 	for (auto i (1); i < 60; ++i)
 	{
-		ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::test_genesis_key.pub, key2.pub, nano::Gxrb_ratio));
-		ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio * i, system.nodes[0]->balance (nano::test_genesis_key.pub));
+		ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, nano::Gxrb_ratio));
+		ASSERT_EQ (nano::genesis_amount - nano::Gxrb_ratio * i, system.nodes[0]->balance (nano::dev_genesis_key.pub));
 	}
 }
 
@@ -950,8 +950,8 @@ TEST (wallet, change_seed)
 	uint32_t index (4);
 	auto prv = nano::deterministic_key (seed1, index);
 	pub = nano::pub_key (prv);
-	wallet->insert_adhoc (nano::test_genesis_key.prv, false);
-	auto block (wallet->send_action (nano::test_genesis_key.pub, pub, 100));
+	wallet->insert_adhoc (nano::dev_genesis_key.prv, false);
+	auto block (wallet->send_action (nano::dev_genesis_key.pub, pub, 100));
 	ASSERT_NE (nullptr, block);
 	system.nodes[0]->block_processor.flush ();
 	{
@@ -984,8 +984,8 @@ TEST (wallet, deterministic_restore)
 		auto prv = nano::deterministic_key (seed1, index);
 		pub = nano::pub_key (prv);
 	}
-	wallet->insert_adhoc (nano::test_genesis_key.prv, false);
-	auto block (wallet->send_action (nano::test_genesis_key.pub, pub, 100));
+	wallet->insert_adhoc (nano::dev_genesis_key.prv, false);
+	auto block (wallet->send_action (nano::dev_genesis_key.pub, pub, 100));
 	ASSERT_NE (nullptr, block);
 	system.nodes[0]->block_processor.flush ();
 	{
@@ -1007,12 +1007,12 @@ TEST (work_watcher, update)
 	node_flags.disable_request_loop = true;
 	auto & node = *system.add_node (node_config, node_flags);
 	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	auto const block1 (wallet.send_action (nano::dev_genesis_key.pub, key.pub, 100));
 	auto difficulty1 (block1->difficulty ());
 	auto multiplier1 (nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty1, nano::work_threshold (block1->work_version (), nano::block_details (nano::epoch::epoch_0, true, false, false))), node.network_params.network.publish_thresholds.epoch_1));
-	auto const block2 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 200));
+	auto const block2 (wallet.send_action (nano::dev_genesis_key.pub, key.pub, 200));
 	auto difficulty2 (block2->difficulty ());
 	auto multiplier2 (nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty2, nano::work_threshold (block2->work_version (), nano::block_details (nano::epoch::epoch_0, true, false, false))), node.network_params.network.publish_thresholds.epoch_1));
 	double updated_multiplier1{ multiplier1 }, updated_multiplier2{ multiplier2 }, target_multiplier{ std::max (multiplier1, multiplier2) + 1e-6 };
@@ -1055,11 +1055,11 @@ TEST (work_watcher, propagate)
 	node_flags.disable_request_loop = true;
 	auto & node = *system.add_node (node_config, node_flags);
 	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv);
 	node_config.peering_port = nano::get_available_port ();
 	auto & node_passive = *system.add_node (node_config);
 	nano::keypair key;
-	auto const block (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	auto const block (wallet.send_action (nano::dev_genesis_key.pub, key.pub, 100));
 	ASSERT_TIMELY (5s, node_passive.ledger.block_exists (block->hash ()));
 	auto const multiplier (nano::normalized_multiplier (nano::difficulty::to_multiplier (block->difficulty (), nano::work_threshold (block->work_version (), nano::block_details (nano::epoch::epoch_0, false, false, false))), node.network_params.network.publish_thresholds.epoch_1));
 	auto updated_multiplier{ multiplier };
@@ -1102,10 +1102,10 @@ TEST (work_watcher, removed_after_win)
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
 	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	ASSERT_EQ (0, wallet.wallets.watcher->size ());
-	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	auto const block1 (wallet.send_action (nano::dev_genesis_key.pub, key.pub, 100));
 	ASSERT_EQ (1, wallet.wallets.watcher->size ());
 	ASSERT_TIMELY (5s, !node.wallets.watcher->is_watched (block1->qualified_root ()));
 	ASSERT_EQ (0, node.wallets.watcher->size ());
@@ -1119,15 +1119,15 @@ TEST (work_watcher, removed_after_lose)
 	node_config.work_watcher_period = 1s;
 	auto & node = *system.add_node (node_config);
 	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100));
+	auto const block1 (wallet.send_action (nano::dev_genesis_key.pub, key.pub, 100));
 	ASSERT_TRUE (node.wallets.watcher->is_watched (block1->qualified_root ()));
 	nano::genesis genesis;
-	auto fork1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto fork1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::xrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	node.process_active (fork1);
 	node.block_processor.flush ();
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, fork1));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, fork1));
 	nano::confirm_ack message (vote);
 	node.network.process_message (message, nullptr);
 	ASSERT_TIMELY (5s, !node.wallets.watcher->is_watched (block1->qualified_root ()));
@@ -1148,7 +1148,7 @@ TEST (work_watcher, generation_disabled)
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::genesis genesis;
 	nano::keypair key;
-	auto block (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Mxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ())));
+	auto block (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Mxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ())));
 	auto difficulty (block->difficulty ());
 	node.wallets.watcher->add (block);
 	ASSERT_FALSE (node.process_local (block).code != nano::process_result::progress);
@@ -1180,10 +1180,10 @@ TEST (work_watcher, cancel)
 	node_config.enable_voting = false;
 	auto & node = *system.add_node (node_config);
 	auto & wallet (*system.wallet (0));
-	wallet.insert_adhoc (nano::test_genesis_key.prv, false);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv, false);
 	nano::keypair key;
-	auto work1 (node.work_generate_blocking (nano::test_genesis_key.pub));
-	auto const block1 (wallet.send_action (nano::test_genesis_key.pub, key.pub, 100, *work1, false));
+	auto work1 (node.work_generate_blocking (nano::dev_genesis_key.pub));
+	auto const block1 (wallet.send_action (nano::dev_genesis_key.pub, key.pub, 100, *work1, false));
 	{
 		nano::unique_lock<std::mutex> lock (node.active.mutex);
 		// Prevent active difficulty repopulating multipliers
@@ -1230,15 +1230,15 @@ TEST (wallet, limited_difficulty)
 	// Upgrade the genesis account to epoch 2
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_2));
-	ASSERT_EQ (nano::epoch::epoch_2, node.store.block_version (node.store.tx_begin_read (), node.latest (nano::test_genesis_key.pub)));
-	wallet.insert_adhoc (nano::test_genesis_key.prv, false);
+	ASSERT_EQ (nano::epoch::epoch_2, node.store.block_version (node.store.tx_begin_read (), node.latest (nano::dev_genesis_key.pub)));
+	wallet.insert_adhoc (nano::dev_genesis_key.prv, false);
 	{
 		// Force active difficulty to an impossibly high value
 		nano::lock_guard<std::mutex> guard (node.active.mutex);
 		node.active.trended_active_multiplier = 1024 * 1024 * 1024;
 	}
 	ASSERT_EQ (node.max_work_generate_difficulty (nano::work_version::work_1), node.active.limited_active_difficulty (*genesis.open));
-	auto send = wallet.send_action (nano::test_genesis_key.pub, nano::keypair ().pub, 1, 1);
+	auto send = wallet.send_action (nano::dev_genesis_key.pub, nano::keypair ().pub, 1, 1);
 	ASSERT_NE (nullptr, send);
 }
 
@@ -1252,7 +1252,7 @@ TEST (wallet, epoch_2_validation)
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_2));
 
-	wallet.insert_adhoc (nano::test_genesis_key.prv, false);
+	wallet.insert_adhoc (nano::dev_genesis_key.prv, false);
 
 	// Test send and receive blocks
 	// An epoch 2 receive block should be generated with lower difficulty with high probability
@@ -1261,10 +1261,10 @@ TEST (wallet, epoch_2_validation)
 	auto amount = node.config.receive_minimum.number ();
 	while (++tries < max_tries)
 	{
-		auto send = wallet.send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, amount, 1);
+		auto send = wallet.send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, amount, 1);
 		ASSERT_NE (nullptr, send);
 
-		auto receive = wallet.receive_action (*send, nano::test_genesis_key.pub, amount, 1);
+		auto receive = wallet.receive_action (*send, nano::dev_genesis_key.pub, amount, 1);
 		ASSERT_NE (nullptr, receive);
 		if (receive->difficulty () < node.network_params.network.publish_thresholds.base)
 		{
@@ -1275,7 +1275,7 @@ TEST (wallet, epoch_2_validation)
 	ASSERT_LT (tries, max_tries);
 
 	// Test a change block
-	ASSERT_NE (nullptr, wallet.change_action (nano::test_genesis_key.pub, nano::keypair ().pub, 1));
+	ASSERT_NE (nullptr, wallet.change_action (nano::dev_genesis_key.pub, nano::keypair ().pub, 1));
 }
 
 // Receiving from an upgraded account uses the lower threshold and upgrades the receiving account
@@ -1299,19 +1299,19 @@ TEST (wallet, epoch_2_receive_propagation)
 		nano::state_block_builder builder;
 
 		// Send and open the account
-		wallet.insert_adhoc (nano::test_genesis_key.prv, false);
+		wallet.insert_adhoc (nano::dev_genesis_key.prv, false);
 		wallet.insert_adhoc (key.prv, false);
 		auto amount = node.config.receive_minimum.number ();
-		auto send1 = wallet.send_action (nano::test_genesis_key.pub, key.pub, amount, 1);
+		auto send1 = wallet.send_action (nano::dev_genesis_key.pub, key.pub, amount, 1);
 		ASSERT_NE (nullptr, send1);
-		ASSERT_NE (nullptr, wallet.receive_action (*send1, nano::test_genesis_key.pub, amount, 1));
+		ASSERT_NE (nullptr, wallet.receive_action (*send1, nano::dev_genesis_key.pub, amount, 1));
 
 		// Upgrade the genesis account to epoch 2
 		auto epoch2 = system.upgrade_genesis_epoch (node, nano::epoch::epoch_2);
 		ASSERT_NE (nullptr, epoch2);
 
 		// Send a block
-		auto send2 = wallet.send_action (nano::test_genesis_key.pub, key.pub, amount, 1);
+		auto send2 = wallet.send_action (nano::dev_genesis_key.pub, key.pub, amount, 1);
 		ASSERT_NE (nullptr, send2);
 
 		// Receiving should use the lower difficulty
@@ -1353,12 +1353,12 @@ TEST (wallet, epoch_2_receive_unopened)
 		nano::state_block_builder builder;
 
 		// Send
-		wallet.insert_adhoc (nano::test_genesis_key.prv, false);
+		wallet.insert_adhoc (nano::dev_genesis_key.prv, false);
 		auto amount = node.config.receive_minimum.number ();
-		auto send1 = wallet.send_action (nano::test_genesis_key.pub, key.pub, amount, 1);
+		auto send1 = wallet.send_action (nano::dev_genesis_key.pub, key.pub, amount, 1);
 
 		// Upgrade unopened account to epoch_2
-		auto epoch2_unopened = nano::state_block (key.pub, 0, 0, 0, node.network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (key.pub, node.network_params.network.publish_thresholds.epoch_2));
+		auto epoch2_unopened = nano::state_block (key.pub, 0, 0, 0, node.network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (key.pub, node.network_params.network.publish_thresholds.epoch_2));
 		ASSERT_EQ (nano::process_result::progress, node.process (epoch2_unopened).code);
 
 		wallet.insert_adhoc (key.prv, false);
@@ -1384,7 +1384,7 @@ TEST (wallet, foreach_representative_deadlock)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	node.wallets.compute_reps ();
 	ASSERT_EQ (1, node.wallets.reps ().voting);
 	node.wallets.foreach_representative ([&node](nano::public_key const & pub, nano::raw_key const & prv) {

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -122,18 +122,18 @@ TEST (wallets, vote_minimum)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::genesis genesis;
-	nano::state_block send1 (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.vote_minimum.number (), key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ()));
+	nano::state_block send1 (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.vote_minimum.number (), key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, node1.process (send1).code);
 	nano::state_block open1 (key1.pub, 0, key1.pub, node1.config.vote_minimum.number (), send1.hash (), key1.prv, key1.pub, *system.work.generate (key1.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open1).code);
 	// send2 with amount vote_minimum - 1 (not voting representative)
-	nano::state_block send2 (nano::test_genesis_key.pub, send1.hash (), nano::test_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 2 * node1.config.vote_minimum.number () + 1, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1.hash ()));
+	nano::state_block send2 (nano::dev_genesis_key.pub, send1.hash (), nano::dev_genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 2 * node1.config.vote_minimum.number () + 1, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1.hash ()));
 	ASSERT_EQ (nano::process_result::progress, node1.process (send2).code);
 	nano::state_block open2 (key2.pub, 0, key2.pub, node1.config.vote_minimum.number () - 1, send2.hash (), key2.prv, key2.pub, *system.work.generate (key2.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open2).code);
 	auto wallet (node1.wallets.items.begin ()->second);
 	ASSERT_EQ (0, wallet->representatives.size ());
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	wallet->insert_adhoc (key1.prv);
 	wallet->insert_adhoc (key2.prv);
 	node1.wallets.compute_reps ();

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -144,14 +144,14 @@ TEST (websocket, confirmation)
 	ASSERT_TIMELY (5s, ack_ready);
 
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto balance = nano::genesis_amount;
 	auto send_amount = node1->config.online_weight_minimum.number () + 1;
 	// Quick-confirm a block, legacy blocks should work without filtering
 	{
-		nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+		nano::block_hash previous (node1->latest (nano::dev_genesis_key.pub));
 		balance -= send_amount;
-		auto send (std::make_shared<nano::send_block> (previous, key.pub, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto send (std::make_shared<nano::send_block> (previous, key.pub, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		node1->process_active (send);
 	}
 
@@ -159,9 +159,9 @@ TEST (websocket, confirmation)
 
 	// Quick confirm a state block
 	{
-		nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+		nano::block_hash previous (node1->latest (nano::dev_genesis_key.pub));
 		balance -= send_amount;
-		auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, balance, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, balance, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		node1->process_active (send);
 	}
 
@@ -193,7 +193,7 @@ TEST (websocket, stopped_election)
 	// Create election, then erase it, causing a websocket message to be emitted
 	nano::keypair key1;
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	nano::publish publish1 (send1);
 	auto channel1 (node1->network.udp_channels.create (node1->network.endpoint ()));
 	node1->network.process_message (publish1, channel1);
@@ -235,14 +235,14 @@ TEST (websocket, confirmation_options)
 	ASSERT_TIMELY (5s, ack_ready);
 
 	// Confirm a state block for an in-wallet account
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	auto balance = nano::genesis_amount;
 	auto send_amount = node1->config.online_weight_minimum.number () + 1;
-	nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+	nano::block_hash previous (node1->latest (nano::dev_genesis_key.pub));
 	{
 		balance -= send_amount;
-		auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, balance, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, balance, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		node1->process_active (send);
 		previous = send->hash ();
 	}
@@ -265,7 +265,7 @@ TEST (websocket, confirmation_options)
 	// Quick-confirm another block
 	{
 		balance -= send_amount;
-		auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, balance, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, balance, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		node1->process_active (send);
 		previous = send->hash ();
 	}
@@ -284,7 +284,7 @@ TEST (websocket, confirmation_options)
 		boost::property_tree::ptree election_info = event.get_child ("message.election_info");
 		auto tally (election_info.get<std::string> ("tally"));
 		auto time (election_info.get<std::string> ("time"));
-		// Duration and request count may be zero on testnet, so we only check that they're present
+		// Duration and request count may be zero on devnet, so we only check that they're present
 		ASSERT_EQ (1, election_info.count ("duration"));
 		ASSERT_EQ (1, election_info.count ("request_count"));
 		ASSERT_EQ (1, election_info.count ("voters"));
@@ -316,7 +316,7 @@ TEST (websocket, confirmation_options)
 	// When filtering options are enabled, legacy blocks are always filtered
 	{
 		balance -= send_amount;
-		auto send (std::make_shared<nano::send_block> (previous, key.pub, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto send (std::make_shared<nano::send_block> (previous, key.pub, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		node1->process_active (send);
 		previous = send->hash ();
 	}
@@ -342,14 +342,14 @@ TEST (websocket, confirmation_options_update)
 		client.await_ack ();
 		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
 		// Now update filter with an account and wait for a response
-		std::string add_message = boost::str (boost::format (R"json({"action": "update", "topic": "confirmation", "ack": "true", "options": {"accounts_add": ["%1%"]}})json") % nano::test_genesis_key.pub.to_account ());
+		std::string add_message = boost::str (boost::format (R"json({"action": "update", "topic": "confirmation", "ack": "true", "options": {"accounts_add": ["%1%"]}})json") % nano::dev_genesis_key.pub.to_account ());
 		client.send_message (add_message);
 		client.await_ack ();
 		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
 		added = true;
 		EXPECT_TRUE (client.get_response ());
 		// Update the filter again, removing the account
-		std::string delete_message = boost::str (boost::format (R"json({"action": "update", "topic": "confirmation", "ack": "true", "options": {"accounts_del": ["%1%"]}})json") % nano::test_genesis_key.pub.to_account ());
+		std::string delete_message = boost::str (boost::format (R"json({"action": "update", "topic": "confirmation", "ack": "true", "options": {"accounts_del": ["%1%"]}})json") % nano::dev_genesis_key.pub.to_account ());
 		client.send_message (delete_message);
 		client.await_ack ();
 		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
@@ -362,11 +362,11 @@ TEST (websocket, confirmation_options_update)
 	ASSERT_TIMELY (5s, added);
 
 	// Confirm a block
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::genesis genesis;
 	nano::keypair key;
-	auto previous (node1->latest (nano::test_genesis_key.pub));
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+	auto previous (node1->latest (nano::dev_genesis_key.pub));
+	auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 	node1->process_active (send);
 
 	// Wait for delete acknowledgement
@@ -374,7 +374,7 @@ TEST (websocket, confirmation_options_update)
 
 	// Confirm another block
 	previous = send->hash ();
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, nano::genesis_amount - 2 * nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 	node1->process_active (send2);
 
 	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
@@ -404,9 +404,9 @@ TEST (websocket, vote)
 
 	// Quick-confirm a block
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, nano::genesis_amount - (node1->config.online_weight_minimum.number () + 1), key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	nano::block_hash previous (node1->latest (nano::dev_genesis_key.pub));
+	auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, nano::genesis_amount - (node1->config.online_weight_minimum.number () + 1), key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 	node1->process_active (send);
 
 	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
@@ -444,7 +444,7 @@ TEST (websocket, vote_options_type)
 
 	// Custom made votes for simplicity
 	nano::genesis genesis;
-	auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, 0, genesis.open));
+	auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 0, genesis.open));
 	nano::websocket::message_builder builder;
 	auto msg (builder.vote_received (vote, nano::vote_code::replay));
 	node1->websocket_server->broadcast (msg);
@@ -474,7 +474,7 @@ TEST (websocket, vote_options_representatives)
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1]() {
 		fake_websocket_client client (config.websocket_config.port);
-		std::string message = boost::str (boost::format (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["%1%"]}})json") % nano::test_genesis_key.pub.to_account ());
+		std::string message = boost::str (boost::format (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["%1%"]}})json") % nano::dev_genesis_key.pub.to_account ());
 		client.send_message (message);
 		client.await_ack ();
 		ack_ready = true;
@@ -494,12 +494,12 @@ TEST (websocket, vote_options_representatives)
 	// Quick-confirm a block
 	nano::keypair key;
 	auto balance = nano::genesis_amount;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto send_amount = node1->config.online_weight_minimum.number () + 1;
 	auto confirm_block = [&]() {
-		nano::block_hash previous (node1->latest (nano::test_genesis_key.pub));
+		nano::block_hash previous (node1->latest (nano::dev_genesis_key.pub));
 		balance -= send_amount;
-		auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, balance, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, balance, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		node1->process_active (send);
 	};
 	confirm_block ();
@@ -815,7 +815,7 @@ TEST (websocket, new_unconfirmed_block)
 
 	// Process a new block
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - 1, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 1, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	ASSERT_EQ (nano::process_result::progress, node1->process_local (send1).code);
 
 	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);

--- a/nano/fuzzer_test/fuzz_buffer.cpp
+++ b/nano/fuzzer_test/fuzz_buffer.cpp
@@ -10,7 +10,7 @@
 
 namespace nano
 {
-void force_nano_test_network ();
+void force_nano_dev_network ();
 }
 namespace
 {
@@ -62,7 +62,7 @@ void fuzz_message_parser (const uint8_t * Data, size_t Size)
 	static bool initialized = false;
 	if (!initialized)
 	{
-		nano::force_nano_test_network ();
+		nano::force_nano_dev_network ();
 		initialized = true;
 		system0 = std::make_shared<nano::system> (1);
 		node0 = system0->nodes[0];

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -25,7 +25,7 @@ work_thresholds const network_constants::publish_dev (
 0xf000000000000000 // 8x lower than epoch_1
 );
 
-const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, beta and dev.";
+const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
 uint8_t get_major_node_version ()
 {

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -19,13 +19,13 @@ work_thresholds const network_constants::publish_beta (
 0xffffe00000000000 // 2x lower than epoch_1
 );
 
-work_thresholds const network_constants::publish_test (
+work_thresholds const network_constants::publish_dev (
 0xfe00000000000000, // Very low for tests
 0xffc0000000000000, // 8x higher than epoch_1
 0xf000000000000000 // 8x lower than epoch_1
 );
 
-const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, beta and test.";
+const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, beta and dev.";
 
 uint8_t get_major_node_version ()
 {
@@ -44,9 +44,9 @@ uint8_t get_pre_release_node_version ()
 	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PRE_RELEASE_VERSION_STRING));
 }
 
-void force_nano_test_network ()
+void force_nano_dev_network ()
 {
-	nano::network_constants::set_active_network (nano::nano_networks::nano_test_network);
+	nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
 }
 
 bool running_within_valgrind ()

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -28,7 +28,7 @@ const char * const NANO_PRE_RELEASE_VERSION_STRING = xstr (PRE_RELEASE_VERSION_S
 
 const char * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
 
-/** Is TSAN/ASAN test build */
+/** Is TSAN/ASAN dev build */
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
 const bool is_sanitizer_build = true;
@@ -55,9 +55,9 @@ uint8_t get_pre_release_node_version ();
  */
 enum class nano_networks
 {
-	// Low work parameters, publicly known genesis key, test IP ports
-	nano_test_network = 0,
-	rai_test_network = 0,
+	// Low work parameters, publicly known genesis key, dev IP ports
+	nano_dev_network = 0,
+	rai_dev_network = 0,
 	// Normal work parameters, secret beta genesis key, beta IP ports
 	nano_beta_network = 1,
 	rai_beta_network = 1,
@@ -101,7 +101,7 @@ public:
 
 	network_constants (nano_networks network_a) :
 	current_network (network_a),
-	publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : publish_test)
+	publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : publish_dev)
 	{
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
@@ -110,13 +110,13 @@ public:
 		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : 45000;
 		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : 46000;
 		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : 47000;
-		request_interval_ms = is_test_network () ? 20 : 500;
+		request_interval_ms = is_dev_network () ? 20 : 500;
 	}
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;
 	static const nano::work_thresholds publish_beta;
-	static const nano::work_thresholds publish_test;
+	static const nano::work_thresholds publish_dev;
 
 	/** Error message when an invalid network is specified */
 	static const char * active_network_err_msg;
@@ -151,7 +151,7 @@ public:
 	/**
 	 * Optionally called on startup to override the global active network.
 	 * If not called, the compile-time option will be used.
-	 * @param network_a The new active network. Valid values are "live", "beta" and "test"
+	 * @param network_a The new active network. Valid values are "live", "beta" and "dev"
 	 */
 	static bool set_active_network (std::string network_a)
 	{
@@ -164,9 +164,9 @@ public:
 		{
 			active_network = nano::nano_networks::nano_beta_network;
 		}
-		else if (network_a == "test")
+		else if (network_a == "dev")
 		{
-			active_network = nano::nano_networks::nano_test_network;
+			active_network = nano::nano_networks::nano_dev_network;
 		}
 		else
 		{
@@ -177,7 +177,7 @@ public:
 
 	const char * get_current_network_as_string () const
 	{
-		return is_live_network () ? "live" : is_beta_network () ? "beta" : "test";
+		return is_live_network () ? "live" : is_beta_network () ? "beta" : "dev";
 	}
 
 	bool is_live_network () const
@@ -188,9 +188,9 @@ public:
 	{
 		return current_network == nano_networks::nano_beta_network;
 	}
-	bool is_test_network () const
+	bool is_dev_network () const
 	{
-		return current_network == nano_networks::nano_test_network;
+		return current_network == nano_networks::nano_dev_network;
 	}
 
 	/** Initial value is ACTIVE_NETWORK compile flag, but can be overridden by a CLI flag */
@@ -204,12 +204,12 @@ std::string get_rpc_toml_config_path (boost::filesystem::path const & data_path)
 std::string get_access_toml_config_path (boost::filesystem::path const & data_path);
 std::string get_qtwallet_toml_config_path (boost::filesystem::path const & data_path);
 
-/** Called by gtest_main to enforce test network */
-void force_nano_test_network ();
+/** Called by gtest_main to enforce dev network */
+void force_nano_dev_network ();
 
 /** Checks if we are running inside a valgrind instance */
 bool running_within_valgrind ();
 
-/** Set the active network to the test network */
-void force_nano_test_network ();
+/** Set the active network to the dev network */
+void force_nano_dev_network ();
 }

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -64,6 +64,9 @@ enum class nano_networks
 	// Normal work parameters, secret live key, live IP ports
 	nano_live_network = 2,
 	rai_live_network = 2,
+	// Normal work parameters, secret test genesis key, test IP ports
+	nano_test_network = 3,
+	rai_test_network = 3,
 };
 
 struct work_thresholds
@@ -101,15 +104,15 @@ public:
 
 	network_constants (nano_networks network_a) :
 	current_network (network_a),
-	publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : publish_dev)
+	publish_thresholds ((is_live_network () || is_test_network ()) ? publish_full : is_beta_network () ? publish_beta : publish_dev)
 	{
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
 
-		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : 44000;
-		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : 45000;
-		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : 46000;
-		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : 47000;
+		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : is_test_network () ? 17075 : 44000;
+		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : is_test_network () ? 17076 : 45000;
+		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : is_test_network () ? 17077 : 46000;
+		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : is_test_network () ? 17078 : 47000;
 		request_interval_ms = is_dev_network () ? 20 : 500;
 	}
 
@@ -168,6 +171,10 @@ public:
 		{
 			active_network = nano::nano_networks::nano_dev_network;
 		}
+		else if (network_a == "test")
+		{
+			active_network = nano::nano_networks::nano_test_network;
+		}
 		else
 		{
 			error = true;
@@ -177,7 +184,7 @@ public:
 
 	const char * get_current_network_as_string () const
 	{
-		return is_live_network () ? "live" : is_beta_network () ? "beta" : "dev";
+		return is_live_network () ? "live" : is_beta_network () ? "beta" : is_test_network () ? "test" : "dev";
 	}
 
 	bool is_live_network () const
@@ -191,6 +198,10 @@ public:
 	bool is_dev_network () const
 	{
 		return current_network == nano_networks::nano_dev_network;
+	}
+	bool is_test_network () const
+	{
+		return current_network == nano_networks::nano_test_network;
 	}
 
 	/** Initial value is ACTIVE_NETWORK compile flag, but can be overridden by a CLI flag */

--- a/nano/lib/lmdbconfig.cpp
+++ b/nano/lib/lmdbconfig.cpp
@@ -37,7 +37,7 @@ nano::error nano::lmdb_config::deserialize_toml (nano::tomlconfig & toml, bool i
 	toml.get_optional<size_t> ("map_size", map_size);
 
 	// For now we accept either setting, but not both
-	if (!params.network.is_test_network () && is_deprecated_lmdb_dbs_used && default_max_databases != max_databases)
+	if (!params.network.is_dev_network () && is_deprecated_lmdb_dbs_used && default_max_databases != max_databases)
 	{
 		toml.get_error ().set ("Both the deprecated node.lmdb_max_dbs and the new node.lmdb.max_databases setting are used. Please use max_databases only.");
 	}

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -53,7 +53,7 @@ public:
 	unsigned io_threads{ (4 < std::thread::hardware_concurrency ()) ? std::thread::hardware_concurrency () : 4 };
 	std::string ipc_address;
 	uint16_t ipc_port{ network_constants.default_ipc_port };
-	unsigned num_ipc_connections{ network_constants.is_live_network () ? 8u : network_constants.is_beta_network () ? 4u : 1u };
+	unsigned num_ipc_connections{ (network_constants.is_live_network ()||network_constants.is_test_network ()) ? 8u : network_constants.is_beta_network () ? 4u : 1u };
 	static unsigned json_version ()
 	{
 		return 1;

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -53,7 +53,7 @@ public:
 	unsigned io_threads{ (4 < std::thread::hardware_concurrency ()) ? std::thread::hardware_concurrency () : 4 };
 	std::string ipc_address;
 	uint16_t ipc_port{ network_constants.default_ipc_port };
-	unsigned num_ipc_connections{ (network_constants.is_live_network ()||network_constants.is_test_network ()) ? 8u : network_constants.is_beta_network () ? 4u : 1u };
+	unsigned num_ipc_connections{ (network_constants.is_live_network () || network_constants.is_test_network ()) ? 8u : network_constants.is_beta_network () ? 4u : 1u };
 	static unsigned json_version ()
 	{
 		return 1;

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -136,7 +136,7 @@ uint64_t nano::work_v1::value (nano::root const & root_a, uint64_t work_a)
 uint64_t nano::work_v1::value (nano::root const & root_a, uint64_t work_a)
 {
 	static nano::network_constants network_constants;
-	if (!network_constants.is_test_network ())
+	if (!network_constants.is_dev_network ())
 	{
 		debug_assert (false);
 		std::exit (1);
@@ -199,7 +199,7 @@ opencl (opencl_a)
 	static_assert (ATOMIC_INT_LOCK_FREE == 2, "Atomic int needed");
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
-	auto count (network_constants.is_test_network () ? std::min (max_threads_a, 1u) : std::min (max_threads_a, std::max (1u, boost::thread::hardware_concurrency ())));
+	auto count (network_constants.is_dev_network () ? std::min (max_threads_a, 1u) : std::min (max_threads_a, std::max (1u, boost::thread::hardware_concurrency ())));
 	if (opencl)
 	{
 		// One thread to handle OpenCL
@@ -368,14 +368,14 @@ void nano::work_pool::generate (nano::work_version const version_a, nano::root c
 boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a)
 {
 	static nano::network_constants network_constants;
-	debug_assert (network_constants.is_test_network ());
+	debug_assert (network_constants.is_dev_network ());
 	return generate (nano::work_version::work_1, root_a, network_constants.publish_thresholds.base);
 }
 
 boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a, uint64_t difficulty_a)
 {
 	static nano::network_constants network_constants;
-	debug_assert (network_constants.is_test_network ());
+	debug_assert (network_constants.is_dev_network ());
 	return generate (nano::work_version::work_1, root_a, difficulty_a);
 }
 

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -29,7 +29,7 @@ using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost
 
 namespace nano
 {
-void force_nano_test_network ();
+void force_nano_dev_network ();
 }
 
 namespace beast = boost::beast;
@@ -419,7 +419,7 @@ account_info account_info_rpc (boost::asio::io_context & ioc, tcp::resolver::res
 /** This launches a node and fires a lot of send/recieve RPC requests at it (configurable), then other nodes are tested to make sure they observe these blocks as well. */
 int main (int argc, char * const * argv)
 {
-	nano::force_nano_test_network ();
+	nano::force_nano_dev_network ();
 
 	boost::program_options::options_description description ("Command line options");
 
@@ -572,7 +572,7 @@ int main (int argc, char * const * argv)
 		std::string wallet = wallet_create_rpc (ioc, primary_node_results);
 
 		// Add genesis account to it
-		wallet_add_rpc (ioc, primary_node_results, wallet, nano::test_genesis_key.prv.data.to_string ());
+		wallet_add_rpc (ioc, primary_node_results, wallet, nano::dev_genesis_key.prv.data.to_string ());
 
 		// Add destination accounts
 		for (auto & account : destination_accounts)

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -89,9 +89,9 @@ int main (int argc, char * const * argv)
 		("debug_verify_profile_batch", "Profile batch signature verification")
 		("debug_profile_bootstrap", "Profile bootstrap style blocks processing (at least 10GB of free storage space required)")
 		("debug_profile_sign", "Profile signature generation")
-		("debug_profile_process", "Profile active blocks processing (only for nano_test_network)")
-		("debug_profile_votes", "Profile votes processing (only for nano_test_network)")
-		("debug_profile_frontiers_confirmation", "Profile frontiers confirmation speed (only for nano_test_network)")
+		("debug_profile_process", "Profile active blocks processing (only for nano_dev_network)")
+		("debug_profile_votes", "Profile votes processing (only for nano_dev_network)")
+		("debug_profile_frontiers_confirmation", "Profile frontiers confirmation speed (only for nano_dev_network)")
 		("debug_random_feed", "Generates output to RNG test suites")
 		("debug_rpc", "Read an RPC command from stdin and invoke it. Network operations will have no effect.")
 		("debug_peers", "Display peer IPv6:port connections")
@@ -165,7 +165,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("compare_rep_weights"))
 		{
-			if (!nano::network_constants ().is_test_network ())
+			if (!nano::network_constants ().is_dev_network ())
 			{
 				auto node_flags = nano::inactive_node_flag_defaults ();
 				nano::update_flags (node_flags, vm);
@@ -896,8 +896,8 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_process"))
 		{
-			nano::network_constants::set_active_network (nano::nano_networks::nano_test_network);
-			nano::network_params test_params;
+			nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t num_accounts (100000);
 			size_t num_iterations (5); // 100,000 * 5 * 2 = 1,000,000 blocks
@@ -912,7 +912,7 @@ int main (int argc, char * const * argv)
 			nano::node_flags node_flags;
 			nano::update_flags (node_flags, vm);
 			auto node (std::make_shared<nano::node> (io_ctx, 24001, path, alarm, logging, work, node_flags));
-			nano::block_hash genesis_latest (node->latest (test_params.ledger.test_genesis_key.pub));
+			nano::block_hash genesis_latest (node->latest (dev_params.ledger.dev_genesis_key.pub));
 			nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
 			// Generating keys
 			std::vector<nano::keypair> keys (num_accounts);
@@ -925,12 +925,12 @@ int main (int argc, char * const * argv)
 				genesis_balance = genesis_balance - 1000000000;
 
 				auto send = builder.state ()
-				            .account (test_params.ledger.test_genesis_key.pub)
+				            .account (dev_params.ledger.dev_genesis_key.pub)
 				            .previous (genesis_latest)
-				            .representative (test_params.ledger.test_genesis_key.pub)
+				            .representative (dev_params.ledger.dev_genesis_key.pub)
 				            .balance (genesis_balance)
 				            .link (keys[i].pub)
-				            .sign (test_params.ledger.test_genesis_key.prv, test_params.ledger.test_genesis_key.pub)
+				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
 				            .work (*work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
 				            .build ();
 
@@ -1022,8 +1022,8 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_votes"))
 		{
-			nano::network_constants::set_active_network (nano::nano_networks::nano_test_network);
-			nano::network_params test_params;
+			nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t num_elections (40000);
 			size_t num_representatives (25);
@@ -1036,7 +1036,7 @@ int main (int argc, char * const * argv)
 			auto path (nano::unique_path ());
 			logging.init (path);
 			auto node (std::make_shared<nano::node> (io_ctx, 24001, path, alarm, logging, work));
-			nano::block_hash genesis_latest (node->latest (test_params.ledger.test_genesis_key.pub));
+			nano::block_hash genesis_latest (node->latest (dev_params.ledger.dev_genesis_key.pub));
 			nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
 			// Generating keys
 			std::vector<nano::keypair> keys (num_representatives);
@@ -1047,12 +1047,12 @@ int main (int argc, char * const * argv)
 				genesis_balance = genesis_balance - balance;
 
 				auto send = builder.state ()
-				            .account (test_params.ledger.test_genesis_key.pub)
+				            .account (dev_params.ledger.dev_genesis_key.pub)
 				            .previous (genesis_latest)
-				            .representative (test_params.ledger.test_genesis_key.pub)
+				            .representative (dev_params.ledger.dev_genesis_key.pub)
 				            .balance (genesis_balance)
 				            .link (keys[i].pub)
-				            .sign (test_params.ledger.test_genesis_key.prv, test_params.ledger.test_genesis_key.pub)
+				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
 				            .work (*work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
 				            .build ();
 
@@ -1079,12 +1079,12 @@ int main (int argc, char * const * argv)
 				nano::keypair destination;
 
 				auto send = builder.state ()
-				            .account (test_params.ledger.test_genesis_key.pub)
+				            .account (dev_params.ledger.dev_genesis_key.pub)
 				            .previous (genesis_latest)
-				            .representative (test_params.ledger.test_genesis_key.pub)
+				            .representative (dev_params.ledger.dev_genesis_key.pub)
 				            .balance (genesis_balance)
 				            .link (destination.pub)
-				            .sign (test_params.ledger.test_genesis_key.prv, test_params.ledger.test_genesis_key.pub)
+				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
 				            .work (*work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
 				            .build ();
 
@@ -1132,8 +1132,8 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_frontiers_confirmation"))
 		{
-			nano::force_nano_test_network ();
-			nano::network_params test_params;
+			nano::force_nano_dev_network ();
+			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t count (32 * 1024);
 			auto count_it = vm.find ("count");
@@ -1166,7 +1166,7 @@ int main (int argc, char * const * argv)
 			flags.disable_wallet_bootstrap = true;
 			flags.disable_bootstrap_listener = true;
 			auto node1 (std::make_shared<nano::node> (io_ctx1, path1, alarm1, config1, work, flags, 0));
-			nano::block_hash genesis_latest (node1->latest (test_params.ledger.test_genesis_key.pub));
+			nano::block_hash genesis_latest (node1->latest (dev_params.ledger.dev_genesis_key.pub));
 			nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
 			// Generating blocks
 			std::deque<std::shared_ptr<nano::block>> blocks;
@@ -1176,13 +1176,13 @@ int main (int argc, char * const * argv)
 				genesis_balance = genesis_balance - 1;
 
 				auto send = builder.state ()
-				            .account (test_params.ledger.test_genesis_key.pub)
+				            .account (dev_params.ledger.dev_genesis_key.pub)
 				            .previous (genesis_latest)
-				            .representative (test_params.ledger.test_genesis_key.pub)
+				            .representative (dev_params.ledger.dev_genesis_key.pub)
 				            .balance (genesis_balance)
 				            .link (key.pub)
-				            .sign (test_params.ledger.test_genesis_key.prv, test_params.ledger.test_genesis_key.pub)
-				            .work (*work.generate (nano::work_version::work_1, genesis_latest, test_params.network.publish_thresholds.epoch_1))
+				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
+				            .work (*work.generate (nano::work_version::work_1, genesis_latest, dev_params.network.publish_thresholds.epoch_1))
 				            .build ();
 
 				genesis_latest = send->hash ();
@@ -1194,7 +1194,7 @@ int main (int argc, char * const * argv)
 				            .balance (1)
 				            .link (genesis_latest)
 				            .sign (key.prv, key.pub)
-				            .work (*work.generate (nano::work_version::work_1, key.pub, test_params.network.publish_thresholds.epoch_1))
+				            .work (*work.generate (nano::work_version::work_1, key.pub, dev_params.network.publish_thresholds.epoch_1))
 				            .build ();
 
 				blocks.push_back (std::move (send));
@@ -1285,7 +1285,7 @@ int main (int argc, char * const * argv)
 			// Insert representative
 			std::cout << "Initializing representative\n";
 			auto wallet (node1->wallets.create (nano::random_wallet_id ()));
-			wallet->insert_adhoc (test_params.ledger.test_genesis_key.prv);
+			wallet->insert_adhoc (dev_params.ledger.dev_genesis_key.prv);
 			node2->network.merge_peer (node1->network.endpoint ());
 			while (node2->rep_crawler.representative_count () == 0)
 			{

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -94,7 +94,7 @@ int main (int argc, char * const * argv)
 		("config", boost::program_options::value<std::vector<nano::config_key_value_pair>>()->multitoken(), "Pass RPC configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
 		("daemon", "Start RPC daemon")
 		("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
-		("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or test)")
+		("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or dev)")
 		("version", "Prints out version");
 	// clang-format on
 

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -94,7 +94,7 @@ int main (int argc, char * const * argv)
 		("config", boost::program_options::value<std::vector<nano::config_key_value_pair>>()->multitoken(), "Pass RPC configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
 		("daemon", "Start RPC daemon")
 		("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
-		("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or dev)")
+		("network", boost::program_options::value<std::string> (), "Use the supplied network (live, test, beta or dev)")
 		("version", "Prints out version");
 	// clang-format on
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -21,8 +21,8 @@ node (node_a),
 multipliers_cb (20, 1.),
 trended_active_multiplier (1.0),
 generator (node_a.config, node_a.ledger, node_a.wallets, node_a.vote_processor, node_a.history, node_a.network),
-check_all_elections_period (node_a.network_params.network.is_test_network () ? 10ms : 5s),
-election_time_to_live (node_a.network_params.network.is_test_network () ? 0s : 2s),
+check_all_elections_period (node_a.network_params.network.is_dev_network () ? 10ms : 5s),
+election_time_to_live (node_a.network_params.network.is_dev_network () ? 0s : 2s),
 prioritized_cutoff (std::max<size_t> (1, node_a.config.active_elections_size / 10)),
 thread ([this]() {
 	nano::thread_role::set (nano::thread_role::name::request_loop);
@@ -56,7 +56,7 @@ void nano::active_transactions::confirm_prioritized_frontiers (nano::transaction
 	bool half_princpal_representative (representative && rep_counts.half_principal > 0);
 	/* Check less frequently for regular nodes in auto mode */
 	bool agressive_mode (half_princpal_representative || node.config.frontiers_confirmation == nano::frontiers_confirmation_mode::always);
-	auto is_test_network = node.network_params.network.is_test_network ();
+	auto is_dev_network = node.network_params.network.is_dev_network ();
 	auto roots_size = size ();
 	auto check_time_exceeded = std::chrono::steady_clock::now () >= next_frontier_check;
 	auto max_elections = 1000ull;
@@ -64,7 +64,7 @@ void nano::active_transactions::confirm_prioritized_frontiers (nano::transaction
 	bool wallets_check_required = (!skip_wallets || !priority_wallet_cementable_frontiers.empty ()) && !agressive_mode;
 	// Minimise dropping real-time transactions, set the number of frontiers added to a factor of the maximum number of possible active elections
 	auto max_active = node.config.active_elections_size / 20;
-	if (roots_size <= max_active && (check_time_exceeded || wallets_check_required || (!is_test_network && low_active_elections && agressive_mode)))
+	if (roots_size <= max_active && (check_time_exceeded || wallets_check_required || (!is_dev_network && low_active_elections && agressive_mode)))
 	{
 		// When the number of active elections is low increase max number of elections for setting confirmation height.
 		if (max_active > roots_size + max_elections)
@@ -112,10 +112,10 @@ void nano::active_transactions::confirm_prioritized_frontiers (nano::transaction
 
 		auto request_interval (std::chrono::milliseconds (node.network_params.network.request_interval_ms));
 		auto rel_time_next_frontier_check = request_interval * (agressive_mode ? 20 : 60);
-		// Decrease check time for test network
-		int test_network_factor = is_test_network ? 1000 : 1;
+		// Decrease check time for dev network
+		int dev_network_factor = is_dev_network ? 1000 : 1;
 
-		next_frontier_check = steady_clock::now () + (rel_time_next_frontier_check / test_network_factor);
+		next_frontier_check = steady_clock::now () + (rel_time_next_frontier_check / dev_network_factor);
 	}
 }
 
@@ -301,7 +301,7 @@ void nano::active_transactions::frontiers_confirmation (nano::unique_lock<std::m
 		auto time_spent_prioritizing_wallet_accounts = request_interval / 250;
 		lock_a.unlock ();
 		auto transaction = node.store.tx_begin_read ();
-		prioritize_frontiers_for_confirmation (transaction, node.network_params.network.is_test_network () ? std::chrono::milliseconds (50) : time_spent_prioritizing_ledger_accounts, time_spent_prioritizing_wallet_accounts);
+		prioritize_frontiers_for_confirmation (transaction, node.network_params.network.is_dev_network () ? std::chrono::milliseconds (50) : time_spent_prioritizing_ledger_accounts, time_spent_prioritizing_wallet_accounts);
 		confirm_prioritized_frontiers (transaction);
 		lock_a.lock ();
 	}
@@ -1015,7 +1015,7 @@ void nano::active_transactions::update_active_multiplier (nano::unique_lock<std:
 	last_prioritized_multiplier.reset ();
 	double multiplier (1.);
 	// Heurestic to filter out non-saturated network and frontier confirmation
-	if (roots.size () >= prioritized_cutoff || (node.network_params.network.is_test_network () && !roots.empty ()))
+	if (roots.size () >= prioritized_cutoff || (node.network_params.network.is_dev_network () && !roots.empty ()))
 	{
 		auto & sorted_roots = roots.get<tag_difficulty> ();
 		std::vector<double> prioritized;
@@ -1027,7 +1027,7 @@ void nano::active_transactions::update_active_multiplier (nano::unique_lock<std:
 				prioritized.push_back (it->adjusted_multiplier);
 			}
 		}
-		if (prioritized.size () > 10 || (node.network_params.network.is_test_network () && !prioritized.empty ()))
+		if (prioritized.size () > 10 || (node.network_params.network.is_dev_network () && !prioritized.empty ()))
 		{
 			multiplier = prioritized[prioritized.size () / 2];
 		}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -272,7 +272,7 @@ private:
 	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, const std::string &);
 
 	friend class active_transactions_activate_dependencies_invalid_Test;
-	friend class active_transactions_dropped_cleanup_Test;
+	friend class active_transactions_dropped_cleanup_dev;
 	friend class active_transactions_vote_replays_Test;
 	friend class confirmation_height_prioritize_frontiers_Test;
 	friend class confirmation_height_prioritize_frontiers_overwrite_Test;

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -132,7 +132,7 @@ public:
 	static constexpr double required_frontier_confirmation_ratio = 0.8;
 	static constexpr unsigned frontier_confirmation_blocks_limit = 128 * 1024;
 	static constexpr unsigned requeued_pulls_limit = 256;
-	static constexpr unsigned requeued_pulls_limit_test = 2;
+	static constexpr unsigned requeued_pulls_limit_dev = 2;
 	static constexpr unsigned requeued_pulls_processed_blocks_factor = 4096;
 	static constexpr unsigned bulk_push_cost_limit = 200;
 	static constexpr std::chrono::seconds lazy_flush_delay_sec = std::chrono::seconds (5);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -16,7 +16,7 @@ constexpr size_t nano::bootstrap_limits::bootstrap_max_confirm_frontiers;
 constexpr double nano::bootstrap_limits::required_frontier_confirmation_ratio;
 constexpr unsigned nano::bootstrap_limits::frontier_confirmation_blocks_limit;
 constexpr unsigned nano::bootstrap_limits::requeued_pulls_limit;
-constexpr unsigned nano::bootstrap_limits::requeued_pulls_limit_test;
+constexpr unsigned nano::bootstrap_limits::requeued_pulls_limit_dev;
 
 nano::bootstrap_attempt::bootstrap_attempt (std::shared_ptr<nano::node> node_a, nano::bootstrap_mode mode_a, uint64_t incremental_id_a, std::string id_a) :
 node (node_a),
@@ -320,7 +320,7 @@ void nano::bootstrap_attempt_legacy::restart_condition ()
 	- not completed frontiers confirmation
 	- more than 256 pull retries usually indicating issues with requested pulls
 	- or 128k processed blocks indicating large bootstrap */
-	if (!frontiers_confirmation_pending && !frontiers_confirmed && (requeued_pulls > (!node->network_params.network.is_test_network () ? nano::bootstrap_limits::requeued_pulls_limit : nano::bootstrap_limits::requeued_pulls_limit_test) || total_blocks > nano::bootstrap_limits::frontier_confirmation_blocks_limit))
+	if (!frontiers_confirmation_pending && !frontiers_confirmed && (requeued_pulls > (!node->network_params.network.is_dev_network () ? nano::bootstrap_limits::requeued_pulls_limit : nano::bootstrap_limits::requeued_pulls_limit_dev) || total_blocks > nano::bootstrap_limits::frontier_confirmation_blocks_limit))
 	{
 		frontiers_confirmation_pending = true;
 	}
@@ -485,7 +485,7 @@ bool nano::bootstrap_attempt_legacy::confirm_frontiers (nano::unique_lock<std::m
 			else if (i < max_requests)
 			{
 				node->network.broadcast_confirm_req_batched_many (batched_confirm_req_bundle);
-				std::this_thread::sleep_for (std::chrono::milliseconds (!node->network_params.network.is_test_network () ? 500 : 5));
+				std::this_thread::sleep_for (std::chrono::milliseconds (!node->network_params.network.is_dev_network () ? 500 : 5));
 			}
 		}
 		if (!confirmed)

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -48,7 +48,7 @@ void nano::add_node_options (boost::program_options::options_description & descr
 	("vacuum", "Compact database. If data_path is missing, the database in data directory is compacted.")
 	("snapshot", "Compact database and create snapshot, functions similar to vacuum but does not replace the existing database")
 	("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
-	("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or test)")
+	("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or dev)")
 	("clear_send_ids", "Remove all send IDs from the database (dangerous: not intended for production use)")
 	("online_weight_clear", "Clear online weight history records")
 	("peer_clear", "Clear online peers database dump")

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -48,7 +48,7 @@ void nano::add_node_options (boost::program_options::options_description & descr
 	("vacuum", "Compact database. If data_path is missing, the database in data directory is compacted.")
 	("snapshot", "Compact database and create snapshot, functions similar to vacuum but does not replace the existing database")
 	("data_path", boost::program_options::value<std::string> (), "Use the supplied path as the data directory")
-	("network", boost::program_options::value<std::string> (), "Use the supplied network (live, beta or dev)")
+	("network", boost::program_options::value<std::string> (), "Use the supplied network (live, test, beta or dev)")
 	("clear_send_ids", "Remove all send IDs from the database (dangerous: not intended for production use)")
 	("online_weight_clear", "Clear online weight history records")
 	("peer_clear", "Clear online peers database dump")

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1544,7 +1544,7 @@ bool nano::parse_tcp_endpoint (std::string const & string, nano::tcp_endpoint & 
 
 std::chrono::seconds nano::telemetry_cache_cutoffs::network_to_time (network_constants const & network_constants)
 {
-	return std::chrono::seconds{ network_constants.is_live_network () ? live : network_constants.is_beta_network () ? beta : dev };
+	return std::chrono::seconds{ (network_constants.is_live_network () || network_constants.is_test_network ()) ? live : network_constants.is_beta_network () ? beta : dev };
 }
 
 nano::node_singleton_memory_pool_purge_guard::node_singleton_memory_pool_purge_guard () :

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -16,7 +16,7 @@ std::bitset<16> constexpr nano::message_header::block_type_mask;
 std::bitset<16> constexpr nano::message_header::count_mask;
 std::bitset<16> constexpr nano::message_header::telemetry_size_mask;
 
-std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::test;
+std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::dev;
 std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::beta;
 std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::live;
 
@@ -1544,7 +1544,7 @@ bool nano::parse_tcp_endpoint (std::string const & string, nano::tcp_endpoint & 
 
 std::chrono::seconds nano::telemetry_cache_cutoffs::network_to_time (network_constants const & network_constants)
 {
-	return std::chrono::seconds{ network_constants.is_live_network () ? live : network_constants.is_beta_network () ? beta : test };
+	return std::chrono::seconds{ network_constants.is_live_network () ? live : network_constants.is_beta_network () ? beta : dev };
 }
 
 nano::node_singleton_memory_pool_purge_guard::node_singleton_memory_pool_purge_guard () :

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -477,7 +477,7 @@ public:
 class telemetry_cache_cutoffs
 {
 public:
-	static std::chrono::seconds constexpr test{ 3 };
+	static std::chrono::seconds constexpr dev{ 3 };
 	static std::chrono::seconds constexpr beta{ 15 };
 	static std::chrono::seconds constexpr live{ 60 };
 

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -442,7 +442,7 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 						logger.always_log (boost::str (boost::format ("Cemented %1% blocks in %2% %3% (bounded processor)") % cemented_blocks.size () % time_spent_cementing % cemented_batch_timer.unit ()));
 
 						// Update the maximum amount of blocks to write next time based on the time it took to cement this batch.
-						if (!network_params.network.is_test_network ())
+						if (!network_params.network.is_dev_network ())
 						{
 							if (time_spent_cementing > maximum_batch_write_time)
 							{
@@ -519,7 +519,7 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 	}
 	release_assert (!error);
 	// Tests should check this already at the end, but not all blocks may have elections (e.g from manual calls to confirmation_height_processor::add), this should catch any inconsistencies on live/beta though
-	if (!network_params.network.is_test_network ())
+	if (!network_params.network.is_dev_network ())
 	{
 		// Bail if there was an error. This indicates that there was a fatal issue with the ledger
 		// (the blocks probably got rolled back when they shouldn't have).

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -358,8 +358,8 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 			if (!error && pending.height > confirmation_height)
 			{
 				auto block = ledger.store.block_get (transaction, pending.hash);
-				debug_assert (network_params.network.is_test_network () || block != nullptr);
-				debug_assert (network_params.network.is_test_network () || block->sideband ().height == pending.height);
+				debug_assert (network_params.network.is_dev_network () || block != nullptr);
+				debug_assert (network_params.network.is_dev_network () || block->sideband ().height == pending.height);
 
 				if (!block)
 				{
@@ -401,7 +401,7 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 	release_assert (!error);
 
 	// Tests should check this already at the end, but not all blocks may have elections (e.g from manual calls to confirmation_height_processor::add), this should catch any inconsistencies on live/beta though
-	if (!network_params.network.is_test_network ())
+	if (!network_params.network.is_dev_network ())
 	{
 		auto blocks_confirmed_stats = ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed);
 		auto observer_stats = ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out);

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -4,8 +4,8 @@
 using namespace std::chrono_literals;
 
 nano::confirmation_solicitor::confirmation_solicitor (nano::network & network_a, nano::network_constants const & params_a) :
-max_confirm_req_batches (params_a.is_test_network () ? 1 : 20),
-max_block_broadcasts (params_a.is_test_network () ? 4 : 30),
+max_confirm_req_batches (params_a.is_dev_network () ? 1 : 20),
+max_block_broadcasts (params_a.is_dev_network () ? 4 : 30),
 max_election_requests (30),
 max_election_broadcasts (std::max<size_t> (network_a.fanout () / 2, 1)),
 network (network_a)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -14,7 +14,7 @@ int constexpr nano::election::confirmed_duration_factor;
 
 std::chrono::milliseconds nano::election::base_latency () const
 {
-	return node.network_params.network.is_test_network () ? 25ms : 1000ms;
+	return node.network_params.network.is_dev_network () ? 25ms : 1000ms;
 }
 
 nano::election_vote_result::election_vote_result (bool replay_a, bool processed_a)
@@ -378,7 +378,7 @@ nano::election_vote_result nano::election::vote (nano::account rep, uint64_t seq
 	auto online_stake (node.online_reps.online_stake ());
 	auto weight (node.ledger.weight (rep));
 	auto should_process (false);
-	if (node.network_params.network.is_test_network () || weight > node.minimum_principal_weight (online_stake))
+	if (node.network_params.network.is_dev_network () || weight > node.minimum_principal_weight (online_stake))
 	{
 		unsigned int cooldown;
 		if (weight < online_stake / 100) // 0.1% to 1%

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -71,7 +71,7 @@ void nano::json_handler::process_request (bool unsafe_a)
 			// Try the rest of the options
 			if (action == "wallet_seed")
 			{
-				if (unsafe_a || node.network_params.network.is_test_network ())
+				if (unsafe_a || node.network_params.network.is_dev_network ())
 				{
 					wallet_seed ();
 				}

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -69,7 +69,7 @@ txn_tracking_enabled (txn_tracking_config_a.enable)
 			nano::network_constants network_constants;
 			if (!is_fresh_db)
 			{
-				if (!network_constants.is_test_network ())
+				if (!network_constants.is_dev_network ())
 				{
 					std::cout << "Upgrade in progress..." << std::endl;
 				}
@@ -88,7 +88,7 @@ txn_tracking_enabled (txn_tracking_config_a.enable)
 				}
 			}
 
-			if (needs_vacuuming && !network_constants.is_test_network ())
+			if (needs_vacuuming && !network_constants.is_dev_network ())
 			{
 				logger.always_log ("Preparing vacuum...");
 				auto vacuum_success = vacuum_after_upgrade (path_a, lmdb_config_a);

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -36,7 +36,7 @@ void nano::logging::init (boost::filesystem::path const & application_path_a)
 		}
 
 		nano::network_constants network_constants;
-		if (!network_constants.is_test_network ())
+		if (!network_constants.is_dev_network ())
 		{
 #ifdef BOOST_WINDOWS
 			if (nano::event_log_reg_entry_exists () || nano::is_windows_elevated ())

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1062,19 +1062,19 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::work_version
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::block & block_a)
 {
-	debug_assert (network_params.network.is_test_network ());
+	debug_assert (network_params.network.is_dev_network ());
 	return work_generate_blocking (block_a, default_difficulty (nano::work_version::work_1));
 }
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a)
 {
-	debug_assert (network_params.network.is_test_network ());
+	debug_assert (network_params.network.is_dev_network ());
 	return work_generate_blocking (root_a, default_difficulty (nano::work_version::work_1));
 }
 
 boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const & root_a, uint64_t difficulty_a)
 {
-	debug_assert (network_params.network.is_test_network ());
+	debug_assert (network_params.network.is_dev_network ());
 	return work_generate_blocking (nano::work_version::work_1, root_a, difficulty_a);
 }
 
@@ -1720,7 +1720,7 @@ std::unique_ptr<nano::block_store> nano::make_store (nano::logger_mt & logger, b
 		/** To use RocksDB in tests make sure the node is built with the cmake variable -DNANO_ROCKSDB=ON and the environment variable TEST_USE_ROCKSDB=1 is set */
 		static nano::network_constants network_constants;
 		auto use_rocksdb_str = std::getenv ("TEST_USE_ROCKSDB");
-		if (use_rocksdb_str && (boost::lexical_cast<int> (use_rocksdb_str) == 1) && network_constants.is_test_network ())
+		if (use_rocksdb_str && (boost::lexical_cast<int> (use_rocksdb_str) == 1) && network_constants.is_dev_network ())
 		{
 			return make_rocksdb ();
 		}

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -17,6 +17,7 @@ const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
 const char * default_beta_peer_network = "peering-beta.nano.org";
 const char * default_live_peer_network = "peering.nano.org";
+const char * default_test_peer_network = "peering-test.nano.org";
 }
 
 nano::node_config::node_config () :
@@ -59,6 +60,10 @@ external_address (boost::asio::ip::address_v6{}.to_string ())
 			preconfigured_representatives.emplace_back ("2399A083C600AA0572F5E36247D978FCFC840405F8D4B6D33161C0066A55F431");
 			preconfigured_representatives.emplace_back ("2298FAB7C61058E77EA554CB93EDEEDA0692CBFCC540AB213B2836B29029E23A");
 			preconfigured_representatives.emplace_back ("3FE80B4BC842E82C1C18ABFEEC47EA989E63953BC82AC411F304D13833D52A56");
+			break;
+		case nano::nano_networks::nano_test_network:
+			preconfigured_peers.push_back (default_test_peer_network);
+			preconfigured_representatives.push_back (network_params.ledger.genesis_account);
 			break;
 		default:
 			debug_assert (false);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -37,7 +37,7 @@ external_address (boost::asio::ip::address_v6{}.to_string ())
 	}
 	switch (network_params.network.network ())
 	{
-		case nano::nano_networks::nano_test_network:
+		case nano::nano_networks::nano_dev_network:
 			enable_voting = true;
 			preconfigured_representatives.push_back (network_params.ledger.genesis_account);
 			break;
@@ -319,7 +319,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		bool is_deprecated_lmdb_dbs_used = lmdb_max_dbs_default != deprecated_lmdb_max_dbs;
 
 		// Note: using the deprecated setting will result in a fail-fast config error in the future
-		if (!network_params.network.is_test_network () && is_deprecated_lmdb_dbs_used)
+		if (!network_params.network.is_dev_network () && is_deprecated_lmdb_dbs_used)
 		{
 			std::cerr << "WARNING: The node.lmdb_max_dbs setting is deprecated and will be removed in a future version." << std::endl;
 			std::cerr << "Please use the node.lmdb.max_databases setting instead." << std::endl;
@@ -398,7 +398,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_elections_size <= 250 && !network.is_test_network ())
+		if (active_elections_size <= 250 && !network.is_dev_network ())
 		{
 			toml.get_error ().set ("active_elections_size must be greater than 250");
 		}
@@ -704,7 +704,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_elections_size <= 250 && !network.is_test_network ())
+		if (active_elections_size <= 250 && !network.is_dev_network ())
 		{
 			json.get_error ().set ("active_elections_size must be greater than 250");
 		}

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -73,7 +73,7 @@ public:
 	uint16_t callback_port{ 0 };
 	std::string callback_target;
 	int deprecated_lmdb_max_dbs{ 128 };
-	bool allow_local_peers{ !network_params.network.is_live_network () }; // disable by default for live network
+	bool allow_local_peers{ !(network_params.network.is_live_network () || network_params.network.is_test_network ()) }; // disable by default for live network
 	nano::stat_config stat_config;
 	nano::ipc::ipc_config ipc_config;
 	std::string external_address;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -78,10 +78,10 @@ public:
 	nano::ipc::ipc_config ipc_config;
 	std::string external_address;
 	uint16_t external_port{ 0 };
-	std::chrono::milliseconds block_processor_batch_max_time{ network_params.network.is_test_network () ? std::chrono::milliseconds (500) : std::chrono::milliseconds (5000) };
+	std::chrono::milliseconds block_processor_batch_max_time{ network_params.network.is_dev_network () ? std::chrono::milliseconds (500) : std::chrono::milliseconds (5000) };
 	std::chrono::seconds unchecked_cutoff_time{ std::chrono::seconds (4 * 60 * 60) }; // 4 hours
 	/** Timeout for initiated async operations */
-	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_test_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
+	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_dev_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
 	size_t active_elections_size{ 50000 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -28,7 +28,7 @@ std::string nano::port_mapping::get_config_port (std::string const & node_port_a
 
 void nano::port_mapping::refresh_devices ()
 {
-	if (!network_params.network.is_test_network ())
+	if (!network_params.network.is_dev_network ())
 	{
 		upnp_state upnp_l;
 		int discover_error_l = 0;
@@ -74,7 +74,7 @@ nano::endpoint nano::port_mapping::external_address ()
 
 void nano::port_mapping::refresh_mapping ()
 {
-	debug_assert (!network_params.network.is_test_network ());
+	debug_assert (!network_params.network.is_dev_network ());
 	if (on)
 	{
 		nano::lock_guard<std::mutex> guard_l (mutex);
@@ -113,7 +113,7 @@ void nano::port_mapping::refresh_mapping ()
 bool nano::port_mapping::check_mapping ()
 {
 	// Long discovery time and fast setup/teardown make this impractical for testing
-	debug_assert (!network_params.network.is_test_network ());
+	debug_assert (!network_params.network.is_dev_network ());
 	bool result_l (true);
 	nano::lock_guard<std::mutex> guard_l (mutex);
 	auto node_port_l (std::to_string (node.network.endpoint ().port ()));

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -98,7 +98,7 @@ void nano::rep_crawler::ongoing_crawl ()
 		node.keepalive_preconfigured (node.config.preconfigured_peers);
 	}
 	// Reduce crawl frequency when there's enough total peer weight
-	unsigned next_run_ms = node.network_params.network.is_test_network () ? 100 : sufficient_weight ? 7000 : 3000;
+	unsigned next_run_ms = node.network_params.network.is_dev_network () ? 100 : sufficient_weight ? 7000 : 3000;
 	std::weak_ptr<nano::node> node_w (node.shared ());
 	node.alarm.add (now + std::chrono::milliseconds (next_run_ms), [node_w, this]() {
 		if (auto node_l = node_w.lock ())
@@ -138,7 +138,7 @@ void nano::rep_crawler::query (std::vector<std::shared_ptr<nano::transport::chan
 	{
 		nano::lock_guard<std::mutex> lock (active_mutex);
 		// Don't send same block multiple times in tests
-		if (node.network_params.network.is_test_network ())
+		if (node.network_params.network.is_dev_network ())
 		{
 			for (auto i (0); active.count (hash) != 0 && i < 4; ++i)
 			{

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -12,8 +12,8 @@
 #include <nano/secure/ledger.hpp>
 
 nano::request_aggregator::request_aggregator (nano::network_constants const & network_constants_a, nano::node_config const & config_a, nano::stat & stats_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
-max_delay (network_constants_a.is_test_network () ? 50 : 300),
-small_delay (network_constants_a.is_test_network () ? 10 : 50),
+max_delay (network_constants_a.is_dev_network () ? 50 : 300),
+small_delay (network_constants_a.is_dev_network () ? 10 : 50),
 max_channel_requests (config_a.max_queued_requests),
 stats (stats_a),
 local_votes (history_a),

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -369,7 +369,7 @@ size_t nano::rocksdb_store::count (nano::transaction const & transaction_a, tabl
 	// This should only be used in tests
 	else if (table_a == tables::accounts)
 	{
-		debug_assert (network_constants ().is_test_network ());
+		debug_assert (network_constants ().is_dev_network ());
 		for (auto i (latest_begin (transaction_a)), n (latest_end ()); i != n; ++i)
 		{
 			++sum;

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -216,7 +216,7 @@ void nano::socket::checkup ()
 	std::weak_ptr<nano::socket> this_w (shared_from_this ());
 	if (auto node_l = node.lock ())
 	{
-		node_l->alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (node_l->network_params.network.is_test_network () ? 1 : 2), [this_w, node_l]() {
+		node_l->alarm.add (std::chrono::steady_clock::now () + std::chrono::seconds (node_l->network_params.network.is_dev_network () ? 1 : 2), [this_w, node_l]() {
 			if (auto this_l = this_w.lock ())
 			{
 				uint64_t now (nano::seconds_since_epoch ());
@@ -381,7 +381,7 @@ void nano::server_socket::on_connection (std::function<bool(std::shared_ptr<nano
 								// Make sure the new connection doesn't idle. Note that in most cases, the callback is going to start
 								// an IO operation immediately, which will start a timer.
 								new_connection->checkup ();
-								new_connection->start_timer (node_l->network_params.network.is_test_network () ? std::chrono::seconds (2) : node_l->network_params.node.idle_timeout);
+								new_connection->start_timer (node_l->network_params.network.is_dev_network () ? std::chrono::seconds (2) : node_l->network_params.node.idle_timeout);
 								node_l->stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 								this_l->connections.push_back (new_connection);
 								this_l->evict_dead_connections ();

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -129,7 +129,7 @@ private:
 	std::chrono::seconds const cache_cutoff{ nano::telemetry_cache_cutoffs::network_to_time (network_params.network) };
 
 	// The maximum time spent waiting for a response to a telemetry request
-	std::chrono::seconds const response_time_cutoff{ network_params.network.is_test_network () ? (is_sanitizer_build || nano::running_within_valgrind () ? 6 : 3) : 10 };
+	std::chrono::seconds const response_time_cutoff{ network_params.network.is_dev_network () ? (is_sanitizer_build || nano::running_within_valgrind () ? 6 : 3) : 10 };
 
 	std::unordered_map<nano::endpoint, std::vector<std::function<void(telemetry_data_response const &)>>> callbacks;
 

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -176,20 +176,20 @@ uint64_t nano::system::work_generate_limited (nano::block_hash const & root_a, u
 std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a, nano::ledger & ledger_a, nano::epoch epoch_a)
 {
 	auto transaction (ledger_a.store.tx_begin_write ());
-	auto test_genesis_key = nano::ledger_constants (nano::nano_networks::nano_test_network).test_genesis_key;
-	auto account = test_genesis_key.pub;
+	auto dev_genesis_key = nano::ledger_constants (nano::nano_networks::nano_dev_network).dev_genesis_key;
+	auto account = dev_genesis_key.pub;
 	auto latest = ledger_a.latest (transaction, account);
 	auto balance = ledger_a.account_balance (transaction, account);
 
 	nano::state_block_builder builder;
 	std::error_code ec;
 	auto epoch = builder
-	             .account (test_genesis_key.pub)
+	             .account (dev_genesis_key.pub)
 	             .previous (latest)
 	             .balance (balance)
 	             .link (ledger_a.epoch_link (epoch_a))
-	             .representative (test_genesis_key.pub)
-	             .sign (test_genesis_key.prv, test_genesis_key.pub)
+	             .representative (dev_genesis_key.pub)
+	             .sign (dev_genesis_key.prv, dev_genesis_key.pub)
 	             .work (*pool_a.generate (latest, nano::work_threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
 	             .build (ec);
 
@@ -355,7 +355,7 @@ void nano::system::generate_receive (nano::node & node_a)
 	}
 	if (send_block != nullptr)
 	{
-		auto receive_error (wallet (0)->receive_sync (send_block, nano::ledger_constants (nano::nano_networks::nano_test_network).genesis_account, std::numeric_limits<nano::uint128_t>::max ()));
+		auto receive_error (wallet (0)->receive_sync (send_block, nano::ledger_constants (nano::nano_networks::nano_dev_network).genesis_account, std::numeric_limits<nano::uint128_t>::max ()));
 		(void)receive_error;
 	}
 }
@@ -480,9 +480,9 @@ void nano::system::generate_send_new (nano::node & node_a, std::vector<nano::acc
 void nano::system::generate_mass_activity (uint32_t count_a, nano::node & node_a)
 {
 	std::vector<nano::account> accounts;
-	auto test_genesis_key = nano::ledger_constants (nano::nano_networks::nano_test_network).test_genesis_key;
-	wallet (0)->insert_adhoc (test_genesis_key.prv);
-	accounts.push_back (test_genesis_key.pub);
+	auto dev_genesis_key = nano::ledger_constants (nano::nano_networks::nano_dev_network).dev_genesis_key;
+	wallet (0)->insert_adhoc (dev_genesis_key.prv);
+	accounts.push_back (dev_genesis_key.pub);
 	auto previous (std::chrono::steady_clock::now ());
 	for (uint32_t i (0); i < count_a; ++i)
 	{
@@ -535,7 +535,7 @@ uint16_t nano::get_available_port ()
 	return available_port;
 }
 
-void nano::cleanup_test_directories_on_exit ()
+void nano::cleanup_dev_directories_on_exit ()
 {
 	// Makes sure everything is cleaned up
 	nano::logging::release_file_sink ();

--- a/nano/node/testing.hpp
+++ b/nano/node/testing.hpp
@@ -58,6 +58,6 @@ public:
 std::unique_ptr<nano::state_block> upgrade_epoch (nano::work_pool &, nano::ledger &, nano::epoch);
 void blocks_confirm (nano::node &, std::vector<std::shared_ptr<nano::block>> const &);
 uint16_t get_available_port ();
-void cleanup_test_directories_on_exit ();
+void cleanup_dev_directories_on_exit ();
 }
 REGISTER_ERROR_CODES (nano, error_system);

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -442,7 +442,7 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 	}
 	// Attempt to start TCP connections to known UDP peers
 	nano::tcp_endpoint invalid_endpoint (boost::asio::ip::address_v6::any (), 0);
-	if (!node.network_params.network.is_test_network () && !node.flags.disable_udp)
+	if (!node.network_params.network.is_dev_network () && !node.flags.disable_udp)
 	{
 		size_t random_count (std::min (static_cast<size_t> (6), static_cast<size_t> (std::ceil (std::sqrt (node.network.udp_channels.size ())))));
 		for (auto i (0); i <= random_count; ++i)

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -104,7 +104,7 @@ std::shared_ptr<nano::transport::channel_udp> nano::transport::udp_channels::ins
 {
 	debug_assert (endpoint_a.address ().is_v6 ());
 	std::shared_ptr<nano::transport::channel_udp> result;
-	if (!node.network.not_a_peer (endpoint_a, node.config.allow_local_peers) && (node.network_params.network.is_test_network () || !max_ip_connections (endpoint_a)))
+	if (!node.network.not_a_peer (endpoint_a, node.config.allow_local_peers) && (node.network_params.network.is_dev_network () || !max_ip_connections (endpoint_a)))
 	{
 		nano::unique_lock<std::mutex> lock (mutex);
 		auto existing (channels.get<endpoint_tag> ().find (endpoint_a));
@@ -334,9 +334,9 @@ void nano::transport::udp_channels::stop ()
 		nano::lock_guard<std::mutex> lock (mutex);
 		local_endpoint = nano::endpoint (boost::asio::ip::address_v6::loopback (), 0);
 
-		// On test-net, close directly to avoid address-reuse issues. On livenet, close
+		// On devnet, close directly to avoid address-reuse issues. On livenet, close
 		// through the strand as multiple IO threads may access the socket.
-		if (node.network_params.network.is_test_network ())
+		if (node.network_params.network.is_dev_network ())
 		{
 			this->close_socket ();
 		}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1150,7 +1150,7 @@ void nano::wallet::work_update (nano::transaction const & transaction_a, nano::a
 void nano::wallet::work_ensure (nano::account const & account_a, nano::root const & root_a)
 {
 	using namespace std::chrono_literals;
-	std::chrono::seconds const precache_delay = wallets.node.network_params.network.is_test_network () ? 1s : 10s;
+	std::chrono::seconds const precache_delay = wallets.node.network_params.network.is_dev_network () ? 1s : 10s;
 
 	wallets.delayed_work->operator[] (account_a) = root_a;
 
@@ -1795,7 +1795,7 @@ void nano::wallets::ongoing_compute_reps ()
 {
 	compute_reps ();
 	auto & node_l (node);
-	auto compute_delay (network_params.network.is_test_network () ? std::chrono::milliseconds (10) : std::chrono::milliseconds (15 * 60 * 1000)); // Representation drifts quickly on the test network but very slowly on the live network
+	auto compute_delay (network_params.network.is_dev_network () ? std::chrono::milliseconds (10) : std::chrono::milliseconds (15 * 60 * 1000)); // Representation drifts quickly on the test network but very slowly on the live network
 	node.alarm.add (std::chrono::steady_clock::now () + compute_delay, [&node_l]() {
 		node_l.wallets.ongoing_compute_reps ();
 	});

--- a/nano/qt_system/entry.cpp
+++ b/nano/qt_system/entry.cpp
@@ -10,7 +10,7 @@
 #include <thread>
 int main (int argc, char ** argv)
 {
-	nano::force_nano_test_network ();
+	nano::force_nano_dev_network ();
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
 	QApplication application (argc, argv);
 	QCoreApplication::setOrganizationName ("Nano");

--- a/nano/qt_test/entry.cpp
+++ b/nano/qt_test/entry.cpp
@@ -6,18 +6,18 @@
 QApplication * test_application = nullptr;
 namespace nano
 {
-void cleanup_test_directories_on_exit ();
-void force_nano_test_network ();
+void cleanup_dev_directories_on_exit ();
+void force_nano_dev_network ();
 }
 
 int main (int argc, char ** argv)
 {
-	nano::force_nano_test_network ();
+	nano::force_nano_dev_network ();
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
 	QApplication application (argc, argv);
 	test_application = &application;
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_test_directories_on_exit ();
+	nano::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -258,9 +258,9 @@ TEST (wallet, send)
 {
 	nano_qt::eventloop_processor processor;
 	nano::system system (2);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::public_key key1 (system.wallet (1)->insert_adhoc (nano::keypair ().prv));
-	auto account (nano::test_genesis_key.pub);
+	auto account (nano::dev_genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	ASSERT_NE (wallet->rendering_ratio, nano::raw_ratio);
@@ -291,13 +291,13 @@ TEST (wallet, send_locked)
 {
 	nano_qt::eventloop_processor processor;
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	{
 		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
 		system.wallet (0)->enter_password (transaction, "0");
 	}
-	auto account (nano::test_genesis_key.pub);
+	auto account (nano::dev_genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->send_blocks, Qt::LeftButton);
@@ -332,7 +332,7 @@ TEST (wallet, process_block)
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	QTest::mouseClick (wallet->advanced.enter_block, Qt::LeftButton);
 	ASSERT_EQ (wallet->block_entry.window, wallet->main_stack->currentWidget ());
-	nano::send_block send (latest, key1.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+	nano::send_block send (latest, key1.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 	std::string previous;
 	send.hashables.previous.encode_hex (previous);
 	std::string balance;
@@ -361,16 +361,16 @@ TEST (wallet, create_send)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto account (nano::test_genesis_key.pub);
+	auto account (nano::dev_genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	wallet->client_window->show ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	QTest::mouseClick (wallet->advanced.create_block, Qt::LeftButton);
 	QTest::mouseClick (wallet->block_creation.send, Qt::LeftButton);
-	QTest::keyClicks (wallet->block_creation.account, nano::test_genesis_key.pub.to_account ().c_str ());
+	QTest::keyClicks (wallet->block_creation.account, nano::dev_genesis_key.pub.to_account ().c_str ());
 	QTest::keyClicks (wallet->block_creation.amount, "100000000000000000000");
 	QTest::keyClicks (wallet->block_creation.destination, key.pub.to_account ().c_str ());
 	QTest::mouseClick (wallet->block_creation.create, Qt::LeftButton);
@@ -391,14 +391,14 @@ TEST (wallet, create_open_receive)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 100);
-	nano::block_hash latest1 (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 100);
-	nano::block_hash latest2 (system.nodes[0]->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 100);
+	nano::block_hash latest1 (system.nodes[0]->latest (nano::dev_genesis_key.pub));
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 100);
+	nano::block_hash latest2 (system.nodes[0]->latest (nano::dev_genesis_key.pub));
 	ASSERT_NE (latest1, latest2);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto account (nano::test_genesis_key.pub);
+	auto account (nano::dev_genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	wallet->client_window->show ();
@@ -406,7 +406,7 @@ TEST (wallet, create_open_receive)
 	QTest::mouseClick (wallet->advanced.create_block, Qt::LeftButton);
 	wallet->block_creation.open->click ();
 	QTest::keyClicks (wallet->block_creation.source, latest1.to_string ().c_str ());
-	QTest::keyClicks (wallet->block_creation.representative, nano::test_genesis_key.pub.to_account ().c_str ());
+	QTest::keyClicks (wallet->block_creation.representative, nano::dev_genesis_key.pub.to_account ().c_str ());
 	QTest::mouseClick (wallet->block_creation.create, Qt::LeftButton);
 	std::string json1 (wallet->block_creation.block->toPlainText ().toStdString ());
 	ASSERT_FALSE (json1.empty ());
@@ -440,15 +440,15 @@ TEST (wallet, create_change)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto account (nano::test_genesis_key.pub);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto account (nano::dev_genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	wallet->client_window->show ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	QTest::mouseClick (wallet->advanced.create_block, Qt::LeftButton);
 	wallet->block_creation.change->click ();
-	QTest::keyClicks (wallet->block_creation.account, nano::test_genesis_key.pub.to_account ().c_str ());
+	QTest::keyClicks (wallet->block_creation.account, nano::dev_genesis_key.pub.to_account ().c_str ());
 	QTest::keyClicks (wallet->block_creation.representative, key.pub.to_account ().c_str ());
 	wallet->block_creation.create->click ();
 	std::string json (wallet->block_creation.block->toPlainText ().toStdString ());
@@ -483,15 +483,15 @@ TEST (history, short_text)
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, genesis, ledger.cache);
 		nano::keypair key;
-		auto latest (ledger.latest (transaction, nano::test_genesis_key.pub));
-		nano::send_block send (latest, nano::test_genesis_key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+		auto latest (ledger.latest (transaction, nano::dev_genesis_key.pub));
+		nano::send_block send (latest, nano::dev_genesis_key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-		nano::receive_block receive (send.hash (), send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::receive_block receive (send.hash (), send.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send.hash ()));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-		nano::change_block change (receive.hash (), key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive.hash ()));
+		nano::change_block change (receive.hash (), key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive.hash ()));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
 	}
-	nano_qt::history history (ledger, nano::test_genesis_key.pub, *wallet);
+	nano_qt::history history (ledger, nano::dev_genesis_key.pub, *wallet);
 	history.refresh ();
 	ASSERT_EQ (4, history.model->rowCount ());
 }
@@ -513,7 +513,7 @@ TEST (wallet, startup_work)
 	uint64_t work1;
 	{
 		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		ASSERT_TRUE (wallet->wallet_m->store.work_get (transaction, nano::test_genesis_key.pub, work1));
+		ASSERT_TRUE (wallet->wallet_m->store.work_get (transaction, nano::dev_genesis_key.pub, work1));
 	}
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	QTest::keyClicks (wallet->accounts.account_key_line, "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4");
@@ -524,7 +524,7 @@ TEST (wallet, startup_work)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		again = wallet->wallet_m->store.work_get (transaction, nano::test_genesis_key.pub, work1);
+		again = wallet->wallet_m->store.work_get (transaction, nano::dev_genesis_key.pub, work1);
 	}
 }
 
@@ -591,17 +591,17 @@ TEST (wallet, republish)
 {
 	nano_qt::eventloop_processor processor;
 	nano::system system (2);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	nano::block_hash hash;
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_write ());
-		auto latest (system.nodes[0]->ledger.latest (transaction, nano::test_genesis_key.pub));
-		nano::send_block block (latest, key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+		auto latest (system.nodes[0]->ledger.latest (transaction, nano::dev_genesis_key.pub));
+		nano::send_block block (latest, key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 		hash = block.hash ();
 		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
 	}
-	auto account (nano::test_genesis_key.pub);
+	auto account (nano::dev_genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
@@ -610,9 +610,9 @@ TEST (wallet, republish)
 	ASSERT_EQ (wallet->block_viewer.window, wallet->main_stack->currentWidget ());
 	QTest::keyClicks (wallet->block_viewer.hash, hash.to_string ().c_str ());
 	QTest::mouseClick (wallet->block_viewer.rebroadcast, Qt::LeftButton);
-	ASSERT_FALSE (system.nodes[1]->balance (nano::test_genesis_key.pub).is_zero ());
+	ASSERT_FALSE (system.nodes[1]->balance (nano::dev_genesis_key.pub).is_zero ());
 	system.deadline_set (10s);
-	while (system.nodes[1]->balance (nano::test_genesis_key.pub).is_zero ())
+	while (system.nodes[1]->balance (nano::dev_genesis_key.pub).is_zero ())
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -630,7 +630,7 @@ TEST (wallet, ignore_empty_adhoc)
 	ASSERT_EQ (wallet->advanced.window, wallet->main_stack->currentWidget ());
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	ASSERT_EQ (wallet->accounts.window, wallet->main_stack->currentWidget ());
-	QTest::keyClicks (wallet->accounts.account_key_line, nano::test_genesis_key.prv.data.to_string ().c_str ());
+	QTest::keyClicks (wallet->accounts.account_key_line, nano::dev_genesis_key.prv.data.to_string ().c_str ());
 	QTest::mouseClick (wallet->accounts.account_key_button, Qt::LeftButton);
 	ASSERT_EQ (1, wallet->accounts.model->rowCount ());
 	ASSERT_EQ (0, wallet->accounts.account_key_line->text ().length ());
@@ -797,7 +797,7 @@ TEST (wallet, DISABLED_synchronizing)
 	{
 		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		auto latest (system1.nodes[0]->ledger.latest (transaction, nano::genesis_account));
-		nano::send_block send (latest, key1, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system1.work.generate (latest));
+		nano::send_block send (latest, key1, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system1.work.generate (latest));
 		system1.nodes[0]->ledger.process (transaction, send);
 	}
 	ASSERT_EQ (0, wallet->active_status.active.count (nano_qt::status_types::synchronizing));

--- a/nano/rpc_test/entry.cpp
+++ b/nano/rpc_test/entry.cpp
@@ -4,17 +4,17 @@
 #include <gtest/gtest.h>
 namespace nano
 {
-void cleanup_test_directories_on_exit ();
-void force_nano_test_network ();
+void cleanup_dev_directories_on_exit ();
+void force_nano_dev_network ();
 }
 
 int main (int argc, char ** argv)
 {
-	nano::force_nano_test_network ();
+	nano::force_nano_dev_network ();
 	nano::set_use_memory_pools (false);
 	nano::node_singleton_memory_pool_purge_guard cleanup_guard;
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_test_directories_on_exit ();
+	nano::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -188,7 +188,7 @@ TEST (rpc, account_balance)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_balance");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -212,7 +212,7 @@ TEST (rpc, account_block_count)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_block_count");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -263,8 +263,8 @@ TEST (rpc, account_weight)
 	nano::keypair key;
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
-	nano::block_hash latest (node1.latest (nano::test_genesis_key.pub));
-	nano::change_block block (latest, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	nano::block_hash latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::change_block block (latest, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	ASSERT_EQ (nano::process_result::progress, node1.process (block).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -288,7 +288,7 @@ TEST (rpc, wallet_contains)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -302,7 +302,7 @@ TEST (rpc, wallet_contains)
 	node->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_contains");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -327,7 +327,7 @@ TEST (rpc, wallet_doesnt_contain)
 	node->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_contains");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -339,7 +339,7 @@ TEST (rpc, validate_account_number)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -350,7 +350,7 @@ TEST (rpc, validate_account_number)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "validate_account_number");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	std::string exists_text (response.json.get<std::string> ("valid"));
@@ -361,7 +361,7 @@ TEST (rpc, validate_account_invalid)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -371,7 +371,7 @@ TEST (rpc, validate_account_invalid)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	std::string account;
-	nano::test_genesis_key.pub.encode_account (account);
+	nano::dev_genesis_key.pub.encode_account (account);
 	account[0] ^= 0x1;
 	boost::property_tree::ptree request;
 	request.put ("action", "validate_account_number");
@@ -387,7 +387,7 @@ TEST (rpc, send)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -401,11 +401,11 @@ TEST (rpc, send)
 	node->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
-	request.put ("source", nano::test_genesis_key.pub.to_account ());
-	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("source", nano::dev_genesis_key.pub.to_account ());
+	request.put ("destination", nano::dev_genesis_key.pub.to_account ());
 	request.put ("amount", "100");
 	std::thread thread2 ([&system, node]() {
-		ASSERT_TIMELY (10s, node->balance (nano::test_genesis_key.pub) != nano::genesis_amount);
+		ASSERT_TIMELY (10s, node->balance (nano::dev_genesis_key.pub) != nano::genesis_amount);
 	});
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (10s, response.status != 0);
@@ -414,7 +414,7 @@ TEST (rpc, send)
 	nano::block_hash block;
 	ASSERT_FALSE (block.decode_hex (block_text));
 	ASSERT_TRUE (node->ledger.block_exists (block));
-	ASSERT_EQ (node->latest (nano::test_genesis_key.pub), block);
+	ASSERT_EQ (node->latest (nano::dev_genesis_key.pub), block);
 	thread2.join ();
 }
 
@@ -435,8 +435,8 @@ TEST (rpc, send_fail)
 	node->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
-	request.put ("source", nano::test_genesis_key.pub.to_account ());
-	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("source", nano::dev_genesis_key.pub.to_account ());
+	request.put ("destination", nano::dev_genesis_key.pub.to_account ());
 	request.put ("amount", "100");
 	std::atomic<bool> done (false);
 	system.deadline_set (10s);
@@ -454,7 +454,7 @@ TEST (rpc, send_work)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -468,15 +468,15 @@ TEST (rpc, send_work)
 	node->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
-	request.put ("source", nano::test_genesis_key.pub.to_account ());
-	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("source", nano::dev_genesis_key.pub.to_account ());
+	request.put ("destination", nano::dev_genesis_key.pub.to_account ());
 	request.put ("amount", "100");
 	request.put ("work", "1");
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (10s, response.status != 0);
 	ASSERT_EQ (std::error_code (nano::error_common::invalid_work).message (), response.json.get<std::string> ("error"));
 	request.erase ("work");
-	request.put ("work", nano::to_string_hex (*node->work_generate_blocking (node->latest (nano::test_genesis_key.pub))));
+	request.put ("work", nano::to_string_hex (*node->work_generate_blocking (node->latest (nano::dev_genesis_key.pub))));
 	test_response response2 (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (10s, response2.status != 0);
 	ASSERT_EQ (200, response2.status);
@@ -484,7 +484,7 @@ TEST (rpc, send_work)
 	nano::block_hash block;
 	ASSERT_FALSE (block.decode_hex (block_text));
 	ASSERT_TRUE (node->ledger.block_exists (block));
-	ASSERT_EQ (node->latest (nano::test_genesis_key.pub), block);
+	ASSERT_EQ (node->latest (nano::dev_genesis_key.pub), block);
 }
 
 TEST (rpc, send_work_disabled)
@@ -493,7 +493,7 @@ TEST (rpc, send_work_disabled)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto & node = *add_ipc_enabled_node (system, node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node, node_rpc_config);
@@ -507,8 +507,8 @@ TEST (rpc, send_work_disabled)
 	node.wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
-	request.put ("source", nano::test_genesis_key.pub.to_account ());
-	request.put ("destination", nano::test_genesis_key.pub.to_account ());
+	request.put ("source", nano::dev_genesis_key.pub.to_account ());
+	request.put ("destination", nano::dev_genesis_key.pub.to_account ());
 	request.put ("amount", "100");
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
@@ -522,7 +522,7 @@ TEST (rpc, send_idempotent)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -536,7 +536,7 @@ TEST (rpc, send_idempotent)
 	node->wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
-	request.put ("source", nano::test_genesis_key.pub.to_account ());
+	request.put ("source", nano::dev_genesis_key.pub.to_account ());
 	request.put ("destination", nano::account (0).to_account ());
 	request.put ("amount", (nano::genesis_amount - (nano::genesis_amount / 4)).convert_to<std::string> ());
 	request.put ("id", "123abc");
@@ -547,13 +547,13 @@ TEST (rpc, send_idempotent)
 	nano::block_hash block;
 	ASSERT_FALSE (block.decode_hex (block_text));
 	ASSERT_TRUE (node->ledger.block_exists (block));
-	ASSERT_EQ (node->balance (nano::test_genesis_key.pub), nano::genesis_amount / 4);
+	ASSERT_EQ (node->balance (nano::dev_genesis_key.pub), nano::genesis_amount / 4);
 	test_response response2 (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response2.status != 0);
 	ASSERT_EQ (200, response2.status);
 	ASSERT_EQ ("", response2.json.get<std::string> ("error", ""));
 	ASSERT_EQ (block_text, response2.json.get<std::string> ("block"));
-	ASSERT_EQ (node->balance (nano::test_genesis_key.pub), nano::genesis_amount / 4);
+	ASSERT_EQ (node->balance (nano::dev_genesis_key.pub), nano::genesis_amount / 4);
 	request.erase ("id");
 	request.put ("id", "456def");
 	test_response response3 (request, rpc.config.port, system.io_ctx);
@@ -571,7 +571,7 @@ TEST (rpc, send_epoch_2)
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_2));
 
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv, false);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv, false);
 
 	auto target_difficulty = nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false));
 	ASSERT_LT (node.network_params.network.publish_thresholds.entry, target_difficulty);
@@ -590,7 +590,7 @@ TEST (rpc, send_epoch_2)
 	node.wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
-	request.put ("source", nano::test_genesis_key.pub.to_account ());
+	request.put ("source", nano::dev_genesis_key.pub.to_account ());
 	request.put ("destination", nano::keypair ().pub.to_account ());
 	request.put ("amount", "1");
 
@@ -798,7 +798,7 @@ TEST (rpc, wallet_representative_set_force)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -827,7 +827,7 @@ TEST (rpc, wallet_representative_set_force)
 	{
 		auto transaction (node->store.tx_begin_read ());
 		nano::account_info info;
-		if (!node->store.account_get (transaction, nano::test_genesis_key.pub, info))
+		if (!node->store.account_get (transaction, nano::dev_genesis_key.pub, info))
 		{
 			representative = info.representative;
 		}
@@ -840,7 +840,7 @@ TEST (rpc, account_list)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -878,7 +878,7 @@ TEST (rpc, wallet_key_valid)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -967,7 +967,7 @@ TEST (rpc, wallet_export)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -989,14 +989,14 @@ TEST (rpc, wallet_export)
 	nano::kdf kdf;
 	nano::wallet_store store (error, kdf, transaction, nano::genesis_account, 1, "0", wallet_json);
 	ASSERT_FALSE (error);
-	ASSERT_TRUE (store.exists (transaction, nano::test_genesis_key.pub));
+	ASSERT_TRUE (store.exists (transaction, nano::dev_genesis_key.pub));
 }
 
 TEST (rpc, wallet_destroy)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	auto wallet_id (node->wallets.items.begin ()->first);
 	nano::node_rpc_config node_rpc_config;
@@ -1021,7 +1021,7 @@ TEST (rpc, account_move)
 	auto node = add_ipc_enabled_node (system);
 	auto wallet_id (node->wallets.items.begin ()->first);
 	auto destination (system.wallet (0));
-	destination->insert_adhoc (nano::test_genesis_key.prv);
+	destination->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	auto source_id = nano::random_wallet_id ();
 	auto source (node->wallets.create (source_id));
@@ -1048,7 +1048,7 @@ TEST (rpc, account_move)
 	ASSERT_EQ (200, response.status);
 	ASSERT_EQ ("1", response.json.get<std::string> ("moved"));
 	ASSERT_TRUE (destination->exists (key.pub));
-	ASSERT_TRUE (destination->exists (nano::test_genesis_key.pub));
+	ASSERT_TRUE (destination->exists (nano::dev_genesis_key.pub));
 	auto transaction (node->wallets.tx_begin_read ());
 	ASSERT_EQ (source->store.end (), source->store.begin (transaction));
 }
@@ -1104,11 +1104,11 @@ TEST (rpc, chain)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto genesis (node->latest (nano::test_genesis_key.pub));
+	auto genesis (node->latest (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (genesis.is_zero ());
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -1140,11 +1140,11 @@ TEST (rpc, chain_limit)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto genesis (node->latest (nano::test_genesis_key.pub));
+	auto genesis (node->latest (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (genesis.is_zero ());
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -1175,11 +1175,11 @@ TEST (rpc, chain_offset)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto genesis (node->latest (nano::test_genesis_key.pub));
+	auto genesis (node->latest (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (genesis.is_zero ());
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -1250,7 +1250,7 @@ TEST (rpc, frontier)
 		frontier.decode_hex (i->second.get<std::string> (""));
 		frontiers[account] = frontier;
 	}
-	ASSERT_EQ (1, frontiers.erase (nano::test_genesis_key.pub));
+	ASSERT_EQ (1, frontiers.erase (nano::dev_genesis_key.pub));
 	ASSERT_EQ (source, frontiers);
 }
 
@@ -1334,17 +1334,17 @@ TEST (rpc, history)
 {
 	nano::system system;
 	auto node0 = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto change (system.wallet (0)->change_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub));
 	ASSERT_NE (nullptr, change);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, node0->config.receive_minimum.number ()));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send);
-	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, node0->config.receive_minimum.number ()));
+	auto receive (system.wallet (0)->receive_action (*send, nano::dev_genesis_key.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive);
 	nano::genesis genesis;
-	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (node0->latest (nano::genesis_account)));
-	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (usend.hash ()));
-	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (ureceive.hash ()));
+	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (node0->latest (nano::genesis_account)));
+	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (usend.hash ()));
+	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (ureceive.hash ()));
 	{
 		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
@@ -1375,23 +1375,23 @@ TEST (rpc, history)
 	ASSERT_EQ (5, history_l.size ());
 	ASSERT_EQ ("receive", std::get<0> (history_l[0]));
 	ASSERT_EQ (ureceive.hash ().to_string (), std::get<3> (history_l[0]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[0]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[0]));
 	ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[0]));
 	ASSERT_EQ (5, history_l.size ());
 	ASSERT_EQ ("send", std::get<0> (history_l[1]));
 	ASSERT_EQ (usend.hash ().to_string (), std::get<3> (history_l[1]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
 	ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[1]));
 	ASSERT_EQ ("receive", std::get<0> (history_l[2]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
 	ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[2]));
 	ASSERT_EQ (receive->hash ().to_string (), std::get<3> (history_l[2]));
 	ASSERT_EQ ("send", std::get<0> (history_l[3]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
 	ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[3]));
 	ASSERT_EQ (send->hash ().to_string (), std::get<3> (history_l[3]));
 	ASSERT_EQ ("receive", std::get<0> (history_l[4]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[4]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[4]));
 	ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), std::get<2> (history_l[4]));
 	ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[4]));
 }
@@ -1400,17 +1400,17 @@ TEST (rpc, account_history)
 {
 	nano::system system;
 	auto node0 = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto change (system.wallet (0)->change_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub));
 	ASSERT_NE (nullptr, change);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, node0->config.receive_minimum.number ()));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send);
-	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, node0->config.receive_minimum.number ()));
+	auto receive (system.wallet (0)->receive_action (*send, nano::dev_genesis_key.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive);
 	nano::genesis genesis;
-	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (node0->latest (nano::genesis_account)));
-	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (usend.hash ()));
-	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node0->work_generate_blocking (ureceive.hash ()));
+	nano::state_block usend (nano::genesis_account, node0->latest (nano::genesis_account), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (node0->latest (nano::genesis_account)));
+	nano::state_block ureceive (nano::genesis_account, usend.hash (), nano::genesis_account, nano::genesis_amount, usend.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (usend.hash ()));
+	nano::state_block uchange (nano::genesis_account, ureceive.hash (), nano::keypair ().pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node0->work_generate_blocking (ureceive.hash ()));
 	{
 		auto transaction (node0->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, usend).code);
@@ -1443,26 +1443,26 @@ TEST (rpc, account_history)
 		ASSERT_EQ (5, history_l.size ());
 		ASSERT_EQ ("receive", std::get<0> (history_l[0]));
 		ASSERT_EQ (ureceive.hash ().to_string (), std::get<3> (history_l[0]));
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[0]));
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[0]));
 		ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[0]));
 		ASSERT_EQ ("6", std::get<4> (history_l[0])); // change block (height 7) is skipped by account_history since "raw" is not set
 		ASSERT_EQ ("send", std::get<0> (history_l[1]));
 		ASSERT_EQ (usend.hash ().to_string (), std::get<3> (history_l[1]));
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
 		ASSERT_EQ (nano::Gxrb_ratio.convert_to<std::string> (), std::get<2> (history_l[1]));
 		ASSERT_EQ ("5", std::get<4> (history_l[1]));
 		ASSERT_EQ ("receive", std::get<0> (history_l[2]));
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
 		ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[2]));
 		ASSERT_EQ (receive->hash ().to_string (), std::get<3> (history_l[2]));
 		ASSERT_EQ ("4", std::get<4> (history_l[2]));
 		ASSERT_EQ ("send", std::get<0> (history_l[3]));
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
 		ASSERT_EQ (node0->config.receive_minimum.to_string_dec (), std::get<2> (history_l[3]));
 		ASSERT_EQ (send->hash ().to_string (), std::get<3> (history_l[3]));
 		ASSERT_EQ ("3", std::get<4> (history_l[3]));
 		ASSERT_EQ ("receive", std::get<0> (history_l[4]));
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[4]));
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[4]));
 		ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), std::get<2> (history_l[4]));
 		ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[4]));
 		ASSERT_EQ ("1", std::get<4> (history_l[4])); // change block (height 2) is skipped
@@ -1486,7 +1486,7 @@ TEST (rpc, account_history)
 	// Test filtering
 	scoped_thread_name_io.reset ();
 	auto account2 (system.wallet (0)->deterministic_insert ());
-	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, account2, node0->config.receive_minimum.number ()));
+	auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, account2, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send2);
 	auto receive2 (system.wallet (0)->receive_action (*send2, account2, node0->config.receive_minimum.number ()));
 	scoped_thread_name_io.renew ();
@@ -1495,7 +1495,7 @@ TEST (rpc, account_history)
 	{
 		boost::property_tree::ptree request;
 		request.put ("action", "account_history");
-		request.put ("account", nano::test_genesis_key.pub.to_account ());
+		request.put ("account", nano::dev_genesis_key.pub.to_account ());
 		boost::property_tree::ptree other_account;
 		other_account.put ("", account2.to_account ());
 		boost::property_tree::ptree filtered_accounts;
@@ -1513,7 +1513,7 @@ TEST (rpc, account_history)
 		request.put ("action", "account_history");
 		request.put ("account", account2.to_account ());
 		boost::property_tree::ptree other_account;
-		other_account.put ("", nano::test_genesis_key.pub.to_account ());
+		other_account.put ("", nano::dev_genesis_key.pub.to_account ());
 		boost::property_tree::ptree filtered_accounts;
 		filtered_accounts.push_back (std::make_pair ("", other_account));
 		request.add_child ("account_filter", filtered_accounts);
@@ -1529,12 +1529,12 @@ TEST (rpc, history_count)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto change (system.wallet (0)->change_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub));
 	ASSERT_NE (nullptr, change);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, node->config.receive_minimum.number ()));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send);
-	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, node->config.receive_minimum.number ()));
+	auto receive (system.wallet (0)->receive_action (*send, nano::dev_genesis_key.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -1561,8 +1561,8 @@ TEST (rpc, process_block)
 	auto & node1 = *add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
 	nano::rpc_config rpc_config (nano::get_available_port (), true);
@@ -1579,7 +1579,7 @@ TEST (rpc, process_block)
 		test_response response (request, rpc.config.port, system.io_ctx);
 		ASSERT_TIMELY (5s, response.status != 0);
 		ASSERT_EQ (200, response.status);
-		ASSERT_TIMELY (10s, node1.latest (nano::test_genesis_key.pub) == send.hash ());
+		ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == send.hash ());
 		std::string send_hash (response.json.get<std::string> ("hash"));
 		ASSERT_EQ (send.hash ().to_string (), send_hash);
 	}
@@ -1599,8 +1599,8 @@ TEST (rpc, process_json_block)
 	auto & node1 = *add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
 	nano::rpc_config rpc_config (nano::get_available_port (), true);
@@ -1625,7 +1625,7 @@ TEST (rpc, process_json_block)
 		test_response response (request, rpc.config.port, system.io_ctx);
 		ASSERT_TIMELY (5s, response.status != 0);
 		ASSERT_EQ (200, response.status);
-		ASSERT_TIMELY (10s, node1.latest (nano::test_genesis_key.pub) == send.hash ());
+		ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == send.hash ());
 		std::string send_hash (response.json.get<std::string> ("hash"));
 		ASSERT_EQ (send.hash ().to_string (), send_hash);
 	}
@@ -1640,8 +1640,8 @@ TEST (rpc, process_block_with_work_watcher)
 	node_config.max_work_generate_multiplier = 1e6;
 	auto & node1 = *add_ipc_enabled_node (system, node_config);
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, latest, nano::test_genesis_key.pub, nano::genesis_amount - 100, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest)));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, latest, nano::dev_genesis_key.pub, nano::genesis_amount - 100, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest)));
 	auto difficulty1 (send->difficulty ());
 	auto multiplier1 = nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty1, node1.network_params.network.publish_thresholds.epoch_1), node1.network_params.network.publish_thresholds.epoch_1);
 	nano::node_rpc_config node_rpc_config;
@@ -1660,7 +1660,7 @@ TEST (rpc, process_block_with_work_watcher)
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
-	ASSERT_TIMELY (10s, node1.latest (nano::test_genesis_key.pub) == send->hash ());
+	ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == send->hash ());
 	system.deadline_set (10s);
 	auto updated (false);
 	double updated_multiplier;
@@ -1722,8 +1722,8 @@ TEST (rpc, process_block_no_work)
 	auto & node1 = *add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	send.block_work_set (0);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -1751,8 +1751,8 @@ TEST (rpc, process_republish)
 	auto & node3 = *add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node3.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node3.work_generate_blocking (latest));
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node3, node_rpc_config);
 	nano::rpc_config rpc_config (nano::get_available_port (), true);
@@ -1768,7 +1768,7 @@ TEST (rpc, process_republish)
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
-	ASSERT_TIMELY (10s, node2.latest (nano::test_genesis_key.pub) == send.hash ());
+	ASSERT_TIMELY (10s, node2.latest (nano::dev_genesis_key.pub) == send.hash ());
 }
 
 TEST (rpc, process_subtype_send)
@@ -1778,8 +1778,8 @@ TEST (rpc, process_subtype_send)
 	system.add_node ();
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
 	nano::rpc_config rpc_config (nano::get_available_port (), true);
@@ -1808,7 +1808,7 @@ TEST (rpc, process_subtype_send)
 	ASSERT_TIMELY (10s, response3.status != 0);
 	ASSERT_EQ (200, response3.status);
 	ASSERT_EQ (send.hash ().to_string (), response3.json.get<std::string> ("hash"));
-	ASSERT_TIMELY (10s, system.nodes[1]->latest (nano::test_genesis_key.pub) == send.hash ());
+	ASSERT_TIMELY (10s, system.nodes[1]->latest (nano::dev_genesis_key.pub) == send.hash ());
 }
 
 TEST (rpc, process_subtype_open)
@@ -1817,8 +1817,8 @@ TEST (rpc, process_subtype_open)
 	auto & node1 = *add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	ASSERT_EQ (nano::process_result::progress, node1.process (send).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (send).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -1860,13 +1860,13 @@ TEST (rpc, process_subtype_receive)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	ASSERT_EQ (nano::process_result::progress, node1.process (send).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (send).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	node1.active.insert (std::make_shared<nano::state_block> (send));
-	nano::state_block receive (nano::test_genesis_key.pub, send.hash (), nano::test_genesis_key.pub, nano::genesis_amount, send.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
+	nano::state_block receive (nano::dev_genesis_key.pub, send.hash (), nano::dev_genesis_key.pub, nano::genesis_amount, send.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
 	nano::rpc_config rpc_config (nano::get_available_port (), true);
@@ -1896,7 +1896,7 @@ TEST (rpc, process_subtype_receive)
 	ASSERT_TIMELY (10s, response3.status != 0);
 	ASSERT_EQ (200, response3.status);
 	ASSERT_EQ (receive.hash ().to_string (), response3.json.get<std::string> ("hash"));
-	ASSERT_TIMELY (10s, node2.latest (nano::test_genesis_key.pub) == receive.hash ());
+	ASSERT_TIMELY (10s, node2.latest (nano::dev_genesis_key.pub) == receive.hash ());
 }
 
 TEST (rpc, process_ledger_insufficient_work)
@@ -1904,10 +1904,10 @@ TEST (rpc, process_ledger_insufficient_work)
 	nano::system system;
 	auto & node = *add_ipc_enabled_node (system);
 	ASSERT_LT (node.network_params.network.publish_thresholds.entry, node.network_params.network.publish_thresholds.epoch_1);
-	auto latest (node.latest (nano::test_genesis_key.pub));
+	auto latest (node.latest (nano::dev_genesis_key.pub));
 	auto min_difficulty = node.network_params.network.publish_thresholds.entry;
 	auto max_difficulty = node.network_params.network.publish_thresholds.epoch_1;
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, system.work_generate_limited (latest, min_difficulty, max_difficulty));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, system.work_generate_limited (latest, min_difficulty, max_difficulty));
 	ASSERT_LT (send.difficulty (), max_difficulty);
 	ASSERT_GE (send.difficulty (), min_difficulty);
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -1939,8 +1939,8 @@ TEST (rpc, process_difficulty_update_flood)
 	auto & node_passive = *system.nodes[0];
 	auto & node = *add_ipc_enabled_node (system);
 
-	auto latest (node.latest (nano::test_genesis_key.pub));
-	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node.work_generate_blocking (latest));
+	auto latest (node.latest (nano::dev_genesis_key.pub));
+	nano::state_block send (nano::genesis_account, latest, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node.work_generate_blocking (latest));
 
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -2121,7 +2121,7 @@ TEST (rpc, payment_end_nonempty)
 {
 	nano::system system;
 	auto node1 = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto transaction (node1->wallets.tx_begin_read ());
 	system.wallet (0)->init_free_accounts (transaction);
 	auto wallet_id (node1->wallets.items.begin ()->first);
@@ -2136,7 +2136,7 @@ TEST (rpc, payment_end_nonempty)
 	boost::property_tree::ptree request1;
 	request1.put ("action", "payment_end");
 	request1.put ("wallet", wallet_id.to_string ());
-	request1.put ("account", nano::test_genesis_key.pub.to_account ());
+	request1.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response1.status != 0);
 	ASSERT_EQ (200, response1.status);
@@ -2147,7 +2147,7 @@ TEST (rpc, payment_zero_balance)
 {
 	nano::system system;
 	auto node1 = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto transaction (node1->wallets.tx_begin_read ());
 	system.wallet (0)->init_free_accounts (transaction);
 	auto wallet_id (node1->wallets.items.begin ()->first);
@@ -2168,7 +2168,7 @@ TEST (rpc, payment_zero_balance)
 	auto account_text (response1.json.get<std::string> ("account"));
 	nano::account account;
 	ASSERT_FALSE (account.decode_account (account_text));
-	ASSERT_NE (nano::test_genesis_key.pub, account);
+	ASSERT_NE (nano::dev_genesis_key.pub, account);
 }
 
 TEST (rpc, payment_begin_reuse)
@@ -2250,7 +2250,7 @@ TEST (rpc, payment_wait)
 	nano::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -2271,10 +2271,10 @@ TEST (rpc, payment_wait)
 	ASSERT_EQ ("nothing", response1.json.get<std::string> ("status"));
 	request1.put ("timeout", "100000");
 	scoped_thread_name_io.reset ();
-	system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Mxrb_ratio);
+	system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Mxrb_ratio);
 	system.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (500), [&]() {
 		system.nodes.front ()->worker.push_task ([&]() {
-			system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Mxrb_ratio);
+			system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Mxrb_ratio);
 		});
 	});
 	scoped_thread_name_io.renew ();
@@ -2359,8 +2359,8 @@ TEST (rpc, pending)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto block1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (5s, !node->active.active (*block1));
 	nano::node_rpc_config node_rpc_config;
@@ -2445,7 +2445,7 @@ TEST (rpc, pending)
 			ASSERT_EQ (i->second.get<uint8_t> ("min_version"), 0);
 		}
 		ASSERT_EQ (amounts[block1->hash ()], 100);
-		ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
+		ASSERT_EQ (sources[block1->hash ()], nano::dev_genesis_key.pub);
 	}
 
 	request.put ("account", key1.pub.to_account ());
@@ -2473,8 +2473,8 @@ TEST (rpc, pending_burn)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::account burn (0);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, burn, 100));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto block1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, burn, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (5s, !node->active.active (*block1));
 	nano::node_rpc_config node_rpc_config;
@@ -2503,10 +2503,10 @@ TEST (rpc, search_pending)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto wallet (node->wallets.items.begin ()->first.to_string ());
-	auto latest (node->latest (nano::test_genesis_key.pub));
-	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - node->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (latest));
+	auto latest (node->latest (nano::dev_genesis_key.pub));
+	nano::send_block block (latest, nano::dev_genesis_key.pub, nano::genesis_amount - node->config.receive_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node->work_generate_blocking (latest));
 	{
 		auto transaction (node->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, block).code);
@@ -2525,7 +2525,7 @@ TEST (rpc, search_pending)
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
-	ASSERT_TIMELY (10s, node->balance (nano::test_genesis_key.pub) == nano::genesis_amount);
+	ASSERT_TIMELY (10s, node->balance (nano::dev_genesis_key.pub) == nano::genesis_amount);
 }
 
 TEST (rpc, version)
@@ -2533,7 +2533,7 @@ TEST (rpc, version)
 	nano::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -2559,7 +2559,7 @@ TEST (rpc, version)
 	ASSERT_EQ (node1->store.vendor_get (), response1.json.get<std::string> ("store_vendor"));
 	auto network_label (node1->network_params.network.get_current_network_as_string ());
 	ASSERT_EQ (network_label, response1.json.get<std::string> ("network"));
-	auto genesis_open (node1->latest (nano::test_genesis_key.pub));
+	auto genesis_open (node1->latest (nano::dev_genesis_key.pub));
 	ASSERT_EQ (genesis_open.to_string (), response1.json.get<std::string> ("network_identifier"));
 	ASSERT_EQ (BUILD_INFO, response1.json.get<std::string> ("build_info"));
 	auto headers (response1.resp.base ());
@@ -2582,7 +2582,7 @@ TEST (rpc, work_generate)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -2805,7 +2805,7 @@ TEST (rpc, work_generate_block_high)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	nano::keypair key;
-	nano::state_block block (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, *node->work_generate_blocking (key.pub));
+	nano::state_block block (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, *node->work_generate_blocking (key.pub));
 	nano::block_hash hash (block.root ());
 	auto block_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, block.block_work ()));
 	boost::property_tree::ptree request;
@@ -2837,7 +2837,7 @@ TEST (rpc, work_generate_block_low)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	nano::keypair key;
-	nano::state_block block (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, 0);
+	nano::state_block block (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, 0);
 	auto threshold (node->default_difficulty (block.work_version ()));
 	block.block_work_set (system.work_generate_limited (block.root (), threshold, nano::difficulty::from_multiplier (node->config.max_work_generate_multiplier / 10, threshold)));
 	nano::block_hash hash (block.root ());
@@ -2881,7 +2881,7 @@ TEST (rpc, work_generate_block_root_mismatch)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	nano::keypair key;
-	nano::state_block block (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, *node->work_generate_blocking (key.pub));
+	nano::state_block block (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, *node->work_generate_blocking (key.pub));
 	nano::block_hash hash (1);
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
@@ -2908,8 +2908,8 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 	auto epoch2 = system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2);
 	ASSERT_NE (nullptr, epoch2);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -2919,7 +2919,7 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
-	nano::state_block block (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, 0);
+	nano::state_block block (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, 0);
 	auto threshold (nano::work_threshold (block.work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	block.block_work_set (system.work_generate_limited (block.root (), 1, threshold - 1));
 	nano::block_hash hash (block.root ());
@@ -2957,7 +2957,7 @@ TEST (rpc, work_cancel)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -2992,7 +2992,7 @@ TEST (rpc, work_peer_bad)
 	auto & node1 = *add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -3018,7 +3018,7 @@ TEST (rpc, work_peer_one)
 	auto & node1 = *add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -3230,16 +3230,16 @@ TEST (rpc, available_supply)
 	ASSERT_EQ (200, response1.status);
 	ASSERT_EQ ("0", response1.json.get<std::string> ("available"));
 	scoped_thread_name_io.reset ();
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	scoped_thread_name_io.renew ();
 	test_response response2 (request1, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response2.status != 0);
 	ASSERT_EQ (200, response2.status);
 	ASSERT_EQ ("1", response2.json.get<std::string> ("available"));
 	scoped_thread_name_io.reset ();
-	auto block2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, 0, 100)); // Sending to burning 0 account
+	auto block2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, 0, 100)); // Sending to burning 0 account
 	scoped_thread_name_io.renew ();
 	test_response response3 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
@@ -3400,7 +3400,7 @@ TEST (rpc, account_representative_set)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -3433,7 +3433,7 @@ TEST (rpc, account_representative_set_work_disabled)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto & node = *add_ipc_enabled_node (system, node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node, node_rpc_config);
@@ -3465,7 +3465,7 @@ TEST (rpc, account_representative_set_epoch_2)
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_2));
 
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv, false);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv, false);
 
 	auto target_difficulty = nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, false, false));
 	ASSERT_LT (node.network_params.network.publish_thresholds.entry, target_difficulty);
@@ -3484,7 +3484,7 @@ TEST (rpc, account_representative_set_epoch_2)
 	node.wallets.items.begin ()->first.encode_hex (wallet);
 	request.put ("wallet", wallet);
 	request.put ("action", "account_representative_set");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	request.put ("representative", nano::keypair ().pub.to_account ());
 
 	// Test that the correct error is given if there is insufficient work
@@ -3505,8 +3505,8 @@ TEST (rpc, bootstrap)
 	nano::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	nano::system system1 (1);
-	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system1.nodes[0]->work_generate_blocking (latest));
+	auto latest (system1.nodes[0]->latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, nano::genesis_account, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system1.nodes[0]->work_generate_blocking (latest));
 	{
 		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
@@ -3676,7 +3676,7 @@ TEST (rpc, wallet_frontiers)
 {
 	nano::system system0;
 	auto node = add_ipc_enabled_node (system0);
-	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system0.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -3709,7 +3709,7 @@ TEST (rpc, work_validate)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -3846,11 +3846,11 @@ TEST (rpc, successors)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
-	auto genesis (node->latest (nano::test_genesis_key.pub));
+	auto genesis (node->latest (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (genesis.is_zero ());
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	ASSERT_NE (nullptr, block);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -3890,8 +3890,8 @@ TEST (rpc, bootstrap_any)
 	nano::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	nano::system system1 (1);
-	auto latest (system1.nodes[0]->latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, nano::genesis_account, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system1.nodes[0]->work_generate_blocking (latest));
+	auto latest (system1.nodes[0]->latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, nano::genesis_account, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system1.nodes[0]->work_generate_blocking (latest));
 	{
 		auto transaction (system1.nodes[0]->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, send).code);
@@ -3922,8 +3922,8 @@ TEST (rpc, republish)
 	nano::genesis genesis;
 	auto & node1 = *add_ipc_enabled_node (system);
 	system.add_node ();
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
 	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
@@ -3941,7 +3941,7 @@ TEST (rpc, republish)
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
-	ASSERT_TIMELY (10s, system.nodes[1]->balance (nano::test_genesis_key.pub) != nano::genesis_amount);
+	ASSERT_TIMELY (10s, system.nodes[1]->balance (nano::dev_genesis_key.pub) != nano::genesis_amount);
 	auto & blocks_node (response.json.get_child ("blocks"));
 	std::vector<nano::block_hash> blocks;
 	for (auto i (blocks_node.begin ()), n (blocks_node.end ()); i != n; ++i)
@@ -4043,7 +4043,7 @@ TEST (rpc, accounts_balances)
 	request.put ("action", "accounts_balances");
 	boost::property_tree::ptree entry;
 	boost::property_tree::ptree peers_l;
-	entry.put ("", nano::test_genesis_key.pub.to_account ());
+	entry.put ("", nano::dev_genesis_key.pub.to_account ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
 	test_response response (request, rpc.config.port, system.io_ctx);
@@ -4052,7 +4052,7 @@ TEST (rpc, accounts_balances)
 	for (auto & balances : response.json.get_child ("balances"))
 	{
 		std::string account_text (balances.first);
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 		std::string balance_text (balances.second.get<std::string> ("balance"));
 		ASSERT_EQ ("340282366920938463463374607431768211455", balance_text);
 		std::string pending_text (balances.second.get<std::string> ("pending"));
@@ -4064,7 +4064,7 @@ TEST (rpc, accounts_frontiers)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -4077,7 +4077,7 @@ TEST (rpc, accounts_frontiers)
 	request.put ("action", "accounts_frontiers");
 	boost::property_tree::ptree entry;
 	boost::property_tree::ptree peers_l;
-	entry.put ("", nano::test_genesis_key.pub.to_account ());
+	entry.put ("", nano::dev_genesis_key.pub.to_account ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
 	test_response response (request, rpc.config.port, system.io_ctx);
@@ -4086,7 +4086,7 @@ TEST (rpc, accounts_frontiers)
 	for (auto & frontiers : response.json.get_child ("frontiers"))
 	{
 		std::string account_text (frontiers.first);
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 		std::string frontier_text (frontiers.second.get<std::string> (""));
 		ASSERT_EQ (node->latest (nano::genesis_account), frontier_text);
 	}
@@ -4097,8 +4097,8 @@ TEST (rpc, accounts_pending)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto block1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (10s, !node->active.active (*block1));
 	nano::node_rpc_config node_rpc_config;
@@ -4186,7 +4186,7 @@ TEST (rpc, accounts_pending)
 			}
 		}
 		ASSERT_EQ (amounts[block1->hash ()], 100);
-		ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
+		ASSERT_EQ (sources[block1->hash ()], nano::dev_genesis_key.pub);
 	}
 
 	request.put ("include_only_confirmed", "true");
@@ -4232,10 +4232,10 @@ TEST (rpc, wallet_info)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	nano::account account (system.wallet (0)->deterministic_insert ());
 	{
 		auto transaction (node->wallets.tx_begin_write ());
@@ -4274,7 +4274,7 @@ TEST (rpc, wallet_balances)
 {
 	nano::system system0;
 	auto node = add_ipc_enabled_node (system0);
-	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system0.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -4295,7 +4295,7 @@ TEST (rpc, wallet_balances)
 	for (auto & balances : response.json.get_child ("balances"))
 	{
 		std::string account_text (balances.first);
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 		std::string balance_text (balances.second.get<std::string> ("balance"));
 		ASSERT_EQ ("340282366920938463463374607431768211455", balance_text);
 		std::string pending_text (balances.second.get<std::string> ("pending"));
@@ -4304,7 +4304,7 @@ TEST (rpc, wallet_balances)
 	nano::keypair key;
 	scoped_thread_name_io.reset ();
 	system0.wallet (0)->insert_adhoc (key.prv);
-	auto send (system0.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, 1));
+	auto send (system0.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
 	scoped_thread_name_io.renew ();
 	request.put ("threshold", "2");
 	test_response response1 (request, rpc.config.port, system0.io_ctx);
@@ -4316,7 +4316,7 @@ TEST (rpc, wallet_balances)
 	for (auto & balances : response1.json.get_child ("balances"))
 	{
 		std::string account_text (balances.first);
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 		std::string balance_text (balances.second.get<std::string> ("balance"));
 		ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
 		std::string pending_text (balances.second.get<std::string> ("pending"));
@@ -4329,9 +4329,9 @@ TEST (rpc, pending_exists)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto hash0 (node->latest (nano::genesis_account));
-	auto block1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	auto block1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 100));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (5s, !node->active.active (*block1));
 	nano::node_rpc_config node_rpc_config;
@@ -4371,9 +4371,9 @@ TEST (rpc, wallet_pending)
 	nano::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	nano::keypair key1;
-	system0.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system0.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system0.wallet (0)->insert_adhoc (key1.prv);
-	auto block1 (system0.wallet (0)->send_action (nano::test_genesis_key.pub, key1.pub, 100));
+	auto block1 (system0.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 100));
 	auto iterations (0);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	while (system0.nodes[0]->active.active (*block1))
@@ -4469,7 +4469,7 @@ TEST (rpc, wallet_pending)
 		}
 	}
 	ASSERT_EQ (amounts[block1->hash ()], 100);
-	ASSERT_EQ (sources[block1->hash ()], nano::test_genesis_key.pub);
+	ASSERT_EQ (sources[block1->hash ()], nano::dev_genesis_key.pub);
 
 	request.put ("include_only_confirmed", "true");
 	check_block_response_count (system0, rpc, request, 1);
@@ -4537,8 +4537,8 @@ TEST (rpc, work_get)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	system.wallet (0)->work_cache_blocking (nano::test_genesis_key.pub, node->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	system.wallet (0)->work_cache_blocking (nano::dev_genesis_key.pub, node->latest (nano::dev_genesis_key.pub));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -4550,7 +4550,7 @@ TEST (rpc, work_get)
 	boost::property_tree::ptree request;
 	request.put ("action", "work_get");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -4565,8 +4565,8 @@ TEST (rpc, wallet_work_get)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	system.wallet (0)->work_cache_blocking (nano::test_genesis_key.pub, node->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	system.wallet (0)->work_cache_blocking (nano::dev_genesis_key.pub, node->latest (nano::dev_genesis_key.pub));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -4585,7 +4585,7 @@ TEST (rpc, wallet_work_get)
 	for (auto & works : response.json.get_child ("works"))
 	{
 		std::string account_text (works.first);
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 		std::string work_text (works.second.get<std::string> (""));
 		uint64_t work (1);
 		node->wallets.items.begin ()->second->store.work_get (transaction, nano::genesis_account, work);
@@ -4597,7 +4597,7 @@ TEST (rpc, work_set)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	uint64_t work0 (100);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -4610,7 +4610,7 @@ TEST (rpc, work_set)
 	boost::property_tree::ptree request;
 	request.put ("action", "work_set");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	request.put ("work", nano::to_string_hex (work0));
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
@@ -4627,9 +4627,9 @@ TEST (rpc, search_pending_all)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto latest (node->latest (nano::test_genesis_key.pub));
-	nano::send_block block (latest, nano::test_genesis_key.pub, nano::genesis_amount - node->config.receive_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (latest));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto latest (node->latest (nano::dev_genesis_key.pub));
+	nano::send_block block (latest, nano::dev_genesis_key.pub, nano::genesis_amount - node->config.receive_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node->work_generate_blocking (latest));
 	{
 		auto transaction (node->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, block).code);
@@ -4647,7 +4647,7 @@ TEST (rpc, search_pending_all)
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
-	ASSERT_TIMELY (10s, node->balance (nano::test_genesis_key.pub) == nano::genesis_amount);
+	ASSERT_TIMELY (10s, node->balance (nano::dev_genesis_key.pub) == nano::genesis_amount);
 }
 
 TEST (rpc, wallet_republish)
@@ -4656,16 +4656,16 @@ TEST (rpc, wallet_republish)
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::genesis genesis;
 	nano::keypair key;
-	while (key.pub < nano::test_genesis_key.pub)
+	while (key.pub < nano::dev_genesis_key.pub)
 	{
 		nano::keypair key1;
 		key.pub = key1.pub;
 		key.prv.data = key1.prv.data;
 	}
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
 	nano::open_block open (send.hash (), key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
@@ -4700,12 +4700,12 @@ TEST (rpc, delegators)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -4717,7 +4717,7 @@ TEST (rpc, delegators)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "delegators");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -4728,7 +4728,7 @@ TEST (rpc, delegators)
 		delegators.put ((i->first), (i->second.get<std::string> ("")));
 	}
 	ASSERT_EQ (2, delegators.size ());
-	ASSERT_EQ ("100", delegators.get<std::string> (nano::test_genesis_key.pub.to_account ()));
+	ASSERT_EQ ("100", delegators.get<std::string> (nano::dev_genesis_key.pub.to_account ()));
 	ASSERT_EQ ("340282366920938463463374607431768211355", delegators.get<std::string> (key.pub.to_account ()));
 }
 
@@ -4737,12 +4737,12 @@ TEST (rpc, delegators_count)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -4754,7 +4754,7 @@ TEST (rpc, delegators_count)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "delegators_count");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -4793,19 +4793,19 @@ TEST (rpc, account_info)
 	}
 
 	scoped_thread_name_io.reset ();
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
 	auto time (nano::seconds_since_epoch ());
 	{
 		auto transaction = node1.store.tx_begin_write ();
-		node1.store.confirmation_height_put (transaction, nano::test_genesis_key.pub, { 1, genesis.hash () });
+		node1.store.confirmation_height_put (transaction, nano::dev_genesis_key.pub, { 1, genesis.hash () });
 	}
 	scoped_thread_name_io.renew ();
 
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
 		ASSERT_TIMELY (5s, response.status != 0);
@@ -4848,7 +4848,7 @@ TEST (rpc, account_info)
 		std::string pending2 (response.json.get<std::string> ("pending"));
 		ASSERT_EQ ("0", pending2);
 		std::string representative2 (response.json.get<std::string> ("representative"));
-		ASSERT_EQ (nano::test_genesis_key.pub.to_account (), representative2);
+		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), representative2);
 	}
 }
 
@@ -4859,7 +4859,7 @@ TEST (rpc, json_block_input)
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
-	nano::state_block send (nano::genesis_account, node1.latest (nano::test_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block send (nano::genesis_account, node1.latest (nano::dev_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -4897,10 +4897,10 @@ TEST (rpc, json_block_output)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -4942,7 +4942,7 @@ TEST (rpc, blocks_info)
 			std::string hash_text (blocks.first);
 			ASSERT_EQ (node->latest (nano::genesis_account).to_string (), hash_text);
 			std::string account_text (blocks.second.get<std::string> ("block_account"));
-			ASSERT_EQ (nano::test_genesis_key.pub.to_account (), account_text);
+			ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 			std::string amount_text (blocks.second.get<std::string> ("amount"));
 			ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), amount_text);
 			std::string blocks_text (blocks.second.get<std::string> ("contents"));
@@ -5011,13 +5011,13 @@ TEST (rpc, blocks_info_subtype)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, nano::Gxrb_ratio));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send);
 	auto receive (system.wallet (0)->receive_action (*send, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, receive);
-	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, key.pub));
+	auto change (system.wallet (0)->change_action (nano::dev_genesis_key.pub, key.pub));
 	ASSERT_NE (nullptr, change);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -5054,7 +5054,7 @@ TEST (rpc, work_peers_all)
 {
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -5106,16 +5106,16 @@ TEST (rpc, ledger)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto & node1 (*system.nodes[0]);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
 	auto genesis_balance (nano::genesis_amount);
 	auto send_amount (genesis_balance - 100);
 	genesis_balance -= send_amount;
-	nano::send_block send (latest, key.pub, genesis_balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	nano::send_block send (latest, key.pub, genesis_balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	auto time (nano::seconds_since_epoch ());
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -5174,7 +5174,7 @@ TEST (rpc, ledger)
 			ASSERT_EQ ("0", pending.get ());
 			boost::optional<std::string> representative (account.second.get_optional<std::string> ("representative"));
 			ASSERT_TRUE (representative.is_initialized ());
-			ASSERT_EQ (nano::test_genesis_key.pub.to_account (), representative.get ());
+			ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), representative.get ());
 		}
 	}
 	// Test threshold
@@ -5192,7 +5192,7 @@ TEST (rpc, ledger)
 	}
 	auto send2_amount (50);
 	genesis_balance -= send2_amount;
-	nano::send_block send2 (send.hash (), key.pub, genesis_balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
+	nano::send_block send2 (send.hash (), key.pub, genesis_balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
 	scoped_thread_name_io.reset ();
 	node1.process (send2);
 	scoped_thread_name_io.renew ();
@@ -5250,13 +5250,13 @@ TEST (rpc, block_create)
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
 	auto send_work = *node1.work_generate_blocking (latest);
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, send_work);
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, send_work);
 	auto open_work = *node1.work_generate_blocking (key.pub);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, open_work);
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, open_work);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -5269,7 +5269,7 @@ TEST (rpc, block_create)
 	request.put ("action", "block_create");
 	request.put ("type", "send");
 	request.put ("wallet", node1.wallets.items.begin ()->first.to_string ());
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	request.put ("previous", latest.to_string ());
 	request.put ("amount", "340282366920938463463374607431768211355");
 	request.put ("destination", key.pub.to_account ());
@@ -5296,7 +5296,7 @@ TEST (rpc, block_create)
 	std::string key_text;
 	key.prv.data.encode_hex (key_text);
 	request1.put ("key", key_text);
-	request1.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request1.put ("representative", nano::dev_genesis_key.pub.to_account ());
 	request1.put ("source", send.hash ().to_string ());
 	request1.put ("work", nano::to_string_hex (open_work));
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
@@ -5334,7 +5334,7 @@ TEST (rpc, block_create)
 	ASSERT_EQ (change.hash (), change_block->hash ());
 	scoped_thread_name_io.reset ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (change).code);
-	nano::send_block send2 (send.hash (), key.pub, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
+	nano::send_block send2 (send.hash (), key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (send.hash ()));
 	ASSERT_EQ (nano::process_result::progress, node1.process (send2).code);
 	scoped_thread_name_io.renew ();
 	boost::property_tree::ptree request2;
@@ -5365,14 +5365,14 @@ TEST (rpc, block_create_state)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
 	request.put ("type", "state");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	request.put ("previous", genesis.hash ().to_string ());
-	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("representative", nano::dev_genesis_key.pub.to_account ());
 	request.put ("balance", (nano::genesis_amount - nano::Gxrb_ratio).convert_to<std::string> ());
 	request.put ("link", key.pub.to_account ());
 	request.put ("work", nano::to_string_hex (*node->work_generate_blocking (genesis.hash ())));
@@ -5407,8 +5407,8 @@ TEST (rpc, block_create_state_open)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto send_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
@@ -5416,7 +5416,7 @@ TEST (rpc, block_create_state_open)
 	request.put ("key", key.prv.data.to_string ());
 	request.put ("account", key.pub.to_account ());
 	request.put ("previous", 0);
-	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("representative", nano::dev_genesis_key.pub.to_account ());
 	request.put ("balance", nano::Gxrb_ratio.convert_to<std::string> ());
 	request.put ("link", send_block->hash ().to_string ());
 	request.put ("work", nano::to_string_hex (*node->work_generate_blocking (key.pub)));
@@ -5465,14 +5465,14 @@ TEST (rpc, block_create_state_request_work)
 		auto node = add_ipc_enabled_node (system);
 		nano::keypair key;
 		nano::genesis genesis;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		scoped_io_thread_name_change scoped_thread_name_io;
 		boost::property_tree::ptree request;
 		request.put ("action", "block_create");
 		request.put ("type", "state");
 		request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
-		request.put ("account", nano::test_genesis_key.pub.to_account ());
-		request.put ("representative", nano::test_genesis_key.pub.to_account ());
+		request.put ("account", nano::dev_genesis_key.pub.to_account ());
+		request.put ("representative", nano::dev_genesis_key.pub.to_account ());
 		request.put ("balance", (nano::genesis_amount - nano::Gxrb_ratio).convert_to<std::string> ());
 		request.put ("link", key.pub.to_account ());
 		request.put ("previous", previous);
@@ -5501,10 +5501,10 @@ TEST (rpc, block_create_open_epoch_v2)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
-	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
@@ -5512,7 +5512,7 @@ TEST (rpc, block_create_open_epoch_v2)
 	request.put ("key", key.prv.data.to_string ());
 	request.put ("account", key.pub.to_account ());
 	request.put ("previous", 0);
-	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("representative", nano::dev_genesis_key.pub.to_account ());
 	request.put ("balance", nano::Gxrb_ratio.convert_to<std::string> ());
 	request.put ("link", send_block->hash ().to_string ());
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -5552,21 +5552,21 @@ TEST (rpc, block_create_receive_epoch_v2)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1));
-	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
-	nano::state_block open (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, *node->work_generate_blocking (key.pub));
+	nano::state_block open (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, *node->work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node->process (open).code);
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
-	auto send_block_2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send_block_2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
 	request.put ("type", "state");
 	request.put ("key", key.prv.data.to_string ());
 	request.put ("account", key.pub.to_account ());
 	request.put ("previous", open.hash ().to_string ());
-	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("representative", nano::dev_genesis_key.pub.to_account ());
 	request.put ("balance", (2 * nano::Gxrb_ratio).convert_to<std::string> ());
 	request.put ("link", send_block_2->hash ().to_string ());
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -5605,12 +5605,12 @@ TEST (rpc, block_create_send_epoch_v2)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::genesis genesis;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
-	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
-	nano::state_block open (key.pub, 0, nano::test_genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, *node->work_generate_blocking (key.pub));
+	nano::state_block open (key.pub, 0, nano::dev_genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, *node->work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node->process (open).code);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
@@ -5618,9 +5618,9 @@ TEST (rpc, block_create_send_epoch_v2)
 	request.put ("key", key.prv.data.to_string ());
 	request.put ("account", key.pub.to_account ());
 	request.put ("previous", open.hash ().to_string ());
-	request.put ("representative", nano::test_genesis_key.pub.to_account ());
+	request.put ("representative", nano::dev_genesis_key.pub.to_account ());
 	request.put ("balance", 0);
-	request.put ("link", nano::test_genesis_key.pub.to_string ());
+	request.put ("link", nano::dev_genesis_key.pub.to_string ());
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -5656,8 +5656,8 @@ TEST (rpc, block_hash)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -5763,10 +5763,10 @@ TEST (rpc, wallet_ledger)
 	nano::keypair key;
 	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest (node1.latest (nano::test_genesis_key.pub));
-	nano::send_block send (latest, key.pub, 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node1.work_generate_blocking (latest));
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
 	node1.process (send);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *node1.work_generate_blocking (key.pub));
 	ASSERT_EQ (nano::process_result::progress, node1.process (open).code);
 	auto time (nano::seconds_since_epoch ());
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -5845,7 +5845,7 @@ TEST (rpc, wallet_add_watch)
 	request.put ("action", "wallet_add_watch");
 	boost::property_tree::ptree entry;
 	boost::property_tree::ptree peers_l;
-	entry.put ("", nano::test_genesis_key.pub.to_account ());
+	entry.put ("", nano::dev_genesis_key.pub.to_account ());
 	peers_l.push_back (std::make_pair ("", entry));
 	request.add_child ("accounts", peers_l);
 	test_response response (request, rpc.config.port, system.io_ctx);
@@ -5853,7 +5853,7 @@ TEST (rpc, wallet_add_watch)
 	ASSERT_EQ (200, response.status);
 	std::string success (response.json.get<std::string> ("success"));
 	ASSERT_TRUE (success.empty ());
-	ASSERT_TRUE (system.wallet (0)->exists (nano::test_genesis_key.pub));
+	ASSERT_TRUE (system.wallet (0)->exists (nano::dev_genesis_key.pub));
 
 	// Make sure using special wallet key as pubkey fails
 	nano::public_key bad_key (1);
@@ -5875,9 +5875,9 @@ TEST (rpc, online_reps)
 	auto node1 (system.nodes[0]);
 	auto node2 = add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_TRUE (node2->online_reps.online_stake () == node2->config.online_weight_minimum.number ());
-	auto send_block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send_block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (10s, !node2->online_reps.list ().empty ());
@@ -5896,7 +5896,7 @@ TEST (rpc, online_reps)
 	auto representatives (response.json.get_child ("representatives"));
 	auto item (representatives.begin ());
 	ASSERT_NE (representatives.end (), item);
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), item->second.get<std::string> (""));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), item->second.get<std::string> (""));
 	boost::optional<std::string> weight (item->second.get_optional<std::string> ("weight"));
 	ASSERT_FALSE (weight.is_initialized ());
 	ASSERT_TIMELY (5s, node2->block (send_block->hash ()));
@@ -5907,13 +5907,13 @@ TEST (rpc, online_reps)
 	auto representatives2 (response2.json.get_child ("representatives"));
 	auto item2 (representatives2.begin ());
 	ASSERT_NE (representatives2.end (), item2);
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), item2->first);
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), item2->first);
 	auto weight2 (item2->second.get<std::string> ("weight"));
-	ASSERT_EQ (node2->weight (nano::test_genesis_key.pub).convert_to<std::string> (), weight2);
+	ASSERT_EQ (node2->weight (nano::dev_genesis_key.pub).convert_to<std::string> (), weight2);
 	//Test accounts filter
 	scoped_thread_name_io.reset ();
 	auto new_rep (system.wallet (1)->deterministic_insert ());
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, new_rep, node1->config.receive_minimum.number ()));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, new_rep, node1->config.receive_minimum.number ()));
 	scoped_thread_name_io.renew ();
 	ASSERT_NE (nullptr, send);
 	ASSERT_TIMELY (10s, node2->block (send->hash ()));
@@ -5923,7 +5923,7 @@ TEST (rpc, online_reps)
 	ASSERT_NE (nullptr, receive);
 	ASSERT_TIMELY (5s, node2->block (receive->hash ()));
 	scoped_thread_name_io.reset ();
-	auto change (system.wallet (0)->change_action (nano::test_genesis_key.pub, new_rep));
+	auto change (system.wallet (0)->change_action (nano::dev_genesis_key.pub, new_rep));
 	scoped_thread_name_io.renew ();
 	ASSERT_NE (nullptr, change);
 	ASSERT_TIMELY (5s, node2->block (change->hash ()));
@@ -5949,13 +5949,13 @@ TEST (rpc, confirmation_height_currently_processing)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = add_ipc_enabled_node (system, node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
-	auto previous_genesis_chain_hash = node->latest (nano::test_genesis_key.pub);
+	auto previous_genesis_chain_hash = node->latest (nano::dev_genesis_key.pub);
 	{
 		auto transaction = node->store.tx_begin_write ();
 		nano::keypair key1;
-		nano::send_block send (previous_genesis_chain_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio - 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous_genesis_chain_hash));
+		nano::send_block send (previous_genesis_chain_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio - 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous_genesis_chain_hash));
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
 		previous_genesis_chain_hash = send.hash ();
 	}
@@ -6015,9 +6015,9 @@ TEST (rpc, confirmation_history)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_TRUE (node->active.list_recently_cemented ().empty ());
-	auto block (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto block (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (10s, !node->active.list_recently_cemented ().empty ());
 	nano::node_rpc_config node_rpc_config;
@@ -6054,11 +6054,11 @@ TEST (rpc, confirmation_history_hash)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_TRUE (node->active.list_recently_cemented ().empty ());
-	auto send1 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
-	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
-	auto send3 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send1 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	auto send3 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	ASSERT_TIMELY (10s, node->active.list_recently_cemented ().size () == 3);
 	nano::node_rpc_config node_rpc_config;
@@ -6093,9 +6093,9 @@ TEST (rpc, block_confirm)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::test_genesis_key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *node->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node->work_generate_blocking (genesis.hash ())));
 	{
 		auto transaction (node->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
@@ -6121,7 +6121,7 @@ TEST (rpc, block_confirm_absent)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -6342,13 +6342,13 @@ TEST (rpc, unopened)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::account account1 (1), account2 (account1.number () + 1);
-	auto genesis (node->latest (nano::test_genesis_key.pub));
+	auto genesis (node->latest (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (genesis.is_zero ());
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, account1, 1));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, account1, 1));
 	ASSERT_NE (nullptr, send);
-	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, account2, 10));
+	auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, account2, 10));
 	ASSERT_NE (nullptr, send2);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -6422,10 +6422,10 @@ TEST (rpc, unopened_burn)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto genesis (node->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto genesis (node->latest (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (genesis.is_zero ());
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::burn_account, 1));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::burn_account, 1));
 	ASSERT_NE (nullptr, send);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
@@ -6492,16 +6492,16 @@ TEST (rpc, wallet_history)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	auto node = add_ipc_enabled_node (system, node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto timestamp1 (nano::seconds_since_epoch ());
-	auto send (system.wallet (0)->send_action (nano::test_genesis_key.pub, nano::test_genesis_key.pub, node->config.receive_minimum.number ()));
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, nano::dev_genesis_key.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send);
 	auto timestamp2 (nano::seconds_since_epoch ());
-	auto receive (system.wallet (0)->receive_action (*send, nano::test_genesis_key.pub, node->config.receive_minimum.number ()));
+	auto receive (system.wallet (0)->receive_action (*send, nano::dev_genesis_key.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, receive);
 	nano::keypair key;
 	auto timestamp3 (nano::seconds_since_epoch ());
-	auto send2 (system.wallet (0)->send_action (nano::test_genesis_key.pub, key.pub, node->config.receive_minimum.number ()));
+	auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send2);
 	system.deadline_set (10s);
 	scoped_io_thread_name_change scoped_thread_name_io;
@@ -6529,26 +6529,26 @@ TEST (rpc, wallet_history)
 	ASSERT_EQ (key.pub.to_account (), std::get<1> (history_l[0]));
 	ASSERT_EQ (node->config.receive_minimum.to_string_dec (), std::get<2> (history_l[0]));
 	ASSERT_EQ (send2->hash ().to_string (), std::get<3> (history_l[0]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[0]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<4> (history_l[0]));
 	ASSERT_EQ (std::to_string (timestamp3), std::get<5> (history_l[0]));
 	ASSERT_EQ ("receive", std::get<0> (history_l[1]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[1]));
 	ASSERT_EQ (node->config.receive_minimum.to_string_dec (), std::get<2> (history_l[1]));
 	ASSERT_EQ (receive->hash ().to_string (), std::get<3> (history_l[1]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[1]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<4> (history_l[1]));
 	ASSERT_EQ (std::to_string (timestamp2), std::get<5> (history_l[1]));
 	ASSERT_EQ ("send", std::get<0> (history_l[2]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[2]));
 	ASSERT_EQ (node->config.receive_minimum.to_string_dec (), std::get<2> (history_l[2]));
 	ASSERT_EQ (send->hash ().to_string (), std::get<3> (history_l[2]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[2]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<4> (history_l[2]));
 	ASSERT_EQ (std::to_string (timestamp1), std::get<5> (history_l[2]));
 	// Genesis block
 	ASSERT_EQ ("receive", std::get<0> (history_l[3]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<1> (history_l[3]));
 	ASSERT_EQ (nano::genesis_amount.convert_to<std::string> (), std::get<2> (history_l[3]));
 	ASSERT_EQ (nano::genesis_hash.to_string (), std::get<3> (history_l[3]));
-	ASSERT_EQ (nano::test_genesis_key.pub.to_account (), std::get<4> (history_l[3]));
+	ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), std::get<4> (history_l[3]));
 }
 
 TEST (rpc, sign_hash)
@@ -6556,7 +6556,7 @@ TEST (rpc, sign_hash)
 	nano::system system;
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
-	nano::state_block send (nano::genesis_account, node1.latest (nano::test_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block send (nano::genesis_account, node1.latest (nano::dev_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -6591,7 +6591,7 @@ TEST (rpc, sign_block)
 	auto & node1 = *add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
-	nano::state_block send (nano::genesis_account, node1.latest (nano::test_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+	nano::state_block send (nano::genesis_account, node1.latest (nano::dev_genesis_key.pub), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
@@ -6684,8 +6684,8 @@ TEST (rpc, block_confirmed)
 	// Open an account directly in the ledger
 	{
 		auto transaction = node->store.tx_begin_write ();
-		nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
-		nano::send_block send1 (latest, key.pub, 300, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+		nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
+		nano::send_block send1 (latest, key.pub, 300, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
 
 		nano::open_block open1 (send1.hash (), nano::genesis_account, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
@@ -6694,7 +6694,7 @@ TEST (rpc, block_confirmed)
 	scoped_thread_name_io.renew ();
 
 	// This should not be confirmed
-	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+	nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 	request.put ("hash", latest.to_string ());
 	test_response response2 (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response2.status != 0);
@@ -6703,7 +6703,7 @@ TEST (rpc, block_confirmed)
 	ASSERT_FALSE (response2.json.get<bool> ("confirmed"));
 
 	// Create and process a new send block
-	auto send = std::make_shared<nano::send_block> (latest, key.pub, 10, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+	auto send = std::make_shared<nano::send_block> (latest, key.pub, 10, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 	node->process_active (send);
 	node->block_processor.flush ();
 	node->block_confirm (send);
@@ -6929,7 +6929,7 @@ TEST (rpc, simultaneous_calls)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_block_count");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 
 	constexpr auto num = 100;
 	std::array<std::unique_ptr<test_response>, num> test_responses;
@@ -6984,7 +6984,7 @@ TEST (rpc, in_process)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_balance");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
@@ -7041,13 +7041,13 @@ TEST (rpc, deprecated_account_format)
 	rpc.start ();
 	boost::property_tree::ptree request;
 	request.put ("action", "account_info");
-	request.put ("account", nano::test_genesis_key.pub.to_account ());
+	request.put ("account", nano::dev_genesis_key.pub.to_account ());
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
 	boost::optional<std::string> deprecated_account_format (response.json.get_optional<std::string> ("deprecated_account_format"));
 	ASSERT_FALSE (deprecated_account_format.is_initialized ());
-	std::string account_text (nano::test_genesis_key.pub.to_account ());
+	std::string account_text (nano::dev_genesis_key.pub.to_account ());
 	account_text[4] = '-';
 	request.put ("account", account_text);
 	test_response response2 (request, rpc.config.port, system.io_ctx);
@@ -7064,15 +7064,15 @@ TEST (rpc, epoch_upgrade)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1, key2, key3;
-	nano::keypair epoch_signer (nano::test_genesis_key);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - 1, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash))); // to opened account
+	nano::keypair epoch_signer (nano::dev_genesis_key);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, nano::genesis_hash, nano::dev_genesis_key.pub, nano::genesis_amount - 1, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash))); // to opened account
 	ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ()))); // to unopened account (pending)
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ()))); // to unopened account (pending)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send2).code);
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2->hash ()))); // to burn (0)
+	auto send3 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send2->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 3, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send2->hash ()))); // to burn (0)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send3).code);
 	nano::account max_account (std::numeric_limits<nano::uint256_t>::max ());
-	auto send4 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 4, max_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3->hash ()))); // to max account
+	auto send4 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send3->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 4, max_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send3->hash ()))); // to max account
 	ASSERT_EQ (nano::process_result::progress, node->process (*send4).code);
 	auto open (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 1, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
@@ -7122,10 +7122,10 @@ TEST (rpc, epoch_upgrade)
 	}
 
 	// Epoch 2 upgrade
-	auto genesis_latest (node->latest (nano::test_genesis_key.pub));
-	auto send5 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis_latest, nano::test_genesis_key.pub, nano::genesis_amount - 5, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis_latest))); // to burn (0)
+	auto genesis_latest (node->latest (nano::dev_genesis_key.pub));
+	auto send5 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis_latest, nano::dev_genesis_key.pub, nano::genesis_amount - 5, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis_latest))); // to burn (0)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send5).code);
-	auto send6 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send5->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 6, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send5->hash ()))); // to key1 (again)
+	auto send6 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send5->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 6, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send5->hash ()))); // to key1 (again)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send6).code);
 	auto key1_latest (node->latest (key1.pub));
 	auto send7 (std::make_shared<nano::state_block> (key1.pub, key1_latest, key1.pub, 0, key3.pub, key1.prv, key1.pub, *system.work.generate (key1_latest))); // to key3
@@ -7168,15 +7168,15 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	node_config.work_threads = 4;
 	auto node = add_ipc_enabled_node (system, node_config);
 	nano::keypair key1, key2, key3;
-	nano::keypair epoch_signer (nano::test_genesis_key);
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - 1, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash))); // to opened account
+	nano::keypair epoch_signer (nano::dev_genesis_key);
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, nano::genesis_hash, nano::dev_genesis_key.pub, nano::genesis_amount - 1, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash))); // to opened account
 	ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
-	auto send2 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send1->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 2, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ()))); // to unopened account (pending)
+	auto send2 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 2, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ()))); // to unopened account (pending)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send2).code);
-	auto send3 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send2->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 3, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send2->hash ()))); // to burn (0)
+	auto send3 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send2->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 3, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send2->hash ()))); // to burn (0)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send3).code);
 	nano::account max_account (std::numeric_limits<nano::uint256_t>::max ());
-	auto send4 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send3->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 4, max_account, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send3->hash ()))); // to max account
+	auto send4 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send3->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 4, max_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send3->hash ()))); // to max account
 	ASSERT_EQ (nano::process_result::progress, node->process (*send4).code);
 	auto open (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 1, send1->hash (), key1.prv, key1.pub, *system.work.generate (key1.pub)));
 	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
@@ -7223,10 +7223,10 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	}
 
 	// Epoch 2 upgrade
-	auto genesis_latest (node->latest (nano::test_genesis_key.pub));
-	auto send5 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis_latest, nano::test_genesis_key.pub, nano::genesis_amount - 5, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis_latest))); // to burn (0)
+	auto genesis_latest (node->latest (nano::dev_genesis_key.pub));
+	auto send5 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, genesis_latest, nano::dev_genesis_key.pub, nano::genesis_amount - 5, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis_latest))); // to burn (0)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send5).code);
-	auto send6 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, send5->hash (), nano::test_genesis_key.pub, nano::genesis_amount - 6, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send5->hash ()))); // to key1 (again)
+	auto send6 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, send5->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 6, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send5->hash ()))); // to key1 (again)
 	ASSERT_EQ (nano::process_result::progress, node->process (*send6).code);
 	auto key1_latest (node->latest (key1.pub));
 	auto send7 (std::make_shared<nano::state_block> (key1.pub, key1_latest, key1.pub, 0, key3.pub, key1.prv, key1.pub, *system.work.generate (key1_latest))); // to key3
@@ -7270,7 +7270,7 @@ TEST (rpc, account_lazy_start)
 	auto node1 = system.add_node (node_flags);
 	nano::keypair key;
 	// Generating test chain
-	auto send1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, nano::genesis_hash, nano::test_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, nano::genesis_hash, nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
 	auto open (std::make_shared<nano::open_block> (send1->hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub)));
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
@@ -7311,14 +7311,14 @@ TEST (rpc, receive)
 	auto wallet = system.wallet (0);
 	std::string wallet_text;
 	node.wallets.items.begin ()->first.encode_hex (wallet_text);
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	wallet->insert_adhoc (key1.prv);
-	auto send1 (wallet->send_action (nano::test_genesis_key.pub, key1.pub, node.config.receive_minimum.number (), *node.work_generate_blocking (nano::genesis_hash)));
-	ASSERT_TIMELY (5s, node.balance (nano::test_genesis_key.pub) != nano::genesis_amount);
+	auto send1 (wallet->send_action (nano::dev_genesis_key.pub, key1.pub, node.config.receive_minimum.number (), *node.work_generate_blocking (nano::genesis_hash)));
+	ASSERT_TIMELY (5s, node.balance (nano::dev_genesis_key.pub) != nano::genesis_amount);
 	ASSERT_TIMELY (10s, !node.store.account_exists (node.store.tx_begin_read (), key1.pub));
 	// Send below minimum receive amount
-	auto send2 (wallet->send_action (nano::test_genesis_key.pub, key1.pub, node.config.receive_minimum.number () - 1, *node.work_generate_blocking (send1->hash ())));
+	auto send2 (wallet->send_action (nano::dev_genesis_key.pub, key1.pub, node.config.receive_minimum.number () - 1, *node.work_generate_blocking (send1->hash ())));
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (node, node_rpc_config);
@@ -7365,11 +7365,11 @@ TEST (rpc, receive_unopened)
 	auto wallet = system.wallet (0);
 	std::string wallet_text;
 	node.wallets.items.begin ()->first.encode_hex (wallet_text);
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	// Test receiving for unopened account
 	nano::keypair key1;
-	auto send1 (wallet->send_action (nano::test_genesis_key.pub, key1.pub, node.config.receive_minimum.number () - 1, *node.work_generate_blocking (nano::genesis_hash)));
-	ASSERT_TIMELY (5s, !node.balance (nano::test_genesis_key.pub) != nano::genesis_amount);
+	auto send1 (wallet->send_action (nano::dev_genesis_key.pub, key1.pub, node.config.receive_minimum.number () - 1, *node.work_generate_blocking (nano::genesis_hash)));
+	ASSERT_TIMELY (5s, !node.balance (nano::dev_genesis_key.pub) != nano::genesis_amount);
 	ASSERT_FALSE (node.store.account_exists (node.store.tx_begin_read (), key1.pub));
 	ASSERT_TRUE (node.store.block_exists (node.store.tx_begin_read (), send1->hash ()));
 	wallet->insert_adhoc (key1.prv); // should not auto receive, amount sent was lower than minimum
@@ -7395,15 +7395,15 @@ TEST (rpc, receive_unopened)
 		ASSERT_FALSE (node.store.account_get (node.store.tx_begin_read (), key1.pub, info));
 		ASSERT_EQ (info.head, info.open_block);
 		ASSERT_EQ (info.head.to_string (), receive_text);
-		ASSERT_EQ (info.representative, nano::test_genesis_key.pub);
+		ASSERT_EQ (info.representative, nano::dev_genesis_key.pub);
 	}
 	scoped_thread_name_io.reset ();
 
 	// Test receiving for an unopened with a different wallet representative
 	nano::keypair key2;
-	auto prev_amount (node.balance (nano::test_genesis_key.pub));
-	auto send2 (wallet->send_action (nano::test_genesis_key.pub, key2.pub, node.config.receive_minimum.number () - 1, *node.work_generate_blocking (send1->hash ())));
-	ASSERT_TIMELY (5s, !node.balance (nano::test_genesis_key.pub) != prev_amount);
+	auto prev_amount (node.balance (nano::dev_genesis_key.pub));
+	auto send2 (wallet->send_action (nano::dev_genesis_key.pub, key2.pub, node.config.receive_minimum.number () - 1, *node.work_generate_blocking (send1->hash ())));
+	ASSERT_TIMELY (5s, !node.balance (nano::dev_genesis_key.pub) != prev_amount);
 	ASSERT_FALSE (node.store.account_exists (node.store.tx_begin_read (), key2.pub));
 	ASSERT_TRUE (node.store.block_exists (node.store.tx_begin_read (), send2->hash ()));
 	nano::public_key rep;
@@ -7436,13 +7436,13 @@ TEST (rpc, receive_work_disabled)
 	auto wallet = system.wallet (1);
 	std::string wallet_text;
 	node.wallets.items.begin ()->first.encode_hex (wallet_text);
-	wallet->insert_adhoc (nano::test_genesis_key.prv);
+	wallet->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key1;
 	nano::genesis genesis;
 	ASSERT_TRUE (worker_node.work_generation_enabled ());
-	auto send1 (wallet->send_action (nano::test_genesis_key.pub, key1.pub, node.config.receive_minimum.number () - 1, *worker_node.work_generate_blocking (genesis.hash ()), false));
+	auto send1 (wallet->send_action (nano::dev_genesis_key.pub, key1.pub, node.config.receive_minimum.number () - 1, *worker_node.work_generate_blocking (genesis.hash ()), false));
 	ASSERT_TRUE (send1 != nullptr);
-	ASSERT_TIMELY (5s, node.balance (nano::test_genesis_key.pub) != nano::genesis_amount);
+	ASSERT_TIMELY (5s, node.balance (nano::dev_genesis_key.pub) != nano::genesis_amount);
 	ASSERT_FALSE (node.store.account_exists (node.store.tx_begin_read (), key1.pub));
 	ASSERT_TRUE (node.store.block_exists (node.store.tx_begin_read (), send1->hash ()));
 	wallet->insert_adhoc (key1.prv);
@@ -7688,8 +7688,8 @@ TEST (rpc, confirmation_active)
 	rpc.start ();
 
 	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), nano::public_key (), nano::genesis_amount - 200, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send1->hash ())));
+	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send2 (std::make_shared<nano::send_block> (send1->hash (), nano::public_key (), nano::genesis_amount - 200, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	node1.process_active (send1);
 	node1.process_active (send2);
 	nano::blocks_confirm (node1, { send1, send2 });
@@ -7729,7 +7729,7 @@ TEST (rpc, confirmation_info)
 	rpc.start ();
 
 	nano::genesis genesis;
-	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ())));
 	node1.process_active (send);
 	node1.block_processor.flush ();
 	ASSERT_FALSE (node1.active.empty ());

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -86,7 +86,7 @@ network (network_a), ledger (network), voting (network), node (network), portmap
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_dev_work = 8;
 	kdf_work = network.is_dev_network () ? kdf_dev_work : kdf_full_work;
-	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'R', 'B' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'R', 'C' } } : std::array<uint8_t, 2>{ {'R', 'X'} };
+	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'R', 'B' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'R', 'C' } } : std::array<uint8_t, 2>{ { 'R', 'X' } };
 }
 
 uint8_t nano::protocol_constants::protocol_version_min (bool use_epoch_2_min_version_a) const

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -25,11 +25,11 @@ nano::nano_networks nano::network_constants::active_network = nano::nano_network
 
 namespace
 {
-char const * test_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4";
-char const * test_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
+char const * dev_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4";
+char const * dev_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
 char const * beta_public_key_data = "259A4384075F73E19BEE72C0F23C491E30A678FBBD31D55D3982099D3CDA8116"; // nano_1betag41gqumw8fywwp1yay6k9jinswhqhbjtogmm1ibmnyfo1apej3medr3
 char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA"; // xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3
-char const * test_genesis_data = R"%%%({
+char const * dev_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
 	"representative": "xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo",
@@ -56,6 +56,7 @@ char const * live_genesis_data = R"%%%({
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
 	})%%%";
 
+
 std::shared_ptr<nano::block> parse_block_from_genesis_data (std::string const & genesis_data_a)
 {
 	boost::property_tree::ptree tree;
@@ -74,9 +75,9 @@ nano::network_params::network_params (nano::nano_networks network_a) :
 network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
 {
 	unsigned constexpr kdf_full_work = 64 * 1024;
-	unsigned constexpr kdf_test_work = 8;
-	kdf_work = network.is_test_network () ? kdf_test_work : kdf_full_work;
-	header_magic_number = network.is_test_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'R', 'B' } } : std::array<uint8_t, 2>{ { 'R', 'C' } };
+	unsigned constexpr kdf_dev_work = 8;
+	kdf_work = network.is_dev_network () ? kdf_dev_work : kdf_full_work;
+	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'R', 'B' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'R', 'C' } } : std::array<uint8_t, 2>{ {'R', 'X'} };
 }
 
 uint8_t nano::protocol_constants::protocol_version_min (bool use_epoch_2_min_version_a) const
@@ -91,15 +92,15 @@ ledger_constants (network_constants.network ())
 
 nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
 zero_key ("0"),
-test_genesis_key (test_private_key_data),
-nano_test_account (test_public_key_data),
+dev_genesis_key (dev_private_key_data),
+nano_dev_account (dev_public_key_data),
 nano_beta_account (beta_public_key_data),
 nano_live_account (live_public_key_data),
-nano_test_genesis (test_genesis_data),
+nano_dev_genesis (dev_genesis_data),
 nano_beta_genesis (beta_genesis_data),
 nano_live_genesis (live_genesis_data),
-genesis_account (network_a == nano::nano_networks::nano_test_network ? nano_test_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_account),
-genesis_block (network_a == nano::nano_networks::nano_test_network ? nano_test_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : nano_live_genesis),
+genesis_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_account),
+genesis_block (network_a == nano::nano_networks::nano_dev_network ? nano_dev_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : nano_live_genesis),
 genesis_hash (parse_block_from_genesis_data (genesis_block)->hash ()),
 genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 burn_account (0)
@@ -113,7 +114,7 @@ burn_account (0)
 	nano::account nano_live_epoch_v2_signer;
 	auto error (nano_live_epoch_v2_signer.decode_account ("nano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
 	debug_assert (!error);
-	auto epoch_v2_signer (network_a == nano::nano_networks::nano_test_network ? nano_test_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_epoch_v2_signer);
+	auto epoch_v2_signer (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_epoch_v2_signer);
 	const char * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);
@@ -127,24 +128,24 @@ nano::random_constants::random_constants ()
 
 nano::node_constants::node_constants (nano::network_constants & network_constants)
 {
-	period = network_constants.is_test_network () ? std::chrono::seconds (1) : std::chrono::seconds (60);
-	half_period = network_constants.is_test_network () ? std::chrono::milliseconds (500) : std::chrono::milliseconds (30 * 1000);
-	idle_timeout = network_constants.is_test_network () ? period * 15 : period * 2;
+	period = network_constants.is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (60);
+	half_period = network_constants.is_dev_network () ? std::chrono::milliseconds (500) : std::chrono::milliseconds (30 * 1000);
+	idle_timeout = network_constants.is_dev_network () ? period * 15 : period * 2;
 	cutoff = period * 5;
 	syn_cookie_cutoff = std::chrono::seconds (5);
 	backup_interval = std::chrono::minutes (5);
-	search_pending_interval = network_constants.is_test_network () ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
+	search_pending_interval = network_constants.is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
 	peer_interval = search_pending_interval;
 	unchecked_cleaning_interval = std::chrono::minutes (30);
-	process_confirmed_interval = network_constants.is_test_network () ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
-	max_peers_per_ip = network_constants.is_test_network () ? 10 : 5;
+	process_confirmed_interval = network_constants.is_dev_network () ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
+	max_peers_per_ip = network_constants.is_dev_network () ? 10 : 5;
 	max_weight_samples = network_constants.is_live_network () ? 4032 : 288;
 	weight_period = 5 * 60; // 5 minutes
 }
 
 nano::voting_constants::voting_constants (nano::network_constants & network_constants)
 {
-	max_cache = network_constants.is_test_network () ? 256 : 128 * 1024;
+	max_cache = network_constants.is_dev_network () ? 256 : 128 * 1024;
 }
 
 nano::portmapping_constants::portmapping_constants (nano::network_constants & network_constants)
@@ -155,12 +156,12 @@ nano::portmapping_constants::portmapping_constants (nano::network_constants & ne
 
 nano::bootstrap_constants::bootstrap_constants (nano::network_constants & network_constants)
 {
-	lazy_max_pull_blocks = network_constants.is_test_network () ? 2 : 512;
-	lazy_min_pull_blocks = network_constants.is_test_network () ? 1 : 32;
-	frontier_retry_limit = network_constants.is_test_network () ? 2 : 16;
-	lazy_retry_limit = network_constants.is_test_network () ? 2 : frontier_retry_limit * 10;
-	lazy_destinations_retry_limit = network_constants.is_test_network () ? 1 : frontier_retry_limit / 4;
-	gap_cache_bootstrap_start_interval = network_constants.is_test_network () ? std::chrono::milliseconds (5) : std::chrono::milliseconds (30 * 1000);
+	lazy_max_pull_blocks = network_constants.is_dev_network () ? 2 : 512;
+	lazy_min_pull_blocks = network_constants.is_dev_network () ? 1 : 32;
+	frontier_retry_limit = network_constants.is_dev_network () ? 2 : 16;
+	lazy_retry_limit = network_constants.is_dev_network () ? 2 : frontier_retry_limit * 10;
+	lazy_destinations_retry_limit = network_constants.is_dev_network () ? 1 : frontier_retry_limit / 4;
+	gap_cache_bootstrap_start_interval = network_constants.is_dev_network () ? std::chrono::milliseconds (5) : std::chrono::milliseconds (30 * 1000);
 }
 
 // Create a new random keypair

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -29,6 +29,7 @@ char const * dev_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E
 char const * dev_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
 char const * beta_public_key_data = "259A4384075F73E19BEE72C0F23C491E30A678FBBD31D55D3982099D3CDA8116"; // nano_1betag41gqumw8fywwp1yay6k9jinswhqhbjtogmm1ibmnyfo1apej3medr3
 char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA"; // xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3
+char const * test_public_key_data = "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"; // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
 char const * dev_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
@@ -56,6 +57,14 @@ char const * live_genesis_data = R"%%%({
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
 	})%%%";
 
+char const * test_genesis_data = R"%%%({
+	"type": "open",
+	"source": "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED",
+	"representative": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
+	"account": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
+	"work": "bc1ef279c1a34eb1",
+	"signature": "15049467CAEE3EC768639E8E35792399B6078DA763DA4EBA8ECAD33B0EDC4AF2E7403893A5A602EB89B978DABEF1D6606BB00F3C0EE11449232B143B6E07170E"
+	})%%%";
 
 std::shared_ptr<nano::block> parse_block_from_genesis_data (std::string const & genesis_data_a)
 {
@@ -96,11 +105,13 @@ dev_genesis_key (dev_private_key_data),
 nano_dev_account (dev_public_key_data),
 nano_beta_account (beta_public_key_data),
 nano_live_account (live_public_key_data),
+nano_test_account (test_public_key_data),
 nano_dev_genesis (dev_genesis_data),
 nano_beta_genesis (beta_genesis_data),
 nano_live_genesis (live_genesis_data),
-genesis_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_account),
-genesis_block (network_a == nano::nano_networks::nano_dev_network ? nano_dev_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : nano_live_genesis),
+nano_test_genesis (test_genesis_data),
+genesis_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_account),
+genesis_block (network_a == nano::nano_networks::nano_dev_network ? nano_dev_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : network_a == nano::nano_networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
 genesis_hash (parse_block_from_genesis_data (genesis_block)->hash ()),
 genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 burn_account (0)
@@ -114,7 +125,7 @@ burn_account (0)
 	nano::account nano_live_epoch_v2_signer;
 	auto error (nano_live_epoch_v2_signer.decode_account ("nano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
 	debug_assert (!error);
-	auto epoch_v2_signer (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_epoch_v2_signer);
+	auto epoch_v2_signer (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_epoch_v2_signer);
 	const char * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);
@@ -139,7 +150,7 @@ nano::node_constants::node_constants (nano::network_constants & network_constant
 	unchecked_cleaning_interval = std::chrono::minutes (30);
 	process_confirmed_interval = network_constants.is_dev_network () ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
 	max_peers_per_ip = network_constants.is_dev_network () ? 10 : 5;
-	max_weight_samples = network_constants.is_live_network () ? 4032 : 288;
+	max_weight_samples = (network_constants.is_live_network () || network_constants.is_test_network ()) ? 4032 : 288;
 	weight_period = 5 * 60; // 5 minutes
 }
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -376,9 +376,11 @@ public:
 	nano::account nano_dev_account;
 	nano::account nano_beta_account;
 	nano::account nano_live_account;
+	nano::account nano_test_account;
 	std::string nano_dev_genesis;
 	std::string nano_beta_genesis;
 	std::string nano_live_genesis;
+	std::string nano_test_genesis;
 	nano::account genesis_account;
 	std::string genesis_block;
 	nano::block_hash genesis_hash;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -372,11 +372,11 @@ public:
 	ledger_constants (nano::network_constants & network_constants);
 	ledger_constants (nano::nano_networks network_a);
 	nano::keypair zero_key;
-	nano::keypair test_genesis_key;
-	nano::account nano_test_account;
+	nano::keypair dev_genesis_key;
+	nano::account nano_dev_account;
 	nano::account nano_beta_account;
 	nano::account nano_live_account;
-	std::string nano_test_genesis;
+	std::string nano_dev_genesis;
 	std::string nano_beta_genesis;
 	std::string nano_live_genesis;
 	nano::account genesis_account;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -800,7 +800,7 @@ nano::uint128_t nano::ledger::account_pending (nano::transaction const & transac
 
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a, nano::signature_verification verification)
 {
-	debug_assert (!nano::work_validate_entry (block_a) || network_params.network.is_test_network ());
+	debug_assert (!nano::work_validate_entry (block_a) || network_params.network.is_dev_network ());
 	ledger_processor processor (*this, transaction_a, verification);
 	block_a.visit (processor);
 	if (processor.result.code == nano::process_result::progress)

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -42,6 +42,16 @@ boost::filesystem::path nano::working_path (bool legacy)
 				result /= "RaiBlocks";
 			}
 			break;
+		case nano::nano_networks::nano_test_network:
+			if (!legacy)
+			{
+				result /= "NanoTest";
+			}
+			else
+			{
+				result /= "RaiBlocksTest";
+			}
+			break;
 	}
 	return result;
 }

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -12,14 +12,14 @@ boost::filesystem::path nano::working_path (bool legacy)
 	auto result (nano::app_path ());
 	switch (network_constants.network ())
 	{
-		case nano::nano_networks::nano_test_network:
+		case nano::nano_networks::nano_dev_network:
 			if (!legacy)
 			{
-				result /= "NanoTest";
+				result /= "NanoDev";
 			}
 			else
 			{
-				result /= "RaiBlocksTest";
+				result /= "RaiBlocksDev";
 			}
 			break;
 		case nano::nano_networks::nano_beta_network:

--- a/nano/slow_test/entry.cpp
+++ b/nano/slow_test/entry.cpp
@@ -3,16 +3,16 @@
 #include <gtest/gtest.h>
 namespace nano
 {
-void cleanup_test_directories_on_exit ();
-void force_nano_test_network ();
+void cleanup_dev_directories_on_exit ();
+void force_nano_dev_network ();
 }
 
 int main (int argc, char ** argv)
 {
-	nano::force_nano_test_network ();
+	nano::force_nano_dev_network ();
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_test_directories_on_exit ();
+	nano::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -20,7 +20,7 @@ TEST (system, generate_mass_activity)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.enable_voting = false; // Prevent blocks cementing
 	auto node = system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	uint32_t count (20);
 	system.generate_mass_activity (count, *system.nodes[0]);
 	auto transaction (system.nodes[0]->store.tx_begin_read ());
@@ -37,7 +37,7 @@ TEST (system, generate_mass_activity_long)
 	auto node = system.add_node (node_config);
 	system.wallet (0)->wallets.watcher->stop (); // Stop work watcher
 	nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	uint32_t count (1000000000);
 	system.generate_mass_activity (count, *system.nodes[0]);
 	auto transaction (system.nodes[0]->store.tx_begin_read ());
@@ -57,7 +57,7 @@ TEST (system, receive_while_synchronizing)
 		node_config.enable_voting = false; // Prevent blocks cementing
 		auto node = system.add_node (node_config);
 		nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 		uint32_t count (1000);
 		system.generate_mass_activity (count, *system.nodes[0]);
 		nano::keypair key;
@@ -66,12 +66,12 @@ TEST (system, receive_while_synchronizing)
 		auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, system.nodes[0]->network.endpoint (), node1->network_params.protocol.protocol_version));
 		node1->network.send_keepalive (channel);
 		auto wallet (node1->wallets.create (1));
-		wallet->insert_adhoc (nano::test_genesis_key.prv); // For voting
+		wallet->insert_adhoc (nano::dev_genesis_key.prv); // For voting
 		ASSERT_EQ (key.pub, wallet->insert_adhoc (key.prv));
 		node1->start ();
 		system.nodes.push_back (node1);
 		system.alarm.add (std::chrono::steady_clock::now () + std::chrono::milliseconds (200), ([&system, &key]() {
-			auto hash (system.wallet (0)->send_sync (nano::test_genesis_key.pub, key.pub, system.nodes[0]->config.receive_minimum.number ()));
+			auto hash (system.wallet (0)->send_sync (nano::dev_genesis_key.pub, key.pub, system.nodes[0]->config.receive_minimum.number ()));
 			auto transaction (system.nodes[0]->store.tx_begin_read ());
 			auto block (system.nodes[0]->store.block_get (transaction, hash));
 			std::string block_text;
@@ -101,16 +101,16 @@ TEST (ledger, deep_account_compute)
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key;
 	auto balance (nano::genesis_amount - 1);
-	nano::send_block send (genesis.hash (), key.pub, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (genesis.hash ()));
+	nano::send_block send (genesis.hash (), key.pub, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *pool.generate (key.pub));
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *pool.generate (key.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
 	auto sprevious (send.hash ());
 	auto rprevious (open.hash ());
 	for (auto i (0), n (100000); i != n; ++i)
 	{
 		balance -= 1;
-		nano::send_block send (sprevious, key.pub, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (sprevious));
+		nano::send_block send (sprevious, key.pub, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (sprevious));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 		sprevious = send.hash ();
 		nano::receive_block receive (rprevious, send.hash (), key.prv, key.pub, *pool.generate (rprevious));
@@ -132,21 +132,21 @@ TEST (wallet, multithreaded_send_async)
 		nano::system system (1);
 		nano::keypair key;
 		auto wallet_l (system.wallet (0));
-		wallet_l->insert_adhoc (nano::test_genesis_key.prv);
+		wallet_l->insert_adhoc (nano::dev_genesis_key.prv);
 		wallet_l->insert_adhoc (key.prv);
 		for (auto i (0); i < 20; ++i)
 		{
 			threads.push_back (boost::thread ([wallet_l, &key]() {
 				for (auto i (0); i < 1000; ++i)
 				{
-					wallet_l->send_async (nano::test_genesis_key.pub, key.pub, 1000, [](std::shared_ptr<nano::block> block_a) {
+					wallet_l->send_async (nano::dev_genesis_key.pub, key.pub, 1000, [](std::shared_ptr<nano::block> block_a) {
 						ASSERT_FALSE (block_a == nullptr);
 						ASSERT_FALSE (block_a->hash ().is_zero ());
 					});
 				}
 			}));
 		}
-		ASSERT_TIMELY (1000s, system.nodes[0]->balance (nano::test_genesis_key.pub) == (nano::genesis_amount - 20 * 1000 * 1000));
+		ASSERT_TIMELY (1000s, system.nodes[0]->balance (nano::dev_genesis_key.pub) == (nano::genesis_amount - 20 * 1000 * 1000));
 	}
 	for (auto i (threads.begin ()), n (threads.end ()); i != n; ++i)
 	{
@@ -186,15 +186,15 @@ TEST (node, fork_storm)
 	nano::node_flags flags;
 	flags.disable_max_peers_per_ip = true;
 	nano::system system (64, nano::transport::transport_type::tcp, flags);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	auto previous (system.nodes[0]->latest (nano::test_genesis_key.pub));
-	auto balance (system.nodes[0]->balance (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	auto previous (system.nodes[0]->latest (nano::dev_genesis_key.pub));
+	auto balance (system.nodes[0]->balance (nano::dev_genesis_key.pub));
 	ASSERT_FALSE (previous.is_zero ());
 	for (auto j (0); j != system.nodes.size (); ++j)
 	{
 		balance -= 1;
 		nano::keypair key;
-		nano::send_block send (previous, key.pub, balance, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0);
+		nano::send_block send (previous, key.pub, balance, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0);
 		system.nodes[j]->work_generate_blocking (send);
 		previous = send.hash ();
 		for (auto i (0); i != system.nodes.size (); ++i)
@@ -391,7 +391,7 @@ TEST (store, unchecked_load)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
-	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	constexpr auto num_unchecked = 1000000;
 	for (auto i (0); i < 1000000; ++i)
 	{
@@ -406,10 +406,10 @@ TEST (store, vote_load)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
-	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	for (auto i (0); i < 1000000; ++i)
 	{
-		auto vote (std::make_shared<nano::vote> (nano::test_genesis_key.pub, nano::test_genesis_key.prv, i, block));
+		auto vote (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, i, block));
 		node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_udp> (system.nodes[0]->network.udp_channels, system.nodes[0]->network.endpoint (), system.nodes[0]->network_params.protocol.protocol_version));
 	}
 }
@@ -435,13 +435,13 @@ TEST (wallets, rep_scan)
 TEST (node, mass_vote_by_hash)
 {
 	nano::system system (1);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::block_hash previous (nano::genesis_hash);
 	nano::keypair key;
 	std::vector<std::shared_ptr<nano::state_block>> blocks;
 	for (auto i (0); i < 10000; ++i)
 	{
-		auto block (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous, nano::test_genesis_key.pub, nano::genesis_amount - (i + 1) * nano::Gxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous)));
+		auto block (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous, nano::dev_genesis_key.pub, nano::genesis_amount - (i + 1) * nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous)));
 		previous = block->hash ();
 		blocks.push_back (block);
 	}
@@ -460,13 +460,13 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	// The number of frontiers should be more than the nano::confirmation_height::unbounded_cutoff to test the amount of blocks confirmed is correct.
 	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
-	nano::keypair last_keypair = nano::test_genesis_key;
-	auto last_open_hash = node->latest (nano::test_genesis_key.pub);
+	nano::keypair last_keypair = nano::dev_genesis_key;
+	auto last_open_hash = node->latest (nano::dev_genesis_key.pub);
 	{
 		auto transaction = node->store.tx_begin_write ();
 		for (auto i = num_accounts - 1; i > 0; --i)
@@ -531,11 +531,11 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
-	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
+	auto ladev_genesis = node->latest (nano::dev_genesis_key.pub);
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -544,12 +544,12 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 			nano::keypair key;
 			system.wallet (0)->insert_adhoc (key.prv);
 
-			nano::send_block send (latest_genesis, key.pub, node->config.online_weight_minimum.number (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis));
+			nano::send_block send (ladev_genesis, key.pub, node->config.online_weight_minimum.number (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (ladev_genesis));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			auto open = std::make_shared<nano::open_block> (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
+			auto open = std::make_shared<nano::open_block> (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 			open_blocks.push_back (std::move (open));
-			latest_genesis = send.hash ();
+			ladev_genesis = send.hash ();
 		}
 	}
 
@@ -594,15 +594,15 @@ TEST (confirmation_height, long_chains)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
-	nano::block_hash latest (node->latest (nano::test_genesis_key.pub));
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
+	nano::block_hash latest (node->latest (nano::dev_genesis_key.pub));
 	system.wallet (0)->insert_adhoc (key1.prv);
 
 	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_blocks = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 
 	// First open the other account
-	nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + num_blocks + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest));
+	nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + num_blocks + 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 	nano::open_block open (send.hash (), nano::genesis_account, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -617,7 +617,7 @@ TEST (confirmation_height, long_chains)
 		auto transaction = node->store.tx_begin_write ();
 		for (auto i = num_blocks - 1; i > 0; --i)
 		{
-			nano::send_block send (previous_genesis_chain_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + i + 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous_genesis_chain_hash));
+			nano::send_block send (previous_genesis_chain_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + i + 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous_genesis_chain_hash));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
 			nano::receive_block receive (previous_destination_chain_hash, send.hash (), key1.prv, key1.pub, *system.work.generate (previous_destination_chain_hash));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive).code);
@@ -628,12 +628,12 @@ TEST (confirmation_height, long_chains)
 	}
 
 	// Send one from destination to genesis and pocket it
-	nano::send_block send1 (previous_destination_chain_hash, nano::test_genesis_key.pub, nano::Gxrb_ratio - 2, key1.prv, key1.pub, *system.work.generate (previous_destination_chain_hash));
-	auto receive1 (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, previous_genesis_chain_hash, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio + 1, send1.hash (), nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (previous_genesis_chain_hash)));
+	nano::send_block send1 (previous_destination_chain_hash, nano::dev_genesis_key.pub, nano::Gxrb_ratio - 2, key1.prv, key1.pub, *system.work.generate (previous_destination_chain_hash));
+	auto receive1 (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, previous_genesis_chain_hash, nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio + 1, send1.hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (previous_genesis_chain_hash)));
 
 	// Unpocketed. Send to a non-existing account to prevent auto receives from the wallet adjusting expected confirmation height
 	nano::keypair key2;
-	nano::state_block send2 (nano::genesis_account, receive1->hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key2.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (receive1->hash ()));
+	nano::state_block send2 (nano::genesis_account, receive1->hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key2.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (receive1->hash ()));
 
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -655,9 +655,9 @@ TEST (confirmation_height, long_chains)
 
 	auto transaction (node->store.tx_begin_read ());
 	nano::account_info account_info;
-	ASSERT_FALSE (node->store.account_get (transaction, nano::test_genesis_key.pub, account_info));
+	ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::test_genesis_key.pub, confirmation_height_info));
+	ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 	ASSERT_EQ (num_blocks + 2, confirmation_height_info.height);
 	ASSERT_EQ (num_blocks + 3, account_info.block_count); // Includes the unpocketed send
 
@@ -689,14 +689,14 @@ TEST (confirmation_height, dynamic_algorithm)
 	auto node = system.add_node (node_config);
 	nano::genesis genesis;
 	nano::keypair key;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	auto const num_blocks = nano::confirmation_height::unbounded_cutoff;
-	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
+	auto ladev_genesis = node->latest (nano::dev_genesis_key.pub);
 	std::vector<std::shared_ptr<nano::state_block>> state_blocks;
 	for (auto i = 0; i < num_blocks; ++i)
 	{
-		auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, latest_genesis, nano::test_genesis_key.pub, nano::genesis_amount - i - 1, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis)));
-		latest_genesis = send->hash ();
+		auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, ladev_genesis, nano::dev_genesis_key.pub, nano::genesis_amount - i - 1, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (ladev_genesis)));
+		ladev_genesis = send->hash ();
 		state_blocks.push_back (send);
 	}
 	{
@@ -710,7 +710,7 @@ TEST (confirmation_height, dynamic_algorithm)
 	node->confirmation_height_processor.add (state_blocks.front ()->hash ());
 	ASSERT_TIMELY (20s, node->ledger.cache.cemented_count == 2);
 
-	node->confirmation_height_processor.add (latest_genesis);
+	node->confirmation_height_processor.add (ladev_genesis);
 
 	ASSERT_TIMELY (20s, node->ledger.cache.cemented_count == num_blocks + 1);
 
@@ -741,16 +741,16 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config);
 		nano::keypair key;
-		system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
-		auto latest_genesis = node->latest (nano::test_genesis_key.pub);
+		auto ladev_genesis = node->latest (nano::dev_genesis_key.pub);
 		std::vector<std::shared_ptr<nano::state_block>> state_blocks;
 		auto const num_blocks = nano::confirmation_height::unbounded_cutoff - 2;
 
 		auto add_block_to_genesis_chain = [&](nano::write_transaction & transaction) {
 			static int num = 0;
-			auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, latest_genesis, nano::test_genesis_key.pub, nano::genesis_amount - num - 1, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis)));
-			latest_genesis = send->hash ();
+			auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, ladev_genesis, nano::dev_genesis_key.pub, nano::genesis_amount - num - 1, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (ladev_genesis)));
+			ladev_genesis = send->hash ();
 			state_blocks.push_back (send);
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 			++num;
@@ -810,7 +810,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	nano::node_flags node_flags;
 	node_flags.confirmation_height_processor_mode = nano::confirmation_height_mode::unbounded;
 	auto node = system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
 #ifndef NDEBUG
 	auto const num_accounts = 10000;
@@ -818,7 +818,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	auto const num_accounts = 100000;
 #endif
 
-	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
+	auto ladev_genesis = node->latest (nano::dev_genesis_key.pub);
 	std::vector<nano::keypair> keys;
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 	{
@@ -828,12 +828,12 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 			nano::keypair key;
 			keys.emplace_back (key);
 
-			nano::send_block send (latest_genesis, key.pub, nano::genesis_amount - 1 - i, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis));
+			nano::send_block send (ladev_genesis, key.pub, nano::genesis_amount - 1 - i, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (ladev_genesis));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			auto open = std::make_shared<nano::open_block> (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
+			auto open = std::make_shared<nano::open_block> (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 			open_blocks.push_back (std::move (open));
-			latest_genesis = send.hash ();
+			ladev_genesis = send.hash ();
 		}
 	}
 
@@ -929,7 +929,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 
 	auto const num_accounts = 100000;
 
-	auto latest_genesis = nano::genesis_hash;
+	auto ladev_genesis = nano::genesis_hash;
 	std::vector<nano::keypair> keys;
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 
@@ -944,12 +944,12 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 		{
 			nano::keypair key;
 			keys.emplace_back (key);
-			nano::send_block send (latest_genesis, key.pub, nano::genesis_amount - 1 - i, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *pool.generate (latest_genesis));
+			nano::send_block send (ladev_genesis, key.pub, nano::genesis_amount - 1 - i, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (ladev_genesis));
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-			auto open = std::make_shared<nano::open_block> (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *pool.generate (key.pub));
+			auto open = std::make_shared<nano::open_block> (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *pool.generate (key.pub));
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 			open_blocks.push_back (std::move (open));
-			latest_genesis = send.hash ();
+			ladev_genesis = send.hash ();
 		}
 	}
 
@@ -1027,11 +1027,11 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 
 	auto num_accounts = node->active.max_priority_cementable_frontiers * 2;
-	nano::keypair last_keypair = nano::test_genesis_key;
-	auto last_open_hash = node->latest (nano::test_genesis_key.pub);
+	nano::keypair last_keypair = nano::dev_genesis_key;
+	auto last_open_hash = node->latest (nano::dev_genesis_key.pub);
 	// Clear confirmation height so that the genesis account has the same amount of uncemented blocks as the other frontiers
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -1069,9 +1069,9 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 
 	// Add a new frontier with 1 block, it should not be added to the frontier container because it is not higher than any already in the maxed out container
 	nano::keypair key;
-	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
-	nano::send_block send (latest_genesis, key.pub, nano::Gxrb_ratio - 1, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis));
-	nano::open_block open (send.hash (), nano::test_genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
+	auto ladev_genesis = node->latest (nano::dev_genesis_key.pub);
+	nano::send_block send (ladev_genesis, key.pub, nano::Gxrb_ratio - 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (ladev_genesis));
+	nano::open_block open (send.hash (), nano::dev_genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
 	{
 		auto transaction = node->store.tx_begin_write ();
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
@@ -1083,7 +1083,7 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	ASSERT_EQ (node->active.priority_wallet_cementable_frontiers_size (), num_accounts / 2);
 
 	// The account now has an extra block (2 in total) so has 1 more uncemented block than the next smallest frontier in the collection.
-	nano::send_block send1 (send.hash (), key.pub, nano::Gxrb_ratio - 2, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (send.hash ()));
+	nano::send_block send1 (send.hash (), key.pub, nano::Gxrb_ratio - 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send.hash ()));
 	nano::receive_block receive (open.hash (), send1.hash (), key.prv, key.pub, *system.work.generate (open.hash ()));
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -1258,13 +1258,13 @@ TEST (telemetry, under_load)
 	nano::genesis genesis;
 	nano::keypair key;
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::test_genesis_key.prv);
+	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto latest_genesis = node->latest (nano::test_genesis_key.pub);
+	auto ladev_genesis = node->latest (nano::dev_genesis_key.pub);
 	auto num_blocks = 150000;
-	auto send (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, latest_genesis, nano::test_genesis_key.pub, nano::genesis_amount - num_blocks, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (latest_genesis)));
+	auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, ladev_genesis, nano::dev_genesis_key.pub, nano::genesis_amount - num_blocks, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (ladev_genesis)));
 	node->process_active (send);
-	latest_genesis = send->hash ();
+	ladev_genesis = send->hash ();
 	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, num_blocks, send->hash (), key.prv, key.pub, *system.work.generate (key.pub)));
 	node->process_active (open);
 	auto latest_key = open->hash ();
@@ -1279,7 +1279,7 @@ TEST (telemetry, under_load)
 		}
 	};
 
-	std::thread thread1 (thread_func, nano::test_genesis_key, latest_genesis, nano::genesis_amount - num_blocks);
+	std::thread thread1 (thread_func, nano::dev_genesis_key, ladev_genesis, nano::genesis_amount - num_blocks);
 	std::thread thread2 (thread_func, key, latest_key, num_blocks);
 
 	ASSERT_TIMELY (200s, node1->ledger.cache.block_count == num_blocks * 2 + 3);
@@ -1397,7 +1397,7 @@ TEST (telemetry, many_nodes)
 	// Give all nodes a non-default number of blocks
 	nano::keypair key;
 	nano::genesis genesis;
-	nano::state_block send (nano::test_genesis_key.pub, genesis.hash (), nano::test_genesis_key.pub, nano::genesis_amount - nano::Mxrb_ratio, key.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, *system.work.generate (genesis.hash ()));
+	nano::state_block send (nano::dev_genesis_key.pub, genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Mxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (genesis.hash ()));
 	for (auto node : system.nodes)
 	{
 		auto transaction (node->store.tx_begin_write ());
@@ -1544,8 +1544,8 @@ TEST (node, mass_epoch_upgrader)
 		//node_config.work_peers = { { "192.168.1.101", 7000 } };
 		auto & node = *system.add_node (node_config);
 
-		auto balance = node.balance (nano::test_genesis_key.pub);
-		auto latest = node.latest (nano::test_genesis_key.pub);
+		auto balance = node.balance (nano::dev_genesis_key.pub);
+		auto latest = node.latest (nano::dev_genesis_key.pub);
 		nano::uint128_t amount = 1;
 
 		// Send to all accounts
@@ -1558,12 +1558,12 @@ TEST (node, mass_epoch_upgrader)
 				nano::state_block_builder builder;
 				std::error_code ec;
 				auto block = builder
-				             .account (nano::test_genesis_key.pub)
+				             .account (nano::dev_genesis_key.pub)
 				             .previous (latest)
 				             .balance (balance)
 				             .link (info.key.pub)
-				             .representative (nano::test_genesis_key.pub)
-				             .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
+				             .representative (nano::dev_genesis_key.pub)
+				             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 				             .work (*node.work_generate_blocking (latest, nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
 				             .build (ec);
 				ASSERT_FALSE (ec);
@@ -1597,7 +1597,7 @@ TEST (node, mass_epoch_upgrader)
 		ASSERT_EQ (1 + total_accounts + opened.size (), node.ledger.cache.block_count);
 		ASSERT_EQ (1 + opened.size (), node.ledger.cache.account_count);
 
-		nano::keypair epoch_signer (nano::test_genesis_key);
+		nano::keypair epoch_signer (nano::dev_genesis_key);
 
 		auto const block_count_before = node.ledger.cache.block_count.load ();
 		auto const total_to_upgrade = 1 + total_accounts;
@@ -1678,19 +1678,19 @@ TEST (node, mass_block_new)
 	nano::state_block_builder builder;
 	std::vector<std::shared_ptr<nano::state_block>> send_blocks;
 	auto send_threshold (nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false)));
-	auto latest_genesis = node.latest (nano::test_genesis_key.pub);
+	auto ladev_genesis = node.latest (nano::dev_genesis_key.pub);
 	for (auto i = 0; i < num_blocks; ++i)
 	{
 		auto send = builder.make_block ()
-		            .account (nano::test_genesis_key.pub)
-		            .previous (latest_genesis)
+		            .account (nano::dev_genesis_key.pub)
+		            .previous (ladev_genesis)
 		            .balance (nano::genesis_amount - i - 1)
-		            .representative (nano::test_genesis_key.pub)
+		            .representative (nano::dev_genesis_key.pub)
 		            .link (keys[i].pub)
-		            .sign (nano::test_genesis_key.prv, nano::test_genesis_key.pub)
-		            .work (*system.work.generate (nano::work_version::work_1, latest_genesis, send_threshold))
+		            .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+		            .work (*system.work.generate (nano::work_version::work_1, ladev_genesis, send_threshold))
 		            .build ();
-		latest_genesis = send->hash ();
+		ladev_genesis = send->hash ();
 		send_blocks.push_back (std::move (send));
 	}
 	std::cout << "Send blocks built, start processing" << std::endl;

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -12,17 +12,17 @@ using namespace std::chrono_literals;
 /* Convenience constants for tests which are always on the test network */
 namespace
 {
-nano::ledger_constants test_constants (nano::nano_networks::nano_test_network);
+nano::ledger_constants dev_constants (nano::nano_networks::nano_dev_network);
 }
 
-nano::keypair const & nano::zero_key (test_constants.zero_key);
-nano::keypair const & nano::test_genesis_key (test_constants.test_genesis_key);
-nano::account const & nano::nano_test_account (test_constants.nano_test_account);
-std::string const & nano::nano_test_genesis (test_constants.nano_test_genesis);
-nano::account const & nano::genesis_account (test_constants.genesis_account);
-nano::block_hash const & nano::genesis_hash (test_constants.genesis_hash);
-nano::uint128_t const & nano::genesis_amount (test_constants.genesis_amount);
-nano::account const & nano::burn_account (test_constants.burn_account);
+nano::keypair const & nano::zero_key (dev_constants.zero_key);
+nano::keypair const & nano::dev_genesis_key (dev_constants.dev_genesis_key);
+nano::account const & nano::nano_dev_account (dev_constants.nano_dev_account);
+std::string const & nano::nano_dev_genesis (dev_constants.nano_dev_genesis);
+nano::account const & nano::genesis_account (dev_constants.genesis_account);
+nano::block_hash const & nano::genesis_hash (dev_constants.genesis_hash);
+nano::uint128_t const & nano::genesis_amount (dev_constants.genesis_amount);
+nano::account const & nano::burn_account (dev_constants.burn_account);
 
 void nano::wait_peer_connections (nano::system & system_a)
 {

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -54,11 +54,11 @@ class network_params;
 class system;
 
 extern nano::keypair const & zero_key;
-extern nano::keypair const & test_genesis_key;
-extern std::string const & nano_test_genesis;
+extern nano::keypair const & dev_genesis_key;
+extern std::string const & nano_dev_genesis;
 extern std::string const & genesis_block;
 extern nano::block_hash const & genesis_hash;
-extern nano::public_key const & nano_test_account;
+extern nano::public_key const & nano_dev_account;
 extern nano::public_key const & genesis_account;
 extern nano::public_key const & burn_account;
 extern nano::uint128_t const & genesis_amount;


### PR DESCRIPTION
This PR would migrate the existing nano_test_network to the nano_dev_network as tests are typically only run for development purposes and free up the nano_test_network to allow for a test network to be created that would have the same network values as the main network but allow for integration testing and other service testing without having to use the live network.
Currently the new nano_test_network has not been deployed, but the intent behind putting this in now as opposed to later would eliminate further rebasing or merging as other tests come into the develop branch with the existing nano_test_network and nano::test_* 