### PR TITLE
Make logging election tally an optional config

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -283,7 +283,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 		status.type = nano::election_status_type::stopped;
 		if (node.config.logging.election_expiration_tally_logging ())
 		{
-			log_votes (tally (), "Election expired");
+			log_votes (tally (), "Election expired: ");
 		}
 	}
 	return result;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -281,7 +281,10 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 		result = true;
 		state_change (state_m.load (), nano::election::state_t::expired_unconfirmed);
 		status.type = nano::election_status_type::stopped;
-		log_votes (tally ());
+		if (node.config.logging.election_expiration_tally_logging ())
+		{
+			log_votes (tally (), "Election expired");
+		}
 	}
 	return result;
 }
@@ -344,7 +347,7 @@ void nano::election::confirm_if_quorum ()
 	}
 	if (have_quorum (tally_l, sum))
 	{
-		if (node.config.logging.vote_logging () || blocks.size () > 1)
+		if (node.config.logging.vote_logging () || (node.config.logging.election_fork_tally_logging () && blocks.size () > 1))
 		{
 			log_votes (tally_l);
 		}
@@ -352,11 +355,11 @@ void nano::election::confirm_if_quorum ()
 	}
 }
 
-void nano::election::log_votes (nano::tally_t const & tally_a) const
+void nano::election::log_votes (nano::tally_t const & tally_a, std::string const & prefix_a) const
 {
 	std::stringstream tally;
 	std::string line_end (node.config.logging.single_line_record () ? "\t" : "\n");
-	tally << boost::str (boost::format ("%1%Vote tally for root %2%") % line_end % root.to_string ());
+	tally << boost::str (boost::format ("%1%%2%Vote tally for root %3%") % prefix_a % line_end % root.to_string ());
 	for (auto i (tally_a.begin ()), n (tally_a.end ()); i != n; ++i)
 	{
 		tally << boost::str (boost::format ("%1%Block %2% weight %3%") % line_end % i->second->hash ().to_string () % i->first.convert_to<std::string> ());

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -79,7 +79,7 @@ public:
 	void confirm_once (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
 	// Confirm this block if quorum is met
 	void confirm_if_quorum ();
-	void log_votes (nano::tally_t const &) const;
+	void log_votes (nano::tally_t const &, std::string const & = "") const;
 	bool publish (std::shared_ptr<nano::block> block_a);
 	size_t last_votes_size ();
 	void update_dependent ();

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -126,6 +126,8 @@ nano::error nano::logging::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("ledger", ledger_logging_value, "Log ledger related messages.\ntype:bool");
 	toml.put ("ledger_duplicate", ledger_duplicate_logging_value, "Log when a duplicate block is attempted inserted into the ledger.\ntype:bool");
 	toml.put ("vote", vote_logging_value, "Vote logging. Enabling this option leads to a high volume.\nof log messages which may affect node performance.\ntype:bool");
+	toml.put ("election_expiration", election_expiration_tally_logging_value, "Log election tally on expiration.\ntype:bool");
+	toml.put ("election_fork", election_fork_tally_logging_value, "Log election tally when more than one block is seen.\ntype:bool");
 	toml.put ("network", network_logging_value, "Log network related messages.\ntype:bool");
 	toml.put ("network_timeout", network_timeout_logging_value, "Log TCP timeouts.\ntype:bool");
 	toml.put ("network_message", network_message_logging_value, "Log network errors and message details.\ntype:bool");
@@ -159,6 +161,8 @@ nano::error nano::logging::deserialize_toml (nano::tomlconfig & toml)
 	toml.get<bool> ("ledger", ledger_logging_value);
 	toml.get<bool> ("ledger_duplicate", ledger_duplicate_logging_value);
 	toml.get<bool> ("vote", vote_logging_value);
+	toml.get<bool> ("election_expiration", election_expiration_tally_logging_value);
+	toml.get<bool> ("election_fork", election_fork_tally_logging_value);
 	toml.get<bool> ("network", network_logging_value);
 	toml.get<bool> ("network_timeout", network_timeout_logging_value);
 	toml.get<bool> ("network_message", network_message_logging_value);
@@ -289,6 +293,16 @@ bool nano::logging::ledger_duplicate_logging () const
 bool nano::logging::vote_logging () const
 {
 	return vote_logging_value;
+}
+
+bool nano::logging::election_expiration_tally_logging () const
+{
+	return election_expiration_tally_logging_value;
+}
+
+bool nano::logging::election_fork_tally_logging () const
+{
+	return election_fork_tally_logging_value;
 }
 
 bool nano::logging::network_logging () const

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -45,6 +45,8 @@ public:
 	bool ledger_logging () const;
 	bool ledger_duplicate_logging () const;
 	bool vote_logging () const;
+	bool election_fork_tally_logging () const;
+	bool election_expiration_tally_logging () const;
 	bool network_logging () const;
 	bool network_timeout_logging () const;
 	bool network_message_logging () const;
@@ -70,6 +72,8 @@ public:
 	bool ledger_logging_value{ false };
 	bool ledger_duplicate_logging_value{ false };
 	bool vote_logging_value{ false };
+	bool election_fork_tally_logging_value{ false };
+	bool election_expiration_tally_logging_value{ false };
 	bool network_logging_value{ true };
 	bool network_timeout_logging_value{ false };
 	bool network_message_logging_value{ false };


### PR DESCRIPTION
One config for logging on expired elections, another for confirmed elections with multiple blocks, both default to false.

Since these are similar in output, added a prefix "Election expired" to differentiate them, e.g.:
```
[2020-Aug-19 16:02:50.492453]: Election expired
Vote tally for root E5E09C2BF257A50E8F5E823D9BAC1B70E15A6EA5EF06AC66B3F55B1AD689E1F0
Block D0170F94D063F4F06469EE8E3D7CCC126120C32948F7D56ED816A84CAEAF2521 weight 6652414849999999639484121623621009408
nano_1robotghjtaub18dmo1ihkzg9jjs53ukthxrpt5x7eie3pg7k4ahb5i1uw64 0 D0170F94D063F4F06469EE8E3D7CCC126120C32948F7D56ED816A84CAEAF2521
```