### PR TITLE
Use multiple threads in CLI debug_account_versions and debug_unconfirmed_frontiers

### DIFF
--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -166,6 +166,8 @@ template <class T>
 class locked
 {
 public:
+	using value_type = T;
+
 	template <typename... Args>
 	locked (Args &&... args) :
 	obj (std::forward<Args> (args)...)

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1862,7 +1862,8 @@ int main (int argc, char * const * argv)
 			// Cache the accounts in a collection to make searching quicker against unchecked keys. Group by epoch
 			nano::locked<std::vector<boost::unordered_set<nano::account>>> opened_account_versions_shared (epoch_count);
 			using opened_account_versions_t = decltype (opened_account_versions_shared)::value_type;
-			node->store.latest_for_each_par ([&opened_account_versions_shared, epoch_count](nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
+			node->store.latest_for_each_par (
+			[&opened_account_versions_shared, epoch_count](nano::read_transaction const & /*unused*/, nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
 				// First cache locally
 				opened_account_versions_t opened_account_versions_l (epoch_count);
 				for (; i != n; ++i)
@@ -1898,7 +1899,8 @@ int main (int argc, char * const * argv)
 			// Iterate all pending blocks and collect the lowest version for each unopened account
 			nano::locked<boost::unordered_map<nano::account, std::underlying_type_t<nano::epoch>>> unopened_highest_pending_shared;
 			using unopened_highest_pending_t = decltype (unopened_highest_pending_shared)::value_type;
-			node->store.pending_for_each_par ([&unopened_highest_pending_shared, &opened_accounts](nano::store_iterator<nano::pending_key, nano::pending_info> i, nano::store_iterator<nano::pending_key, nano::pending_info> n) {
+			node->store.pending_for_each_par (
+			[&unopened_highest_pending_shared, &opened_accounts](nano::read_transaction const & /*unused*/, nano::store_iterator<nano::pending_key, nano::pending_info> i, nano::store_iterator<nano::pending_key, nano::pending_info> n) {
 				// First cache locally
 				unopened_highest_pending_t unopened_highest_pending_l;
 				for (; i != n; ++i)

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1861,9 +1861,10 @@ int main (int argc, char * const * argv)
 			auto const epoch_count = nano::normalized_epoch (nano::epoch::max) + static_cast<std::underlying_type<nano::epoch>::type> (1);
 			// Cache the accounts in a collection to make searching quicker against unchecked keys. Group by epoch
 			nano::locked<std::vector<boost::unordered_set<nano::account>>> opened_account_versions_shared (epoch_count);
+			using opened_account_versions_t = decltype (opened_account_versions_shared)::value_type;
 			node->store.latest_for_each_par ([&opened_account_versions_shared, epoch_count](nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
 				// First cache locally
-				std::vector<boost::unordered_set<nano::account>> opened_account_versions_l (epoch_count);
+				opened_account_versions_t opened_account_versions_l (epoch_count);
 				for (; i != n; ++i)
 				{
 					auto const & account (i->first);
@@ -1896,9 +1897,10 @@ int main (int argc, char * const * argv)
 
 			// Iterate all pending blocks and collect the lowest version for each unopened account
 			nano::locked<boost::unordered_map<nano::account, std::underlying_type_t<nano::epoch>>> unopened_highest_pending_shared;
+			using unopened_highest_pending_t = decltype (unopened_highest_pending_shared)::value_type;
 			node->store.pending_for_each_par ([&unopened_highest_pending_shared, &opened_accounts](nano::store_iterator<nano::pending_key, nano::pending_info> i, nano::store_iterator<nano::pending_key, nano::pending_info> n) {
 				// First cache locally
-				boost::unordered_map<nano::account, std::underlying_type_t<nano::epoch>> unopened_highest_pending_l;
+				unopened_highest_pending_t unopened_highest_pending_l;
 				for (; i != n; ++i)
 				{
 					nano::pending_key const & key (i->first);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1958,11 +1958,9 @@ int main (int argc, char * const * argv)
 
 			auto unconfirmed_frontiers = node->ledger.unconfirmed_frontiers ();
 			std::cout << "Account: Height delta | Frontier | Confirmed frontier\n";
-			for (auto & unconfirmed_frontier : unconfirmed_frontiers)
+			for (auto const & [height_delta, unconfirmed_info] : unconfirmed_frontiers)
 			{
-				auto const & unconfirmed_info = unconfirmed_frontier.second;
-
-				std::cout << (boost::format ("%1%: %2% %3% %4%\n") % unconfirmed_info.account.to_account () % unconfirmed_frontier.first % unconfirmed_info.frontier.to_string () % unconfirmed_info.cemented_frontier.to_string ()).str ();
+				std::cout << (boost::format ("%1%: %2% %3% %4%\n") % unconfirmed_info.account.to_account () % height_delta % unconfirmed_info.frontier.to_string () % unconfirmed_info.cemented_frontier.to_string ()).str ();
 			}
 
 			std::cout << "\nNumber of unconfirmed frontiers: " << unconfirmed_frontiers.size () << std::endl;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -682,9 +682,9 @@ public:
 	virtual nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> blocks_begin (nano::transaction const & transaction_a) const = 0;
 	virtual nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> blocks_end () const = 0;
 
-	virtual void latest_for_each_par (std::function<void(nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) = 0;
-	virtual void confirmation_height_for_each_par (std::function<void(nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) = 0;
-	virtual void pending_for_each_par (std::function<void(nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const &) = 0;
+	virtual void latest_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) = 0;
+	virtual void confirmation_height_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) = 0;
+	virtual void pending_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const &) = 0;
 
 	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 	virtual std::mutex & get_cache_mutex () = 0;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -684,6 +684,7 @@ public:
 
 	virtual void latest_for_each_par (std::function<void(nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) = 0;
 	virtual void confirmation_height_for_each_par (std::function<void(nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) = 0;
+	virtual void pending_for_each_par (std::function<void(nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const &) = 0;
 
 	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 	virtual std::mutex & get_cache_mutex () = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -731,6 +731,19 @@ public:
 		});
 	}
 
+	void pending_for_each_par (std::function<void(nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) override
+	{
+		parallel_traversal<nano::uint512_t> (
+		[&action_a, this](nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {
+			auto transaction (this->tx_begin_read ());
+			nano::uint512_union union_start (start);
+			nano::uint512_union union_end (end);
+			nano::pending_key key_start (union_start.uint256s[0].number (), union_start.uint256s[1].number ());
+			nano::pending_key key_end (union_end.uint256s[0].number (), union_end.uint256s[1].number ());
+			action_a (this->pending_begin (transaction, key_start), !is_last ? this->pending_begin (transaction, key_end) : this->pending_end ());
+		});
+	}
+
 	int const minimum_version{ 14 };
 
 protected:

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -713,34 +713,34 @@ public:
 		return count (transaction_a, tables::unchecked);
 	}
 
-	void latest_for_each_par (std::function<void(nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) override
+	void latest_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) override
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
 			auto transaction (this->tx_begin_read ());
-			action_a (this->latest_begin (transaction, start), !is_last ? this->latest_begin (transaction, end) : this->latest_end ());
+			action_a (transaction, this->latest_begin (transaction, start), !is_last ? this->latest_begin (transaction, end) : this->latest_end ());
 		});
 	}
 
-	void confirmation_height_for_each_par (std::function<void(nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) override
+	void confirmation_height_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) override
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
 			auto transaction (this->tx_begin_read ());
-			action_a (this->confirmation_height_begin (transaction, start), !is_last ? this->confirmation_height_begin (transaction, end) : this->confirmation_height_end ());
+			action_a (transaction, this->confirmation_height_begin (transaction, start), !is_last ? this->confirmation_height_begin (transaction, end) : this->confirmation_height_end ());
 		});
 	}
 
-	void pending_for_each_par (std::function<void(nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) override
+	void pending_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) override
 	{
 		parallel_traversal<nano::uint512_t> (
 		[&action_a, this](nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
 			nano::uint512_union union_start (start);
 			nano::uint512_union union_end (end);
 			nano::pending_key key_start (union_start.uint256s[0].number (), union_start.uint256s[1].number ());
 			nano::pending_key key_end (union_end.uint256s[0].number (), union_end.uint256s[1].number ());
-			action_a (this->pending_begin (transaction, key_start), !is_last ? this->pending_begin (transaction, key_end) : this->pending_end ());
+			auto transaction (this->tx_begin_read ());
+			action_a (transaction, this->pending_begin (transaction, key_start), !is_last ? this->pending_begin (transaction, key_end) : this->pending_end ());
 		});
 	}
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1232,9 +1232,10 @@ bool nano::ledger::block_confirmed (nano::transaction const & transaction_a, nan
 std::multimap<uint64_t, nano::uncemented_info, std::greater<>> nano::ledger::unconfirmed_frontiers () const
 {
 	nano::locked<std::multimap<uint64_t, nano::uncemented_info, std::greater<>>> result;
+	using result_t = decltype (result)::value_type;
 
 	store.latest_for_each_par ([this, &result](nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
-		std::multimap<uint64_t, nano::uncemented_info, std::greater<>> unconfirmed_frontiers_l;
+		result_t unconfirmed_frontiers_l;
 		auto transaction (this->store.tx_begin_read ());
 		for (; i != n; ++i)
 		{


### PR DESCRIPTION
- Add parallelized pending table traversal (thanks @wezrule)
- Expose transaction in parallel traversal methods
- Optimize CLI debug_account_versions
  - Use parallel table traversal for frontiers and pending
  - Merge sets to do a single lookup of opened accounts
  - Change to boost::unordered_set and unordered_map for performance in very large containers
- Optimize CLI debug_unconfirmed_frontiers
  - ledger::unconfirmed_frontiers now traverses the accounts table in parallel.
  - The frontiers table is not traversed sequentially anymore, but this still results in a speed up from what I saw.
- Add value_type alias to nano::locked

Comparisons in different systems (cold and warm) are appreciated