### PR TITLE
Add missing include(msvc2017)

### DIFF
--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <thread>
 
 // Some builds (mac) fail due to "Boost.Stacktrace requires `_Unwind_Backtrace` function".


### PR DESCRIPTION
`assert_internal` didn't compile on msvc2017/14.12, due to missing `operator <<` for string_view. Adding the string_view header fixed it.