### PR TITLE
Process async test should use state block

### DIFF
--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -83,6 +83,8 @@ std::string nano::error_common_messages::message (int ev) const
 			return "Invalid type conversion";
 		case nano::error_common::invalid_work:
 			return "Invalid work";
+		case nano::error_common::is_not_state_block:
+			return "Must be a state block";
 		case nano::error_common::numeric_conversion:
 			return "Numeric conversion error";
 		case nano::error_common::tracking_not_enabled:

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -53,6 +53,7 @@ enum class error_common
 	invalid_type_conversion,
 	invalid_work,
 	insufficient_balance,
+	is_not_state_block,
 	numeric_conversion,
 	tracking_not_enabled,
 	wallet_lmdb_max_dbs,

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3137,8 +3137,15 @@ void nano::json_handler::process ()
 				}
 				else
 				{
-					rpc_l->node.process_local_async (block, watch_work_l);
-					rpc_l->response_l.put ("started", "1");
+					if (block->type () == nano::block_type::state)
+					{
+						rpc_l->node.process_local_async (block, watch_work_l);
+						rpc_l->response_l.put ("started", "1");
+					}
+					else
+					{
+						rpc_l->ec = nano::error_common::is_not_state_block;
+					}
 				}
 			}
 			else

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1924,13 +1924,6 @@ TEST (rpc, process_block_async)
 	std::string json;
 	send.serialize_json (json);
 	request.put ("block", json);
-	{
-		test_response response (request, rpc.config.port, system.io_ctx);
-		ASSERT_TIMELY (5s, response.status != 0);
-		ASSERT_EQ (200, response.status);
-		ASSERT_EQ ("1", response.json.get<std::string> ("started"));
-		ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == send.hash ());
-	}
 	request.put ("json_block", true);
 	{
 		test_response response (request, rpc.config.port, system.io_ctx);
@@ -1938,6 +1931,26 @@ TEST (rpc, process_block_async)
 		ASSERT_EQ (200, response.status);
 		std::error_code ec (nano::error_blocks::invalid_block);
 		ASSERT_EQ (ec.message (), response.json.get<std::string> ("error"));
+	}
+	request.put ("json_block", false);
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+		std::error_code ec (nano::error_common::is_not_state_block);
+		ASSERT_EQ (ec.message (), response.json.get<std::string> ("error"));
+	}
+
+	auto state_send (std::make_shared<nano::state_block> (nano::dev_genesis_key.pub, latest, nano::dev_genesis_key.pub, nano::genesis_amount - 100, nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest)));
+	std::string json1;
+	state_send->serialize_json (json1);
+	request.put ("block", json1);
+	{
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+		ASSERT_EQ ("1", response.json.get<std::string> ("started"));
+		ASSERT_TIMELY (10s, node1.latest (nano::dev_genesis_key.pub) == state_send->hash ());
 	}
 }
 


### PR DESCRIPTION
rpc.process_block_async test is currently failing. `process_local` requires the block to be a state block, but the test was using a legacy send block. Have updated it the rpc to check for this and updated the test