### PR TITLE
Properly initialize array of atomics in ws server

### DIFF
--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -557,6 +557,10 @@ socket (io_ctx_a)
 {
 	try
 	{
+		for (std::atomic<std::size_t> & item : topic_subscriber_count)
+		{
+			item = std::size_t (0);
+		}
 		acceptor.open (endpoint_a.protocol ());
 		acceptor.set_option (boost::asio::socket_base::reuse_address (true));
 		acceptor.bind (endpoint_a);

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -336,7 +336,7 @@ namespace websocket
 		socket_type socket;
 		std::mutex sessions_mutex;
 		std::vector<std::weak_ptr<session>> sessions;
-		std::array<std::atomic<std::size_t>, number_topics> topic_subscriber_count{};
+		std::array<std::atomic<std::size_t>, number_topics> topic_subscriber_count;
 		std::atomic<bool> stopped{ false };
 	};
 }


### PR DESCRIPTION
Came across [1] where C++20 fixes atomic default initialization. I believe this issue applies to the array of atomics in websockets. Recent compilers seem to do the right thing, and worst case is unnecessary checks with `subscriptions.find`, but should be fixed nevertheless.

[1] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0883r2.pdf