### PR TITLE
Fixing boost to 1.70 on windows via artifact cache

### DIFF
--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -13,7 +13,6 @@ if (${env:artifact} -eq 1) {
         $env:NETWORK_CFG = "live"
     }
     $env:NANO_SHARED_BOOST = "ON"
-    $env:ROCKS_LIB = '-DROCKSDB_LIBRARIES="c:\vcpkg\installed\x64-windows-static\lib\rocksdb.lib"'
     $env:NANO_TEST = "-DNANO_TEST=OFF"
     $env:TRAVIS_TAG = ${env:TAG}
     
@@ -23,11 +22,9 @@ if (${env:artifact} -eq 1) {
 else {
     if ( ${env:RELEASE} -eq 1 ) {
         $env:BUILD_TYPE = "RelWithDebInfo"
-        $env:ROCKS_LIB = '-DROCKSDB_LIBRARIES="c:\vcpkg\installed\x64-windows-static\lib\rocksdb.lib"'
     }
     else { 
         $env:BUILD_TYPE = "Debug"
-        $env:ROCKS_LIB = '-DROCKSDB_LIBRARIES="c:\vcpkg\installed\x64-windows-static\debug\lib\rocksdbd.lib"'
     }
     $env:NANO_SHARED_BOOST = "OFF"
     $env:NETWORK_CFG = "dev"
@@ -38,7 +35,7 @@ else {
 
 mkdir build
 Push-Location build
-$env:BOOST_ROOT = ${env:BOOST_ROOT_1_69_0}
+$env:BOOST_ROOT = ${env:BOOST_ROOT_1_72_0}
 
 #accessibility of Boost dlls for generating config samples
 $ENV:PATH = "$ENV:PATH;$ENV:BOOST_ROOT\lib"

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -35,7 +35,6 @@ else {
 
 mkdir build
 Push-Location build
-$env:BOOST_ROOT = ${env:BOOST_ROOT_1_72_0}
 
 #accessibility of Boost dlls for generating config samples
 $ENV:PATH = "$ENV:PATH;$ENV:BOOST_ROOT\lib"

--- a/ci/actions/windows/install_deps.ps1
+++ b/ci/actions/windows/install_deps.ps1
@@ -48,12 +48,11 @@ function Get-RedirectedUri {
         $redirectUri
     }
 }
-
+$boost_url = Get-RedirectedUri "https://repo.nano.org/artifacts/boost-msvc14.2-1.70-full.zip"
+$BOOST_ROOT = "c:\local\boost_1_70_0"
 $qt5_root = "c:\qt"
-$rocksdb_url = Get-RedirectedUri "https://repo.nano.org/artifacts/rocksdb-msvc-14.2-6.6.4-Md.7z"
 $qt5base_url = Get-RedirectedUri "https://repo.nano.org/artifacts/5.13.1-0-201909031231qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z"
 $qt5winextra_url = Get-RedirectedUri "https://repo.nano.org/artifacts/5.13.1-0-201909031231qtwinextras-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z"
-$rocksdb_artifact = "${env:TMP}\rocksdb.7z"
 $qt5base_artifact = "${env:TMP}\qt5base.7z"
 $qt5winextra_artifact = "${env:TMP}\qt5winextra.7z"
 
@@ -64,7 +63,9 @@ Push-Location $qt5_root
 7z x "${env:TMP}\qt5*.7z" -aoa
 Pop-Location
 
-Push-Location ${env:VCPKG_INSTALLATION_ROOT} 
-(New-Object System.Net.WebClient).DownloadFile($rocksdb_url, $rocksdb_artifact)
-7z x $rocksdb_artifact -aoa
-Pop-Location 
+
+mkdir $BOOST_ROOT
+Write-Output "BOOST_ROOT=$BOOST_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+(New-Object System.Net.WebClient).DownloadFile($boost_url, "${env:TMP}\boost-msvc.zip")
+Push-Location $BOOST_ROOT
+7z x "${env:TMP}\boost-msvc.zip" -aoa


### PR DESCRIPTION
addresses https://github.com/actions/virtual-environments/issues/1847
by using artifacts fixed at 1.70 as we do in the other environments
once merged will allow windows tests to pass

additional changes finish out cleanup of rocksdb move from cache to submodule