### PR TITLE
TSAN error in confirmation height unbounded

### DIFF
--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -65,6 +65,7 @@ void nano::confirmation_height_unbounded::process ()
 			debug_assert (current == original_block->hash ());
 			// This is the original block passed so can use it directly
 			block = original_block;
+			nano::lock_guard<std::mutex> guard (block_cache_mutex);
 			block_cache[original_block->hash ()] = original_block;
 		}
 		else
@@ -206,6 +207,7 @@ void nano::confirmation_height_unbounded::collect_unconfirmed_receive_and_source
 		{
 			debug_assert (hash == hash_a);
 			block = block_a;
+			nano::lock_guard<std::mutex> guard (block_cache_mutex);
 			block_cache[hash] = block_a;
 		}
 		else


### PR DESCRIPTION
Error found by @SergiySW in the `node.auto_bootstrap` test
`block_cache` was not protected in a couple places