### PR TITLE
Customizing Test Network Parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ if (NANO_GUI OR RAIBLOCKS_GUI)
 			nano/qt_test/entry.cpp
 			nano/qt_test/qt.cpp)
 
-		target_link_libraries(qt_test test_common gtest gtest_main qt Qt5::Test)
+		target_link_libraries(qt_test node secure test_common gtest gtest_main qt Qt5::Test)
 
 		set_target_properties (qt_test PROPERTIES COMPILE_FLAGS "-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")
 	endif ()

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -7,145 +7,145 @@
 
 namespace
 {
-	// useful for boost_lexical cast to allow conversion of hex strings
-	template <typename ElemT>
-	struct HexTo
+// useful for boost_lexical cast to allow conversion of hex strings
+template <typename ElemT>
+struct HexTo
+{
+	ElemT value;
+	operator ElemT () const
 	{
-		ElemT value;
-		operator ElemT() const
-		{
-			return value;
-		}
-		friend std::istream &operator>>(std::istream &in, HexTo &out)
-		{
-			in >> std::hex >> out.value;
-			return in;
-		}
-	};
+		return value;
+	}
+	friend std::istream & operator>> (std::istream & in, HexTo & out)
+	{
+		in >> std::hex >> out.value;
+		return in;
+	}
+};
 } // namespace
 
 namespace nano
 {
-	work_thresholds const network_constants::publish_full(
-		0xffffffc000000000,
-		0xfffffff800000000, // 8x higher than epoch_1
-		0xfffffe0000000000	// 8x lower than epoch_1
-	);
+work_thresholds const network_constants::publish_full (
+0xffffffc000000000,
+0xfffffff800000000, // 8x higher than epoch_1
+0xfffffe0000000000 // 8x lower than epoch_1
+);
 
-	work_thresholds const network_constants::publish_beta(
-		0xfffff00000000000, // 64x lower than publish_full.epoch_1
-		0xfffff00000000000, // same as epoch_1
-		0xffffe00000000000	// 2x lower than epoch_1
-	);
+work_thresholds const network_constants::publish_beta (
+0xfffff00000000000, // 64x lower than publish_full.epoch_1
+0xfffff00000000000, // same as epoch_1
+0xffffe00000000000 // 2x lower than epoch_1
+);
 
-	work_thresholds const network_constants::publish_dev(
-		0xfe00000000000000, // Very low for tests
-		0xffc0000000000000, // 8x higher than epoch_1
-		0xf000000000000000	// 8x lower than epoch_1
-	);
+work_thresholds const network_constants::publish_dev (
+0xfe00000000000000, // Very low for tests
+0xffc0000000000000, // 8x higher than epoch_1
+0xf000000000000000 // 8x lower than epoch_1
+);
 
-	work_thresholds const network_constants::publish_test( //defaults to live network levels
-		get_env_threshold_or_default("NANO_TEST_EPOCH_1", 0xffffffc000000000),
-		get_env_threshold_or_default("NANO_TEST_EPOCH_2", 0xfffffff800000000),	   // 8x higher than epoch_1
-		get_env_threshold_or_default("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
-	);
+work_thresholds const network_constants::publish_test ( //defaults to live network levels
+get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
+get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
+get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
+);
 
-	const char *network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
+const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
-	uint8_t get_major_node_version()
-	{
-		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_MAJOR_VERSION_STRING));
-	}
-	uint8_t get_minor_node_version()
-	{
-		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_MINOR_VERSION_STRING));
-	}
-	uint8_t get_patch_node_version()
-	{
-		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_PATCH_VERSION_STRING));
-	}
-	uint8_t get_pre_release_node_version()
-	{
-		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_PRE_RELEASE_VERSION_STRING));
-	}
+uint8_t get_major_node_version ()
+{
+	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_MAJOR_VERSION_STRING));
+}
+uint8_t get_minor_node_version ()
+{
+	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_MINOR_VERSION_STRING));
+}
+uint8_t get_patch_node_version ()
+{
+	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PATCH_VERSION_STRING));
+}
+uint8_t get_pre_release_node_version ()
+{
+	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PRE_RELEASE_VERSION_STRING));
+}
 
