### PR TITLE
Don't null out telemetry object

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -689,7 +689,6 @@ void nano::node::stop ()
 		if (telemetry)
 		{
 			telemetry->stop ();
-			telemetry = nullptr;
 		}
 		if (websocket_server)
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -686,10 +686,7 @@ void nano::node::stop ()
 		active.stop ();
 		confirmation_height_processor.stop ();
 		network.stop ();
-		if (telemetry)
-		{
-			telemetry->stop ();
-		}
+		telemetry->stop ();
 		if (websocket_server)
 		{
 			websocket_server->stop ();


### PR DESCRIPTION
This issue occurred in:
nano::transport::tcp_channels::start_tcp_receive_node_id
node_l->telemetry->get_metrics_single_peer_async