### PR TITLE
Optional async for process RPC

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -31,7 +31,7 @@ node (node_a),
 write_database_queue (write_database_queue_a),
 state_block_signature_verification (node.checker, node.ledger.network_params.ledger.epochs, node.config, node.logger, node.flags.block_processor_verification_size)
 {
-	state_block_signature_verification.blocks_verified_callback = [this](std::deque<nano::unchecked_info> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures) {
+	state_block_signature_verification.blocks_verified_callback = [this](std::deque<std::pair<nano::unchecked_info, bool>> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures) {
 		this->process_verified_state_blocks (items, verifications, hashes, blocks_signatures);
 	};
 	state_block_signature_verification.transition_inactive_callback = [this]() {
@@ -101,7 +101,7 @@ void nano::block_processor::add (nano::unchecked_info const & info_a, const bool
 	bool quarter_full (size () > node.flags.block_processor_full_size / 4);
 	if (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || info_a.block->type () == nano::block_type::open || !info_a.account.is_zero ()))
 	{
-		state_block_signature_verification.add (info_a);
+		state_block_signature_verification.add (info_a, false);
 	}
 	else if (push_front_preference_a && !quarter_full)
 	{
@@ -110,7 +110,7 @@ void nano::block_processor::add (nano::unchecked_info const & info_a, const bool
 		If deque is a quarter full then push back to allow other blocks processing. */
 		{
 			nano::lock_guard<std::mutex> guard (mutex);
-			blocks.push_front (info_a);
+			blocks.emplace_front (info_a, false);
 		}
 		condition.notify_all ();
 	}
@@ -118,10 +118,17 @@ void nano::block_processor::add (nano::unchecked_info const & info_a, const bool
 	{
 		{
 			nano::lock_guard<std::mutex> guard (mutex);
-			blocks.push_back (info_a);
+			blocks.emplace_front (info_a, false);
 		}
 		condition.notify_all ();
 	}
+}
+
+void nano::block_processor::add_local (nano::unchecked_info const & info_a, bool const watch_work_a)
+{
+	release_assert (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || !info_a.account.is_zero ()));
+	debug_assert (!nano::work_validate_entry (*info_a.block));
+	state_block_signature_verification.add (info_a, watch_work_a);
 }
 
 void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
@@ -193,34 +200,34 @@ bool nano::block_processor::have_blocks ()
 	return have_blocks_ready () || state_block_signature_verification.size () != 0;
 }
 
-void nano::block_processor::process_verified_state_blocks (std::deque<nano::unchecked_info> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures)
+void nano::block_processor::process_verified_state_blocks (std::deque<std::pair<nano::unchecked_info, bool>> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures)
 {
 	{
 		nano::unique_lock<std::mutex> lk (mutex);
 		for (auto i (0); i < verifications.size (); ++i)
 		{
 			debug_assert (verifications[i] == 1 || verifications[i] == 0);
-			auto & item (items.front ());
+			auto & [item, watch_work] = items.front ();
 			if (!item.block->link ().is_zero () && node.ledger.is_epoch_link (item.block->link ()))
 			{
 				// Epoch blocks
 				if (verifications[i] == 1)
 				{
 					item.verified = nano::signature_verification::valid_epoch;
-					blocks.push_back (std::move (item));
+					blocks.emplace_back (std::move (item), watch_work);
 				}
 				else
 				{
 					// Possible regular state blocks with epoch link (send subtype)
 					item.verified = nano::signature_verification::unknown;
-					blocks.push_back (std::move (item));
+					blocks.emplace_back (std::move (item), watch_work);
 				}
 			}
 			else if (verifications[i] == 1)
 			{
 				// Non epoch blocks
 				item.verified = nano::signature_verification::valid;
-				blocks.push_back (std::move (item));
+				blocks.emplace_back (std::move (item), watch_work);
 			}
 			else
 			{
@@ -251,6 +258,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 		{
 			node.logger.always_log (boost::str (boost::format ("%1% blocks (+ %2% state blocks) (+ %3% forced, %4% updates) in processing queue") % blocks.size () % state_block_signature_verification.size () % forced.size () % updates.size ()));
 		}
+		bool watch_work{ false };
 		if (!updates.empty ())
 		{
 			auto block (updates.front ());
@@ -270,7 +278,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 			bool force (false);
 			if (forced.empty ())
 			{
-				info = blocks.front ();
+				std::tie (info, watch_work) = blocks.front ();
 				blocks.pop_front ();
 				hash = info.block->hash ();
 			}
@@ -316,7 +324,7 @@ void nano::block_processor::process_batch (nano::unique_lock<std::mutex> & lock_
 				}
 			}
 			number_of_blocks_processed++;
-			process_one (transaction, post_events, info, false, force);
+			process_one (transaction, post_events, info, watch_work, force);
 		}
 		lock_a.lock ();
 	}

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -53,7 +53,8 @@ public:
 	size_t size ();
 	bool full ();
 	bool half_full ();
-	void add (nano::unchecked_info const &, const bool = false);
+	void add_local (nano::unchecked_info const & info_a, bool const = false);
+	void add (nano::unchecked_info const &, bool const = false);
 	void add (std::shared_ptr<nano::block> const &, uint64_t = 0);
 	void force (std::shared_ptr<nano::block> const &);
 	void update (std::shared_ptr<nano::block> const &);
@@ -74,12 +75,12 @@ private:
 	void process_live (nano::transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &, nano::process_return const &, const bool = false, nano::block_origin const = nano::block_origin::remote);
 	void process_old (nano::transaction const &, std::shared_ptr<nano::block> const &, nano::block_origin const);
 	void requeue_invalid (nano::block_hash const &, nano::unchecked_info const &);
-	void process_verified_state_blocks (std::deque<nano::unchecked_info> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &);
+	void process_verified_state_blocks (std::deque<std::pair<nano::unchecked_info, bool>> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &);
 	bool stopped{ false };
 	bool active{ false };
 	bool awaiting_write{ false };
 	std::chrono::steady_clock::time_point next_log;
-	std::deque<nano::unchecked_info> blocks;
+	std::deque<std::pair<nano::unchecked_info, bool>> blocks;
 	std::deque<std::shared_ptr<nano::block>> forced;
 	std::deque<std::shared_ptr<nano::block>> updates;
 	nano::condition_variable condition;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2953,6 +2953,7 @@ void nano::json_handler::process ()
 {
 	node.worker.push_task (create_worker_task ([](std::shared_ptr<nano::json_handler> const & rpc_l) {
 		const bool watch_work_l = rpc_l->request.get<bool> ("watch_work", true);
+		const bool is_async = rpc_l->request.get<bool> ("async", false);
 		auto block (rpc_l->block_impl (true));
 
 		// State blocks subtype check
@@ -3026,80 +3027,88 @@ void nano::json_handler::process ()
 		{
 			if (!nano::work_validate_entry (*block))
 			{
-				auto result (rpc_l->node.process_local (block, watch_work_l));
-				switch (result.code)
+				if (!is_async)
 				{
-					case nano::process_result::progress:
+					auto result (rpc_l->node.process_local (block, watch_work_l));
+					switch (result.code)
 					{
-						rpc_l->response_l.put ("hash", block->hash ().to_string ());
-						break;
-					}
-					case nano::process_result::gap_previous:
-					{
-						rpc_l->ec = nano::error_process::gap_previous;
-						break;
-					}
-					case nano::process_result::gap_source:
-					{
-						rpc_l->ec = nano::error_process::gap_source;
-						break;
-					}
-					case nano::process_result::old:
-					{
-						rpc_l->ec = nano::error_process::old;
-						break;
-					}
-					case nano::process_result::bad_signature:
-					{
-						rpc_l->ec = nano::error_process::bad_signature;
-						break;
-					}
-					case nano::process_result::negative_spend:
-					{
-						// TODO once we get RPC versioning, this should be changed to "negative spend"
-						rpc_l->ec = nano::error_process::negative_spend;
-						break;
-					}
-					case nano::process_result::balance_mismatch:
-					{
-						rpc_l->ec = nano::error_process::balance_mismatch;
-						break;
-					}
-					case nano::process_result::unreceivable:
-					{
-						rpc_l->ec = nano::error_process::unreceivable;
-						break;
-					}
-					case nano::process_result::block_position:
-					{
-						rpc_l->ec = nano::error_process::block_position;
-						break;
-					}
-					case nano::process_result::fork:
-					{
-						const bool force = rpc_l->request.get<bool> ("force", false);
-						if (force)
+						case nano::process_result::progress:
 						{
-							rpc_l->node.active.erase (*block);
-							rpc_l->node.block_processor.force (block);
 							rpc_l->response_l.put ("hash", block->hash ().to_string ());
+							break;
 						}
-						else
+						case nano::process_result::gap_previous:
 						{
-							rpc_l->ec = nano::error_process::fork;
+							rpc_l->ec = nano::error_process::gap_previous;
+							break;
 						}
-						break;
+						case nano::process_result::gap_source:
+						{
+							rpc_l->ec = nano::error_process::gap_source;
+							break;
+						}
+						case nano::process_result::old:
+						{
+							rpc_l->ec = nano::error_process::old;
+							break;
+						}
+						case nano::process_result::bad_signature:
+						{
+							rpc_l->ec = nano::error_process::bad_signature;
+							break;
+						}
+						case nano::process_result::negative_spend:
+						{
+							// TODO once we get RPC versioning, this should be changed to "negative spend"
+							rpc_l->ec = nano::error_process::negative_spend;
+							break;
+						}
+						case nano::process_result::balance_mismatch:
+						{
+							rpc_l->ec = nano::error_process::balance_mismatch;
+							break;
+						}
+						case nano::process_result::unreceivable:
+						{
+							rpc_l->ec = nano::error_process::unreceivable;
+							break;
+						}
+						case nano::process_result::block_position:
+						{
+							rpc_l->ec = nano::error_process::block_position;
+							break;
+						}
+						case nano::process_result::fork:
+						{
+							const bool force = rpc_l->request.get<bool> ("force", false);
+							if (force)
+							{
+								rpc_l->node.active.erase (*block);
+								rpc_l->node.block_processor.force (block);
+								rpc_l->response_l.put ("hash", block->hash ().to_string ());
+							}
+							else
+							{
+								rpc_l->ec = nano::error_process::fork;
+							}
+							break;
+						}
+						case nano::process_result::insufficient_work:
+						{
+							rpc_l->ec = nano::error_process::insufficient_work;
+							break;
+						}
+						default:
+						{
+							rpc_l->ec = nano::error_process::other;
+							break;
+						}
 					}
-					case nano::process_result::insufficient_work:
-					{
-						rpc_l->ec = nano::error_process::insufficient_work;
-						break;
-					}
-					default:
-					{
-						rpc_l->ec = nano::error_process::other;
-						break;
-					}
+				}
+				else
+				{
+					rpc_l->node.process_local_async (block, watch_work_l);
+					rpc_l->response_l.put ("started", "1");
 				}
 			}
 			else

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -616,7 +616,7 @@ void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 
 nano::process_return nano::node::process (nano::block & block_a)
 {
-	auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }, { tables::confirmation_height }));
+	auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
 	auto result (ledger.process (transaction, block_a));
 	return result;
 }
@@ -631,8 +631,17 @@ nano::process_return nano::node::process_local (std::shared_ptr<nano::block> con
 	block_processor.wait_write ();
 	// Process block
 	block_post_events post_events ([& store = store] { return store.tx_begin_read (); });
-	auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }, { tables::confirmation_height }));
+	auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
 	return block_processor.process_one (transaction, post_events, info, work_watcher_a, false, nano::block_origin::local);
+}
+
+void nano::node::process_local_async (std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a)
+{
+	// Add block hash as recently arrived to trigger automatic rebroadcast and election
+	block_arrival.add (block_a->hash ());
+	// Set current time to trigger automatic rebroadcast and election
+	nano::unchecked_info info (block_a, block_a->account (), nano::seconds_since_epoch (), nano::signature_verification::unknown);
+	block_processor.add_local (info, work_watcher_a);
 }
 
 void nano::node::start ()

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -114,6 +114,7 @@ public:
 	void process_active (std::shared_ptr<nano::block> const &);
 	nano::process_return process (nano::block &);
 	nano::process_return process_local (std::shared_ptr<nano::block> const &, bool const = false);
+	void process_local_async (std::shared_ptr<nano::block> const &, bool const = false);
 	void keepalive_preconfigured (std::vector<std::string> const &);
 	nano::block_hash latest (nano::account const &);
 	nano::uint128_t balance (nano::account const &);

--- a/nano/node/state_block_signature_verification.hpp
+++ b/nano/node/state_block_signature_verification.hpp
@@ -19,12 +19,12 @@ class state_block_signature_verification
 public:
 	state_block_signature_verification (nano::signature_checker &, nano::epochs &, nano::node_config &, nano::logger_mt &, uint64_t);
 	~state_block_signature_verification ();
-	void add (nano::unchecked_info const & info_a);
+	void add (nano::unchecked_info const & info_a, bool watch_work_a);
 	size_t size ();
 	void stop ();
 	bool is_active ();
 
-	std::function<void(std::deque<nano::unchecked_info> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &)> blocks_verified_callback;
+	std::function<void(std::deque<std::pair<nano::unchecked_info, bool>> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &)> blocks_verified_callback;
 	std::function<void()> transition_inactive_callback;
 
 private:
@@ -36,13 +36,13 @@ private:
 	std::mutex mutex;
 	bool stopped{ false };
 	bool active{ false };
-	std::deque<nano::unchecked_info> state_blocks;
+	std::deque<std::pair<nano::unchecked_info, bool>> state_blocks;
 	nano::condition_variable condition;
 	std::thread thread;
 
 	void run (uint64_t block_processor_verification_size);
-	std::deque<nano::unchecked_info> setup_items (size_t);
-	void verify_state_blocks (std::deque<nano::unchecked_info> &);
+	std::deque<std::pair<nano::unchecked_info, bool>> setup_items (size_t);
+	void verify_state_blocks (std::deque<std::pair<nano::unchecked_info, bool>> &);
 };
 
 std::unique_ptr<nano::container_info_component> collect_container_info (state_block_signature_verification & state_block_signature_verification, const std::string & name);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1903,6 +1903,100 @@ TEST (rpc, process_block_with_work_watcher)
 	}
 }
 
