### PR TITLE
Wallet create causing crash when confirming blocks

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -364,7 +364,7 @@ TEST (node, search_pending)
 	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_pending ());
+	ASSERT_FALSE (system.wallet (0)->search_pending (system.wallet (0)->wallets.tx_begin_read ()));
 	ASSERT_TIMELY (10s, !node->balance (key2.pub).is_zero ());
 }
 
@@ -377,7 +377,7 @@ TEST (node, search_pending_same)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_pending ());
+	ASSERT_FALSE (system.wallet (0)->search_pending (system.wallet (0)->wallets.tx_begin_read ()));
 	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
 }
 
@@ -394,7 +394,7 @@ TEST (node, search_pending_multiple)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev_genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (key3.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_pending ());
+	ASSERT_FALSE (system.wallet (0)->search_pending (system.wallet (0)->wallets.tx_begin_read ()));
 	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
 }
 
@@ -424,7 +424,7 @@ TEST (node, search_pending_confirmed)
 		system.wallet (0)->store.erase (transaction, nano::dev_genesis_key.pub);
 	}
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_pending ());
+	ASSERT_FALSE (system.wallet (0)->search_pending (system.wallet (0)->wallets.tx_begin_read ()));
 	{
 		nano::lock_guard<std::mutex> guard (node->active.mutex);
 		auto existing1 (node->active.blocks.find (send1->hash ()));
@@ -470,7 +470,7 @@ TEST (node, search_pending_pruned)
 
 	// Receive pruned block
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (1)->search_pending ());
+	ASSERT_FALSE (system.wallet (1)->search_pending (system.wallet (1)->wallets.tx_begin_read ()));
 	{
 		nano::lock_guard<std::mutex> guard (node2->active.mutex);
 		auto existing1 (node2->active.blocks.find (send1->hash ()));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1213,7 +1213,7 @@ TEST (wallet, search_pending)
 
 	// Pending search should start an election
 	ASSERT_TRUE (node.active.empty ());
-	ASSERT_FALSE (wallet.search_pending ());
+	ASSERT_FALSE (wallet.search_pending (wallet.wallets.tx_begin_read ()));
 	auto election = node.active.election (send->qualified_root ());
 	ASSERT_NE (nullptr, election);
 
@@ -1230,7 +1230,7 @@ TEST (wallet, search_pending)
 
 	// Pending search should create the receive block
 	ASSERT_EQ (2, node.ledger.cache.block_count);
-	ASSERT_FALSE (wallet.search_pending ());
+	ASSERT_FALSE (wallet.search_pending (wallet.wallets.tx_begin_read ()));
 	ASSERT_TIMELY (3s, node.balance (nano::genesis_account) == nano::genesis_amount);
 	auto receive_hash = node.ledger.latest (node.store.tx_begin_read (), nano::genesis_account);
 	auto receive = node.block (receive_hash);

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -177,7 +177,9 @@ TEST (wallets, search_pending)
 		flags.disable_search_pending = true;
 		auto & node (*system.add_node (config, flags));
 
+		nano::unique_lock<std::mutex> lk (node.wallets.mutex);
 		auto wallets = node.wallets.get_wallets ();
+		lk.unlock ();
 		ASSERT_EQ (1, wallets.size ());
 		auto wallet_id = wallets.begin ()->first;
 		auto wallet = wallets.begin ()->second;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -207,7 +207,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 					election_lk.unlock ();
 					add_recently_cemented (status_l);
 					auto destination (block_a->link ().is_zero () ? block_a->destination () : block_a->link ().as_account ());
-					node.receive_confirmed (node.wallets.tx_begin_read (), transaction, hash, destination);
+					node.receive_confirmed (transaction, hash, destination);
 					nano::account account (0);
 					nano::uint128_t amount (0);
 					bool is_state_send (false);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3457,7 +3457,7 @@ void nano::json_handler::search_pending ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto error (wallet->search_pending ());
+		auto error (wallet->search_pending (wallet->wallets.tx_begin_read ()));
 		response_l.put ("started", !error);
 	}
 	response_errors ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1281,9 +1281,10 @@ void nano::node::ongoing_online_weight_calculation ()
 
 void nano::node::receive_confirmed (nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a)
 {
+	nano::unique_lock<std::mutex> lk (wallets.mutex);
 	auto wallets_l = wallets.get_wallets ();
-	// The wallet transaction should be created after calling get_wallets to make sure the
 	auto wallet_transaction = wallets.tx_begin_read ();
+	lk.unlock ();
 	for ([[maybe_unused]] auto const & [id, wallet] : wallets_l)
 	{
 		if (wallet->store.exists (wallet_transaction, destination_a))

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1279,15 +1279,18 @@ void nano::node::ongoing_online_weight_calculation ()
 	ongoing_online_weight_calculation_queue ();
 }
 
-void nano::node::receive_confirmed (nano::transaction const & wallet_transaction_a, nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a)
+void nano::node::receive_confirmed (nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a)
 {
-	for ([[maybe_unused]] auto const & [id, wallet] : wallets.get_wallets ())
+	auto wallets_l = wallets.get_wallets ();
+	// The wallet transaction should be created after calling get_wallets to make sure the
+	auto wallet_transaction = wallets.tx_begin_read ();
+	for ([[maybe_unused]] auto const & [id, wallet] : wallets_l)
 	{
-		if (wallet->store.exists (wallet_transaction_a, destination_a))
+		if (wallet->store.exists (wallet_transaction, destination_a))
 		{
 			nano::account representative;
 			nano::pending_info pending;
-			representative = wallet->store.representative (wallet_transaction_a);
+			representative = wallet->store.representative (wallet_transaction);
 			auto error (store.pending_get (block_transaction_a, nano::pending_key (destination_a, hash_a), pending));
 			if (!error)
 			{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1281,9 +1281,8 @@ void nano::node::ongoing_online_weight_calculation ()
 
 void nano::node::receive_confirmed (nano::transaction const & wallet_transaction_a, nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a)
 {
-	for (auto const & [id /*unused*/, wallet] : wallets.get_wallets ())
+	for ([[maybe_unused]] auto const & [id, wallet] : wallets.get_wallets ())
 	{
-		(void)id;
 		if (wallet->store.exists (wallet_transaction_a, destination_a))
 		{
 			nano::account representative;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -109,7 +109,7 @@ public:
 	void stop ();
 	std::shared_ptr<nano::node> shared ();
 	int store_version ();
-	void receive_confirmed (nano::transaction const & wallet_transaction_a, nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a);
+	void receive_confirmed (nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a);
 	void process_confirmed_data (nano::transaction const &, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account &, nano::uint128_t &, bool &, nano::account &);
 	void process_confirmed (nano::election_status const &, uint64_t = 0);
 	void process_active (std::shared_ptr<nano::block> const &);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1894,21 +1894,14 @@ nano::uint128_t const nano::wallets::high_priority = std::numeric_limits<nano::u
 
 nano::store_iterator<nano::account, nano::wallet_value> nano::wallet_store::begin (nano::transaction const & transaction_a)
 {
-	if (!db_exists (transaction_a))
-	{
-		return nano::store_iterator<nano::account, nano::wallet_value> (nullptr);
-	}
-	return nano::store_iterator<nano::account, nano::wallet_value> (std::make_unique<nano::mdb_iterator<nano::account, nano::wallet_value>> (transaction_a, handle, nano::mdb_val (nano::account (special_count))));
+	nano::store_iterator<nano::account, nano::wallet_value> result (std::make_unique<nano::mdb_iterator<nano::account, nano::wallet_value>> (transaction_a, handle, nano::mdb_val (nano::account (special_count))));
+	return result;
 }
 
 nano::store_iterator<nano::account, nano::wallet_value> nano::wallet_store::begin (nano::transaction const & transaction_a, nano::account const & key)
 {
-	if (!db_exists (transaction_a))
-	{
-		return nano::store_iterator<nano::account, nano::wallet_value> (nullptr);
-	}
-
-	return nano::store_iterator<nano::account, nano::wallet_value> (std::make_unique<nano::mdb_iterator<nano::account, nano::wallet_value>> (transaction_a, handle, nano::mdb_val (key)));
+	nano::store_iterator<nano::account, nano::wallet_value> result (std::make_unique<nano::mdb_iterator<nano::account, nano::wallet_value>> (transaction_a, handle, nano::mdb_val (key)));
+	return result;
 }
 
 nano::store_iterator<nano::account, nano::wallet_value> nano::wallet_store::find (nano::transaction const & transaction_a, nano::account const & key)
@@ -1937,14 +1930,6 @@ nano::store_iterator<nano::account, nano::wallet_value> nano::wallet_store::end 
 {
 	return nano::store_iterator<nano::account, nano::wallet_value> (nullptr);
 }
-
-bool nano::wallet_store::db_exists (nano::transaction const & transaction_a) const
-{
-	unsigned int dummy_flags;
-	auto err = mdb_dbi_flags (static_cast<MDB_txn *> (transaction_a.get_handle ()), handle, &dummy_flags);
-	return (err == MDB_SUCCESS);
-}
-
 nano::mdb_wallets_store::mdb_wallets_store (boost::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
 environment (error, path_a, nano::mdb_env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
 {

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -146,7 +146,7 @@ public:
 	void work_update (nano::transaction const &, nano::account const &, nano::root const &, uint64_t);
 	// Schedule work generation after a few seconds
 	void work_ensure (nano::account const &, nano::root const &);
-	bool search_pending ();
+	bool search_pending (nano::transaction const &);
 	void init_free_accounts (nano::transaction const &);
 	uint32_t deterministic_check (nano::transaction const & transaction_a, uint32_t index);
 	/** Changes the wallet seed and returns the first account */

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -114,7 +114,6 @@ public:
 
 private:
 	MDB_txn * tx (nano::transaction const &) const;
-	bool db_exists (nano::transaction const &) const;
 };
 // A wallet is a set of account keys encrypted by a common encryption key
 class wallet final : public std::enable_shared_from_this<nano::wallet>

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -114,6 +114,7 @@ public:
 
 private:
 	MDB_txn * tx (nano::transaction const &) const;
+	bool db_exists (nano::transaction const &) const;
 };
 // A wallet is a set of account keys encrypted by a common encryption key
 class wallet final : public std::enable_shared_from_this<nano::wallet>

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1922,7 +1922,7 @@ wallet (wallet_a)
 		this->wallet.pop_main_stack ();
 	});
 	QObject::connect (search_for_receivables, &QPushButton::released, [this]() {
-		std::thread ([this] { this->wallet.wallet_m->search_pending (); }).detach ();
+		std::thread ([this] { this->wallet.wallet_m->search_pending (this->wallet.wallet_m->wallets.tx_begin_read ()); }).detach ();
 	});
 	QObject::connect (bootstrap, &QPushButton::released, [this]() {
 		std::thread ([this] { this->wallet.node.bootstrap_initiator.bootstrap (); }).detach ();

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1818,3 +1818,49 @@ TEST (node, mass_block_new)
 	process_all (receive_blocks);
 	std::cout << "Receive blocks time: " << timer.stop ().count () << " " << timer.unit () << "\n\n";
 }
+
+TEST (node, wallet_create_block_confirm_conflicts)
+{
+	for (int i = 0; i < 5; ++i)
+	{
+		nano::system system;
+		nano::node_config node_config (nano::get_available_port (), system.logging);
+		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+		auto node = system.add_node (node_config);
+		auto const num_blocks = 10000;
+
+		// First open the other account
+		auto latest = nano::genesis_hash;
+		nano::keypair key1;
+		{
+			auto transaction = node->store.tx_begin_write ();
+			for (auto i = num_blocks - 1; i > 0; --i)
+			{
+				nano::send_block send (latest, key1.pub, nano::genesis_amount - nano::Gxrb_ratio + i + 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
+				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
+				latest = send.hash ();
+			}
+		}
+
+		// Keep creating wallets. This is to check that there is no issues present when confirming blocks at the same time.
+		std::atomic<bool> done{ false };
+		std::thread t ([node, &done]() {
+			while (!done)
+			{
+				node->wallets.create (nano::random_wallet_id ());
+			}
+		});
+
+		// Call block confirm on the top level send block which will confirm everything underneath on both accounts.
+		{
+			auto election_insertion_result (node->active.insert (node->store.block_get (node->store.tx_begin_read (), latest)));
+			ASSERT_TRUE (election_insertion_result.inserted);
+			ASSERT_NE (nullptr, election_insertion_result.election);
+			election_insertion_result.election->force_confirm ();
+		}
+
+		ASSERT_TIMELY (120s, node->ledger.block_confirmed (node->store.tx_begin_read (), latest) && node->confirmation_height_processor.current () == 0);
+		done = true;
+		t.join ();
+	}
+}


### PR DESCRIPTION
This bug was found by @PlasmaPower and nicely documented [here](https://github.com/nanocurrency/nano-node/issues/3030).

I think this can be resolved by checking that the `handle` is valid inside `wallet_store::begin`. There doesn't seem to be a standard way to test that so I'm just checking that the `mdb_dbi_flags` doesn't return an error (that function calls `TXN_DBI_EXIST` which checks that the transaction and dbi arguments are correct and returns EINVAL if they aren't), a few others did that too but this one seemed to make the most sense.

The new slow test added seems to more often than not hit the bug on a single iteration, but doing 5 in a loop just to increase the probability.

Couple unrelated changes I made: Added `[[maybe_unused]` in `receive_confirmed` & removed an unnecessary `std::move` in `wallets::queue_wallet_action`