-	std::string get_env_or_default(char const *variable_name, std::string default_value)
-	{
-		auto value = getenv(variable_name);
-		return value ? value : default_value;
-	}
+std::string get_env_or_default (char const * variable_name, std::string default_value)
+{
+	auto value = getenv (variable_name);
+	return value ? value : default_value;
+}
 
-	uint64_t get_env_threshold_or_default(char const *variable_name, uint64_t const default_value)
-	{
-		auto *value = getenv(variable_name);
-		return value ? boost::lexical_cast<HexTo<uint64_t>>(value) : default_value;
-	}
+uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t const default_value)
+{
+	auto * value = getenv (variable_name);
+	return value ? boost::lexical_cast<HexTo<uint64_t>> (value) : default_value;
+}
 
-	uint16_t test_node_port()
-	{
-		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
-		return boost::lexical_cast<uint16_t>(test_env);
-	}
-	uint16_t test_rpc_port()
-	{
-		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
-		return boost::lexical_cast<uint16_t>(test_env);
-	}
-	uint16_t test_ipc_port()
-	{
-		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
-		return boost::lexical_cast<uint16_t>(test_env);
-	}
-	uint16_t test_websocket_port()
-	{
-		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
-		return boost::lexical_cast<uint16_t>(test_env);
-	}
+uint16_t test_node_port ()
+{
+	auto test_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+uint16_t test_rpc_port ()
+{
+	auto test_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+uint16_t test_ipc_port ()
+{
+	auto test_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+uint16_t test_websocket_port ()
+{
+	auto test_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
 
-	std::array<uint8_t, 2> test_magic_number()
-	{
-		auto test_env = get_env_or_default("NANO_TEST_MAGIC_NUMBER", "RX");
-		std::array<uint8_t, 2> ret;
-		std::copy(test_env.begin(), test_env.end(), ret.data());
-		return ret;
-	}
+std::array<uint8_t, 2> test_magic_number ()
+{
+	auto test_env = get_env_or_default ("NANO_TEST_MAGIC_NUMBER", "RX");
+	std::array<uint8_t, 2> ret;
+	std::copy (test_env.begin (), test_env.end (), ret.data ());
+	return ret;
+}
 
-	void force_nano_dev_network()
-	{
-		nano::network_constants::set_active_network(nano::nano_networks::nano_dev_network);
-	}
+void force_nano_dev_network ()
+{
+	nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+}
 
-	bool running_within_valgrind()
-	{
-		return (RUNNING_ON_VALGRIND > 0);
-	}
+bool running_within_valgrind ()
+{
+	return (RUNNING_ON_VALGRIND > 0);
+}
 
-	std::string get_config_path(boost::filesystem::path const &data_path)
-	{
-		return (data_path / "config.json").string();
-	}
+std::string get_config_path (boost::filesystem::path const & data_path)
+{
+	return (data_path / "config.json").string ();
+}
 
-	std::string get_rpc_config_path(boost::filesystem::path const &data_path)
-	{
-		return (data_path / "rpc_config.json").string();
-	}
+std::string get_rpc_config_path (boost::filesystem::path const & data_path)
+{
+	return (data_path / "rpc_config.json").string ();
+}
 
-	std::string get_node_toml_config_path(boost::filesystem::path const &data_path)
-	{
-		return (data_path / "config-node.toml").string();
-	}
+std::string get_node_toml_config_path (boost::filesystem::path const & data_path)
+{
+	return (data_path / "config-node.toml").string ();
+}
 
-	std::string get_rpc_toml_config_path(boost::filesystem::path const &data_path)
-	{
-		return (data_path / "config-rpc.toml").string();
-	}
+std::string get_rpc_toml_config_path (boost::filesystem::path const & data_path)
+{
+	return (data_path / "config-rpc.toml").string ();
+}
 
-	std::string get_qtwallet_toml_config_path(boost::filesystem::path const &data_path)
-	{
-		return (data_path / "config-qtwallet.toml").string();
-	}
-	std::string get_access_toml_config_path(boost::filesystem::path const &data_path)
-	{
-		return (data_path / "config-access.toml").string();
-	}
+std::string get_qtwallet_toml_config_path (boost::filesystem::path const & data_path)
+{
+	return (data_path / "config-qtwallet.toml").string ();
+}
+std::string get_access_toml_config_path (boost::filesystem::path const & data_path)
+{
+	return (data_path / "config-access.toml").string ();
+}
 } // namespace nano

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -25,6 +25,12 @@ work_thresholds const network_constants::publish_dev (
 0xf000000000000000 // 8x lower than epoch_1
 );
 
+work_thresholds const network_constants::publish_test ( //defaults to live network levels
+GetEnvThresholdOrDefault ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
+GetEnvThresholdOrDefault ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
+GetEnvThresholdOrDefault ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
+);
+
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
 uint8_t get_major_node_version ()
@@ -42,6 +48,59 @@ uint8_t get_patch_node_version ()
 uint8_t get_pre_release_node_version ()
 {
 	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PRE_RELEASE_VERSION_STRING));
+}
+
+std::string GetEnvOrDefault (const std::string & variable_name, const std::string & default_value)
+{
+	const char * value = getenv (variable_name.c_str ());
+	return value ? value : default_value;
+}
+
+uint64_t GetEnvThresholdOrDefault (const std::string & variable_name, const uint64_t & default_value)
+{
+	const char * value = getenv (variable_name.c_str ());
+	return value ? std::strtoull (value, NULL, 16) : default_value;
+}
+
+int test_node_port ()
+{
+	auto test_node_env = nano::GetEnvOrDefault ("NANO_TEST_NODE_PORT", "17075");
+	int ret;
+	std::istringstream iss (test_node_env);
+	iss >> ret;
+	return ret;
+}
+int test_rpc_port ()
+{
+	auto test_env = nano::GetEnvOrDefault ("NANO_TEST_RPC_PORT", "17076");
+	int ret;
+	std::istringstream iss (test_env);
+	iss >> ret;
+	return ret;
+}
+int test_ipc_port ()
+{
+	auto test_env = nano::GetEnvOrDefault ("NANO_TEST_IPC_PORT", "17077");
+	int ret;
+	std::istringstream iss (test_env);
+	iss >> ret;
+	return ret;
+}
+int test_websocket_port ()
+{
+	auto test_env = nano::GetEnvOrDefault ("NANO_TEST_WEBSOCKET_PORT", "17078");
+	int ret;
+	std::istringstream iss (test_env);
+	iss >> ret;
+	return ret;
+}
+
+std::array<uint8_t, 2> test_magic_number ()
+{
+	auto test_env = GetEnvOrDefault ("NANO_TEST_MAGIC_NUMBER", "RX");
+	std::array<uint8_t, 2> ret;
+	std::copy (test_env.begin (), test_env.end (), ret.data ());
+	return ret;
 }
 
 void force_nano_dev_network ()

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -26,9 +26,9 @@ work_thresholds const network_constants::publish_dev (
 );
 
 work_thresholds const network_constants::publish_test ( //defaults to live network levels
-GetEnvThresholdOrDefault ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
-GetEnvThresholdOrDefault ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
-GetEnvThresholdOrDefault ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
+get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
+get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
+get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
 );
 
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
@@ -50,13 +50,13 @@ uint8_t get_pre_release_node_version ()
 	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PRE_RELEASE_VERSION_STRING));
 }
 
