### PR TITLE
Move channel drop policy off of nano::socket and remove channel concurrency value as redundant

### DIFF
--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -18,19 +18,11 @@ TEST (socket, drop_policy)
 
 	std::vector<std::shared_ptr<nano::socket>> connections;
 
-	// We're going to write twice the queue size + 1, and the server isn't reading
-	// The total number of drops should thus be 1 (the socket allows doubling the queue size for no_socket_drop)
-	size_t max_write_queue_size = 0;
-	{
-		auto client_dummy (std::make_shared<nano::socket> (*node, boost::none, nano::socket::concurrency::multi_writer));
-		max_write_queue_size = client_dummy->get_max_write_queue_size ();
-	}
-
 	auto func = [&](size_t total_message_count, nano::buffer_drop_policy drop_policy) {
 		auto server_port (nano::get_available_port ());
-		boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), server_port);
+		boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::any (), server_port);
 
-		auto server_socket (std::make_shared<nano::server_socket> (*node, endpoint, 1, nano::socket::concurrency::multi_writer));
+		auto server_socket = std::make_shared<nano::server_socket> (*node, endpoint, 1);
 		boost::system::error_code ec;
 		server_socket->start (ec);
 		ASSERT_FALSE (ec);
@@ -41,29 +33,34 @@ TEST (socket, drop_policy)
 			return true;
 		});
 
-		auto client (std::make_shared<nano::socket> (*node, boost::none, nano::socket::concurrency::multi_writer));
+		auto client = std::make_shared<nano::socket> (*node, boost::none);
+		nano::transport::channel_tcp channel{ *node, client };
 		nano::util::counted_completion write_completion (total_message_count);
 
-		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), server_port),
-		[client, total_message_count, node, &write_completion, &drop_policy](boost::system::error_code const & ec_a) {
+		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), server_port),
+		[&channel, total_message_count, node, &write_completion, &drop_policy, client](boost::system::error_code const & ec_a) mutable {
 			for (int i = 0; i < total_message_count; i++)
 			{
 				std::vector<uint8_t> buff (1);
-				client->async_write (
-				nano::shared_const_buffer (std::move (buff)), [&write_completion](boost::system::error_code const & ec, size_t size_a) {
+				channel.send_buffer (
+				nano::shared_const_buffer (std::move (buff)), [&write_completion, client](boost::system::error_code const & ec, size_t size_a) mutable {
+					client.reset ();
 					write_completion.increment ();
 				},
 				drop_policy);
 			}
 		});
-		write_completion.await_count_for (std::chrono::seconds (5));
+		ASSERT_FALSE (write_completion.await_count_for (std::chrono::seconds (5)));
+		ASSERT_EQ (1, client.use_count ());
 	};
 
-	func (max_write_queue_size * 2 + 1, nano::buffer_drop_policy::no_socket_drop);
+	// We're going to write twice the queue size + 1, and the server isn't reading
+	// The total number of drops should thus be 1 (the socket allows doubling the queue size for no_socket_drop)
+	func (nano::socket::queue_size_max * 2 + 1, nano::buffer_drop_policy::no_socket_drop);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_no_socket_drop, nano::stat::dir::out));
 	ASSERT_EQ (0, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out));
 
-	func (max_write_queue_size + 1, nano::buffer_drop_policy::limiter);
+	func (nano::socket::queue_size_max + 1, nano::buffer_drop_policy::limiter);
 	// The stats are accumulated from before
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_no_socket_drop, nano::stat::dir::out));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out));
@@ -123,7 +120,7 @@ TEST (socket, concurrent_writes)
 
 	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), 25000);
 
-	auto server_socket (std::make_shared<nano::server_socket> (*node, endpoint, max_connections, nano::socket::concurrency::multi_writer));
+	auto server_socket = std::make_shared<nano::server_socket> (*node, endpoint, max_connections);
 	boost::system::error_code ec;
 	server_socket->start (ec);
 	ASSERT_FALSE (ec);
