### PR TITLE
Update online_weight_quorum default to 67

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -571,7 +571,6 @@ TEST (node_config, serialization)
 	config1.bootstrap_fraction_numerator = 10;
 	config1.receive_minimum = 10;
 	config1.online_weight_minimum = 10;
-	config1.online_weight_quorum = 10;
 	config1.password_fanout = 20;
 	config1.enable_voting = false;
 	config1.callback_address = "dev";
@@ -588,7 +587,6 @@ TEST (node_config, serialization)
 	ASSERT_NE (config2.peering_port, config1.peering_port);
 	ASSERT_NE (config2.logging.node_lifetime_tracing_value, config1.logging.node_lifetime_tracing_value);
 	ASSERT_NE (config2.online_weight_minimum, config1.online_weight_minimum);
-	ASSERT_NE (config2.online_weight_quorum, config1.online_weight_quorum);
 	ASSERT_NE (config2.password_fanout, config1.password_fanout);
 	ASSERT_NE (config2.enable_voting, config1.enable_voting);
 	ASSERT_NE (config2.callback_address, config1.callback_address);
@@ -606,7 +604,6 @@ TEST (node_config, serialization)
 	ASSERT_EQ (config2.peering_port, config1.peering_port);
 	ASSERT_EQ (config2.logging.node_lifetime_tracing_value, config1.logging.node_lifetime_tracing_value);
 	ASSERT_EQ (config2.online_weight_minimum, config1.online_weight_minimum);
