### PR TITLE
Logging exception handler and fix for stable_log_filename on windows

### DIFF
--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -101,10 +101,11 @@ void nano::logging::init (boost::filesystem::path const & application_path_a)
 			{
 				// Create temp stream to first create the file
 				std::ofstream stream (file_name.string ());
-
-				// Set permissions before opening otherwise Windows only has read permissions
-				nano::set_secure_perm_file (file_name);
 			}
+
+			// Set permissions before opening otherwise Windows only has read permissions
+			nano::set_secure_perm_file (file_name);
+
 #else
 			debug_assert (false);
 #endif

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/log/expressions.hpp>
+#include <boost/log/utility/exception_handler.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/file.hpp>
@@ -81,11 +82,12 @@ void nano::logging::init (boost::filesystem::path const & application_path_a)
 		if (stable_log_filename)
 		{
 #if BOOST_VERSION >= 107000
+			auto const file_name = path / "node.log";
 			// Logging to node.log and node_<pattern> instead of log_<pattern>.log is deliberate. This way,
 			// existing log monitoring scripts expecting the old logfile structure will fail immediately instead
 			// of reading only rotated files with old entries.
 			file_sink = boost::log::add_file_log (boost::log::keywords::target = path,
-			boost::log::keywords::file_name = path / "node.log",
+			boost::log::keywords::file_name = file_name,
 			boost::log::keywords::target_file_name = path / "node_%Y-%m-%d_%H-%M-%S.%N.log",
 			boost::log::keywords::open_mode = std::ios_base::out | std::ios_base::app, // append to node.log if it exists
 			boost::log::keywords::enable_final_rotation = false, // for stable log filenames, don't rotate on destruction
@@ -94,6 +96,15 @@ void nano::logging::init (boost::filesystem::path const & application_path_a)
 			boost::log::keywords::scan_method = boost::log::sinks::file::scan_method::scan_matching,
 			boost::log::keywords::max_size = max_size, // max total size in bytes of all log files
 			boost::log::keywords::format = format_with_timestamp);
+
+			if (!boost::filesystem::exists (file_name))
+			{
+				// Create temp stream to first create the file
+				std::ofstream stream (file_name.string ());
+
+				// Set permissions before opening otherwise Windows only has read permissions
+				nano::set_secure_perm_file (file_name);
+			}
 #else
 			debug_assert (false);
 #endif
@@ -108,6 +119,16 @@ void nano::logging::init (boost::filesystem::path const & application_path_a)
 			boost::log::keywords::max_size = max_size,
 			boost::log::keywords::format = format_with_timestamp);
 		}
+
+		struct exception_handler
+		{
+			void operator() (std::exception const & e) const
+			{
+				std::cerr << "Logging exception: " << e.what () << std::endl;
+			}
+		};
+
+		boost::log::core::get ()->set_exception_handler (boost::log::make_exception_handler<std::exception> (exception_handler ()));
 	}
 	//clang-format on
 }
@@ -118,6 +139,7 @@ void nano::logging::release_file_sink ()
 	{
 		boost::log::core::get ()->remove_sink (nano::logging::file_sink);
 		nano::logging::file_sink.reset ();
+		logging_already_added.clear ();
 	}
 }
 


### PR DESCRIPTION
Although our logger has never thrown in normal conditions, it has been reported to when stressing the RPC in a RAM node, especially with a low rotation file size. This adds an exception handler that handles by simply printing to stderr. I could not find a way to test the handler in a unit test.

Also fixes an issue with the `stable_log_filename` config on Windows. The `node.log` file was being created with read-only permissions, so writing to the file after restarting the node would throw an exception. This will be noted in the documentation. However, this also couldn't be unit tested because the file gets the full permissions by default.

The change to `nano::logging::release_file_sink ()` enables the added test.