### PR TITLE
Remove unnecessary heap allocations during ed25519 hashing

### DIFF
--- a/crypto/ed25519-donna/ed25519-hash-custom.h
+++ b/crypto/ed25519-donna/ed25519-hash-custom.h
@@ -9,10 +9,9 @@
 	void ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen);
 */
 
-typedef struct ed25519_hash_context_t
-{
-    void * blake2;
-} ed25519_hash_context;
+#include <nano/crypto/blake2/blake2.h>
+
+typedef blake2b_state ed25519_hash_context;
 
 void ed25519_hash_init (ed25519_hash_context * ctx);
 

--- a/nano/crypto_lib/interface.cpp
+++ b/nano/crypto_lib/interface.cpp
@@ -9,19 +9,17 @@ void ed25519_randombytes_unsafe (void * out, size_t outlen)
 }
 void ed25519_hash_init (ed25519_hash_context * ctx)
 {
-	ctx->blake2 = new blake2b_state;
-	blake2b_init (reinterpret_cast<blake2b_state *> (ctx->blake2), 64);
+	blake2b_init (ctx, 64);
 }
 
 void ed25519_hash_update (ed25519_hash_context * ctx, uint8_t const * in, size_t inlen)
 {
-	blake2b_update (reinterpret_cast<blake2b_state *> (ctx->blake2), in, inlen);
+	blake2b_update (ctx, in, inlen);
 }
 
 void ed25519_hash_final (ed25519_hash_context * ctx, uint8_t * out)
 {
-	blake2b_final (reinterpret_cast<blake2b_state *> (ctx->blake2), out, 64);
-	delete reinterpret_cast<blake2b_state *> (ctx->blake2);
+	blake2b_final (ctx, out, 64);
 }
 
 void ed25519_hash (uint8_t * out, uint8_t const * in, size_t inlen)


### PR DESCRIPTION
This should help alleviate heap contention a bit on our multithreaded workload when there's a lot of verification going on. There were two heap (de)allocations for signing [1] and one for verification, which after this are stack allocations. Marking as experiment since it's about signing.

[1] `ed25519_sign` hashes directly, and then again through `ed25519_hram`