### PR TITLE
Enable OpenCL on macOS

### DIFF
--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -11,7 +11,11 @@
 #include <string>
 #include <vector>
 
+#if defined(__APPLE__)
+bool nano::opencl_loaded{ true };
+#else
 bool nano::opencl_loaded{ false };
+#endif
 
 namespace
 {


### PR DESCRIPTION
The `opencl_loaded` flag is never set on macOS on the develop branch, which forces cpu based work generation. Since there's no manual opencl dynlib loading on macOS, this PR sets the flag directly after checking against `__APPLE__`