@@ -148,7 +145,7 @@ TEST (socket, concurrent_writes)
 	std::vector<std::shared_ptr<nano::socket>> clients;
 	for (unsigned i = 0; i < client_count; i++)
 	{
-		auto client (std::make_shared<nano::socket> (*node, boost::none, nano::socket::concurrency::multi_writer));
+		auto client = std::make_shared<nano::socket> (*node, boost::none);
 		clients.push_back (client);
 		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), 25000),
 		[&connection_count_completion](boost::system::error_code const & ec_a) {

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -8,11 +8,10 @@
 
 #include <limits>
 
-nano::socket::socket (nano::node & node_a, boost::optional<std::chrono::seconds> io_timeout_a, nano::socket::concurrency concurrency_a) :
+nano::socket::socket (nano::node & node_a, boost::optional<std::chrono::seconds> io_timeout_a) :
 strand{ node_a.io_ctx.get_executor () },
 tcp_socket{ node_a.io_ctx },
 node{ node_a },
-writer_concurrency{ concurrency_a },
 next_deadline{ std::numeric_limits<uint64_t>::max () },
 last_completion_time{ 0 },
 io_timeout{ io_timeout_a }
@@ -69,115 +68,41 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> buffer_a, s
 	}
 }
 
-void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
+void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a)
 {
-	auto this_l (shared_from_this ());
 	if (!closed)
 	{
-		if (writer_concurrency == nano::socket::concurrency::multi_writer)
-		{
-			boost::asio::post (strand, boost::asio::bind_executor (strand, [buffer_a, callback_a, this_l, drop_policy_a]() {
-				if (!this_l->closed)
-				{
-					bool write_in_progress = !this_l->send_queue.empty ();
-					auto queue_size = this_l->send_queue.size ();
-					if (queue_size < this_l->queue_size_max || (drop_policy_a == nano::buffer_drop_policy::no_socket_drop && queue_size < (this_l->queue_size_max * 2)))
-					{
-						this_l->send_queue.emplace_back (nano::socket::queue_item{ buffer_a, callback_a });
-					}
-					else
-					{
-						if (drop_policy_a == nano::buffer_drop_policy::no_socket_drop)
-						{
-							this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_write_no_socket_drop, nano::stat::dir::out);
-						}
-						else
-						{
-							this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out);
-						}
-
-						if (callback_a)
-						{
-							callback_a (boost::system::errc::make_error_code (boost::system::errc::no_buffer_space), 0);
-						}
-					}
-					if (!write_in_progress)
-					{
-						this_l->write_queued_messages ();
-					}
-				}
-				else
-				{
+		++queue_size;
+		boost::asio::post (strand, boost::asio::bind_executor (strand, [buffer_a, callback_a, this_l = shared_from_this ()]() {
+			if (!this_l->closed)
+			{
+				this_l->start_timer ();
+				nano::async_write (this_l->tcp_socket, buffer_a,
+				boost::asio::bind_executor (this_l->strand,
+				[buffer_a, callback_a, this_l](boost::system::error_code ec, std::size_t size_a) {
+					--this_l->queue_size;
+					this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
+					this_l->stop_timer ();
 					if (callback_a)
 					{
-						callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
+						callback_a (ec, size_a);
 					}
-				}
-			}));
-		}
-		else
-		{
-			start_timer ();
-			nano::async_write (tcp_socket, buffer_a,
-			boost::asio::bind_executor (strand,
-			[this_l, callback_a](boost::system::error_code const & ec, size_t size_a) {
-				this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
-				this_l->stop_timer ();
+				}));
+			}
+			else
+			{
 				if (callback_a)
 				{
-					callback_a (ec, size_a);
+					callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 				}
-			}));
-		}
+			}
+		}));
 	}
 	else if (callback_a)
 	{
 		node.background ([callback_a]() {
 			callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 		});
-	}
-}
-
-void nano::socket::write_queued_messages ()
-{
-	if (!closed)
-	{
-		std::weak_ptr<nano::socket> this_w (shared_from_this ());
-		auto msg (send_queue.front ());
-		start_timer ();
-		nano::async_write (tcp_socket, msg.buffer,
-		boost::asio::bind_executor (strand,
-		[msg, this_w](boost::system::error_code ec, std::size_t size_a) {
-			if (auto this_l = this_w.lock ())
-			{
-				this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
-
-				this_l->stop_timer ();
-
-				if (!this_l->closed)
-				{
-					if (msg.callback)
-					{
-						msg.callback (ec, size_a);
-					}
-
-					this_l->send_queue.pop_front ();
-					if (!ec && !this_l->send_queue.empty ())
-					{
-						this_l->write_queued_messages ();
-					}
-					else if (this_l->send_queue.empty ())
-					{
-						// Idle TCP realtime client socket after writes
-						this_l->start_timer (this_l->node.network_params.node.idle_timeout);
-					}
-				}
-				else if (msg.callback)
-				{
-					msg.callback (ec, size_a);
-				}
-			}
-		}));
 	}
 }
 