-std::string GetEnvOrDefault (const std::string & variable_name, const std::string & default_value)
+std::string get_env_or_default (const std::string & variable_name, const std::string & default_value)
 {
 	const char * value = getenv (variable_name.c_str ());
 	return value ? value : default_value;
 }
 
-uint64_t GetEnvThresholdOrDefault (const std::string & variable_name, const uint64_t & default_value)
+uint64_t get_env_threshold_or_default (const std::string & variable_name, const uint64_t & default_value)
 {
 	const char * value = getenv (variable_name.c_str ());
 	return value ? std::strtoull (value, NULL, 16) : default_value;
@@ -64,7 +64,7 @@ uint64_t GetEnvThresholdOrDefault (const std::string & variable_name, const uint
 
 int test_node_port ()
 {
-	auto test_node_env = nano::GetEnvOrDefault ("NANO_TEST_NODE_PORT", "17075");
+	auto test_node_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
 	int ret;
 	std::istringstream iss (test_node_env);
 	iss >> ret;
@@ -72,7 +72,7 @@ int test_node_port ()
 }
 int test_rpc_port ()
 {
-	auto test_env = nano::GetEnvOrDefault ("NANO_TEST_RPC_PORT", "17076");
+	auto test_env = nano::get_env_or_default ("NANO_TEST_RPC_PORT", "17076");
 	int ret;
 	std::istringstream iss (test_env);
 	iss >> ret;
@@ -80,7 +80,7 @@ int test_rpc_port ()
 }
 int test_ipc_port ()
 {
-	auto test_env = nano::GetEnvOrDefault ("NANO_TEST_IPC_PORT", "17077");
+	auto test_env = nano::get_env_or_default ("NANO_TEST_IPC_PORT", "17077");
 	int ret;
 	std::istringstream iss (test_env);
 	iss >> ret;
@@ -88,7 +88,7 @@ int test_ipc_port ()
 }
 int test_websocket_port ()
 {
-	auto test_env = nano::GetEnvOrDefault ("NANO_TEST_WEBSOCKET_PORT", "17078");
+	auto test_env = nano::get_env_or_default ("NANO_TEST_WEBSOCKET_PORT", "17078");
 	int ret;
 	std::istringstream iss (test_env);
 	iss >> ret;
@@ -97,7 +97,7 @@ int test_websocket_port ()
 
 std::array<uint8_t, 2> test_magic_number ()
 {
-	auto test_env = GetEnvOrDefault ("NANO_TEST_MAGIC_NUMBER", "RX");
+	auto test_env = get_env_or_default ("NANO_TEST_MAGIC_NUMBER", "RX");
 	std::array<uint8_t, 2> ret;
 	std::copy (test_env.begin (), test_env.end (), ret.data ());
 	return ret;

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -5,140 +5,147 @@
 
 #include <valgrind/valgrind.h>
 
+namespace
+{
+	// useful for boost_lexical cast to allow conversion of hex strings
+	template <typename ElemT>
+	struct HexTo
+	{
+		ElemT value;
+		operator ElemT() const
+		{
+			return value;
+		}
+		friend std::istream &operator>>(std::istream &in, HexTo &out)
+		{
+			in >> std::hex >> out.value;
+			return in;
+		}
+	};
+} // namespace
+
 namespace nano
 {
-work_thresholds const network_constants::publish_full (
-0xffffffc000000000,
-0xfffffff800000000, // 8x higher than epoch_1
-0xfffffe0000000000 // 8x lower than epoch_1
-);
+	work_thresholds const network_constants::publish_full(
+		0xffffffc000000000,
+		0xfffffff800000000, // 8x higher than epoch_1
+		0xfffffe0000000000	// 8x lower than epoch_1
+	);
 
-work_thresholds const network_constants::publish_beta (
-0xfffff00000000000, // 64x lower than publish_full.epoch_1
-0xfffff00000000000, // same as epoch_1
-0xffffe00000000000 // 2x lower than epoch_1
-);
+	work_thresholds const network_constants::publish_beta(
+		0xfffff00000000000, // 64x lower than publish_full.epoch_1
+		0xfffff00000000000, // same as epoch_1
+		0xffffe00000000000	// 2x lower than epoch_1
+	);
 
-work_thresholds const network_constants::publish_dev (
-0xfe00000000000000, // Very low for tests
-0xffc0000000000000, // 8x higher than epoch_1
-0xf000000000000000 // 8x lower than epoch_1
-);
+	work_thresholds const network_constants::publish_dev(
+		0xfe00000000000000, // Very low for tests
+		0xffc0000000000000, // 8x higher than epoch_1
+		0xf000000000000000	// 8x lower than epoch_1
+	);
 
-work_thresholds const network_constants::publish_test ( //defaults to live network levels
-get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
-get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
-get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
-);
+	work_thresholds const network_constants::publish_test( //defaults to live network levels
+		get_env_threshold_or_default("NANO_TEST_EPOCH_1", 0xffffffc000000000),
+		get_env_threshold_or_default("NANO_TEST_EPOCH_2", 0xfffffff800000000),	   // 8x higher than epoch_1
+		get_env_threshold_or_default("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
+	);
 
-const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
+	const char *network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
-uint8_t get_major_node_version ()
-{
-	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_MAJOR_VERSION_STRING));
-}
-uint8_t get_minor_node_version ()
-{
-	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_MINOR_VERSION_STRING));
-}
-uint8_t get_patch_node_version ()
-{
-	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PATCH_VERSION_STRING));
-}
-uint8_t get_pre_release_node_version ()
-{
-	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PRE_RELEASE_VERSION_STRING));
-}
+	uint8_t get_major_node_version()
+	{
+		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_MAJOR_VERSION_STRING));
+	}
+	uint8_t get_minor_node_version()
+	{
+		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_MINOR_VERSION_STRING));
+	}
+	uint8_t get_patch_node_version()
+	{
+		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_PATCH_VERSION_STRING));
+	}
+	uint8_t get_pre_release_node_version()
+	{
+		return boost::numeric_cast<uint8_t>(boost::lexical_cast<int>(NANO_PRE_RELEASE_VERSION_STRING));
+	}
 
