### PR TITLE
[RocksDB] assert compare data and not the address on iterator operator==

### DIFF
--- a/nano/node/rocksdb/rocksdb_iterator.hpp
+++ b/nano/node/rocksdb/rocksdb_iterator.hpp
@@ -125,7 +125,7 @@ public:
 
 		auto result (std::memcmp (current.first.data (), other_a->current.first.data (), current.first.size ()) == 0);
 		debug_assert (!result || (current.first.size () == other_a->current.first.size ()));
-		debug_assert (!result || (current.second.data () == other_a->current.second.data ()));
+		debug_assert (!result || std::memcmp (current.second.data (), other_a->current.second.data (), current.second.size ()) == 0);
 		debug_assert (!result || (current.second.size () == other_a->current.second.size ()));
 		return result;
 	}


### PR DESCRIPTION
This solves a crash on startup when populating the ledger cache.