### PR TITLE
Recognize IPv4-mapped loopback addresses

### DIFF
--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -32,7 +32,8 @@ nano::rpc::~rpc ()
 void nano::rpc::start ()
 {
 	auto endpoint (boost::asio::ip::tcp::endpoint (boost::asio::ip::make_address_v6 (config.address), config.port));
-	if (!endpoint.address ().is_loopback () && config.enable_control)
+	bool const is_loopback = (endpoint.address ().is_loopback () || (endpoint.address ().to_v6 ().is_v4_mapped () && boost::asio::ip::make_address_v4 (boost::asio::ip::v4_mapped, endpoint.address ().to_v6 ()).is_loopback ()));
+	if (!is_loopback && config.enable_control)
 	{
 		auto warning = boost::str (boost::format ("WARNING: control-level RPCs are enabled on non-local address %1%, potentially allowing wallet access outside local computer") % endpoint.address ().to_string ());
 		std::cout << warning << std::endl;


### PR DESCRIPTION
Address `::ffff:127.0.0.1` and similar aren't currently detected as loopback, which issues the config warning about binding to a non-local address.

Tested `::1`, `::ffff:127.0.0.1`, `::ffff:0.0.0.0`, only the third one produced the warning.

Thanks to Jav on discord for the notice.