### PR TITLE
Wallet store adhoc keys inconsistency with reps container

### DIFF
--- a/nano/node/lmdb/lmdb_txn.cpp
+++ b/nano/node/lmdb/lmdb_txn.cpp
@@ -97,9 +97,13 @@ nano::write_mdb_txn::~write_mdb_txn ()
 
 void nano::write_mdb_txn::commit ()
 {
-	auto status (mdb_txn_commit (handle));
-	release_assert (status == MDB_SUCCESS);
-	txn_callbacks.txn_end (this);
+	if (active)
+	{
+		auto status (mdb_txn_commit (handle));
+		release_assert (status == MDB_SUCCESS);
+		txn_callbacks.txn_end (this);
+		active = false;
+	}
 }
 
 void nano::write_mdb_txn::renew ()
@@ -107,6 +111,7 @@ void nano::write_mdb_txn::renew ()
 	auto status (mdb_txn_begin (env, nullptr, 0, &handle));
 	release_assert (status == MDB_SUCCESS);
 	txn_callbacks.txn_start (this);
+	active = true;
 }
 
 void * nano::write_mdb_txn::get_handle () const

--- a/nano/node/lmdb/lmdb_txn.hpp
+++ b/nano/node/lmdb/lmdb_txn.hpp
@@ -48,6 +48,7 @@ public:
 	MDB_txn * handle;
 	nano::mdb_env const & env;
 	mdb_txn_callbacks txn_callbacks;
+	bool active{ true };
 };
 
 class mdb_txn_stats

--- a/nano/node/rocksdb/rocksdb_txn.cpp
+++ b/nano/node/rocksdb/rocksdb_txn.cpp
@@ -53,18 +53,22 @@ nano::write_rocksdb_txn::~write_rocksdb_txn ()
 
 void nano::write_rocksdb_txn::commit ()
 {
-	auto status = txn->Commit ();
-
-	// If there are no available memtables try again a few more times
-	constexpr auto num_attempts = 10;
-	auto attempt_num = 0;
-	while (status.IsTryAgain () && attempt_num < num_attempts)
+	if (active)
 	{
-		status = txn->Commit ();
-		++attempt_num;
-	}
+		auto status = txn->Commit ();
 
-	release_assert (status.ok ());
+		// If there are no available memtables try again a few more times
+		constexpr auto num_attempts = 10;
+		auto attempt_num = 0;
+		while (status.IsTryAgain () && attempt_num < num_attempts)
+		{
+			status = txn->Commit ();
+			++attempt_num;
+		}
+
+		release_assert (status.ok ());
+		active = false;
+	}
 }
 
 void nano::write_rocksdb_txn::renew ()
@@ -72,6 +76,7 @@ void nano::write_rocksdb_txn::renew ()
 	rocksdb::OptimisticTransactionOptions txn_options;
 	txn_options.set_snapshot = true;
 	db->BeginTransaction (rocksdb::WriteOptions (), txn_options, txn);
+	active = true;
 }
 
 void * nano::write_rocksdb_txn::get_handle () const

--- a/nano/node/rocksdb/rocksdb_txn.hpp
+++ b/nano/node/rocksdb/rocksdb_txn.hpp
@@ -41,6 +41,7 @@ private:
 	std::vector<nano::tables> tables_requiring_locks;
 	std::vector<nano::tables> tables_no_locks;
 	std::unordered_map<nano::tables, std::mutex> & mutexes;
+	bool active{ true };
 
 	void lock ();
 	void unlock ();

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -128,7 +128,6 @@ public:
 	void enter_initial_password ();
 	bool enter_password (nano::transaction const &, std::string const &);
 	nano::public_key insert_adhoc (nano::raw_key const &, bool = true);
-	nano::public_key insert_adhoc (nano::transaction const &, nano::raw_key const &, bool = true);
 	bool insert_watch (nano::transaction const &, nano::public_key const &);
 	nano::public_key deterministic_insert (nano::transaction const &, bool = true);
 	nano::public_key deterministic_insert (uint32_t, bool = true);


### PR DESCRIPTION
When a wallet key is added in `insert_adhoc` but it's possible that the write transaction hasn't commited while the `representatives` container has been updated. If `nano::wallets::compute_reps` is called at the same time the `representatives` are cleared and never repopulated from the store. This was made more evident with test failures in https://github.com/nanocurrency/nano-node/pull/2871.

Also modifying the `write_transaction` so that `commit ()` can be called without having to renew it before destruction, so it operates similarly to `std::unique_lock` for instance.

There is also an issue with deterministic wallet inserts, which can be handled separately (as well as adding tests)