### PR TITLE
Election encapsulation

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -55,7 +55,7 @@ TEST (active_transactions, confirm_active)
 	// At least one confirmation request
 	ASSERT_GT (election->confirmation_request_count, 0u);
 	// Blocks were cleared (except for not_an_account)
-	ASSERT_EQ (1, election->blocks.size ());
+	ASSERT_EQ (1, election->blocks ().size ());
 }
 }
 
@@ -1306,7 +1306,7 @@ TEST (active_transactions, activate_account_chain)
 	auto result = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_TRUE (result.inserted);
 	ASSERT_EQ (1, node.active.size ());
-	ASSERT_EQ (1, result.election->blocks.count (send->hash ()));
+	ASSERT_EQ (1, result.election->blocks ().count (send->hash ()));
 	auto result2 = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_FALSE (result2.inserted);
 	ASSERT_EQ (result2.election, result.election);
@@ -1317,7 +1317,7 @@ TEST (active_transactions, activate_account_chain)
 	auto result3 = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_FALSE (result3.inserted);
 	ASSERT_NE (nullptr, result3.election);
-	ASSERT_EQ (1, result3.election->blocks.count (send2->hash ()));
+	ASSERT_EQ (1, result3.election->blocks ().count (send2->hash ()));
 	result3.election->force_confirm ();
 	ASSERT_TIMELY (3s, node.block_confirmed (send2->hash ()));
 	// On cementing, the next election is started
@@ -1326,11 +1326,11 @@ TEST (active_transactions, activate_account_chain)
 	auto result4 = node.active.activate (nano::dev_genesis_key.pub);
 	ASSERT_FALSE (result4.inserted);
 	ASSERT_NE (nullptr, result4.election);
-	ASSERT_EQ (1, result4.election->blocks.count (send3->hash ()));
+	ASSERT_EQ (1, result4.election->blocks ().count (send3->hash ()));
 	auto result5 = node.active.activate (key.pub);
 	ASSERT_FALSE (result5.inserted);
 	ASSERT_NE (nullptr, result5.election);
-	ASSERT_EQ (1, result5.election->blocks.count (open->hash ()));
+	ASSERT_EQ (1, result5.election->blocks ().count (open->hash ()));
 	result5.election->force_confirm ();
 	ASSERT_TIMELY (3s, node.block_confirmed (open->hash ()));
 	// Until send3 is also confirmed, the receive block should not activate

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -710,10 +710,7 @@ TEST (active_transactions, dropped_cleanup)
 
 	// Now simulate dropping the election, which performs a cleanup in the background using the node worker
 	ASSERT_FALSE (election->confirmed ());
-	{
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
-		election->cleanup ();
-	}
+	node.active.erase (*block);
 
 	// Push a worker task to ensure the cleanup is already performed
 	std::atomic<bool> flag{ false };

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -879,12 +879,9 @@ TEST (bootstrap_processor, bootstrap_fork)
 	ASSERT_EQ (nano::process_result::progress, node0->process (*send).code);
 	// Confirm send block to vote later
 	node0->block_confirm (send);
