### PR TITLE
Limit failures for confirmed lazy bootstrap bulk pull

### DIFF
--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -55,7 +55,7 @@ nano::bulk_pull_client::~bulk_pull_client ()
 
 void nano::bulk_pull_client::request ()
 {
-	debug_assert (!pull.head.is_zero () || pull.retry_limit != std::numeric_limits<unsigned>::max ());
+	debug_assert (!pull.head.is_zero () || pull.retry_limit <= connection->node->network_params.bootstrap.lazy_retry_limit);
 	expected = pull.head;
 	nano::bulk_pull req;
 	if (pull.head == pull.head_original && pull.attempts % 4 < 3)
@@ -219,7 +219,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 			// Is block expected?
 			bool block_expected (false);
 			// Unconfirmed head is used only for lazy destinations if legacy bootstrap is not available, see nano::bootstrap_attempt::lazy_destinations_increment (...)
-			bool unconfirmed_account_head (connection->node->flags.disable_legacy_bootstrap && pull_blocks == 0 && pull.retry_limit != std::numeric_limits<unsigned>::max () && expected == pull.account_or_head && block->account () == pull.account_or_head);
+			bool unconfirmed_account_head (connection->node->flags.disable_legacy_bootstrap && pull_blocks == 0 && pull.retry_limit <= connection->node->network_params.bootstrap.lazy_retry_limit && expected == pull.account_or_head && block->account () == pull.account_or_head);
 			if (hash == expected || unconfirmed_account_head)
 			{
 				expected = block->previous ();

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -404,7 +404,7 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 			attempt_l->pull_started ();
 			condition.notify_all ();
 		}
-		else if (attempt_l->mode == nano::bootstrap_mode::lazy && (pull.retry_limit == std::numeric_limits<unsigned>::max () || pull.attempts <= pull.retry_limit + (pull.processed / node.network_params.bootstrap.lazy_max_pull_blocks)))
+		else if (attempt_l->mode == nano::bootstrap_mode::lazy && (pull.attempts <= pull.retry_limit + (pull.processed / node.network_params.bootstrap.lazy_max_pull_blocks)))
 		{
 			debug_assert (pull.account_or_head == pull.head);
 			if (!attempt_l->lazy_processed_or_exists (pull.account_or_head.as_block_hash ()))

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -507,7 +507,7 @@ bool nano::bootstrap_attempt_lazy::lazy_processed_or_exists (nano::block_hash co
 unsigned nano::bootstrap_attempt_lazy::lazy_retry_limit_confirmed ()
 {
 	debug_assert (!mutex.try_lock ());
-	if (total_blocks % 1024 == 0)
+	if (total_blocks % 1024 == 512 || peer_count == 0)
 	{
 		// Prevent too frequent network locks
 		peer_count = node->network.size ();

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -512,7 +512,8 @@ unsigned nano::bootstrap_attempt_lazy::lazy_retry_limit_confirmed ()
 		// Prevent too frequent network locks
 		peer_count = node->network.size ();
 	}
-	return std::max (2 * node->network_params.bootstrap.lazy_retry_limit, 2 * nano::narrow_cast<unsigned> (peer_count));
+	auto multiplier (node->flags.disable_legacy_bootstrap ? 3 : 2);
+	return multiplier * std::max (node->network_params.bootstrap.lazy_retry_limit, nano::narrow_cast<unsigned> (peer_count));
 }
 
 void nano::bootstrap_attempt_lazy::get_information (boost::property_tree::ptree & tree_a)

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -512,8 +512,8 @@ unsigned nano::bootstrap_attempt_lazy::lazy_retry_limit_confirmed ()
 		// Prevent too frequent network locks
 		peer_count = node->network.size ();
 	}
-	auto multiplier (node->flags.disable_legacy_bootstrap ? 3 : 2);
-	return multiplier * std::max (node->network_params.bootstrap.lazy_retry_limit, nano::narrow_cast<unsigned> (peer_count));
+	auto multiplier (node->flags.disable_legacy_bootstrap ? 2 : 1.25);
+	return multiplier * std::max (node->network_params.bootstrap.lazy_retry_limit, 2 * nano::narrow_cast<unsigned> (peer_count));
 }
 
 void nano::bootstrap_attempt_lazy::get_information (boost::property_tree::ptree & tree_a)

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -37,7 +37,7 @@ public:
 	bool process_block (std::shared_ptr<nano::block>, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned) override;
 	void run () override;
 	void lazy_start (nano::hash_or_account const &, bool confirmed = true) override;
-	void lazy_add (nano::hash_or_account const &, unsigned = std::numeric_limits<unsigned>::max ());
+	void lazy_add (nano::hash_or_account const &, unsigned);
 	void lazy_add (nano::pull_info const &) override;
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &, bool) override;
 	bool lazy_finished ();
@@ -54,6 +54,7 @@ public:
 	void lazy_blocks_erase (nano::block_hash const &);
 	bool lazy_blocks_processed (nano::block_hash const &);
 	bool lazy_processed_or_exists (nano::block_hash const &) override;
+	unsigned lazy_retry_limit_confirmed ();
 	void get_information (boost::property_tree::ptree &) override;
 	std::unordered_set<size_t> lazy_blocks;
 	std::unordered_map<nano::block_hash, nano::lazy_state_backlog_item> lazy_state_backlog;
@@ -79,6 +80,7 @@ public:
 	lazy_destinations;
 	// clang-format on
 	std::atomic<size_t> lazy_blocks_count{ 0 };
+	size_t peer_count{ 0 };
 	std::atomic<bool> lazy_destinations_flushed{ false };
 	/** The maximum number of records to be read in while iterating over long lazy containers */
 	static uint64_t constexpr batch_read_size = 256;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -171,7 +171,7 @@ nano::bootstrap_constants::bootstrap_constants (nano::network_constants & networ
 	lazy_max_pull_blocks = network_constants.is_dev_network () ? 2 : 512;
 	lazy_min_pull_blocks = network_constants.is_dev_network () ? 1 : 32;
 	frontier_retry_limit = network_constants.is_dev_network () ? 2 : 16;
-	lazy_retry_limit = network_constants.is_dev_network () ? 2 : frontier_retry_limit * 10;
+	lazy_retry_limit = network_constants.is_dev_network () ? 2 : frontier_retry_limit * 4;
 	lazy_destinations_retry_limit = network_constants.is_dev_network () ? 1 : frontier_retry_limit / 4;
 	gap_cache_bootstrap_start_interval = network_constants.is_dev_network () ? std::chrono::milliseconds (5) : std::chrono::milliseconds (30 * 1000);
 }


### PR DESCRIPTION
Considering that node always can start new attempt and cached votes don't include root to find out flipped votes