### PR TITLE
Database final votes support

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1791,6 +1791,36 @@ TEST (mdb_block_store, upgrade_v19_v20)
 	ASSERT_LT (19, store.version_get (transaction));
 }
 
+TEST (mdb_block_store, upgrade_v20_v21)
+{
+	if (nano::using_rocksdb_in_tests ())
+	{
+		// Don't test this in rocksdb mode
+		return;
+	}
+	auto path (nano::unique_path ());
+	nano::genesis genesis;
+	nano::logger_mt logger;
+	nano::stat stats;
+	{
+		nano::mdb_store store (logger, path);
+		nano::ledger ledger (store, stats);
+		auto transaction (store.tx_begin_write ());
+		store.initialize (transaction, genesis, ledger.cache);
+		// Delete pruned table
+		ASSERT_FALSE (mdb_drop (store.env.tx (transaction), store.final_votes, 1));
+		store.version_put (transaction, 20);
+	}
+	// Upgrading should create the table
+	nano::mdb_store store (logger, path);
+	ASSERT_FALSE (store.init_error ());
+	ASSERT_NE (store.final_votes, 0);
+
+	// Version should be correct
+	auto transaction (store.tx_begin_read ());
+	ASSERT_LT (19, store.version_get (transaction));
+}
+
 TEST (mdb_block_store, upgrade_backup)
 {
 	if (nano::using_rocksdb_in_tests ())
@@ -1867,7 +1897,7 @@ TEST (block_store, confirmation_height)
 		ASSERT_EQ (confirmation_height_info.height, 10);
 		ASSERT_EQ (confirmation_height_info.frontier, cemented_frontier3);
 
-		// Check cleaning of confirmation heights
+		// Check clearing of confirmation heights
 		store->confirmation_height_clear (transaction);
 	}
 	auto transaction (store->tx_begin_read ());
@@ -1876,6 +1906,36 @@ TEST (block_store, confirmation_height)
 	ASSERT_TRUE (store->confirmation_height_get (transaction, account1, confirmation_height_info));
 	ASSERT_TRUE (store->confirmation_height_get (transaction, account2, confirmation_height_info));
 	ASSERT_TRUE (store->confirmation_height_get (transaction, account3, confirmation_height_info));
+}
+
+// Test various confirmation height values as well as clearing them
+TEST (block_store, final_vote)
+{
+	if (nano::using_rocksdb_in_tests ())
+	{
+		// Don't test this in rocksdb mode as deletions cause inaccurate counts
+		return;
+	}
+	auto path (nano::unique_path ());
+	nano::logger_mt logger;
+	auto store = nano::make_store (logger, path);
+
+	{
+		auto qualified_root = nano::genesis ().open->qualified_root ();
+		auto transaction (store->tx_begin_write ());
+		store->final_vote_put (transaction, qualified_root, nano::block_hash (2));
+		ASSERT_EQ (store->final_vote_count (transaction), 1);
+		store->final_vote_clear (transaction);
+		ASSERT_EQ (store->final_vote_count (transaction), 0);
+		store->final_vote_put (transaction, qualified_root, nano::block_hash (2));
+		ASSERT_EQ (store->final_vote_count (transaction), 1);
+		// Clearing with incorrect root shouldn't remove
+		store->final_vote_clear (transaction, qualified_root.previous ());
+		ASSERT_EQ (store->final_vote_count (transaction), 1);
+		// Clearing with correct root should remove
+		store->final_vote_clear (transaction, qualified_root.root ());
+		ASSERT_EQ (store->final_vote_count (transaction), 0);
+	}
 }
 
 // Ledger versions are not forward compatible

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3777,6 +3777,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 		store.version_put (transaction, version);
 		send->sideband_set ({});
 		store.block_put (transaction, send->hash (), *send);
+		store.final_vote_put (transaction, send->qualified_root (), nano::block_hash (2));
 	}
 
 	auto error = ledger.migrate_lmdb_to_rocksdb (path);
