### PR TITLE
Fix intermittent rpc.receive_work_disabled segfaults

### DIFF
--- a/nano/node/ipc/action_handler.cpp
+++ b/nano/node/ipc/action_handler.cpp
@@ -66,7 +66,7 @@ subscriber (subscriber_a)
 void nano::ipc::action_handler::on_topic_confirmation (nanoapi::Envelope const & envelope_a)
 {
 	auto confirmationTopic (get_message<nanoapi::TopicConfirmation> (envelope_a));
-	ipc_server.get_broker ().subscribe (subscriber, std::move (confirmationTopic));
+	ipc_server.get_broker ()->subscribe (subscriber, std::move (confirmationTopic));
 	nanoapi::EventAckT ack;
 	create_response (ack);
 }
@@ -75,7 +75,7 @@ void nano::ipc::action_handler::on_service_register (nanoapi::Envelope const & e
 {
 	require_oneof (envelope_a, { nano::ipc::access_permission::api_service_register, nano::ipc::access_permission::service });
 	auto query (get_message<nanoapi::ServiceRegister> (envelope_a));
-	ipc_server.get_broker ().service_register (query->service_name, this->subscriber);
+	ipc_server.get_broker ()->service_register (query->service_name, this->subscriber);
 	nanoapi::SuccessT success;
 	create_response (success);
 }
@@ -90,7 +90,7 @@ void nano::ipc::action_handler::on_service_stop (nanoapi::Envelope const & envel
 	}
 	else
 	{
-		ipc_server.get_broker ().service_stop (query->service_name);
+		ipc_server.get_broker ()->service_stop (query->service_name);
 	}
 	nanoapi::SuccessT success;
 	create_response (success);
@@ -99,7 +99,7 @@ void nano::ipc::action_handler::on_service_stop (nanoapi::Envelope const & envel
 void nano::ipc::action_handler::on_topic_service_stop (nanoapi::Envelope const & envelope_a)
 {
 	auto topic (get_message<nanoapi::TopicServiceStop> (envelope_a));
-	ipc_server.get_broker ().subscribe (subscriber, std::move (topic));
+	ipc_server.get_broker ()->subscribe (subscriber, std::move (topic));
 	nanoapi::EventAckT ack;
 	create_response (ack);
 }

--- a/nano/node/ipc/ipc_broker.cpp
+++ b/nano/node/ipc/ipc_broker.cpp
@@ -21,14 +21,14 @@ std::shared_ptr<flatbuffers::Parser> nano::ipc::subscriber::get_parser (nano::ip
 
 void nano::ipc::broker::start ()
 {
-	node.observers.blocks.add ([this](nano::election_status const & status_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
+	node.observers.blocks.add ([this_l = shared_from_this ()](nano::election_status const & status_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
 		debug_assert (status_a.type != nano::election_status_type::ongoing);
 
 		try
 		{
 			// The subscriber(s) may be gone after the count check, but the only consequence
 			// is that broadcast is called only to not find any live sessions.
-			if (confirmation_subscriber_count () > 0)
+			if (this_l->confirmation_subscriber_count () > 0)
 			{
 				auto confirmation (std::make_shared<nanoapi::EventConfirmationT> ());
 
@@ -59,12 +59,12 @@ void nano::ipc::broker::start ()
 				confirmation->election_info->voter_count = status_a.voter_count;
 				confirmation->election_info->request_count = status_a.confirmation_request_count;
 
-				broadcast (confirmation);
+				this_l->broadcast (confirmation);
 			}
 		}
 		catch (nano::error const & err)
 		{
-			this->node.logger.always_log ("IPC: could not broadcast message: ", err.get_message ());
+			this_l->node.logger.always_log ("IPC: could not broadcast message: ", err.get_message ());
 		}
 	});
 }

--- a/nano/node/ipc/ipc_broker.hpp
+++ b/nano/node/ipc/ipc_broker.hpp
@@ -74,7 +74,7 @@ namespace ipc
 	 * The broker manages subscribers and performs message broadcasting
 	 * @note Add subscribe overloads for new topics
 	 */
-	class broker final
+	class broker final : public std::enable_shared_from_this<broker>
 	{
 	public:
 		broker (nano::node & node_a);

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -578,7 +578,7 @@ void await_hup_signal (std::shared_ptr<boost::asio::signal_set> const & signals,
 nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a) :
 node (node_a),
 node_rpc_config (node_rpc_config_a),
-broker (node_a)
+broker (std::make_shared<nano::ipc::broker> (node_a))
 {
 	try
 	{
@@ -614,7 +614,7 @@ broker (node_a)
 
 		if (!transports.empty ())
 		{
-			broker.start ();
+			broker->start ();
 		}
 	}
 	catch (std::runtime_error const & ex)
@@ -636,7 +636,7 @@ void nano::ipc::ipc_server::stop ()
 	}
 }
 
-nano::ipc::broker & nano::ipc::ipc_server::get_broker ()
+std::shared_ptr<nano::ipc::broker> nano::ipc::ipc_server::get_broker ()
 {
 	return broker;
 }

--- a/nano/node/ipc/ipc_server.hpp
+++ b/nano/node/ipc/ipc_server.hpp
@@ -8,6 +8,7 @@
 #include <nano/node/node_rpc_config.hpp>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 
 namespace flatbuffers
@@ -34,13 +35,13 @@ namespace ipc
 
 		/** Unique counter/id shared across sessions */
 		std::atomic<uint64_t> id_dispenser{ 1 };
-		nano::ipc::broker & get_broker ();
+		std::shared_ptr<nano::ipc::broker> get_broker ();
 		nano::ipc::access & get_access ();
 		nano::error reload_access_config ();
 
 	private:
 		void setup_callbacks ();
-		nano::ipc::broker broker;
+		std::shared_ptr<nano::ipc::broker> broker;
 		nano::ipc::access access;
 		std::unique_ptr<dsock_file_remover> file_remover;
 		std::vector<std::shared_ptr<nano::ipc::transport>> transports;


### PR DESCRIPTION
`rpc.receive_work_disabled` occasionally segfaults/asserts on a mutex

Root cause seems to be that `active_transactions` sporadically notifies through `observers.blocks` in this rpc test after the ipc server has gone out of scope when the unit test ends, segfaulting. By making the ipc broker shared_from_this, it's still around for observers.blocks events during teardown.

Still expecting CI to fail on rpc tests until #3043 is merged