### PR TITLE
Remove recently dropped check to restart elections

### DIFF
--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -261,8 +261,6 @@ char const * nano::mutex_identifier (mutexes mutex)
 			return "blockstore_cache";
 		case mutexes::confirmation_height_processor:
 			return "confirmation_height_processor";
-		case mutexes::dropped_elections:
-			return "dropped_elections";
 		case mutexes::election_winner_details:
 			return "election_winner_details";
 		case mutexes::gap_cache:

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -25,7 +25,6 @@ enum class mutexes
 	block_uniquer,
 	blockstore_cache,
 	confirmation_height_processor,
-	dropped_elections,
 	election_winner_details,
 	gap_cache,
 	network_filter,

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -105,34 +105,6 @@ public:
 	bool aggressive_mode{ false };
 };
 
-class dropped_elections final
-{
-public:
-	dropped_elections (nano::stat &);
-	void add (nano::qualified_root const &);
-	void erase (nano::qualified_root const &);
-	std::chrono::steady_clock::time_point find (nano::qualified_root const &) const;
-	size_t size () const;
-
-	static size_t constexpr capacity{ 16 * 1024 };
-
-	// clang-format off
-	class tag_sequence {};
-	class tag_root {};
-	using ordered_dropped = boost::multi_index_container<nano::election_timepoint,
-	mi::indexed_by<
-		mi::sequenced<mi::tag<tag_sequence>>,
-		mi::hashed_unique<mi::tag<tag_root>,
-			mi::member<nano::election_timepoint, decltype(nano::election_timepoint::root), &nano::election_timepoint::root>>>>;
-	// clang-format on
-
-private:
-	ordered_dropped items;
-	mutable nano::mutex mutex{ mutex_identifier (mutexes::dropped_elections) };
-
-	nano::stat & stats;
-};
-
 class election_insertion_result final
 {
 public:
@@ -222,7 +194,6 @@ public:
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
 	std::deque<nano::election_status> list_recently_cemented ();
 	std::deque<nano::election_status> recently_cemented;
-	dropped_elections recently_dropped;
 
 	void add_recently_cemented (nano::election_status const &);
 	void add_recently_confirmed (nano::qualified_root const &, nano::block_hash const &);


### PR DESCRIPTION
Up until "recently", a new write transaction was opened to update work on the ledger for every single block. Now with deferred work updates on the block processor, it is no more expensive than processing a new block, so it makes sense to remove this constraint of having been recently dropped. This improves quality of service.

The previously implicit check for confirmed dependents (since the election was dropped) is now explicit. The work on the ledger is updated regardless of that check passing.

The election is not immediately inserted as *active* anymore, same behavior as the normal election insertion path.

Note that if an election is active, the work is **not** updated on the ledger. That behavior also seems desirable. This could be achieved by updating the store after the block is identified as old, directly within `ledger::process`. For post-processing, a flag can be passed to `blockprocessor::process_old`, at which point `active_transactions::restart` can be scrapped since it becomes a simple election insertion + stats update (with a dependents confirmed check). Since this change would touch ledger code I am leaving for others to do it. There's also the question if the confirmed status should be checked within the ledger processing code.

Note: only tested via core_test.