### PR TITLE
Relax mutex requirement for retrieving active difficulty

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -874,9 +874,9 @@ void nano::active_transactions::update_active_multiplier (nano::unique_lock<std:
 	debug_assert (difficulty >= node.network_params.network.publish_thresholds.entry);
 
 	trended_active_multiplier = avg_multiplier;
-	//lock_a.unlock ();
+	lock_a.unlock ();
 	node.observers.difficulty.notify (difficulty);
-	//lock_a.lock ();
+	lock_a.lock ();
 }
 
 uint64_t nano::active_transactions::active_difficulty ()

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -874,7 +874,9 @@ void nano::active_transactions::update_active_multiplier (nano::unique_lock<std:
 	debug_assert (difficulty >= node.network_params.network.publish_thresholds.entry);
 
 	trended_active_multiplier = avg_multiplier;
+	//lock_a.unlock ();
 	node.observers.difficulty.notify (difficulty);
+	//lock_a.lock ();
 }
 
 uint64_t nano::active_transactions::active_difficulty ()

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -904,8 +904,7 @@ uint64_t nano::active_transactions::limited_active_difficulty (nano::work_versio
 
 double nano::active_transactions::active_multiplier ()
 {
-	nano::lock_guard<std::mutex> lock (mutex);
-	return trended_active_multiplier;
+	return trended_active_multiplier.load ();
 }
 
 // List of active blocks in elections

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -199,7 +199,7 @@ public:
 	nano::node & node;
 	mutable std::mutex mutex;
 	boost::circular_buffer<double> multipliers_cb;
-	double trended_active_multiplier;
+	std::atomic<double> trended_active_multiplier;
 	size_t priority_cementable_frontiers_size ();
 	size_t priority_wallet_cementable_frontiers_size ();
 	boost::circular_buffer<double> difficulty_trend ();


### PR DESCRIPTION
By making `trended_active_multiplier` an atomic. This is important to not grab the active mutex in an I/O thread (telemetry_req handling). Thanks to @Srayman who ran a concurrency analyzer and discovered this.

Also added unlocking the mutex before calling the active difficulty update observers.