-std::string get_env_or_default (const std::string & variable_name, const std::string & default_value)
-{
-	const char * value = getenv (variable_name.c_str ());
-	return value ? value : default_value;
-}
+	std::string get_env_or_default(char const *variable_name, std::string default_value)
+	{
+		auto value = getenv(variable_name);
+		return value ? value : default_value;
+	}
 
-uint64_t get_env_threshold_or_default (const std::string & variable_name, const uint64_t & default_value)
-{
-	const char * value = getenv (variable_name.c_str ());
-	return value ? std::strtoull (value, NULL, 16) : default_value;
-}
+	uint64_t get_env_threshold_or_default(char const *variable_name, uint64_t const default_value)
+	{
+		auto *value = getenv(variable_name);
+		return value ? boost::lexical_cast<HexTo<uint64_t>>(value) : default_value;
+	}
 
-int test_node_port ()
-{
-	auto test_node_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
-	int ret;
-	std::istringstream iss (test_node_env);
-	iss >> ret;
-	return ret;
-}
-int test_rpc_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_RPC_PORT", "17076");
-	int ret;
-	std::istringstream iss (test_env);
-	iss >> ret;
-	return ret;
-}
-int test_ipc_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_IPC_PORT", "17077");
-	int ret;
-	std::istringstream iss (test_env);
-	iss >> ret;
-	return ret;
-}
-int test_websocket_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_WEBSOCKET_PORT", "17078");
-	int ret;
-	std::istringstream iss (test_env);
-	iss >> ret;
-	return ret;
-}
+	uint16_t test_node_port()
+	{
+		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
+		return boost::lexical_cast<uint16_t>(test_env);
+	}
+	uint16_t test_rpc_port()
+	{
+		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
+		return boost::lexical_cast<uint16_t>(test_env);
+	}
+	uint16_t test_ipc_port()
+	{
+		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
+		return boost::lexical_cast<uint16_t>(test_env);
+	}
+	uint16_t test_websocket_port()
+	{
+		auto test_env = nano::get_env_or_default("NANO_TEST_NODE_PORT", "17075");
+		return boost::lexical_cast<uint16_t>(test_env);
+	}
 
