### PR TITLE
follow lib naming convention of pre-compiled boost on windows

### DIFF
--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -37,7 +37,7 @@ mkdir build
 Push-Location build
 
 #accessibility of Boost dlls for generating config samples
-$ENV:PATH = "$ENV:PATH;$ENV:BOOST_ROOT\lib"
+$ENV:PATH = "$ENV:PATH;$ENV:BOOST_ROOT\lib64-msvc-14.2"
 
 & ..\ci\actions\windows\configure.bat
 if (${LastExitCode} -ne 0) {


### PR DESCRIPTION
During the fixing of boost 1.70 on windows the path to libs needed to be updated
This is due to nano_node being called to generate sample configs