### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://docs.nano.org/node-implementation/contributing/#security-vulnerability-disclosure
+    about: DO NOT SUBMIT SECURITY VULNERABILITIES IN PUBLIC REPOSITORIES - find out how to privately submit in our documentation.
+  - name: Nano Community Forum
+    url: https://forum.nano.org
+    about: Ask questions, get wallet or other support, and discuss Nano with the community.
+    

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -31,7 +31,7 @@ body:
     description: Please provide your proposed solution taking into account    - Details of the technical implementation - Tradeoffs made in design decisions - Caveats and considerations for the future  If multiple solutions are being presented, please present them separately and provide comparisons at the end.
   validations:
     required: true
-- type: dropwn
+- type: dropdown
   attributes:
     label: If this feature is approved, would you be willing to submit a pull request with the solution?
     options:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,5 @@
 name: Request a new node feature
 description: For requesting new node or protocol related features
-title: ""
-issue_body: true
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,54 @@
+name: Request a new node feature
+description: For requesting new node or protocol related features
+title: ""
+issue_body: true
+body:
+- type: markdown
+  attributes:
+    value: |
+      NOTE: Feature requests without sufficient detail, or those with a broad scope and no prior discussion with the community, are best posted in the [Nano Forum](https://forum.nano.org) first for feedback and evaluating relevance.
+- type: textarea
+  attributes:
+    label: Summary
+    description: Provide a summary of the feature you are requesting
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What problem would be solved by this feature?
+    description: Describe in detail the problem you are aiming to solve with the feature and what is considered to be in-scope and out-of-scope.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Are there any previous requests for this feature?
+    description: If there have been any previous requests for the feature, or related features, include them as links
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Do you have a suggested solution?
+    description: Please provide your proposed solution taking into account    - Details of the technical implementation - Tradeoffs made in design decisions - Caveats and considerations for the future  If multiple solutions are being presented, please present them separately and provide comparisons at the end.
+  validations:
+    required: true
+- type: dropwn
+  attributes:
+    label: If this feature is approved, would you be willing to submit a pull request with the solution?
+    options:
+      - I would
+      - I would not
+      - I am willing to collaborate
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Possible solution
+    description: If available, provide possible solutions to the issue
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Supporting files
+    description: When applicable, add links out to helpful [log files](https://docs.nano.org/running-a-node/troubleshooting/#log-files) and [dump files](https://docs.nano.org/running-a-node/troubleshooting/#what-to-do-if-the-node-crashes-linux) related to the issue.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/node-issue.yml
+++ b/.github/ISSUE_TEMPLATE/node-issue.yml
@@ -1,6 +1,5 @@
 name: Report a node/protocol issue
 description: For reporting issues with the node software and related protocol
-title: ""
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/node-issue.yml
+++ b/.github/ISSUE_TEMPLATE/node-issue.yml
@@ -1,0 +1,72 @@
+name: Report a node/protocol issue
+description: For reporting issues with the node software and related protocol
+title: ""
+issue_body: true
+body:
+- type: markdown
+  attributes:
+    value: |
+      NOTE: If this is a security issue that could impact network availability, consensus or other sensitive areas of the node and network operations, please see the [Security vulnerability disclosure documentation](https://docs.nano.org/node-implementation/contributing/#security-vulnerability-disclosure) to learn how to submit the issue directly to the Nano Foundation.
+- type: textarea
+  attributes:
+    label: Summary
+    description: Brief summary of the issue you are facing.
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: Node version
+    description: Select the node version this issue was discovered in. If this was produced in a release other than the latest, please try with the latest release before submitting.
+    options:
+      - V21.2
+      - V21.1
+      - V21.0
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Build details
+    description: Was this using provided binaries, Docker container or manually built? Any special build options?
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: OS and version
+    description: Which operating system was this running on? Which version?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce the behavior
+    description: Please walk us through step-by-step how to reproduce the issue. Provide any build scripts, Docker commands, RPC/CLI commands, etc. required to reproduce the behavior.
+    value: |
+      1.
+      2.
+      3.
+      ...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: Describe what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    description: Describe what actually happened.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Possible solution
+    description: If available, provide possible solutions to the issue.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Supporting files
+    description: When applicable, add links out to helpful [log files](https://docs.nano.org/running-a-node/troubleshooting/#log-files) and [dump files](https://docs.nano.org/running-a-node/troubleshooting/#what-to-do-if-the-node-crashes-linux) related to the issue.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/node-issue.yml
+++ b/.github/ISSUE_TEMPLATE/node-issue.yml
@@ -1,7 +1,6 @@
 name: Report a node/protocol issue
 description: For reporting issues with the node software and related protocol
 title: ""
-issue_body: true
 body:
 - type: markdown
   attributes:
@@ -13,14 +12,10 @@ body:
     description: Brief summary of the issue you are facing.
   validations:
     required: true
-- type: dropdown
+- type: input
   attributes:
     label: Node version
     description: Select the node version this issue was discovered in. If this was produced in a release other than the latest, please try with the latest release before submitting.
-    options:
-      - V21.2
-      - V21.1
-      - V21.0
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
This PR adds some new options when attempting to add a new issue:

- `config.yml` prevents blank issue creation and adds external links for vulnerability issues and forum discussions
- `node-issue.yml` and `feature-request.yml` adds issue templates in a new beta format GitHub is providing which allows specific fields in the issue form - this should be reviewed by viewing the individual file in GitHub which will render it