### PR TITLE
Renew UPNP port lease

### DIFF
--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -84,9 +84,8 @@ void nano::port_mapping::refresh_mapping ()
 		// We don't map the RPC port because, unless RPC authentication was added, this would almost always be a security risk
 		for (auto & protocol : protocols | boost::adaptors::filtered ([](auto const & p) { return p.enabled; }))
 		{
-			auto const lease_duration = std::chrono::duration_cast<std::chrono::seconds> (network_params.portmapping.lease_duration);
 			auto upnp_description = std::string ("Nano Node (") + network_params.network.get_current_network_as_string () + ")";
-			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (lease_duration.count ()).c_str ()));
+			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (network_params.portmapping.lease_duration.count ()).c_str ()));
 			if (node.config.logging.upnp_details_logging ())
 			{
 				node.logger.always_log (boost::str (boost::format ("UPnP %1% port mapping response: %2%") % protocol.name % add_port_mapping_error_l));
@@ -97,7 +96,7 @@ void nano::port_mapping::refresh_mapping ()
 				node.logger.always_log (boost::str (boost::format ("UPnP %1%:%2% mapped to %3%") % protocol.external_address % config_port_l % node_port_l));
 
 				// Refresh mapping before the leasing ends
-				node.alarm.add (std::chrono::steady_clock::now () + lease_duration - std::chrono::seconds (10), [node_l = node.shared ()]() {
+				node.alarm.add (std::chrono::steady_clock::now () + network_params.portmapping.lease_duration - std::chrono::seconds (10), [node_l = node.shared ()]() {
 					node_l->port_mapping.refresh_mapping ();
 				});
 			}
@@ -125,7 +124,7 @@ bool nano::port_mapping::check_mapping ()
 		std::array<char, 16> remaining_mapping_duration_l;
 		remaining_mapping_duration_l.fill (0);
 		auto verify_port_mapping_error_l (UPNP_GetSpecificPortMappingEntry (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), protocol.name, nullptr, int_client_l.data (), int_port_l.data (), nullptr, nullptr, remaining_mapping_duration_l.data ()));
-		if (verify_port_mapping_error_l == UPNPCOMMAND_SUCCESS)
+		if (verify_port_mapping_error_l == UPNPCOMMAND_SUCCESS || atoi (remaining_mapping_duration_l.data ()) <= (network_params.portmapping.lease_duration.count () / 2))
 		{
 			result_l = false;
 		}


### PR DESCRIPTION
Bug pointed out by Ricki and Srayman where UPNP was not renewing
The remaining lease time was being recorded but not checked when setting if refresh_mapping() was called
fixed logic