### PR TITLE
Don't delete crash dump files with --debug_generate_crash_report

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -828,18 +828,6 @@ int main (int argc, char * const * argv)
 						std::cerr << "Error: Check that addr2line is installed and that nano_node_crash_load_address_dump_*.txt files exist." << std::endl;
 						result = -1;
 					}
-					else
-					{
-						// Delete the crash dump files. The user won't care about them after this.
-						num = 0;
-						while (boost::filesystem::exists (boost::str (format % num)))
-						{
-							boost::filesystem::remove (boost::str (format % num));
-							++num;
-						}
-
-						boost::filesystem::remove ("nano_node_backtrace.dump");
-					}
 				}
 				else
 				{
@@ -847,6 +835,10 @@ int main (int argc, char * const * argv)
 					result = -1;
 				}
 #endif
+				if (result == 0)
+				{
+					std::cout << (boost::format ("%1% created") % crash_report_filename).str () << std::endl;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
When there is a segmentation fault we generate a `nano_node_backtrace.dump` file containing a stacktrace and on linux  a bunch of `nano_node_crash_load_address_dump_*.txt` files containing the load addresses for the node executable and all shared libraries. These are deleted after being used by `--debug_generate_crash_report`, which is maybe not what is desired so no longer deleting them. Also added some output stating what file is generated.