-std::array<uint8_t, 2> test_magic_number ()
-{
-	auto test_env = get_env_or_default ("NANO_TEST_MAGIC_NUMBER", "RX");
-	std::array<uint8_t, 2> ret;
-	std::copy (test_env.begin (), test_env.end (), ret.data ());
-	return ret;
-}
+	std::array<uint8_t, 2> test_magic_number()
+	{
+		auto test_env = get_env_or_default("NANO_TEST_MAGIC_NUMBER", "RX");
+		std::array<uint8_t, 2> ret;
+		std::copy(test_env.begin(), test_env.end(), ret.data());
+		return ret;
+	}
 
-void force_nano_dev_network ()
-{
-	nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
-}
+	void force_nano_dev_network()
+	{
+		nano::network_constants::set_active_network(nano::nano_networks::nano_dev_network);
+	}
 
-bool running_within_valgrind ()
-{
-	return (RUNNING_ON_VALGRIND > 0);
-}
+	bool running_within_valgrind()
+	{
+		return (RUNNING_ON_VALGRIND > 0);
+	}
 
-std::string get_config_path (boost::filesystem::path const & data_path)
-{
-	return (data_path / "config.json").string ();
-}
+	std::string get_config_path(boost::filesystem::path const &data_path)
+	{
+		return (data_path / "config.json").string();
+	}
 
