### PR TITLE
Remove debug_assert which is hit calling block_confirm on already confirmed block.

### DIFF
--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -537,19 +537,10 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 	// Bail if there was an error. This indicates that there was a fatal issue with the ledger
 	// (the blocks probably got rolled back when they shouldn't have).
 	release_assert (!error);
-	// Tests should check this already at the end, but not all blocks may have elections (e.g from manual calls to confirmation_height_processor::add), this should catch any inconsistencies on live/beta though
-	if (!network_params.network.is_dev_network ())
+	if (!network_params.network.is_dev_network () && time_spent_cementing > maximum_batch_write_time)
 	{
-		auto blocks_confirmed_stats = ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed);
-		auto observer_stats = ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out);
-		debug_assert (blocks_confirmed_stats == observer_stats);
-
-		// Lower batch_write_size if it took too long to write that amount.
-		if (time_spent_cementing > maximum_batch_write_time)
-		{
-			// Reduce (unless we have hit a floor)
-			batch_write_size = std::max<uint64_t> (minimum_batch_write_size, batch_write_size - amount_to_change);
-		}
+		// Reduce (unless we have hit a floor)
+		batch_write_size = std::max<uint64_t> (minimum_batch_write_size, batch_write_size - amount_to_change);
 	}
 
 	debug_assert (pending_writes.empty ());

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -411,13 +411,6 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 	notify_observers_callback (cemented_blocks);
 	release_assert (!error);
 
-	// Tests should check this already at the end, but not all blocks may have elections (e.g from manual calls to confirmation_height_processor::add), this should catch any inconsistencies on live/beta though
-	if (!network_params.network.is_dev_network ())
-	{
-		auto blocks_confirmed_stats = ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed);
-		auto observer_stats = ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out);
-		debug_assert (blocks_confirmed_stats == observer_stats);
-	}
 	debug_assert (pending_writes.empty ());
 	debug_assert (pending_writes_size == 0);
 	timer.restart ();


### PR DESCRIPTION
@clemahieu hit this calling block_confirm on a block already confirmed. The `debug_assert` relied on nothing else calling the observers which is not the case with block_confirm. We have tests which check the value of the observer stats so simpler to just remove the assert. 