### PR TITLE
Temporarily pause the request loop in extreme situations

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -349,17 +349,17 @@ void nano::active_transactions::request_loop ()
 		}
 		lock.lock ();
 
-		// Account for the time spent in request_confirm by defining the wakeup point beforehand
-		const auto wakeup_l (std::chrono::steady_clock::now () + std::chrono::milliseconds (node.network_params.network.request_interval_ms));
+		const auto stamp_l = std::chrono::steady_clock::now ();
 
 		// frontiers_confirmation should be above update_active_multiplier to ensure new sorted roots are updated
 		frontiers_confirmation (lock);
 		update_active_multiplier (lock);
 		request_confirm (lock);
 
-		// Sleep until all broadcasts are done, plus the remaining loop time
 		if (!stopped)
 		{
+			constexpr auto min_sleep_l = std::chrono::milliseconds (250);
+			const auto wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
 			condition.wait_until (lock, wakeup_l, [&wakeup_l, &stopped = stopped] { return stopped || std::chrono::steady_clock::now () >= wakeup_l; });
 		}
 	}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -341,6 +341,14 @@ void nano::active_transactions::request_loop ()
 
 	while (!stopped && !node.flags.disable_request_loop)
 	{
+		// If many votes are queued, ensure at least the currently active ones finish processing
+		lock.unlock ();
+		if (node.vote_processor.half_full ())
+		{
+			node.vote_processor.flush_active ();
+		}
+		lock.lock ();
+
 		// Account for the time spent in request_confirm by defining the wakeup point beforehand
 		const auto wakeup_l (std::chrono::steady_clock::now () + std::chrono::milliseconds (node.network_params.network.request_interval_ms));
 

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -222,6 +222,15 @@ void nano::vote_processor::flush ()
 	}
 }
 
+void nano::vote_processor::flush_active ()
+{
+	nano::unique_lock<std::mutex> lock (mutex);
+	while (is_active)
+	{
+		condition.wait (lock);
+	}
+}
+
 size_t nano::vote_processor::size ()
 {
 	nano::lock_guard<std::mutex> guard (mutex);
@@ -232,6 +241,11 @@ bool nano::vote_processor::empty ()
 {
 	nano::lock_guard<std::mutex> guard (mutex);
 	return votes.empty ();
+}
+
+bool nano::vote_processor::half_full ()
+{
+	return size () >= max_votes / 2;
 }
 
 void nano::vote_processor::calculate_weights ()

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -40,8 +40,11 @@ public:
 	nano::vote_code vote_blocking (std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>, bool = false);
 	void verify_votes (std::deque<std::pair<std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>>> const &);
 	void flush ();
+	/** Block until the currently active processing cycle finishes */
+	void flush_active ();
 	size_t size ();
 	bool empty ();
+	bool half_full ();
 	void calculate_weights ();
 	void stop ();
 


### PR DESCRIPTION
- If the queue of votes is very large, pause until the currently active votes (not captured by `size()`) are processed
- Add a minimum sleep time of 250ms for extreme situations where the request loop takes too long

The goal is to not be doing extra requests when there is a high chance votes have already arrived and were not yet processed.