### PR TITLE
Allow [[deprecated]] attribute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (WIN32)
 
 else ()
 	if (NANO_WARN_TO_ERR)
-		add_compile_options(-Werror)
+		add_compile_options(-Werror -Wno-deprecated-declarations)
 	endif ()
 
 	if ((${USING_TSAN} AND ${USING_ASAN}) OR

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -339,7 +339,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 			auto lmdb_config_l (toml.get_required_child ("lmdb"));
 			lmdb_config.deserialize_toml (lmdb_config_l, is_deprecated_lmdb_dbs_used);
 
-			// Note that the lmdb config fails is both the deprecated and new setting are changed.
+			// Note that the lmdb config fails if both the deprecated and new setting are changed.
 			if (is_deprecated_lmdb_dbs_used)
 			{
 				lmdb_config.max_databases = deprecated_lmdb_max_dbs;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -73,7 +73,7 @@ public:
 	std::string callback_address;
 	uint16_t callback_port{ 0 };
 	std::string callback_target;
-	int deprecated_lmdb_max_dbs{ 128 };
+	[[deprecated]] int deprecated_lmdb_max_dbs{ 128 };
 	bool allow_local_peers{ !(network_params.network.is_live_network () || network_params.network.is_test_network ()) }; // disable by default for live network
 	nano::stat_config stat_config;
 	nano::ipc::ipc_config ipc_config;


### PR DESCRIPTION
@cryptocode noted some issues with using `[[deprecated]]` on CI. It's because it generates a warning if the thing being deprecated is used in the codebase. Which CI then turns into an error. This adds `-Wno-deprecated-declarations` to prevent the error, I think still showing a warning is good because then any deprecations are still clearly visible. I've also added one in nodeconfig.hpp mainly just to test that it is working correctly with CI. And also updated a typo.