@@ -3806,6 +3807,8 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_FALSE (rocksdb_store.confirmation_height_get (rocksdb_transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 2);
 	ASSERT_EQ (confirmation_height_info.frontier, send->hash ());
+	ASSERT_TRUE (rocksdb_store.final_vote_get (rocksdb_transaction, nano::root (send->previous ())).size () == 1);
+	ASSERT_EQ (rocksdb_store.final_vote_get (rocksdb_transaction, nano::root (send->previous ()))[0], nano::block_hash (2));
 
 	auto unchecked_infos = rocksdb_store.unchecked_get (rocksdb_transaction, nano::genesis_hash);
 	ASSERT_EQ (unchecked_infos.size (), 1);

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -199,6 +199,7 @@ void nano::mdb_store::open_databases (bool & error_a, nano::transaction const & 
 	accounts = accounts_v0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pending", flags, &pending_v0) != 0;
 	pending = pending_v0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "final_votes", flags, &final_votes) != 0;
 
 	auto version_l = version_get (transaction_a);
 	if (version_l < 19)
@@ -280,6 +281,9 @@ bool nano::mdb_store::do_upgrades (nano::write_transaction & transaction_a, bool
 			upgrade_v19_to_v20 (transaction_a);
 			[[fallthrough]];
 		case 20:
+			upgrade_v20_to_v21 (transaction_a);
+			[[fallthrough]];
+		case 21:
 			break;
 		default:
 			logger.always_log (boost::str (boost::format ("The version of the ledger (%1%) is too high for this node") % version_l));
@@ -745,6 +749,14 @@ void nano::mdb_store::upgrade_v19_to_v20 (nano::write_transaction const & transa
 	logger.always_log ("Finished creating new pruned table");
 }
 
+void nano::mdb_store::upgrade_v20_to_v21 (nano::write_transaction const & transaction_a)
+{
+	logger.always_log ("Preparing v20 to v21 database upgrade...");
+	mdb_dbi_open (env.tx (transaction_a), "final_votes", MDB_CREATE, &final_votes);
+	version_put (transaction_a, 21);
+	logger.always_log ("Finished creating new final_vote table");
+}
+
 /** Takes a filepath, appends '_backup_<timestamp>' to the end (but before any extension) and saves that file in the same directory */
 void nano::mdb_store::create_backup_file (nano::mdb_env & env_a, boost::filesystem::path const & filepath_a, nano::logger_mt & logger_a)
 {
@@ -865,6 +877,8 @@ MDB_dbi nano::mdb_store::table_to_dbi (tables table_a) const
 			return pruned;
 		case tables::confirmation_height:
 			return confirmation_height;
+		case tables::final_votes:
+			return final_votes;
 		default:
 			release_assert (false);
 			return peers;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -192,6 +192,12 @@ public:
 	 */
 	MDB_dbi blocks{ 0 };
 
+	/**
+	 * Maps root to block hash for generated final votes.
+	 * nano::qualified_root -> nano::block_hash
+	 */
+	MDB_dbi final_votes{ 0 };
+
 	bool exists (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 
@@ -234,6 +240,7 @@ private:
 	void upgrade_v17_to_v18 (nano::write_transaction const &);
 	void upgrade_v18_to_v19 (nano::write_transaction const &);
 	void upgrade_v19_to_v20 (nano::write_transaction const &);
+	void upgrade_v20_to_v21 (nano::write_transaction const &);
 
 	std::shared_ptr<nano::block> block_get_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 	nano::mdb_val block_raw_get_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_type & type_a) const;

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -99,7 +99,8 @@ std::unordered_map<const char *, nano::tables> nano::rocksdb_store::create_cf_na
 		{ "meta", tables::meta },
 		{ "peers", tables::peers },
 		{ "confirmation_height", tables::confirmation_height },
-		{ "pruned", tables::pruned } };
+		{ "pruned", tables::pruned },
+		{ "final_votes", tables::final_votes } };
 
 	debug_assert (map.size () == all_tables ().size () + 1);
 	return map;
@@ -267,6 +268,11 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_cf_options (std::string co
 		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 	}
+	else if (cf_name_a == "final_votes")
+	{
+		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
+		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
+	}
 	else if (cf_name_a == rocksdb::kDefaultColumnFamilyName)
 	{
 		// Do nothing.
@@ -355,6 +361,8 @@ rocksdb::ColumnFamilyHandle * nano::rocksdb_store::table_to_column_family (table
 			return get_handle ("pruned");
 		case tables::confirmation_height:
 			return get_handle ("confirmation_height");
+		case tables::final_votes:
+			return get_handle ("final_votes");
 		default:
 			release_assert (false);
 			return get_handle ("");
@@ -494,6 +502,11 @@ uint64_t nano::rocksdb_store::count (nano::transaction const & transaction_a, ta
 	}
 	// This should be correct at node start, later only cache should be used
 	else if (table_a == tables::pruned)
+	{
+		db->GetIntProperty (table_to_column_family (table_a), "rocksdb.estimate-num-keys", &sum);
+	}
+	// This should be accurate as long as there continues to be no deletes or duplicate entries.
+	else if (table_a == tables::final_votes)
 	{
 		db->GetIntProperty (table_to_column_family (table_a), "rocksdb.estimate-num-keys", &sum);
 	}
@@ -742,7 +755,7 @@ void nano::rocksdb_store::on_flush (rocksdb::FlushJobInfo const & flush_job_info
 
 std::vector<nano::tables> nano::rocksdb_store::all_tables () const
 {
-	return std::vector<nano::tables>{ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers, tables::meta, tables::online_weight, tables::peers, tables::pending, tables::pruned, tables::unchecked, tables::vote };
+	return std::vector<nano::tables>{ tables::accounts, tables::blocks, tables::confirmation_height, tables::final_votes, tables::frontiers, tables::meta, tables::online_weight, tables::peers, tables::pending, tables::pruned, tables::unchecked, tables::vote };
 }
 
 bool nano::rocksdb_store::copy_db (boost::filesystem::path const & destination_path)

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -536,6 +536,7 @@ enum class tables
 	blocks,
 	confirmation_height,
 	default_unused, // RocksDB only
+	final_votes,
 	frontiers,
 	meta,
 	online_weight,
@@ -724,8 +725,19 @@ public:
 	virtual void pruned_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const = 0;
 	virtual void blocks_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;
 	virtual void frontiers_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const = 0;
+	virtual void final_vote_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const = 0;
 
 	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+
+	virtual bool final_vote_put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
+	virtual std::vector<nano::block_hash> final_vote_get (nano::transaction const & transaction_a, nano::root const & root_a) = 0;
+	virtual void final_vote_del (nano::write_transaction const & transaction_a, nano::root const & root_a) = 0;
+	virtual size_t final_vote_count (nano::transaction const & transaction_a) const = 0;
+	virtual void final_vote_clear (nano::write_transaction const &, nano::root const &) = 0;
+	virtual void final_vote_clear (nano::write_transaction const &) = 0;
+	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const = 0;
+	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_end () const = 0;
 
 	virtual unsigned max_block_write_batch_num () const = 0;
 

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -243,6 +243,11 @@ public:
 		return nano::store_iterator<nano::block_hash, std::nullptr_t> (nullptr);
 	}
 
+	nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_end () const override
+	{
+		return nano::store_iterator<nano::qualified_root, nano::block_hash> (nullptr);
+	}
+
 	nano::store_iterator<nano::block_hash, nano::account> frontiers_end () const override
 	{
 		return nano::store_iterator<nano::block_hash, nano::account> (nullptr);
@@ -592,6 +597,65 @@ public:
 		return exists (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a));
 	}
 
+	bool final_vote_put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override
+	{
+		nano::db_val<Val> value;
+		auto status = get (transaction_a, tables::final_votes, nano::db_val<Val> (root_a), value);
+		release_assert (success (status) || not_found (status));
+		bool result (true);
+		if (success (status))
+		{
+			result = static_cast<nano::block_hash> (value) == hash_a;
+		}
+		else
+		{
+			status = put (transaction_a, tables::final_votes, root_a, hash_a);
+			release_assert_success (status);
+		}
+		return result;
+	}
+
+	std::vector<nano::block_hash> final_vote_get (nano::transaction const & transaction_a, nano::root const & root_a) override
+	{
+		std::vector<nano::block_hash> result;
+		nano::qualified_root key_start (root_a.raw, 0);
+		for (auto i (final_vote_begin (transaction_a, key_start)), n (final_vote_end ()); i != n && nano::qualified_root (i->first).root () == root_a; ++i)
+		{
+			result.push_back (i->second);
+		}
+		return result;
+	}
+
+	size_t final_vote_count (nano::transaction const & transaction_a) const override
+	{
+		return count (transaction_a, tables::final_votes);
+	}
+
+	void final_vote_del (nano::write_transaction const & transaction_a, nano::root const & root_a) override
+	{
+		std::vector<nano::qualified_root> final_vote_qualified_roots;
+		for (auto i (final_vote_begin (transaction_a, nano::qualified_root (root_a.raw, 0))), n (final_vote_end ()); i != n && nano::qualified_root (i->first).root () == root_a; ++i)
+		{
+			final_vote_qualified_roots.push_back (i->first);
+		}
+
+		for (auto & final_vote_qualified_root : final_vote_qualified_roots)
+		{
+			auto status (del (transaction_a, tables::final_votes, nano::db_val<Val> (final_vote_qualified_root)));
+			release_assert_success (status);
+		}
+	}
+
+	void final_vote_clear (nano::write_transaction const & transaction_a, nano::root const & root_a) override
+	{
+		final_vote_del (transaction_a, root_a);
+	}
+
+	void final_vote_clear (nano::write_transaction const & transaction_a) override
+	{
+		drop (transaction_a, nano::tables::final_votes);
+	}
+
 	void confirmation_height_clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override
 	{
 		confirmation_height_del (transaction_a, account_a);
@@ -682,6 +746,16 @@ public:
 		return make_iterator<nano::block_hash, std::nullptr_t> (transaction_a, tables::pruned);
 	}
 
+	nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const override
+	{
+		return make_iterator<nano::qualified_root, nano::block_hash> (transaction_a, tables::final_votes, nano::db_val<Val> (root_a));
+	}
+
+	nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a) const override
+	{
+		return make_iterator<nano::qualified_root, nano::block_hash> (transaction_a, tables::final_votes);
+	}
+
 	size_t unchecked_count (nano::transaction const & transaction_a) override
 	{
 		return count (transaction_a, tables::unchecked);
@@ -758,11 +832,20 @@ public:
 		});
 	}
 