@@ -247,21 +172,6 @@ void nano::socket::close ()
 	}));
 }
 
-void nano::socket::flush_send_queue_callbacks ()
-{
-	while (!send_queue.empty ())
-	{
-		auto & item = send_queue.front ();
-		if (item.callback)
-		{
-			node.background ([callback = std::move (item.callback)]() {
-				callback (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
-			});
-		}
-		send_queue.pop_front ();
-	}
-}
-
 // This must be called from a strand or the destructor
 void nano::socket::close_internal ()
 {
@@ -273,7 +183,6 @@ void nano::socket::close_internal ()
 		// Ignore error code for shutdown as it is best-effort
 		tcp_socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both, ec);
 		tcp_socket.close (ec);
-		flush_send_queue_callbacks ();
 		if (ec)
 		{
 			node.logger.try_log ("Failed to close socket gracefully: ", ec.message ());
@@ -287,18 +196,11 @@ nano::tcp_endpoint nano::socket::remote_endpoint () const
 	return remote;
 }
 
-void nano::socket::set_writer_concurrency (concurrency writer_concurrency_a)
-{
-	writer_concurrency = writer_concurrency_a;
-}
-
-size_t nano::socket::get_max_write_queue_size () const
-{
-	return queue_size_max;
-}
-
-nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a, nano::socket::concurrency concurrency_a) :
-socket (node_a, std::chrono::seconds::max (), concurrency_a), acceptor (node_a.io_ctx), local (local_a), max_inbound_connections (max_connections_a), concurrency_new_connections (concurrency_a)
+nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a) :
+socket{ node_a, std::chrono::seconds::max () },
+acceptor{ node_a.io_ctx },
+local{ local_a },
+max_inbound_connections{ max_connections_a }
 {
 }
 
