### PR TITLE
[RocksDB] Reduce number of blocks processed in batch by block processor

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -72,11 +72,20 @@ TEST (node_DeathTest, DISABLED_readonly_block_store_not_exist)
 TEST (node_DeathTest, readonly_block_store_not_exist)
 #endif
 {
-	// For ASSERT_DEATH_IF_SUPPORTED
-	testing::FLAGS_gtest_death_test_style = "threadsafe";
-
 	// This is a read-only node with no ledger file
-	ASSERT_EXIT (nano::inactive_node (nano::unique_path (), nano::inactive_node_flag_defaults ()), ::testing::ExitedWithCode (1), "");
+#if NANO_ROCKSDB
+	if (nano::using_rocksdb_in_tests ())
+	{
+		nano::inactive_node node (nano::unique_path (), nano::inactive_node_flag_defaults ());
+		ASSERT_TRUE (node.node->init_error ());
+	}
+	else
+	{
+		ASSERT_EXIT (nano::inactive_node node (nano::unique_path (), nano::inactive_node_flag_defaults ()), ::testing::ExitedWithCode (1), "");
+	}
+#else
+	ASSERT_EXIT (nano::inactive_node node (nano::unique_path (), nano::inactive_node_flag_defaults ()), ::testing::ExitedWithCode (1), "");
+#endif
 }
 
 TEST (node, password_fanout)
@@ -3358,6 +3367,7 @@ TEST (node, block_processor_full)
 {
 	nano::system system;
 	nano::node_flags node_flags;
+	node_flags.force_use_write_database_queue = true;
 	node_flags.block_processor_full_size = 3;
 	auto & node = *system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
 	nano::genesis genesis;
@@ -3405,6 +3415,7 @@ TEST (node, block_processor_half_full)
 	nano::system system;
 	nano::node_flags node_flags;
 	node_flags.block_processor_full_size = 6;
+	node_flags.force_use_write_database_queue = true;
 	auto & node = *system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
 	nano::genesis genesis;
 	nano::state_block_builder builder;

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -220,7 +220,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 	timer_l.start ();
 	// Processing blocks
 	unsigned number_of_blocks_processed (0), number_of_forced_processed (0);
-	while ((!blocks.empty () || !forced.empty ()) && (timer_l.before_deadline (node.config.block_processor_batch_max_time) || (number_of_blocks_processed < node.flags.block_processor_batch_size)) && !awaiting_write)
+	while ((!blocks.empty () || !forced.empty ()) && (timer_l.before_deadline (node.config.block_processor_batch_max_time) || (number_of_blocks_processed < node.flags.block_processor_batch_size)) && !awaiting_write && number_of_blocks_processed < node.store.max_block_write_batch_num ())
 	{
 		if ((blocks.size () + state_block_signature_verification.size () + forced.size () > 64) && should_log ())
 		{

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -1153,5 +1153,10 @@ bool nano::mdb_store::upgrade_counters::are_equal () const
 	return (before_v0 == after_v0) && (before_v1 == after_v1);
 }
 
+unsigned nano::mdb_store::max_block_write_batch_num () const
+{
+	return std::numeric_limits<unsigned>::max ();
+}
+
 // Explicitly instantiate
 template class nano::block_store_partial<MDB_val, nano::mdb_store>;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -51,6 +51,8 @@ public:
 
 	void serialize_memory_stats (boost::property_tree::ptree &) override;
 
+	unsigned max_block_write_batch_num () const override;
+
 private:
 	nano::logger_mt & logger;
 	bool error{ false };

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -72,6 +72,7 @@ private:
 	std::shared_ptr<rocksdb::TableFactory> small_table_factory;
 	std::unordered_map<nano::tables, std::mutex> write_lock_mutexes;
 	nano::rocksdb_config rocksdb_config;
+	unsigned const max_block_write_batch_num_m;
 
 	class tombstone_info
 	{

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -46,6 +46,8 @@ public:
 	bool copy_db (boost::filesystem::path const & destination) override;
 	void rebuild_db (nano::write_transaction const & transaction_a) override;
 
+	unsigned max_block_write_batch_num () const override;
+
 	template <typename Key, typename Value>
 	nano::store_iterator<Key, Value> make_iterator (nano::transaction const & transaction_a, tables table_a) const
 	{
@@ -110,6 +112,8 @@ private:
 	std::unordered_map<const char *, nano::tables> create_cf_name_table_map () const;
 
 	std::vector<rocksdb::ColumnFamilyDescriptor> create_column_families ();
+	unsigned long long base_memtable_size_bytes () const;
+	unsigned long long blocks_memtable_size_bytes () const;
 
 	constexpr static int base_memtable_size = 16;
 	constexpr static int base_block_cache_size = 8;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -675,9 +675,9 @@ public:
 	virtual bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
 	virtual void confirmation_height_del (nano::write_transaction const & transaction_a, nano::account const & account_a) = 0;
 	virtual uint64_t confirmation_height_count (nano::transaction const & transaction_a) = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const = 0;
 
 	virtual nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> blocks_begin (nano::transaction const & transaction_a) const = 0;
 	virtual nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> blocks_end () const = 0;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -685,6 +685,8 @@ public:
 	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 	virtual std::mutex & get_cache_mutex () = 0;
 
+	virtual unsigned max_block_write_batch_num () const = 0;
+
 	virtual bool copy_db (boost::filesystem::path const & destination) = 0;
 	virtual void rebuild_db (nano::write_transaction const & transaction_a) = 0;
 

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -331,7 +331,7 @@ public:
 		return nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> (nullptr);
 	}
 
-	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () override
+	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const override
 	{
 		return nano::store_iterator<nano::account, nano::confirmation_height_info> (nullptr);
 	}
@@ -686,12 +686,12 @@ public:
 		return make_iterator<nano::endpoint_key, nano::no_value> (transaction_a, tables::peers);
 	}
 
-	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) override
+	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const override
 	{
 		return make_iterator<nano::account, nano::confirmation_height_info> (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a));
 	}
 
-	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) override
+	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const override
 	{
 		return make_iterator<nano::account, nano::confirmation_height_info> (transaction_a, tables::confirmation_height);
 	}


### PR DESCRIPTION
I got a write transaction commit error during block processing with RocksDB:
>Transaction could not check for conflicts for operation at SequenceNumber 4308405 as the MemTable only contains changes newer than SequenceNumber 4340971. Increasing the value of the max_write_buffer_number_to_maintain option could reduce the frequency of this error.

That option is deprecated and don't really want to increase the number of memtables either (currently at 2). Reducing the amount of blocks processed seems to resolve this, we currently do 5s by default, and even more with `--fast_bootstrap`.

Tested a full bootstrap on beta with `--fast_bootstrap`, took 40 minutes to get all 3.5M checked blocks, and live took me 7 hours.
Bugs: Fix incorrect `debug_assert` comparison and some failing tests on RocksDB