### PR TITLE
Add support for defer_lock in nano::unique_lock

### DIFF
--- a/nano/core_test/locks.cpp
+++ b/nano/core_test/locks.cpp
@@ -178,4 +178,15 @@ TEST (locks, condition_variable_wait_until)
 	// Should be 1 report
 	ASSERT_EQ (num_matches (ss.str ()), 1);
 }
+
+TEST (locks, defer_lock)
+{
+	std::mutex mutex;
+	nano::unique_lock<std::mutex> lock (mutex, std::defer_lock);
+	ASSERT_FALSE (lock.owns_lock ());
+	ASSERT_TRUE (lock.try_lock ());
+	ASSERT_TRUE (lock.owns_lock ());
+	lock.unlock ();
+	ASSERT_FALSE (lock.owns_lock ());
+}
 #endif

--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -73,6 +73,12 @@ mut (std::addressof (mutex))
 }
 
 template <typename Mutex, typename U>
+unique_lock<Mutex, U>::unique_lock (Mutex & mutex, std::defer_lock_t) noexcept :
+mut (std::addressof (mutex))
+{
+}
+
+template <typename Mutex, typename U>
 void unique_lock<Mutex, U>::lock_impl ()
 {
 	timer.start ();

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -56,6 +56,7 @@ class unique_lock final
 public:
 	unique_lock () = default;
 	explicit unique_lock (Mutex & mutex_a);
+	unique_lock (Mutex & mutex_a, std::defer_lock_t) noexcept;
 	unique_lock (unique_lock && other) = delete;
 	unique_lock & operator= (unique_lock && other) noexcept;
 	~unique_lock () noexcept;


### PR DESCRIPTION
Needs NANO_TIMED_LOCKS CMake variable > 0 to test, otherwise it defaults to using std::unique_lock

This is necessary to build since #2901 but not caught by CI due to not using this developer-oriented feature