### PR TITLE
Add confirmed_height in account_info RPC to be consistent

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -638,15 +638,16 @@ void nano::json_handler::account_info ()
 			response_l.put ("modified_timestamp", std::to_string (info.modified));
 			response_l.put ("block_count", std::to_string (info.block_count));
 			response_l.put ("account_version", epoch_as_string (info.epoch ()));
-			response_l.put ("confirmation_height", std::to_string (confirmation_height_info.height));
 			auto confirmed_frontier = confirmation_height_info.frontier.to_string ();
 			if (include_confirmed)
 			{
+				response_l.put ("confirmed_height", std::to_string (confirmation_height_info.height));
 				response_l.put ("confirmed_frontier", confirmed_frontier);
 			}
 			else
 			{
 				// For backwards compatibility purposes
+				response_l.put ("confirmation_height", std::to_string (confirmation_height_info.height));
 				response_l.put ("confirmation_height_frontier", confirmed_frontier);
 			}
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4859,9 +4859,9 @@ TEST (rpc, account_info)
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
 		ASSERT_TIMELY (5s, response.status != 0);
-		std::string balance (response.json.get<std::string> ("balance"));
+		auto balance (response.json.get<std::string> ("balance"));
 		ASSERT_EQ ("25", balance);
-		std::string confirmed_balance (response.json.get<std::string> ("confirmed_balance"));
+		auto confirmed_balance (response.json.get<std::string> ("confirmed_balance"));
 		ASSERT_EQ ("340282366920938463463374607431768211455", confirmed_balance);
 
 		auto representative (response.json.get<std::string> ("representative"));
@@ -4869,6 +4869,12 @@ TEST (rpc, account_info)
 
 		auto confirmed_representative (response.json.get<std::string> ("confirmed_representative"));
 		ASSERT_EQ (confirmed_representative, nano::dev_genesis_key.pub.to_account ());
+
+		auto confirmed_frontier (response.json.get<std::string> ("confirmed_frontier"));
+		ASSERT_EQ (nano::genesis_hash.to_string (), confirmed_frontier);
+
+		auto confirmed_height (response.json.get<uint64_t> ("confirmed_height"));
+		ASSERT_EQ (1, confirmed_height);
 	}
 
 	request.put ("account", key1.pub.to_account ());
@@ -4897,6 +4903,12 @@ TEST (rpc, account_info)
 
 		auto confirmed_representative (response.json.get_optional<std::string> ("confirmed_representative"));
 		ASSERT_FALSE (confirmed_representative.is_initialized ());
+
+		auto confirmed_frontier (response.json.get_optional<std::string> ("confirmed_frontier"));
+		ASSERT_FALSE (confirmed_frontier.is_initialized ());
+
+		auto confirmed_height (response.json.get_optional<uint64_t> ("confirmed_height"));
+		ASSERT_FALSE (confirmed_height.is_initialized ());
 	}
 }
 


### PR DESCRIPTION
https://github.com/nanocurrency/nano-node/pull/3022 added `include_confirmed`, there is already `confirmation_height` but I think to be consistent with the naming of the other new fields this should become `confirmed_height` in the presence of these flags so that they all have `confirmed_` prefix.