### PR TITLE
Fix core_test build with Boost 1.74

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -109,7 +109,7 @@ private:
 	void write_response ()
 	{
 		auto this_l = shared_from_this ();
-		response.set (http::field::content_length, response.body ().size ());
+		response.content_length (response.body ().size ());
 		http::async_write (socket, response, [this_l](beast::error_code ec, std::size_t /*size_a*/) {
 			this_l->socket.shutdown (tcp::socket::shutdown_send, ec);
 			this_l->socket.close ();


### PR DESCRIPTION
Sample: https://www.boost.org/doc/libs/1_74_0/libs/beast/example/doc/http_examples.hpp
Since at least: https://www.boost.org/doc/libs/1_66_0/libs/beast/doc/html/beast/ref/boost__beast__http__message/content_length.html