### PR TITLE
Lower request loop min_sleep for tests

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -358,7 +358,7 @@ void nano::active_transactions::request_loop ()
 
 		if (!stopped)
 		{
-			constexpr auto min_sleep_l = std::chrono::milliseconds (250);
+			const auto min_sleep_l = std::chrono::milliseconds (node.network_params.network.request_interval_ms / 2);
 			const auto wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
 			condition.wait_until (lock, wakeup_l, [&wakeup_l, &stopped = stopped] { return stopped || std::chrono::steady_clock::now () >= wakeup_l; });
 		}


### PR DESCRIPTION
Missed in #2900 as all tests are passing, but on closer inspection the ones making use of the request loop are slower.

Before:
```
[ RUN      ] active_transactions.confirm_active
[       OK ] active_transactions.confirm_active (1139 ms)
[ RUN      ] active_transactions.confirm_frontier
[       OK ] active_transactions.confirm_frontier (1062 ms)
[ RUN      ] active_transactions.keep_local
[       OK ] active_transactions.keep_local (2257 ms)
```

After:
```
[ RUN      ] active_transactions.confirm_active
[       OK ] active_transactions.confirm_active (555 ms)
[ RUN      ] active_transactions.confirm_frontier
[       OK ] active_transactions.confirm_frontier (442 ms)
[ RUN      ] active_transactions.keep_local
[       OK ] active_transactions.keep_local (598 ms)
```