-	ASSERT_EQ (config2.online_weight_quorum, config1.online_weight_quorum);
 	ASSERT_EQ (config2.password_fanout, config1.password_fanout);
 	ASSERT_EQ (config2.enable_voting, config1.enable_voting);
 	ASSERT_EQ (config2.callback_address, config1.callback_address);

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -168,7 +168,6 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.secondary_work_peers, defaults.node.secondary_work_peers);
 	ASSERT_EQ (conf.node.work_watcher_period, defaults.node.work_watcher_period);
 	ASSERT_EQ (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
-	ASSERT_EQ (conf.node.online_weight_quorum, defaults.node.online_weight_quorum);
 	ASSERT_EQ (conf.node.election_hint_weight_percent, defaults.node.election_hint_weight_percent);
 	ASSERT_EQ (conf.node.password_fanout, defaults.node.password_fanout);
 	ASSERT_EQ (conf.node.peering_port, defaults.node.peering_port);
@@ -404,7 +403,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	lmdb_max_dbs = 999
 	network_threads = 999
 	online_weight_minimum = "999"
-	online_weight_quorum = 99
 	election_hint_weight_percent = 19
 	password_fanout = 999
 	peering_port = 999
@@ -573,7 +571,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.max_pruning_depth, defaults.node.max_pruning_depth);
 	ASSERT_NE (conf.node.work_watcher_period, defaults.node.work_watcher_period);
 	ASSERT_NE (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
-	ASSERT_NE (conf.node.online_weight_quorum, defaults.node.online_weight_quorum);
 	ASSERT_NE (conf.node.election_hint_weight_percent, defaults.node.election_hint_weight_percent);
 	ASSERT_NE (conf.node.password_fanout, defaults.node.password_fanout);
 	ASSERT_NE (conf.node.peering_port, defaults.node.peering_port);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1995,7 +1995,7 @@ void nano::json_handler::confirmation_info ()
 void nano::json_handler::confirmation_quorum ()
 {
 	response_l.put ("quorum_delta", node.online_reps.delta ().convert_to<std::string> ());
-	response_l.put ("online_weight_quorum_percent", std::to_string (node.config.online_weight_quorum));
+	response_l.put ("online_weight_quorum_percent", std::to_string (node.online_reps.online_weight_quorum));
 	response_l.put ("online_weight_minimum", node.config.online_weight_minimum.to_string_dec ());
 	response_l.put ("online_stake_total", node.online_reps.online ().convert_to<std::string> ());
 	response_l.put ("trended_stake_total", node.online_reps.trended ().convert_to<std::string> ());

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -77,7 +77,6 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("bootstrap_fraction_numerator", bootstrap_fraction_numerator, "Change bootstrap threshold (online stake / 256 * bootstrap_fraction_numerator).\ntype:uint32");
 	toml.put ("receive_minimum", receive_minimum.to_string_dec (), "Minimum receive amount. Only affects node wallets. A large amount is recommended to avoid automatic work generation for tiny transactions.\ntype:string,amount,raw");
 	toml.put ("online_weight_minimum", online_weight_minimum.to_string_dec (), "Online weight minimum required to confirm a block.\ntype:string,amount,raw");
-	toml.put ("online_weight_quorum", online_weight_quorum, "Percentage of votes required to confirm blocks. A value below 50 is not recommended.\ntype:uint64");
 	toml.put ("election_hint_weight_percent", election_hint_weight_percent, "Percentage of online weight to hint at starting an election. Defaults to 10.\ntype:uint32,[5,50]");
 	toml.put ("password_fanout", password_fanout, "Password fanout factor.\ntype:uint64");
 	toml.put ("io_threads", io_threads, "Number of threads dedicated to I/O operations. Defaults to the number of CPU threads, and at least 4.\ntype:uint64");
@@ -310,7 +309,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 
 		toml.get<uint16_t> ("peering_port", peering_port);
 		toml.get<unsigned> ("bootstrap_fraction_numerator", bootstrap_fraction_numerator);
-		toml.get<unsigned> ("online_weight_quorum", online_weight_quorum);
 		toml.get<unsigned> ("election_hint_weight_percent", election_hint_weight_percent);
 		toml.get<unsigned> ("password_fanout", password_fanout);
 		toml.get<unsigned> ("io_threads", io_threads);
@@ -399,10 +397,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 
 		// Validate ranges
 		nano::network_params network_params;
-		if (online_weight_quorum > 100)
-		{
-			toml.get_error ().set ("online_weight_quorum must be less than 100");
-		}
 		if (election_hint_weight_percent < 5 || election_hint_weight_percent > 50)
 		{
 			toml.get_error ().set ("election_hint_weight_percent must be a number between 5 and 50");
@@ -488,7 +482,6 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put_child ("preconfigured_representatives", preconfigured_representatives_l);
 
 	json.put ("online_weight_minimum", online_weight_minimum.to_string_dec ());
-	json.put ("online_weight_quorum", online_weight_quorum);
 	json.put ("password_fanout", password_fanout);
 	json.put ("io_threads", io_threads);
 	json.put ("network_threads", network_threads);
@@ -674,7 +667,6 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		}
 		json.get<uint16_t> ("peering_port", peering_port);
 		json.get<unsigned> ("bootstrap_fraction_numerator", bootstrap_fraction_numerator);
-		json.get<unsigned> ("online_weight_quorum", online_weight_quorum);
 		json.get<unsigned> ("password_fanout", password_fanout);
 		json.get<unsigned> ("io_threads", io_threads);
 		json.get<unsigned> ("work_threads", work_threads);
@@ -713,10 +705,6 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 
 		nano::network_constants network;
 		// Validate ranges
-		if (online_weight_quorum > 100)
-		{
-			json.get_error ().set ("online_weight_quorum must be less than 100");
-		}
 		if (password_fanout < 16 || password_fanout > 1024 * 1024)
 		{
 			json.get_error ().set ("password_fanout must be a number between 16 and 1048576");

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -55,7 +55,6 @@ public:
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (100) };
 	unsigned vote_generator_threshold{ 3 };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
-	unsigned online_weight_quorum{ 50 };
 	unsigned election_hint_weight_percent{ 10 };
 	unsigned password_fanout{ 1024 };
 	unsigned io_threads{ std::max<unsigned> (4, std::thread::hardware_concurrency ()) };

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -3,8 +3,6 @@
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/ledger.hpp>
 
-unsigned constexpr nano::online_reps::online_weight_quorum;
-
 nano::online_reps::online_reps (nano::ledger & ledger_a, nano::node_config const & config_a) :
 ledger{ ledger_a },
 config{ config_a }

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -3,6 +3,8 @@
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/ledger.hpp>
 
+unsigned constexpr nano::online_reps::online_weight_quorum;
+
 nano::online_reps::online_reps (nano::ledger & ledger_a, nano::node_config const & config_a) :
 ledger{ ledger_a },
 config{ config_a }
@@ -97,7 +99,7 @@ nano::uint128_t nano::online_reps::delta () const
 {
 	nano::lock_guard<std::mutex> lock (mutex);
 	auto weight = std::max ({ online_m, trended_m, config.online_weight_minimum.number () });
-	auto result ((weight / 100) * config.online_weight_quorum);
+	auto result ((weight / 100) * online_weight_quorum);
 	return result;
 }
 

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -37,6 +37,7 @@ public:
 	/** List of online representatives, both the currently sampling ones and the ones observed in the previous sampling period */
 	std::vector<nano::account> list ();
 	void clear ();
+	static unsigned constexpr online_weight_quorum = 67;
 
 private:
 	class rep_info


### PR DESCRIPTION
[PR #2884](https://github.com/nanocurrency/nano-node/pull/2884) was originally intended to include changes to the default quorum value from 50% to 67%. This update includes this change.

Previously the online weight minimum of 60M was being applied as the floor for the number of votes required for quorum, but this caused the actual quorum % required to increase as online weight dropped towards that minimum 60M instead of staying consistent. With [#2884](https://github.com/nanocurrency/nano-node/pull/2884) the quorum % is consistent regardless of online weight and thus the more online weight there is, the higher the vote amounts required. In order to provide similar security on the network prior to #2884, this update sets a 67% default value for quorum.

Given current online weight of 92M on the main network, this 67% requirements equates to ~61.6M votes required, just above the previous 60M, so little impact to confirmation times is expected.