### PR TITLE
Convert nano::network periodic functions to use a steady timer instead of callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ set(Boost_USE_MULTITHREADED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package (Boost 1.69.0 REQUIRED COMPONENTS filesystem log log_setup thread program_options system)
+find_package (Boost 1.69.0 REQUIRED COMPONENTS coroutine filesystem log log_setup thread program_options system)
 
 if (NANO_ROCKSDB)
 	find_package (RocksDB REQUIRED)
@@ -426,8 +426,6 @@ if (NANO_FUZZER_TEST)
 endif ()
 
 if (NANO_TEST OR RAIBLOCKS_TEST)
-	find_package (Boost 1.69.0 REQUIRED COMPONENTS coroutine)
-
 	if(WIN32)
 		if(MSVC_VERSION)
 			if(MSVC_VERSION GREATER_EQUAL 1910)

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -158,6 +158,7 @@ target_link_libraries (node
 	libminiupnpc-static
 	argon2
 	lmdb
+	Boost::coroutine
 	Boost::filesystem
 	Boost::log_setup
 	Boost::log

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -754,7 +754,7 @@ void nano::network::ongoing_syn_cookie_cleanup ()
 		boost::system::error_code ec;
 		while (!stopped && !ec)
 		{
-			syn_cookies.purge (std::chrono::steady_clock::now () - nano::transport::syn_cookie_cutoff);
+			this->syn_cookies.purge (std::chrono::steady_clock::now () - nano::transport::syn_cookie_cutoff);
 			cookie_timer.expires_from_now (nano::transport::syn_cookie_cutoff * 2);
 			cookie_timer.async_wait (yield[ec]);
 		}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -5,6 +5,7 @@
 #include <nano/node/telemetry.hpp>
 #include <nano/secure/buffer.hpp>
 
+#include <boost/asio/steady_timer.hpp>
 #include <boost/format.hpp>
 #include <boost/variant/get.hpp>
 
@@ -21,7 +22,10 @@ publish_filter (256 * 1024),
 udp_channels (node_a, port_a),
 tcp_channels (node_a),
 port (port_a),
-disconnect_observer ([]() {})
+disconnect_observer ([]() {}),
+cleanup_timer{ node_a.io_ctx },
+cookie_timer{ node_a.io_ctx },
+keepalive_timer{ node_a.io_ctx }
 {
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
@@ -132,6 +136,9 @@ void nano::network::stop ()
 		{
 			thread.join ();
 		}
+		cleanup_timer.cancel ();
+		cookie_timer.cancel ();
+		keepalive_timer.cancel ();
 	}
 }
 
@@ -727,38 +734,47 @@ void nano::network::cleanup (std::chrono::steady_clock::time_point const & cutof
 
 void nano::network::ongoing_cleanup ()
 {
-	cleanup (std::chrono::steady_clock::now () - node.network_params.node.cutoff);
-	std::weak_ptr<nano::node> node_w (node.shared ());
-	node.alarm.add (std::chrono::steady_clock::now () + node.network_params.node.period, [node_w]() {
-		if (auto node_l = node_w.lock ())
+	node.spawn (
+	[this](boost::asio::yield_context yield) {
+		boost::system::error_code ec;
+		while (!stopped && !ec)
 		{
-			node_l->network.ongoing_cleanup ();
+			cleanup (std::chrono::steady_clock::now () - node.network_params.node.cutoff);
+			cleanup_timer.expires_from_now (node.network_params.node.period);
+			cleanup_timer.async_wait (yield[ec]);
 		}
+		debug_assert (stopped || ec == boost::asio::error::operation_aborted);
 	});
 }
 
 void nano::network::ongoing_syn_cookie_cleanup ()
 {
-	syn_cookies.purge (std::chrono::steady_clock::now () - nano::transport::syn_cookie_cutoff);
-	std::weak_ptr<nano::node> node_w (node.shared ());
-	node.alarm.add (std::chrono::steady_clock::now () + (nano::transport::syn_cookie_cutoff * 2), [node_w]() {
-		if (auto node_l = node_w.lock ())
+	node.spawn (
+	[this](boost::asio::yield_context yield) {
+		boost::system::error_code ec;
+		while (!stopped && !ec)
 		{
-			node_l->network.ongoing_syn_cookie_cleanup ();
+			syn_cookies.purge (std::chrono::steady_clock::now () - nano::transport::syn_cookie_cutoff);
+			cookie_timer.expires_from_now (nano::transport::syn_cookie_cutoff * 2);
+			cookie_timer.async_wait (yield[ec]);
 		}
+		debug_assert (stopped || ec == boost::asio::error::operation_aborted);
 	});
 }
 
 void nano::network::ongoing_keepalive ()
 {
-	flood_keepalive (0.75f);
-	flood_keepalive_self (0.25f);
-	std::weak_ptr<nano::node> node_w (node.shared ());
-	node.alarm.add (std::chrono::steady_clock::now () + node.network_params.node.half_period, [node_w]() {
-		if (auto node_l = node_w.lock ())
+	node.spawn (
+	[this](boost::asio::yield_context yield) {
+		boost::system::error_code ec;
+		while (!stopped && !ec)
 		{
-			node_l->network.ongoing_keepalive ();
+			flood_keepalive (0.75f);
+			flood_keepalive_self (0.25f);
+			keepalive_timer.expires_from_now (node.network_params.node.half_period);
+			keepalive_timer.async_wait (yield[ec]);
 		}
+		debug_assert (stopped || ec == boost::asio::error::operation_aborted);
 	});
 }
 

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -195,6 +195,9 @@ public:
 	// Called when a new channel is observed
 	std::function<void(std::shared_ptr<nano::transport::channel>)> channel_observer;
 	std::atomic<bool> stopped{ false };
+	boost::asio::steady_timer cleanup_timer;
+	boost::asio::steady_timer cookie_timer;
+	boost::asio::steady_timer keepalive_timer;
 	static unsigned const broadcast_interval_ms = 10;
 	static size_t const buffer_size = 512;
 	static size_t const confirm_req_hashes_max = 7;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <nano/boost/asio/spawn.hpp>
 #include <nano/lib/alarm.hpp>
+#include <nano/lib/config.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/lib/worker.hpp>
@@ -29,7 +31,6 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/utility.hpp>
 
-#include <boost/asio/spawn.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -99,12 +100,7 @@ public:
 	template <typename... Params>
 	void spawn (Params... args)
 	{
-		boost::coroutines::attributes attributes (boost::coroutines::stack_allocator::traits_type::default_size ());
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-		attributes = boost::coroutines::attributes (128 * 1024);
-#endif
-#endif
+		boost::coroutines::attributes attributes{ boost::coroutines::stack_allocator::traits_type::default_size () * (is_sanitizer_build ? 2 : 1) };
 		boost::asio::spawn (io_ctx, std::forward<Params> (args)..., attributes);
 	}
 	bool copy_with_compaction (boost::filesystem::path const &);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -29,6 +29,7 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/utility.hpp>
 
+#include <boost/asio/spawn.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -94,6 +95,17 @@ public:
 	void background (T action_a)
 	{
 		alarm.io_ctx.post (action_a);
+	}
+	template <typename... Params>
+	void spawn (Params... args)
+	{
+		boost::coroutines::attributes attributes (boost::coroutines::stack_allocator::traits_type::default_size ());
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+		attributes = boost::coroutines::attributes (128 * 1024);
+#endif
+#endif
+		boost::asio::spawn (io_ctx, std::forward<Params> (args)..., attributes);
 	}
 	bool copy_with_compaction (boost::filesystem::path const &);
 	void keepalive (std::string const &, uint16_t);


### PR DESCRIPTION
This change pulls in the boost coroutine library into the node.

Additionally, it rewrites the ongoing_cleanup function in nano::network in terms of steady timers, which is easier to reason around instead of callback loops through nano::alarm.