-	{
-		auto election = node0->active.election (send->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		nano::lock_guard<std::mutex> guard (node0->active.mutex);
-		election->confirm_once ();
-	}
+	auto election = node0->active.election (send->qualified_root ());
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 	ASSERT_TIMELY (2s, node0->block_confirmed (send->hash ()));
 	node0->active.erase (*send);
 	auto open_work (*system.work.generate (key.pub));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -151,12 +151,9 @@ TEST (confirmation_height, multiple_accounts)
 		node->process_active (receive3);
 		node->block_processor.flush ();
 		node->block_confirm (receive3);
-		{
-			auto election = node->active.election (receive3->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (receive3->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
 
@@ -435,12 +432,9 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		node->process_active (receive4);
 		node->block_processor.flush ();
 		node->block_confirm (receive4);
-		{
-			auto election = node->active.election (receive4->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (receive4->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
 
@@ -509,12 +503,9 @@ TEST (confirmation_height, send_receive_self)
 		add_callback_stats (*node);
 
 		node->block_confirm (receive3);
-		{
-			auto election = node->active.election (receive3->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (receive3->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 6);
 
@@ -609,12 +600,9 @@ TEST (confirmation_height, all_block_types)
 
 		add_callback_stats (*node);
 		node->block_confirm (state_send2);
-		{
-			auto election = node->active.election (state_send2->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (state_send2->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 15);
 
@@ -1025,12 +1013,9 @@ TEST (confirmation_height, callback_confirmed_history)
 			auto write_guard = node->write_database_queue.wait (nano::writer::testing);
 
 			// Confirm send1
-			{
-				auto election = node->active.election (send1->qualified_root ());
-				ASSERT_NE (nullptr, election);
-				nano::lock_guard<std::mutex> guard (node->active.mutex);
-				election->confirm_once ();
-			}
+			auto election = node->active.election (send1->qualified_root ());
+			ASSERT_NE (nullptr, election);
+			election->force_confirm ();
 			ASSERT_TIMELY (10s, node->active.size () == 0);
 			ASSERT_EQ (0, node->active.list_recently_cemented ().size ());
 			{
@@ -1104,12 +1089,9 @@ TEST (confirmation_height, dependent_election)
 		node->block_confirm (send1);
 		// Start an election and confirm it
 		node->block_confirm (send2);
-		{
-			auto election = node->active.election (send2->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (send2->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 3);
 
@@ -1186,12 +1168,9 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		add_callback_stats (*node, &observer_order, &mutex);
 
 		node->block_confirm (open1);
-		{
-			auto election = node->active.election (open1->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (open1->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
 
 		auto transaction = node->store.tx_begin_read ();
@@ -1279,12 +1258,9 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		add_callback_stats (*node);
 
 		node->block_confirm (open1);
-		{
-			auto election = node->active.election (open1->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (open1->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 6);
 
 		auto transaction = node->store.tx_begin_read ();
@@ -1329,23 +1305,17 @@ TEST (confirmation_height, election_winner_details_clearing)
 		add_callback_stats (*node);
 
 		node->block_confirm (send1);
-		{
-			auto election = node->active.election (send1->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		auto election = node->active.election (send1->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 2);
 
 		ASSERT_EQ (0, node->active.election_winner_details_size ());
 		node->block_confirm (send);
-		{
-			auto election = node->active.election (send->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		election = node->active.election (send->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		// Wait until this block is confirmed
 		ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 1 || node->confirmation_height_processor.current ().is_zero ());
@@ -1353,12 +1323,9 @@ TEST (confirmation_height, election_winner_details_clearing)
 		ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
 
 		node->block_confirm (send2);
-		{
-			auto election = node->active.election (send2->qualified_root ());
-			ASSERT_NE (nullptr, election);
-			nano::lock_guard<std::mutex> guard (node->active.mutex);
-			election->confirm_once ();
-		}
+		election = node->active.election (send2->qualified_root ());
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 3);
 

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -51,6 +51,8 @@ TEST (confirmation_solicitor, batches)
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 }
 
+namespace nano
+{
 TEST (confirmation_solicitor, different_hash)
 {
 	nano::system system;
@@ -73,15 +75,12 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
 	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
 	send->sideband_set ({});
-	{
-		nano::lock_guard<std::mutex> guard (node2.active.mutex);
-		auto election (std::make_shared<nano::election> (node2, send, nullptr, false, nano::election_behavior::normal));
-		// Add a vote for something else, not the winner
-		election->last_votes[representative.account] = { std::chrono::steady_clock::now (), 1, 1 };
-		// Ensure the request and broadcast goes through
-		ASSERT_FALSE (solicitor.add (*election));
-		ASSERT_FALSE (solicitor.broadcast (*election));
-	}
+	auto election (std::make_shared<nano::election> (node2, send, nullptr, false, nano::election_behavior::normal));
+	// Add a vote for something else, not the winner
+	election->last_votes[representative.account] = { std::chrono::steady_clock::now (), 1, 1 };
+	// Ensure the request and broadcast goes through
+	ASSERT_FALSE (solicitor.add (*election));
+	ASSERT_FALSE (solicitor.broadcast (*election));
 	// One publish through directed broadcasting and another through random flooding
 	ASSERT_EQ (2, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 	solicitor.flush ();
@@ -112,32 +111,26 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
 	auto send (std::make_shared<nano::send_block> (nano::genesis_hash, nano::keypair ().pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (nano::genesis_hash)));
 	send->sideband_set ({});
+	auto election (std::make_shared<nano::election> (node2, send, nullptr, false, nano::election_behavior::normal));
+	// Add a vote for something else, not the winner
+	for (auto const & rep : representatives)
 	{
-		nano::lock_guard<std::mutex> guard (node2.active.mutex);
-		auto election (std::make_shared<nano::election> (node2, send, nullptr, false, nano::election_behavior::normal));
-		// Add a vote for something else, not the winner
-		for (auto const & rep : representatives)
-		{
-			election->last_votes[rep.account] = { std::chrono::steady_clock::now (), 1, 1 };
-		}
-		ASSERT_FALSE (solicitor.add (*election));
-		ASSERT_FALSE (solicitor.broadcast (*election));
+		nano::lock_guard<std::mutex> guard (node1.active.mutex);
+		election->last_votes[rep.account] = { std::chrono::steady_clock::now (), 1, 1 };
 	}
+	ASSERT_FALSE (solicitor.add (*election));
+	ASSERT_FALSE (solicitor.broadcast (*election));
 	solicitor.flush ();
 	// All requests went through, the last one would normally not go through due to the cap but a vote for a different hash does not count towards the cap
 	ASSERT_EQ (max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 
 	solicitor.prepare (representatives);
-	{
-		nano::lock_guard<std::mutex> guard (node2.active.mutex);
-		auto election (std::make_shared<nano::election> (node2, send, nullptr, false, nano::election_behavior::normal));
-		// Erase all votes
-		election->last_votes.clear ();
-		ASSERT_FALSE (solicitor.add (*election));
-		ASSERT_FALSE (solicitor.broadcast (*election));
-	}
+	auto election2 (std::make_shared<nano::election> (node2, send, nullptr, false, nano::election_behavior::normal));
+	ASSERT_FALSE (solicitor.add (*election2));
+	ASSERT_FALSE (solicitor.broadcast (*election2));
 
 	solicitor.flush ();
 	// All requests but one went through, due to the cap
 	ASSERT_EQ (2 * max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
+}
 }

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -20,11 +20,8 @@ TEST (conflicts, start_stop)
 	ASSERT_EQ (0, node1.active.size ());
 	auto election1 = node1.active.insert (send1);
 	ASSERT_EQ (1, node1.active.size ());
-	{
-		nano::lock_guard<std::mutex> guard (node1.active.mutex);
-		ASSERT_NE (nullptr, election1.election);
-		ASSERT_EQ (1, election1.election->last_votes.size ());
-	}
+	ASSERT_NE (nullptr, election1.election);
+	ASSERT_EQ (1, election1.election->votes ().size ());
 }
 
 TEST (conflicts, add_existing)
@@ -44,13 +41,10 @@ TEST (conflicts, add_existing)
 	ASSERT_EQ (1, node1.active.size ());
 	auto vote1 (std::make_shared<nano::vote> (key2.pub, key2.prv, 0, send2));
 	node1.active.vote (vote1);
-	ASSERT_EQ (1, node1.active.size ());
-	{
-		nano::lock_guard<std::mutex> guard (node1.active.mutex);
-		ASSERT_NE (nullptr, election1.election);
-		ASSERT_EQ (2, election1.election->last_votes.size ());
-		ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (key2.pub));
-	}
+	ASSERT_NE (nullptr, election1.election);
+	ASSERT_EQ (2, election1.election->votes ().size ());
+	auto votes (election1.election->votes ());
+	ASSERT_NE (votes.end (), votes.find (key2.pub));
 }
 
 TEST (conflicts, add_two)

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -73,12 +73,9 @@ TEST (gap_cache, gap_bootstrap)
 	ASSERT_EQ (nano::genesis_amount, node2.balance (nano::genesis_account));
 	// Confirm send block, allowing voting on the upcoming block
 	node1.block_confirm (send);
-	{
-		auto election = node1.active.election (send->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		nano::lock_guard<std::mutex> guard (node1.active.mutex);
-		election->confirm_once ();
-	}
+	auto election = node1.active.election (send->qualified_root ());
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 	ASSERT_TIMELY (2s, node1.block_confirmed (send->hash ()));
 	node1.active.erase (*send);
 	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -767,10 +767,7 @@ TEST (votes, check_signature)
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
 	auto election1 = node1.active.insert (send1);
-	{
-		nano::lock_guard<std::mutex> lock (node1.active.mutex);
-		ASSERT_EQ (1, election1.election->last_votes.size ());
-	}
+	ASSERT_EQ (1, election1.election->votes ().size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	vote1->signature.bytes[0] ^= 1;
 	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, nano::endpoint (boost::asio::ip::address_v6 (), 0), node1.network_params.protocol.protocol_version)));
@@ -790,18 +787,17 @@ TEST (votes, add_one)
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	auto election1 = node1.active.insert (send1);
-	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	ASSERT_EQ (1, election1.election->last_votes.size ());
-	lock.unlock ();
+	ASSERT_EQ (1, election1.election->votes ().size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2));
-	lock.lock ();
-	ASSERT_EQ (2, election1.election->last_votes.size ());
-	auto existing1 (election1.election->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_NE (election1.election->last_votes.end (), existing1);
+	ASSERT_EQ (2, election1.election->votes ().size ());
+	auto votes1 (election1.election->votes ());
+	auto existing1 (votes1.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (votes1.end (), existing1);
 	ASSERT_EQ (send1->hash (), existing1->second.hash);
+	nano::lock_guard<std::mutex> guard (node1.active.mutex);
 	auto winner (*election1.election->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
 	ASSERT_EQ (nano::genesis_amount - 100, winner.first);
@@ -818,24 +814,25 @@ TEST (votes, add_two)
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	auto election1 = node1.active.insert (send1);
-	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	lock.unlock ();
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (genesis.hash (), key2.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	auto vote2 (std::make_shared<nano::vote> (key2.pub, key2.prv, 1, send2));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2));
 	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
-	lock.lock ();
-	ASSERT_EQ (3, election1.election->last_votes.size ());
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (key2.pub));
-	ASSERT_EQ (send2->hash (), election1.election->last_votes[key2.pub].hash);
+	ASSERT_EQ (3, election1.election->votes ().size ());
+	auto votes1 (election1.election->votes ());
+	ASSERT_NE (votes1.end (), votes1.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), votes1[nano::dev_genesis_key.pub].hash);
+	ASSERT_NE (votes1.end (), votes1.find (key2.pub));
+	ASSERT_EQ (send2->hash (), votes1[key2.pub].hash);
+	nano::lock_guard<std::mutex> guard (node1.active.mutex);
 	auto winner (*election1.election->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
 }
 
+namespace nano
+{
 // Higher sequence numbers change the vote
 TEST (votes, add_existing)
 {
@@ -910,12 +907,14 @@ TEST (votes, add_old)
 		election1.election->last_votes[nano::dev_genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	}
 	node1.vote_processor.vote_blocking (vote2, channel);
-	ASSERT_EQ (2, election1.election->last_votes_size ());
+	ASSERT_EQ (2, election1.election->votes ().size ());
+	auto votes (election1.election->votes ());
+	ASSERT_NE (votes.end (), votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), votes[nano::dev_genesis_key.pub].hash);
 	nano::lock_guard<std::mutex> lock (node1.active.mutex);
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
 	auto winner (*election1.election->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
+}
 }
 
 // Lower sequence numbers are accepted for different accounts
@@ -936,24 +935,26 @@ TEST (votes, add_old_different_account)
 	ASSERT_NE (nullptr, election1);
 	auto election2 = node1.active.election (send2->qualified_root ());
 	ASSERT_NE (nullptr, election2);
-	ASSERT_EQ (1, election1->last_votes_size ());
-	ASSERT_EQ (1, election2->last_votes_size ());
+	ASSERT_EQ (1, election1->votes ().size ());
+	ASSERT_EQ (1, election2->votes ().size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send1));
 	auto channel (std::make_shared<nano::transport::channel_udp> (node1.network.udp_channels, node1.network.endpoint (), node1.network_params.protocol.protocol_version));
 	auto vote_result1 (node1.vote_processor.vote_blocking (vote1, channel));
 	ASSERT_EQ (nano::vote_code::vote, vote_result1);
-	ASSERT_EQ (2, election1->last_votes_size ());
-	ASSERT_EQ (1, election2->last_votes_size ());
+	ASSERT_EQ (2, election1->votes ().size ());
+	ASSERT_EQ (1, election2->votes ().size ());
 	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 1, send2));
 	auto vote_result2 (node1.vote_processor.vote_blocking (vote2, channel));
 	ASSERT_EQ (nano::vote_code::vote, vote_result2);
-	ASSERT_EQ (2, election1->last_votes_size ());
-	ASSERT_EQ (2, election2->last_votes_size ());
-	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	ASSERT_NE (election1->last_votes.end (), election1->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_NE (election2->last_votes.end (), election2->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1->last_votes[nano::dev_genesis_key.pub].hash);
-	ASSERT_EQ (send2->hash (), election2->last_votes[nano::dev_genesis_key.pub].hash);
+	ASSERT_EQ (2, election1->votes ().size ());
+	ASSERT_EQ (2, election2->votes ().size ());
+	auto votes1 (election1->votes ());
+	auto votes2 (election2->votes ());
+	ASSERT_NE (votes1.end (), votes1.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (votes2.end (), votes2.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), votes1[nano::dev_genesis_key.pub].hash);
+	ASSERT_EQ (send2->hash (), votes2[nano::dev_genesis_key.pub].hash);
+	nano::lock_guard<std::mutex> lock (node1.active.mutex);
 	auto winner1 (*election1->tally ().begin ());
 	ASSERT_EQ (*send1, *winner1.second);
 	auto winner2 (*election2->tally ().begin ());
@@ -980,10 +981,11 @@ TEST (votes, add_cooldown)
 	node1.work_generate_blocking (*send2);
 	auto vote2 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, 2, send2));
 	node1.vote_processor.vote_blocking (vote2, channel);
-	nano::unique_lock<std::mutex> lock (node1.active.mutex);
-	ASSERT_EQ (2, election1.election->last_votes.size ());
-	ASSERT_NE (election1.election->last_votes.end (), election1.election->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_EQ (send1->hash (), election1.election->last_votes[nano::dev_genesis_key.pub].hash);
+	ASSERT_EQ (2, election1.election->votes ().size ());
+	auto votes (election1.election->votes ());
+	ASSERT_NE (votes.end (), votes.find (nano::dev_genesis_key.pub));
+	ASSERT_EQ (send1->hash (), votes[nano::dev_genesis_key.pub].hash);
+	nano::lock_guard<std::mutex> lock (node1.active.mutex);
 	auto winner (*election1.election->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1070,9 +1070,9 @@ TEST (node, fork_publish_inactive)
 		auto & blocks (election->blocks);
 		ASSERT_NE (blocks.end (), blocks.find (send1->hash ()));
 		ASSERT_NE (blocks.end (), blocks.find (send2->hash ()));
-		ASSERT_NE (election->status.winner, send1);
-		ASSERT_NE (election->status.winner, send2);
 	}
+	ASSERT_NE (election->winner (), send1);
+	ASSERT_NE (election->winner (), send2);
 }
 
 TEST (node, fork_keep)
@@ -1372,9 +1372,9 @@ TEST (node, fork_open)
 		election = node1.active.election (publish3.block->qualified_root ());
 		nano::lock_guard<std::mutex> guard (node1.active.mutex);
 		ASSERT_EQ (2, election->blocks.size ());
-		ASSERT_EQ (publish2.block->hash (), election->status.winner->hash ());
-		ASSERT_FALSE (election->confirmed ());
 	}
+	ASSERT_EQ (publish2.block->hash (), election->winner ()->hash ());
+	ASSERT_FALSE (election->confirmed ());
 	ASSERT_TRUE (node1.block (publish2.block->hash ()));
 	ASSERT_FALSE (node1.block (publish3.block->hash ()));
 }
@@ -3919,7 +3919,7 @@ TEST (node, rollback_vote_self)
 			lock.unlock ();
 			ASSERT_EQ (2, election->votes ().size ());
 			// The winner changed
-			ASSERT_EQ (election->status.winner, fork);
+			ASSERT_EQ (election->winner (), fork);
 		}
 		// Even without the rollback being finished, the aggregator must reply with a vote for the new winner, not the old one
 		ASSERT_TRUE (node.history.votes (send2->root (), send2->hash ()).empty ());

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -185,12 +185,9 @@ TEST (request_aggregator, split)
 	}
 	// Confirm all blocks
 	node.block_confirm (blocks.back ());
-	{
-		auto election (node.active.election (blocks.back ()->qualified_root ()));
-		ASSERT_NE (nullptr, election);
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
-		election->confirm_once ();
-	}
+	auto election (node.active.election (blocks.back ()->qualified_root ()));
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 	ASSERT_TIMELY (5s, max_vbh + 2 == node.ledger.cache.cemented_count);
 	ASSERT_EQ (max_vbh + 1, request.size ());
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
@@ -364,12 +361,9 @@ TEST (request_aggregator, cannot_vote)
 
 	// Confirm send1
 	node.block_confirm (send1);
-	{
-		auto election (node.active.election (send1->qualified_root ()));
-		ASSERT_NE (nullptr, election);
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
-		election->confirm_once ();
-	}
+	auto election (node.active.election (send1->qualified_root ()));
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 	ASSERT_TIMELY (3s, node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send2));
 	node.aggregator.add (channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -80,13 +80,13 @@ TEST (vote_processor, invalid_signature)
 	genesis.open->sideband_set (nano::block_sideband (nano::genesis_account, 0, nano::genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 	auto election (node.active.insert (genesis.open));
 	ASSERT_TRUE (election.election && election.inserted);
-	ASSERT_EQ (1, election.election->last_votes.size ());
+	ASSERT_EQ (1, election.election->votes ().size ());
 	node.vote_processor.vote (vote_invalid, channel);
 	node.vote_processor.flush ();
-	ASSERT_EQ (1, election.election->last_votes.size ());
+	ASSERT_EQ (1, election.election->votes ().size ());
 	node.vote_processor.vote (vote, channel);
 	node.vote_processor.flush ();
-	ASSERT_EQ (2, election.election->last_votes.size ());
+	ASSERT_EQ (2, election.election->votes ().size ());
 }
 
 TEST (vote_processor, no_capacity)
@@ -213,8 +213,9 @@ TEST (vote_processor, no_broadcast_local)
 	// Make sure the vote was processed
 	auto election (node.active.election (send->qualified_root ()));
 	ASSERT_NE (nullptr, election);
-	auto existing (election->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_NE (election->last_votes.end (), existing);
+	auto votes (election->votes ());
+	auto existing (votes.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (votes.end (), existing);
 	ASSERT_EQ (vote->sequence, existing->second.sequence);
 	// Ensure the vote, from a local representative, was not broadcast on processing - it should be flooded on generation instead
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
@@ -245,8 +246,9 @@ TEST (vote_processor, no_broadcast_local)
 	// Make sure the vote was processed
 	auto election2 (node.active.election (send2->qualified_root ()));
 	ASSERT_NE (nullptr, election2);
-	auto existing2 (election2->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_NE (election2->last_votes.end (), existing2);
+	auto votes2 (election2->votes ());
+	auto existing2 (votes2.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (votes2.end (), existing2);
 	ASSERT_EQ (vote2->sequence, existing2->second.sequence);
 	// Ensure the vote was broadcast
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
@@ -278,8 +280,9 @@ TEST (vote_processor, no_broadcast_local)
 	// Make sure the vote was processed
 	auto election3 (node.active.election (open->qualified_root ()));
 	ASSERT_NE (nullptr, election3);
-	auto existing3 (election3->last_votes.find (nano::dev_genesis_key.pub));
-	ASSERT_NE (election3->last_votes.end (), existing3);
+	auto votes3 (election3->votes ());
+	auto existing3 (votes3.find (nano::dev_genesis_key.pub));
+	ASSERT_NE (votes3.end (), existing3);
 	ASSERT_EQ (vote3->sequence, existing3->second.sequence);
 	// Ensure the vote wass not broadcasst
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1251,11 +1251,10 @@ TEST (work_watcher, confirm_while_generating)
 		notified = true;
 	});
 	// Confirm the block
-	{
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
-		ASSERT_EQ (1, node.active.roots.size ());
-		node.active.roots.begin ()->election->confirm_once ();
-	}
+	ASSERT_EQ (1, node.active.size ());
+	auto election (node.active.election (block1->qualified_root ()));
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 	ASSERT_TIMELY (5s, node.block_confirmed (block1->hash ()));
 	ASSERT_EQ (0, node.work.size ());
 	ASSERT_TRUE (notified);
@@ -1485,10 +1484,7 @@ TEST (wallet, search_pending)
 	wallet.store.erase (node.wallets.tx_begin_write (), nano::genesis_account);
 
 	// Now confirm the election
-	{
-		nano::lock_guard<std::mutex> guard (node.active.mutex);
-		election->confirm_once ();
-	}
+	election->force_confirm ();
 
 	ASSERT_TIMELY (5s, node.block_confirmed (send->hash ()) && node.active.empty ());
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1013,8 +1013,8 @@ double nano::active_transactions::normalized_multiplier (nano::block const & blo
 	{
 		auto election (*root_it_a);
 		debug_assert (election != roots.end ());
-		auto find_block (election->election->blocks.find (block_a.hash ()));
-		if (find_block != election->election->blocks.end () && find_block->second->has_sideband ())
+		auto find_block (election->election->last_blocks.find (block_a.hash ()));
+		if (find_block != election->election->last_blocks.end () && find_block->second->has_sideband ())
 		{
 			threshold = nano::work_threshold (block_a.work_version (), find_block->second->sideband ().details);
 		}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1113,18 +1113,6 @@ double nano::active_transactions::active_multiplier ()
 	return trended_active_multiplier.load ();
 }
 
-// List of active blocks in elections
-std::deque<std::shared_ptr<nano::block>> nano::active_transactions::list_blocks ()
-{
-	std::deque<std::shared_ptr<nano::block>> result;
-	nano::lock_guard<std::mutex> lock (mutex);
-	for (auto & root : roots)
-	{
-		result.push_back (root.election->status.winner);
-	}
-	return result;
-}
-
 std::deque<nano::election_status> nano::active_transactions::list_recently_cemented ()
 {
 	nano::lock_guard<std::mutex> lock (mutex);

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -195,7 +195,6 @@ public:
 	uint64_t limited_active_difficulty (nano::block const &);
 	uint64_t limited_active_difficulty (nano::work_version const, uint64_t const);
 	double active_multiplier ();
-	std::deque<std::shared_ptr<nano::block>> list_blocks ();
 	void erase (nano::block const &);
 	bool empty ();
 	size_t size ();

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -244,6 +244,8 @@ private:
 	bool update_difficulty_impl (roots_iterator const &, nano::block const &);
 	void request_loop ();
 	void request_confirm (nano::unique_lock<std::mutex> &);
+	// Erase all blocks from active and, if not confirmed, clear digests from network filters
+	void cleanup_election (nano::election_cleanup_info const &);
 	nano::condition_variable condition;
 	bool started{ false };
 	std::atomic<bool> stopped{ false };

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -479,6 +479,12 @@ void nano::election::prioritize_election (nano::vote_generator_session & generat
 	generator_session_a.add (root, status.winner->hash ());
 }
 
+std::shared_ptr<nano::block> nano::election::winner ()
+{
+	nano::lock_guard<std::mutex> guard (node.active.mutex);
+	return status.winner;
+}
+
 void nano::election::generate_votes ()
 {
 	debug_assert (!node.active.mutex.try_lock ());

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -508,3 +508,10 @@ void nano::election::remove_votes (nano::block_hash const & hash_a)
 		node.history.erase (root);
 	}
 }
+
+void nano::election::force_confirm (nano::election_status_type type_a)
+{
+	release_assert (node.network_params.network.is_dev_network ());
+	nano::lock_guard<std::mutex> guard (node.active.mutex);
+	confirm_once (type_a);
+}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -28,7 +28,7 @@ height (block_a->sideband ().height),
 root (block_a->root ())
 {
 	last_votes.emplace (node.network_params.random.not_an_account, nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () });
-	blocks.emplace (block_a->hash (), block_a);
+	last_blocks.emplace (block_a->hash (), block_a);
 }
 
 void nano::election::confirm_once (nano::election_status_type type_a)
@@ -41,7 +41,7 @@ void nano::election::confirm_once (nano::election_status_type type_a)
 		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		status.confirmation_request_count = confirmation_request_count;
-		status.block_count = nano::narrow_cast<decltype (status.block_count)> (blocks.size ());
+		status.block_count = nano::narrow_cast<decltype (status.block_count)> (last_blocks.size ());
 		status.voter_count = nano::narrow_cast<decltype (status.voter_count)> (last_votes.size ());
 		status.type = type_a;
 		auto status_l (status);
@@ -255,8 +255,8 @@ nano::tally_t nano::election::tally ()
 	nano::tally_t result;
 	for (auto item : block_weights)
 	{
-		auto block (blocks.find (item.first));
-		if (block != blocks.end ())
+		auto block (last_blocks.find (item.first));
+		if (block != last_blocks.end ())
 		{
 			result.emplace (item.second, block->second);
 		}
@@ -286,7 +286,7 @@ void nano::election::confirm_if_quorum ()
 	}
 	if (have_quorum (tally_l, sum))
 	{
-		if (node.config.logging.vote_logging () || (node.config.logging.election_fork_tally_logging () && blocks.size () > 1))
+		if (node.config.logging.vote_logging () || (node.config.logging.election_fork_tally_logging () && last_blocks.size () > 1))
 		{
 			log_votes (tally_l);
 		}
@@ -372,7 +372,7 @@ bool nano::election::publish (std::shared_ptr<nano::block> block_a)
 {
 	// Do not insert new blocks if already confirmed
 	auto result (confirmed ());
-	if (!result && blocks.size () >= 10)
+	if (!result && last_blocks.size () >= 10)
 	{
 		if (last_tally[block_a->hash ()] < node.online_reps.online_stake () / 10)
 		{
@@ -381,10 +381,10 @@ bool nano::election::publish (std::shared_ptr<nano::block> block_a)
 	}
 	if (!result)
 	{
-		auto existing = blocks.find (block_a->hash ());
-		if (existing == blocks.end ())
+		auto existing = last_blocks.find (block_a->hash ());
+		if (existing == last_blocks.end ())
 		{
-			blocks.emplace (std::make_pair (block_a->hash (), block_a));
+			last_blocks.emplace (std::make_pair (block_a->hash (), block_a));
 			if (!insert_inactive_votes_cache (block_a->hash ()))
 			{
 				// Even if no votes were in cache, they could be in the election
@@ -410,7 +410,7 @@ void nano::election::cleanup ()
 	bool unconfirmed (!confirmed ());
 	auto winner_root (status.winner->qualified_root ());
 	auto const & winner_hash (status.winner->hash ());
-	for (auto const & block : blocks)
+	for (auto const & block : last_blocks)
 	{
 		auto & hash (block.first);
 		auto erased (node.active.blocks.erase (hash));
@@ -428,7 +428,7 @@ void nano::election::cleanup ()
 		node.active.recently_dropped.add (winner_root);
 
 		// Clear network filter in another thread
-		node.worker.push_task ([node_l = node.shared (), blocks_l = std::move (blocks)]() {
+		node.worker.push_task ([node_l = node.shared (), blocks_l = std::move (last_blocks)]() {
 			for (auto const & block : blocks_l)
 			{
 				node_l->network.publish_filter.clear (block.second);
@@ -514,6 +514,13 @@ void nano::election::force_confirm (nano::election_status_type type_a)
 	release_assert (node.network_params.network.is_dev_network ());
 	nano::lock_guard<std::mutex> guard (node.active.mutex);
 	confirm_once (type_a);
+}
+
+std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> nano::election::blocks ()
+{
+	debug_assert (node.network_params.network.is_dev_network ());
+	nano::lock_guard<std::mutex> guard (node.active.mutex);
+	return last_blocks;
 }
 
 std::unordered_map<nano::account, nano::vote_info> nano::election::votes ()

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -7,10 +7,6 @@
 
 using namespace std::chrono;
 
-int constexpr nano::election::passive_duration_factor;
-int constexpr nano::election::active_request_count_min;
-int constexpr nano::election::confirmed_duration_factor;
-
 std::chrono::milliseconds nano::election::base_latency () const
 {
 	return node.network_params.network.is_dev_network () ? 25ms : 1000ms;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -21,7 +21,7 @@ nano::election_vote_result::election_vote_result (bool replay_a, bool processed_
 nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> block_a, std::function<void(std::shared_ptr<nano::block>)> const & confirmation_action_a, bool prioritized_a, nano::election_behavior election_behavior_a) :
 confirmation_action (confirmation_action_a),
 prioritized_m (prioritized_a),
-election_behavior (election_behavior_a),
+behavior (election_behavior_a),
 node (node_a),
 status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
 height (block_a->sideband ().height),
@@ -474,7 +474,7 @@ bool nano::election::prioritized () const
 
 bool nano::election::optimistic () const
 {
-	return election_behavior == nano::election_behavior::optimistic;
+	return behavior == nano::election_behavior::optimistic;
 }
 
 void nano::election::prioritize_election (nano::vote_generator_session & generator_session_a)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -247,9 +247,9 @@ bool nano::election::have_quorum (nano::tally_t const & tally_a, nano::uint128_t
 nano::tally_t nano::election::tally ()
 {
 	std::unordered_map<nano::block_hash, nano::uint128_t> block_weights;
-	for (auto vote_info : last_votes)
+	for (auto const & [account, info] : last_votes)
 	{
-		block_weights[vote_info.second.hash] += node.ledger.weight (vote_info.first);
+		block_weights[info.hash] += node.ledger.weight (account);
 	}
 	last_tally = block_weights;
 	nano::tally_t result;
@@ -270,9 +270,9 @@ void nano::election::confirm_if_quorum ()
 	debug_assert (!tally_l.empty ());
 	auto winner (tally_l.begin ());
 	auto block_l (winner->second);
-	auto winner_hash_l (block_l->hash ());
+	auto const & winner_hash_l (block_l->hash ());
 	status.tally = winner->first;
-	auto status_winner_hash_l (status.winner->hash ());
+	auto const & status_winner_hash_l (status.winner->hash ());
 	nano::uint128_t sum (0);
 	for (auto & i : tally_l)
 	{
@@ -415,7 +415,7 @@ void nano::election::cleanup ()
 {
 	bool unconfirmed (!confirmed ());
 	auto winner_root (status.winner->qualified_root ());
-	auto winner_hash (status.winner->hash ());
+	auto const & winner_hash (status.winner->hash ());
 	for (auto const & block : blocks)
 	{
 		auto & hash (block.first);

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -405,12 +405,6 @@ bool nano::election::publish (std::shared_ptr<nano::block> block_a)
 	return result;
 }
 
-size_t nano::election::last_votes_size ()
-{
-	nano::lock_guard<std::mutex> lock (node.active.mutex);
-	return last_votes.size ();
-}
-
 void nano::election::cleanup ()
 {
 	bool unconfirmed (!confirmed ());
@@ -514,4 +508,11 @@ void nano::election::force_confirm (nano::election_status_type type_a)
 	release_assert (node.network_params.network.is_dev_network ());
 	nano::lock_guard<std::mutex> guard (node.active.mutex);
 	confirm_once (type_a);
+}
+
+std::unordered_map<nano::account, nano::vote_info> nano::election::votes ()
+{
+	debug_assert (node.network_params.network.is_dev_network ());
+	nano::lock_guard<std::mutex> guard (node.active.mutex);
+	return last_votes;
 }

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -36,6 +36,13 @@ enum class election_behavior
 	normal,
 	optimistic
 };
+struct election_cleanup_info final
+{
+	bool confirmed;
+	nano::qualified_root root;
+	nano::block_hash winner;
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
+};
 
 class election final : public std::enable_shared_from_this<nano::election>
 {
@@ -94,8 +101,7 @@ public: // Interface
 	// Confirm this block if quorum is met
 	void confirm_if_quorum ();
 	void prioritize_election (nano::vote_generator_session &);
-	// Erase all blocks from active and, if not confirmed, clear digests from network filters
-	void cleanup ();
+	nano::election_cleanup_info cleanup_info () const;
 
 public: // Information
 	uint64_t const height;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -90,7 +90,6 @@ public: // Interface
 	election (nano::node &, std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const &, bool, nano::election_behavior);
 	nano::election_vote_result vote (nano::account, uint64_t, nano::block_hash);
 	bool publish (std::shared_ptr<nano::block> block_a);
-	void confirm_once (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
 	size_t insert_inactive_votes_cache (nano::block_hash const &);
 	// Confirm this block if quorum is met
 	void confirm_if_quorum ();
@@ -105,6 +104,7 @@ public: // Information
 
 private:
 	void transition_active_impl ();
+	void confirm_once (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
 	void broadcast_block (nano::confirmation_solicitor &);
 	void send_confirm_req (nano::confirmation_solicitor &);
 	// Calculate votes for local representatives
@@ -122,5 +122,8 @@ private:
 	static std::chrono::seconds constexpr late_blocks_delay{ 5 };
 
 	friend class active_transactions;
+
+public: // Only used in tests
+	void force_confirm (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
 };
 }

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -65,53 +65,61 @@ private: // State management
 
 	bool valid_change (nano::election::state_t, nano::election::state_t) const;
 	bool state_change (nano::election::state_t, nano::election::state_t);
-	void broadcast_block (nano::confirmation_solicitor &);
-	void send_confirm_req (nano::confirmation_solicitor &);
-	// Calculate votes for local representatives
-	void generate_votes ();
-	void remove_votes (nano::block_hash const &);
 	std::atomic<bool> prioritized_m = { false };
-
-public:
-	election (nano::node &, std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const &, bool, nano::election_behavior);
-	nano::election_vote_result vote (nano::account, uint64_t, nano::block_hash);
-	nano::tally_t tally ();
-	// Check if we have vote quorum
-	bool have_quorum (nano::tally_t const &, nano::uint128_t) const;
-	void confirm_once (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
-	// Confirm this block if quorum is met
-	void confirm_if_quorum ();
-	void log_votes (nano::tally_t const &, std::string const & = "") const;
-	bool publish (std::shared_ptr<nano::block> block_a);
-	size_t last_votes_size ();
-	size_t insert_inactive_votes_cache (nano::block_hash const &);
-	bool prioritized () const;
-	bool optimistic () const;
-	void prioritize_election (nano::vote_generator_session &);
-	// Erase all blocks from active and, if not confirmed, clear digests from network filters
-	void cleanup ();
 
 public: // State transitions
 	bool transition_time (nano::confirmation_solicitor &);
 	void transition_active ();
 
-private:
-	void transition_active_impl ();
-
-public:
+public: // Status
 	bool confirmed () const;
 	bool failed () const;
-	nano::election_behavior election_behavior{ nano::election_behavior::normal };
-	nano::node & node;
-	std::unordered_map<nano::account, nano::vote_info> last_votes;
-	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
-	std::chrono::steady_clock::time_point election_start = { std::chrono::steady_clock::now () };
+	bool prioritized () const;
+	bool optimistic () const;
+
+	void log_votes (nano::tally_t const &, std::string const & = "") const;
+	nano::tally_t tally ();
+	bool have_quorum (nano::tally_t const &, nano::uint128_t) const;
+
 	nano::election_status status;
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
+	std::unordered_map<nano::account, nano::vote_info> last_votes;
 	unsigned confirmation_request_count{ 0 };
-	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
-	std::chrono::seconds late_blocks_delay{ 5 };
+
+public: // Interface
+	election (nano::node &, std::shared_ptr<nano::block>, std::function<void(std::shared_ptr<nano::block>)> const &, bool, nano::election_behavior);
+	nano::election_vote_result vote (nano::account, uint64_t, nano::block_hash);
+	bool publish (std::shared_ptr<nano::block> block_a);
+	void confirm_once (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
+	size_t insert_inactive_votes_cache (nano::block_hash const &);
+	// Confirm this block if quorum is met
+	void confirm_if_quorum ();
+	void prioritize_election (nano::vote_generator_session &);
+	// Erase all blocks from active and, if not confirmed, clear digests from network filters
+	void cleanup ();
+	size_t last_votes_size ();
+
+public: // Information
 	uint64_t const height;
 	nano::root const root;
+
+private:
+	void transition_active_impl ();
+	void broadcast_block (nano::confirmation_solicitor &);
+	void send_confirm_req (nano::confirmation_solicitor &);
+	// Calculate votes for local representatives
+	void generate_votes ();
+	void remove_votes (nano::block_hash const &);
+
+private:
+	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
+
+	nano::election_behavior const election_behavior{ nano::election_behavior::normal };
+	std::chrono::steady_clock::time_point const election_start = { std::chrono::steady_clock::now () };
+
+	nano::node & node;
+
+	static std::chrono::seconds constexpr late_blocks_delay{ 5 };
 
 	friend class active_transactions;
 };

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -77,6 +77,7 @@ public: // Status
 	bool failed () const;
 	bool prioritized () const;
 	bool optimistic () const;
+	std::shared_ptr<nano::block> winner ();
 
 	void log_votes (nano::tally_t const &, std::string const & = "") const;
 	nano::tally_t tally ();

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -13,6 +13,7 @@ namespace nano
 {
 class channel;
 class confirmation_solicitor;
+class json_handler;
 class node;
 class vote_generator_session;
 class vote_info final
@@ -83,7 +84,6 @@ public: // Status
 
 	nano::election_status status;
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
-	std::unordered_map<nano::account, nano::vote_info> last_votes;
 	unsigned confirmation_request_count{ 0 };
 
 public: // Interface
@@ -96,7 +96,6 @@ public: // Interface
 	void prioritize_election (nano::vote_generator_session &);
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void cleanup ();
-	size_t last_votes_size ();
 
 public: // Information
 	uint64_t const height;
@@ -112,6 +111,7 @@ private:
 	void remove_votes (nano::block_hash const &);
 
 private:
+	std::unordered_map<nano::account, nano::vote_info> last_votes;
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 
 	nano::election_behavior const behavior{ nano::election_behavior::normal };
@@ -122,8 +122,16 @@ private:
 	static std::chrono::seconds constexpr late_blocks_delay{ 5 };
 
 	friend class active_transactions;
+	friend class confirmation_solicitor;
+	friend class json_handler;
 
 public: // Only used in tests
 	void force_confirm (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
+	std::unordered_map<nano::account, nano::vote_info> votes ();
+
+	friend class confirmation_solicitor_different_hash_Test;
+	friend class confirmation_solicitor_bypass_max_requests_cap_Test;
+	friend class votes_add_existing_Test;
+	friend class votes_add_old_Test;
 };
 }

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -84,7 +84,6 @@ public: // Status
 	bool have_quorum (nano::tally_t const &, nano::uint128_t) const;
 
 	nano::election_status status;
-	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks;
 	unsigned confirmation_request_count{ 0 };
 
 public: // Interface
@@ -112,6 +111,7 @@ private:
 	void remove_votes (nano::block_hash const &);
 
 private:
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> last_blocks;
 	std::unordered_map<nano::account, nano::vote_info> last_votes;
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 
@@ -129,6 +129,7 @@ private:
 public: // Only used in tests
 	void force_confirm (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
 	std::unordered_map<nano::account, nano::vote_info> votes ();
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks ();
 
 	friend class confirmation_solicitor_different_hash_Test;
 	friend class confirmation_solicitor_bypass_max_requests_cap_Test;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -114,7 +114,7 @@ private:
 private:
 	std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 
-	nano::election_behavior const election_behavior{ nano::election_behavior::normal };
+	nano::election_behavior const behavior{ nano::election_behavior::normal };
 	std::chrono::steady_clock::time_point const election_start = { std::chrono::steady_clock::now () };
 
 	nano::node & node;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -52,9 +52,9 @@ private: // State management
 		expired_confirmed,
 		expired_unconfirmed
 	};
-	static int constexpr passive_duration_factor = 5;
-	static int constexpr active_request_count_min = 2;
-	static int constexpr confirmed_duration_factor = 5;
+	static unsigned constexpr passive_duration_factor = 5;
+	static unsigned constexpr active_request_count_min = 2;
+	static unsigned constexpr confirmed_duration_factor = 5;
 	std::atomic<nano::election::state_t> state_m = { state_t::passive };
 
 	// These time points must be protected by this mutex

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6733,12 +6733,9 @@ TEST (rpc, block_confirmed)
 	node->process_active (send);
 	node->block_processor.flush ();
 	node->block_confirm (send);
-	{
-		auto election = node->active.election (send->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		nano::lock_guard<std::mutex> guard (node->active.mutex);
-		election->confirm_once ();
-	}
+	auto election = node->active.election (send->qualified_root ());
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 
 	// Wait until the confirmation height has been set
 	ASSERT_TIMELY (10s, node->ledger.block_confirmed (node->store.tx_begin_read (), send->hash ()) && !node->confirmation_height_processor.is_processing_block (send->hash ()));
@@ -7729,12 +7726,9 @@ TEST (rpc, confirmation_active)
 	node1.process_active (send2);
 	nano::blocks_confirm (node1, { send1, send2 });
 	ASSERT_EQ (2, node1.active.size ());
-	{
-		nano::lock_guard<std::mutex> guard (node1.active.mutex);
-		auto info (node1.active.roots.find (send1->qualified_root ()));
-		ASSERT_NE (node1.active.roots.end (), info);
-		info->election->confirm_once ();
-	}
+	auto election (node1.active.election (send1->qualified_root ()));
+	ASSERT_NE (nullptr, election);
+	election->force_confirm ();
 
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_active");

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -490,8 +490,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 		auto election_insertion_result (node->active.insert (block));
 		ASSERT_TRUE (election_insertion_result.inserted);
 		ASSERT_NE (nullptr, election_insertion_result.election);
-		nano::lock_guard<std::mutex> guard (node->active.mutex);
-		election_insertion_result.election->confirm_once ();
+		election_insertion_result.election->force_confirm ();
 	}
 
 	ASSERT_TIMELY (120s, node->ledger.block_confirmed (node->store.tx_begin_read (), last_open_hash));
@@ -559,8 +558,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 		auto election_insertion_result (node->active.insert (open_block));
 		ASSERT_TRUE (election_insertion_result.inserted);
 		ASSERT_NE (nullptr, election_insertion_result.election);
-		nano::lock_guard<std::mutex> guard (node->active.mutex);
-		election_insertion_result.election->confirm_once ();
+		election_insertion_result.election->force_confirm ();
 	}
 
 	auto const num_blocks_to_confirm = (num_accounts - 1) * 2;
@@ -647,8 +645,7 @@ TEST (confirmation_height, long_chains)
 		auto election_insertion_result (node->active.insert (receive1));
 		ASSERT_TRUE (election_insertion_result.inserted);
 		ASSERT_NE (nullptr, election_insertion_result.election);
-		nano::lock_guard<std::mutex> guard (node->active.mutex);
-		election_insertion_result.election->confirm_once ();
+		election_insertion_result.election->force_confirm ();
 	}
 
 	ASSERT_TIMELY (30s, node->ledger.block_confirmed (node->store.tx_begin_read (), receive1->hash ()));
@@ -845,8 +842,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 		node->block_confirm (open_block);
 		auto election = node->active.election (open_block->qualified_root ());
 		ASSERT_NE (nullptr, election);
-		nano::lock_guard<std::mutex> guard (node->active.mutex);
-		election->confirm_once ();
+		election->force_confirm ();
 	}
 
 	system.deadline_set (100s);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -224,8 +224,10 @@ TEST (node, fork_storm)
 			}
 			else
 			{
-				nano::lock_guard<std::mutex> lock (node_a->active.mutex);
-				if (node_a->active.roots.begin ()->election->last_votes_size () == 1)
+				nano::unique_lock<std::mutex> lock (node_a->active.mutex);
+				auto election = node_a->active.roots.begin ()->election;
+				lock.unlock ();
+				if (election->votes ().size () == 1)
 				{
 					++single;
 				}


### PR DESCRIPTION
Boilerplate code split from #2925 to keep its scope to a minimum. The commits here serve as a changelog.

Passed TSAN runs of `core_test` and `rpc_test`