### PR TITLE
Indentation for initializers

### DIFF
--- a/.clang-format.base
+++ b/.clang-format.base
@@ -17,7 +17,6 @@ AllowShortLoopsOnASingleLine: false
 BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: AfterColon
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 0
 ContinuationIndentWidth: 0
 KeepEmptyLinesAtTheStartOfBlocks: false
 IndentCaseLabels: true

--- a/nano/core_test/fakes/websocket_client.hpp
+++ b/nano/core_test/fakes/websocket_client.hpp
@@ -17,7 +17,7 @@ class fake_websocket_client
 {
 public:
 	fake_websocket_client (unsigned port) :
-	socket (std::make_shared<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>> (ioc))
+	    socket (std::make_shared<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>> (ioc))
 	{
 		std::string const host = "::1";
 		boost::asio::ip::tcp::resolver resolver{ ioc };

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -36,13 +36,13 @@ class work_peer_connection : public std::enable_shared_from_this<work_peer_conne
 
 public:
 	work_peer_connection (asio::io_context & ioc_a, work_peer_type const type_a, nano::work_version const version_a, nano::work_pool & pool_a, std::function<void(bool const)> on_generation_a, std::function<void()> on_cancel_a) :
-	socket (ioc_a),
-	type (type_a),
-	version (version_a),
-	work_pool (pool_a),
-	on_generation (on_generation_a),
-	on_cancel (on_cancel_a),
-	timer (ioc_a)
+	    socket (ioc_a),
+	    type (type_a),
+	    version (version_a),
+	    work_pool (pool_a),
+	    on_generation (on_generation_a),
+	    on_cancel (on_cancel_a),
+	    timer (ioc_a)
 	{
 	}
 	void start ()
@@ -200,12 +200,12 @@ class fake_work_peer : public std::enable_shared_from_this<fake_work_peer>
 public:
 	fake_work_peer () = delete;
 	fake_work_peer (nano::work_pool & pool_a, asio::io_context & ioc_a, unsigned short port_a, work_peer_type const type_a, nano::work_version const version_a = nano::work_version::work_1) :
-	pool (pool_a),
-	endpoint (tcp::v4 (), port_a),
-	ioc (ioc_a),
-	acceptor (ioc_a, endpoint),
-	type (type_a),
-	version (version_a)
+	    pool (pool_a),
+	    endpoint (tcp::v4 (), port_a),
+	    ioc (ioc_a),
+	    acceptor (ioc_a, endpoint),
+	    type (type_a),
+	    version (version_a)
 	{
 	}
 	void start ()

--- a/nano/core_test/memory_pool.cpp
+++ b/nano/core_test/memory_pool.cpp
@@ -17,7 +17,7 @@ public:
 	using value_type = T;
 
 	explicit record_allocations_new_delete_allocator (std::vector<size_t> * allocated) :
-	allocated (allocated)
+	    allocated (allocated)
 	{
 	}
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -832,7 +832,7 @@ class json_initial_value_test final
 {
 public:
 	explicit json_initial_value_test (std::string const & text_a) :
-	text (text_a)
+	    text (text_a)
 	{
 	}
 	nano::error serialize_json (nano::jsonconfig & json)

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 
-
 TEST (processor_service, bad_send_signature)
 {
 	nano::logger_mt logger;

--- a/nano/ipc_flatbuffers_lib/flatbuffer_producer.cpp
+++ b/nano/ipc_flatbuffers_lib/flatbuffer_producer.cpp
@@ -6,7 +6,7 @@ nano::ipc::flatbuffer_producer::flatbuffer_producer ()
 }
 
 nano::ipc::flatbuffer_producer::flatbuffer_producer (std::shared_ptr<flatbuffers::FlatBufferBuilder> const & builder_a) :
-fbb (builder_a)
+    fbb (builder_a)
 {
 }
 

--- a/nano/lib/asio.cpp
+++ b/nano/lib/asio.cpp
@@ -1,31 +1,31 @@
 #include <nano/lib/asio.hpp>
 
 nano::shared_const_buffer::shared_const_buffer (const std::vector<uint8_t> & data) :
-m_data (std::make_shared<std::vector<uint8_t>> (data)),
-m_buffer (boost::asio::buffer (*m_data))
+    m_data (std::make_shared<std::vector<uint8_t>> (data)),
+    m_buffer (boost::asio::buffer (*m_data))
 {
 }
 
 nano::shared_const_buffer::shared_const_buffer (std::vector<uint8_t> && data) :
-m_data (std::make_shared<std::vector<uint8_t>> (std::move (data))),
-m_buffer (boost::asio::buffer (*m_data))
+    m_data (std::make_shared<std::vector<uint8_t>> (std::move (data))),
+    m_buffer (boost::asio::buffer (*m_data))
 {
 }
 
 nano::shared_const_buffer::shared_const_buffer (uint8_t data) :
-shared_const_buffer (std::vector<uint8_t>{ data })
+    shared_const_buffer (std::vector<uint8_t>{ data })
 {
 }
 
 nano::shared_const_buffer::shared_const_buffer (std::string const & data) :
-m_data (std::make_shared<std::vector<uint8_t>> (data.begin (), data.end ())),
-m_buffer (boost::asio::buffer (*m_data))
+    m_data (std::make_shared<std::vector<uint8_t>> (data.begin (), data.end ())),
+    m_buffer (boost::asio::buffer (*m_data))
 {
 }
 
 nano::shared_const_buffer::shared_const_buffer (std::shared_ptr<std::vector<uint8_t>> const & data) :
-m_data (data),
-m_buffer (boost::asio::buffer (*m_data))
+    m_data (data),
+    m_buffer (boost::asio::buffer (*m_data))
 {
 }
 

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -221,9 +221,9 @@ void nano::send_block::block_work_set (uint64_t work_a)
 }
 
 nano::send_hashables::send_hashables (nano::block_hash const & previous_a, nano::account const & destination_a, nano::amount const & balance_a) :
-previous (previous_a),
-destination (destination_a),
-balance (balance_a)
+    previous (previous_a),
+    destination (destination_a),
+    balance (balance_a)
 {
 }
 
@@ -364,14 +364,14 @@ bool nano::send_block::deserialize_json (boost::property_tree::ptree const & tre
 }
 
 nano::send_block::send_block (nano::block_hash const & previous_a, nano::account const & destination_a, nano::amount const & balance_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :
-hashables (previous_a, destination_a, balance_a),
-signature (nano::sign_message (prv_a, pub_a, hash ())),
-work (work_a)
+    hashables (previous_a, destination_a, balance_a),
+    signature (nano::sign_message (prv_a, pub_a, hash ())),
+    work (work_a)
 {
 }
 
 nano::send_block::send_block (bool & error_a, nano::stream & stream_a) :
-hashables (error_a, stream_a)
+    hashables (error_a, stream_a)
 {
 	if (!error_a)
 	{
@@ -388,7 +388,7 @@ hashables (error_a, stream_a)
 }
 
 nano::send_block::send_block (bool & error_a, boost::property_tree::ptree const & tree_a) :
-hashables (error_a, tree_a)
+    hashables (error_a, tree_a)
 {
 	if (!error_a)
 	{
@@ -474,9 +474,9 @@ void nano::send_block::signature_set (nano::signature const & signature_a)
 }
 
 nano::open_hashables::open_hashables (nano::block_hash const & source_a, nano::account const & representative_a, nano::account const & account_a) :
-source (source_a),
-representative (representative_a),
-account (account_a)
+    source (source_a),
+    representative (representative_a),
+    account (account_a)
 {
 }
 
@@ -525,22 +525,22 @@ void nano::open_hashables::hash (blake2b_state & hash_a) const
 }
 
 nano::open_block::open_block (nano::block_hash const & source_a, nano::account const & representative_a, nano::account const & account_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :
-hashables (source_a, representative_a, account_a),
-signature (nano::sign_message (prv_a, pub_a, hash ())),
-work (work_a)
+    hashables (source_a, representative_a, account_a),
+    signature (nano::sign_message (prv_a, pub_a, hash ())),
+    work (work_a)
 {
 	debug_assert (!representative_a.is_zero ());
 }
 
 nano::open_block::open_block (nano::block_hash const & source_a, nano::account const & representative_a, nano::account const & account_a, std::nullptr_t) :
-hashables (source_a, representative_a, account_a),
-work (0)
+    hashables (source_a, representative_a, account_a),
+    work (0)
 {
 	signature.clear ();
 }
 
 nano::open_block::open_block (bool & error_a, nano::stream & stream_a) :
-hashables (error_a, stream_a)
+    hashables (error_a, stream_a)
 {
 	if (!error_a)
 	{
@@ -557,7 +557,7 @@ hashables (error_a, stream_a)
 }
 
 nano::open_block::open_block (bool & error_a, boost::property_tree::ptree const & tree_a) :
-hashables (error_a, tree_a)
+    hashables (error_a, tree_a)
 {
 	if (!error_a)
 	{
@@ -745,8 +745,8 @@ void nano::open_block::signature_set (nano::signature const & signature_a)
 }
 
 nano::change_hashables::change_hashables (nano::block_hash const & previous_a, nano::account const & representative_a) :
-previous (previous_a),
-representative (representative_a)
+    previous (previous_a),
+    representative (representative_a)
 {
 }
 
@@ -788,14 +788,14 @@ void nano::change_hashables::hash (blake2b_state & hash_a) const
 }
 
 nano::change_block::change_block (nano::block_hash const & previous_a, nano::account const & representative_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :
-hashables (previous_a, representative_a),
-signature (nano::sign_message (prv_a, pub_a, hash ())),
-work (work_a)
+    hashables (previous_a, representative_a),
+    signature (nano::sign_message (prv_a, pub_a, hash ())),
+    work (work_a)
 {
 }
 
 nano::change_block::change_block (bool & error_a, nano::stream & stream_a) :
-hashables (error_a, stream_a)
+    hashables (error_a, stream_a)
 {
 	if (!error_a)
 	{
@@ -812,7 +812,7 @@ hashables (error_a, stream_a)
 }
 
 nano::change_block::change_block (bool & error_a, boost::property_tree::ptree const & tree_a) :
-hashables (error_a, tree_a)
+    hashables (error_a, tree_a)
 {
 	if (!error_a)
 	{
@@ -994,11 +994,11 @@ void nano::change_block::signature_set (nano::signature const & signature_a)
 }
 
 nano::state_hashables::state_hashables (nano::account const & account_a, nano::block_hash const & previous_a, nano::account const & representative_a, nano::amount const & balance_a, nano::link const & link_a) :
-account (account_a),
-previous (previous_a),
-representative (representative_a),
-balance (balance_a),
-link (link_a)
+    account (account_a),
+    previous (previous_a),
+    representative (representative_a),
+    balance (balance_a),
+    link (link_a)
 {
 }
 
@@ -1061,14 +1061,14 @@ void nano::state_hashables::hash (blake2b_state & hash_a) const
 }
 
 nano::state_block::state_block (nano::account const & account_a, nano::block_hash const & previous_a, nano::account const & representative_a, nano::amount const & balance_a, nano::link const & link_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :
-hashables (account_a, previous_a, representative_a, balance_a, link_a),
-signature (nano::sign_message (prv_a, pub_a, hash ())),
-work (work_a)
+    hashables (account_a, previous_a, representative_a, balance_a, link_a),
+    signature (nano::sign_message (prv_a, pub_a, hash ())),
+    work (work_a)
 {
 }
 
 nano::state_block::state_block (bool & error_a, nano::stream & stream_a) :
-hashables (error_a, stream_a)
+    hashables (error_a, stream_a)
 {
 	if (!error_a)
 	{
@@ -1086,7 +1086,7 @@ hashables (error_a, stream_a)
 }
 
 nano::state_block::state_block (bool & error_a, boost::property_tree::ptree const & tree_a) :
-hashables (error_a, tree_a)
+    hashables (error_a, tree_a)
 {
 	if (!error_a)
 	{
@@ -1506,14 +1506,14 @@ bool nano::receive_block::deserialize_json (boost::property_tree::ptree const & 
 }
 
 nano::receive_block::receive_block (nano::block_hash const & previous_a, nano::block_hash const & source_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :
-hashables (previous_a, source_a),
-signature (nano::sign_message (prv_a, pub_a, hash ())),
-work (work_a)
+    hashables (previous_a, source_a),
+    signature (nano::sign_message (prv_a, pub_a, hash ())),
+    work (work_a)
 {
 }
 
 nano::receive_block::receive_block (bool & error_a, nano::stream & stream_a) :
-hashables (error_a, stream_a)
+    hashables (error_a, stream_a)
 {
 	if (!error_a)
 	{
@@ -1530,7 +1530,7 @@ hashables (error_a, stream_a)
 }
 
 nano::receive_block::receive_block (bool & error_a, boost::property_tree::ptree const & tree_a) :
-hashables (error_a, tree_a)
+    hashables (error_a, tree_a)
 {
 	if (!error_a)
 	{
@@ -1620,8 +1620,8 @@ nano::block_type nano::receive_block::type () const
 }
 
 nano::receive_hashables::receive_hashables (nano::block_hash const & previous_a, nano::block_hash const & source_a) :
-previous (previous_a),
-source (source_a)
+    previous (previous_a),
+    source (source_a)
 {
 }
 
@@ -1663,7 +1663,7 @@ void nano::receive_hashables::hash (blake2b_state & hash_a) const
 }
 
 nano::block_details::block_details (nano::epoch const epoch_a, bool const is_send_a, bool const is_receive_a, bool const is_epoch_a) :
-epoch (epoch_a), is_send (is_send_a), is_receive (is_receive_a), is_epoch (is_epoch_a)
+    epoch (epoch_a), is_send (is_send_a), is_receive (is_receive_a), is_epoch (is_epoch_a)
 {
 }
 
@@ -1735,24 +1735,24 @@ std::string nano::state_subtype (nano::block_details const details_a)
 }
 
 nano::block_sideband::block_sideband (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t const height_a, uint64_t const timestamp_a, nano::block_details const & details_a, nano::epoch const source_epoch_a) :
-successor (successor_a),
-account (account_a),
-balance (balance_a),
-height (height_a),
-timestamp (timestamp_a),
-details (details_a),
-source_epoch (source_epoch_a)
+    successor (successor_a),
+    account (account_a),
+    balance (balance_a),
+    height (height_a),
+    timestamp (timestamp_a),
+    details (details_a),
+    source_epoch (source_epoch_a)
 {
 }
 
 nano::block_sideband::block_sideband (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t const height_a, uint64_t const timestamp_a, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a) :
-successor (successor_a),
-account (account_a),
-balance (balance_a),
-height (height_a),
-timestamp (timestamp_a),
-details (epoch_a, is_send, is_receive, is_epoch),
-source_epoch (source_epoch_a)
+    successor (successor_a),
+    account (account_a),
+    balance (balance_a),
+    height (height_a),
+    timestamp (timestamp_a),
+    details (epoch_a, is_send, is_receive, is_epoch),
+    source_epoch (source_epoch_a)
 {
 }
 

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -92,9 +92,9 @@ struct work_thresholds
 	uint64_t const entry;
 
 	constexpr work_thresholds (uint64_t epoch_1_a, uint64_t epoch_2_a, uint64_t epoch_2_receive_a) :
-	epoch_1 (epoch_1_a), epoch_2 (epoch_2_a), epoch_2_receive (epoch_2_receive_a),
-	base (std::max ({ epoch_1, epoch_2, epoch_2_receive })),
-	entry (std::min ({ epoch_1, epoch_2, epoch_2_receive }))
+	    epoch_1 (epoch_1_a), epoch_2 (epoch_2_a), epoch_2_receive (epoch_2_receive_a),
+	    base (std::max ({ epoch_1, epoch_2, epoch_2_receive })),
+	    entry (std::min ({ epoch_1, epoch_2, epoch_2_receive }))
 	{
 	}
 	work_thresholds () = delete;
@@ -108,13 +108,13 @@ class network_constants
 {
 public:
 	network_constants () :
-	network_constants (network_constants::active_network)
+	    network_constants (network_constants::active_network)
 	{
 	}
 
 	network_constants (nano_networks network_a) :
-	current_network (network_a),
-	publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : is_test_network () ? publish_test : publish_dev)
+	    current_network (network_a),
+	    publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : is_test_network () ? publish_test : publish_dev)
 	{
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%

--- a/nano/lib/configbase.hpp
+++ b/nano/lib/configbase.hpp
@@ -42,7 +42,7 @@ class configbase : public nano::error_aware<>
 public:
 	configbase () = default;
 	configbase (std::shared_ptr<nano::error> const & error_a) :
-	error (error_a)
+	    error (error_a)
 	{
 	}
 

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -208,7 +208,7 @@ namespace std
 {
 template <>
 struct is_error_code_enum<boost::system::errc::errc_t>
-: public std::true_type
+    : public std::true_type
 {
 };
 

--- a/nano/lib/ipc.cpp
+++ b/nano/lib/ipc.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/utility.hpp>
 
 nano::ipc::socket_base::socket_base (boost::asio::io_context & io_ctx_a) :
-io_timer (io_ctx_a)
+    io_timer (io_ctx_a)
 {
 }
 
@@ -33,7 +33,7 @@ void nano::ipc::socket_base::timer_cancel ()
 }
 
 nano::ipc::dsock_file_remover::dsock_file_remover (std::string const & file_a) :
-filename (file_a)
+    filename (file_a)
 {
 	std::remove (filename.c_str ());
 }

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -46,7 +46,7 @@ class socket_client : public nano::ipc::socket_base, public channel, public std:
 {
 public:
 	socket_client (boost::asio::io_context & io_ctx_a, ENDPOINT_TYPE endpoint_a) :
-	socket_base (io_ctx_a), endpoint (endpoint_a), socket (io_ctx_a), resolver (io_ctx_a), strand (io_ctx_a.get_executor ())
+	    socket_base (io_ctx_a), endpoint (endpoint_a), socket (io_ctx_a), resolver (io_ctx_a), strand (io_ctx_a.get_executor ())
 	{
 	}
 
@@ -172,7 +172,7 @@ private:
 	{
 	public:
 		queue_item (nano::shared_const_buffer const & buffer_a, std::function<void(boost::system::error_code const &, size_t)> callback_a) :
-		buffer (buffer_a), callback (callback_a)
+		    buffer (buffer_a), callback (callback_a)
 		{
 		}
 		nano::shared_const_buffer buffer;
@@ -197,7 +197,7 @@ class client_impl : public nano::ipc::ipc_client_impl
 {
 public:
 	explicit client_impl (boost::asio::io_context & io_ctx_a) :
-	io_ctx (io_ctx_a)
+	    io_ctx (io_ctx_a)
 	{
 	}
 
@@ -249,7 +249,7 @@ private:
 }
 
 nano::ipc::ipc_client::ipc_client (boost::asio::io_context & io_ctx_a) :
-io_ctx (io_ctx_a)
+    io_ctx (io_ctx_a)
 {
 }
 

--- a/nano/lib/jsonconfig.cpp
+++ b/nano/lib/jsonconfig.cpp
@@ -7,13 +7,13 @@
 #include <cstddef>
 
 nano::jsonconfig::jsonconfig () :
-tree (tree_default)
+    tree (tree_default)
 {
 	error = std::make_shared<nano::error> ();
 }
 
 nano::jsonconfig::jsonconfig (boost::property_tree::ptree & tree_a, std::shared_ptr<nano::error> const & error_a) :
-nano::configbase (error_a), tree (tree_a)
+    nano::configbase (error_a), tree (tree_a)
 {
 	if (!error)
 	{

--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -59,7 +59,7 @@ void output_if_blocked_long_enough (nano::timer<std::chrono::milliseconds> & tim
 #endif
 
 lock_guard<nano::mutex>::lock_guard (nano::mutex & mutex) :
-mut (mutex)
+    mut (mutex)
 {
 	timer.start ();
 
@@ -77,14 +77,14 @@ lock_guard<nano::mutex>::~lock_guard () noexcept
 
 template <typename Mutex, typename U>
 unique_lock<Mutex, U>::unique_lock (Mutex & mutex) :
-mut (std::addressof (mutex))
+    mut (std::addressof (mutex))
 {
 	lock_impl ();
 }
 
 template <typename Mutex, typename U>
 unique_lock<Mutex, U>::unique_lock (Mutex & mutex, std::defer_lock_t) noexcept :
-mut (std::addressof (mutex))
+    mut (std::addressof (mutex))
 {
 }
 

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -48,8 +48,8 @@ public:
 	mutex () = default;
 	mutex (const char * name_a)
 #if USING_NANO_TIMED_LOCKS
-	:
-	name (name_a)
+	    :
+	    name (name_a)
 #endif
 	{
 #if USING_NANO_TIMED_LOCKS
@@ -121,7 +121,7 @@ class lock_guard final
 {
 public:
 	explicit lock_guard (Mutex & mutex_a) :
-	guard (mutex_a)
+	    guard (mutex_a)
 	{
 	}
 
@@ -267,14 +267,14 @@ public:
 
 	template <typename... Args>
 	locked (Args &&... args) :
-	obj (std::forward<Args> (args)...)
+	    obj (std::forward<Args> (args)...)
 	{
 	}
 
 	struct scoped_lock final
 	{
 		scoped_lock (locked * owner_a) :
-		owner (owner_a)
+		    owner (owner_a)
 		{
 			owner->mutex.lock ();
 		}

--- a/nano/lib/logger_mt.hpp
+++ b/nano/lib/logger_mt.hpp
@@ -75,7 +75,7 @@ public:
 	 * @param min_log_delta_a The minimum time between successive output
 	 */
 	explicit logger_mt (std::chrono::milliseconds const & min_log_delta_a) :
-	min_log_delta (min_log_delta_a)
+	    min_log_delta (min_log_delta_a)
 	{
 	}
 

--- a/nano/lib/memory.cpp
+++ b/nano/lib/memory.cpp
@@ -24,7 +24,7 @@ void nano::set_use_memory_pools (bool use_memory_pools_a)
 }
 
 nano::cleanup_guard::cleanup_guard (std::vector<std::function<void()>> const & cleanup_funcs_a) :
-cleanup_funcs (cleanup_funcs_a)
+    cleanup_funcs (cleanup_funcs_a)
 {
 }
 

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -782,7 +782,7 @@ std::string nano::uint128_union::to_string_dec () const
 }
 
 nano::hash_or_account::hash_or_account (uint64_t value_a) :
-raw (value_a)
+    raw (value_a)
 {
 }
 

--- a/nano/lib/optional_ptr.hpp
+++ b/nano/lib/optional_ptr.hpp
@@ -24,7 +24,7 @@ public:
 	optional_ptr () = default;
 
 	optional_ptr (T const & value) :
-	ptr (new T{ value })
+	    ptr (new T{ value })
 	{
 	}
 

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -55,14 +55,14 @@ nano::error nano::rpc_secure_config::deserialize_toml (nano::tomlconfig & toml)
 }
 
 nano::rpc_config::rpc_config () :
-address (boost::asio::ip::address_v6::loopback ().to_string ())
+    address (boost::asio::ip::address_v6::loopback ().to_string ())
 {
 }
 
 nano::rpc_config::rpc_config (uint16_t port_a, bool enable_control_a) :
-address (boost::asio::ip::address_v6::loopback ().to_string ()),
-port (port_a),
-enable_control (enable_control_a)
+    address (boost::asio::ip::address_v6::loopback ().to_string ()),
+    port (port_a),
+    enable_control (enable_control_a)
 {
 }
 
@@ -184,7 +184,7 @@ nano::error nano::rpc_config::deserialize_toml (nano::tomlconfig & toml)
 }
 
 nano::rpc_process_config::rpc_process_config () :
-ipc_address (boost::asio::ip::address_v6::loopback ().to_string ())
+    ipc_address (boost::asio::ip::address_v6::loopback ().to_string ())
 {
 }
 

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -175,7 +175,7 @@ public:
 	std::string filename;
 
 	explicit file_writer (std::string const & filename) :
-	filename (filename)
+	    filename (filename)
 	{
 		log.open (filename.c_str (), std::ofstream::out);
 	}
@@ -283,7 +283,7 @@ std::vector<nano::stat_histogram::bin> nano::stat_histogram::get_bins () const
 }
 
 nano::stat::stat (nano::stat_config config) :
-config (config)
+    config (config)
 {
 }
 

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -98,7 +98,7 @@ public:
 	{
 	public:
 		bin (uint64_t start_inclusive_a, uint64_t end_exclusive_a) :
-		start_inclusive (start_inclusive_a), end_exclusive (end_exclusive_a)
+		    start_inclusive (start_inclusive_a), end_exclusive (end_exclusive_a)
 		{
 		}
 		uint64_t start_inclusive;
@@ -120,7 +120,7 @@ class stat_entry final
 {
 public:
 	stat_entry (size_t capacity, size_t interval) :
-	samples (capacity), sample_interval (interval)
+	    samples (capacity), sample_interval (interval)
 	{
 	}
 

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -120,7 +120,7 @@ void nano::thread_attributes::set (boost::thread::attributes & attrs)
 }
 
 nano::thread_runner::thread_runner (boost::asio::io_context & io_ctx_a, unsigned service_threads_a) :
-io_guard (boost::asio::make_work_guard (io_ctx_a))
+    io_guard (boost::asio::make_work_guard (io_ctx_a))
 {
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
@@ -197,8 +197,8 @@ void nano::thread_runner::stop_event_processing ()
 }
 
 nano::thread_pool::thread_pool (unsigned num_threads, nano::thread_role::name thread_name) :
-num_threads (num_threads),
-thread_pool_m (std::make_unique<boost::asio::thread_pool> (num_threads))
+    num_threads (num_threads),
+    thread_pool_m (std::make_unique<boost::asio::thread_pool> (num_threads))
 {
 	set_thread_names (num_threads, thread_name);
 }

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -90,7 +90,7 @@ class relaxed_atomic_integral
 public:
 	relaxed_atomic_integral () noexcept = default;
 	constexpr relaxed_atomic_integral (T desired) noexcept :
-	atomic (desired)
+	    atomic (desired)
 	{
 	}
 

--- a/nano/lib/timer.cpp
+++ b/nano/lib/timer.cpp
@@ -45,7 +45,7 @@ std::string typed_unit ()
 
 template <typename UNIT, typename CLOCK>
 nano::timer<UNIT, CLOCK>::timer (nano::timer_state state_a, std::string const & description_a) :
-desc (description_a)
+    desc (description_a)
 {
 	if (state_a == nano::timer_state::started)
 	{
@@ -55,14 +55,14 @@ desc (description_a)
 
 template <typename UNIT, typename CLOCK>
 nano::timer<UNIT, CLOCK>::timer (std::string const & description_a) :
-desc (description_a)
+    desc (description_a)
 {
 }
 
 template <typename UNIT, typename CLOCK>
 nano::timer<UNIT, CLOCK>::timer (std::string const & description_a, nano::timer<UNIT, CLOCK> * parent_a) :
-parent (parent_a),
-desc (description_a)
+    parent (parent_a),
+    desc (description_a)
 {
 }
 

--- a/nano/lib/tomlconfig.cpp
+++ b/nano/lib/tomlconfig.cpp
@@ -4,13 +4,13 @@
 #include <boost/filesystem/convenience.hpp>
 
 nano::tomlconfig::tomlconfig () :
-tree (cpptoml::make_table ())
+    tree (cpptoml::make_table ())
 {
 	error = std::make_shared<nano::error> ();
 }
 
 nano::tomlconfig::tomlconfig (std::shared_ptr<cpptoml::table> const & tree_a, std::shared_ptr<nano::error> const & error_a) :
-nano::configbase (error_a), tree (tree_a)
+    nano::configbase (error_a), tree (tree_a)
 {
 	if (!error)
 	{

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -30,7 +30,7 @@
 #endif
 
 nano::container_info_composite::container_info_composite (std::string const & name) :
-name (name)
+    name (name)
 {
 }
 
@@ -55,7 +55,7 @@ const std::string & nano::container_info_composite::get_name () const
 }
 
 nano::container_info_leaf::container_info_leaf (const container_info & info) :
-info (info)
+    info (info)
 {
 }
 

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -199,10 +199,10 @@ double nano::denormalized_multiplier (double const multiplier_a, uint64_t const 
 }
 
 nano::work_pool::work_pool (unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
-ticket (0),
-done (false),
-pow_rate_limiter (pow_rate_limiter_a),
-opencl (opencl_a)
+    ticket (0),
+    done (false),
+    pow_rate_limiter (pow_rate_limiter_a),
+    opencl (opencl_a)
 {
 	static_assert (ATOMIC_INT_LOCK_FREE == 2, "Atomic int needed");
 	boost::thread::attributes attrs;

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -48,7 +48,7 @@ class work_item final
 {
 public:
 	work_item (nano::work_version const version_a, nano::root const & item_a, uint64_t difficulty_a, std::function<void(boost::optional<uint64_t> const &)> const & callback_a) :
-	version (version_a), item (item_a), difficulty (difficulty_a), callback (callback_a)
+	    version (version_a), item (item_a), difficulty (difficulty_a), callback (callback_a)
 	{
 	}
 	nano::work_version const version;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -2041,7 +2041,7 @@ std::istream & operator>> (std::istream & in, uint64_from_hex & out_val)
 }
 
 address_library_pair::address_library_pair (uint64_t address, std::string library) :
-address (address), library (library)
+    address (address), library (library)
 {
 }
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -19,19 +19,19 @@ size_t constexpr nano::active_transactions::max_active_elections_frontier_insert
 constexpr std::chrono::minutes nano::active_transactions::expired_optimistic_election_info_cutoff;
 
 nano::active_transactions::active_transactions (nano::node & node_a, nano::confirmation_height_processor & confirmation_height_processor_a) :
-recently_dropped (node_a.stats),
-confirmation_height_processor (confirmation_height_processor_a),
-node (node_a),
-multipliers_cb (20, 1.),
-trended_active_multiplier (1.0),
-generator (node_a.config, node_a.ledger, node_a.wallets, node_a.vote_processor, node_a.history, node_a.network, node_a.stats),
-check_all_elections_period (node_a.network_params.network.is_dev_network () ? 10ms : 5s),
-election_time_to_live (node_a.network_params.network.is_dev_network () ? 0s : 2s),
-prioritized_cutoff (std::max<size_t> (1, node_a.config.active_elections_size / 10)),
-thread ([this]() {
-	nano::thread_role::set (nano::thread_role::name::request_loop);
-	request_loop ();
-})
+    recently_dropped (node_a.stats),
+    confirmation_height_processor (confirmation_height_processor_a),
+    node (node_a),
+    multipliers_cb (20, 1.),
+    trended_active_multiplier (1.0),
+    generator (node_a.config, node_a.ledger, node_a.wallets, node_a.vote_processor, node_a.history, node_a.network, node_a.stats),
+    check_all_elections_period (node_a.network_params.network.is_dev_network () ? 10ms : 5s),
+    election_time_to_live (node_a.network_params.network.is_dev_network () ? 0s : 2s),
+    prioritized_cutoff (std::max<size_t> (1, node_a.config.active_elections_size / 10)),
+    thread ([this]() {
+	    nano::thread_role::set (nano::thread_role::name::request_loop);
+	    request_loop ();
+    })
 {
 	// Register a callback which will get called after a block is cemented
 	confirmation_height_processor.add_cemented_observer ([this](std::shared_ptr<nano::block> const & callback_block_a) {
@@ -1544,13 +1544,13 @@ size_t nano::active_transactions::election_winner_details_size ()
 }
 
 nano::cementable_account::cementable_account (nano::account const & account_a, size_t blocks_uncemented_a) :
-account (account_a), blocks_uncemented (blocks_uncemented_a)
+    account (account_a), blocks_uncemented (blocks_uncemented_a)
 {
 }
 
 nano::expired_optimistic_election_info::expired_optimistic_election_info (std::chrono::steady_clock::time_point expired_time_a, nano::account account_a) :
-expired_time (expired_time_a),
-account (account_a)
+    expired_time (expired_time_a),
+    account (account_a)
 {
 }
 
@@ -1590,7 +1590,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (ac
 }
 
 nano::dropped_elections::dropped_elections (nano::stat & stats_a) :
-stats (stats_a)
+    stats (stats_a)
 {
 }
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -68,9 +68,9 @@ class inactive_cache_information final
 public:
 	inactive_cache_information () = default;
 	inactive_cache_information (std::chrono::steady_clock::time_point arrival, nano::block_hash hash, nano::account initial_rep_a, uint64_t initial_timestamp_a, nano::inactive_cache_status status) :
-	arrival (arrival),
-	hash (hash),
-	status (status)
+	    arrival (arrival),
+	    hash (hash),
+	    status (status)
 	{
 		voters.reserve (8);
 		voters.emplace_back (initial_rep_a, initial_timestamp_a);

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -11,7 +11,7 @@
 std::chrono::milliseconds constexpr nano::block_processor::confirmation_request_delay;
 
 nano::block_post_events::block_post_events (std::function<nano::read_transaction ()> && get_transaction_a) :
-get_transaction (std::move (get_transaction_a))
+    get_transaction (std::move (get_transaction_a))
 {
 }
 
@@ -26,10 +26,10 @@ nano::block_post_events::~block_post_events ()
 }
 
 nano::block_processor::block_processor (nano::node & node_a, nano::write_database_queue & write_database_queue_a) :
-next_log (std::chrono::steady_clock::now ()),
-node (node_a),
-write_database_queue (write_database_queue_a),
-state_block_signature_verification (node.checker, node.ledger.network_params.ledger.epochs, node.config, node.logger, node.flags.block_processor_verification_size)
+    next_log (std::chrono::steady_clock::now ()),
+    node (node_a),
+    write_database_queue (write_database_queue_a),
+    state_block_signature_verification (node.checker, node.ledger.network_params.ledger.epochs, node.config, node.logger, node.flags.block_processor_verification_size)
 {
 	state_block_signature_verification.blocks_verified_callback = [this](std::deque<std::pair<nano::unchecked_info, bool>> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures) {
 		this->process_verified_state_blocks (items, verifications, hashes, blocks_signatures);

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 
 nano::bootstrap_initiator::bootstrap_initiator (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 	connections = std::make_shared<nano::bootstrap_connections> (node);
 	bootstrap_initiator_threads.push_back (boost::thread ([this]() {

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -19,10 +19,10 @@ constexpr unsigned nano::bootstrap_limits::requeued_pulls_limit;
 constexpr unsigned nano::bootstrap_limits::requeued_pulls_limit_dev;
 
 nano::bootstrap_attempt::bootstrap_attempt (std::shared_ptr<nano::node> const & node_a, nano::bootstrap_mode mode_a, uint64_t incremental_id_a, std::string id_a) :
-node (node_a),
-incremental_id (incremental_id_a),
-id (id_a),
-mode (mode_a)
+    node (node_a),
+    incremental_id (incremental_id_a),
+    id (id_a),
+    mode (mode_a)
 {
 	if (id.empty ())
 	{

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -8,23 +8,23 @@
 #include <boost/format.hpp>
 
 nano::pull_info::pull_info (nano::hash_or_account const & account_or_head_a, nano::block_hash const & head_a, nano::block_hash const & end_a, uint64_t bootstrap_id_a, count_t count_a, unsigned retry_limit_a) :
-account_or_head (account_or_head_a),
-head (head_a),
-head_original (head_a),
-end (end_a),
-count (count_a),
-retry_limit (retry_limit_a),
-bootstrap_id (bootstrap_id_a)
+    account_or_head (account_or_head_a),
+    head (head_a),
+    head_original (head_a),
+    end (end_a),
+    count (count_a),
+    retry_limit (retry_limit_a),
+    bootstrap_id (bootstrap_id_a)
 {
 }
 
 nano::bulk_pull_client::bulk_pull_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a, nano::pull_info const & pull_a) :
-connection (connection_a),
-attempt (attempt_a),
-known_account (0),
-pull (pull_a),
-pull_blocks (0),
-unexpected_count (0)
+    connection (connection_a),
+    attempt (attempt_a),
+    known_account (0),
+    pull (pull_a),
+    pull_blocks (0),
+    unexpected_count (0)
 {
 	attempt->condition.notify_all ();
 }
@@ -285,10 +285,10 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 }
 
 nano::bulk_pull_account_client::bulk_pull_account_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a, nano::account const & account_a) :
-connection (connection_a),
-attempt (attempt_a),
-account (account_a),
-pull_blocks (0)
+    connection (connection_a),
+    attempt (attempt_a),
+    account (account_a),
+    pull_blocks (0)
 {
 	attempt->condition.notify_all ();
 }
@@ -620,8 +620,8 @@ void nano::bulk_pull_server::no_block_sent (boost::system::error_code const & ec
 }
 
 nano::bulk_pull_server::bulk_pull_server (std::shared_ptr<nano::bootstrap_server> const & connection_a, std::unique_ptr<nano::bulk_pull> request_a) :
-connection (connection_a),
-request (std::move (request_a))
+    connection (connection_a),
+    request (std::move (request_a))
 {
 	set_current_end ();
 }
@@ -940,9 +940,9 @@ void nano::bulk_pull_account_server::complete (boost::system::error_code const &
 }
 
 nano::bulk_pull_account_server::bulk_pull_account_server (std::shared_ptr<nano::bootstrap_server> const & connection_a, std::unique_ptr<nano::bulk_pull_account> request_a) :
-connection (connection_a),
-request (std::move (request_a)),
-current_key (0, 0)
+    connection (connection_a),
+    request (std::move (request_a)),
+    current_key (0, 0)
 {
 	/*
 	 * Setup the streaming response for the first call to "send_frontier" and  "send_next_block"

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -6,8 +6,8 @@
 #include <boost/format.hpp>
 
 nano::bulk_push_client::bulk_push_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a) :
-connection (connection_a),
-attempt (attempt_a)
+    connection (connection_a),
+    attempt (attempt_a)
 {
 }
 
@@ -112,8 +112,8 @@ void nano::bulk_push_client::push_block (nano::block const & block_a)
 }
 
 nano::bulk_push_server::bulk_push_server (std::shared_ptr<nano::bootstrap_server> const & connection_a) :
-receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
-connection (connection_a)
+    receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
+    connection (connection_a)
 {
 	receive_buffer->resize (256);
 }

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -14,12 +14,12 @@ constexpr unsigned nano::bootstrap_limits::bootstrap_max_new_connections;
 constexpr unsigned nano::bootstrap_limits::requeued_pulls_processed_blocks_factor;
 
 nano::bootstrap_client::bootstrap_client (std::shared_ptr<nano::node> const & node_a, std::shared_ptr<nano::bootstrap_connections> const & connections_a, std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a) :
-node (node_a),
-connections (connections_a),
-channel (channel_a),
-socket (socket_a),
-receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
-start_time_m (std::chrono::steady_clock::now ())
+    node (node_a),
+    connections (connections_a),
+    channel (channel_a),
+    socket (socket_a),
+    receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
+    start_time_m (std::chrono::steady_clock::now ())
 {
 	++connections->connections_count;
 	receive_buffer->resize (256);
@@ -60,7 +60,7 @@ void nano::bootstrap_client::stop (bool force)
 }
 
 nano::bootstrap_connections::bootstrap_connections (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 }
 

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -37,11 +37,11 @@ void nano::frontier_req_client::run ()
 }
 
 nano::frontier_req_client::frontier_req_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a) :
-connection (connection_a),
-attempt (attempt_a),
-current (0),
-count (0),
-bulk_push_cost (0)
+    connection (connection_a),
+    attempt (attempt_a),
+    current (0),
+    count (0),
+    bulk_push_cost (0)
 {
 	next ();
 }
@@ -222,11 +222,11 @@ void nano::frontier_req_client::next ()
 }
 
 nano::frontier_req_server::frontier_req_server (std::shared_ptr<nano::bootstrap_server> const & connection_a, std::unique_ptr<nano::frontier_req> request_a) :
-connection (connection_a),
-current (request_a->start.number () - 1),
-frontier (0),
-request (std::move (request_a)),
-count (0)
+    connection (connection_a),
+    current (request_a->start.number () - 1),
+    frontier (0),
+    request (std::move (request_a)),
+    count (0)
 {
 	next ();
 }

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -14,7 +14,7 @@ constexpr double nano::bootstrap_limits::lazy_batch_pull_count_resize_ratio;
 constexpr size_t nano::bootstrap_limits::lazy_blocks_restart_limit;
 
 nano::bootstrap_attempt_lazy::bootstrap_attempt_lazy (std::shared_ptr<nano::node> const & node_a, uint64_t incremental_id_a, std::string const & id_a) :
-nano::bootstrap_attempt (node_a, nano::bootstrap_mode::lazy, incremental_id_a, id_a)
+    nano::bootstrap_attempt (node_a, nano::bootstrap_mode::lazy, incremental_id_a, id_a)
 {
 	node->bootstrap_initiator.notify_listeners (true);
 }
@@ -462,7 +462,7 @@ void nano::bootstrap_attempt_lazy::get_information (boost::property_tree::ptree 
 }
 
 nano::bootstrap_attempt_wallet::bootstrap_attempt_wallet (std::shared_ptr<nano::node> const & node_a, uint64_t incremental_id_a, std::string id_a) :
-nano::bootstrap_attempt (node_a, nano::bootstrap_mode::wallet_lazy, incremental_id_a, id_a)
+    nano::bootstrap_attempt (node_a, nano::bootstrap_mode::wallet_lazy, incremental_id_a, id_a)
 {
 	node->bootstrap_initiator.notify_listeners (true);
 }

--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -6,7 +6,7 @@
 #include <boost/format.hpp>
 
 nano::bootstrap_attempt_legacy::bootstrap_attempt_legacy (std::shared_ptr<nano::node> const & node_a, uint64_t incremental_id_a, std::string const & id_a) :
-nano::bootstrap_attempt (node_a, nano::bootstrap_mode::legacy, incremental_id_a, id_a)
+    nano::bootstrap_attempt (node_a, nano::bootstrap_mode::legacy, incremental_id_a, id_a)
 {
 	node->bootstrap_initiator.notify_listeners (true);
 }

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -8,8 +8,8 @@
 #include <boost/variant/get.hpp>
 
 nano::bootstrap_listener::bootstrap_listener (uint16_t port_a, nano::node & node_a) :
-node (node_a),
-port (port_a)
+    node (node_a),
+    port (port_a)
 {
 }
 
@@ -104,9 +104,9 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (bo
 }
 
 nano::bootstrap_server::bootstrap_server (std::shared_ptr<nano::socket> const & socket_a, std::shared_ptr<nano::node> const & node_a) :
-receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
-socket (socket_a),
-node (node_a)
+    receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
+    socket (socket_a),
+    node (node_a)
 {
 	receive_buffer->resize (1024);
 }
@@ -617,7 +617,7 @@ class request_response_visitor : public nano::message_visitor
 {
 public:
 	explicit request_response_visitor (std::shared_ptr<nano::bootstrap_server> const & connection_a) :
-	connection (connection_a)
+	    connection (connection_a)
 	{
 	}
 	void keepalive (nano::keepalive const & message_a) override

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -50,9 +50,9 @@ uint64_t nano::ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint1
 }
 
 nano::message_header::message_header (nano::message_type type_a) :
-version_max (get_protocol_constants ().protocol_version),
-version_using (get_protocol_constants ().protocol_version),
-type (type_a)
+    version_max (get_protocol_constants ().protocol_version),
+    version_using (get_protocol_constants ().protocol_version),
+    type (type_a)
 {
 }
 
@@ -111,12 +111,12 @@ uint8_t nano::message_header::version_min () const
 }
 
 nano::message::message (nano::message_type type_a) :
-header (type_a)
+    header (type_a)
 {
 }
 
 nano::message::message (nano::message_header const & header_a) :
-header (header_a)
+    header (header_a)
 {
 }
 
@@ -323,12 +323,12 @@ std::string nano::message_parser::status_string ()
 }
 
 nano::message_parser::message_parser (nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a) :
-publish_filter (publish_filter_a),
-block_uniquer (block_uniquer_a),
-vote_uniquer (vote_uniquer_a),
-visitor (visitor_a),
-pool (pool_a),
-status (parse_status::success)
+    publish_filter (publish_filter_a),
+    block_uniquer (block_uniquer_a),
+    vote_uniquer (vote_uniquer_a),
+    visitor (visitor_a),
+    pool (pool_a),
+    status (parse_status::success)
 {
 }
 
@@ -545,7 +545,7 @@ bool nano::message_parser::at_end (nano::stream & stream_a)
 }
 
 nano::keepalive::keepalive () :
-message (nano::message_type::keepalive)
+    message (nano::message_type::keepalive)
 {
 	nano::endpoint endpoint (boost::asio::ip::address_v6{}, 0);
 	for (auto i (peers.begin ()), n (peers.end ()); i != n; ++i)
@@ -555,7 +555,7 @@ message (nano::message_type::keepalive)
 }
 
 nano::keepalive::keepalive (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a)
+    message (header_a)
 {
 	if (!error_a)
 	{
@@ -606,8 +606,8 @@ bool nano::keepalive::operator== (nano::keepalive const & other_a) const
 }
 
 nano::publish::publish (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a, nano::uint128_t const & digest_a, nano::block_uniquer * uniquer_a) :
-message (header_a),
-digest (digest_a)
+    message (header_a),
+    digest (digest_a)
 {
 	if (!error_a)
 	{
@@ -616,8 +616,8 @@ digest (digest_a)
 }
 
 nano::publish::publish (std::shared_ptr<nano::block> const & block_a) :
-message (nano::message_type::publish),
-block (block_a)
+    message (nano::message_type::publish),
+    block (block_a)
 {
 	header.block_type_set (block->type ());
 }
@@ -648,7 +648,7 @@ bool nano::publish::operator== (nano::publish const & other_a) const
 }
 
 nano::confirm_req::confirm_req (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a, nano::block_uniquer * uniquer_a) :
-message (header_a)
+    message (header_a)
 {
 	if (!error_a)
 	{
@@ -657,15 +657,15 @@ message (header_a)
 }
 
 nano::confirm_req::confirm_req (std::shared_ptr<nano::block> const & block_a) :
-message (nano::message_type::confirm_req),
-block (block_a)
+    message (nano::message_type::confirm_req),
+    block (block_a)
 {
 	header.block_type_set (block->type ());
 }
 
 nano::confirm_req::confirm_req (std::vector<std::pair<nano::block_hash, nano::root>> const & roots_hashes_a) :
-message (nano::message_type::confirm_req),
-roots_hashes (roots_hashes_a)
+    message (nano::message_type::confirm_req),
+    roots_hashes (roots_hashes_a)
 {
 	// not_a_block (1) block type for hashes + roots request
 	header.block_type_set (nano::block_type::not_a_block);
@@ -674,8 +674,8 @@ roots_hashes (roots_hashes_a)
 }
 
 nano::confirm_req::confirm_req (nano::block_hash const & hash_a, nano::root const & root_a) :
-message (nano::message_type::confirm_req),
-roots_hashes (std::vector<std::pair<nano::block_hash, nano::root>> (1, std::make_pair (hash_a, root_a)))
+    message (nano::message_type::confirm_req),
+    roots_hashes (std::vector<std::pair<nano::block_hash, nano::root>> (1, std::make_pair (hash_a, root_a)))
 {
 	debug_assert (!roots_hashes.empty ());
 	// not_a_block (1) block type for hashes + roots request
@@ -788,8 +788,8 @@ size_t nano::confirm_req::size (nano::block_type type_a, size_t count)
 }
 
 nano::confirm_ack::confirm_ack (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a, nano::vote_uniquer * uniquer_a) :
-message (header_a),
-vote (nano::make_shared<nano::vote> (error_a, stream_a, header.block_type ()))
+    message (header_a),
+    vote (nano::make_shared<nano::vote> (error_a, stream_a, header.block_type ()))
 {
 	if (!error_a && uniquer_a)
 	{
@@ -798,8 +798,8 @@ vote (nano::make_shared<nano::vote> (error_a, stream_a, header.block_type ()))
 }
 
 nano::confirm_ack::confirm_ack (std::shared_ptr<nano::vote> const & vote_a) :
-message (nano::message_type::confirm_ack),
-vote (vote_a)
+    message (nano::message_type::confirm_ack),
+    vote (vote_a)
 {
 	debug_assert (!vote_a->blocks.empty ());
 	auto & first_vote_block (vote_a->blocks[0]);
@@ -848,12 +848,12 @@ size_t nano::confirm_ack::size (nano::block_type type_a, size_t count)
 }
 
 nano::frontier_req::frontier_req () :
-message (nano::message_type::frontier_req)
+    message (nano::message_type::frontier_req)
 {
 }
 
 nano::frontier_req::frontier_req (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a)
+    message (header_a)
 {
 	if (!error_a)
 	{
@@ -898,12 +898,12 @@ bool nano::frontier_req::operator== (nano::frontier_req const & other_a) const
 }
 
 nano::bulk_pull::bulk_pull () :
-message (nano::message_type::bulk_pull)
+    message (nano::message_type::bulk_pull)
 {
 }
 
 nano::bulk_pull::bulk_pull (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a)
+    message (header_a)
 {
 	if (!error_a)
 	{
@@ -994,12 +994,12 @@ void nano::bulk_pull::set_count_present (bool value_a)
 }
 
 nano::bulk_pull_account::bulk_pull_account () :
-message (nano::message_type::bulk_pull_account)
+    message (nano::message_type::bulk_pull_account)
 {
 }
 
 nano::bulk_pull_account::bulk_pull_account (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a)
+    message (header_a)
 {
 	if (!error_a)
 	{
@@ -1039,12 +1039,12 @@ bool nano::bulk_pull_account::deserialize (nano::stream & stream_a)
 }
 
 nano::bulk_push::bulk_push () :
-message (nano::message_type::bulk_push)
+    message (nano::message_type::bulk_push)
 {
 }
 
 nano::bulk_push::bulk_push (nano::message_header const & header_a) :
-message (header_a)
+    message (header_a)
 {
 }
 
@@ -1065,12 +1065,12 @@ void nano::bulk_push::visit (nano::message_visitor & visitor_a) const
 }
 
 nano::telemetry_req::telemetry_req () :
-message (nano::message_type::telemetry_req)
+    message (nano::message_type::telemetry_req)
 {
 }
 
 nano::telemetry_req::telemetry_req (nano::message_header const & header_a) :
-message (header_a)
+    message (header_a)
 {
 }
 
@@ -1091,12 +1091,12 @@ void nano::telemetry_req::visit (nano::message_visitor & visitor_a) const
 }
 
 nano::telemetry_ack::telemetry_ack () :
-message (nano::message_type::telemetry_ack)
+    message (nano::message_type::telemetry_ack)
 {
 }
 
 nano::telemetry_ack::telemetry_ack (bool & error_a, nano::stream & stream_a, nano::message_header const & message_header) :
-message (message_header)
+    message (message_header)
 {
 	if (!error_a)
 	{
@@ -1105,8 +1105,8 @@ message (message_header)
 }
 
 nano::telemetry_ack::telemetry_ack (nano::telemetry_data const & telemetry_data_a) :
-message (nano::message_type::telemetry_ack),
-data (telemetry_data_a)
+    message (nano::message_type::telemetry_ack),
+    data (telemetry_data_a)
 {
 	debug_assert (telemetry_data::size + telemetry_data_a.unknown_data.size () <= message_header::telemetry_size_mask.to_ulong ()); // Maximum size the mask allows
 	header.extensions &= ~message_header::telemetry_size_mask;
@@ -1344,17 +1344,17 @@ bool nano::telemetry_data::validate_signature () const
 }
 
 nano::node_id_handshake::node_id_handshake (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-message (header_a),
-query (boost::none),
-response (boost::none)
+    message (header_a),
+    query (boost::none),
+    response (boost::none)
 {
 	error_a = deserialize (stream_a);
 }
 
 nano::node_id_handshake::node_id_handshake (boost::optional<nano::uint256_union> query, boost::optional<std::pair<nano::account, nano::signature>> response) :
-message (nano::message_type::node_id_handshake),
-query (query),
-response (response)
+    message (nano::message_type::node_id_handshake),
+    query (query),
+    response (response)
 {
 	if (query)
 	{
@@ -1545,6 +1545,6 @@ std::chrono::seconds nano::telemetry_cache_cutoffs::network_to_time (network_con
 }
 
 nano::node_singleton_memory_pool_purge_guard::node_singleton_memory_pool_purge_guard () :
-cleanup_guard ({ nano::block_memory_pool_purge, nano::purge_shared_ptr_singleton_pool_memory<nano::vote>, nano::purge_shared_ptr_singleton_pool_memory<nano::election>, nano::purge_singleton_inactive_votes_cache_pool_memory })
+    cleanup_guard ({ nano::block_memory_pool_purge, nano::purge_shared_ptr_singleton_pool_memory<nano::vote>, nano::purge_shared_ptr_singleton_pool_memory<nano::election>, nano::purge_singleton_inactive_votes_cache_pool_memory })
 {
 }

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -11,17 +11,17 @@
 #include <numeric>
 
 nano::confirmation_height_bounded::confirmation_height_bounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, std::shared_ptr<nano::block> const & original_block_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
-ledger (ledger_a),
-write_database_queue (write_database_queue_a),
-batch_separate_pending_min_time (batch_separate_pending_min_time_a),
-logging (logging_a),
-logger (logger_a),
-stopped (stopped_a),
-original_block (original_block_a),
-batch_write_size (batch_write_size_a),
-notify_observers_callback (notify_observers_callback_a),
-notify_block_already_cemented_observers_callback (notify_block_already_cemented_observers_callback_a),
-awaiting_processing_size_callback (awaiting_processing_size_callback_a)
+    ledger (ledger_a),
+    write_database_queue (write_database_queue_a),
+    batch_separate_pending_min_time (batch_separate_pending_min_time_a),
+    logging (logging_a),
+    logger (logger_a),
+    stopped (stopped_a),
+    original_block (original_block_a),
+    batch_write_size (batch_write_size_a),
+    notify_observers_callback (notify_observers_callback_a),
+    notify_block_already_cemented_observers_callback (notify_block_already_cemented_observers_callback_a),
+    awaiting_processing_size_callback (awaiting_processing_size_callback_a)
 {
 }
 
@@ -562,34 +562,34 @@ void nano::confirmation_height_bounded::clear_process_vars ()
 }
 
 nano::confirmation_height_bounded::receive_chain_details::receive_chain_details (nano::account const & account_a, uint64_t height_a, nano::block_hash const & hash_a, nano::block_hash const & top_level_a, boost::optional<nano::block_hash> next_a, uint64_t bottom_height_a, nano::block_hash const & bottom_most_a) :
-account (account_a),
-height (height_a),
-hash (hash_a),
-top_level (top_level_a),
-next (next_a),
-bottom_height (bottom_height_a),
-bottom_most (bottom_most_a)
+    account (account_a),
+    height (height_a),
+    hash (hash_a),
+    top_level (top_level_a),
+    next (next_a),
+    bottom_height (bottom_height_a),
+    bottom_most (bottom_most_a)
 {
 }
 
 nano::confirmation_height_bounded::write_details::write_details (nano::account const & account_a, uint64_t bottom_height_a, nano::block_hash const & bottom_hash_a, uint64_t top_height_a, nano::block_hash const & top_hash_a) :
-account (account_a),
-bottom_height (bottom_height_a),
-bottom_hash (bottom_hash_a),
-top_height (top_height_a),
-top_hash (top_hash_a)
+    account (account_a),
+    bottom_height (bottom_height_a),
+    bottom_hash (bottom_hash_a),
+    top_height (top_height_a),
+    top_hash (top_hash_a)
 {
 }
 
 nano::confirmation_height_bounded::receive_source_pair::receive_source_pair (confirmation_height_bounded::receive_chain_details const & receive_details_a, const block_hash & source_a) :
-receive_details (receive_details_a),
-source_hash (source_a)
+    receive_details (receive_details_a),
+    source_hash (source_a)
 {
 }
 
 nano::confirmation_height_bounded::confirmed_info::confirmed_info (uint64_t confirmed_height_a, nano::block_hash const & iterated_frontier_a) :
-confirmed_height (confirmed_height_a),
-iterated_frontier (iterated_frontier_a)
+    confirmed_height (confirmed_height_a),
+    iterated_frontier (iterated_frontier_a)
 {
 }
 

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -12,18 +12,18 @@
 #include <numeric>
 
 nano::confirmation_height_processor::confirmation_height_processor (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, boost::latch & latch, confirmation_height_mode mode_a) :
-ledger (ledger_a),
-write_database_queue (write_database_queue_a),
-// clang-format off
+    ledger (ledger_a),
+    write_database_queue (write_database_queue_a),
+    // clang-format off
 unbounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, original_block, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
 bounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, original_block, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
-// clang-format on
-thread ([this, &latch, mode_a]() {
-	nano::thread_role::set (nano::thread_role::name::confirmation_height_processing);
-	// Do not start running the processing thread until other threads have finished their operations
-	latch.wait ();
-	this->run (mode_a);
-})
+    // clang-format on
+    thread ([this, &latch, mode_a]() {
+	    nano::thread_role::set (nano::thread_role::name::confirmation_height_processing);
+	    // Do not start running the processing thread until other threads have finished their operations
+	    latch.wait ();
+	    this->run (mode_a);
+    })
 {
 }
 

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -9,17 +9,17 @@
 #include <numeric>
 
 nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, std::shared_ptr<nano::block> const & original_block_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
-ledger (ledger_a),
-write_database_queue (write_database_queue_a),
-batch_separate_pending_min_time (batch_separate_pending_min_time_a),
-logging (logging_a),
-logger (logger_a),
-stopped (stopped_a),
-original_block (original_block_a),
-batch_write_size (batch_write_size_a),
-notify_observers_callback (notify_observers_callback_a),
-notify_block_already_cemented_observers_callback (notify_block_already_cemented_observers_callback_a),
-awaiting_processing_size_callback (awaiting_processing_size_callback_a)
+    ledger (ledger_a),
+    write_database_queue (write_database_queue_a),
+    batch_separate_pending_min_time (batch_separate_pending_min_time_a),
+    logging (logging_a),
+    logger (logger_a),
+    stopped (stopped_a),
+    original_block (original_block_a),
+    batch_write_size (batch_write_size_a),
+    notify_observers_callback (notify_observers_callback_a),
+    notify_block_already_cemented_observers_callback (notify_block_already_cemented_observers_callback_a),
+    awaiting_processing_size_callback (awaiting_processing_size_callback_a)
 {
 }
 
@@ -486,23 +486,23 @@ uint64_t nano::confirmation_height_unbounded::block_cache_size () const
 }
 
 nano::confirmation_height_unbounded::conf_height_details::conf_height_details (nano::account const & account_a, nano::block_hash const & hash_a, uint64_t height_a, uint64_t num_blocks_confirmed_a, std::vector<nano::block_hash> const & block_callback_data_a) :
-account (account_a),
-hash (hash_a),
-height (height_a),
-num_blocks_confirmed (num_blocks_confirmed_a),
-block_callback_data (block_callback_data_a)
+    account (account_a),
+    hash (hash_a),
+    height (height_a),
+    num_blocks_confirmed (num_blocks_confirmed_a),
+    block_callback_data (block_callback_data_a)
 {
 }
 
 nano::confirmation_height_unbounded::receive_source_pair::receive_source_pair (std::shared_ptr<conf_height_details> const & receive_details_a, const block_hash & source_a) :
-receive_details (receive_details_a),
-source_hash (source_a)
+    receive_details (receive_details_a),
+    source_hash (source_a)
 {
 }
 
 nano::confirmation_height_unbounded::confirmed_iterated_pair::confirmed_iterated_pair (uint64_t confirmed_height_a, uint64_t iterated_height_a) :
-confirmed_height (confirmed_height_a),
-iterated_height (iterated_height_a)
+    confirmed_height (confirmed_height_a),
+    iterated_height (iterated_height_a)
 {
 }
 

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -4,11 +4,11 @@
 using namespace std::chrono_literals;
 
 nano::confirmation_solicitor::confirmation_solicitor (nano::network & network_a, nano::network_constants const & params_a) :
-max_confirm_req_batches (params_a.is_dev_network () ? 1 : 20),
-max_block_broadcasts (params_a.is_dev_network () ? 4 : 30),
-max_election_requests (50),
-max_election_broadcasts (std::max<size_t> (network_a.fanout () / 2, 1)),
-network (network_a)
+    max_confirm_req_batches (params_a.is_dev_network () ? 1 : 20),
+    max_block_broadcasts (params_a.is_dev_network () ? 4 : 30),
+    max_election_requests (50),
+    max_election_broadcasts (std::max<size_t> (network_a.fanout () / 2, 1)),
+    network (network_a)
 {
 }
 

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 nano::daemon_config::daemon_config (boost::filesystem::path const & data_path_a) :
-data_path (data_path_a)
+    data_path (data_path_a)
 {
 }
 

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -21,13 +21,13 @@ std::shared_ptr<request_type> nano::distributed_work::peer_request::get_prepared
 }
 
 nano::distributed_work::distributed_work (nano::node & node_a, nano::work_request const & request_a, std::chrono::seconds const & backoff_a) :
-node (node_a),
-node_w (node_a.shared ()),
-request (request_a),
-backoff (backoff_a),
-strand (node_a.io_ctx.get_executor ()),
-need_resolve (request_a.peers),
-elapsed (nano::timer_state::started, "distributed work generation timer")
+    node (node_a),
+    node_w (node_a.shared ()),
+    request (request_a),
+    backoff (backoff_a),
+    strand (node_a.io_ctx.get_executor ()),
+    need_resolve (request_a.peers),
+    elapsed (nano::timer_state::started, "distributed work generation timer")
 {
 	debug_assert (!finished);
 	debug_assert (status == work_generation_status::ongoing);

--- a/nano/node/distributed_work.hpp
+++ b/nano/node/distributed_work.hpp
@@ -55,8 +55,8 @@ class distributed_work final : public std::enable_shared_from_this<nano::distrib
 	{
 	public:
 		peer_request (boost::asio::io_context & io_ctx_a, nano::tcp_endpoint const & endpoint_a) :
-		endpoint (endpoint_a),
-		socket (io_ctx_a)
+		    endpoint (endpoint_a),
+		    socket (io_ctx_a)
 		{
 		}
 		std::shared_ptr<request_type> get_prepared_json_request (std::string const &) const;

--- a/nano/node/distributed_work_factory.cpp
+++ b/nano/node/distributed_work_factory.cpp
@@ -3,7 +3,7 @@
 #include <nano/node/node.hpp>
 
 nano::distributed_work_factory::distributed_work_factory (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 }
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -19,15 +19,15 @@ nano::election_vote_result::election_vote_result (bool replay_a, bool processed_
 }
 
 nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> const & block_a, std::function<void(std::shared_ptr<nano::block> const &)> const & confirmation_action_a, std::function<void(nano::account const &)> const & live_vote_action_a, bool prioritized_a, nano::election_behavior election_behavior_a) :
-confirmation_action (confirmation_action_a),
-live_vote_action (live_vote_action_a),
-prioritized_m (prioritized_a),
-behavior (election_behavior_a),
-node (node_a),
-status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
-height (block_a->sideband ().height),
-root (block_a->root ()),
-qualified_root (block_a->qualified_root ())
+    confirmation_action (confirmation_action_a),
+    live_vote_action (live_vote_action_a),
+    prioritized_m (prioritized_a),
+    behavior (election_behavior_a),
+    node (node_a),
+    status ({ block_a, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
+    height (block_a->sideband ().height),
+    root (block_a->root ()),
+    qualified_root (block_a->qualified_root ())
 {
 	last_votes.emplace (node.network_params.random.not_an_account, nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () });
 	last_blocks.emplace (block_a->hash (), block_a);

--- a/nano/node/gap_cache.cpp
+++ b/nano/node/gap_cache.cpp
@@ -5,7 +5,7 @@
 #include <boost/format.hpp>
 
 nano::gap_cache::gap_cache (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 }
 

--- a/nano/node/ipc/action_handler.cpp
+++ b/nano/node/ipc/action_handler.cpp
@@ -56,10 +56,10 @@ auto nano::ipc::action_handler::handler_map () -> std::unordered_map<nanoapi::Me
 }
 
 nano::ipc::action_handler::action_handler (nano::node & node_a, nano::ipc::ipc_server & server_a, std::weak_ptr<nano::ipc::subscriber> const & subscriber_a, std::shared_ptr<flatbuffers::FlatBufferBuilder> const & builder_a) :
-flatbuffer_producer (builder_a),
-node (node_a),
-ipc_server (server_a),
-subscriber (subscriber_a)
+    flatbuffer_producer (builder_a),
+    node (node_a),
+    ipc_server (server_a),
+    subscriber (subscriber_a)
 {
 }
 

--- a/nano/node/ipc/flatbuffers_handler.cpp
+++ b/nano/node/ipc/flatbuffers_handler.cpp
@@ -58,10 +58,10 @@ boost::optional<boost::filesystem::path> get_api_path ()
 }
 
 nano::ipc::flatbuffers_handler::flatbuffers_handler (nano::node & node_a, nano::ipc::ipc_server & ipc_server_a, std::shared_ptr<nano::ipc::subscriber> const & subscriber_a, nano::ipc::ipc_config const & ipc_config_a) :
-node (node_a),
-ipc_server (ipc_server_a),
-subscriber (subscriber_a),
-ipc_config (ipc_config_a)
+    node (node_a),
+    ipc_server (ipc_server_a),
+    subscriber (subscriber_a),
+    ipc_config (ipc_config_a)
 {
 }
 

--- a/nano/node/ipc/ipc_broker.cpp
+++ b/nano/node/ipc/ipc_broker.cpp
@@ -7,7 +7,7 @@
 #include <nano/node/node.hpp>
 
 nano::ipc::broker::broker (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 }
 

--- a/nano/node/ipc/ipc_broker.hpp
+++ b/nano/node/ipc/ipc_broker.hpp
@@ -62,7 +62,7 @@ namespace ipc
 	{
 	public:
 		subscription (std::weak_ptr<nano::ipc::subscriber> const & subscriber_a, std::shared_ptr<TopicType> const & topic_a) :
-		subscriber (subscriber_a), topic (topic_a)
+		    subscriber (subscriber_a), topic (topic_a)
 		{
 		}
 

--- a/nano/node/ipc/ipc_config.hpp
+++ b/nano/node/ipc/ipc_config.hpp
@@ -53,7 +53,7 @@ namespace ipc
 	{
 	public:
 		ipc_config_tcp_socket () :
-		port (network_constants.default_ipc_port)
+		    port (network_constants.default_ipc_port)
 		{
 		}
 		nano::network_constants network_constants;

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -37,9 +37,9 @@ class session final : public nano::ipc::socket_base, public std::enable_shared_f
 {
 public:
 	session (nano::ipc::ipc_server & server_a, boost::asio::io_context & io_ctx_a, nano::ipc::ipc_config_transport & config_transport_a) :
-	socket_base (io_ctx_a),
-	server (server_a), node (server_a.node), session_id (server_a.id_dispenser.fetch_add (1)),
-	io_ctx (io_ctx_a), strand (io_ctx_a.get_executor ()), socket (io_ctx_a), config_transport (config_transport_a)
+	    socket_base (io_ctx_a),
+	    server (server_a), node (server_a.node), session_id (server_a.id_dispenser.fetch_add (1)),
+	    io_ctx (io_ctx_a), strand (io_ctx_a.get_executor ()), socket (io_ctx_a), config_transport (config_transport_a)
 	{
 		if (node.config.logging.log_ipc ())
 		{
@@ -63,7 +63,7 @@ public:
 		{
 		public:
 			subscriber_impl (std::shared_ptr<session> const & session_a) :
-			session_m (session_a)
+			    session_m (session_a)
 			{
 			}
 			virtual void async_send_message (uint8_t const * data_a, size_t length_a, std::function<void(nano::error const &)> broadcast_completion_handler_a) override
@@ -478,7 +478,7 @@ class socket_transport : public nano::ipc::transport
 {
 public:
 	socket_transport (nano::ipc::ipc_server & server_a, ENDPOINT_TYPE endpoint_a, nano::ipc::ipc_config_transport & config_transport_a, int concurrency_a) :
-	server (server_a), config_transport (config_transport_a)
+	    server (server_a), config_transport (config_transport_a)
 	{
 		// Using a per-transport event dispatcher?
 		if (concurrency_a > 0)
@@ -576,9 +576,9 @@ void await_hup_signal (std::shared_ptr<boost::asio::signal_set> const & signals,
 }
 
 nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a) :
-node (node_a),
-node_rpc_config (node_rpc_config_a),
-broker (std::make_shared<nano::ipc::broker> (node_a))
+    node (node_a),
+    node_rpc_config (node_rpc_config_a),
+    broker (std::make_shared<nano::ipc::broker> (node_a))
 {
 	try
 	{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -26,11 +26,11 @@ const char * epoch_as_string (nano::epoch);
 }
 
 nano::json_handler::json_handler (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a, std::string const & body_a, std::function<void(std::string const &)> const & response_a, std::function<void()> stop_callback_a) :
-body (body_a),
-node (node_a),
-response (response_a),
-stop_callback (stop_callback_a),
-node_rpc_config (node_rpc_config_a)
+    body (body_a),
+    node (node_a),
+    response (response_a),
+    stop_callback (stop_callback_a),
+    node_rpc_config (node_rpc_config_a)
 {
 }
 
@@ -2225,12 +2225,12 @@ class history_visitor : public nano::block_visitor
 {
 public:
 	history_visitor (nano::json_handler & handler_a, bool raw_a, nano::transaction & transaction_a, boost::property_tree::ptree & tree_a, nano::block_hash const & hash_a, std::vector<nano::public_key> const & accounts_filter_a) :
-	handler (handler_a),
-	raw (raw_a),
-	transaction (transaction_a),
-	tree (tree_a),
-	hash (hash_a),
-	accounts_filter (accounts_filter_a)
+	    handler (handler_a),
+	    raw (raw_a),
+	    transaction (transaction_a),
+	    tree (tree_a),
+	    hash (hash_a),
+	    accounts_filter (accounts_filter_a)
 	{
 	}
 	virtual ~history_visitor () = default;

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -171,10 +171,10 @@ class inprocess_rpc_handler final : public nano::rpc_handler_interface
 public:
 	inprocess_rpc_handler (
 	nano::node & node_a, nano::ipc::ipc_server & ipc_server_a, nano::node_rpc_config const & node_rpc_config_a, std::function<void()> stop_callback_a = []() {}) :
-	node (node_a),
-	ipc_server (ipc_server_a),
-	stop_callback (stop_callback_a),
-	node_rpc_config (node_rpc_config_a)
+	    node (node_a),
+	    ipc_server (ipc_server_a),
+	    stop_callback (stop_callback_a),
+	    node_rpc_config (node_rpc_config_a)
 	{
 	}
 

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -29,7 +29,7 @@ size_t mdb_val::size () const
 
 template <>
 mdb_val::db_val (size_t size_a, void * data_a) :
-value ({ size_a, data_a })
+    value ({ size_a, data_a })
 {
 }
 
@@ -41,10 +41,10 @@ void mdb_val::convert_buffer_to_value ()
 }
 
 nano::mdb_store::mdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade_a) :
-logger (logger_a),
-env (error, path_a, nano::mdb_env::options::make ().set_config (lmdb_config_a).set_use_no_mem_init (true)),
-mdb_txn_tracker (logger_a, txn_tracking_config_a, block_processor_batch_max_time_a),
-txn_tracking_enabled (txn_tracking_config_a.enable)
+    logger (logger_a),
+    env (error, path_a, nano::mdb_env::options::make ().set_config (lmdb_config_a).set_use_no_mem_init (true)),
+    mdb_txn_tracker (logger_a, txn_tracking_config_a, block_processor_batch_max_time_a),
+    txn_tracking_enabled (txn_tracking_config_a.enable)
 {
 	if (!error)
 	{
@@ -1181,8 +1181,8 @@ std::shared_ptr<nano::block> nano::mdb_store::block_get_v14 (nano::transaction c
 }
 
 nano::mdb_store::upgrade_counters::upgrade_counters (uint64_t count_before_v0, uint64_t count_before_v1) :
-before_v0 (count_before_v0),
-before_v1 (count_before_v1)
+    before_v0 (count_before_v0),
+    before_v1 (count_before_v1)
 {
 }
 

--- a/nano/node/lmdb/lmdb_iterator.hpp
+++ b/nano/node/lmdb/lmdb_iterator.hpp
@@ -165,20 +165,20 @@ class mdb_merge_iterator : public store_iterator_impl<T, U>
 {
 public:
 	mdb_merge_iterator (nano::transaction const & transaction_a, MDB_dbi db1_a, MDB_dbi db2_a) :
-	impl1 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db1_a)),
-	impl2 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db2_a))
+	    impl1 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db1_a)),
+	    impl2 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db2_a))
 	{
 	}
 
 	mdb_merge_iterator () :
-	impl1 (std::make_unique<nano::mdb_iterator<T, U>> ()),
-	impl2 (std::make_unique<nano::mdb_iterator<T, U>> ())
+	    impl1 (std::make_unique<nano::mdb_iterator<T, U>> ()),
+	    impl2 (std::make_unique<nano::mdb_iterator<T, U>> ())
 	{
 	}
 
 	mdb_merge_iterator (nano::transaction const & transaction_a, MDB_dbi db1_a, MDB_dbi db2_a, MDB_val const & val_a) :
-	impl1 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db1_a, val_a)),
-	impl2 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db2_a, val_a))
+	    impl1 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db1_a, val_a)),
+	    impl2 (std::make_unique<nano::mdb_iterator<T, U>> (transaction_a, db2_a, val_a))
 	{
 	}
 

--- a/nano/node/lmdb/lmdb_txn.cpp
+++ b/nano/node/lmdb/lmdb_txn.cpp
@@ -35,7 +35,7 @@ class matches_txn final
 {
 public:
 	explicit matches_txn (const nano::transaction_impl * transaction_impl_a) :
-	transaction_impl (transaction_impl_a)
+	    transaction_impl (transaction_impl_a)
 	{
 	}
 
@@ -50,7 +50,7 @@ private:
 }
 
 nano::read_mdb_txn::read_mdb_txn (nano::mdb_env const & environment_a, nano::mdb_txn_callbacks txn_callbacks_a) :
-txn_callbacks (txn_callbacks_a)
+    txn_callbacks (txn_callbacks_a)
 {
 	auto status (mdb_txn_begin (environment_a, nullptr, MDB_RDONLY, &handle));
 	release_assert (status == 0);
@@ -84,8 +84,8 @@ void * nano::read_mdb_txn::get_handle () const
 }
 
 nano::write_mdb_txn::write_mdb_txn (nano::mdb_env const & environment_a, nano::mdb_txn_callbacks txn_callbacks_a) :
-env (environment_a),
-txn_callbacks (txn_callbacks_a)
+    env (environment_a),
+    txn_callbacks (txn_callbacks_a)
 {
 	renew ();
 }
@@ -126,9 +126,9 @@ bool nano::write_mdb_txn::contains (nano::tables table_a) const
 }
 
 nano::mdb_txn_tracker::mdb_txn_tracker (nano::logger_mt & logger_a, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a) :
-logger (logger_a),
-txn_tracking_config (txn_tracking_config_a),
-block_processor_batch_max_time (block_processor_batch_max_time_a)
+    logger (logger_a),
+    txn_tracking_config (txn_tracking_config_a),
+    block_processor_batch_max_time (block_processor_batch_max_time_a)
 {
 }
 
@@ -229,9 +229,9 @@ void nano::mdb_txn_tracker::erase (const nano::transaction_impl * transaction_im
 }
 
 nano::mdb_txn_stats::mdb_txn_stats (const nano::transaction_impl * transaction_impl) :
-transaction_impl (transaction_impl),
-thread_name (nano::thread_role::get_string ()),
-stacktrace (std::make_shared<boost::stacktrace::stacktrace> ())
+    transaction_impl (transaction_impl),
+    thread_name (nano::thread_role::get_string ()),
+    stacktrace (std::make_shared<boost::stacktrace::stacktrace> ())
 {
 	timer.start ();
 }

--- a/nano/node/lmdb/wallet_value.cpp
+++ b/nano/node/lmdb/wallet_value.cpp
@@ -8,8 +8,8 @@ nano::wallet_value::wallet_value (nano::db_val<MDB_val> const & val_a)
 }
 
 nano::wallet_value::wallet_value (nano::raw_key const & key_a, uint64_t work_a) :
-key (key_a),
-work (work_a)
+    key (key_a),
+    work (work_a)
 {
 }
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -12,17 +12,17 @@
 #include <numeric>
 
 nano::network::network (nano::node & node_a, uint16_t port_a) :
-syn_cookies (node_a.network_params.node.max_peers_per_ip),
-buffer_container (node_a.stats, nano::network::buffer_size, 4096), // 2Mb receive buffer
-resolver (node_a.io_ctx),
-limiter (node_a.config.bandwidth_limit_burst_ratio, node_a.config.bandwidth_limit),
-tcp_message_manager (node_a.config.tcp_incoming_connections_max),
-node (node_a),
-publish_filter (256 * 1024),
-udp_channels (node_a, port_a),
-tcp_channels (node_a),
-port (port_a),
-disconnect_observer ([]() {})
+    syn_cookies (node_a.network_params.node.max_peers_per_ip),
+    buffer_container (node_a.stats, nano::network::buffer_size, 4096), // 2Mb receive buffer
+    resolver (node_a.io_ctx),
+    limiter (node_a.config.bandwidth_limit_burst_ratio, node_a.config.bandwidth_limit),
+    tcp_message_manager (node_a.config.tcp_incoming_connections_max),
+    node (node_a),
+    publish_filter (256 * 1024),
+    udp_channels (node_a, port_a),
+    tcp_channels (node_a),
+    port (port_a),
+    disconnect_observer ([]() {})
 {
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
@@ -378,8 +378,8 @@ class network_message_visitor : public nano::message_visitor
 {
 public:
 	network_message_visitor (nano::node & node_a, std::shared_ptr<nano::transport::channel> const & channel_a) :
-	node (node_a),
-	channel (channel_a)
+	    node (node_a),
+	    channel (channel_a)
 	{
 	}
 	void keepalive (nano::keepalive const & message_a) override
@@ -796,12 +796,12 @@ void nano::network::erase (nano::transport::channel const & channel_a)
 }
 
 nano::message_buffer_manager::message_buffer_manager (nano::stat & stats_a, size_t size, size_t count) :
-stats (stats_a),
-free (count),
-full (count),
-slab (size * count),
-entries (count),
-stopped (false)
+    stats (stats_a),
+    free (count),
+    full (count),
+    slab (size * count),
+    entries (count),
+    stopped (false)
 {
 	debug_assert (count > 0);
 	debug_assert (size > 0);
@@ -884,7 +884,7 @@ void nano::message_buffer_manager::stop ()
 }
 
 nano::tcp_message_manager::tcp_message_manager (unsigned incoming_connections_max_a) :
-max_entries (incoming_connections_max_a * nano::tcp_message_manager::max_entries_per_connection + 1)
+    max_entries (incoming_connections_max_a * nano::tcp_message_manager::max_entries_per_connection + 1)
 {
 	debug_assert (max_entries > 0);
 }
@@ -935,7 +935,7 @@ void nano::tcp_message_manager::stop ()
 }
 
 nano::syn_cookies::syn_cookies (size_t max_cookies_per_ip_a) :
-max_cookies_per_ip (max_cookies_per_ip_a)
+    max_cookies_per_ip (max_cookies_per_ip_a)
 {
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -80,53 +80,53 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (re
 }
 
 nano::node::node (boost::asio::io_context & io_ctx_a, uint16_t peering_port_a, boost::filesystem::path const & application_path_a, nano::logging const & logging_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
-node (io_ctx_a, application_path_a, nano::node_config (peering_port_a, logging_a), work_a, flags_a, seq)
+    node (io_ctx_a, application_path_a, nano::node_config (peering_port_a, logging_a), work_a, flags_a, seq)
 {
 }
 
 nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
-write_database_queue (!flags_a.force_use_write_database_queue && (config_a.rocksdb_config.enable || nano::using_rocksdb_in_tests ())),
-io_ctx (io_ctx_a),
-node_initialized_latch (1),
-config (config_a),
-stats (config.stat_config),
-workers (std::max (3u, config.io_threads / 4), nano::thread_role::name::worker),
-flags (flags_a),
-work (work_a),
-distributed_work (*this),
-logger (config_a.logging.min_time_between_log_output),
-store_impl (nano::make_store (logger, application_path_a, flags.read_only, true, config_a.rocksdb_config, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
-store (*store_impl),
-wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),
-wallets_store (*wallets_store_impl),
-gap_cache (*this),
-ledger (store, stats, flags_a.generate_cache),
-checker (config.signature_checker_threads),
-network (*this, config.peering_port),
-telemetry (std::make_shared<nano::telemetry> (network, workers, observers.telemetry, stats, network_params, flags.disable_ongoing_telemetry_requests)),
-bootstrap_initiator (*this),
-bootstrap (config.peering_port, *this),
-application_path (application_path_a),
-port_mapping (*this),
-rep_crawler (*this),
-vote_processor (checker, active, observers, stats, config, flags, logger, online_reps, rep_crawler, ledger, network_params),
-warmed_up (0),
-block_processor (*this, write_database_queue),
-// clang-format off
+    write_database_queue (!flags_a.force_use_write_database_queue && (config_a.rocksdb_config.enable || nano::using_rocksdb_in_tests ())),
+    io_ctx (io_ctx_a),
+    node_initialized_latch (1),
+    config (config_a),
+    stats (config.stat_config),
+    workers (std::max (3u, config.io_threads / 4), nano::thread_role::name::worker),
+    flags (flags_a),
+    work (work_a),
+    distributed_work (*this),
+    logger (config_a.logging.min_time_between_log_output),
+    store_impl (nano::make_store (logger, application_path_a, flags.read_only, true, config_a.rocksdb_config, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
+    store (*store_impl),
+    wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),
+    wallets_store (*wallets_store_impl),
+    gap_cache (*this),
+    ledger (store, stats, flags_a.generate_cache),
+    checker (config.signature_checker_threads),
+    network (*this, config.peering_port),
+    telemetry (std::make_shared<nano::telemetry> (network, workers, observers.telemetry, stats, network_params, flags.disable_ongoing_telemetry_requests)),
+    bootstrap_initiator (*this),
+    bootstrap (config.peering_port, *this),
+    application_path (application_path_a),
+    port_mapping (*this),
+    rep_crawler (*this),
+    vote_processor (checker, active, observers, stats, config, flags, logger, online_reps, rep_crawler, ledger, network_params),
+    warmed_up (0),
+    block_processor (*this, write_database_queue),
+    // clang-format off
 block_processor_thread ([this]() {
 	nano::thread_role::set (nano::thread_role::name::block_processing);
 	this->block_processor.process_blocks ();
 }),
-// clang-format on
-online_reps (ledger, config),
-history{ config.network_params.voting },
-vote_uniquer (block_uniquer),
-confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
-active (*this, confirmation_height_processor),
-aggregator (network_params.network, config, stats, active.generator, history, ledger, wallets, active),
-wallets (wallets_store.init_error (), *this),
-startup_time (std::chrono::steady_clock::now ()),
-node_seq (seq)
+    // clang-format on
+    online_reps (ledger, config),
+    history{ config.network_params.voting },
+    vote_uniquer (block_uniquer),
+    confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
+    active (*this, confirmation_height_processor),
+    aggregator (network_params.network, config, stats, active.generator, history, ledger, wallets, active),
+    wallets (wallets_store.init_error (), *this),
+    startup_time (std::chrono::steady_clock::now ()),
+    node_seq (seq)
 {
 	if (!init_error ())
 	{
@@ -1735,8 +1735,8 @@ std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> nano::node::get_
 }
 
 nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
-io_context (std::make_shared<boost::asio::io_context> ()),
-work (1)
+    io_context (std::make_shared<boost::asio::io_context> ()),
+    work (1)
 {
 	boost::system::error_code error_chmod;
 
@@ -1773,14 +1773,14 @@ nano::node_wrapper::~node_wrapper ()
 }
 
 nano::inactive_node::inactive_node (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
-node_wrapper (path_a, config_path_a, node_flags_a),
-node (node_wrapper.node)
+    node_wrapper (path_a, config_path_a, node_flags_a),
+    node (node_wrapper.node)
 {
 	node_wrapper.node->active.stop ();
 }
 
 nano::inactive_node::inactive_node (boost::filesystem::path const & path_a, nano::node_flags const & node_flags_a) :
-inactive_node (path_a, path_a, node_flags_a)
+    inactive_node (path_a, path_a, node_flags_a)
 {
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -21,14 +21,14 @@ const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TE
 }
 
 nano::node_config::node_config () :
-node_config (0, nano::logging ())
+    node_config (0, nano::logging ())
 {
 }
 
 nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & logging_a) :
-peering_port (peering_port_a),
-logging (logging_a),
-external_address (boost::asio::ip::address_v6{}.to_string ())
+    peering_port (peering_port_a),
+    logging (logging_a),
+    external_address (boost::asio::ip::address_v6{}.to_string ())
 {
 	// The default constructor passes 0 to indicate we should use the default port,
 	// which is determined at node startup based on active network.

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -4,8 +4,8 @@
 #include <nano/secure/ledger.hpp>
 
 nano::online_reps::online_reps (nano::ledger & ledger_a, nano::node_config const & config_a) :
-ledger{ ledger_a },
-config{ config_a }
+    ledger{ ledger_a },
+    config{ config_a }
 {
 	if (!ledger.store.init_error ())
 	{

--- a/nano/node/openclconfig.cpp
+++ b/nano/node/openclconfig.cpp
@@ -3,9 +3,9 @@
 #include <nano/node/openclconfig.hpp>
 
 nano::opencl_config::opencl_config (unsigned platform_a, unsigned device_a, unsigned threads_a) :
-platform (platform_a),
-device (device_a),
-threads (threads_a)
+    platform (platform_a),
+    device (device_a),
+    threads (threads_a)
 {
 }
 

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -251,16 +251,16 @@ void nano::opencl_environment::dump (std::ostream & stream)
 }
 
 nano::opencl_work::opencl_work (bool & error_a, nano::opencl_config const & config_a, nano::opencl_environment & environment_a, nano::logger_mt & logger_a) :
-config (config_a),
-context (0),
-attempt_buffer (0),
-result_buffer (0),
-item_buffer (0),
-difficulty_buffer (0),
-program (0),
-kernel (0),
-queue (0),
-logger (logger_a)
+    config (config_a),
+    context (0),
+    attempt_buffer (0),
+    result_buffer (0),
+    item_buffer (0),
+    difficulty_buffer (0),
+    program (0),
+    kernel (0),
+    queue (0),
+    logger (logger_a)
 {
 	error_a |= config.platform >= environment_a.platforms.size ();
 	if (!error_a)

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -8,8 +8,8 @@
 #include <upnperrors.h>
 
 nano::port_mapping::port_mapping (nano::node & node_a) :
-node (node_a),
-protocols ({ { { "TCP", boost::asio::ip::address_v4::any (), 0, true }, { "UDP", boost::asio::ip::address_v4::any (), 0, !node_a.flags.disable_udp } } })
+    node (node_a),
+    protocols ({ { { "TCP", boost::asio::ip::address_v4::any (), 0, true }, { "UDP", boost::asio::ip::address_v4::any (), 0, !node_a.flags.disable_udp } } })
 {
 }
 

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -4,7 +4,7 @@
 #include <boost/format.hpp>
 
 nano::rep_crawler::rep_crawler (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 	if (!node.flags.disable_rep_crawler)
 	{

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -29,7 +29,7 @@ class representative
 public:
 	representative () = default;
 	representative (nano::account account_a, nano::amount weight_a, std::shared_ptr<nano::transport::channel> const & channel_a) :
-	account (account_a), weight (weight_a), channel (channel_a)
+	    account (account_a), weight (weight_a), channel (channel_a)
 	{
 		debug_assert (channel != nullptr);
 	}

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -12,16 +12,16 @@
 #include <nano/secure/ledger.hpp>
 
 nano::request_aggregator::request_aggregator (nano::network_constants const & network_constants_a, nano::node_config const & config_a, nano::stat & stats_a, nano::vote_generator & generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
-max_delay (network_constants_a.is_dev_network () ? 50 : 300),
-small_delay (network_constants_a.is_dev_network () ? 10 : 50),
-max_channel_requests (config_a.max_queued_requests),
-stats (stats_a),
-local_votes (history_a),
-ledger (ledger_a),
-wallets (wallets_a),
-active (active_a),
-generator (generator_a),
-thread ([this]() { run (); })
+    max_delay (network_constants_a.is_dev_network () ? 50 : 300),
+    small_delay (network_constants_a.is_dev_network () ? 10 : 50),
+    max_channel_requests (config_a.max_queued_requests),
+    stats (stats_a),
+    local_votes (history_a),
+    ledger (ledger_a),
+    wallets (wallets_a),
+    active (active_a),
+    generator (generator_a),
+    thread ([this]() { run (); })
 {
 	generator.set_reply_action ([this](std::shared_ptr<nano::vote> const & vote_a, std::shared_ptr<nano::transport::channel> const & channel_a) {
 		this->reply_action (vote_a, channel_a);

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -42,8 +42,8 @@ class request_aggregator final
 	{
 		channel_pool () = delete;
 		explicit channel_pool (std::shared_ptr<nano::transport::channel> const & channel_a) :
-		channel (channel_a),
-		endpoint (nano::transport::map_endpoint_to_v6 (channel_a->get_endpoint ()))
+		    channel (channel_a),
+		    endpoint (nano::transport::map_endpoint_to_v6 (channel_a->get_endpoint ()))
 		{
 		}
 		std::vector<std::pair<nano::block_hash, nano::root>> hashes_roots;

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -22,7 +22,7 @@ class event_listener : public rocksdb::EventListener
 {
 public:
 	event_listener (std::function<void(rocksdb::FlushJobInfo const &)> const & flush_completed_cb_a) :
-	flush_completed_cb (flush_completed_cb_a)
+	    flush_completed_cb (flush_completed_cb_a)
 	{
 	}
 
@@ -52,7 +52,7 @@ size_t rocksdb_val::size () const
 
 template <>
 rocksdb_val::db_val (size_t size_a, void * data_a) :
-value (static_cast<const char *> (data_a), size_a)
+    value (static_cast<const char *> (data_a), size_a)
 {
 }
 
@@ -64,10 +64,10 @@ void rocksdb_val::convert_buffer_to_value ()
 }
 
 nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::rocksdb_config const & rocksdb_config_a, bool open_read_only_a) :
-logger{ logger_a },
-rocksdb_config{ rocksdb_config_a },
-max_block_write_batch_num_m{ nano::narrow_cast<unsigned> (blocks_memtable_size_bytes () / (2 * (sizeof (nano::block_type) + nano::state_block::size + nano::block_sideband::size (nano::block_type::state)))) },
-cf_name_table_map{ create_cf_name_table_map () }
+    logger{ logger_a },
+    rocksdb_config{ rocksdb_config_a },
+    max_block_write_batch_num_m{ nano::narrow_cast<unsigned> (blocks_memtable_size_bytes () / (2 * (sizeof (nano::block_type) + nano::state_block::size + nano::block_sideband::size (nano::block_type::state)))) },
+    cf_name_table_map{ create_cf_name_table_map () }
 {
 	boost::system::error_code error_mkdir, error_chmod;
 	boost::filesystem::create_directories (path_a, error_mkdir);
@@ -907,8 +907,8 @@ std::string nano::rocksdb_store::error_string (int status) const
 }
 
 nano::rocksdb_store::tombstone_info::tombstone_info (uint64_t num_since_last_flush_a, uint64_t const max_a) :
-num_since_last_flush (num_since_last_flush_a),
-max (max_a)
+    num_since_last_flush (num_since_last_flush_a),
+    max (max_a)
 {
 }
 

--- a/nano/node/rocksdb/rocksdb_iterator.hpp
+++ b/nano/node/rocksdb/rocksdb_iterator.hpp
@@ -70,7 +70,7 @@ public:
 	}
 
 	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a) :
-	rocksdb_iterator (db, transaction_a, handle_a, nullptr)
+	    rocksdb_iterator (db, transaction_a, handle_a, nullptr)
 	{
 	}
 

--- a/nano/node/rocksdb/rocksdb_txn.cpp
+++ b/nano/node/rocksdb/rocksdb_txn.cpp
@@ -1,7 +1,7 @@
 #include <nano/node/rocksdb/rocksdb_txn.hpp>
 
 nano::read_rocksdb_txn::read_rocksdb_txn (rocksdb::DB * db_a) :
-db (db_a)
+    db (db_a)
 {
 	if (db_a)
 	{
@@ -33,10 +33,10 @@ void * nano::read_rocksdb_txn::get_handle () const
 }
 
 nano::write_rocksdb_txn::write_rocksdb_txn (rocksdb::OptimisticTransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a) :
-db (db_a),
-tables_requiring_locks (tables_requiring_locks_a),
-tables_no_locks (tables_no_locks_a),
-mutexes (mutexes_a)
+    db (db_a),
+    tables_requiring_locks (tables_requiring_locks_a),
+    tables_no_locks (tables_no_locks_a),
+    mutexes (mutexes_a)
 {
 	lock ();
 	rocksdb::OptimisticTransactionOptions txn_options;

--- a/nano/node/signatures.cpp
+++ b/nano/node/signatures.cpp
@@ -4,7 +4,7 @@
 #include <nano/node/signatures.hpp>
 
 nano::signature_checker::signature_checker (unsigned num_threads) :
-thread_pool (num_threads, nano::thread_role::name::signature_checking)
+    thread_pool (num_threads, nano::thread_role::name::signature_checking)
 {
 }
 

--- a/nano/node/signatures.hpp
+++ b/nano/node/signatures.hpp
@@ -13,7 +13,7 @@ class signature_check_set final
 {
 public:
 	signature_check_set (size_t size, unsigned char const ** messages, size_t * message_lengths, unsigned char const ** pub_keys, unsigned char const ** signatures, int * verifications) :
-	size (size), messages (messages), message_lengths (message_lengths), pub_keys (pub_keys), signatures (signatures), verifications (verifications)
+	    size (size), messages (messages), message_lengths (message_lengths), pub_keys (pub_keys), signatures (signatures), verifications (verifications)
 	{
 	}
 
@@ -45,7 +45,7 @@ private:
 	struct Task final
 	{
 		Task (nano::signature_check_set & check, size_t pending) :
-		check (check), pending (pending)
+		    check (check), pending (pending)
 		{
 		}
 		~Task ()

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -9,12 +9,12 @@
 #include <limits>
 
 nano::socket::socket (nano::node & node_a, boost::optional<std::chrono::seconds> io_timeout_a) :
-strand{ node_a.io_ctx.get_executor () },
-tcp_socket{ node_a.io_ctx },
-node{ node_a },
-next_deadline{ std::numeric_limits<uint64_t>::max () },
-last_completion_time{ 0 },
-io_timeout{ io_timeout_a }
+    strand{ node_a.io_ctx.get_executor () },
+    tcp_socket{ node_a.io_ctx },
+    node{ node_a },
+    next_deadline{ std::numeric_limits<uint64_t>::max () },
+    last_completion_time{ 0 },
+    io_timeout{ io_timeout_a }
 {
 	if (!io_timeout)
 	{
@@ -197,10 +197,10 @@ nano::tcp_endpoint nano::socket::remote_endpoint () const
 }
 
 nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a) :
-socket{ node_a, std::chrono::seconds::max () },
-acceptor{ node_a.io_ctx },
-local{ local_a },
-max_inbound_connections{ max_connections_a }
+    socket{ node_a, std::chrono::seconds::max () },
+    acceptor{ node_a.io_ctx },
+    local{ local_a },
+    max_inbound_connections{ max_connections_a }
 {
 }
 

--- a/nano/node/state_block_signature_verification.cpp
+++ b/nano/node/state_block_signature_verification.cpp
@@ -10,14 +10,14 @@
 #include <boost/format.hpp>
 
 nano::state_block_signature_verification::state_block_signature_verification (nano::signature_checker & signature_checker, nano::epochs & epochs, nano::node_config & node_config, nano::logger_mt & logger, uint64_t state_block_signature_verification_size) :
-signature_checker (signature_checker),
-epochs (epochs),
-node_config (node_config),
-logger (logger),
-thread ([this, state_block_signature_verification_size]() {
-	nano::thread_role::set (nano::thread_role::name::state_block_signature_verification);
-	this->run (state_block_signature_verification_size);
-})
+    signature_checker (signature_checker),
+    epochs (epochs),
+    node_config (node_config),
+    logger (logger),
+    thread ([this, state_block_signature_verification_size]() {
+	    nano::thread_role::set (nano::thread_role::name::state_block_signature_verification);
+	    this->run (state_block_signature_verification_size);
+    })
 {
 }
 

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -19,12 +19,12 @@
 using namespace std::chrono_literals;
 
 nano::telemetry::telemetry (nano::network & network_a, nano::thread_pool & workers_a, nano::observer_set<nano::telemetry_data const &, nano::endpoint const &> & observers_a, nano::stat & stats_a, nano::network_params & network_params_a, bool disable_ongoing_requests_a) :
-network (network_a),
-workers (workers_a),
-observers (observers_a),
-stats (stats_a),
-network_params (network_params_a),
-disable_ongoing_requests (disable_ongoing_requests_a)
+    network (network_a),
+    workers (workers_a),
+    observers (observers_a),
+    stats (stats_a),
+    network_params (network_params_a),
+    disable_ongoing_requests (disable_ongoing_requests_a)
 {
 }
 
@@ -154,7 +154,7 @@ void nano::telemetry::ongoing_req_all_peers (std::chrono::milliseconds next_requ
 				{
 					std::shared_ptr<nano::transport::channel> channel;
 					channel_wrapper (std::shared_ptr<nano::transport::channel> const & channel_a) :
-					channel (channel_a)
+					    channel (channel_a)
 					{
 					}
 					nano::endpoint endpoint () const
@@ -454,10 +454,10 @@ size_t nano::telemetry::telemetry_data_size ()
 }
 
 nano::telemetry_info::telemetry_info (nano::endpoint const & endpoint_a, nano::telemetry_data const & data_a, std::chrono::steady_clock::time_point last_response_a, bool undergoing_request_a) :
-endpoint (endpoint_a),
-data (data_a),
-last_response (last_response_a),
-undergoing_request (undergoing_request_a)
+    endpoint (endpoint_a),
+    data (data_a),
+    last_response (last_response_a),
+    undergoing_request (undergoing_request_a)
 {
 }
 

--- a/nano/node/testing.cpp
+++ b/nano/node/testing.cpp
@@ -112,7 +112,7 @@ nano::system::system ()
 }
 
 nano::system::system (uint16_t count_a, nano::transport::transport_type type_a, nano::node_flags flags_a) :
-system ()
+    system ()
 {
 	nodes.reserve (count_a);
 	for (uint16_t i (0); i < count_a; ++i)
@@ -277,10 +277,10 @@ class traffic_generator : public std::enable_shared_from_this<traffic_generator>
 {
 public:
 	traffic_generator (uint32_t count_a, uint32_t wait_a, std::shared_ptr<nano::node> const & node_a, nano::system & system_a) :
-	count (count_a),
-	wait (wait_a),
-	node (node_a),
-	system (system_a)
+	    count (count_a),
+	    wait (wait_a),
+	    node (node_a),
+	    system (system_a)
 	{
 	}
 	void run ()

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -5,8 +5,8 @@
 #include <boost/format.hpp>
 
 nano::transport::channel_tcp::channel_tcp (nano::node & node_a, std::weak_ptr<nano::socket> socket_a) :
-channel (node_a),
-socket (socket_a)
+    channel (node_a),
+    socket (socket_a)
 {
 }
 
@@ -111,7 +111,7 @@ void nano::transport::channel_tcp::set_endpoint ()
 }
 
 nano::transport::tcp_channels::tcp_channels (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 }
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -146,7 +146,7 @@ namespace transport
 			std::shared_ptr<nano::socket> socket;
 			std::shared_ptr<nano::bootstrap_server> response_server;
 			channel_tcp_wrapper (std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a, std::shared_ptr<nano::bootstrap_server> const & server_a) :
-			channel (channel_a), socket (socket_a), response_server (server_a)
+			    channel (channel_a), socket (socket_a), response_server (server_a)
 			{
 			}
 			nano::tcp_endpoint endpoint () const
@@ -184,8 +184,8 @@ namespace transport
 			std::chrono::steady_clock::time_point last_attempt{ std::chrono::steady_clock::now () };
 
 			explicit tcp_endpoint_attempt (nano::tcp_endpoint const & endpoint_a) :
-			endpoint (endpoint_a),
-			address (endpoint_a.address ())
+			    endpoint (endpoint_a),
+			    address (endpoint_a.address ())
 			{
 			}
 		};

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -80,7 +80,7 @@ nano::tcp_endpoint nano::transport::map_endpoint_to_tcp (nano::endpoint const & 
 }
 
 nano::transport::channel::channel (nano::node & node_a) :
-node (node_a)
+    node (node_a)
 {
 	set_network_version (node_a.network_params.protocol.protocol_version);
 }
@@ -117,7 +117,7 @@ void nano::transport::channel::send (nano::message const & message_a, std::funct
 }
 
 nano::transport::channel_loopback::channel_loopback (nano::node & node_a) :
-channel (node_a), endpoint (node_a.network.endpoint ())
+    channel (node_a), endpoint (node_a.network.endpoint ())
 {
 	set_node_id (node_a.node_id.pub);
 	set_network_version (node_a.network_params.protocol.protocol_version);
@@ -254,7 +254,7 @@ bool nano::transport::reserved_address (nano::endpoint const & endpoint_a, bool 
 using namespace std::chrono_literals;
 
 nano::bandwidth_limiter::bandwidth_limiter (const double limit_burst_ratio_a, const size_t limit_a) :
-bucket (static_cast<size_t> (limit_a * limit_burst_ratio_a), limit_a)
+    bucket (static_cast<size_t> (limit_a * limit_burst_ratio_a), limit_a)
 {
 }
 

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -8,9 +8,9 @@
 #include <boost/format.hpp>
 
 nano::transport::channel_udp::channel_udp (nano::transport::udp_channels & channels_a, nano::endpoint const & endpoint_a, uint8_t protocol_version_a) :
-channel (channels_a.node),
-endpoint (endpoint_a),
-channels (channels_a)
+    channel (channels_a.node),
+    endpoint (endpoint_a),
+    channels (channels_a)
 {
 	set_network_version (protocol_version_a);
 	debug_assert (endpoint_a.address ().is_v6 ());
@@ -62,8 +62,8 @@ std::string nano::transport::channel_udp::to_string () const
 }
 
 nano::transport::udp_channels::udp_channels (nano::node & node_a, uint16_t port_a) :
-node (node_a),
-strand (node_a.io_ctx.get_executor ())
+    node (node_a),
+    strand (node_a.io_ctx.get_executor ())
 {
 	if (!node.flags.disable_udp)
 	{
@@ -365,8 +365,8 @@ class udp_message_visitor : public nano::message_visitor
 {
 public:
 	udp_message_visitor (nano::node & node_a, nano::endpoint const & endpoint_a) :
-	node (node_a),
-	endpoint (endpoint_a)
+	    node (node_a),
+	    endpoint (endpoint_a)
 	{
 	}
 	void keepalive (nano::keepalive const & message_a) override

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -135,7 +135,7 @@ namespace transport
 		public:
 			std::shared_ptr<nano::transport::channel_udp> channel;
 			channel_udp_wrapper (std::shared_ptr<nano::transport::channel_udp> const & channel_a) :
-			channel (channel_a)
+			    channel (channel_a)
 			{
 			}
 			nano::endpoint endpoint () const
@@ -170,7 +170,7 @@ namespace transport
 			std::chrono::steady_clock::time_point last_attempt{ std::chrono::steady_clock::now () };
 
 			explicit endpoint_attempt (nano::endpoint const & endpoint_a) :
-			endpoint (endpoint_a)
+			    endpoint (endpoint_a)
 			{
 			}
 		};

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -16,24 +16,24 @@
 #include <boost/format.hpp>
 
 nano::vote_processor::vote_processor (nano::signature_checker & checker_a, nano::active_transactions & active_a, nano::node_observers & observers_a, nano::stat & stats_a, nano::node_config & config_a, nano::node_flags & flags_a, nano::logger_mt & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a) :
-checker (checker_a),
-active (active_a),
-observers (observers_a),
-stats (stats_a),
-config (config_a),
-logger (logger_a),
-online_reps (online_reps_a),
-rep_crawler (rep_crawler_a),
-ledger (ledger_a),
-network_params (network_params_a),
-max_votes (flags_a.vote_processor_capacity),
-started (false),
-stopped (false),
-is_active (false),
-thread ([this]() {
-	nano::thread_role::set (nano::thread_role::name::vote_processing);
-	process_loop ();
-})
+    checker (checker_a),
+    active (active_a),
+    observers (observers_a),
+    stats (stats_a),
+    config (config_a),
+    logger (logger_a),
+    online_reps (online_reps_a),
+    rep_crawler (rep_crawler_a),
+    ledger (ledger_a),
+    network_params (network_params_a),
+    max_votes (flags_a.vote_processor_capacity),
+    started (false),
+    stopped (false),
+    is_active (false),
+    thread ([this]() {
+	    nano::thread_role::set (nano::thread_role::name::vote_processing);
+	    process_loop ();
+    })
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	condition.wait (lock, [& started = started] { return started; });

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -150,15 +150,15 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (na
 }
 
 nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stat & stats_a) :
-config (config_a),
-ledger (ledger_a),
-wallets (wallets_a),
-vote_processor (vote_processor_a),
-history (history_a),
-spacing{ config_a.network_params.voting.delay },
-network (network_a),
-stats (stats_a),
-thread ([this]() { run (); })
+    config (config_a),
+    ledger (ledger_a),
+    wallets (wallets_a),
+    vote_processor (vote_processor_a),
+    history (history_a),
+    spacing{ config_a.network_params.voting.delay },
+    network (network_a),
+    stats (stats_a),
+    thread ([this]() { run (); })
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	condition.wait (lock, [& started = started] { return started; });
@@ -392,7 +392,7 @@ void nano::vote_generator::run ()
 }
 
 nano::vote_generator_session::vote_generator_session (nano::vote_generator & vote_generator_a) :
-generator (vote_generator_a)
+    generator (vote_generator_a)
 {
 }
 

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -7,8 +7,8 @@
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index_container.hpp>
 
@@ -41,20 +41,22 @@ class vote_spacing final
 		std::chrono::steady_clock::time_point time;
 		nano::block_hash hash;
 	};
-	
+
 	boost::multi_index_container<entry,
 	mi::indexed_by<
-		mi::hashed_non_unique<mi::tag<class tag_root>,
-			mi::member<entry, nano::root, &entry::root>>,
-		mi::ordered_non_unique<mi::tag<class tag_time>,
-			mi::member<entry, std::chrono::steady_clock::time_point, &entry::time>>
-	>>
+	mi::hashed_non_unique<mi::tag<class tag_root>,
+	mi::member<entry, nano::root, &entry::root>>,
+	mi::ordered_non_unique<mi::tag<class tag_time>,
+	mi::member<entry, std::chrono::steady_clock::time_point, &entry::time>>>>
 	recent;
 	std::chrono::milliseconds const delay;
 	void trim ();
+
 public:
 	vote_spacing (std::chrono::milliseconds const & delay) :
-	delay{ delay } {}
+	delay{ delay }
+	{
+	}
 	bool votable (nano::root const & root_a, nano::block_hash const & hash_a) const;
 	void flag (nano::root const & root_a, nano::block_hash const & hash_a);
 	size_t size () const;

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -54,7 +54,7 @@ class vote_spacing final
 
 public:
 	vote_spacing (std::chrono::milliseconds const & delay) :
-	delay{ delay }
+	    delay{ delay }
 	{
 	}
 	bool votable (nano::root const & root_a, nano::block_hash const & hash_a) const;
@@ -68,9 +68,9 @@ class local_vote_history final
 	{
 	public:
 		local_vote (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a) :
-		root (root_a),
-		hash (hash_a),
-		vote (vote_a)
+		    root (root_a),
+		    hash (hash_a),
+		    vote (vote_a)
 		{
 		}
 		nano::root root;
@@ -80,7 +80,7 @@ class local_vote_history final
 
 public:
 	local_vote_history (nano::voting_constants const & constants) :
-	constants{ constants }
+	    constants{ constants }
 	{
 	}
 	void add (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -256,9 +256,9 @@ size_t const nano::wallet_store::check_iv_index (0);
 size_t const nano::wallet_store::seed_iv_index (1);
 
 nano::wallet_store::wallet_store (bool & init_a, nano::kdf & kdf_a, nano::transaction & transaction_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a, std::string const & json_a) :
-password (0, fanout_a),
-wallet_key_mem (0, fanout_a),
-kdf (kdf_a)
+    password (0, fanout_a),
+    wallet_key_mem (0, fanout_a),
+    kdf (kdf_a)
 {
 	init_a = false;
 	initialize (transaction_a, init_a, wallet_a);
@@ -312,9 +312,9 @@ kdf (kdf_a)
 }
 
 nano::wallet_store::wallet_store (bool & init_a, nano::kdf & kdf_a, nano::transaction & transaction_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a) :
-password (0, fanout_a),
-wallet_key_mem (0, fanout_a),
-kdf (kdf_a)
+    password (0, fanout_a),
+    wallet_key_mem (0, fanout_a),
+    kdf (kdf_a)
 {
 	init_a = false;
 	initialize (transaction_a, init_a, wallet_a);
@@ -659,16 +659,16 @@ void nano::kdf::phs (nano::raw_key & result_a, std::string const & password_a, n
 }
 
 nano::wallet::wallet (bool & init_a, nano::transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a) :
-lock_observer ([](bool, bool) {}),
-store (init_a, wallets_a.kdf, transaction_a, wallets_a.node.config.random_representative (), wallets_a.node.config.password_fanout, wallet_a),
-wallets (wallets_a)
+    lock_observer ([](bool, bool) {}),
+    store (init_a, wallets_a.kdf, transaction_a, wallets_a.node.config.random_representative (), wallets_a.node.config.password_fanout, wallet_a),
+    wallets (wallets_a)
 {
 }
 
 nano::wallet::wallet (bool & init_a, nano::transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a, std::string const & json) :
-lock_observer ([](bool, bool) {}),
-store (init_a, wallets_a.kdf, transaction_a, wallets_a.node.config.random_representative (), wallets_a.node.config.password_fanout, wallet_a, json),
-wallets (wallets_a)
+    lock_observer ([](bool, bool) {}),
+    store (init_a, wallets_a.kdf, transaction_a, wallets_a.node.config.random_representative (), wallets_a.node.config.password_fanout, wallet_a, json),
+    wallets (wallets_a)
 {
 }
 
@@ -1320,8 +1320,8 @@ void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::r
 }
 
 nano::work_watcher::work_watcher (nano::node & node_a) :
-node (node_a),
-stopped (false)
+    node (node_a),
+    stopped (false)
 {
 	node.observers.blocks.add ([this](nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
 		this->remove (*status_a.winner);
@@ -1462,15 +1462,15 @@ void nano::wallets::do_wallet_actions ()
 }
 
 nano::wallets::wallets (bool error_a, nano::node & node_a) :
-observer ([](bool) {}),
-node (node_a),
-env (boost::polymorphic_downcast<nano::mdb_wallets_store *> (node_a.wallets_store_impl.get ())->environment),
-stopped (false),
-watcher (std::make_shared<nano::work_watcher> (node_a)),
-thread ([this]() {
-	nano::thread_role::set (nano::thread_role::name::wallet_actions);
-	do_wallet_actions ();
-})
+    observer ([](bool) {}),
+    node (node_a),
+    env (boost::polymorphic_downcast<nano::mdb_wallets_store *> (node_a.wallets_store_impl.get ())->environment),
+    stopped (false),
+    watcher (std::make_shared<nano::work_watcher> (node_a)),
+    thread ([this]() {
+	    nano::thread_role::set (nano::thread_role::name::wallet_actions);
+	    do_wallet_actions ();
+    })
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	if (!error_a)
@@ -1935,7 +1935,7 @@ nano::store_iterator<nano::account, nano::wallet_value> nano::wallet_store::end 
 	return nano::store_iterator<nano::account, nano::wallet_value> (nullptr);
 }
 nano::mdb_wallets_store::mdb_wallets_store (boost::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
-environment (error, path_a, nano::mdb_env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
+    environment (error, path_a, nano::mdb_env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
 {
 }
 

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -13,13 +13,13 @@
 #include <chrono>
 
 nano::websocket::confirmation_options::confirmation_options (nano::wallets & wallets_a) :
-wallets (wallets_a)
+    wallets (wallets_a)
 {
 }
 
 nano::websocket::confirmation_options::confirmation_options (boost::property_tree::ptree const & options_a, nano::wallets & wallets_a, nano::logger_mt & logger_a) :
-wallets (wallets_a),
-logger (logger_a)
+    wallets (wallets_a),
+    logger (logger_a)
 {
 	// Non-account filtering options
 	include_block = options_a.get<bool> ("include_block", true);
@@ -232,7 +232,7 @@ bool nano::websocket::vote_options::should_filter (nano::websocket::message cons
 }
 
 nano::websocket::session::session (nano::websocket::listener & listener_a, socket_type socket_a) :
-ws_listener (listener_a), ws (std::move (socket_a)), strand (ws.get_executor ())
+    ws_listener (listener_a), ws (std::move (socket_a)), strand (ws.get_executor ())
 {
 	ws.text (true);
 	ws_listener.get_logger ().try_log ("Websocket: session started");
@@ -549,10 +549,10 @@ void nano::websocket::listener::stop ()
 }
 
 nano::websocket::listener::listener (nano::logger_mt & logger_a, nano::wallets & wallets_a, boost::asio::io_context & io_ctx_a, boost::asio::ip::tcp::endpoint endpoint_a) :
-logger (logger_a),
-wallets (wallets_a),
-acceptor (io_ctx_a),
-socket (io_ctx_a)
+    logger (logger_a),
+    wallets (wallets_a),
+    acceptor (io_ctx_a),
+    socket (io_ctx_a)
 {
 	try
 	{

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -75,11 +75,11 @@ namespace websocket
 	{
 	public:
 		message (nano::websocket::topic topic_a) :
-		topic (topic_a)
+		    topic (topic_a)
 		{
 		}
 		message (nano::websocket::topic topic_a, boost::property_tree::ptree & tree_a) :
-		topic (topic_a), contents (tree_a)
+		    topic (topic_a), contents (tree_a)
 		{
 		}
 

--- a/nano/node/websocketconfig.cpp
+++ b/nano/node/websocketconfig.cpp
@@ -4,8 +4,8 @@
 #include <nano/node/websocketconfig.hpp>
 
 nano::websocket::config::config () :
-port (network_constants.default_websocket_port),
-address (boost::asio::ip::address_v6::loopback ().to_string ())
+    port (network_constants.default_websocket_port),
+    address (boost::asio::ip::address_v6::loopback ().to_string ())
 {
 }
 

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -5,13 +5,13 @@
 #include <algorithm>
 
 nano::write_guard::write_guard (std::function<void()> guard_finish_callback_a) :
-guard_finish_callback (guard_finish_callback_a)
+    guard_finish_callback (guard_finish_callback_a)
 {
 }
 
 nano::write_guard::write_guard (nano::write_guard && write_guard_a) noexcept :
-guard_finish_callback (std::move (write_guard_a.guard_finish_callback)),
-owns (write_guard_a.owns)
+    guard_finish_callback (std::move (write_guard_a.guard_finish_callback)),
+    owns (write_guard_a.owns)
 {
 	write_guard_a.owns = false;
 	write_guard_a.guard_finish_callback = nullptr;
@@ -51,17 +51,17 @@ void nano::write_guard::release ()
 }
 
 nano::write_database_queue::write_database_queue (bool use_noops_a) :
-guard_finish_callback ([use_noops_a, &queue = queue, &mutex = mutex, &cv = cv]() {
-	if (!use_noops_a)
-	{
-		{
-			nano::lock_guard<nano::mutex> guard (mutex);
-			queue.pop_front ();
-		}
-		cv.notify_all ();
-	}
-}),
-use_noops (use_noops_a)
+    guard_finish_callback ([use_noops_a, &queue = queue, &mutex = mutex, &cv = cv]() {
+	    if (!use_noops_a)
+	    {
+		    {
+			    nano::lock_guard<nano::mutex> guard (mutex);
+			    queue.pop_front ();
+		    }
+		    cv.notify_all ();
+	    }
+    }),
+    use_noops (use_noops_a)
 {
 }
 

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -49,25 +49,25 @@ bool nano_qt::eventloop_processor::event (QEvent * event_a)
 }
 
 nano_qt::eventloop_event::eventloop_event (std::function<void()> const & action_a) :
-QEvent (QEvent::Type::User),
-action (action_a)
+    QEvent (QEvent::Type::User),
+    action (action_a)
 {
 }
 
 nano_qt::self_pane::self_pane (nano_qt::wallet & wallet_a, nano::account const & account_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-self_layout (new QHBoxLayout),
-self_window (new QWidget),
-your_account_label (new QLabel ("Your Nano account:")),
-account_window (new QWidget),
-account_layout (new QHBoxLayout),
-account_text (new QLineEdit),
-copy_button (new QPushButton ("Copy")),
-balance_window (new QWidget),
-balance_layout (new QHBoxLayout),
-balance_label (new QLabel),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    self_layout (new QHBoxLayout),
+    self_window (new QWidget),
+    your_account_label (new QLabel ("Your Nano account:")),
+    account_window (new QWidget),
+    account_layout (new QHBoxLayout),
+    account_text (new QLineEdit),
+    copy_button (new QPushButton ("Copy")),
+    balance_window (new QWidget),
+    balance_layout (new QHBoxLayout),
+    balance_label (new QLabel),
+    wallet (wallet_a)
 {
 	your_account_label->setStyleSheet ("font-weight: bold;");
 	std::string network = wallet.node.network_params.network.get_current_network_as_string ();
@@ -121,20 +121,20 @@ void nano_qt::self_pane::set_balance_text (std::pair<nano::uint128_t, nano::uint
 }
 
 nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
-wallet_balance_label (new QLabel),
-window (new QWidget),
-layout (new QVBoxLayout),
-model (new QStandardItemModel),
-view (new QTableView),
-use_account (new QPushButton ("Use account")),
-create_account (new QPushButton ("Create account")),
-import_wallet (new QPushButton ("Import wallet")),
-backup_seed (new QPushButton ("Copy wallet seed to clipboard")),
-separator (new QFrame),
-account_key_line (new QLineEdit),
-account_key_button (new QPushButton ("Import adhoc key")),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    wallet_balance_label (new QLabel),
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    model (new QStandardItemModel),
+    view (new QTableView),
+    use_account (new QPushButton ("Use account")),
+    create_account (new QPushButton ("Create account")),
+    import_wallet (new QPushButton ("Import wallet")),
+    backup_seed (new QPushButton ("Copy wallet seed to clipboard")),
+    separator (new QFrame),
+    account_key_line (new QLineEdit),
+    account_key_button (new QPushButton ("Import adhoc key")),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	separator->setFrameShape (QFrame::HLine);
 	separator->setFrameShadow (QFrame::Sunken);
@@ -321,21 +321,21 @@ void nano_qt::accounts::refresh ()
 }
 
 nano_qt::import::import (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-seed_label (new QLabel ("Seed:")),
-seed (new QLineEdit),
-clear_label (new QLabel ("Modifying seed clears existing keys\nType 'clear keys' below to confirm:")),
-clear_line (new QLineEdit),
-import_seed (new QPushButton ("Import seed")),
-separator (new QFrame),
-filename_label (new QLabel ("Path to file:")),
-filename (new QLineEdit),
-password_label (new QLabel ("Password:")),
-password (new QLineEdit),
-perform (new QPushButton ("Import")),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    seed_label (new QLabel ("Seed:")),
+    seed (new QLineEdit),
+    clear_label (new QLabel ("Modifying seed clears existing keys\nType 'clear keys' below to confirm:")),
+    clear_line (new QLineEdit),
+    import_seed (new QPushButton ("Import seed")),
+    separator (new QFrame),
+    filename_label (new QLabel ("Path to file:")),
+    filename (new QLineEdit),
+    password_label (new QLabel ("Password:")),
+    password (new QLineEdit),
+    perform (new QPushButton ("Import")),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	layout->addWidget (seed_label);
 	layout->addWidget (seed);
@@ -476,17 +476,17 @@ wallet (wallet_a)
 }
 
 nano_qt::history::history (nano::ledger & ledger_a, nano::account const & account_a, nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-model (new QStandardItemModel),
-view (new QTableView),
-tx_window (new QWidget),
-tx_layout (new QHBoxLayout),
-tx_label (new QLabel ("Account history count:")),
-tx_count (new QSpinBox),
-ledger (ledger_a),
-account (account_a),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    model (new QStandardItemModel),
+    view (new QTableView),
+    tx_window (new QWidget),
+    tx_layout (new QHBoxLayout),
+    tx_label (new QLabel ("Account history count:")),
+    tx_count (new QSpinBox),
+    ledger (ledger_a),
+    account (account_a),
+    wallet (wallet_a)
 { /*
 	tx_count->setRange (1, 256);
 	tx_layout->addWidget (tx_label);
@@ -514,8 +514,8 @@ class short_text_visitor : public nano::block_visitor
 {
 public:
 	short_text_visitor (nano::transaction const & transaction_a, nano::ledger & ledger_a) :
-	transaction (transaction_a),
-	ledger (ledger_a)
+	    transaction (transaction_a),
+	    ledger (ledger_a)
 	{
 	}
 	void send_block (nano::send_block const & block_a)
@@ -641,18 +641,18 @@ void nano_qt::history::refresh ()
 }
 
 nano_qt::block_viewer::block_viewer (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-hash_label (new QLabel ("Hash:")),
-hash (new QLineEdit),
-block_label (new QLabel ("Block:")),
-block (new QPlainTextEdit),
-successor_label (new QLabel ("Successor:")),
-successor (new QLineEdit),
-retrieve (new QPushButton ("Retrieve")),
-rebroadcast (new QPushButton ("Rebroadcast")),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    hash_label (new QLabel ("Hash:")),
+    hash (new QLineEdit),
+    block_label (new QLabel ("Block:")),
+    block (new QPlainTextEdit),
+    successor_label (new QLabel ("Successor:")),
+    successor (new QLineEdit),
+    retrieve (new QPushButton ("Retrieve")),
+    rebroadcast (new QPushButton ("Rebroadcast")),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	layout->addWidget (hash_label);
 	layout->addWidget (hash);
@@ -741,18 +741,18 @@ void nano_qt::block_viewer::rebroadcast_action (nano::block_hash const & hash_a)
 }
 
 nano_qt::account_viewer::account_viewer (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-account_label (new QLabel ("Account:")),
-account_line (new QLineEdit),
-refresh (new QPushButton ("Refresh")),
-balance_window (new QWidget),
-balance_layout (new QHBoxLayout),
-balance_label (new QLabel),
-history (wallet_a.node.ledger, account, wallet_a),
-back (new QPushButton ("Back")),
-account (wallet_a.account),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    account_label (new QLabel ("Account:")),
+    account_line (new QLineEdit),
+    refresh (new QPushButton ("Refresh")),
+    balance_window (new QWidget),
+    balance_layout (new QHBoxLayout),
+    balance_label (new QLabel),
+    history (wallet_a.node.ledger, account, wallet_a),
+    back (new QPushButton ("Back")),
+    account (wallet_a.account),
+    wallet (wallet_a)
 {
 	layout->addWidget (account_label);
 	layout->addWidget (account_line);
@@ -796,14 +796,14 @@ wallet (wallet_a)
 }
 
 nano_qt::stats_viewer::stats_viewer (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-refresh (new QPushButton ("Refresh")),
-clear (new QPushButton ("Clear Statistics")),
-model (new QStandardItemModel),
-view (new QTableView),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    refresh (new QPushButton ("Refresh")),
+    clear (new QPushButton ("Clear Statistics")),
+    model (new QStandardItemModel),
+    view (new QTableView),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	model->setHorizontalHeaderItem (0, new QStandardItem ("Last updated"));
 	model->setHorizontalHeaderItem (1, new QStandardItem ("Type"));
@@ -887,7 +887,7 @@ void nano_qt::stats_viewer::refresh_stats ()
 }
 
 nano_qt::status::status (nano_qt::wallet & wallet_a) :
-wallet (wallet_a)
+    wallet (wallet_a)
 {
 	wallet.status->setToolTip ("Wallet status, block count (blocks downloaded)");
 	active.insert (nano_qt::status_types::nominal);
@@ -1000,45 +1000,45 @@ std::string nano_qt::status::color ()
 }
 
 nano_qt::wallet::wallet (QApplication & application_a, nano_qt::eventloop_processor & processor_a, nano::node & node_a, std::shared_ptr<nano::wallet> const & wallet_a, nano::account & account_a) :
-rendering_ratio (nano::Mxrb_ratio),
-node (node_a),
-wallet_m (wallet_a),
-account (account_a),
-processor (processor_a),
-history (node.ledger, account, *this),
-accounts (*this),
-self (*this, account_a),
-settings (*this),
-advanced (*this),
-block_creation (*this),
-block_entry (*this),
-block_viewer (*this),
-account_viewer (*this),
-stats_viewer (*this),
-import (*this),
-application (application_a),
-status (new QLabel),
-main_stack (new QStackedWidget),
-client_window (new QWidget),
-client_layout (new QVBoxLayout),
-entry_window (new QWidget),
-entry_window_layout (new QVBoxLayout),
-separator (new QFrame),
-account_history_label (new QLabel ("Account history:")),
-send_blocks (new QPushButton ("Send")),
-settings_button (new QPushButton ("Settings")),
-accounts_button (new QPushButton ("Accounts")),
-show_advanced (new QPushButton ("Advanced")),
-send_blocks_window (new QWidget),
-send_blocks_layout (new QVBoxLayout),
-send_account_label (new QLabel ("Destination account:")),
-send_account (new QLineEdit),
-send_count_label (new QLabel ("Amount:")),
-send_count (new QLineEdit),
-send_blocks_send (new QPushButton ("Send")),
-send_blocks_back (new QPushButton ("Back")),
-active_status (*this),
-needs_deterministic_restore (false)
+    rendering_ratio (nano::Mxrb_ratio),
+    node (node_a),
+    wallet_m (wallet_a),
+    account (account_a),
+    processor (processor_a),
+    history (node.ledger, account, *this),
+    accounts (*this),
+    self (*this, account_a),
+    settings (*this),
+    advanced (*this),
+    block_creation (*this),
+    block_entry (*this),
+    block_viewer (*this),
+    account_viewer (*this),
+    stats_viewer (*this),
+    import (*this),
+    application (application_a),
+    status (new QLabel),
+    main_stack (new QStackedWidget),
+    client_window (new QWidget),
+    client_layout (new QVBoxLayout),
+    entry_window (new QWidget),
+    entry_window_layout (new QVBoxLayout),
+    separator (new QFrame),
+    account_history_label (new QLabel ("Account history:")),
+    send_blocks (new QPushButton ("Send")),
+    settings_button (new QPushButton ("Settings")),
+    accounts_button (new QPushButton ("Accounts")),
+    show_advanced (new QPushButton ("Advanced")),
+    send_blocks_window (new QWidget),
+    send_blocks_layout (new QVBoxLayout),
+    send_account_label (new QLabel ("Destination account:")),
+    send_account (new QLineEdit),
+    send_count_label (new QLabel ("Amount:")),
+    send_count (new QLineEdit),
+    send_blocks_send (new QPushButton ("Send")),
+    send_blocks_back (new QPushButton ("Back")),
+    active_status (*this),
+    needs_deterministic_restore (false)
 {
 	update_connected ();
 	empty_password ();
@@ -1486,21 +1486,21 @@ void nano_qt::wallet::pop_main_stack ()
 }
 
 nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-password (new QLineEdit),
-lock_toggle (new QPushButton ("Unlock")),
-sep1 (new QFrame),
-new_password (new QLineEdit),
-retype_password (new QLineEdit),
-change (new QPushButton ("Set/Change password")),
-sep2 (new QFrame),
-representative (new QLabel ("Account representative:")),
-current_representative (new QLabel),
-new_representative (new QLineEdit),
-change_rep (new QPushButton ("Change representative")),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    password (new QLineEdit),
+    lock_toggle (new QPushButton ("Unlock")),
+    sep1 (new QFrame),
+    new_password (new QLineEdit),
+    retype_password (new QLineEdit),
+    change (new QPushButton ("Set/Change password")),
+    sep2 (new QFrame),
+    representative (new QLabel ("Account representative:")),
+    current_representative (new QLabel),
+    new_representative (new QLineEdit),
+    change_rep (new QPushButton ("Change representative")),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	password->setPlaceholderText ("Password");
 	password->setEchoMode (QLineEdit::EchoMode::Password);
@@ -1735,45 +1735,45 @@ void nano_qt::settings::update_locked (bool invalid, bool vulnerable)
 }
 
 nano_qt::advanced_actions::advanced_actions (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-show_ledger (new QPushButton ("Ledger")),
-show_peers (new QPushButton ("Peers")),
-search_for_receivables (new QPushButton ("Search for receivables")),
-bootstrap (new QPushButton ("Initiate bootstrap")),
-wallet_refresh (new QPushButton ("Refresh Wallet")),
-create_block (new QPushButton ("Create Block")),
-enter_block (new QPushButton ("Enter Block")),
-block_viewer (new QPushButton ("Block Viewer")),
-account_viewer (new QPushButton ("Account Viewer")),
-stats_viewer (new QPushButton ("Node Statistics")),
-scale_window (new QWidget),
-scale_layout (new QHBoxLayout),
-scale_label (new QLabel ("Scale:")),
-ratio_group (new QButtonGroup),
-mnano_unit (new QRadioButton ("Mnano")),
-knano_unit (new QRadioButton ("knano")),
-nano_unit (new QRadioButton ("nano")),
-raw_unit (new QRadioButton ("raw")),
-back (new QPushButton ("Back")),
-ledger_window (new QWidget),
-ledger_layout (new QVBoxLayout),
-ledger_model (new QStandardItemModel),
-ledger_view (new QTableView),
-ledger_refresh (new QPushButton ("Refresh")),
-ledger_back (new QPushButton ("Back")),
-peers_window (new QWidget),
-peers_layout (new QVBoxLayout),
-peers_model (new QStandardItemModel),
-peers_view (new QTableView),
-peer_summary_layout (new QHBoxLayout),
-bootstrap_label (new QLabel ("IPV6:port \"::ffff:192.168.0.1:7075\"")),
-peer_count_label (new QLabel ("")),
-bootstrap_line (new QLineEdit),
-peers_bootstrap (new QPushButton ("Initiate Bootstrap")),
-peers_refresh (new QPushButton ("Refresh")),
-peers_back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    show_ledger (new QPushButton ("Ledger")),
+    show_peers (new QPushButton ("Peers")),
+    search_for_receivables (new QPushButton ("Search for receivables")),
+    bootstrap (new QPushButton ("Initiate bootstrap")),
+    wallet_refresh (new QPushButton ("Refresh Wallet")),
+    create_block (new QPushButton ("Create Block")),
+    enter_block (new QPushButton ("Enter Block")),
+    block_viewer (new QPushButton ("Block Viewer")),
+    account_viewer (new QPushButton ("Account Viewer")),
+    stats_viewer (new QPushButton ("Node Statistics")),
+    scale_window (new QWidget),
+    scale_layout (new QHBoxLayout),
+    scale_label (new QLabel ("Scale:")),
+    ratio_group (new QButtonGroup),
+    mnano_unit (new QRadioButton ("Mnano")),
+    knano_unit (new QRadioButton ("knano")),
+    nano_unit (new QRadioButton ("nano")),
+    raw_unit (new QRadioButton ("raw")),
+    back (new QPushButton ("Back")),
+    ledger_window (new QWidget),
+    ledger_layout (new QVBoxLayout),
+    ledger_model (new QStandardItemModel),
+    ledger_view (new QTableView),
+    ledger_refresh (new QPushButton ("Refresh")),
+    ledger_back (new QPushButton ("Back")),
+    peers_window (new QWidget),
+    peers_layout (new QVBoxLayout),
+    peers_model (new QStandardItemModel),
+    peers_view (new QTableView),
+    peer_summary_layout (new QHBoxLayout),
+    bootstrap_label (new QLabel ("IPV6:port \"::ffff:192.168.0.1:7075\"")),
+    peer_count_label (new QLabel ("")),
+    bootstrap_line (new QLineEdit),
+    peers_bootstrap (new QPushButton ("Initiate Bootstrap")),
+    peers_refresh (new QPushButton ("Refresh")),
+    peers_back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	ratio_group->addButton (mnano_unit);
 	ratio_group->addButton (knano_unit);
@@ -2003,13 +2003,13 @@ void nano_qt::advanced_actions::refresh_stats ()
 }
 
 nano_qt::block_entry::block_entry (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-block (new QPlainTextEdit),
-status (new QLabel),
-process (new QPushButton ("Process")),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    block (new QPlainTextEdit),
+    status (new QLabel),
+    process (new QPushButton ("Process")),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	layout->addWidget (block);
 	layout->addWidget (status);
@@ -2056,29 +2056,29 @@ wallet (wallet_a)
 }
 
 nano_qt::block_creation::block_creation (nano_qt::wallet & wallet_a) :
-window (new QWidget),
-layout (new QVBoxLayout),
-group (new QButtonGroup),
-button_layout (new QHBoxLayout),
-send (new QRadioButton ("Send")),
-receive (new QRadioButton ("Receive")),
-change (new QRadioButton ("Change")),
-open (new QRadioButton ("Open")),
-account_label (new QLabel ("Account:")),
-account (new QLineEdit),
-source_label (new QLabel ("Source:")),
-source (new QLineEdit),
-amount_label (new QLabel ("Amount:")),
-amount (new QLineEdit),
-destination_label (new QLabel ("Destination:")),
-destination (new QLineEdit),
-representative_label (new QLabel ("Representative:")),
-representative (new QLineEdit),
-block (new QPlainTextEdit),
-status (new QLabel),
-create (new QPushButton ("Create")),
-back (new QPushButton ("Back")),
-wallet (wallet_a)
+    window (new QWidget),
+    layout (new QVBoxLayout),
+    group (new QButtonGroup),
+    button_layout (new QHBoxLayout),
+    send (new QRadioButton ("Send")),
+    receive (new QRadioButton ("Receive")),
+    change (new QRadioButton ("Change")),
+    open (new QRadioButton ("Open")),
+    account_label (new QLabel ("Account:")),
+    account (new QLineEdit),
+    source_label (new QLabel ("Source:")),
+    source (new QLineEdit),
+    amount_label (new QLabel ("Amount:")),
+    amount (new QLineEdit),
+    destination_label (new QLabel ("Destination:")),
+    destination (new QLineEdit),
+    representative_label (new QLabel ("Representative:")),
+    representative (new QLineEdit),
+    block (new QPlainTextEdit),
+    status (new QLabel),
+    create (new QPushButton ("Create")),
+    back (new QPushButton ("Back")),
+    wallet (wallet_a)
 {
 	group->addButton (send);
 	group->addButton (receive);

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -12,11 +12,11 @@
 #endif
 
 nano::rpc::rpc (boost::asio::io_context & io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
-config (config_a),
-acceptor (io_ctx_a),
-logger (std::chrono::milliseconds (0)),
-io_ctx (io_ctx_a),
-rpc_handler_interface (rpc_handler_interface_a)
+    config (config_a),
+    acceptor (io_ctx_a),
+    logger (std::chrono::milliseconds (0)),
+    io_ctx (io_ctx_a),
+    rpc_handler_interface (rpc_handler_interface_a)
 {
 	rpc_handler_interface.rpc_instance (*this);
 }

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -15,12 +15,12 @@
 #include <boost/format.hpp>
 
 nano::rpc_connection::rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface) :
-socket (io_ctx),
-strand (io_ctx.get_executor ()),
-io_ctx (io_ctx),
-logger (logger),
-rpc_config (rpc_config),
-rpc_handler_interface (rpc_handler_interface)
+    socket (io_ctx),
+    strand (io_ctx.get_executor ()),
+    io_ctx (io_ctx),
+    logger (logger),
+    rpc_config (rpc_config),
+    rpc_handler_interface (rpc_handler_interface)
 {
 	responded.clear ();
 }

--- a/nano/rpc/rpc_connection_secure.cpp
+++ b/nano/rpc/rpc_connection_secure.cpp
@@ -5,8 +5,8 @@
 #include <boost/polymorphic_pointer_cast.hpp>
 
 nano::rpc_connection_secure::rpc_connection_secure (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger_mt & logger, nano::rpc_handler_interface & rpc_handler_interface, boost::asio::ssl::context & ssl_context) :
-nano::rpc_connection (rpc_config, io_ctx, logger, rpc_handler_interface),
-stream (socket, ssl_context)
+    nano::rpc_connection (rpc_config, io_ctx, logger, rpc_handler_interface),
+    stream (socket, ssl_context)
 {
 }
 

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -19,12 +19,12 @@ std::string filter_request (boost::property_tree::ptree tree_a);
 }
 
 nano::rpc_handler::rpc_handler (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void(std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger_mt & logger) :
-body (body_a),
-request_id (request_id_a),
-response (response_a),
-rpc_config (rpc_config),
-rpc_handler_interface (rpc_handler_interface_a),
-logger (logger)
+    body (body_a),
+    request_id (request_id_a),
+    response (response_a),
+    rpc_config (rpc_config),
+    rpc_handler_interface (rpc_handler_interface_a),
+    logger (logger)
 {
 }
 

--- a/nano/rpc/rpc_request_processor.cpp
+++ b/nano/rpc/rpc_request_processor.cpp
@@ -6,12 +6,12 @@
 #include <boost/endian/conversion.hpp>
 
 nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
-ipc_address (rpc_config.rpc_process.ipc_address),
-ipc_port (rpc_config.rpc_process.ipc_port),
-thread ([this]() {
-	nano::thread_role::set (nano::thread_role::name::rpc_request_processor);
-	this->run ();
-})
+    ipc_address (rpc_config.rpc_process.ipc_address),
+    ipc_port (rpc_config.rpc_process.ipc_port),
+    thread ([this]() {
+	    nano::thread_role::set (nano::thread_role::name::rpc_request_processor);
+	    this->run ();
+    })
 {
 	nano::lock_guard<nano::mutex> lk (this->request_mutex);
 	this->connections.reserve (rpc_config.rpc_process.num_ipc_connections);

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -12,7 +12,7 @@ namespace nano
 struct ipc_connection
 {
 	ipc_connection (nano::ipc::ipc_client && client_a, bool is_available_a) :
-	client (std::move (client_a)), is_available (is_available_a)
+	    client (std::move (client_a)), is_available (is_available_a)
 	{
 	}
 
@@ -23,17 +23,17 @@ struct ipc_connection
 struct rpc_request
 {
 	rpc_request (const std::string & action_a, const std::string & body_a, std::function<void(std::string const &)> response_a) :
-	action (action_a), body (body_a), response (response_a)
+	    action (action_a), body (body_a), response (response_a)
 	{
 	}
 
 	rpc_request (int rpc_api_version_a, const std::string & body_a, std::function<void(std::string const &)> response_a) :
-	rpc_api_version (rpc_api_version_a), body (body_a), response (response_a)
+	    rpc_api_version (rpc_api_version_a), body (body_a), response (response_a)
 	{
 	}
 
 	rpc_request (int rpc_api_version_a, const std::string & action_a, const std::string & body_a, std::function<void(std::string const &)> response_a) :
-	rpc_api_version (rpc_api_version_a), action (action_a), body (body_a), response (response_a)
+	    rpc_api_version (rpc_api_version_a), action (action_a), body (body_a), response (response_a)
 	{
 	}
 
@@ -73,7 +73,7 @@ class ipc_rpc_processor final : public nano::rpc_handler_interface
 {
 public:
 	ipc_rpc_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
-	rpc_request_processor (io_ctx, rpc_config)
+	    rpc_request_processor (io_ctx, rpc_config)
 	{
 	}
 

--- a/nano/rpc/rpc_secure.cpp
+++ b/nano/rpc/rpc_secure.cpp
@@ -104,8 +104,8 @@ void nano::rpc_secure::load_certs (boost::asio::ssl::context & context_a)
 }
 
 nano::rpc_secure::rpc_secure (boost::asio::io_context & context_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
-rpc (context_a, config_a, rpc_handler_interface_a),
-ssl_context (boost::asio::ssl::context::tlsv12_server)
+    rpc (context_a, config_a, rpc_handler_interface_a),
+    ssl_context (boost::asio::ssl::context::tlsv12_server)
 {
 	load_certs (ssl_context);
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -26,14 +26,14 @@ class test_response
 {
 public:
 	test_response (boost::property_tree::ptree const & request_a, boost::asio::io_context & io_ctx_a) :
-	request (request_a),
-	sock (io_ctx_a)
+	    request (request_a),
+	    sock (io_ctx_a)
 	{
 	}
 
 	test_response (boost::property_tree::ptree const & request_a, uint16_t port_a, boost::asio::io_context & io_ctx_a) :
-	request (request_a),
-	sock (io_ctx_a)
+	    request (request_a),
+	    sock (io_ctx_a)
 	{
 		run (port_a);
 	}

--- a/nano/secure/blockstore.cpp
+++ b/nano/secure/blockstore.cpp
@@ -2,9 +2,9 @@
 #include <nano/secure/blockstore.hpp>
 
 nano::representative_visitor::representative_visitor (nano::transaction const & transaction_a, nano::block_store & store_a) :
-transaction (transaction_a),
-store (store_a),
-result (0)
+    transaction (transaction_a),
+    store (store_a),
+    result (0)
 {
 }
 
@@ -45,7 +45,7 @@ void nano::representative_visitor::state_block (nano::state_block const & block_
 }
 
 nano::read_transaction::read_transaction (std::unique_ptr<nano::read_transaction_impl> read_transaction_impl) :
-impl (std::move (read_transaction_impl))
+    impl (std::move (read_transaction_impl))
 {
 }
 
@@ -71,7 +71,7 @@ void nano::read_transaction::refresh () const
 }
 
 nano::write_transaction::write_transaction (std::unique_ptr<nano::write_transaction_impl> write_transaction_impl) :
-impl (std::move (write_transaction_impl))
+    impl (std::move (write_transaction_impl))
 {
 	/*
 	 * For IO threads, we do not want them to block on creating write transactions.

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -41,70 +41,70 @@ class db_val
 {
 public:
 	db_val (Val const & value_a) :
-	value (value_a)
+	    value (value_a)
 	{
 	}
 
 	db_val () :
-	db_val (0, nullptr)
+	    db_val (0, nullptr)
 	{
 	}
 
 	db_val (std::nullptr_t) :
-	db_val (0, this)
+	    db_val (0, this)
 	{
 	}
 
 	db_val (nano::uint128_union const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::uint128_union *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::uint128_union *> (&val_a))
 	{
 	}
 
 	db_val (nano::uint256_union const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::uint256_union *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::uint256_union *> (&val_a))
 	{
 	}
 
 	db_val (nano::uint512_union const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::uint512_union *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::uint512_union *> (&val_a))
 	{
 	}
 
 	db_val (nano::qualified_root const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::qualified_root *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::qualified_root *> (&val_a))
 	{
 	}
 
 	db_val (nano::account_info const & val_a) :
-	db_val (val_a.db_size (), const_cast<nano::account_info *> (&val_a))
+	    db_val (val_a.db_size (), const_cast<nano::account_info *> (&val_a))
 	{
 	}
 
 	db_val (nano::account_info_v14 const & val_a) :
-	db_val (val_a.db_size (), const_cast<nano::account_info_v14 *> (&val_a))
+	    db_val (val_a.db_size (), const_cast<nano::account_info_v14 *> (&val_a))
 	{
 	}
 
 	db_val (nano::pending_info const & val_a) :
-	db_val (val_a.db_size (), const_cast<nano::pending_info *> (&val_a))
+	    db_val (val_a.db_size (), const_cast<nano::pending_info *> (&val_a))
 	{
 		static_assert (std::is_standard_layout<nano::pending_info>::value, "Standard layout is required");
 	}
 
 	db_val (nano::pending_info_v14 const & val_a) :
-	db_val (val_a.db_size (), const_cast<nano::pending_info_v14 *> (&val_a))
+	    db_val (val_a.db_size (), const_cast<nano::pending_info_v14 *> (&val_a))
 	{
 		static_assert (std::is_standard_layout<nano::pending_info_v14>::value, "Standard layout is required");
 	}
 
 	db_val (nano::pending_key const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::pending_key *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::pending_key *> (&val_a))
 	{
 		static_assert (std::is_standard_layout<nano::pending_key>::value, "Standard layout is required");
 	}
 
 	db_val (nano::unchecked_info const & val_a) :
-	buffer (std::make_shared<std::vector<uint8_t>> ())
+	    buffer (std::make_shared<std::vector<uint8_t>> ())
 	{
 		{
 			nano::vectorstream stream (*buffer);
@@ -114,13 +114,13 @@ public:
 	}
 
 	db_val (nano::unchecked_key const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::unchecked_key *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::unchecked_key *> (&val_a))
 	{
 		static_assert (std::is_standard_layout<nano::unchecked_key>::value, "Standard layout is required");
 	}
 
 	db_val (nano::confirmation_height_info const & val_a) :
-	buffer (std::make_shared<std::vector<uint8_t>> ())
+	    buffer (std::make_shared<std::vector<uint8_t>> ())
 	{
 		{
 			nano::vectorstream stream (*buffer);
@@ -130,19 +130,19 @@ public:
 	}
 
 	db_val (nano::block_info const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::block_info *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::block_info *> (&val_a))
 	{
 		static_assert (std::is_standard_layout<nano::block_info>::value, "Standard layout is required");
 	}
 
 	db_val (nano::endpoint_key const & val_a) :
-	db_val (sizeof (val_a), const_cast<nano::endpoint_key *> (&val_a))
+	    db_val (sizeof (val_a), const_cast<nano::endpoint_key *> (&val_a))
 	{
 		static_assert (std::is_standard_layout<nano::endpoint_key>::value, "Standard layout is required");
 	}
 
 	db_val (std::shared_ptr<nano::block> const & val_a) :
-	buffer (std::make_shared<std::vector<uint8_t>> ())
+	    buffer (std::make_shared<std::vector<uint8_t>> ())
 	{
 		{
 			nano::vectorstream stream (*buffer);
@@ -152,7 +152,7 @@ public:
 	}
 
 	db_val (uint64_t val_a) :
-	buffer (std::make_shared<std::vector<uint8_t>> ())
+	    buffer (std::make_shared<std::vector<uint8_t>> ())
 	{
 		{
 			boost::endian::native_to_big_inplace (val_a);
@@ -489,13 +489,13 @@ public:
 	{
 	}
 	store_iterator (std::unique_ptr<nano::store_iterator_impl<T, U>> impl_a) :
-	impl (std::move (impl_a))
+	    impl (std::move (impl_a))
 	{
 		impl->fill (current);
 	}
 	store_iterator (nano::store_iterator<T, U> && other_a) :
-	current (std::move (other_a.current)),
-	impl (std::move (other_a.impl))
+	    current (std::move (other_a.current)),
+	    impl (std::move (other_a.impl))
 	{
 	}
 	nano::store_iterator<T, U> & operator++ ()

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -925,8 +925,8 @@ class block_predecessor_set : public nano::block_visitor
 {
 public:
 	block_predecessor_set (nano::write_transaction const & transaction_a, nano::block_store_partial<Val, Derived_Store> & store_a) :
-	transaction (transaction_a),
-	store (store_a)
+	    transaction (transaction_a),
+	    store (store_a)
 	{
 	}
 	virtual ~block_predecessor_set () = default;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -76,12 +76,12 @@ std::shared_ptr<nano::block> parse_block_from_genesis_data (std::string const & 
 }
 
 nano::network_params::network_params () :
-network_params (network_constants::active_network)
+    network_params (network_constants::active_network)
 {
 }
 
 nano::network_params::network_params (nano::nano_networks network_a) :
-network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
+    network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
 {
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_dev_work = 8;
@@ -95,26 +95,26 @@ uint8_t nano::protocol_constants::protocol_version_min () const
 }
 
 nano::ledger_constants::ledger_constants (nano::network_constants & network_constants) :
-ledger_constants (network_constants.network ())
+    ledger_constants (network_constants.network ())
 {
 }
 
 nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
-zero_key ("0"),
-dev_genesis_key (dev_private_key_data),
-nano_dev_account (dev_public_key_data),
-nano_beta_account (beta_public_key_data),
-nano_live_account (live_public_key_data),
-nano_test_account (test_public_key_data),
-nano_dev_genesis (dev_genesis_data),
-nano_beta_genesis (beta_genesis_data),
-nano_live_genesis (live_genesis_data),
-nano_test_genesis (test_genesis_data),
-genesis_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_account),
-genesis_block (network_a == nano::nano_networks::nano_dev_network ? nano_dev_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : network_a == nano::nano_networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
-genesis_hash (parse_block_from_genesis_data (genesis_block)->hash ()),
-genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
-burn_account (0)
+    zero_key ("0"),
+    dev_genesis_key (dev_private_key_data),
+    nano_dev_account (dev_public_key_data),
+    nano_beta_account (beta_public_key_data),
+    nano_live_account (live_public_key_data),
+    nano_test_account (test_public_key_data),
+    nano_dev_genesis (dev_genesis_data),
+    nano_beta_genesis (beta_genesis_data),
+    nano_live_genesis (live_genesis_data),
+    nano_test_genesis (test_genesis_data),
+    genesis_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_account),
+    genesis_block (network_a == nano::nano_networks::nano_dev_network ? nano_dev_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : network_a == nano::nano_networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
+    genesis_hash (parse_block_from_genesis_data (genesis_block)->hash ()),
+    genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
+    burn_account (0)
 {
 	nano::link epoch_link_v1;
 	const char * epoch_message_v1 ("epoch v1 block");
@@ -156,8 +156,8 @@ nano::node_constants::node_constants (nano::network_constants & network_constant
 }
 
 nano::voting_constants::voting_constants (nano::network_constants & network_constants) :
-max_cache{ network_constants.is_dev_network () ? 256U : 128U * 1024 },
-delay{ network_constants.is_dev_network () ? 1 : 15 }
+    max_cache{ network_constants.is_dev_network () ? 256U : 128U * 1024 },
+    delay{ network_constants.is_dev_network () ? 1 : 15 }
 {
 }
 
@@ -186,7 +186,7 @@ nano::keypair::keypair ()
 
 // Create a keypair given a private key
 nano::keypair::keypair (nano::raw_key && prv_a) :
-prv (std::move (prv_a))
+    prv (std::move (prv_a))
 {
 	ed25519_publickey (prv.bytes.data (), pub.bytes.data ());
 }
@@ -207,13 +207,13 @@ void nano::serialize_block (nano::stream & stream_a, nano::block const & block_a
 }
 
 nano::account_info::account_info (nano::block_hash const & head_a, nano::account const & representative_a, nano::block_hash const & open_block_a, nano::amount const & balance_a, uint64_t modified_a, uint64_t block_count_a, nano::epoch epoch_a) :
-head (head_a),
-representative (representative_a),
-open_block (open_block_a),
-balance (balance_a),
-modified (modified_a),
-block_count (block_count_a),
-epoch_m (epoch_a)
+    head (head_a),
+    representative (representative_a),
+    open_block (open_block_a),
+    balance (balance_a),
+    modified (modified_a),
+    block_count (block_count_a),
+    epoch_m (epoch_a)
 {
 }
 
@@ -266,9 +266,9 @@ nano::epoch nano::account_info::epoch () const
 }
 
 nano::pending_info::pending_info (nano::account const & source_a, nano::amount const & amount_a, nano::epoch epoch_a) :
-source (source_a),
-amount (amount_a),
-epoch (epoch_a)
+    source (source_a),
+    amount (amount_a),
+    epoch (epoch_a)
 {
 }
 
@@ -300,8 +300,8 @@ bool nano::pending_info::operator== (nano::pending_info const & other_a) const
 }
 
 nano::pending_key::pending_key (nano::account const & account_a, nano::block_hash const & hash_a) :
-account (account_a),
-hash (hash_a)
+    account (account_a),
+    hash (hash_a)
 {
 }
 
@@ -332,11 +332,11 @@ nano::account const & nano::pending_key::key () const
 }
 
 nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, uint64_t modified_a, nano::signature_verification verified_a, bool confirmed_a) :
-block (block_a),
-account (account_a),
-modified (modified_a),
-verified (verified_a),
-confirmed (confirmed_a)
+    block (block_a),
+    account (account_a),
+    modified (modified_a),
+    verified (verified_a),
+    confirmed (confirmed_a)
 {
 }
 
@@ -370,7 +370,7 @@ bool nano::unchecked_info::deserialize (nano::stream & stream_a)
 }
 
 nano::endpoint_key::endpoint_key (const std::array<uint8_t, 16> & address_a, uint16_t port_a) :
-address (address_a), network_port (boost::endian::native_to_big (port_a))
+    address (address_a), network_port (boost::endian::native_to_big (port_a))
 {
 }
 
@@ -385,8 +385,8 @@ uint16_t nano::endpoint_key::port () const
 }
 
 nano::confirmation_height_info::confirmation_height_info (uint64_t confirmation_height_a, nano::block_hash const & confirmed_frontier_a) :
-height (confirmation_height_a),
-frontier (confirmed_frontier_a)
+    height (confirmation_height_a),
+    frontier (confirmed_frontier_a)
 {
 }
 
@@ -412,8 +412,8 @@ bool nano::confirmation_height_info::deserialize (nano::stream & stream_a)
 }
 
 nano::block_info::block_info (nano::account const & account_a, nano::amount const & balance_a) :
-account (account_a),
-balance (balance_a)
+    account (account_a),
+    balance (balance_a)
 {
 }
 
@@ -491,10 +491,10 @@ std::string nano::vote::to_json () const
 }
 
 nano::vote::vote (nano::vote const & other_a) :
-timestamp{ other_a.timestamp },
-blocks (other_a.blocks),
-account (other_a.account),
-signature (other_a.signature)
+    timestamp{ other_a.timestamp },
+    blocks (other_a.blocks),
+    account (other_a.account),
+    signature (other_a.signature)
 {
 }
 
@@ -542,16 +542,16 @@ nano::vote::vote (bool & error_a, nano::stream & stream_a, nano::block_type type
 }
 
 nano::vote::vote (nano::account const & account_a, nano::raw_key const & prv_a, uint64_t timestamp_a, std::shared_ptr<nano::block> const & block_a) :
-timestamp{ timestamp_a },
-blocks (1, block_a),
-account (account_a),
-signature (nano::sign_message (prv_a, account_a, hash ()))
+    timestamp{ timestamp_a },
+    blocks (1, block_a),
+    account (account_a),
+    signature (nano::sign_message (prv_a, account_a, hash ()))
 {
 }
 
 nano::vote::vote (nano::account const & account_a, nano::raw_key const & prv_a, uint64_t timestamp_a, std::vector<nano::block_hash> const & blocks_a) :
-timestamp{ timestamp_a },
-account (account_a)
+    timestamp{ timestamp_a },
+    account (account_a)
 {
 	debug_assert (!blocks_a.empty ());
 	debug_assert (blocks_a.size () <= 12);
@@ -734,7 +734,7 @@ boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_v
 }
 
 nano::vote_uniquer::vote_uniquer (nano::block_uniquer & uniquer_a) :
-uniquer (uniquer_a)
+    uniquer (uniquer_a)
 {
 }
 
@@ -822,8 +822,8 @@ nano::wallet_id nano::random_wallet_id ()
 }
 
 nano::unchecked_key::unchecked_key (nano::block_hash const & previous_a, nano::block_hash const & hash_a) :
-previous (previous_a),
-hash (hash_a)
+    previous (previous_a),
+    hash (hash_a)
 {
 }
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -17,9 +17,9 @@ class rollback_visitor : public nano::block_visitor
 {
 public:
 	rollback_visitor (nano::write_transaction const & transaction_a, nano::ledger & ledger_a, std::vector<std::shared_ptr<nano::block>> & list_a) :
-	transaction (transaction_a),
-	ledger (ledger_a),
-	list (list_a)
+	    transaction (transaction_a),
+	    ledger (ledger_a),
+	    list (list_a)
 	{
 	}
 	virtual ~rollback_visitor () = default;
@@ -728,18 +728,18 @@ void ledger_processor::open_block (nano::open_block & block_a)
 }
 
 ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::write_transaction const & transaction_a, nano::signature_verification verification_a) :
-ledger (ledger_a),
-transaction (transaction_a),
-verification (verification_a)
+    ledger (ledger_a),
+    transaction (transaction_a),
+    verification (verification_a)
 {
 	result.verified = verification;
 }
 } // namespace
 
 nano::ledger::ledger (nano::block_store & store_a, nano::stat & stat_a, nano::generate_cache const & generate_cache_a) :
-store (store_a),
-stats (stat_a),
-check_bootstrap_weights (true)
+    store (store_a),
+    stats (stat_a),
+    check_bootstrap_weights (true)
 {
 	if (!store.init_error ())
 	{
@@ -1187,9 +1187,9 @@ class dependent_block_visitor : public nano::block_visitor
 {
 public:
 	dependent_block_visitor (nano::ledger const & ledger_a, nano::transaction const & transaction_a) :
-	ledger (ledger_a),
-	transaction (transaction_a),
-	result ({ 0, 0 })
+	    ledger (ledger_a),
+	    transaction (transaction_a),
+	    result ({ 0, 0 })
 	{
 	}
 	void send_block (nano::send_block const & block_a) override
@@ -1540,7 +1540,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 }
 
 nano::uncemented_info::uncemented_info (nano::block_hash const & cemented_frontier, nano::block_hash const & frontier, nano::account const & account) :
-cemented_frontier (cemented_frontier), frontier (frontier), account (account)
+    cemented_frontier (cemented_frontier), frontier (frontier), account (account)
 {
 }
 

--- a/nano/secure/network_filter.cpp
+++ b/nano/secure/network_filter.cpp
@@ -5,7 +5,7 @@
 #include <nano/secure/network_filter.hpp>
 
 nano::network_filter::network_filter (size_t size_a) :
-items (size_a, nano::uint128_t{ 0 })
+    items (size_a, nano::uint128_t{ 0 })
 {
 	nano::random_pool::generate_block (key, key.size ());
 }

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -5,9 +5,9 @@
 #include <lmdb/libraries/liblmdb/lmdb.h>
 
 nano::pending_info_v14::pending_info_v14 (nano::account const & source_a, nano::amount const & amount_a, nano::epoch epoch_a) :
-source (source_a),
-amount (amount_a),
-epoch (epoch_a)
+    source (source_a),
+    amount (amount_a),
+    epoch (epoch_a)
 {
 }
 
@@ -38,14 +38,14 @@ bool nano::pending_info_v14::operator== (nano::pending_info_v14 const & other_a)
 }
 
 nano::account_info_v14::account_info_v14 (nano::block_hash const & head_a, nano::block_hash const & rep_block_a, nano::block_hash const & open_block_a, nano::amount const & balance_a, uint64_t modified_a, uint64_t block_count_a, uint64_t confirmation_height_a, nano::epoch epoch_a) :
-head (head_a),
-rep_block (rep_block_a),
-open_block (open_block_a),
-balance (balance_a),
-modified (modified_a),
-block_count (block_count_a),
-confirmation_height (confirmation_height_a),
-epoch (epoch_a)
+    head (head_a),
+    rep_block (rep_block_a),
+    open_block (open_block_a),
+    balance (balance_a),
+    modified (modified_a),
+    block_count (block_count_a),
+    confirmation_height (confirmation_height_a),
+    epoch (epoch_a)
 {
 }
 
@@ -62,12 +62,12 @@ size_t nano::account_info_v14::db_size () const
 }
 
 nano::block_sideband_v14::block_sideband_v14 (nano::block_type type_a, nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t height_a, uint64_t timestamp_a) :
-type (type_a),
-successor (successor_a),
-account (account_a),
-balance (balance_a),
-height (height_a),
-timestamp (timestamp_a)
+    type (type_a),
+    successor (successor_a),
+    account (account_a),
+    balance (balance_a),
+    height (height_a),
+    timestamp (timestamp_a)
 {
 }
 
@@ -144,22 +144,22 @@ bool nano::block_sideband_v14::deserialize (nano::stream & stream_a)
 }
 
 nano::block_sideband_v18::block_sideband_v18 (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t height_a, uint64_t timestamp_a, nano::block_details const & details_a) :
-successor (successor_a),
-account (account_a),
-balance (balance_a),
-height (height_a),
-timestamp (timestamp_a),
-details (details_a)
+    successor (successor_a),
+    account (account_a),
+    balance (balance_a),
+    height (height_a),
+    timestamp (timestamp_a),
+    details (details_a)
 {
 }
 
 nano::block_sideband_v18::block_sideband_v18 (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t height_a, uint64_t timestamp_a, nano::epoch epoch_a, bool is_send, bool is_receive, bool is_epoch) :
-successor (successor_a),
-account (account_a),
-balance (balance_a),
-height (height_a),
-timestamp (timestamp_a),
-details (epoch_a, is_send, is_receive, is_epoch)
+    successor (successor_a),
+    account (account_a),
+    balance (balance_a),
+    height (height_a),
+    timestamp (timestamp_a),
+    details (epoch_a, is_send, is_receive, is_epoch)
 {
 }
 

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -95,7 +95,7 @@ class boost_log_cerr_redirect
 {
 public:
 	boost_log_cerr_redirect (std::streambuf * new_buffer) :
-	old (std::cerr.rdbuf (new_buffer))
+	    old (std::cerr.rdbuf (new_buffer))
 	{
 		console_sink = (boost::log::add_console_log (std::cerr, boost::log::keywords::format = "%Message%"));
 	}
@@ -164,7 +164,7 @@ namespace util
 		 * @param required_count_a When increment() reaches this count within the deadline, await_count_for() will return false.
 		 */
 		counted_completion (unsigned required_count_a) :
-		required_count (required_count_a)
+		    required_count (required_count_a)
 		{
 		}
 


### PR DESCRIPTION
As discussed in #3139, this modifies the `clang-format` config to add indentation to initializers for better readability.

It was as easy as changing `.clang-tidy.base` and running `./ci/clang-format-all.sh` with Ubuntu's clang-format-8 package. Reviewing this might be easier by recreating the PR and checking it's the same code.

Edit: not sure why tests are failing, as I haven't changed code at all.