-std::string get_rpc_config_path (boost::filesystem::path const & data_path)
-{
-	return (data_path / "rpc_config.json").string ();
-}
+	std::string get_rpc_config_path(boost::filesystem::path const &data_path)
+	{
+		return (data_path / "rpc_config.json").string();
+	}
 
-std::string get_node_toml_config_path (boost::filesystem::path const & data_path)
-{
-	return (data_path / "config-node.toml").string ();
-}
+	std::string get_node_toml_config_path(boost::filesystem::path const &data_path)
+	{
+		return (data_path / "config-node.toml").string();
+	}
 
-std::string get_rpc_toml_config_path (boost::filesystem::path const & data_path)
-{
-	return (data_path / "config-rpc.toml").string ();
-}
+	std::string get_rpc_toml_config_path(boost::filesystem::path const &data_path)
+	{
+		return (data_path / "config-rpc.toml").string();
+	}
 
-std::string get_qtwallet_toml_config_path (boost::filesystem::path const & data_path)
-{
-	return (data_path / "config-qtwallet.toml").string ();
-}
-std::string get_access_toml_config_path (boost::filesystem::path const & data_path)
-{
-	return (data_path / "config-access.toml").string ();
-}
-}
+	std::string get_qtwallet_toml_config_path(boost::filesystem::path const &data_path)
+	{
+		return (data_path / "config-qtwallet.toml").string();
+	}
+	std::string get_access_toml_config_path(boost::filesystem::path const &data_path)
+	{
+		return (data_path / "config-access.toml").string();
+	}
+} // namespace nano

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -50,8 +50,8 @@ uint8_t get_minor_node_version ();
 uint8_t get_patch_node_version ();
 uint8_t get_pre_release_node_version ();
 
-std::string GetEnvOrDefault (const std::string & variable_name, const std::string & default_value);
-uint64_t GetEnvThresholdOrDefault (const std::string & variable_name, const uint64_t & default_value);
+std::string get_env_or_default (const std::string & variable_name, const std::string & default_value);
+uint64_t get_env_threshold_or_default (const std::string & variable_name, const uint64_t & default_value);
 
 int test_node_port ();
 int test_rpc_port ();

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -4,6 +4,7 @@
 #include <boost/version.hpp>
 
 #include <algorithm>
+#include <array>
 #include <string>
 
 namespace boost
@@ -48,6 +49,15 @@ uint8_t get_major_node_version ();
 uint8_t get_minor_node_version ();
 uint8_t get_patch_node_version ();
 uint8_t get_pre_release_node_version ();
+
+std::string GetEnvOrDefault (const std::string & variable_name, const std::string & default_value);
+uint64_t GetEnvThresholdOrDefault (const std::string & variable_name, const uint64_t & default_value);
+
+int test_node_port ();
+int test_rpc_port ();
+int test_ipc_port ();
+int test_websocket_port ();
+std::array<uint8_t, 2> test_magic_number ();
 
 /**
  * Network variants with different genesis blocks and network parameters
@@ -104,15 +114,15 @@ public:
 
 	network_constants (nano_networks network_a) :
 	current_network (network_a),
-	publish_thresholds ((is_live_network () || is_test_network ()) ? publish_full : is_beta_network () ? publish_beta : publish_dev)
+	publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : is_test_network () ? publish_test : publish_dev)
 	{
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
 
-		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : is_test_network () ? 17075 : 44000;
-		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : is_test_network () ? 17076 : 45000;
-		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : is_test_network () ? 17077 : 46000;
-		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : is_test_network () ? 17078 : 47000;
+		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : is_test_network () ? test_node_port () : 44000;
+		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : is_test_network () ? test_rpc_port () : 45000;
+		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : is_test_network () ? test_ipc_port () : 46000;
+		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : is_test_network () ? test_websocket_port () : 47000;
 		request_interval_ms = is_dev_network () ? 20 : 500;
 	}
 
@@ -120,6 +130,7 @@ public:
 	static const nano::work_thresholds publish_full;
 	static const nano::work_thresholds publish_beta;
 	static const nano::work_thresholds publish_dev;
+	static const nano::work_thresholds publish_test;
 
 	/** Error message when an invalid network is specified */
 	static const char * active_network_err_msg;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -50,13 +50,13 @@ uint8_t get_minor_node_version ();
 uint8_t get_patch_node_version ();
 uint8_t get_pre_release_node_version ();
 