+TEST (rpc, process_block_async)
+{
+	nano::system system;
+	auto & node1 = *add_ipc_enabled_node (system);
+	scoped_io_thread_name_change scoped_thread_name_io;
+	nano::keypair key;
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	nano::send_block send (latest, key.pub, 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *node1.work_generate_blocking (latest));
+	nano::node_rpc_config node_rpc_config;
+	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
+	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	rpc_config.rpc_process.ipc_port = node1.config.ipc_config.transport_tcp.port;
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
+	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	request.put ("async", "true");
+	std::string json;
+	send.serialize_json (json);
+	request.put ("block", json);
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+		ASSERT_EQ ("1", response.json.get<std::string> ("started"));
+		ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == send.hash ());
+	}
+	request.put ("json_block", true);
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+		std::error_code ec (nano::error_blocks::invalid_block);
+		ASSERT_EQ (ec.message (), response.json.get<std::string> ("error"));
+	}
+}
+
+TEST (rpc, process_block_async_work_watcher)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.enable_voting = false;
+	node_config.work_watcher_period = 1s;
+	node_config.max_work_generate_multiplier = 1e6;
+	auto & node1 = *add_ipc_enabled_node (system, node_config);
+	nano::keypair key;
+	auto latest (node1.latest (nano::dev_genesis_key.pub));
+	auto send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, latest, nano::dev_genesis_key.pub, nano::genesis_amount - 100, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest)));
+	auto difficulty1 (send->difficulty ());
+	auto multiplier1 = nano::normalized_multiplier (nano::difficulty::to_multiplier (difficulty1, node1.network_params.network.publish_thresholds.epoch_1), node1.network_params.network.publish_thresholds.epoch_1);
+	nano::node_rpc_config node_rpc_config;
+	nano::ipc::ipc_server ipc_server (node1, node_rpc_config);
+	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	rpc_config.rpc_process.ipc_port = node1.config.ipc_config.transport_tcp.port;
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
+	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "process");
+	request.put ("async", "true");
+	request.put ("watch_work", true);
+	std::string json;
+	send->serialize_json (json);
+	request.put ("block", json);
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+		ASSERT_EQ ("1", response.json.get<std::string> ("started"));
+		ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == send->hash ());
+	}
+
+	auto updated (false);
+	double updated_multiplier;
+	while (!updated)
+	{
+		nano::unique_lock<std::mutex> lock (node1.active.mutex);
+		// Fill multipliers_cb and update active difficulty
+		for (auto i (0); i < node1.active.multipliers_cb.size (); i++)
+		{
+			node1.active.multipliers_cb.push_back (multiplier1 * (1 + i / 100.));
+		}
+		node1.active.update_active_multiplier (lock);
+		auto const existing (node1.active.roots.find (send->qualified_root ()));
+		// If existing is junk the block has been confirmed already
+		ASSERT_NE (existing, node1.active.roots.end ());
+		updated = existing->multiplier != multiplier1;
+		updated_multiplier = existing->multiplier;
+		lock.unlock ();
+		ASSERT_NO_ERROR (system.poll ());
+	}
+}
+
 TEST (rpc, process_block_no_work)
 {
 	nano::system system;


### PR DESCRIPTION
Each process call opens a single write transaction which can slow down testing. Add an "async" option to the process RPC which is non blocks (and returns "started":"1" if added) hooks into the block processor and just adds it to the queue,. To know if the block is added the websocket for unconfirmed blocks should be checked.