### PR TITLE
Add pruned node to maker

### DIFF
--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -341,6 +341,12 @@ public:
 	static size_t constexpr size = sizeof (start) + sizeof (age) + sizeof (count);
 };
 
+enum class telemetry_maker : uint8_t
+{
+	nf_node = 0,
+	nf_pruned_node = 1
+};
+
 class telemetry_data
 {
 public:
@@ -359,7 +365,7 @@ public:
 	uint8_t minor_version{ 0 };
 	uint8_t patch_version{ 0 };
 	uint8_t pre_release_version{ 0 };
-	uint8_t maker{ 0 }; // 0 for NF node
+	uint8_t maker{ static_cast<std::underlying_type_t<telemetry_maker>> (telemetry_maker::nf_node) }; // Where this telemetry information originated
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3816,7 +3816,7 @@ void nano::json_handler::telemetry ()
 					if (address.is_loopback () && port == rpc_l->node.network.endpoint ().port ())
 					{
 						// Requesting telemetry metrics locally
-						auto telemetry_data = nano::local_telemetry_data (rpc_l->node.store, rpc_l->node.ledger.cache, rpc_l->node.network, rpc_l->node.config.bandwidth_limit, rpc_l->node.network_params, rpc_l->node.startup_time, rpc_l->node.active.active_difficulty (), rpc_l->node.node_id);
+						auto telemetry_data = nano::local_telemetry_data (rpc_l->node.ledger, rpc_l->node.network, rpc_l->node.config.bandwidth_limit, rpc_l->node.network_params, rpc_l->node.startup_time, rpc_l->node.active.active_difficulty (), rpc_l->node.node_id);
 
 						nano::jsonconfig config_l;
 						auto const should_ignore_identification_metrics = false;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -508,7 +508,7 @@ public:
 		nano::telemetry_ack telemetry_ack;
 		if (!node.flags.disable_providing_telemetry_metrics)
 		{
-			auto telemetry_data = nano::local_telemetry_data (node.store, node.ledger.cache, node.network, node.config.bandwidth_limit, node.network_params, node.startup_time, node.active.active_difficulty (), node.node_id);
+			auto telemetry_data = nano::local_telemetry_data (node.ledger, node.network, node.config.bandwidth_limit, node.network_params, node.startup_time, node.active.active_difficulty (), node.node_id);
 			telemetry_ack = nano::telemetry_ack (telemetry_data);
 		}
 		channel->send (telemetry_ack, nullptr, nano::buffer_drop_policy::no_socket_drop);

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -7,6 +7,7 @@
 #include <nano/node/transport/transport.hpp>
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/buffer.hpp>
+#include <nano/secure/ledger.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -628,24 +629,24 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	return consolidated_data;
 }
 
-nano::telemetry_data nano::local_telemetry_data (nano::block_store & store_a, nano::ledger_cache const & ledger_cache_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a)
+nano::telemetry_data nano::local_telemetry_data (nano::ledger const & ledger_a, nano::network & network_a, uint64_t bandwidth_limit_a, nano::network_params const & network_params_a, std::chrono::steady_clock::time_point statup_time_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a)
 {
 	nano::telemetry_data telemetry_data;
 	telemetry_data.node_id = node_id_a.pub;
-	telemetry_data.block_count = ledger_cache_a.block_count;
-	telemetry_data.cemented_count = ledger_cache_a.cemented_count;
+	telemetry_data.block_count = ledger_a.cache.block_count;
+	telemetry_data.cemented_count = ledger_a.cache.cemented_count;
 	telemetry_data.bandwidth_cap = bandwidth_limit_a;
 	telemetry_data.protocol_version = network_params_a.protocol.protocol_version;
 	telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - statup_time_a).count ();
-	telemetry_data.unchecked_count = store_a.unchecked_count (store_a.tx_begin_read ());
+	telemetry_data.unchecked_count = ledger_a.store.unchecked_count (ledger_a.store.tx_begin_read ());
 	telemetry_data.genesis_block = network_params_a.ledger.genesis_hash;
 	telemetry_data.peer_count = nano::narrow_cast<decltype (telemetry_data.peer_count)> (network_a.size ());
-	telemetry_data.account_count = ledger_cache_a.account_count;
+	telemetry_data.account_count = ledger_a.cache.account_count;
 	telemetry_data.major_version = nano::get_major_node_version ();
 	telemetry_data.minor_version = nano::get_minor_node_version ();
 	telemetry_data.patch_version = nano::get_patch_node_version ();
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
-	telemetry_data.maker = 0; // 0 Indicates it originated from the NF
+	telemetry_data.maker = static_cast<std::underlying_type_t<telemetry_maker>> (ledger_a.pruning ? telemetry_maker::nf_pruned_node : telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = active_difficulty_a;
 	// Make sure this is the final operation!

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -20,6 +20,7 @@ class network;
 class alarm;
 class worker;
 class stat;
+class ledger;
 namespace transport
 {
 	class channel;
@@ -150,5 +151,5 @@ private:
 std::unique_ptr<nano::container_info_component> collect_container_info (telemetry & telemetry, const std::string & name);
 
 nano::telemetry_data consolidate_telemetry_data (std::vector<telemetry_data> const & telemetry_data);
-nano::telemetry_data local_telemetry_data (nano::block_store &, nano::ledger_cache const &, nano::network &, uint64_t, nano::network_params const &, std::chrono::steady_clock::time_point, uint64_t, nano::keypair const &);
+nano::telemetry_data local_telemetry_data (nano::ledger const & ledger_a, nano::network &, uint64_t, nano::network_params const &, std::chrono::steady_clock::time_point, uint64_t, nano::keypair const &);
 }

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -13,7 +13,6 @@ void nano::compare_default_telemetry_response_data_excluding_signature (nano::te
 	ASSERT_EQ (telemetry_data_a.unchecked_count, 0);
 	ASSERT_EQ (telemetry_data_a.account_count, 1);
 	ASSERT_LT (telemetry_data_a.uptime, 100);
-	ASSERT_LT (telemetry_data_a.uptime, 100);
 	ASSERT_EQ (telemetry_data_a.genesis_block, network_params_a.ledger.genesis_hash);
 	ASSERT_EQ (telemetry_data_a.major_version, nano::get_major_node_version ());
 	ASSERT_EQ (telemetry_data_a.minor_version, nano::get_minor_node_version ());

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -13,12 +13,13 @@ void nano::compare_default_telemetry_response_data_excluding_signature (nano::te
 	ASSERT_EQ (telemetry_data_a.unchecked_count, 0);
 	ASSERT_EQ (telemetry_data_a.account_count, 1);
 	ASSERT_LT (telemetry_data_a.uptime, 100);
+	ASSERT_LT (telemetry_data_a.uptime, 100);
 	ASSERT_EQ (telemetry_data_a.genesis_block, network_params_a.ledger.genesis_hash);
 	ASSERT_EQ (telemetry_data_a.major_version, nano::get_major_node_version ());
 	ASSERT_EQ (telemetry_data_a.minor_version, nano::get_minor_node_version ());
 	ASSERT_EQ (telemetry_data_a.patch_version, nano::get_patch_node_version ());
 	ASSERT_EQ (telemetry_data_a.pre_release_version, nano::get_pre_release_node_version ());
-	ASSERT_EQ (telemetry_data_a.maker, 0);
+	ASSERT_EQ (telemetry_data_a.maker, static_cast<std::underlying_type_t<nano::telemetry_maker>> (nano::telemetry_maker::nf_node));
 	ASSERT_GT (telemetry_data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
 	ASSERT_EQ (telemetry_data_a.active_difficulty, active_difficulty_a);
 }


### PR DESCRIPTION
0 is for NF node
1 is for NF pruned node

This allows communication that the node is running a pruned node via telemetry without needing to add a new telemetry signed payload. This limitation will be resolved in v22 and new telemetry data won't be added until v23 at earliest.