-std::string get_env_or_default (const std::string & variable_name, const std::string & default_value);
-uint64_t get_env_threshold_or_default (const std::string & variable_name, const uint64_t & default_value);
+std::string get_env_or_default (char const * variable_name, std::string const default_value);
+uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t const default_value);
 
-int test_node_port ();
-int test_rpc_port ();
-int test_ipc_port ();
-int test_websocket_port ();
+uint16_t test_node_port ();
+uint16_t test_rpc_port ();
+uint16_t test_ipc_port ();
+uint16_t test_websocket_port ();
 std::array<uint8_t, 2> test_magic_number ();
 
 /**

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -17,7 +17,7 @@ const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
 const char * default_beta_peer_network = "peering-beta.nano.org";
 const char * default_live_peer_network = "peering.nano.org";
-const char * default_test_peer_network = "peering-test.nano.org";
+const std::string default_test_peer_network = nano::GetEnvOrDefault ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 
 nano::node_config::node_config () :

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -17,7 +17,7 @@ const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
 const char * default_beta_peer_network = "peering-beta.nano.org";
 const char * default_live_peer_network = "peering.nano.org";
-const std::string default_test_peer_network = nano::GetEnvOrDefault ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
+const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 
 nano::node_config::node_config () :

--- a/nano/rpc_test/CMakeLists.txt
+++ b/nano/rpc_test/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable (rpc_test
 	entry.cpp
 	rpc.cpp)
 
-target_link_libraries(rpc_test node rpc test_common gtest Boost::coroutine)
+target_link_libraries(rpc_test node secure rpc test_common gtest Boost::coroutine)
 
 target_compile_definitions(rpc_test
 	PUBLIC

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -29,7 +29,7 @@ char const * dev_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E
 char const * dev_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
 char const * beta_public_key_data = "A59A439B34662385D48F7FF9CA50030F889BAA9AC320EA5A85AAD777CF82B088"; // nano_3betagfmasj5iqcayzzssba185wamgobois1xbfadcpqgz9r7e6a1zwztn5o
 char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA"; // xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3
-const std::string test_public_key_data = nano::GetEnvOrDefault ("NANO_TEST_GENESIS_PUB", "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
+const std::string test_public_key_data = nano::get_env_or_default ("NANO_TEST_GENESIS_PUB", "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
 char const * dev_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
@@ -57,7 +57,7 @@ char const * live_genesis_data = R"%%%({
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
 	})%%%";
 
-const std::string test_genesis_data = nano::GetEnvOrDefault ("NANO_TEST_GENESIS_BLOCK", R"%%%({
+const std::string test_genesis_data = nano::get_env_or_default ("NANO_TEST_GENESIS_BLOCK", R"%%%({
 	"type": "open",
 	"source": "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED",
 	"representative": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -29,7 +29,7 @@ char const * dev_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E
 char const * dev_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
 char const * beta_public_key_data = "A59A439B34662385D48F7FF9CA50030F889BAA9AC320EA5A85AAD777CF82B088"; // nano_3betagfmasj5iqcayzzssba185wamgobois1xbfadcpqgz9r7e6a1zwztn5o
 char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA"; // xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3
-const std::string test_public_key_data = nano::get_env_or_default ("NANO_TEST_GENESIS_PUB", "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
+std::string const test_public_key_data = nano::get_env_or_default ("NANO_TEST_GENESIS_PUB", "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
 char const * dev_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
@@ -57,7 +57,7 @@ char const * live_genesis_data = R"%%%({
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
 	})%%%";
 
-const std::string test_genesis_data = nano::get_env_or_default ("NANO_TEST_GENESIS_BLOCK", R"%%%({
+std::string const test_genesis_data = nano::get_env_or_default ("NANO_TEST_GENESIS_BLOCK", R"%%%({
 	"type": "open",
 	"source": "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED",
 	"representative": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -29,7 +29,7 @@ char const * dev_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E
 char const * dev_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
 char const * beta_public_key_data = "A59A439B34662385D48F7FF9CA50030F889BAA9AC320EA5A85AAD777CF82B088"; // nano_3betagfmasj5iqcayzzssba185wamgobois1xbfadcpqgz9r7e6a1zwztn5o
 char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA"; // xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3
-char const * test_public_key_data = "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"; // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
+const std::string test_public_key_data = nano::GetEnvOrDefault ("NANO_TEST_GENESIS_PUB", "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
 char const * dev_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
@@ -57,14 +57,14 @@ char const * live_genesis_data = R"%%%({
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
 	})%%%";
 
-char const * test_genesis_data = R"%%%({
+const std::string test_genesis_data = nano::GetEnvOrDefault ("NANO_TEST_GENESIS_BLOCK", R"%%%({
 	"type": "open",
 	"source": "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED",
 	"representative": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
 	"account": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
 	"work": "bc1ef279c1a34eb1",
 	"signature": "15049467CAEE3EC768639E8E35792399B6078DA763DA4EBA8ECAD33B0EDC4AF2E7403893A5A602EB89B978DABEF1D6606BB00F3C0EE11449232B143B6E07170E"
-	})%%%";
+	})%%%");
 
 std::shared_ptr<nano::block> parse_block_from_genesis_data (std::string const & genesis_data_a)
 {
@@ -86,7 +86,7 @@ network (network_a), ledger (network), voting (network), node (network), portmap
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_dev_work = 8;
 	kdf_work = network.is_dev_network () ? kdf_dev_work : kdf_full_work;
-	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'N', 'B' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'R', 'C' } } : std::array<uint8_t, 2>{ { 'R', 'X' } };
+	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'N', 'B' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'R', 'C' } } : nano::test_magic_number ();
 }
 
 uint8_t nano::protocol_constants::protocol_version_min (bool use_epoch_2_min_version_a) const


### PR DESCRIPTION
The test network allows for customization of the following network parameters by setting the appropriate environment variable:
```
export NANO_TEST_EPOCH_1="0xffffffc000000000",
export NANO_TEST_EPOCH_2="0xfffffff800000000",
export NANO_TEST_EPOCH_2_RECV="0xfffffe0000000000",
export NANO_TEST_NODE_PORT="17075",
export NANO_TEST_RPC_PORT="17076",
export NANO_TEST_IPC_PORT="17077",
export NANO_TEST_WEBSOCKET_PORT="17078",
export NANO_TEST_MAGIC_NUMBER="RZ",
export NANO_TEST_PEER_NETWORK="peer-test.nano.org",
export NANO_TEST_GENESIS_PUB="A419090E048FAD6FED5AEE987929BC52FE431C170F7C778ACD43C8B9346AB932",
export NANO_TEST_GENESIS_BLOCK="{\n\t\"type\": \"open\",\n\t\"source\": \"A419090E048FAD6FED5AEE987929BC52FE431C170F7C778ACD43C8B9346AB932\",\n\t\"representative\": \"nano_3b1s3691b5xffzpoounrh6nurnqyaeg3g5uwgy7etiyaq6t8ogbkkithjahe\",\n\t\"account\": \"nano_3b1s3691b5xffzpoounrh6nurnqyaeg3g5uwgy7etiyaq6t8ogbkkithjahe\",\n\t\"work\": \"f6c1644a04a77566\",\n\t\"signature\": \"7830BC72126EAEE1D44CB5BAD431279751E976E46F24DE023FAA1C0FD7A75108F195DE6C8D44F26E49766CEF1FC54518EDD9292D3D278237BD96C1A84B3D1401\"\n\t}"
```
The above would be test with an altered magic, genesis, and default peer_network