+	void final_vote_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const override
+	{
+		parallel_traversal<nano::uint512_t> (
+		[&action_a, this](nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {
+			auto transaction (this->tx_begin_read ());
+			action_a (transaction, this->final_vote_begin (transaction, start), !is_last ? this->final_vote_begin (transaction, end) : this->final_vote_end ());
+		});
+	}
+
 	int const minimum_version{ 14 };
 
 protected:
 	nano::network_params network_params;
-	int const version{ 20 };
+	int const version{ 21 };
 
 	template <typename Key, typename Value>
 	nano::store_iterator<Key, Value> make_iterator (nano::transaction const & transaction_a, tables table_a) const

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1485,6 +1485,15 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 			}
 		});
 
+		store.final_vote_for_each_par (
+		[&rocksdb_store](nano::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i)
+			{
+				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
+				rocksdb_store->final_vote_put (rocksdb_transaction, i->first, i->second);
+			}
+		});
+
 		auto lmdb_transaction (store.tx_begin_read ());
 		auto version = store.version_get (lmdb_transaction);
 		auto rocksdb_transaction (rocksdb_store->tx_begin_write ());
@@ -1504,6 +1513,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 		error |= store.unchecked_count (lmdb_transaction) != rocksdb_store->unchecked_count (rocksdb_transaction);
 		error |= store.peer_count (lmdb_transaction) != rocksdb_store->peer_count (rocksdb_transaction);
 		error |= store.pruned_count (lmdb_transaction) != rocksdb_store->pruned_count (rocksdb_transaction);
+		error |= store.final_vote_count (lmdb_transaction) != rocksdb_store->final_vote_count (rocksdb_transaction);
 		error |= store.online_weight_count (lmdb_transaction) != rocksdb_store->online_weight_count (rocksdb_transaction);
 		error |= store.version_get (lmdb_transaction) != rocksdb_store->version_get (rocksdb_transaction);
 


### PR DESCRIPTION
without node runtime changes

DB store version 21 upgrade (adding final votes table)

CLI changes:
- support command --final_vote_clear
- support option --root for other commands