### PR TITLE
Fix nano::timer tick update after stopping

### DIFF
--- a/nano/core_test/timer.cpp
+++ b/nano/core_test/timer.cpp
@@ -72,3 +72,13 @@ TEST (timer, cummulative_child)
 
 	ASSERT_GT (t1.stop (), 100ms);
 }
+
+TEST (timer, stop)
+{
+	using namespace std::chrono_literals;
+	nano::timer<std::chrono::milliseconds> t1 (nano::timer_state::started);
+	std::this_thread::sleep_for (50ms);
+	auto stop_value = t1.stop ();
+	std::this_thread::sleep_for (50ms);
+	ASSERT_EQ (t1.value (), stop_value);
+}

--- a/nano/lib/timer.cpp
+++ b/nano/lib/timer.cpp
@@ -134,7 +134,10 @@ UNIT nano::timer<UNIT, CLOCK>::stop ()
 template <typename UNIT, typename CLOCK>
 UNIT nano::timer<UNIT, CLOCK>::value ()
 {
-	update_ticks ();
+	if (state != nano::timer_state::stopped)
+	{
+		update_ticks ();
+	}
 	return ticks;
 }
 


### PR DESCRIPTION
Affects timing logging of signatures, block and vote processing.

Thanks @Srayman for the report.