### PR TITLE
Check open file descriptor limit, warn if low

### DIFF
--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -4,6 +4,7 @@
 #include <boost/filesystem.hpp>
 
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string_view>
 #include <thread>

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -37,7 +37,7 @@
 
 std::size_t nano::get_filedescriptor_limit ()
 {
-	auto fd_limit (std::numeric_limits<std::size_t>::max ());
+	std::size_t fd_limit = (std::numeric_limits<std::size_t>::max) ();
 #ifndef _WIN32
 	struct rlimit limit;
 	if (getrlimit (RLIMIT_NOFILE, &limit) == 0)

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -3,6 +3,7 @@
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/filesystem.hpp>
 
+#include <cstddef>
 #include <iostream>
 #include <limits>
 #include <sstream>
@@ -34,14 +35,14 @@
 #include <sys/resource.h>
 #endif
 
-size_t nano::get_filedescriptor_limit ()
+std::size_t nano::get_filedescriptor_limit ()
 {
-	size_t fd_limit = std::numeric_limits<size_t>::max ();
+	std::size_t fd_limit = std::numeric_limits<std::size_t>::max ();
 #ifndef _WIN32
 	struct rlimit limit;
 	if (getrlimit (RLIMIT_NOFILE, &limit) == 0)
 	{
-		fd_limit = static_cast<size_t> (limit.rlim_cur);
+		fd_limit = static_cast<std::size_t> (limit.rlim_cur);
 	}
 #endif
 	return fd_limit;

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -29,6 +29,23 @@
 #endif
 #endif
 
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+size_t nano::get_filedescriptor_limit ()
+{
+	size_t fd_limit = std::numeric_limits<size_t>::max ();
+#ifndef _WIN32
+	struct rlimit limit;
+	if (getrlimit (RLIMIT_NOFILE, &limit) == 0)
+	{
+		fd_limit = static_cast<size_t> (limit.rlim_cur);
+	}
+#endif
+	return fd_limit;
+}
+
 nano::container_info_composite::container_info_composite (std::string const & name) :
 name (name)
 {

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -37,7 +37,7 @@
 
 std::size_t nano::get_filedescriptor_limit ()
 {
-	std::size_t fd_limit = std::numeric_limits<std::size_t>::max ();
+	auto fd_limit (std::numeric_limits<std::size_t>::max ());
 #ifndef _WIN32
 	struct rlimit limit;
 	if (getrlimit (RLIMIT_NOFILE, &limit) == 0)

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -132,6 +132,16 @@ void dump_crash_stacktrace ();
  */
 std::string generate_stacktrace ();
 
+/**
+ * Some systems, especially in virtualized environments, may have very low file descriptor limits,
+ * causing the node to fail. This function attempts to query the limit and returns the value. If the
+ * limit cannot be queried, or running on a Windows system, this returns max-value of size_t.
+ * Increasing the limit programatically is highly system-dependent, and the process may lack the
+ * required permissions; the node thus merely logs low limits as a potential problem and leaves
+ * the system configuration to the user.
+ */
+size_t get_filedescriptor_limit ();
+
 template <typename... T>
 class observer_set final
 {

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -11,6 +11,8 @@
 #include <nano/rpc/rpc.hpp>
 #include <nano/secure/working.hpp>
 
+#include <boost/format.hpp>
+
 #include <csignal>
 #include <iostream>
 
@@ -59,6 +61,15 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 			auto initialization_text = "Starting up Nano node...";
 			std::cout << initialization_text << std::endl;
 			logger.always_log (initialization_text);
+
+			size_t fd_limit = nano::get_filedescriptor_limit ();
+			constexpr size_t fd_limit_recommended_minimum = 16384;
+			if (fd_limit < fd_limit_recommended_minimum)
+			{
+				auto low_fd_text = boost::str (boost::format ("WARNING: The file descriptor limit on this system may be too low (%1%) and should be increased to at least %2%.") % fd_limit % fd_limit_recommended_minimum);
+				std::cerr << low_fd_text << std::endl;
+				logger.always_log (low_fd_text);
+			}
 
 			auto node (std::make_shared<nano::node> (io_ctx, data_path, config.node, opencl_work, flags));
 			if (!node->init_error ())


### PR DESCRIPTION
Sample output (stderr and log)

```
WARNING: The file descriptor limit on this system may be too low (512) 
and should be increased to at least 16384.
```

This can be tested with `docker run --ulimit nofile=512:1024 ...`