@@ -341,7 +243,7 @@ void nano::server_socket::on_connection (std::function<bool(std::shared_ptr<nano
 			if (this_l->connections.size () < this_l->max_inbound_connections)
 			{
 				// Prepare new connection
-				auto new_connection (std::make_shared<nano::socket> (this_l->node, boost::none, this_l->concurrency_new_connections));
+				auto new_connection = std::make_shared<nano::socket> (this_l->node, boost::none);
 				this_l->acceptor.async_accept (new_connection->tcp_socket, new_connection->remote,
 				boost::asio::bind_executor (this_l->strand,
 				[this_l, new_connection, callback_a](boost::system::error_code const & ec_a) {

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -34,28 +34,16 @@ class socket : public std::enable_shared_from_this<nano::socket>
 
 public:
 	/**
-	 * If multi_writer is used, overlapping writes are allowed, including from multiple threads.
-	 * For bootstrapping, reading and writing alternates on a socket, thus single_writer
-	 * should be used to avoid queueing overhead. For live messages, multiple threads may want
-	 * to concurrenctly queue messages on the same socket, thus multi_writer should be used.
-	 */
-	enum class concurrency
-	{
-		single_writer,
-		multi_writer
-	};
-
-	/**
 	 * Constructor
 	 * @param node Owning node
 	 * @param io_timeout If tcp async operation is not completed within the timeout, the socket is closed. If not set, the tcp_io_timeout config option is used.
 	 * @param concurrency write concurrency
 	 */
-	explicit socket (nano::node & node, boost::optional<std::chrono::seconds> io_timeout = boost::none, concurrency = concurrency::single_writer);
+	explicit socket (nano::node & node, boost::optional<std::chrono::seconds> io_timeout = boost::none);
 	virtual ~socket ();
 	void async_connect (boost::asio::ip::tcp::endpoint const &, std::function<void(boost::system::error_code const &)>);
 	void async_read (std::shared_ptr<std::vector<uint8_t>>, size_t, std::function<void(boost::system::error_code const &, size_t)>);
-	void async_write (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
+	void async_write (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr);
 
 	void close ();
 	boost::asio::ip::tcp::endpoint remote_endpoint () const;
@@ -64,10 +52,14 @@ public:
 	/** This can be called to change the maximum idle time, e.g. based on the type of traffic detected. */
 	void set_timeout (std::chrono::seconds io_timeout_a);
 	void start_timer (std::chrono::seconds deadline_a);
-	/** Change write concurrent */
-	void set_writer_concurrency (concurrency writer_concurrency_a);
-	/** Returns the maximum number of buffers in the write queue */
-	size_t get_max_write_queue_size () const;
+	bool max () const
+	{
+		return queue_size >= queue_size_max;
+	}
+	bool full () const
+	{
+		return queue_size >= queue_size_max * 2;
+	}
 
 protected:
 	/** Holds the buffer and callback for queued writes */
@@ -84,25 +76,23 @@ protected:
 
 	/** The other end of the connection */
 	boost::asio::ip::tcp::endpoint remote;
-	/** Send queue, protected by always being accessed in the strand */
-	std::deque<queue_item> send_queue;
-	std::atomic<concurrency> writer_concurrency;
 
 	std::atomic<uint64_t> next_deadline;
 	std::atomic<uint64_t> last_completion_time;
 	std::atomic<bool> timed_out{ false };
 	boost::optional<std::chrono::seconds> io_timeout;
-	size_t const queue_size_max = 128;
+	std::atomic<size_t> queue_size{ 0 };
 
 	/** Set by close() - completion handlers must check this. This is more reliable than checking
 	 error codes as the OS may have already completed the async operation. */
 	std::atomic<bool> closed{ false };
 	void close_internal ();
-	void write_queued_messages ();
 	void start_timer ();
 	void stop_timer ();
 	void checkup ();
-	void flush_send_queue_callbacks ();
+
+public:
+	static size_t constexpr queue_size_max = 128;
 };
 
 /** Socket class for TCP servers */
@@ -116,7 +106,7 @@ public:
 	 * @param max_connections_a Maximum number of concurrent connections
 	 * @param concurrency_a Write concurrency for new connections
 	 */
-	explicit server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a, concurrency concurrency_a = concurrency::single_writer);
+	explicit server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a);
 	/**Start accepting new connections */
 	void start (boost::system::error_code &);
 	/** Stop accepting new connections */
@@ -133,8 +123,6 @@ private:
 	boost::asio::ip::tcp::acceptor acceptor;
 	boost::asio::ip::tcp::endpoint local;
 	size_t max_inbound_connections;
-	/** Concurrency setting for new connections */
-	concurrency concurrency_new_connections;
 	void evict_dead_connections ();
 };
 }

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -41,7 +41,7 @@ namespace transport
 		virtual ~channel () = default;
 		virtual size_t hash_code () const = 0;
 		virtual bool operator== (nano::transport::channel const &) const = 0;
-		void send (nano::message const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter);
+		void send (nano::message const & message_a, std::function<void(boost::system::error_code const &, size_t)> const & callback_a = nullptr, nano::buffer_drop_policy policy_a = nano::buffer_drop_policy::limiter);
 		virtual void send_buffer (nano::shared_const_buffer const &, std::function<void(boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) = 0;
 		virtual std::string to_string () const = 0;
 		virtual nano::endpoint get_endpoint () const = 0;


### PR DESCRIPTION
This commit moves the responsibility for limiting writes to a socket from nano::socket on to nano::channel_tcp. The intended behavior of nano::socket is to be a thin wrapper around a raw tcp socket with the addition of queueing on a strand plus statistics gathering.
The drop policy is part of the channel abstraction which varies depending on the channel used. channel_udp uses the operating system to drop writes it can't service and channel_tcp needs to track the number of outstanding writes to determine what should be dropped.
The drop policy was being passed all the way through to nano::socket, punching a hole through the nano::socket abstraction.

This commit also removes the concurrency enum as redundant. All socket operations were being serialized through the strand implicitly and the only other function of having a non-concurrent channel was to bypass the socket rate limiter. Non-concurrent users of channel_tcp should manage their own rate limiting if they don't want their buffers dropped. The only users of non-concurrent channels appear to be bootstrapping and this limitation already appears to be respected.

This also removes the need for queueing the buffer and callback in a separate container as they're already captured in objects to be executed on the socket's strand. This removes the need to flush the buffers on socket close.