### PR TITLE
Some const correctness, upgrades to c++17, and lint suggestions

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -32,7 +32,7 @@ enum class work_peer_type
 
 class work_peer_connection : public std::enable_shared_from_this<work_peer_connection>
 {
-	const std::string generic_error = "Unable to parse JSON";
+	std::string const generic_error = "Unable to parse JSON";
 
 public:
 	work_peer_connection (asio::io_context & ioc_a, work_peer_type const type_a, nano::work_version const version_a, nano::work_pool & pool_a, std::function<void(bool const)> on_generation_a, std::function<void()> on_cancel_a) :

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 
-
 TEST (processor_service, bad_send_signature)
 {
 	nano::logger_mt logger;

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -79,7 +79,7 @@ TEST (wallets, DISABLED_wallet_create_max)
 	nano::system system (1);
 	bool error (false);
 	nano::wallets wallets (error, *system.nodes[0]);
-	const int nonWalletDbs = 19;
+	int const nonWalletDbs = 19;
 	for (int i = 0; i < system.nodes[0]->config.deprecated_lmdb_max_dbs - nonWalletDbs; i++)
 	{
 		auto wallet_id = nano::random_wallet_id ();

--- a/nano/ipc_flatbuffers_lib/flatbuffer_producer.cpp
+++ b/nano/ipc_flatbuffers_lib/flatbuffer_producer.cpp
@@ -12,7 +12,7 @@ fbb (builder_a)
 
 void nano::ipc::flatbuffer_producer::make_error (int code, std::string const & message)
 {
-	auto msg = fbb->CreateString (message);
+	auto const msg = fbb->CreateString (message);
 	nanoapi::ErrorBuilder builder (*fbb);
 	builder.add_code (code);
 	builder.add_message (msg);

--- a/nano/ipc_flatbuffers_lib/flatbuffer_producer.hpp
+++ b/nano/ipc_flatbuffers_lib/flatbuffer_producer.hpp
@@ -33,8 +33,8 @@ namespace ipc
 		template <typename T>
 		auto make_envelope (flatbuffers::Offset<T> obj)
 		{
-			auto correlation_id_string = fbb->CreateString (correlation_id);
-			auto credentials_string = fbb->CreateString (credentials);
+			auto const correlation_id_string = fbb->CreateString (correlation_id);
+			auto const credentials_string = fbb->CreateString (credentials);
 			nanoapi::EnvelopeBuilder envelope_builder (*fbb);
 			envelope_builder.add_time (std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ());
 			envelope_builder.add_message_type (nanoapi::MessageTraits<T>::enum_value);
@@ -54,7 +54,7 @@ namespace ipc
 		template <typename T>
 		void create_response (flatbuffers::Offset<T> offset)
 		{
-			auto root = make_envelope (offset);
+			auto const root = make_envelope (offset);
 			fbb->Finish (root);
 		}
 
@@ -67,8 +67,8 @@ namespace ipc
 		template <typename T>
 		void create_builder_response (T builder)
 		{
-			auto offset = builder.Finish ();
-			auto root = make_envelope (offset);
+			auto const offset = builder.Finish ();
+			auto const root = make_envelope (offset);
 			fbb->Finish (root);
 		}
 
@@ -77,7 +77,7 @@ namespace ipc
 		/** Set the credentials. This will be added to the envelope. */
 		void set_credentials (std::string const & credentials_a);
 		/** Returns the flatbuffer */
-		std::shared_ptr<flatbuffers::FlatBufferBuilder> get_shared_flatbuffer () const;
+		[[nodiscard]] std::shared_ptr<flatbuffers::FlatBufferBuilder> get_shared_flatbuffer () const;
 
 	private:
 		/** The builder managed by this instance */

--- a/nano/ipc_flatbuffers_lib/flatbuffer_producer.hpp
+++ b/nano/ipc_flatbuffers_lib/flatbuffer_producer.hpp
@@ -77,7 +77,7 @@ namespace ipc
 		/** Set the credentials. This will be added to the envelope. */
 		void set_credentials (std::string const & credentials_a);
 		/** Returns the flatbuffer */
-		[[nodiscard]] std::shared_ptr<flatbuffers::FlatBufferBuilder> get_shared_flatbuffer () const;
+		std::shared_ptr<flatbuffers::FlatBufferBuilder> get_shared_flatbuffer () const;
 
 	private:
 		/** The builder managed by this instance */

--- a/nano/ipc_flatbuffers_test/entry.cpp
+++ b/nano/ipc_flatbuffers_test/entry.cpp
@@ -26,15 +26,15 @@ void read_message_loop (std::shared_ptr<nano::ipc::ipc_client> const & connectio
 			}
 			else
 			{
-				auto envelope (nanoapi::GetEnvelope (buffer->data ()));
+				auto const envelope (nanoapi::GetEnvelope (buffer->data ()));
 				if (envelope->message_type () == nanoapi::Message_EventConfirmation)
 				{
 					std::cout << "Confirmation at " << envelope->time () << std::endl;
-					auto conf (envelope->message_as_EventConfirmation ());
+					auto const conf (envelope->message_as_EventConfirmation ());
 					std::cout << "  Account    : " << conf->account ()->str () << std::endl;
 					std::cout << "  Amount     : " << conf->amount ()->str () << std::endl;
 					std::cout << "  Block type : " << nanoapi::EnumNamesBlock ()[conf->block_type ()] << std::endl;
-					auto state_block = conf->block_as_BlockState ();
+					auto const state_block = conf->block_as_BlockState ();
 					if (state_block)
 					{
 						std::cout << "  Balance    : " << state_block->balance ()->str () << std::endl;
@@ -55,8 +55,8 @@ int main (int argc, char * const * argv)
 	auto connection (std::make_shared<nano::ipc::ipc_client> (io_ctx));
 	// The client only connects to a local live node for now; the test will
 	// be improved later to handle various options, including port and address.
-	std::string ipc_address = "::1";
-	uint16_t ipc_port = 7077;
+	std::string const ipc_address = "::1";
+	uint16_t const ipc_port = 7077;
 	connection->async_connect (ipc_address, ipc_port, [connection](nano::error err) {
 		if (!err)
 		{

--- a/nano/lib/asio.cpp
+++ b/nano/lib/asio.cpp
@@ -29,12 +29,12 @@ m_buffer (boost::asio::buffer (*m_data))
 {
 }
 
-const boost::asio::const_buffer * nano::shared_const_buffer::begin () const
+boost::asio::const_buffer const * nano::shared_const_buffer::begin () const
 {
 	return &m_buffer;
 }
 
-const boost::asio::const_buffer * nano::shared_const_buffer::end () const
+boost::asio::const_buffer const * nano::shared_const_buffer::end () const
 {
 	return &m_buffer + 1;
 }

--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -16,10 +16,10 @@ public:
 	explicit shared_const_buffer (std::vector<uint8_t> && data);
 	explicit shared_const_buffer (std::shared_ptr<std::vector<uint8_t>> const & data);
 
-	const boost::asio::const_buffer * begin () const;
-	const boost::asio::const_buffer * end () const;
+	[[nodiscard]] const boost::asio::const_buffer * begin () const;
+	[[nodiscard]] const boost::asio::const_buffer * end () const;
 
-	size_t size () const;
+	[[nodiscard]] size_t size () const;
 
 private:
 	std::shared_ptr<std::vector<uint8_t>> m_data;

--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -16,10 +16,10 @@ public:
 	explicit shared_const_buffer (std::vector<uint8_t> && data);
 	explicit shared_const_buffer (std::shared_ptr<std::vector<uint8_t>> const & data);
 
-	[[nodiscard]] const boost::asio::const_buffer * begin () const;
-	[[nodiscard]] const boost::asio::const_buffer * end () const;
+	const boost::asio::const_buffer * begin () const;
+	const boost::asio::const_buffer * end () const;
 
-	[[nodiscard]] size_t size () const;
+	size_t size () const;
 
 private:
 	std::shared_ptr<std::vector<uint8_t>> m_data;

--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -16,8 +16,8 @@ public:
 	explicit shared_const_buffer (std::vector<uint8_t> && data);
 	explicit shared_const_buffer (std::shared_ptr<std::vector<uint8_t>> const & data);
 
-	const boost::asio::const_buffer * begin () const;
-	const boost::asio::const_buffer * end () const;
+	boost::asio::const_buffer const * begin () const;
+	boost::asio::const_buffer const * end () const;
 
 	size_t size () const;
 

--- a/nano/lib/blockbuilders.cpp
+++ b/nano/lib/blockbuilders.cpp
@@ -181,11 +181,11 @@ std::error_code check_fields_set (uint8_t block_all_flags, uint8_t build_state)
 	// Figure out which fields are not set. Note that static typing ensures we cannot set values
 	// not applicable to a given block type, we can only forget to set fields. This will be zero
 	// if all fields are set and thus succeed.
-	uint8_t res = block_all_flags ^ build_state;
+	uint8_t const res = block_all_flags ^ build_state;
 	if (res)
 	{
 		// Convert the first bit set to a field mask and look up the error code.
-		auto build_flags_mask = static_cast<uint8_t> (ffs_mask (res));
+		auto const build_flags_mask = static_cast<uint8_t> (ffs_mask (res));
 		debug_assert (ec_map.find (build_flags_mask) != ec_map.end ());
 		ec = ec_map[build_flags_mask];
 	}

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -295,7 +295,7 @@ bool nano::send_block::deserialize (nano::stream & stream_a)
 	}
 	catch (std::exception const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -337,31 +337,35 @@ bool nano::send_block::deserialize_json (boost::property_tree::ptree const & tre
 		auto const work_l (tree_a.get<std::string> ("work"));
 		auto const signature_l (tree_a.get<std::string> ("signature"));
 		auto error = hashables.previous.decode_hex (previous_l);
-		if (error) {
-		    return true;
+		if (error)
+		{
+			return true;
 		}
 
-        error = hashables.destination.decode_account (destination_l);
-		if (error) {
-		    return true;
-        }
+		error = hashables.destination.decode_account (destination_l);
+		if (error)
+		{
+			return true;
+		}
 
-        error = hashables.balance.decode_hex (balance_l);
-        if (error) {
-            return true;
-        }
+		error = hashables.balance.decode_hex (balance_l);
+		if (error)
+		{
+			return true;
+		}
 
-        error = nano::from_string_hex (work_l, work);
-        if (error) {
-            return true;
-        }
+		error = nano::from_string_hex (work_l, work);
+		if (error)
+		{
+			return true;
+		}
 
-        error = signature.decode_hex (signature_l);
-        if
+		error = signature.decode_hex (signature_l);
+		if
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -426,9 +430,9 @@ bool nano::send_block::valid_predecessor (nano::block const & block_a) const
 		case nano::block_type::receive:
 		case nano::block_type::open:
 		case nano::block_type::change:
-		    return true;
+			return true;
 		default:
-		    return false;
+			return false;
 	}
 }
 
@@ -625,7 +629,7 @@ bool nano::open_block::deserialize (nano::stream & stream_a)
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -665,32 +669,32 @@ bool nano::open_block::deserialize_json (boost::property_tree::ptree const & tre
 		auto error = hashables.source.decode_hex (source_l);
 		if (error)
 		{
-		    return true;
-        }
+			return true;
+		}
 
-        error = hashables.representative.decode_hex (representative_l);
-        if (error)
-        {
-            return true;
-        }
+		error = hashables.representative.decode_hex (representative_l);
+		if (error)
+		{
+			return true;
+		}
 
-        error = hashables.account.decode_hex (account_l);
-        if (error)
-        {
-            return true;
-        }
+		error = hashables.account.decode_hex (account_l);
+		if (error)
+		{
+			return true;
+		}
 
-        error = nano::from_string_hex (work_l, work);
-        if (error)
-        {
-            return true;
-        }
+		error = nano::from_string_hex (work_l, work);
+		if (error)
+		{
+			return true;
+		}
 
-        error = signature.decode_hex (signature_l);
+		error = signature.decode_hex (signature_l);
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -879,7 +883,7 @@ bool nano::change_block::deserialize (nano::stream & stream_a)
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -915,26 +919,28 @@ bool nano::change_block::deserialize_json (boost::property_tree::ptree const & t
 		auto const work_l (tree_a.get<std::string> ("work"));
 		auto const signature_l (tree_a.get<std::string> ("signature"));
 		auto error = hashables.previous.decode_hex (previous_l);
-		if (error) {
-		    return true;
-        }
+		if (error)
+		{
+			return true;
+		}
 
-        error = hashables.representative.decode_hex (representative_l);
-        if (error) {
-            return true;
-        }
+		error = hashables.representative.decode_hex (representative_l);
+		if (error)
+		{
+			return true;
+		}
 
-        error = nano::from_string_hex (work_l, work);
-        if (error)
-        {
-            return true;
-        }
+		error = nano::from_string_hex (work_l, work);
+		if (error)
+		{
+			return true;
+		}
 
-        error = signature.decode_hex (signature_l);
-    }
-    catch (std::runtime_error const &)
+		error = signature.decode_hex (signature_l);
+	}
+	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -973,9 +979,9 @@ bool nano::change_block::valid_predecessor (nano::block const & block_a) const
 		case nano::block_type::receive:
 		case nano::block_type::open:
 		case nano::block_type::change:
-		    return true;
+			return true;
 		default:
-		    return false;
+			return false;
 	}
 }
 

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -694,6 +694,10 @@ bool nano::open_block::deserialize_json (boost::property_tree::ptree const & tre
 		}
 
 		error = signature.decode_hex (signature_l);
+		if (error)
+		{
+			return true;
+		}
 	}
 	catch (std::runtime_error const &)
 	{
@@ -940,6 +944,10 @@ bool nano::change_block::deserialize_json (boost::property_tree::ptree const & t
 		}
 
 		error = signature.decode_hex (signature_l);
+		if (error)
+		{
+			return true;
+		}
 	}
 	catch (std::runtime_error const &)
 	{
@@ -1167,7 +1175,6 @@ void nano::state_block::serialize (nano::stream & stream_a) const
 
 bool nano::state_block::deserialize (nano::stream & stream_a)
 {
-	auto error (false);
 	try
 	{
 		read (stream_a, hashables.account);
@@ -1181,10 +1188,10 @@ bool nano::state_block::deserialize (nano::stream & stream_a)
 	}
 	catch (std::runtime_error const &)
 	{
-		error = true;
+		return true;
 	}
 
-	return error;
+	return false;
 }
 
 void nano::state_block::serialize_json (std::string & string_a, bool single_line) const
@@ -1213,48 +1220,64 @@ void nano::state_block::serialize_json (boost::property_tree::ptree & tree) cons
 
 bool nano::state_block::deserialize_json (boost::property_tree::ptree const & tree_a)
 {
-	auto error (false);
 	try
 	{
 		debug_assert (tree_a.get<std::string> ("type") == "state");
-		auto account_l (tree_a.get<std::string> ("account"));
-		auto previous_l (tree_a.get<std::string> ("previous"));
-		auto representative_l (tree_a.get<std::string> ("representative"));
-		auto balance_l (tree_a.get<std::string> ("balance"));
-		auto link_l (tree_a.get<std::string> ("link"));
-		auto work_l (tree_a.get<std::string> ("work"));
-		auto signature_l (tree_a.get<std::string> ("signature"));
-		error = hashables.account.decode_account (account_l);
-		if (!error)
+		auto const account_l (tree_a.get<std::string> ("account"));
+		auto const previous_l (tree_a.get<std::string> ("previous"));
+		auto const representative_l (tree_a.get<std::string> ("representative"));
+		auto const balance_l (tree_a.get<std::string> ("balance"));
+		auto const link_l (tree_a.get<std::string> ("link"));
+		auto const work_l (tree_a.get<std::string> ("work"));
+		auto const signature_l (tree_a.get<std::string> ("signature"));
+		auto error = hashables.account.decode_account (account_l);
+		if (error)
 		{
-			error = hashables.previous.decode_hex (previous_l);
-			if (!error)
-			{
-				error = hashables.representative.decode_account (representative_l);
-				if (!error)
-				{
-					error = hashables.balance.decode_dec (balance_l);
-					if (!error)
-					{
-						error = hashables.link.decode_account (link_l) && hashables.link.decode_hex (link_l);
-						if (!error)
-						{
-							error = nano::from_string_hex (work_l, work);
-							if (!error)
-							{
-								error = signature.decode_hex (signature_l);
-							}
-						}
-					}
-				}
-			}
+			return true;
+		}
+
+		error = hashables.previous.decode_hex (previous_l);
+		if (error)
+		{
+			return true;
+		}
+
+		error = hashables.representative.decode_account (representative_l);
+		if (error)
+		{
+			return true;
+		}
+
+		error = hashables.balance.decode_dec (balance_l);
+		if (error)
+		{
+			return true;
+		}
+
+		error = hashables.link.decode_account (link_l) && hashables.link.decode_hex (link_l);
+		if (error)
+		{
+			return true;
+		}
+
+		error = nano::from_string_hex (work_l, work);
+		if (error)
+		{
+			return true;
+		}
+
+		error = signature.decode_hex (signature_l);
+		if (error)
+		{
+			return true;
 		}
 	}
 	catch (std::runtime_error const &)
 	{
-		error = true;
+		return true;
 	}
-	return error;
+
+	return false;
 }
 
 void nano::state_block::visit (nano::block_visitor & visitor_a) const
@@ -1449,7 +1472,6 @@ void nano::receive_block::serialize (nano::stream & stream_a) const
 
 bool nano::receive_block::deserialize (nano::stream & stream_a)
 {
-	auto error (false);
 	try
 	{
 		read (stream_a, hashables.previous.bytes);
@@ -1459,10 +1481,10 @@ bool nano::receive_block::deserialize (nano::stream & stream_a)
 	}
 	catch (std::runtime_error const &)
 	{
-		error = true;
+		return true;
 	}
 
-	return error;
+	return false;
 }
 
 void nano::receive_block::serialize_json (std::string & string_a, bool single_line) const
@@ -1491,33 +1513,43 @@ void nano::receive_block::serialize_json (boost::property_tree::ptree & tree) co
 
 bool nano::receive_block::deserialize_json (boost::property_tree::ptree const & tree_a)
 {
-	auto error (false);
 	try
 	{
 		debug_assert (tree_a.get<std::string> ("type") == "receive");
-		auto previous_l (tree_a.get<std::string> ("previous"));
-		auto source_l (tree_a.get<std::string> ("source"));
-		auto work_l (tree_a.get<std::string> ("work"));
-		auto signature_l (tree_a.get<std::string> ("signature"));
-		error = hashables.previous.decode_hex (previous_l);
-		if (!error)
+		auto const previous_l (tree_a.get<std::string> ("previous"));
+		auto const source_l (tree_a.get<std::string> ("source"));
+		auto const work_l (tree_a.get<std::string> ("work"));
+		auto const signature_l (tree_a.get<std::string> ("signature"));
+		auto error = hashables.previous.decode_hex (previous_l);
+		if (error)
 		{
-			error = hashables.source.decode_hex (source_l);
-			if (!error)
-			{
-				error = nano::from_string_hex (work_l, work);
-				if (!error)
-				{
-					error = signature.decode_hex (signature_l);
-				}
-			}
+			return true;
+		}
+
+		error = hashables.source.decode_hex (source_l);
+		if (error)
+		{
+			return true;
+		}
+
+		error = nano::from_string_hex (work_l, work);
+		if (error)
+		{
+			return true;
+		}
+
+		error = signature.decode_hex (signature_l);
+		if (error)
+		{
+			return true;
 		}
 	}
 	catch (std::runtime_error const &)
 	{
-		error = true;
+		return true;
 	}
-	return error;
+
+	return false;
 }
 
 nano::receive_block::receive_block (nano::block_hash const & previous_a, nano::block_hash const & source_a, nano::raw_key const & prv_a, nano::public_key const & pub_a, uint64_t work_a) :

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -357,6 +357,7 @@ bool nano::send_block::deserialize_json (boost::property_tree::ptree const & tre
         }
 
         error = signature.decode_hex (signature_l);
+        if
 	}
 	catch (std::runtime_error const &)
 	{

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -361,7 +361,10 @@ bool nano::send_block::deserialize_json (boost::property_tree::ptree const & tre
 		}
 
 		error = signature.decode_hex (signature_l);
-		if
+		if (error)
+		{
+			return true;
+		}
 	}
 	catch (std::runtime_error const &)
 	{

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -48,7 +48,7 @@ public:
 	bool is_epoch{ false };
 
 private:
-	[[nodiscard]] uint8_t packed () const;
+	uint8_t packed () const;
 	void unpack (uint8_t);
 };
 

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -34,7 +34,7 @@ class block_details
 
 public:
 	block_details () = default;
-	block_details (nano::epoch const epoch_a, bool const is_send_a, bool const is_receive_a, bool const is_epoch_a);
+	block_details (nano::epoch epoch_a, bool is_send_a, bool is_receive_a, bool is_epoch_a);
 	static constexpr size_t size ()
 	{
 		return 1;
@@ -48,18 +48,18 @@ public:
 	bool is_epoch{ false };
 
 private:
-	uint8_t packed () const;
+	[[nodiscard]] uint8_t packed () const;
 	void unpack (uint8_t);
 };
 
-std::string state_subtype (nano::block_details const);
+std::string state_subtype (nano::block_details);
 
 class block_sideband final
 {
 public:
 	block_sideband () = default;
-	block_sideband (nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t const, uint64_t const, nano::block_details const &, nano::epoch const source_epoch_a);
-	block_sideband (nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t const, uint64_t const, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a);
+	block_sideband (nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t, uint64_t, nano::block_details const &, nano::epoch source_epoch_a);
+	block_sideband (nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t, uint64_t, nano::epoch epoch_a, bool is_send, bool is_receive, bool is_epoch, nano::epoch source_epoch_a);
 	void serialize (nano::stream &, nano::block_type) const;
 	bool deserialize (nano::stream &, nano::block_type);
 	static size_t size (nano::block_type);

--- a/nano/lib/cli.cpp
+++ b/nano/lib/cli.cpp
@@ -8,8 +8,8 @@
 std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a)
 {
 	std::vector<std::string> overrides;
-	auto const format (boost::format ("%1%=%2%"));
-	auto const format_add_escaped_quotes (boost::format ("%1%=\"%2%\""));
+	auto format (boost::format ("%1%=%2%"));
+	auto format_add_escaped_quotes (boost::format ("%1%=\"%2%\""));
 	for (auto const & pair : key_value_pairs_a)
 	{
 		auto const start = pair.value.find ('[');
@@ -26,8 +26,8 @@ std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pa
 			std::vector<std::string> split_elements;
 			boost::split (split_elements, array_values, boost::is_any_of (","));
 
-			auto const format (boost::format ("%1%"));
-			auto const format_add_escaped_quotes (boost::format ("\"%1%\""));
+			auto format (boost::format ("%1%"));
+			auto format_add_escaped_quotes (boost::format ("\"%1%\""));
 
 			// Rebuild the array string adding escaped quotes if necessary
 			std::ostringstream ss;
@@ -35,7 +35,7 @@ std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pa
 			for (auto i = 0; i < split_elements.size (); ++i)
 			{
 				auto & elem = split_elements[i];
-				auto const already_escaped = elem.find ('\"') != std::string::npos;
+				auto already_escaped = elem.find ('\"') != std::string::npos;
 				ss << ((!already_escaped ? format_add_escaped_quotes : format) % elem).str ();
 				if (i != split_elements.size () - 1)
 				{
@@ -49,7 +49,7 @@ std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pa
 		{
 			value = pair.value;
 		}
-		auto const already_escaped = value.find ('\"') != std::string::npos;
+		auto already_escaped = value.find ('\"') != std::string::npos;
 		overrides.push_back (((!already_escaped ? format_add_escaped_quotes : format) % pair.key % value).str ());
 	}
 	return overrides;

--- a/nano/lib/cli.cpp
+++ b/nano/lib/cli.cpp
@@ -8,26 +8,26 @@
 std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pair> const & key_value_pairs_a)
 {
 	std::vector<std::string> overrides;
-	auto format (boost::format ("%1%=%2%"));
-	auto format_add_escaped_quotes (boost::format ("%1%=\"%2%\""));
-	for (auto pair : key_value_pairs_a)
+	auto const format (boost::format ("%1%=%2%"));
+	auto const format_add_escaped_quotes (boost::format ("%1%=\"%2%\""));
+	for (auto const & pair : key_value_pairs_a)
 	{
-		auto start = pair.value.find ('[');
+		auto const start = pair.value.find ('[');
 
 		std::string value;
-		auto is_array = (start != std::string::npos);
+		auto const is_array = (start != std::string::npos);
 		if (is_array)
 		{
 			// Trim off the square brackets [] of the array
-			auto end = pair.value.find (']');
-			auto array_values = pair.value.substr (start + 1, end - start - 1);
+			auto const end = pair.value.find (']');
+			auto const array_values = pair.value.substr (start + 1, end - start - 1);
 
 			// Split the string by comma
 			std::vector<std::string> split_elements;
 			boost::split (split_elements, array_values, boost::is_any_of (","));
 
-			auto format (boost::format ("%1%"));
-			auto format_add_escaped_quotes (boost::format ("\"%1%\""));
+			auto const format (boost::format ("%1%"));
+			auto const format_add_escaped_quotes (boost::format ("\"%1%\""));
 
 			// Rebuild the array string adding escaped quotes if necessary
 			std::ostringstream ss;
@@ -35,7 +35,7 @@ std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pa
 			for (auto i = 0; i < split_elements.size (); ++i)
 			{
 				auto & elem = split_elements[i];
-				auto already_escaped = elem.find ('\"') != std::string::npos;
+				auto const already_escaped = elem.find ('\"') != std::string::npos;
 				ss << ((!already_escaped ? format_add_escaped_quotes : format) % elem).str ();
 				if (i != split_elements.size () - 1)
 				{
@@ -49,7 +49,7 @@ std::vector<std::string> nano::config_overrides (std::vector<config_key_value_pa
 		{
 			value = pair.value;
 		}
-		auto already_escaped = value.find ('\"') != std::string::npos;
+		auto const already_escaped = value.find ('\"') != std::string::npos;
 		overrides.push_back (((!already_escaped ? format_add_escaped_quotes : format) % pair.key % value).str ());
 	}
 	return overrides;

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -50,7 +50,7 @@ get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x hi
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
 );
 
-const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
+char const * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
 uint8_t get_major_node_version ()
 {

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -9,7 +9,7 @@
 
 namespace boost::filesystem
 {
-	class path;
+class path;
 }
 
 #define xstr(a) ver_str (a)

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -144,7 +144,7 @@ public:
 	unsigned request_interval_ms;
 
 	/** Returns the network this object contains values for */
-	[[nodiscard]] nano_networks network () const
+	nano_networks network () const
 	{
 		return current_network;
 	}
@@ -190,24 +190,24 @@ public:
 		return false;
 	}
 
-	[[nodiscard]] const char * get_current_network_as_string () const
+	const char * get_current_network_as_string () const
 	{
 		return is_live_network () ? "live" : is_beta_network () ? "beta" : is_test_network () ? "test" : "dev";
 	}
 
-	[[nodiscard]] bool is_live_network () const
+	bool is_live_network () const
 	{
 		return current_network == nano_networks::nano_live_network;
 	}
-	[[nodiscard]] bool is_beta_network () const
+	bool is_beta_network () const
 	{
 		return current_network == nano_networks::nano_beta_network;
 	}
-	[[nodiscard]] bool is_dev_network () const
+	bool is_dev_network () const
 	{
 		return current_network == nano_networks::nano_dev_network;
 	}
-	[[nodiscard]] bool is_test_network () const
+	bool is_test_network () const
 	{
 		return current_network == nano_networks::nano_test_network;
 	}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -7,12 +7,9 @@
 #include <array>
 #include <string>
 
-namespace boost
-{
-namespace filesystem
+namespace boost::filesystem
 {
 	class path;
-}
 }
 
 #define xstr(a) ver_str (a)
@@ -50,8 +47,8 @@ uint8_t get_minor_node_version ();
 uint8_t get_patch_node_version ();
 uint8_t get_pre_release_node_version ();
 
-std::string get_env_or_default (char const * variable_name, std::string const default_value);
-uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t const default_value);
+std::string get_env_or_default (char const * variable_name, std::string default_value);
+uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t default_value);
 
 uint16_t test_node_port ();
 uint16_t test_rpc_port ();
@@ -112,7 +109,7 @@ public:
 	{
 	}
 
-	network_constants (nano_networks network_a) :
+	explicit network_constants (nano_networks network_a) :
 	current_network (network_a),
 	publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : is_test_network () ? publish_test : publish_dev)
 	{
@@ -147,7 +144,7 @@ public:
 	unsigned request_interval_ms;
 
 	/** Returns the network this object contains values for */
-	nano_networks network () const
+	[[nodiscard]] nano_networks network () const
 	{
 		return current_network;
 	}
@@ -167,9 +164,8 @@ public:
 	 * If not called, the compile-time option will be used.
 	 * @param network_a The new active network. Valid values are "live", "beta" and "dev"
 	 */
-	static bool set_active_network (std::string network_a)
+	static bool set_active_network (std::string const & network_a)
 	{
-		auto error{ false };
 		if (network_a == "live")
 		{
 			active_network = nano::nano_networks::nano_live_network;
@@ -188,29 +184,30 @@ public:
 		}
 		else
 		{
-			error = true;
+			return true;
 		}
-		return error;
+
+		return false;
 	}
 
-	const char * get_current_network_as_string () const
+	[[nodiscard]] const char * get_current_network_as_string () const
 	{
 		return is_live_network () ? "live" : is_beta_network () ? "beta" : is_test_network () ? "test" : "dev";
 	}
 
-	bool is_live_network () const
+	[[nodiscard]] bool is_live_network () const
 	{
 		return current_network == nano_networks::nano_live_network;
 	}
-	bool is_beta_network () const
+	[[nodiscard]] bool is_beta_network () const
 	{
 		return current_network == nano_networks::nano_beta_network;
 	}
-	bool is_dev_network () const
+	[[nodiscard]] bool is_dev_network () const
 	{
 		return current_network == nano_networks::nano_dev_network;
 	}
-	bool is_test_network () const
+	[[nodiscard]] bool is_test_network () const
 	{
 		return current_network == nano_networks::nano_test_network;
 	}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -18,26 +18,26 @@ class path;
 /**
 * Returns build version information
 */
-const char * const NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
-const char * const NANO_MAJOR_VERSION_STRING = xstr (MAJOR_VERSION_STRING);
-const char * const NANO_MINOR_VERSION_STRING = xstr (MINOR_VERSION_STRING);
-const char * const NANO_PATCH_VERSION_STRING = xstr (PATCH_VERSION_STRING);
-const char * const NANO_PRE_RELEASE_VERSION_STRING = xstr (PRE_RELEASE_VERSION_STRING);
+char const * const NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
+char const * const NANO_MAJOR_VERSION_STRING = xstr (MAJOR_VERSION_STRING);
+char const * const NANO_MINOR_VERSION_STRING = xstr (MINOR_VERSION_STRING);
+char const * const NANO_PATCH_VERSION_STRING = xstr (PATCH_VERSION_STRING);
+char const * const NANO_PRE_RELEASE_VERSION_STRING = xstr (PRE_RELEASE_VERSION_STRING);
 
-const char * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
+char const * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
 
 /** Is TSAN/ASAN dev build */
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
-const bool is_sanitizer_build = true;
+bool const is_sanitizer_build = true;
 #else
-const bool is_sanitizer_build = false;
+bool const is_sanitizer_build = false;
 #endif
 // GCC builds
 #elif defined(__SANITIZE_THREAD__) || defined(__SANITIZE_ADDRESS__)
-const bool is_sanitizer_build = true;
+bool const is_sanitizer_build = true;
 #else
-const bool is_sanitizer_build = false;
+bool const is_sanitizer_build = false;
 #endif
 
 namespace nano

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -190,7 +190,7 @@ public:
 		return false;
 	}
 
-	const char * get_current_network_as_string () const
+	char const * get_current_network_as_string () const
 	{
 		return is_live_network () ? "live" : is_beta_network () ? "beta" : is_test_network () ? "test" : "dev";
 	}

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -278,7 +278,7 @@ std::string nano::error_config_messages::message (int ev) const
 	return "Invalid error code";
 }
 
-const char * nano::error_conversion::detail::generic_category::name () const noexcept
+char const * nano::error_conversion::detail::generic_category::name () const noexcept
 {
 	return boost::system::generic_category ().name ();
 }

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -287,7 +287,7 @@ std::string nano::error_conversion::detail::generic_category::message (int value
 	return boost::system::generic_category ().message (value);
 }
 
-const std::error_category & nano::error_conversion::generic_category ()
+std::error_category const & nano::error_conversion::generic_category ()
 {
 	static detail::generic_category instance;
 	return instance;

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -196,12 +196,9 @@ REGISTER_ERROR_CODES (nano, error_process);
 REGISTER_ERROR_CODES (nano, error_config);
 
 /* boost->std error_code bridge */
-namespace nano
-{
-namespace error_conversion
+namespace nano::error_conversion
 {
 	const std::error_category & generic_category ();
-}
 }
 
 namespace std
@@ -214,22 +211,19 @@ struct is_error_code_enum<boost::system::errc::errc_t>
 
 std::error_code make_error_code (boost::system::errc::errc_t const & e);
 }
-namespace nano
-{
-namespace error_conversion
+namespace nano::error_conversion
 {
 	namespace detail
 	{
 		class generic_category : public std::error_category
 		{
 		public:
-			const char * name () const noexcept override;
-			std::string message (int value) const override;
+			[[nodiscard]] const char * name () const noexcept override;
+			[[nodiscard]] std::string message (int value) const override;
 		};
 	}
 	const std::error_category & generic_category ();
 	std::error_code convert (const boost::system::error_code & error);
-}
 }
 
 namespace nano
@@ -242,19 +236,19 @@ public:
 	error (nano::error const & error_a) = default;
 	error (nano::error && error_a) = default;
 
-	error (std::error_code code_a);
-	error (boost::system::error_code const & code_a);
-	error (std::string message_a);
-	error (std::exception const & exception_a);
+	explicit error (std::error_code code_a);
+	explicit error (boost::system::error_code const & code_a);
+	explicit error (std::string message_a);
+	explicit error (std::exception const & exception_a);
 	error & operator= (nano::error const & err_a);
 	error & operator= (nano::error && err_a);
-	error & operator= (const std::error_code code_a);
+	error & operator= (std::error_code code_a);
 	error & operator= (const boost::system::error_code & code_a);
 	error & operator= (const boost::system::errc::errc_t & code_a);
-	error & operator= (const std::string message_a);
+	error & operator= (std::string message_a);
 	error & operator= (std::exception const & exception_a);
-	bool operator== (const std::error_code code_a) const;
-	bool operator== (const boost::system::error_code code_a) const;
+	bool operator== (std::error_code code_a) const;
+	bool operator== (boost::system::error_code code_a) const;
 	error & then (std::function<nano::error &()> next);
 	template <typename... ErrorCode>
 	error & accept (ErrorCode... err)
@@ -272,12 +266,12 @@ public:
 	explicit operator std::error_code () const;
 	explicit operator bool () const;
 	explicit operator std::string () const;
-	std::string get_message () const;
+	[[nodiscard]] std::string get_message () const;
 	/**
 	 * The error code as an integer. Note that some error codes have platform dependent values.
 	 * A return value of 0 signifies there is no error.
 	 */
-	int error_code_as_int () const;
+	[[nodiscard]] int error_code_as_int () const;
 	error & on_error (std::string message_a);
 	error & on_error (std::error_code code_a, std::string message_a);
 	error & set (std::string message_a, std::error_code code_a = nano::error_common::generic);

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -218,8 +218,8 @@ namespace detail
 	class generic_category : public std::error_category
 	{
 	public:
-		[[nodiscard]] const char * name () const noexcept override;
-		[[nodiscard]] std::string message (int value) const override;
+		const char * name () const noexcept override;
+		std::string message (int value) const override;
 	};
 }
 const std::error_category & generic_category ();
@@ -266,12 +266,12 @@ public:
 	explicit operator std::error_code () const;
 	explicit operator bool () const;
 	explicit operator std::string () const;
-	[[nodiscard]] std::string get_message () const;
+	std::string get_message () const;
 	/**
 	 * The error code as an integer. Note that some error codes have platform dependent values.
 	 * A return value of 0 signifies there is no error.
 	 */
-	[[nodiscard]] int error_code_as_int () const;
+	int error_code_as_int () const;
 	error & on_error (std::string message_a);
 	error & on_error (std::error_code code_a, std::string message_a);
 	error & set (std::string message_a, std::error_code code_a = nano::error_common::generic);

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -198,7 +198,7 @@ REGISTER_ERROR_CODES (nano, error_config);
 /* boost->std error_code bridge */
 namespace nano::error_conversion
 {
-const std::error_category & generic_category ();
+std::error_category const & generic_category ();
 }
 
 namespace std
@@ -218,11 +218,11 @@ namespace detail
 	class generic_category : public std::error_category
 	{
 	public:
-		const char * name () const noexcept override;
+		char const * name () const noexcept override;
 		std::string message (int value) const override;
 	};
 }
-const std::error_category & generic_category ();
+std::error_category const & generic_category ();
 std::error_code convert (const boost::system::error_code & error);
 }
 

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -198,7 +198,7 @@ REGISTER_ERROR_CODES (nano, error_config);
 /* boost->std error_code bridge */
 namespace nano::error_conversion
 {
-	const std::error_category & generic_category ();
+const std::error_category & generic_category ();
 }
 
 namespace std
@@ -213,17 +213,17 @@ std::error_code make_error_code (boost::system::errc::errc_t const & e);
 }
 namespace nano::error_conversion
 {
-	namespace detail
+namespace detail
+{
+	class generic_category : public std::error_category
 	{
-		class generic_category : public std::error_category
-		{
-		public:
-			[[nodiscard]] const char * name () const noexcept override;
-			[[nodiscard]] std::string message (int value) const override;
-		};
-	}
-	const std::error_category & generic_category ();
-	std::error_code convert (const boost::system::error_code & error);
+	public:
+		[[nodiscard]] const char * name () const noexcept override;
+		[[nodiscard]] std::string message (int value) const override;
+	};
+}
+const std::error_category & generic_category ();
+std::error_code convert (const boost::system::error_code & error);
 }
 
 namespace nano

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -162,7 +162,7 @@ enum class error_config
 		class enum_type##_messages : public std::error_category                                                \
 		{                                                                                                      \
 		public:                                                                                                \
-			const char * name () const noexcept override                                                       \
+			char const * name () const noexcept override                                                       \
 			{                                                                                                  \
 				return #enum_type;                                                                             \
 			}                                                                                                  \

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -7,10 +7,10 @@
 namespace nano::ipc
 {
 /**
-	 * The IPC framing format is simple: preamble followed by an encoding specific payload.
-	 * Preamble is uint8_t {'N', encoding_type, reserved, reserved}. Reserved bytes MUST be zero.
-	 * @note This is intentionally not an enum class as the values are only used as vector indices.
-	 */
+ * The IPC framing format is simple: preamble followed by an encoding specific payload.
+ * Preamble is uint8_t {'N', encoding_type, reserved, reserved}. Reserved bytes MUST be zero.
+ * @note This is intentionally not an enum class as the values are only used as vector indices.
+ */
 enum preamble_offset
 {
 	/** Always 'N' */
@@ -34,9 +34,9 @@ public:
 	virtual void close () = 0;
 
 	/**
-		 * Start IO timer.
-		 * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
-		 */
+     * Start IO timer.
+     * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
+     */
 	void timer_start (std::chrono::seconds timeout_a);
 	void timer_expired ();
 	void timer_cancel ();
@@ -47,24 +47,24 @@ private:
 };
 
 /**
-	 * Payload encodings.
-	 */
+ * Payload encodings.
+ */
 enum class payload_encoding : uint8_t
 {
 	/**
-		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
-		 * Response is 32-bit BE payload length followed by payload bytes.
-		 */
+     * Request is preamble followed by 32-bit BE payload length and payload bytes.
+     * Response is 32-bit BE payload length followed by payload bytes.
+     */
 	json_v1 = 0x1,
 
 	/** Request/response is same as json_v1, but exposes unsafe RPC's */
 	json_v1_unsafe = 0x2,
 
 	/**
-		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
-		 * Response is 32-bit BE payload length followed by payload bytes.
-		 * Payloads must be flatbuffer encoded.
-		 */
+     * Request is preamble followed by 32-bit BE payload length and payload bytes.
+     * Response is 32-bit BE payload length followed by payload bytes.
+     * Payloads must be flatbuffer encoded.
+     */
 	flatbuffers = 0x3,
 
 	/** JSON -> Flatbuffers -> JSON  */

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -34,9 +34,9 @@ public:
 	virtual void close () = 0;
 
 	/**
-     * Start IO timer.
-     * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
-     */
+	 * Start IO timer.
+	 * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
+	 */
 	void timer_start (std::chrono::seconds timeout_a);
 	void timer_expired ();
 	void timer_cancel ();
@@ -52,19 +52,19 @@ private:
 enum class payload_encoding : uint8_t
 {
 	/**
-     * Request is preamble followed by 32-bit BE payload length and payload bytes.
-     * Response is 32-bit BE payload length followed by payload bytes.
-     */
+	 * Request is preamble followed by 32-bit BE payload length and payload bytes.
+	 * Response is 32-bit BE payload length followed by payload bytes.
+	 */
 	json_v1 = 0x1,
 
 	/** Request/response is same as json_v1, but exposes unsafe RPC's */
 	json_v1_unsafe = 0x2,
 
 	/**
-     * Request is preamble followed by 32-bit BE payload length and payload bytes.
-     * Response is 32-bit BE payload length followed by payload bytes.
-     * Payloads must be flatbuffer encoded.
-     */
+	 * Request is preamble followed by 32-bit BE payload length and payload bytes.
+	 * Response is 32-bit BE payload length followed by payload bytes.
+	 * Payloads must be flatbuffer encoded.
+	 */
 	flatbuffers = 0x3,
 
 	/** JSON -> Flatbuffers -> JSON  */

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -4,9 +4,7 @@
 
 #include <string>
 
-namespace nano
-{
-namespace ipc
+namespace nano::ipc
 {
 	/**
 	 * The IPC framing format is simple: preamble followed by an encoding specific payload.
@@ -29,7 +27,7 @@ namespace ipc
 	class socket_base
 	{
 	public:
-		socket_base (boost::asio::io_context & io_ctx_a);
+		explicit socket_base (boost::asio::io_context & io_ctx_a);
 		virtual ~socket_base () = default;
 
 		/** Close socket */
@@ -85,11 +83,10 @@ namespace ipc
 	class dsock_file_remover final
 	{
 	public:
-		dsock_file_remover (std::string const & file_a);
+		explicit dsock_file_remover (std::string const & file_a);
 		~dsock_file_remover ();
 
 	private:
 		std::string filename;
 	};
-}
 }

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -6,87 +6,87 @@
 
 namespace nano::ipc
 {
-	/**
+/**
 	 * The IPC framing format is simple: preamble followed by an encoding specific payload.
 	 * Preamble is uint8_t {'N', encoding_type, reserved, reserved}. Reserved bytes MUST be zero.
 	 * @note This is intentionally not an enum class as the values are only used as vector indices.
 	 */
-	enum preamble_offset
-	{
-		/** Always 'N' */
-		lead = 0,
-		/** One of the payload_encoding values */
-		encoding = 1,
-		/** Always zero */
-		reserved_1 = 2,
-		/** Always zero */
-		reserved_2 = 3,
-	};
+enum preamble_offset
+{
+	/** Always 'N' */
+	lead = 0,
+	/** One of the payload_encoding values */
+	encoding = 1,
+	/** Always zero */
+	reserved_1 = 2,
+	/** Always zero */
+	reserved_2 = 3,
+};
 
-	/** Abstract base type for sockets, implementing timer logic and a close operation */
-	class socket_base
-	{
-	public:
-		explicit socket_base (boost::asio::io_context & io_ctx_a);
-		virtual ~socket_base () = default;
+/** Abstract base type for sockets, implementing timer logic and a close operation */
+class socket_base
+{
+public:
+	explicit socket_base (boost::asio::io_context & io_ctx_a);
+	virtual ~socket_base () = default;
 
-		/** Close socket */
-		virtual void close () = 0;
+	/** Close socket */
+	virtual void close () = 0;
 
-		/**
+	/**
 		 * Start IO timer.
 		 * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
 		 */
-		void timer_start (std::chrono::seconds timeout_a);
-		void timer_expired ();
-		void timer_cancel ();
+	void timer_start (std::chrono::seconds timeout_a);
+	void timer_expired ();
+	void timer_cancel ();
 
-	private:
-		/** IO operation timer */
-		boost::asio::deadline_timer io_timer;
-	};
+private:
+	/** IO operation timer */
+	boost::asio::deadline_timer io_timer;
+};
 
-	/**
+/**
 	 * Payload encodings.
 	 */
-	enum class payload_encoding : uint8_t
-	{
-		/**
+enum class payload_encoding : uint8_t
+{
+	/**
 		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
 		 * Response is 32-bit BE payload length followed by payload bytes.
 		 */
-		json_v1 = 0x1,
+	json_v1 = 0x1,
 
-		/** Request/response is same as json_v1, but exposes unsafe RPC's */
-		json_v1_unsafe = 0x2,
+	/** Request/response is same as json_v1, but exposes unsafe RPC's */
+	json_v1_unsafe = 0x2,
 
-		/**
+	/**
 		 * Request is preamble followed by 32-bit BE payload length and payload bytes.
 		 * Response is 32-bit BE payload length followed by payload bytes.
 		 * Payloads must be flatbuffer encoded.
 		 */
-		flatbuffers = 0x3,
+	flatbuffers = 0x3,
 
-		/** JSON -> Flatbuffers -> JSON  */
-		flatbuffers_json = 0x4
-	};
+	/** JSON -> Flatbuffers -> JSON  */
+	flatbuffers_json = 0x4
+};
 
-	/** IPC transport interface */
-	class transport
-	{
-	public:
-		virtual void stop () = 0;
-		virtual ~transport () = default;
-	};
+/** IPC transport interface */
+class transport
+{
+public:
+	virtual void stop () = 0;
+	virtual ~transport () = default;
+};
 
-	/** The domain socket file is attempted to be removed at both startup and shutdown. */
-	class dsock_file_remover final
-	{
-	public:
-		explicit dsock_file_remover (std::string const & file_a);
-		~dsock_file_remover ();
+/** The domain socket file is attempted to be removed at both startup and shutdown. */
+class dsock_file_remover final
+{
+public:
+	explicit dsock_file_remover (std::string const & file_a);
+	~dsock_file_remover ();
 
-	private:
-		std::string filename;
-	};
+private:
+	std::string filename;
+};
 }

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -91,7 +91,7 @@ public:
 	}
 
 #if USING_NANO_TIMED_LOCKS
-	const char * get_name () const
+	char const * get_name () const
 	{
 		return name ? name : "";
 	}
@@ -99,7 +99,7 @@ public:
 
 private:
 #if USING_NANO_TIMED_LOCKS
-	const char * name{ nullptr };
+	char const * name{ nullptr };
 #endif
 	std::mutex mutex_m;
 };

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -46,7 +46,7 @@ class mutex
 {
 public:
 	mutex () = default;
-	mutex (const char * name_a)
+	explicit mutex (const char * name_a)
 #if USING_NANO_TIMED_LOCKS
 	:
 	name (name_a)
@@ -266,14 +266,14 @@ public:
 	using value_type = T;
 
 	template <typename... Args>
-	locked (Args &&... args) :
+	explicit locked (Args &&... args) :
 	obj (std::forward<Args> (args)...)
 	{
 	}
 
 	struct scoped_lock final
 	{
-		scoped_lock (locked * owner_a) :
+		explicit scoped_lock (locked * owner_a) :
 		owner (owner_a)
 		{
 			owner->mutex.lock ();

--- a/nano/lib/memory.hpp
+++ b/nano/lib/memory.hpp
@@ -41,7 +41,7 @@ bool purge_shared_ptr_singleton_pool_memory ()
 class cleanup_guard final
 {
 public:
-	cleanup_guard (std::vector<std::function<void()>> const & cleanup_funcs_a);
+	explicit cleanup_guard (std::vector<std::function<void()>> const & cleanup_funcs_a);
 	~cleanup_guard ();
 
 private:

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -79,9 +79,9 @@ bool nano::public_key::decode_account (std::string const & source_a)
 		return true;
 	}
 
-	auto xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
-	auto nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
-	auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
+	auto const xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
+	auto const nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
+	auto const node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
 	error = (xrb_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
 	if (error)
 	{
@@ -120,7 +120,7 @@ bool nano::public_key::decode_account (std::string const & source_a)
 	}
 
 	*this = (number_l >> 40).convert_to<nano::uint256_t> ();
-	uint64_t check (number_l & static_cast<uint64_t> (0xffffffffff));
+	uint64_t const check (number_l & static_cast<uint64_t> (0xffffffffff));
 	uint64_t validation (0);
 	blake2b_state hash;
 	blake2b_init (&hash, 5);
@@ -217,31 +217,29 @@ void nano::uint256_union::encode_hex (std::string & text) const
 
 bool nano::uint256_union::decode_hex (std::string const & text)
 {
-	auto error (false);
-	if (!text.empty () && text.size () <= 64)
+	if (text.empty () || text.size () > 64)
 	{
-		std::stringstream stream (text);
-		stream << std::hex << std::noshowbase;
-		nano::uint256_t number_l;
-		try
+		return true;
+	}
+
+	std::stringstream stream (text);
+	stream << std::hex << std::noshowbase;
+	nano::uint256_t number_l;
+	try
+	{
+		stream >> number_l;
+		*this = number_l;
+		if (!stream.eof ())
 		{
-			stream >> number_l;
-			*this = number_l;
-			if (!stream.eof ())
-			{
-				error = true;
-			}
-		}
-		catch (std::runtime_error &)
-		{
-			error = true;
+			return true;
 		}
 	}
-	else
+	catch (std::runtime_error &)
 	{
-		error = true;
+		return true;
 	}
-	return error;
+
+	return false;
 }
 
 void nano::uint256_union::encode_dec (std::string & text) const

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -74,54 +74,59 @@ bool nano::public_key::decode_node_id (std::string const & source_a)
 bool nano::public_key::decode_account (std::string const & source_a)
 {
 	auto error (source_a.size () < 5);
-	if (error) {
-	    return true;
+	if (error)
+	{
+		return true;
 	}
 
-    auto xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
-    auto nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
-    auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
-    error = (xrb_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
-    if (error) {
-        return true;
-    }
+	auto xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
+	auto nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
+	auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
+	error = (xrb_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
+	if (error)
+	{
+		return true;
+	}
 
-    if (!xrb_prefix && !nano_prefix && !node_id_prefix) {
-        return true;
-    }
+	if (!xrb_prefix && !nano_prefix && !node_id_prefix)
+	{
+		return true;
+	}
 
-    auto i (source_a.begin () + (xrb_prefix ? 4 : 5));
-    if (*i != '1' && *i != '3')
-    {
-        return true;
-    }
+	auto i (source_a.begin () + (xrb_prefix ? 4 : 5));
+	if (*i != '1' && *i != '3')
+	{
+		return true;
+	}
 
-    nano::uint512_t number_l;
-    for (auto j (source_a.end ()); i != j; ++i)
-    {
-        uint8_t character (*i);
-        error = character < 0x30 || character >= 0x80;
-        if (error) {
-            return true;
-        }
+	nano::uint512_t number_l;
+	for (auto j (source_a.end ()); i != j; ++i)
+	{
+		uint8_t character (*i);
+		error = character < 0x30 || character >= 0x80;
+		if (error)
+		{
+			return true;
+		}
 
-        uint8_t byte (account_decode (character));
-        error = byte == '~';
-        if (error) {
-            return true;
-        }
-        number_l <<= 5;
-        number_l += byte;
-    }
+		uint8_t byte (account_decode (character));
+		error = byte == '~';
+		if (error)
+		{
+			return true;
+		}
+		number_l <<= 5;
+		number_l += byte;
+	}
 
-    *this = (number_l >> 40).convert_to<nano::uint256_t> ();
-    uint64_t check (number_l & static_cast<uint64_t> (0xffffffffff));
-    uint64_t validation (0);
-    blake2b_state hash;
-    blake2b_init (&hash, 5);
-    blake2b_update (&hash, bytes.data (), bytes.size ());
-    blake2b_final (&hash, reinterpret_cast<uint8_t *> (&validation), 5);
-    error = check != validation;
+	*this = (number_l >> 40).convert_to<nano::uint256_t> ();
+	uint64_t check (number_l & static_cast<uint64_t> (0xffffffffff));
+	uint64_t validation (0);
+	blake2b_state hash;
+	blake2b_init (&hash, 5);
+	blake2b_update (&hash, bytes.data (), bytes.size ());
+	blake2b_final (&hash, reinterpret_cast<uint8_t *> (&validation), 5);
+	error = check != validation;
 	return error;
 }
 
@@ -251,25 +256,26 @@ void nano::uint256_union::encode_dec (std::string & text) const
 bool nano::uint256_union::decode_dec (std::string const & text)
 {
 	auto error (text.size () > 78 || (text.size () > 1 && text.front () == '0') || (!text.empty () && text.front () == '-'));
-	if (error) {
-        return true;
-    }
+	if (error)
+	{
+		return true;
+	}
 
-    std::stringstream stream (text);
-    stream << std::dec << std::noshowbase;
-    nano::uint256_t number_l;
-    try
-    {
-        stream >> number_l;
-        *this = number_l;
-        if (!stream.eof ())
-        {
-            return true;
-        }
-    }
-    catch (std::runtime_error &)
-    {
-        return true;
+	std::stringstream stream (text);
+	stream << std::dec << std::noshowbase;
+	nano::uint256_t number_l;
+	try
+	{
+		stream >> number_l;
+		*this = number_l;
+		if (!stream.eof ())
+		{
+			return true;
+		}
+	}
+	catch (std::runtime_error &)
+	{
+		return true;
 	}
 
 	return false;
@@ -332,26 +338,27 @@ void nano::uint512_union::encode_hex (std::string & text) const
 bool nano::uint512_union::decode_hex (std::string const & text)
 {
 	auto error (text.size () > 128);
-	if (error) {
-	    return true;
+	if (error)
+	{
+		return true;
 	}
 
-    std::stringstream stream (text);
-    stream << std::hex << std::noshowbase;
-    nano::uint512_t number_l;
-    try
-    {
-        stream >> number_l;
-        *this = number_l;
-        if (!stream.eof ())
-        {
-            return true;
-        }
-    }
-    catch (std::runtime_error &)
-    {
-        return true;
-    }
+	std::stringstream stream (text);
+	stream << std::hex << std::noshowbase;
+	nano::uint512_t number_l;
+	try
+	{
+		stream >> number_l;
+		*this = number_l;
+		if (!stream.eof ())
+		{
+			return true;
+		}
+	}
+	catch (std::runtime_error &)
+	{
+		return true;
+	}
 
 	return false;
 }
@@ -495,26 +502,27 @@ void nano::uint128_union::encode_hex (std::string & text) const
 bool nano::uint128_union::decode_hex (std::string const & text)
 {
 	auto error (text.size () > 32);
-	if (error) {
-	    return true;
+	if (error)
+	{
+		return true;
 	}
 
-    std::stringstream stream (text);
-    stream << std::hex << std::noshowbase;
-    nano::uint128_t number_l;
-    try
-    {
-        stream >> number_l;
-        *this = number_l;
-        if (!stream.eof ())
-        {
-            return true;
-        }
-    }
-    catch (std::runtime_error &)
-    {
-        return true;
-    }
+	std::stringstream stream (text);
+	stream << std::hex << std::noshowbase;
+	nano::uint128_t number_l;
+	try
+	{
+		stream >> number_l;
+		*this = number_l;
+		if (!stream.eof ())
+		{
+			return true;
+		}
+	}
+	catch (std::runtime_error &)
+	{
+		return true;
+	}
 
 	return false;
 }
@@ -531,27 +539,28 @@ void nano::uint128_union::encode_dec (std::string & text) const
 bool nano::uint128_union::decode_dec (std::string const & text, bool decimal)
 {
 	auto error (text.size () > 39 || (text.size () > 1 && text.front () == '0' && !decimal) || (!text.empty () && text.front () == '-'));
-	if (error) {
-	    return true;
+	if (error)
+	{
+		return true;
 	}
 
-    std::stringstream stream (text);
-    stream << std::dec << std::noshowbase;
-    boost::multiprecision::checked_uint128_t number_l;
-    try
-    {
-        stream >> number_l;
-        nano::uint128_t unchecked (number_l);
-        *this = unchecked;
-        if (!stream.eof ())
-        {
-            return true;
-        }
-    }
-    catch (std::runtime_error &)
-    {
-        return true;
-    }
+	std::stringstream stream (text);
+	stream << std::dec << std::noshowbase;
+	boost::multiprecision::checked_uint128_t number_l;
+	try
+	{
+		stream >> number_l;
+		nano::uint128_t unchecked (number_l);
+		*this = unchecked;
+		if (!stream.eof ())
+		{
+			return true;
+		}
+	}
+	catch (std::runtime_error &)
+	{
+		return true;
+	}
 
 	return false;
 }
@@ -559,87 +568,95 @@ bool nano::uint128_union::decode_dec (std::string const & text, bool decimal)
 bool nano::uint128_union::decode_dec (std::string const & text, nano::uint128_t scale)
 {
 	bool error (text.size () > 40 || (!text.empty () && text.front () == '-'));
-	if (error) {
-	    return true;
+	if (error)
+	{
+		return true;
 	}
 
-    auto const delimiter_position (text.find ('.')); // Dot delimiter hardcoded until decision for supporting other locales
-    if (delimiter_position == std::string::npos)
-    {
-        nano::uint128_union integer;
-        error = integer.decode_dec (text);
-        if (error) {
-            return true;
-        }
+	auto const delimiter_position (text.find ('.')); // Dot delimiter hardcoded until decision for supporting other locales
+	if (delimiter_position == std::string::npos)
+	{
+		nano::uint128_union integer;
+		error = integer.decode_dec (text);
+		if (error)
+		{
+			return true;
+		}
 
-        // Overflow check
-        try
-        {
-            auto const result (boost::multiprecision::checked_uint128_t (integer.number ()) * boost::multiprecision::checked_uint128_t (scale));
-            error = (result > std::numeric_limits<nano::uint128_t>::max ());
-            if (error) {
-                return true;
-            }
+		// Overflow check
+		try
+		{
+			auto const result (boost::multiprecision::checked_uint128_t (integer.number ()) * boost::multiprecision::checked_uint128_t (scale));
+			error = (result > std::numeric_limits<nano::uint128_t>::max ());
+			if (error)
+			{
+				return true;
+			}
 
-            *this = nano::uint128_t (result);
-        }
-        catch (std::overflow_error &)
-        {
-            return true;
-        }
-    }
-    else
-    {
-        nano::uint128_union integer_part;
-        std::string const integer_text (text.substr (0, delimiter_position));
-        error = (integer_text.empty () || integer_part.decode_dec (integer_text));
-        if (error) {
-            return true;
-        }
+			*this = nano::uint128_t (result);
+		}
+		catch (std::overflow_error &)
+		{
+			return true;
+		}
+	}
+	else
+	{
+		nano::uint128_union integer_part;
+		std::string const integer_text (text.substr (0, delimiter_position));
+		error = (integer_text.empty () || integer_part.decode_dec (integer_text));
+		if (error)
+		{
+			return true;
+		}
 
-        // Overflow check
-        try
-        {
-            error = ((boost::multiprecision::checked_uint128_t (integer_part.number ()) * boost::multiprecision::checked_uint128_t (scale)) > std::numeric_limits<nano::uint128_t>::max ());
-        }
-        catch (std::overflow_error &)
-        {
-            return true;
-        }
-        if (error) {
-            return true;
-        }
+		// Overflow check
+		try
+		{
+			error = ((boost::multiprecision::checked_uint128_t (integer_part.number ()) * boost::multiprecision::checked_uint128_t (scale)) > std::numeric_limits<nano::uint128_t>::max ());
+		}
+		catch (std::overflow_error &)
+		{
+			return true;
+		}
+		if (error)
+		{
+			return true;
+		}
 
-        nano::uint128_union decimal_part;
-        std::string const decimal_text (text.substr (delimiter_position + 1, text.length ()));
-        error = (decimal_text.empty () || decimal_part.decode_dec (decimal_text, true));
-        if (error) {
-            return true;
-        }
+		nano::uint128_union decimal_part;
+		std::string const decimal_text (text.substr (delimiter_position + 1, text.length ()));
+		error = (decimal_text.empty () || decimal_part.decode_dec (decimal_text, true));
+		if (error)
+		{
+			return true;
+		}
 
-        // Overflow check
-        auto const scale_length (scale.convert_to<std::string> ().length ());
-        error = (scale_length <= decimal_text.length ());
-        if (error) {
-            return true;
-        }
+		// Overflow check
+		auto const scale_length (scale.convert_to<std::string> ().length ());
+		error = (scale_length <= decimal_text.length ());
+		if (error)
+		{
+			return true;
+		}
 
-        auto const base10 = boost::multiprecision::cpp_int (10);
-        release_assert ((scale_length - decimal_text.length () - 1) <= std::numeric_limits<unsigned>::max ());
-        auto const pow10 = boost::multiprecision::pow (base10, static_cast<unsigned> (scale_length - decimal_text.length () - 1));
-        auto const decimal_part_num = decimal_part.number ();
-        auto const integer_part_scaled = integer_part.number () * scale;
-        auto const decimal_part_mult_pow = decimal_part_num * pow10;
-        auto const result = integer_part_scaled + decimal_part_mult_pow;
+		auto const base10 = boost::multiprecision::cpp_int (10);
+		release_assert ((scale_length - decimal_text.length () - 1) <= std::numeric_limits<unsigned>::max ());
+		auto const pow10 = boost::multiprecision::pow (base10, static_cast<unsigned> (scale_length - decimal_text.length () - 1));
+		auto const decimal_part_num = decimal_part.number ();
+		auto const integer_part_scaled = integer_part.number () * scale;
+		auto const decimal_part_mult_pow = decimal_part_num * pow10;
+		auto const result = integer_part_scaled + decimal_part_mult_pow;
 
-        // Overflow check
-        error = (result > std::numeric_limits<nano::uint128_t>::max ());
-        if (error) {
-            return true;
-        }
+		// Overflow check
+		error = (result > std::numeric_limits<nano::uint128_t>::max ());
+		if (error)
+		{
+			return true;
+		}
 
-        *this = nano::uint128_t (result);
-    }
+		*this = nano::uint128_t (result);
+	}
 
 	return false;
 }
@@ -870,31 +887,33 @@ std::string nano::to_string_hex (uint64_t const value_a)
 bool nano::from_string_hex (std::string const & value_a, uint64_t & target_a)
 {
 	auto error (value_a.empty ());
-	if (error) {
-        return true;
-    }
+	if (error)
+	{
+		return true;
+	}
 
-    error = value_a.size () > 16;
-	if (error) {
-        return true;
-    }
+	error = value_a.size () > 16;
+	if (error)
+	{
+		return true;
+	}
 
-    std::stringstream stream (value_a);
-    stream << std::hex << std::noshowbase;
-    try
-    {
-        uint64_t number_l;
-        stream >> number_l;
-        target_a = number_l;
-        if (!stream.eof ())
-        {
-            return true;
-        }
-    }
-    catch (std::runtime_error &)
-    {
-        return true;
-    }
+	std::stringstream stream (value_a);
+	stream << std::hex << std::noshowbase;
+	try
+	{
+		uint64_t number_l;
+		stream >> number_l;
+		target_a = number_l;
+		if (!stream.eof ())
+		{
+			return true;
+		}
+	}
+	catch (std::runtime_error &)
+	{
+		return true;
+	}
 	return false;
 }
 

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -74,58 +74,54 @@ bool nano::public_key::decode_node_id (std::string const & source_a)
 bool nano::public_key::decode_account (std::string const & source_a)
 {
 	auto error (source_a.size () < 5);
-	if (!error)
-	{
-		auto xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
-		auto nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
-		auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
-		error = (xrb_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
-		if (!error)
-		{
-			if (xrb_prefix || nano_prefix || node_id_prefix)
-			{
-				auto i (source_a.begin () + (xrb_prefix ? 4 : 5));
-				if (*i == '1' || *i == '3')
-				{
-					nano::uint512_t number_l;
-					for (auto j (source_a.end ()); !error && i != j; ++i)
-					{
-						uint8_t character (*i);
-						error = character < 0x30 || character >= 0x80;
-						if (!error)
-						{
-							uint8_t byte (account_decode (character));
-							error = byte == '~';
-							if (!error)
-							{
-								number_l <<= 5;
-								number_l += byte;
-							}
-						}
-					}
-					if (!error)
-					{
-						*this = (number_l >> 40).convert_to<nano::uint256_t> ();
-						uint64_t check (number_l & static_cast<uint64_t> (0xffffffffff));
-						uint64_t validation (0);
-						blake2b_state hash;
-						blake2b_init (&hash, 5);
-						blake2b_update (&hash, bytes.data (), bytes.size ());
-						blake2b_final (&hash, reinterpret_cast<uint8_t *> (&validation), 5);
-						error = check != validation;
-					}
-				}
-				else
-				{
-					error = true;
-				}
-			}
-			else
-			{
-				error = true;
-			}
-		}
+	if (error) {
+	    return true;
 	}
+
+    auto xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
+    auto nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
+    auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
+    error = (xrb_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
+    if (error) {
+        return true;
+    }
+
+    if (!xrb_prefix && !nano_prefix && !node_id_prefix) {
+        return true;
+    }
+
+    auto i (source_a.begin () + (xrb_prefix ? 4 : 5));
+    if (*i != '1' && *i != '3')
+    {
+        return true;
+    }
+
+    nano::uint512_t number_l;
+    for (auto j (source_a.end ()); i != j; ++i)
+    {
+        uint8_t character (*i);
+        error = character < 0x30 || character >= 0x80;
+        if (error) {
+            return true;
+        }
+
+        uint8_t byte (account_decode (character));
+        error = byte == '~';
+        if (error) {
+            return true;
+        }
+        number_l <<= 5;
+        number_l += byte;
+    }
+
+    *this = (number_l >> 40).convert_to<nano::uint256_t> ();
+    uint64_t check (number_l & static_cast<uint64_t> (0xffffffffff));
+    uint64_t validation (0);
+    blake2b_state hash;
+    blake2b_init (&hash, 5);
+    blake2b_update (&hash, bytes.data (), bytes.size ());
+    blake2b_final (&hash, reinterpret_cast<uint8_t *> (&validation), 5);
+    error = check != validation;
 	return error;
 }
 
@@ -255,26 +251,28 @@ void nano::uint256_union::encode_dec (std::string & text) const
 bool nano::uint256_union::decode_dec (std::string const & text)
 {
 	auto error (text.size () > 78 || (text.size () > 1 && text.front () == '0') || (!text.empty () && text.front () == '-'));
-	if (!error)
-	{
-		std::stringstream stream (text);
-		stream << std::dec << std::noshowbase;
-		nano::uint256_t number_l;
-		try
-		{
-			stream >> number_l;
-			*this = number_l;
-			if (!stream.eof ())
-			{
-				error = true;
-			}
-		}
-		catch (std::runtime_error &)
-		{
-			error = true;
-		}
+	if (error) {
+        return true;
+    }
+
+    std::stringstream stream (text);
+    stream << std::dec << std::noshowbase;
+    nano::uint256_t number_l;
+    try
+    {
+        stream >> number_l;
+        *this = number_l;
+        if (!stream.eof ())
+        {
+            return true;
+        }
+    }
+    catch (std::runtime_error &)
+    {
+        return true;
 	}
-	return error;
+
+	return false;
 }
 
 nano::uint256_union::uint256_union (uint64_t value0)
@@ -334,26 +332,28 @@ void nano::uint512_union::encode_hex (std::string & text) const
 bool nano::uint512_union::decode_hex (std::string const & text)
 {
 	auto error (text.size () > 128);
-	if (!error)
-	{
-		std::stringstream stream (text);
-		stream << std::hex << std::noshowbase;
-		nano::uint512_t number_l;
-		try
-		{
-			stream >> number_l;
-			*this = number_l;
-			if (!stream.eof ())
-			{
-				error = true;
-			}
-		}
-		catch (std::runtime_error &)
-		{
-			error = true;
-		}
+	if (error) {
+	    return true;
 	}
-	return error;
+
+    std::stringstream stream (text);
+    stream << std::hex << std::noshowbase;
+    nano::uint512_t number_l;
+    try
+    {
+        stream >> number_l;
+        *this = number_l;
+        if (!stream.eof ())
+        {
+            return true;
+        }
+    }
+    catch (std::runtime_error &)
+    {
+        return true;
+    }
+
+	return false;
 }
 
 bool nano::uint512_union::operator!= (nano::uint512_union const & other_a) const
@@ -495,26 +495,28 @@ void nano::uint128_union::encode_hex (std::string & text) const
 bool nano::uint128_union::decode_hex (std::string const & text)
 {
 	auto error (text.size () > 32);
-	if (!error)
-	{
-		std::stringstream stream (text);
-		stream << std::hex << std::noshowbase;
-		nano::uint128_t number_l;
-		try
-		{
-			stream >> number_l;
-			*this = number_l;
-			if (!stream.eof ())
-			{
-				error = true;
-			}
-		}
-		catch (std::runtime_error &)
-		{
-			error = true;
-		}
+	if (error) {
+	    return true;
 	}
-	return error;
+
+    std::stringstream stream (text);
+    stream << std::hex << std::noshowbase;
+    nano::uint128_t number_l;
+    try
+    {
+        stream >> number_l;
+        *this = number_l;
+        if (!stream.eof ())
+        {
+            return true;
+        }
+    }
+    catch (std::runtime_error &)
+    {
+        return true;
+    }
+
+	return false;
 }
 
 void nano::uint128_union::encode_dec (std::string & text) const
@@ -529,106 +531,117 @@ void nano::uint128_union::encode_dec (std::string & text) const
 bool nano::uint128_union::decode_dec (std::string const & text, bool decimal)
 {
 	auto error (text.size () > 39 || (text.size () > 1 && text.front () == '0' && !decimal) || (!text.empty () && text.front () == '-'));
-	if (!error)
-	{
-		std::stringstream stream (text);
-		stream << std::dec << std::noshowbase;
-		boost::multiprecision::checked_uint128_t number_l;
-		try
-		{
-			stream >> number_l;
-			nano::uint128_t unchecked (number_l);
-			*this = unchecked;
-			if (!stream.eof ())
-			{
-				error = true;
-			}
-		}
-		catch (std::runtime_error &)
-		{
-			error = true;
-		}
+	if (error) {
+	    return true;
 	}
-	return error;
+
+    std::stringstream stream (text);
+    stream << std::dec << std::noshowbase;
+    boost::multiprecision::checked_uint128_t number_l;
+    try
+    {
+        stream >> number_l;
+        nano::uint128_t unchecked (number_l);
+        *this = unchecked;
+        if (!stream.eof ())
+        {
+            return true;
+        }
+    }
+    catch (std::runtime_error &)
+    {
+        return true;
+    }
+
+	return false;
 }
 
 bool nano::uint128_union::decode_dec (std::string const & text, nano::uint128_t scale)
 {
 	bool error (text.size () > 40 || (!text.empty () && text.front () == '-'));
-	if (!error)
-	{
-		auto delimiter_position (text.find (".")); // Dot delimiter hardcoded until decision for supporting other locales
-		if (delimiter_position == std::string::npos)
-		{
-			nano::uint128_union integer;
-			error = integer.decode_dec (text);
-			if (!error)
-			{
-				// Overflow check
-				try
-				{
-					auto result (boost::multiprecision::checked_uint128_t (integer.number ()) * boost::multiprecision::checked_uint128_t (scale));
-					error = (result > std::numeric_limits<nano::uint128_t>::max ());
-					if (!error)
-					{
-						*this = nano::uint128_t (result);
-					}
-				}
-				catch (std::overflow_error &)
-				{
-					error = true;
-				}
-			}
-		}
-		else
-		{
-			nano::uint128_union integer_part;
-			std::string integer_text (text.substr (0, delimiter_position));
-			error = (integer_text.empty () || integer_part.decode_dec (integer_text));
-			if (!error)
-			{
-				// Overflow check
-				try
-				{
-					error = ((boost::multiprecision::checked_uint128_t (integer_part.number ()) * boost::multiprecision::checked_uint128_t (scale)) > std::numeric_limits<nano::uint128_t>::max ());
-				}
-				catch (std::overflow_error &)
-				{
-					error = true;
-				}
-				if (!error)
-				{
-					nano::uint128_union decimal_part;
-					std::string decimal_text (text.substr (delimiter_position + 1, text.length ()));
-					error = (decimal_text.empty () || decimal_part.decode_dec (decimal_text, true));
-					if (!error)
-					{
-						// Overflow check
-						auto scale_length (scale.convert_to<std::string> ().length ());
-						error = (scale_length <= decimal_text.length ());
-						if (!error)
-						{
-							auto base10 = boost::multiprecision::cpp_int (10);
-							release_assert ((scale_length - decimal_text.length () - 1) <= std::numeric_limits<unsigned>::max ());
-							auto pow10 = boost::multiprecision::pow (base10, static_cast<unsigned> (scale_length - decimal_text.length () - 1));
-							auto decimal_part_num = decimal_part.number ();
-							auto integer_part_scaled = integer_part.number () * scale;
-							auto decimal_part_mult_pow = decimal_part_num * pow10;
-							auto result = integer_part_scaled + decimal_part_mult_pow;
-
-							// Overflow check
-							error = (result > std::numeric_limits<nano::uint128_t>::max ());
-							if (!error)
-							{
-								*this = nano::uint128_t (result);
-							}
-						}
-					}
-				}
-			}
-		}
+	if (error) {
+	    return true;
 	}
-	return error;
+
+    auto const delimiter_position (text.find ('.')); // Dot delimiter hardcoded until decision for supporting other locales
+    if (delimiter_position == std::string::npos)
+    {
+        nano::uint128_union integer;
+        error = integer.decode_dec (text);
+        if (error) {
+            return true;
+        }
+
+        // Overflow check
+        try
+        {
+            auto const result (boost::multiprecision::checked_uint128_t (integer.number ()) * boost::multiprecision::checked_uint128_t (scale));
+            error = (result > std::numeric_limits<nano::uint128_t>::max ());
+            if (error) {
+                return true;
+            }
+
+            *this = nano::uint128_t (result);
+        }
+        catch (std::overflow_error &)
+        {
+            return true;
+        }
+    }
+    else
+    {
+        nano::uint128_union integer_part;
+        std::string const integer_text (text.substr (0, delimiter_position));
+        error = (integer_text.empty () || integer_part.decode_dec (integer_text));
+        if (error) {
+            return true;
+        }
+
+        // Overflow check
+        try
+        {
+            error = ((boost::multiprecision::checked_uint128_t (integer_part.number ()) * boost::multiprecision::checked_uint128_t (scale)) > std::numeric_limits<nano::uint128_t>::max ());
+        }
+        catch (std::overflow_error &)
+        {
+            return true;
+        }
+        if (error) {
+            return true;
+        }
+
+        nano::uint128_union decimal_part;
+        std::string const decimal_text (text.substr (delimiter_position + 1, text.length ()));
+        error = (decimal_text.empty () || decimal_part.decode_dec (decimal_text, true));
+        if (error) {
+            return true;
+        }
+
+        // Overflow check
+        auto const scale_length (scale.convert_to<std::string> ().length ());
+        error = (scale_length <= decimal_text.length ());
+        if (error) {
+            return true;
+        }
+
+        auto const base10 = boost::multiprecision::cpp_int (10);
+        release_assert ((scale_length - decimal_text.length () - 1) <= std::numeric_limits<unsigned>::max ());
+        auto const pow10 = boost::multiprecision::pow (base10, static_cast<unsigned> (scale_length - decimal_text.length () - 1));
+        auto const decimal_part_num = decimal_part.number ();
+        auto const integer_part_scaled = integer_part.number () * scale;
+        auto const decimal_part_mult_pow = decimal_part_num * pow10;
+        auto const result = integer_part_scaled + decimal_part_mult_pow;
+
+        // Overflow check
+        error = (result > std::numeric_limits<nano::uint128_t>::max ());
+        if (error) {
+            return true;
+        }
+
+        *this = nano::uint128_t (result);
+    }
+
+	return false;
 }
 
 void format_frac (std::ostringstream & stream, nano::uint128_t value, nano::uint128_t scale, int precision)
@@ -857,30 +870,32 @@ std::string nano::to_string_hex (uint64_t const value_a)
 bool nano::from_string_hex (std::string const & value_a, uint64_t & target_a)
 {
 	auto error (value_a.empty ());
-	if (!error)
-	{
-		error = value_a.size () > 16;
-		if (!error)
-		{
-			std::stringstream stream (value_a);
-			stream << std::hex << std::noshowbase;
-			try
-			{
-				uint64_t number_l;
-				stream >> number_l;
-				target_a = number_l;
-				if (!stream.eof ())
-				{
-					error = true;
-				}
-			}
-			catch (std::runtime_error &)
-			{
-				error = true;
-			}
-		}
-	}
-	return error;
+	if (error) {
+        return true;
+    }
+
+    error = value_a.size () > 16;
+	if (error) {
+        return true;
+    }
+
+    std::stringstream stream (value_a);
+    stream << std::hex << std::noshowbase;
+    try
+    {
+        uint64_t number_l;
+        stream >> number_l;
+        target_a = number_l;
+        if (!stream.eof ())
+        {
+            return true;
+        }
+    }
+    catch (std::runtime_error &)
+    {
+        return true;
+    }
+	return false;
 }
 
 std::string nano::to_string (double const value_a, int const precision_a)

--- a/nano/lib/plat/linux/debugging.cpp
+++ b/nano/lib/plat/linux/debugging.cpp
@@ -16,13 +16,13 @@ int create_load_memory_address_file (dl_phdr_info * info, size_t, void *)
 	static int counter = 0;
 	debug_assert (counter <= 99);
 	// Create filename
-	const char file_prefix[] = "nano_node_crash_load_address_dump_";
+	char const file_prefix[] = "nano_node_crash_load_address_dump_";
 	// Holds the filename prefix, a unique (max 2 digits) number and extension (null terminator is included in file_prefix size)
 	char filename[sizeof (file_prefix) + 2 + 4];
 	snprintf (filename, sizeof (filename), "%s%d.txt", file_prefix, counter);
 
 	// Open file
-	const auto file_descriptor = ::open (filename, O_CREAT | O_WRONLY | O_TRUNC,
+	auto const file_descriptor = ::open (filename, O_CREAT | O_WRONLY | O_TRUNC,
 #if defined(S_IWRITE) && defined(S_IREAD)
 	S_IWRITE | S_IREAD
 #else

--- a/nano/lib/plat/posix/perms.cpp
+++ b/nano/lib/plat/posix/perms.cpp
@@ -3,7 +3,6 @@
 #include <boost/filesystem.hpp>
 
 #include <sys/stat.h>
-#include <sys/types.h>
 
 void nano::set_umask ()
 {

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -193,8 +193,8 @@ namespace nano
 nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides)
 {
 	nano::error error;
-	auto json_config_path = nano::get_rpc_config_path (data_path_a);
-	auto toml_config_path = nano::get_rpc_toml_config_path (data_path_a);
+	auto const json_config_path = nano::get_rpc_config_path (data_path_a);
+	auto const toml_config_path = nano::get_rpc_toml_config_path (data_path_a);
 	if (boost::filesystem::exists (json_config_path))
 	{
 		if (boost::filesystem::exists (toml_config_path))
@@ -244,23 +244,24 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 	config_overrides_stream << std::endl;
 
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
-	if (!error)
+	if (error)
 	{
-		if (boost::filesystem::exists (toml_config_path))
-		{
-			error = toml.read (config_overrides_stream, toml_config_path);
-		}
-		else
-		{
-			error = toml.read (config_overrides_stream);
-		}
+		return true;
+	}
+	if (boost::filesystem::exists (toml_config_path))
+	{
+		error = toml.read (config_overrides_stream, toml_config_path);
+	}
+	else
+	{
+		error = toml.read (config_overrides_stream);
+	}
+	if (error)
+	{
+		return true;
 	}
 
-	if (!error)
-	{
-		error = config_a.deserialize_toml (toml);
-	}
-
+	error = config_a.deserialize_toml (toml);
 	return error;
 }
 

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -246,7 +246,7 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
 	if (error)
 	{
-		return true;
+		return error;
 	}
 	if (boost::filesystem::exists (toml_config_path))
 	{
@@ -258,7 +258,7 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 	}
 	if (error)
 	{
-		return true;
+		return error;
 	}
 
 	error = config_a.deserialize_toml (toml);

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -566,7 +566,7 @@ public:
 	void log_samples (stat_log_sink & sink);
 
 	/** Returns a new JSON log sink */
-	[[nodiscard]] std::unique_ptr<stat_log_sink> log_sink_json () const;
+	std::unique_ptr<stat_log_sink> log_sink_json () const;
 
 	/** Returns string representation of detail */
 	static std::string detail_to_string (uint32_t key);
@@ -579,7 +579,7 @@ private:
 	static std::string dir_to_string (uint32_t key);
 
 	/** Constructs a key given type, detail and direction. This is used as input to update(...) and get_entry(...) */
-	[[nodiscard]] uint32_t key_of (stat::type type, stat::detail detail, stat::dir dir) const
+	uint32_t key_of (stat::type type, stat::detail detail, stat::dir dir) const
 	{
 		return static_cast<uint8_t> (type) << 16 | static_cast<uint8_t> (detail) << 8 | static_cast<uint8_t> (dir);
 	}

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -400,7 +400,7 @@ public:
 	 * Initialize stats with a config.
 	 * @param config Configuration object; deserialized from config.json
 	 */
-	stat (nano::stat_config config);
+	explicit stat (nano::stat_config config);
 
 	/**
 	 * Call this to override the default sample interval and capacity, for a specific stat entry.
@@ -566,7 +566,7 @@ public:
 	void log_samples (stat_log_sink & sink);
 
 	/** Returns a new JSON log sink */
-	std::unique_ptr<stat_log_sink> log_sink_json () const;
+	[[nodiscard]] std::unique_ptr<stat_log_sink> log_sink_json () const;
 
 	/** Returns string representation of detail */
 	static std::string detail_to_string (uint32_t key);
@@ -579,7 +579,7 @@ private:
 	static std::string dir_to_string (uint32_t key);
 
 	/** Constructs a key given type, detail and direction. This is used as input to update(...) and get_entry(...) */
-	uint32_t key_of (stat::type type, stat::detail detail, stat::dir dir) const
+	[[nodiscard]] uint32_t key_of (stat::type type, stat::detail detail, stat::dir dir) const
 	{
 		return static_cast<uint8_t> (type) << 16 | static_cast<uint8_t> (detail) << 8 | static_cast<uint8_t> (dir);
 	}

--- a/nano/lib/timer.hpp
+++ b/nano/lib/timer.hpp
@@ -19,8 +19,8 @@ class timer
 {
 public:
 	timer () = default;
-	timer (nano::timer_state state_a, std::string const & description_a = "timer");
-	timer (std::string const & description_a);
+	explicit timer (nano::timer_state state_a, std::string const & description_a = "timer");
+	explicit timer (std::string const & description_a);
 	timer (std::string const & description_a, timer * parent_a);
 
 	/** Do not output if measured time is below the time units threshold in \p minimum_a */
@@ -83,8 +83,8 @@ public:
 	void print (std::ostream & stream_a);
 
 	/** Returns the SI unit string */
-	std::string unit () const;
-	nano::timer_state current_state () const;
+	[[nodiscard]] std::string unit () const;
+	[[nodiscard]] nano::timer_state current_state () const;
 
 private:
 	timer * parent{ nullptr };

--- a/nano/lib/timer.hpp
+++ b/nano/lib/timer.hpp
@@ -83,8 +83,8 @@ public:
 	void print (std::ostream & stream_a);
 
 	/** Returns the SI unit string */
-	[[nodiscard]] std::string unit () const;
-	[[nodiscard]] nano::timer_state current_state () const;
+	std::string unit () const;
+	nano::timer_state current_state () const;
 
 private:
 	timer * parent{ nullptr };

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -44,12 +44,12 @@ void nano::container_info_composite::add_component (std::unique_ptr<container_in
 	children.push_back (std::move (child));
 }
 
-const std::vector<std::unique_ptr<nano::container_info_component>> & nano::container_info_composite::get_children () const
+std::vector<std::unique_ptr<nano::container_info_component>> const & nano::container_info_composite::get_children () const
 {
 	return children;
 }
 
-const std::string & nano::container_info_composite::get_name () const
+std::string const & nano::container_info_composite::get_name () const
 {
 	return name;
 }
@@ -64,7 +64,7 @@ bool nano::container_info_leaf::is_composite () const
 	return false;
 }
 
-const nano::container_info & nano::container_info_leaf::get_info () const
+nano::container_info const & nano::container_info_leaf::get_info () const
 {
 	return info;
 }

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -89,7 +89,7 @@ class container_info_leaf : public container_info_component
 public:
 	container_info_leaf (container_info const & info);
 	bool is_composite () const override;
-	const container_info & get_info () const;
+	container_info const & get_info () const;
 
 private:
 	container_info info;

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -76,8 +76,8 @@ public:
 	container_info_composite (std::string const & name);
 	bool is_composite () const override;
 	void add_component (std::unique_ptr<container_info_component> child);
-	const std::vector<std::unique_ptr<container_info_component>> & get_children () const;
-	const std::string & get_name () const;
+	std::vector<std::unique_ptr<container_info_component>> const & get_children () const;
+	std::string const & get_name () const;
 
 private:
 	std::string name;

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -190,7 +190,7 @@ double nano::denormalized_multiplier (double const multiplier_a, uint64_t const 
 	auto multiplier (multiplier_a);
 	if (threshold_a == network_constants.publish_thresholds.epoch_1 || threshold_a == network_constants.publish_thresholds.epoch_2_receive)
 	{
-		auto ratio (nano::difficulty::to_multiplier (network_constants.publish_thresholds.epoch_2, threshold_a));
+		auto const ratio (nano::difficulty::to_multiplier (network_constants.publish_thresholds.epoch_2, threshold_a));
 		debug_assert (ratio >= 1);
 		multiplier = multiplier * ratio + 1.0 - ratio;
 		debug_assert (multiplier >= 1);
@@ -242,7 +242,7 @@ void nano::work_pool::loop (uint64_t thread)
 	blake2b_state hash;
 	blake2b_init (&hash, sizeof (output));
 	nano::unique_lock<nano::mutex> lock (mutex);
-	auto pow_sleep = pow_rate_limiter;
+	auto const pow_sleep = pow_rate_limiter;
 	while (!done)
 	{
 		auto empty (pending.empty ());
@@ -253,7 +253,7 @@ void nano::work_pool::loop (uint64_t thread)
 		}
 		if (!empty)
 		{
-			auto current_l (pending.front ());
+			auto const current_l (pending.front ());
 			int ticket_l (ticket);
 			lock.unlock ();
 			output = 0;

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -18,36 +18,36 @@ enum class work_version
 	unspecified,
 	work_1
 };
-std::string to_string (nano::work_version const version_a);
+std::string to_string (nano::work_version version_a);
 
 class block;
 class block_details;
 enum class block_type : uint8_t;
 bool work_validate_entry (nano::block const &);
-bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t const);
+bool work_validate_entry (nano::work_version, nano::root const &, uint64_t);
 
-uint64_t work_difficulty (nano::work_version const, nano::root const &, uint64_t const);
+uint64_t work_difficulty (nano::work_version, nano::root const &, uint64_t);
 
-uint64_t work_threshold_base (nano::work_version const);
-uint64_t work_threshold_entry (nano::work_version const, nano::block_type const);
+uint64_t work_threshold_base (nano::work_version);
+uint64_t work_threshold_entry (nano::work_version, nano::block_type);
 // Ledger threshold
-uint64_t work_threshold (nano::work_version const, nano::block_details const);
+uint64_t work_threshold (nano::work_version, nano::block_details);
 
 namespace work_v1
 {
 	uint64_t value (nano::root const & root_a, uint64_t work_a);
 	uint64_t threshold_base ();
 	uint64_t threshold_entry ();
-	uint64_t threshold (nano::block_details const);
+	uint64_t threshold (nano::block_details);
 }
 
-double normalized_multiplier (double const, uint64_t const);
-double denormalized_multiplier (double const, uint64_t const);
+double normalized_multiplier (double, uint64_t);
+double denormalized_multiplier (double, uint64_t);
 class opencl_work;
 class work_item final
 {
 public:
-	work_item (nano::work_version const version_a, nano::root const & item_a, uint64_t difficulty_a, std::function<void(boost::optional<uint64_t> const &)> const & callback_a) :
+	work_item (nano::work_version version_a, nano::root const & item_a, uint64_t difficulty_a, std::function<void(boost::optional<uint64_t> const &)> const & callback_a) :
 	version (version_a), item (item_a), difficulty (difficulty_a), callback (callback_a)
 	{
 	}
@@ -59,13 +59,13 @@ public:
 class work_pool final
 {
 public:
-	work_pool (unsigned, std::chrono::nanoseconds = std::chrono::nanoseconds (0), std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> = nullptr);
+	explicit work_pool (unsigned, std::chrono::nanoseconds = std::chrono::nanoseconds (0), std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> = nullptr);
 	~work_pool ();
 	void loop (uint64_t);
 	void stop ();
 	void cancel (nano::root const &);
-	void generate (nano::work_version const, nano::root const &, uint64_t, std::function<void(boost::optional<uint64_t> const &)>);
-	boost::optional<uint64_t> generate (nano::work_version const, nano::root const &, uint64_t);
+	void generate (nano::work_version, nano::root const &, uint64_t, std::function<void(boost::optional<uint64_t> const &)>);
+	boost::optional<uint64_t> generate (nano::work_version, nano::root const &, uint64_t);
 	// For tests only
 	boost::optional<uint64_t> generate (nano::root const &);
 	boost::optional<uint64_t> generate (nano::root const &, uint64_t);

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -47,7 +47,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 	if (error)
 	{
 		std::cerr << "Error deserializing config: " << error.get_message () << std::endl;
-		return true;
+		return;
 	}
 
 	config.node.logging.init (data_path);

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -43,126 +43,126 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 	{
 		error = nano::flags_config_conflicts (flags, config.node);
 	}
-	if (!error)
-	{
-		config.node.logging.init (data_path);
-		nano::logger_mt logger{ config.node.logging.min_time_between_log_output };
-		boost::asio::io_context io_ctx;
-		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
-		nano::work_pool opencl_work (config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
-			return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
-		}
-		                                                                                              : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
-		try
-		{
-			// This avoid a blank prompt during any node initialization delays
-			auto initialization_text = "Starting up Nano node...";
-			std::cout << initialization_text << std::endl;
-			logger.always_log (initialization_text);
 
-			auto node (std::make_shared<nano::node> (io_ctx, data_path, config.node, opencl_work, flags));
-			if (!node->init_error ())
-			{
-				auto network_label = node->network_params.network.get_current_network_as_string ();
-				std::cout << "Network: " << network_label << ", version: " << NANO_VERSION_STRING << "\n"
-				          << "Path: " << node->application_path.string () << "\n"
-				          << "Build Info: " << BUILD_INFO << "\n"
-				          << "Database backend: " << node->store.vendor_get () << std::endl;
-				auto voting (node->wallets.reps ().voting);
-				if (voting > 1)
-				{
-					std::cout << "Voting with more than one representative can limit performance: " << voting << " representatives are configured" << std::endl;
-				}
-				node->start ();
-				nano::ipc::ipc_server ipc_server (*node, config.rpc);
-				std::unique_ptr<boost::process::child> rpc_process;
-				std::unique_ptr<boost::process::child> nano_pow_server_process;
-
-				/*if (config.pow_server.enable)
-				{
-					if (!boost::filesystem::exists (config.pow_server.pow_server_path))
-					{
-						std::cerr << std::string ("nano_pow_server is configured to start as a child process, however the file cannot be found at: ") + config.pow_server.pow_server_path << std::endl;
-						std::exit (1);
-					}
-
-					nano_pow_server_process = std::make_unique<boost::process::child> (config.pow_server.pow_server_path, "--config_path", data_path / "config-nano-pow-server.toml");
-				}*/
-
-				std::unique_ptr<nano::rpc> rpc;
-				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
-				if (config.rpc_enable)
-				{
-					if (!config.rpc.child_process.enable)
-					{
-						// Launch rpc in-process
-						nano::rpc_config rpc_config;
-						auto error = nano::read_rpc_config_toml (data_path, rpc_config, flags.rpc_config_overrides);
-						if (error)
-						{
-							std::cout << error.get_message () << std::endl;
-							std::exit (1);
-						}
-						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc_server, config.rpc, [&ipc_server, &workers = node->workers, &io_ctx]() {
-							ipc_server.stop ();
-							workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::seconds (3), [&io_ctx]() {
-								io_ctx.stop ();
-							});
-						});
-						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
-						rpc->start ();
-					}
-					else
-					{
-						// Spawn a child rpc process
-						if (!boost::filesystem::exists (config.rpc.child_process.rpc_path))
-						{
-							throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
-						}
-
-						auto network = node->network_params.network.get_current_network_as_string ();
-						rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
-					}
-				}
-
-				debug_assert (!nano::signal_handler_impl);
-				nano::signal_handler_impl = [&io_ctx]() {
-					io_ctx.stop ();
-					sig_int_or_term = 1;
-				};
-
-				std::signal (SIGINT, &nano::signal_handler);
-				std::signal (SIGTERM, &nano::signal_handler);
-
-				runner = std::make_unique<nano::thread_runner> (io_ctx, node->config.io_threads);
-				runner->join ();
-
-				if (sig_int_or_term == 1)
-				{
-					ipc_server.stop ();
-					node->stop ();
-					if (rpc)
-					{
-						rpc->stop ();
-					}
-				}
-				if (rpc_process)
-				{
-					rpc_process->wait ();
-				}
-			}
-			else
-			{
-				std::cerr << "Error initializing node\n";
-			}
-		}
-		catch (const std::runtime_error & e)
-		{
-			std::cerr << "Error while running node (" << e.what () << ")\n";
-		}
-	}
-	else
+	if (error)
 	{
 		std::cerr << "Error deserializing config: " << error.get_message () << std::endl;
+		return true;
+	}
+
+	config.node.logging.init (data_path);
+	nano::logger_mt logger{ config.node.logging.min_time_between_log_output };
+	boost::asio::io_context io_ctx;
+	auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
+	nano::work_pool opencl_work (config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
+		return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
+	}
+	                                                                                              : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+	try
+	{
+		// This avoid a blank prompt during any node initialization delays
+		auto initialization_text = "Starting up Nano node...";
+		std::cout << initialization_text << std::endl;
+		logger.always_log (initialization_text);
+
+		auto node (std::make_shared<nano::node> (io_ctx, data_path, config.node, opencl_work, flags));
+		if (!node->init_error ())
+		{
+			auto network_label = node->network_params.network.get_current_network_as_string ();
+			std::cout << "Network: " << network_label << ", version: " << NANO_VERSION_STRING << "\n"
+			          << "Path: " << node->application_path.string () << "\n"
+			          << "Build Info: " << BUILD_INFO << "\n"
+			          << "Database backend: " << node->store.vendor_get () << std::endl;
+			auto voting (node->wallets.reps ().voting);
+			if (voting > 1)
+			{
+				std::cout << "Voting with more than one representative can limit performance: " << voting << " representatives are configured" << std::endl;
+			}
+			node->start ();
+			nano::ipc::ipc_server ipc_server (*node, config.rpc);
+			std::unique_ptr<boost::process::child> rpc_process;
+			std::unique_ptr<boost::process::child> nano_pow_server_process;
+
+			/*if (config.pow_server.enable)
+            {
+                if (!boost::filesystem::exists (config.pow_server.pow_server_path))
+                {
+                    std::cerr << std::string ("nano_pow_server is configured to start as a child process, however the file cannot be found at: ") + config.pow_server.pow_server_path << std::endl;
+                    std::exit (1);
+                }
+
+                nano_pow_server_process = std::make_unique<boost::process::child> (config.pow_server.pow_server_path, "--config_path", data_path / "config-nano-pow-server.toml");
+            }*/
+
+			std::unique_ptr<nano::rpc> rpc;
+			std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
+			if (config.rpc_enable)
+			{
+				if (!config.rpc.child_process.enable)
+				{
+					// Launch rpc in-process
+					nano::rpc_config rpc_config;
+					auto error = nano::read_rpc_config_toml (data_path, rpc_config, flags.rpc_config_overrides);
+					if (error)
+					{
+						std::cout << error.get_message () << std::endl;
+						std::exit (1);
+					}
+					rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc_server, config.rpc, [&ipc_server, &workers = node->workers, &io_ctx]() {
+						ipc_server.stop ();
+						workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::seconds (3), [&io_ctx]() {
+							io_ctx.stop ();
+						});
+					});
+					rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
+					rpc->start ();
+				}
+				else
+				{
+					// Spawn a child rpc process
+					if (!boost::filesystem::exists (config.rpc.child_process.rpc_path))
+					{
+						throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
+					}
+
+					auto network = node->network_params.network.get_current_network_as_string ();
+					rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
+				}
+			}
+
+			debug_assert (!nano::signal_handler_impl);
+			nano::signal_handler_impl = [&io_ctx]() {
+				io_ctx.stop ();
+				sig_int_or_term = 1;
+			};
+
+			std::signal (SIGINT, &nano::signal_handler);
+			std::signal (SIGTERM, &nano::signal_handler);
+
+			runner = std::make_unique<nano::thread_runner> (io_ctx, node->config.io_threads);
+			runner->join ();
+
+			if (sig_int_or_term == 1)
+			{
+				ipc_server.stop ();
+				node->stop ();
+				if (rpc)
+				{
+					rpc->stop ();
+				}
+			}
+			if (rpc_process)
+			{
+				rpc_process->wait ();
+			}
+		}
+		else
+		{
+			std::cerr << "Error initializing node\n";
+		}
+	}
+	catch (const std::runtime_error & e)
+	{
+		std::cerr << "Error while running node (" << e.what () << ")\n";
 	}
 }

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -748,7 +748,7 @@ int main (int argc, char * const * argv)
 			}
 			else
 			{
-				for (const auto & text : results)
+				for (auto const & text : results)
 				{
 					uint64_from_hex address_hex;
 					if (boost::conversion::try_lexical_convert (text, address_hex))
@@ -1351,7 +1351,7 @@ int main (int argc, char * const * argv)
 			++errors;
 		};
 
-		auto start_threads = [node, &threads_count, &threads, &mutex, &condition, &finished](const auto & function_a, auto & deque_a) {
+		auto start_threads = [node, &threads_count, &threads, &mutex, &condition, &finished](auto const & function_a, auto & deque_a) {
 			for (auto i (0U); i < threads_count; ++i)
 			{
 				threads.emplace_back ([&function_a, node, &mutex, &condition, &finished, &deque_a]() {
@@ -1612,7 +1612,7 @@ int main (int argc, char * const * argv)
 				if (accounts.size () > accounts_deque_overflow)
 				{
 					auto wait_ms (250 * accounts.size () / accounts_deque_overflow);
-					const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
+					auto const wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
 					condition.wait_until (lock, wakeup);
 				}
 				accounts.emplace_back (i->first, i->second);
@@ -1723,7 +1723,7 @@ int main (int argc, char * const * argv)
 				if (pending.size () > pending_deque_overflow)
 				{
 					auto wait_ms (50 * pending.size () / pending_deque_overflow);
-					const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
+					auto const wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
 					condition.wait_until (lock, wakeup);
 				}
 				pending.emplace_back (i->first, i->second);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -142,1162 +142,1147 @@ int main (int argc, char * const * argv)
 	auto data_path_it = vm.find ("data_path");
 	boost::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
 	auto ec = nano::handle_node_options (vm);
-	if (ec == nano::error_cli::unknown_command)
+	if (ec != nano::error_cli::unknown_command)
 	{
-		if (vm.count ("daemon") > 0)
+		return result;
+	}
+
+	if (vm.count ("daemon") > 0)
+	{
+		nano_daemon::daemon daemon;
+		nano::node_flags flags;
+		auto flags_ec = nano::update_flags (flags, vm);
+		if (flags_ec)
 		{
-			nano_daemon::daemon daemon;
-			nano::node_flags flags;
-			auto flags_ec = nano::update_flags (flags, vm);
-			if (flags_ec)
-			{
-				std::cerr << flags_ec.message () << std::endl;
-				std::exit (1);
-			}
-			daemon.run (data_path, flags);
+			std::cerr << flags_ec.message () << std::endl;
+			std::exit (1);
 		}
-		else if (vm.count ("compare_rep_weights"))
+		daemon.run (data_path, flags);
+	}
+	else if (vm.count ("compare_rep_weights"))
+	{
+		if (nano::network_constants ().is_dev_network ())
 		{
-			if (!nano::network_constants ().is_dev_network ())
+			std::cout << "Not available for the test network" << std::endl;
+			return -1;
+		}
+
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		nano::update_flags (node_flags, vm);
+		node_flags.generate_cache.reps = true;
+		nano::inactive_node inactive_node (data_path, node_flags);
+		auto node = inactive_node.node;
+
+		auto const bootstrap_weights = node->get_bootstrap_weights ();
+		auto const & hardcoded = bootstrap_weights.second;
+		auto const hardcoded_height = bootstrap_weights.first;
+		auto const ledger_unfiltered = node->ledger.cache.rep_weights.get_rep_amounts ();
+		auto const ledger_height = node->ledger.cache.block_count.load ();
+
+		auto get_total = [](decltype (bootstrap_weights.second) const & reps) -> nano::uint128_union {
+			return std::accumulate (reps.begin (), reps.end (), nano::uint128_t{ 0 }, [](auto sum, auto const & rep) { return sum + rep.second; });
+		};
+
+		// Hardcoded weights are filtered to a cummulative weight of 99%, need to do the same for ledger weights
+		std::remove_const_t<decltype (ledger_unfiltered)> ledger;
+		{
+			std::vector<std::pair<nano::account, nano::uint128_t>> sorted;
+			sorted.reserve (ledger_unfiltered.size ());
+			std::copy (ledger_unfiltered.begin (), ledger_unfiltered.end (), std::back_inserter (sorted));
+			std::sort (sorted.begin (), sorted.end (), [](auto const & left, auto const & right) { return left.second > right.second; });
+			auto const total_unfiltered = get_total (ledger_unfiltered);
+			nano::uint128_t sum{ 0 };
+			auto target = (total_unfiltered.number () / 100) * 99;
+			for (auto i (sorted.begin ()), n (sorted.end ()); i != n && sum <= target; sum += i->second, ++i)
 			{
-				auto node_flags = nano::inactive_node_flag_defaults ();
-				nano::update_flags (node_flags, vm);
-				node_flags.generate_cache.reps = true;
-				nano::inactive_node inactive_node (data_path, node_flags);
-				auto node = inactive_node.node;
-
-				auto const bootstrap_weights = node->get_bootstrap_weights ();
-				auto const & hardcoded = bootstrap_weights.second;
-				auto const hardcoded_height = bootstrap_weights.first;
-				auto const ledger_unfiltered = node->ledger.cache.rep_weights.get_rep_amounts ();
-				auto const ledger_height = node->ledger.cache.block_count.load ();
-
-				auto get_total = [](decltype (bootstrap_weights.second) const & reps) -> nano::uint128_union {
-					return std::accumulate (reps.begin (), reps.end (), nano::uint128_t{ 0 }, [](auto sum, auto const & rep) { return sum + rep.second; });
-				};
-
-				// Hardcoded weights are filtered to a cummulative weight of 99%, need to do the same for ledger weights
-				std::remove_const_t<decltype (ledger_unfiltered)> ledger;
-				{
-					std::vector<std::pair<nano::account, nano::uint128_t>> sorted;
-					sorted.reserve (ledger_unfiltered.size ());
-					std::copy (ledger_unfiltered.begin (), ledger_unfiltered.end (), std::back_inserter (sorted));
-					std::sort (sorted.begin (), sorted.end (), [](auto const & left, auto const & right) { return left.second > right.second; });
-					auto const total_unfiltered = get_total (ledger_unfiltered);
-					nano::uint128_t sum{ 0 };
-					auto target = (total_unfiltered.number () / 100) * 99;
-					for (auto i (sorted.begin ()), n (sorted.end ()); i != n && sum <= target; sum += i->second, ++i)
-					{
-						ledger.insert (*i);
-					}
-				}
-
-				auto const total_ledger = get_total (ledger);
-				auto const total_hardcoded = get_total (hardcoded);
-
-				struct mismatched_t
-				{
-					nano::account rep;
-					nano::uint128_union hardcoded;
-					nano::uint128_union ledger;
-					nano::uint128_union diff;
-					std::string get_entry () const
-					{
-						return boost::str (boost::format ("representative %1% hardcoded %2% ledger %3% mismatch %4%")
-						% rep.to_account () % hardcoded.format_balance (nano::Mxrb_ratio, 0, true) % ledger.format_balance (nano::Mxrb_ratio, 0, true) % diff.format_balance (nano::Mxrb_ratio, 0, true));
-					}
-				};
-
-				std::vector<mismatched_t> mismatched;
-				mismatched.reserve (hardcoded.size ());
-				std::transform (hardcoded.begin (), hardcoded.end (), std::back_inserter (mismatched), [&ledger](auto const & rep) {
-					auto ledger_rep (ledger.find (rep.first));
-					nano::uint128_t ledger_weight = (ledger_rep == ledger.end () ? 0 : ledger_rep->second);
-					auto absolute = ledger_weight > rep.second ? ledger_weight - rep.second : rep.second - ledger_weight;
-					return mismatched_t{ rep.first, rep.second, ledger_weight, absolute };
-				});
-
-				// Sort by descending difference
-				std::sort (mismatched.begin (), mismatched.end (), [](mismatched_t const & left, mismatched_t const & right) { return left.diff > right.diff; });
-
-				nano::uint128_union const mismatch_total = std::accumulate (mismatched.begin (), mismatched.end (), nano::uint128_t{ 0 }, [](auto sum, mismatched_t const & sample) { return sum + sample.diff.number (); });
-				nano::uint128_union const mismatch_mean = mismatch_total.number () / mismatched.size ();
-
-				nano::uint512_union mismatch_variance = std::accumulate (mismatched.begin (), mismatched.end (), nano::uint512_t (0), [M = mismatch_mean.number (), N = mismatched.size ()](nano::uint512_t sum, mismatched_t const & sample) {
-					auto x = sample.diff.number ();
-					nano::uint512_t const mean_diff = x > M ? x - M : M - x;
-					nano::uint512_t const sqr = mean_diff * mean_diff;
-					return sum + sqr;
-				})
-				/ mismatched.size ();
-
-				nano::uint128_union const mismatch_stddev = nano::narrow_cast<nano::uint128_t> (boost::multiprecision::sqrt (mismatch_variance.number ()));
-
-				auto const outlier_threshold = std::max (nano::Gxrb_ratio, mismatch_mean.number () + 1 * mismatch_stddev.number ());
-				decltype (mismatched) outliers;
-				std::copy_if (mismatched.begin (), mismatched.end (), std::back_inserter (outliers), [outlier_threshold](mismatched_t const & sample) {
-					return sample.diff > outlier_threshold;
-				});
-
-				auto const newcomer_threshold = std::max (nano::Gxrb_ratio, mismatch_mean.number ());
-				std::vector<std::pair<nano::account, nano::uint128_t>> newcomers;
-				std::copy_if (ledger.begin (), ledger.end (), std::back_inserter (newcomers), [&hardcoded](auto const & rep) {
-					return !hardcoded.count (rep.first) && rep.second;
-				});
-
-				// Sort by descending weight
-				std::sort (newcomers.begin (), newcomers.end (), [](auto const & left, auto const & right) { return left.second > right.second; });
-
-				auto newcomer_entry = [](auto const & rep) {
-					return boost::str (boost::format ("representative %1% hardcoded --- ledger %2%") % rep.first.to_account () % nano::uint128_union (rep.second).format_balance (nano::Mxrb_ratio, 0, true));
-				};
-
-				std::cout << boost::str (boost::format ("hardcoded weight %1% Mnano at %2% blocks\nledger weight %3% Mnano at %4% blocks\nmismatched\n\tsamples %5%\n\ttotal %6% Mnano\n\tmean %7% Mnano\n\tsigma %8% Mnano\n")
-				% total_hardcoded.format_balance (nano::Mxrb_ratio, 0, true)
-				% hardcoded_height
-				% total_ledger.format_balance (nano::Mxrb_ratio, 0, true)
-				% ledger_height
-				% mismatched.size ()
-				% mismatch_total.format_balance (nano::Mxrb_ratio, 0, true)
-				% mismatch_mean.format_balance (nano::Mxrb_ratio, 0, true)
-				% mismatch_stddev.format_balance (nano::Mxrb_ratio, 0, true));
-
-				if (!outliers.empty ())
-				{
-					std::cout << "outliers\n";
-					for (auto const & outlier : outliers)
-					{
-						std::cout << '\t' << outlier.get_entry () << '\n';
-					}
-				}
-
-				if (!newcomers.empty ())
-				{
-					std::cout << "newcomers\n";
-					for (auto const & newcomer : newcomers)
-					{
-						if (newcomer.second > newcomer_threshold)
-						{
-							std::cout << '\t' << newcomer_entry (newcomer) << '\n';
-						}
-					}
-				}
-
-				// Log more data
-				auto const log_threshold = nano::Gxrb_ratio;
-				for (auto const & sample : mismatched)
-				{
-					if (sample.diff > log_threshold)
-					{
-						node->logger.always_log (sample.get_entry ());
-					}
-				}
-				for (auto const & newcomer : newcomers)
-				{
-					if (newcomer.second > log_threshold)
-					{
-						node->logger.always_log (newcomer_entry (newcomer));
-					}
-				}
-			}
-			else
-			{
-				std::cout << "Not available for the test network" << std::endl;
-				result = -1;
+				ledger.insert (*i);
 			}
 		}
-		else if (vm.count ("debug_block_count"))
-		{
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			nano::update_flags (node_flags, vm);
-			node_flags.generate_cache.block_count = true;
-			nano::inactive_node inactive_node (data_path, node_flags);
-			auto node = inactive_node.node;
-			std::cout << boost::str (boost::format ("Block count: %1%\n") % node->ledger.cache.block_count);
-		}
-		else if (vm.count ("debug_bootstrap_generate"))
-		{
-			auto key_it = vm.find ("key");
-			if (key_it != vm.end ())
-			{
-				nano::uint256_union key;
-				if (!key.decode_hex (key_it->second.as<std::string> ()))
-				{
-					nano::keypair genesis (key.to_string ());
-					nano::work_pool work (std::numeric_limits<unsigned>::max ());
-					std::cout << "Genesis: " << genesis.prv.to_string () << "\n"
-					          << "Public: " << genesis.pub.to_string () << "\n"
-					          << "Account: " << genesis.pub.to_account () << "\n";
-					nano::keypair landing;
-					std::cout << "Landing: " << landing.prv.to_string () << "\n"
-					          << "Public: " << landing.pub.to_string () << "\n"
-					          << "Account: " << landing.pub.to_account () << "\n";
-					for (auto i (0); i != 32; ++i)
-					{
-						nano::keypair rep;
-						std::cout << "Rep" << i << ": " << rep.prv.to_string () << "\n"
-						          << "Public: " << rep.pub.to_string () << "\n"
-						          << "Account: " << rep.pub.to_account () << "\n";
-					}
-					nano::network_constants network_constants;
-					nano::uint128_t balance (std::numeric_limits<nano::uint128_t>::max ());
-					nano::open_block genesis_block (reinterpret_cast<const nano::block_hash &> (genesis.pub), genesis.pub, genesis.pub, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, genesis.pub, network_constants.publish_thresholds.epoch_1));
-					std::cout << genesis_block.to_json ();
-					std::cout.flush ();
-					nano::block_hash previous (genesis_block.hash ());
-					for (auto i (0); i != 8; ++i)
-					{
-						nano::uint128_t yearly_distribution (nano::uint128_t (1) << (127 - (i == 7 ? 6 : i)));
-						auto weekly_distribution (yearly_distribution / 52);
-						for (auto j (0); j != 52; ++j)
-						{
-							debug_assert (balance > weekly_distribution);
-							balance = balance < (weekly_distribution * 2) ? 0 : balance - weekly_distribution;
-							nano::send_block send (previous, landing.pub, balance, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, previous, network_constants.publish_thresholds.epoch_1));
-							previous = send.hash ();
-							std::cout << send.to_json ();
-							std::cout.flush ();
-						}
-					}
-				}
-				else
-				{
-					std::cerr << "Invalid key\n";
-					result = -1;
-				}
-			}
-			else
-			{
-				std::cerr << "Bootstrapping requires one <key> option\n";
-				result = -1;
-			}
-		}
-		else if (vm.count ("debug_dump_trended_weight"))
-		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
-			auto current (node->online_reps.trended ());
-			std::cout << boost::str (boost::format ("Trended Weight %1%\n") % current);
-			auto transaction (node->store.tx_begin_read ());
-			for (auto i (node->store.online_weight_begin (transaction)), n (node->store.online_weight_end ()); i != n; ++i)
-			{
-				using time_point = std::chrono::system_clock::time_point;
-				time_point ts (std::chrono::duration_cast<time_point::duration> (std::chrono::nanoseconds (i->first)));
-				std::time_t timestamp = std::chrono::system_clock::to_time_t (ts);
-				std::string weight;
-				i->second.encode_dec (weight);
-				std::cout << boost::str (boost::format ("Timestamp %1% Weight %2%\n") % ctime (&timestamp) % weight);
-			}
-		}
-		else if (vm.count ("debug_dump_representatives"))
-		{
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			nano::update_flags (node_flags, vm);
-			node_flags.generate_cache.reps = true;
-			nano::inactive_node inactive_node (data_path, node_flags);
-			auto node = inactive_node.node;
-			auto transaction (node->store.tx_begin_read ());
-			nano::uint128_t total;
-			auto rep_amounts = node->ledger.cache.rep_weights.get_rep_amounts ();
-			std::map<nano::account, nano::uint128_t> ordered_reps (rep_amounts.begin (), rep_amounts.end ());
-			for (auto const & rep : ordered_reps)
-			{
-				total += rep.second;
-				std::cout << boost::str (boost::format ("%1% %2% %3%\n") % rep.first.to_account () % rep.second.convert_to<std::string> () % total.convert_to<std::string> ());
-			}
-		}
-		else if (vm.count ("debug_dump_frontier_unchecked_dependents"))
-		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
-			std::cout << "Outputting any frontier hashes which have associated key hashes in the unchecked table (may take some time)...\n";
 
-			// Cache the account heads to make searching quicker against unchecked keys.
-			auto transaction (node->store.tx_begin_read ());
-			std::unordered_set<nano::block_hash> frontier_hashes;
-			for (auto i (node->store.accounts_begin (transaction)), n (node->store.accounts_end ()); i != n; ++i)
-			{
-				frontier_hashes.insert (i->second.head);
-			}
+		auto const total_ledger = get_total (ledger);
+		auto const total_hardcoded = get_total (hardcoded);
 
-			// Check all unchecked keys for matching frontier hashes. Indicates an issue with process_batch algorithm
-			for (auto i (node->store.unchecked_begin (transaction)), n (node->store.unchecked_end ()); i != n; ++i)
+		struct mismatched_t
+		{
+			nano::account rep;
+			nano::uint128_union hardcoded;
+			nano::uint128_union ledger;
+			nano::uint128_union diff;
+			std::string get_entry () const
 			{
-				auto it = frontier_hashes.find (i->first.key ());
-				if (it != frontier_hashes.cend ())
+				return boost::str (boost::format ("representative %1% hardcoded %2% ledger %3% mismatch %4%")
+				% rep.to_account () % hardcoded.format_balance (nano::Mxrb_ratio, 0, true) % ledger.format_balance (nano::Mxrb_ratio, 0, true) % diff.format_balance (nano::Mxrb_ratio, 0, true));
+			}
+		};
+
+		std::vector<mismatched_t> mismatched;
+		mismatched.reserve (hardcoded.size ());
+		std::transform (hardcoded.begin (), hardcoded.end (), std::back_inserter (mismatched), [&ledger](auto const & rep) {
+			auto ledger_rep (ledger.find (rep.first));
+			nano::uint128_t ledger_weight = (ledger_rep == ledger.end () ? 0 : ledger_rep->second);
+			auto absolute = ledger_weight > rep.second ? ledger_weight - rep.second : rep.second - ledger_weight;
+			return mismatched_t{ rep.first, rep.second, ledger_weight, absolute };
+		});
+
+		// Sort by descending difference
+		std::sort (mismatched.begin (), mismatched.end (), [](mismatched_t const & left, mismatched_t const & right) { return left.diff > right.diff; });
+
+		nano::uint128_union const mismatch_total = std::accumulate (mismatched.begin (), mismatched.end (), nano::uint128_t{ 0 }, [](auto sum, mismatched_t const & sample) { return sum + sample.diff.number (); });
+		nano::uint128_union const mismatch_mean = mismatch_total.number () / mismatched.size ();
+
+		nano::uint512_union mismatch_variance = std::accumulate (mismatched.begin (), mismatched.end (), nano::uint512_t (0), [M = mismatch_mean.number (), N = mismatched.size ()](nano::uint512_t sum, mismatched_t const & sample) {
+			auto x = sample.diff.number ();
+			nano::uint512_t const mean_diff = x > M ? x - M : M - x;
+			nano::uint512_t const sqr = mean_diff * mean_diff;
+			return sum + sqr;
+		})
+		/ mismatched.size ();
+
+		nano::uint128_union const mismatch_stddev = nano::narrow_cast<nano::uint128_t> (boost::multiprecision::sqrt (mismatch_variance.number ()));
+
+		auto const outlier_threshold = std::max (nano::Gxrb_ratio, mismatch_mean.number () + 1 * mismatch_stddev.number ());
+		decltype (mismatched) outliers;
+		std::copy_if (mismatched.begin (), mismatched.end (), std::back_inserter (outliers), [outlier_threshold](mismatched_t const & sample) {
+			return sample.diff > outlier_threshold;
+		});
+
+		auto const newcomer_threshold = std::max (nano::Gxrb_ratio, mismatch_mean.number ());
+		std::vector<std::pair<nano::account, nano::uint128_t>> newcomers;
+		std::copy_if (ledger.begin (), ledger.end (), std::back_inserter (newcomers), [&hardcoded](auto const & rep) {
+			return !hardcoded.count (rep.first) && rep.second;
+		});
+
+		// Sort by descending weight
+		std::sort (newcomers.begin (), newcomers.end (), [](auto const & left, auto const & right) { return left.second > right.second; });
+
+		auto newcomer_entry = [](auto const & rep) {
+			return boost::str (boost::format ("representative %1% hardcoded --- ledger %2%") % rep.first.to_account () % nano::uint128_union (rep.second).format_balance (nano::Mxrb_ratio, 0, true));
+		};
+
+		std::cout << boost::str (boost::format ("hardcoded weight %1% Mnano at %2% blocks\nledger weight %3% Mnano at %4% blocks\nmismatched\n\tsamples %5%\n\ttotal %6% Mnano\n\tmean %7% Mnano\n\tsigma %8% Mnano\n")
+		% total_hardcoded.format_balance (nano::Mxrb_ratio, 0, true)
+		% hardcoded_height
+		% total_ledger.format_balance (nano::Mxrb_ratio, 0, true)
+		% ledger_height
+		% mismatched.size ()
+		% mismatch_total.format_balance (nano::Mxrb_ratio, 0, true)
+		% mismatch_mean.format_balance (nano::Mxrb_ratio, 0, true)
+		% mismatch_stddev.format_balance (nano::Mxrb_ratio, 0, true));
+
+		if (!outliers.empty ())
+		{
+			std::cout << "outliers\n";
+			for (auto const & outlier : outliers)
+			{
+				std::cout << '\t' << outlier.get_entry () << '\n';
+			}
+		}
+
+		if (!newcomers.empty ())
+		{
+			std::cout << "newcomers\n";
+			for (auto const & newcomer : newcomers)
+			{
+				if (newcomer.second > newcomer_threshold)
 				{
-					std::cout << it->to_string () << "\n";
+					std::cout << '\t' << newcomer_entry (newcomer) << '\n';
 				}
 			}
 		}
-		else if (vm.count ("debug_account_count"))
+
+		// Log more data
+		auto const log_threshold = nano::Gxrb_ratio;
+		for (auto const & sample : mismatched)
 		{
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			nano::update_flags (node_flags, vm);
-			node_flags.generate_cache.account_count = true;
-			nano::inactive_node inactive_node (data_path, node_flags);
-			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % inactive_node.node->ledger.cache.account_count);
-		}
-		else if (vm.count ("debug_profile_kdf"))
-		{
-			nano::network_params network_params;
-			nano::uint256_union result;
-			nano::uint256_union salt (0);
-			std::string password ("");
-			while (true)
+			if (sample.diff > log_threshold)
 			{
-				auto begin1 (std::chrono::high_resolution_clock::now ());
-				auto success (argon2_hash (1, network_params.kdf_work, 1, password.data (), password.size (), salt.bytes.data (), salt.bytes.size (), result.bytes.data (), result.bytes.size (), NULL, 0, Argon2_d, 0x10));
-				(void)success;
-				auto end1 (std::chrono::high_resolution_clock::now ());
-				std::cerr << boost::str (boost::format ("Derivation time: %1%us\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+				node->logger.always_log (sample.get_entry ());
 			}
 		}
-		else if (vm.count ("debug_profile_generate"))
+		for (auto const & newcomer : newcomers)
 		{
-			nano::network_constants network_constants;
-			uint64_t difficulty{ network_constants.publish_full.base };
-			auto multiplier_it = vm.find ("multiplier");
-			if (multiplier_it != vm.end ())
+			if (newcomer.second > log_threshold)
 			{
-				try
+				node->logger.always_log (newcomer_entry (newcomer));
+			}
+		}
+	}
+	else if (vm.count ("debug_block_count"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		nano::update_flags (node_flags, vm);
+		node_flags.generate_cache.block_count = true;
+		nano::inactive_node inactive_node (data_path, node_flags);
+		auto node = inactive_node.node;
+		std::cout << boost::str (boost::format ("Block count: %1%\n") % node->ledger.cache.block_count);
+	}
+	else if (vm.count ("debug_bootstrap_generate"))
+	{
+		auto key_it = vm.find ("key");
+		if (key_it == vm.end ())
+		{
+			std::cerr << "Bootstrapping requires one <key> option\n";
+			return -1;
+		}
+
+		nano::uint256_union key;
+		if (key.decode_hex (key_it->second.as<std::string> ()))
+		{
+			std::cerr << "Invalid key\n";
+			return -1;
+		}
+
+		nano::keypair genesis (key.to_string ());
+		nano::work_pool work (std::numeric_limits<unsigned>::max ());
+		std::cout << "Genesis: " << genesis.prv.to_string () << "\n"
+		          << "Public: " << genesis.pub.to_string () << "\n"
+		          << "Account: " << genesis.pub.to_account () << "\n";
+		nano::keypair landing;
+		std::cout << "Landing: " << landing.prv.to_string () << "\n"
+		          << "Public: " << landing.pub.to_string () << "\n"
+		          << "Account: " << landing.pub.to_account () << "\n";
+		for (auto i (0); i != 32; ++i)
+		{
+			nano::keypair rep;
+			std::cout << "Rep" << i << ": " << rep.prv.to_string () << "\n"
+			          << "Public: " << rep.pub.to_string () << "\n"
+			          << "Account: " << rep.pub.to_account () << "\n";
+		}
+		nano::network_constants network_constants;
+		nano::uint128_t balance (std::numeric_limits<nano::uint128_t>::max ());
+		nano::open_block genesis_block (reinterpret_cast<const nano::block_hash &> (genesis.pub), genesis.pub, genesis.pub, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, genesis.pub, network_constants.publish_thresholds.epoch_1));
+		std::cout << genesis_block.to_json ();
+		std::cout.flush ();
+		nano::block_hash previous (genesis_block.hash ());
+		for (auto i (0); i != 8; ++i)
+		{
+			nano::uint128_t yearly_distribution (nano::uint128_t (1) << (127 - (i == 7 ? 6 : i)));
+			auto weekly_distribution (yearly_distribution / 52);
+			for (auto j (0); j != 52; ++j)
+			{
+				debug_assert (balance > weekly_distribution);
+				balance = balance < (weekly_distribution * 2) ? 0 : balance - weekly_distribution;
+				nano::send_block send (previous, landing.pub, balance, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, previous, network_constants.publish_thresholds.epoch_1));
+				previous = send.hash ();
+				std::cout << send.to_json ();
+				std::cout.flush ();
+			}
+		}
+	}
+	else if (vm.count ("debug_dump_trended_weight"))
+	{
+		auto inactive_node = nano::default_inactive_node (data_path, vm);
+		auto node = inactive_node->node;
+		auto current (node->online_reps.trended ());
+		std::cout << boost::str (boost::format ("Trended Weight %1%\n") % current);
+		auto transaction (node->store.tx_begin_read ());
+		for (auto i (node->store.online_weight_begin (transaction)), n (node->store.online_weight_end ()); i != n; ++i)
+		{
+			using time_point = std::chrono::system_clock::time_point;
+			time_point ts (std::chrono::duration_cast<time_point::duration> (std::chrono::nanoseconds (i->first)));
+			std::time_t timestamp = std::chrono::system_clock::to_time_t (ts);
+			std::string weight;
+			i->second.encode_dec (weight);
+			std::cout << boost::str (boost::format ("Timestamp %1% Weight %2%\n") % ctime (&timestamp) % weight);
+		}
+	}
+	else if (vm.count ("debug_dump_representatives"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		nano::update_flags (node_flags, vm);
+		node_flags.generate_cache.reps = true;
+		nano::inactive_node inactive_node (data_path, node_flags);
+		auto node = inactive_node.node;
+		auto transaction (node->store.tx_begin_read ());
+		nano::uint128_t total;
+		auto rep_amounts = node->ledger.cache.rep_weights.get_rep_amounts ();
+		std::map<nano::account, nano::uint128_t> ordered_reps (rep_amounts.begin (), rep_amounts.end ());
+		for (auto const & rep : ordered_reps)
+		{
+			total += rep.second;
+			std::cout << boost::str (boost::format ("%1% %2% %3%\n") % rep.first.to_account () % rep.second.convert_to<std::string> () % total.convert_to<std::string> ());
+		}
+	}
+	else if (vm.count ("debug_dump_frontier_unchecked_dependents"))
+	{
+		auto inactive_node = nano::default_inactive_node (data_path, vm);
+		auto node = inactive_node->node;
+		std::cout << "Outputting any frontier hashes which have associated key hashes in the unchecked table (may take some time)...\n";
+
+		// Cache the account heads to make searching quicker against unchecked keys.
+		auto transaction (node->store.tx_begin_read ());
+		std::unordered_set<nano::block_hash> frontier_hashes;
+		for (auto i (node->store.accounts_begin (transaction)), n (node->store.accounts_end ()); i != n; ++i)
+		{
+			frontier_hashes.insert (i->second.head);
+		}
+
+		// Check all unchecked keys for matching frontier hashes. Indicates an issue with process_batch algorithm
+		for (auto i (node->store.unchecked_begin (transaction)), n (node->store.unchecked_end ()); i != n; ++i)
+		{
+			auto it = frontier_hashes.find (i->first.key ());
+			if (it != frontier_hashes.cend ())
+			{
+				std::cout << it->to_string () << "\n";
+			}
+		}
+	}
+	else if (vm.count ("debug_account_count"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		nano::update_flags (node_flags, vm);
+		node_flags.generate_cache.account_count = true;
+		nano::inactive_node inactive_node (data_path, node_flags);
+		std::cout << boost::str (boost::format ("Frontier count: %1%\n") % inactive_node.node->ledger.cache.account_count);
+	}
+	else if (vm.count ("debug_profile_kdf"))
+	{
+		nano::network_params network_params;
+		nano::uint256_union result;
+		nano::uint256_union salt (0);
+		std::string password ("");
+		while (true)
+		{
+			auto begin1 (std::chrono::high_resolution_clock::now ());
+			auto success (argon2_hash (1, network_params.kdf_work, 1, password.data (), password.size (), salt.bytes.data (), salt.bytes.size (), result.bytes.data (), result.bytes.size (), NULL, 0, Argon2_d, 0x10));
+			(void)success;
+			auto end1 (std::chrono::high_resolution_clock::now ());
+			std::cerr << boost::str (boost::format ("Derivation time: %1%us\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+		}
+	}
+	else if (vm.count ("debug_profile_generate"))
+	{
+		nano::network_constants network_constants;
+		uint64_t difficulty{ network_constants.publish_full.base };
+		auto multiplier_it = vm.find ("multiplier");
+		if (multiplier_it != vm.end ())
+		{
+			try
+			{
+				auto multiplier (boost::lexical_cast<double> (multiplier_it->second.as<std::string> ()));
+				difficulty = nano::difficulty::from_multiplier (multiplier, difficulty);
+			}
+			catch (boost::bad_lexical_cast &)
+			{
+				std::cerr << "Invalid multiplier\n";
+				return -1;
+			}
+		}
+		else
+		{
+			auto difficulty_it = vm.find ("difficulty");
+			if (difficulty_it != vm.end ())
+			{
+				if (nano::from_string_hex (difficulty_it->second.as<std::string> (), difficulty))
 				{
-					auto multiplier (boost::lexical_cast<double> (multiplier_it->second.as<std::string> ()));
-					difficulty = nano::difficulty::from_multiplier (multiplier, difficulty);
-				}
-				catch (boost::bad_lexical_cast &)
-				{
-					std::cerr << "Invalid multiplier\n";
+					std::cerr << "Invalid difficulty\n";
 					return -1;
 				}
 			}
-			else
-			{
-				auto difficulty_it = vm.find ("difficulty");
-				if (difficulty_it != vm.end ())
-				{
-					if (nano::from_string_hex (difficulty_it->second.as<std::string> (), difficulty))
-					{
-						std::cerr << "Invalid difficulty\n";
-						return -1;
-					}
-				}
-			}
-
-			auto pow_rate_limiter = std::chrono::nanoseconds (0);
-			auto pow_sleep_interval_it = vm.find ("pow_sleep_interval");
-			if (pow_sleep_interval_it != vm.cend ())
-			{
-				pow_rate_limiter = std::chrono::nanoseconds (boost::lexical_cast<uint64_t> (pow_sleep_interval_it->second.as<std::string> ()));
-			}
-
-			nano::work_pool work (std::numeric_limits<unsigned>::max (), pow_rate_limiter);
-			nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
-			if (!result)
-			{
-				std::cerr << boost::str (boost::format ("Starting generation profiling. Difficulty: %1$#x (%2%x from base difficulty %3$#x)\n") % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
-				while (!result)
-				{
-					block.hashables.previous.qwords[0] += 1;
-					auto begin1 (std::chrono::high_resolution_clock::now ());
-					block.block_work_set (*work.generate (nano::work_version::work_1, block.root (), difficulty));
-					auto end1 (std::chrono::high_resolution_clock::now ());
-					std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
-				}
-			}
 		}
-		else if (vm.count ("debug_profile_validate"))
+
+		auto pow_rate_limiter = std::chrono::nanoseconds (0);
+		auto pow_sleep_interval_it = vm.find ("pow_sleep_interval");
+		if (pow_sleep_interval_it != vm.cend ())
 		{
-			uint64_t difficulty{ nano::network_constants ().publish_full.base };
-			std::cerr << "Starting validation profile" << std::endl;
-			auto start (std::chrono::steady_clock::now ());
-			bool valid{ false };
-			nano::block_hash hash{ 0 };
-			uint64_t count{ 10000000U }; // 10M
-			for (uint64_t i (0); i < count; ++i)
-			{
-				valid = nano::work_v1::value (hash, i) > difficulty;
-			}
-			std::ostringstream oss (valid ? "true" : "false"); // IO forces compiler to not dismiss the variable
-			auto total_time (std::chrono::duration_cast<std::chrono::nanoseconds> (std::chrono::steady_clock::now () - start).count ());
-			uint64_t average (total_time / count);
-			std::cout << "Average validation time: " << std::to_string (average) << " ns (" << std::to_string (static_cast<unsigned> (count * 1e9 / total_time)) << " validations/s)" << std::endl;
+			pow_rate_limiter = std::chrono::nanoseconds (boost::lexical_cast<uint64_t> (pow_sleep_interval_it->second.as<std::string> ()));
 		}
-		else if (vm.count ("debug_opencl"))
+
+		nano::work_pool work (std::numeric_limits<unsigned>::max (), pow_rate_limiter);
+		nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
+		if (!result)
 		{
-			nano::network_constants network_constants;
-			bool error (false);
-			nano::opencl_environment environment (error);
-			if (!error)
+			std::cerr << boost::str (boost::format ("Starting generation profiling. Difficulty: %1$#x (%2%x from base difficulty %3$#x)\n") % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
+			while (!result)
 			{
-				unsigned short platform (0);
-				auto platform_it = vm.find ("platform");
-				if (platform_it != vm.end ())
-				{
-					try
-					{
-						platform = boost::lexical_cast<unsigned short> (platform_it->second.as<std::string> ());
-					}
-					catch (boost::bad_lexical_cast &)
-					{
-						std::cerr << "Invalid platform id\n";
-						return -1;
-					}
-				}
-				unsigned short device (0);
-				auto device_it = vm.find ("device");
-				if (device_it != vm.end ())
-				{
-					try
-					{
-						device = boost::lexical_cast<unsigned short> (device_it->second.as<std::string> ());
-					}
-					catch (boost::bad_lexical_cast &)
-					{
-						std::cerr << "Invalid device id\n";
-						return -1;
-					}
-				}
-				unsigned threads (1024 * 1024);
-				auto threads_it = vm.find ("threads");
-				if (threads_it != vm.end ())
-				{
-					try
-					{
-						threads = boost::lexical_cast<unsigned> (threads_it->second.as<std::string> ());
-					}
-					catch (boost::bad_lexical_cast &)
-					{
-						std::cerr << "Invalid threads count\n";
-						return -1;
-					}
-				}
-				uint64_t difficulty (network_constants.publish_full.base);
-				auto multiplier_it = vm.find ("multiplier");
-				if (multiplier_it != vm.end ())
-				{
-					try
-					{
-						auto multiplier (boost::lexical_cast<double> (multiplier_it->second.as<std::string> ()));
-						difficulty = nano::difficulty::from_multiplier (multiplier, difficulty);
-					}
-					catch (boost::bad_lexical_cast &)
-					{
-						std::cerr << "Invalid multiplier\n";
-						return -1;
-					}
-				}
-				else
-				{
-					auto difficulty_it = vm.find ("difficulty");
-					if (difficulty_it != vm.end ())
-					{
-						if (nano::from_string_hex (difficulty_it->second.as<std::string> (), difficulty))
-						{
-							std::cerr << "Invalid difficulty\n";
-							return -1;
-						}
-					}
-				}
-				if (!result)
-				{
-					error |= platform >= environment.platforms.size ();
-					if (!error)
-					{
-						error |= device >= environment.platforms[platform].devices.size ();
-						if (!error)
-						{
-							nano::logger_mt logger;
-							nano::opencl_config config (platform, device, threads);
-							auto opencl (nano::opencl_work::create (true, config, logger));
-							nano::work_pool work_pool (0, std::chrono::nanoseconds (0), opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
-								return opencl->generate_work (version_a, root_a, difficulty_a);
-							}
-							                                                                   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
-							nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
-							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x (%5%x from base difficulty %6$#x)\n") % platform % device % threads % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
-							for (uint64_t i (0); true; ++i)
-							{
-								block.hashables.previous.qwords[0] += 1;
-								auto begin1 (std::chrono::high_resolution_clock::now ());
-								block.block_work_set (*work_pool.generate (nano::work_version::work_1, block.root (), difficulty));
-								auto end1 (std::chrono::high_resolution_clock::now ());
-								std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
-							}
-						}
-						else
-						{
-							std::cout << "Not available device id\n"
-							          << std::endl;
-							result = -1;
-						}
-					}
-					else
-					{
-						std::cout << "Not available platform id\n"
-						          << std::endl;
-						result = -1;
-					}
-				}
-			}
-			else
-			{
-				std::cout << "Error initializing OpenCL" << std::endl;
-				result = -1;
-			}
-		}
-		else if (vm.count ("debug_output_last_backtrace_dump"))
-		{
-			if (boost::filesystem::exists ("nano_node_backtrace.dump"))
-			{
-				// There is a backtrace, so output the contents
-				std::ifstream ifs ("nano_node_backtrace.dump");
-
-				boost::stacktrace::stacktrace st = boost::stacktrace::stacktrace::from_dump (ifs);
-				std::cout << "Latest crash backtrace:\n"
-				          << st << std::endl;
-			}
-		}
-		else if (vm.count ("debug_generate_crash_report"))
-		{
-			if (boost::filesystem::exists ("nano_node_backtrace.dump"))
-			{
-				// There is a backtrace, so output the contents
-				std::ifstream ifs ("nano_node_backtrace.dump");
-				boost::stacktrace::stacktrace st = boost::stacktrace::stacktrace::from_dump (ifs);
-
-				std::string crash_report_filename = "nano_node_crash_report.txt";
-
-#if defined(_WIN32) || defined(__APPLE__)
-				// Only linux has load addresses, so just write the dump to a readable file.
-				// It's the best we can do to keep consistency.
-				std::ofstream ofs (crash_report_filename);
-				ofs << st;
-#else
-				// Read all the nano node files
-				boost::system::error_code err;
-				auto running_executable_filepath = boost::dll::program_location (err);
-				if (!err)
-				{
-					auto num = 0;
-					auto format = boost::format ("nano_node_crash_load_address_dump_%1%.txt");
-					std::vector<address_library_pair> base_addresses;
-
-					// The first one only has the load address
-					uint64_from_hex base_address;
-					std::string line;
-					if (boost::filesystem::exists (boost::str (format % num)))
-					{
-						std::getline (std::ifstream (boost::str (format % num)), line);
-						if (boost::conversion::try_lexical_convert (line, base_address))
-						{
-							base_addresses.emplace_back (base_address.value, running_executable_filepath.string ());
-						}
-					}
-					++num;
-
-					// Now do the rest of the files
-					while (boost::filesystem::exists (boost::str (format % num)))
-					{
-						std::ifstream ifs_dump_filename (boost::str (format % num));
-
-						// 2 lines, the path to the dynamic library followed by the load address
-						std::string dynamic_lib_path;
-						std::getline (ifs_dump_filename, dynamic_lib_path);
-						std::getline (ifs_dump_filename, line);
-
-						if (boost::conversion::try_lexical_convert (line, base_address))
-						{
-							base_addresses.emplace_back (base_address.value, dynamic_lib_path);
-						}
-
-						++num;
-					}
-
-					std::sort (base_addresses.begin (), base_addresses.end ());
-
-					auto address_column_it = vm.find ("address_column");
-					auto column = -1;
-					if (address_column_it != vm.end ())
-					{
-						if (!boost::conversion::try_lexical_convert (address_column_it->second.as<std::string> (), column))
-						{
-							std::cerr << "Error: Invalid address column\n";
-							result = -1;
-						}
-					}
-
-					// Extract the addresses from the dump file.
-					std::stringstream stacktrace_ss;
-					stacktrace_ss << st;
-					std::vector<uint64_t> backtrace_addresses;
-					while (std::getline (stacktrace_ss, line))
-					{
-						std::istringstream iss (line);
-						std::vector<std::string> results (std::istream_iterator<std::string>{ iss }, std::istream_iterator<std::string> ());
-
-						if (column != -1)
-						{
-							if (column < results.size ())
-							{
-								uint64_from_hex address_hex;
-								if (boost::conversion::try_lexical_convert (results[column], address_hex))
-								{
-									backtrace_addresses.push_back (address_hex.value);
-								}
-								else
-								{
-									std::cerr << "Error: Address column does not point to valid addresses\n";
-									result = -1;
-								}
-							}
-							else
-							{
-								std::cerr << "Error: Address column too high\n";
-								result = -1;
-							}
-						}
-						else
-						{
-							for (const auto & text : results)
-							{
-								uint64_from_hex address_hex;
-								if (boost::conversion::try_lexical_convert (text, address_hex))
-								{
-									backtrace_addresses.push_back (address_hex.value);
-									break;
-								}
-							}
-						}
-					}
-
-					// Recreate the crash report with an empty file
-					boost::filesystem::remove (crash_report_filename);
-					{
-						std::ofstream ofs (crash_report_filename);
-						nano::set_secure_perm_file (crash_report_filename);
-					}
-
-					// Hold the results from all addr2line calls, if all fail we can assume that addr2line is not installed,
-					// and inform the user that it needs installing
-					std::vector<int> system_codes;
-
-					auto run_addr2line = [&backtrace_addresses, &base_addresses, &system_codes, &crash_report_filename](bool use_relative_addresses) {
-						for (auto backtrace_address : backtrace_addresses)
-						{
-							// Find the closest address to it
-							for (auto base_address : boost::adaptors::reverse (base_addresses))
-							{
-								if (backtrace_address > base_address.address)
-								{
-									// Addresses need to be in hex for addr2line to work
-									auto address = use_relative_addresses ? backtrace_address - base_address.address : backtrace_address;
-									std::stringstream ss;
-									ss << std::uppercase << std::hex << address;
-
-									// Call addr2line to convert the address into something readable.
-									auto res = std::system (boost::str (boost::format ("addr2line -fCi %1% -e %2% >> %3%") % ss.str () % base_address.library % crash_report_filename).c_str ());
-									system_codes.push_back (res);
-									break;
-								}
-							}
-						}
-					};
-
-					// First run addr2line using absolute addresses
-					run_addr2line (false);
-					{
-						std::ofstream ofs (crash_report_filename, std::ios_base::out | std::ios_base::app);
-						ofs << std::endl
-						    << "Using relative addresses:" << std::endl; // Add an empty line to separate the absolute & relative output
-					}
-
-					// Now run using relative addresses. This will give actual results for other dlls, the results from the nano_node executable.
-					run_addr2line (true);
-
-					if (std::find (system_codes.begin (), system_codes.end (), 0) == system_codes.end ())
-					{
-						std::cerr << "Error: Check that addr2line is installed and that nano_node_crash_load_address_dump_*.txt files exist." << std::endl;
-						result = -1;
-					}
-				}
-				else
-				{
-					std::cerr << "Error: Could not determine running executable path" << std::endl;
-					result = -1;
-				}
-#endif
-				if (result == 0)
-				{
-					std::cout << (boost::format ("%1% created") % crash_report_filename).str () << std::endl;
-				}
-			}
-			else
-			{
-				std::cerr << "Error: nano_node_backtrace.dump could not be found";
-				result = -1;
-			}
-		}
-		else if (vm.count ("debug_verify_profile"))
-		{
-			nano::keypair key;
-			nano::uint256_union message;
-			auto signature = nano::sign_message (key.prv, key.pub, message);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			for (auto i (0u); i < 1000; ++i)
-			{
-				nano::validate_message (key.pub, message, signature);
-			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "Signature verifications " << std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count () << std::endl;
-		}
-		else if (vm.count ("debug_verify_profile_batch"))
-		{
-			nano::keypair key;
-			size_t batch_count (1000);
-			nano::uint256_union message;
-			nano::uint512_union signature (nano::sign_message (key.prv, key.pub, message));
-			std::vector<unsigned char const *> messages (batch_count, message.bytes.data ());
-			std::vector<size_t> lengths (batch_count, sizeof (message));
-			std::vector<unsigned char const *> pub_keys (batch_count, key.pub.bytes.data ());
-			std::vector<unsigned char const *> signatures (batch_count, signature.bytes.data ());
-			std::vector<int> verifications;
-			verifications.resize (batch_count);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			nano::validate_message_batch (messages.data (), lengths.data (), pub_keys.data (), signatures.data (), batch_count, verifications.data ());
-			auto end (std::chrono::high_resolution_clock::now ());
-			std::cerr << "Batch signature verifications " << std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count () << std::endl;
-		}
-		else if (vm.count ("debug_profile_sign"))
-		{
-			std::cerr << "Starting blocks signing profiling\n";
-			while (true)
-			{
-				nano::keypair key;
-				nano::block_hash latest (0);
+				block.hashables.previous.qwords[0] += 1;
 				auto begin1 (std::chrono::high_resolution_clock::now ());
-				for (uint64_t balance (0); balance < 1000; ++balance)
-				{
-					nano::send_block send (latest, key.pub, balance, key.prv, key.pub, 0);
-					latest = send.hash ();
-				}
+				block.block_work_set (*work.generate (nano::work_version::work_1, block.root (), difficulty));
 				auto end1 (std::chrono::high_resolution_clock::now ());
 				std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
 			}
 		}
-		else if (vm.count ("debug_profile_process"))
+	}
+	else if (vm.count ("debug_profile_validate"))
+	{
+		uint64_t difficulty{ nano::network_constants ().publish_full.base };
+		std::cerr << "Starting validation profile" << std::endl;
+		auto start (std::chrono::steady_clock::now ());
+		bool valid{ false };
+		nano::block_hash hash{ 0 };
+		uint64_t count{ 10000000U }; // 10M
+		for (uint64_t i (0); i < count; ++i)
 		{
-			nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
-			nano::network_params dev_params;
-			nano::block_builder builder;
-			size_t num_accounts (100000);
-			size_t num_iterations (5); // 100,000 * 5 * 2 = 1,000,000 blocks
-			size_t max_blocks (2 * num_accounts * num_iterations + num_accounts * 2); //  1,000,000 + 2 * 100,000 = 1,200,000 blocks
-			std::cout << boost::str (boost::format ("Starting pregenerating %1% blocks\n") % max_blocks);
-			nano::node_flags node_flags;
-			nano::update_flags (node_flags, vm);
-			nano::inactive_node inactive_node (nano::unique_path (), data_path, node_flags);
-			auto node = inactive_node.node;
-
-			nano::block_hash genesis_latest (node->latest (dev_params.ledger.dev_genesis_key.pub));
-			nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
-			// Generating keys
-			std::vector<nano::keypair> keys (num_accounts);
-			std::vector<nano::root> frontiers (num_accounts);
-			std::vector<nano::uint128_t> balances (num_accounts, 1000000000);
-			// Generating blocks
-			std::deque<std::shared_ptr<nano::block>> blocks;
-			for (auto i (0); i != num_accounts; ++i)
-			{
-				genesis_balance = genesis_balance - 1000000000;
-
-				auto send = builder.state ()
-				            .account (dev_params.ledger.dev_genesis_key.pub)
-				            .previous (genesis_latest)
-				            .representative (dev_params.ledger.dev_genesis_key.pub)
-				            .balance (genesis_balance)
-				            .link (keys[i].pub)
-				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
-				            .work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				genesis_latest = send->hash ();
-				blocks.push_back (std::move (send));
-
-				auto open = builder.state ()
-				            .account (keys[i].pub)
-				            .previous (0)
-				            .representative (keys[i].pub)
-				            .balance (balances[i])
-				            .link (genesis_latest)
-				            .sign (keys[i].prv, keys[i].pub)
-				            .work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				frontiers[i] = open->hash ();
-				blocks.push_back (std::move (open));
-			}
-			for (auto i (0); i != num_iterations; ++i)
-			{
-				for (auto j (0); j != num_accounts; ++j)
-				{
-					size_t other (num_accounts - j - 1);
-					// Sending to other account
-					--balances[j];
-
-					auto send = builder.state ()
-					            .account (keys[j].pub)
-					            .previous (frontiers[j].as_block_hash ())
-					            .representative (keys[j].pub)
-					            .balance (balances[j])
-					            .link (keys[other].pub)
-					            .sign (keys[j].prv, keys[j].pub)
-					            .work (*node->work.generate (nano::work_version::work_1, frontiers[j], node->network_params.network.publish_thresholds.epoch_1))
-					            .build ();
-
-					frontiers[j] = send->hash ();
-					blocks.push_back (std::move (send));
-					// Receiving
-					++balances[other];
-
-					auto receive = builder.state ()
-					               .account (keys[other].pub)
-					               .previous (frontiers[other].as_block_hash ())
-					               .representative (keys[other].pub)
-					               .balance (balances[other])
-					               .link (frontiers[j].as_block_hash ())
-					               .sign (keys[other].prv, keys[other].pub)
-					               .work (*node->work.generate (nano::work_version::work_1, frontiers[other], node->network_params.network.publish_thresholds.epoch_1))
-					               .build ();
-
-					frontiers[other] = receive->hash ();
-					blocks.push_back (std::move (receive));
-				}
-			}
-			// Processing blocks
-			std::cout << boost::str (boost::format ("Starting processing %1% blocks\n") % max_blocks);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			while (!blocks.empty ())
-			{
-				auto block (blocks.front ());
-				node->process_active (block);
-				blocks.pop_front ();
-			}
-			nano::timer<std::chrono::seconds> timer_l (nano::timer_state::started);
-			while (node->ledger.cache.block_count != max_blocks + 1)
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (10));
-				// Message each 15 seconds
-				if (timer_l.after_deadline (std::chrono::seconds (15)))
-				{
-					timer_l.restart ();
-					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked), %3% remaining") % node->ledger.cache.block_count % node->store.unchecked_count (node->store.tx_begin_read ()) % node->block_processor.size ()) << std::endl;
-				}
-			}
-
-			node->block_processor.flush ();
-			auto end (std::chrono::high_resolution_clock::now ());
-			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
-			node->stop ();
-			std::cout << boost::str (boost::format ("%|1$ 12d| us \n%2% blocks per second\n") % time % (max_blocks * 1000000 / time));
-			release_assert (node->ledger.cache.block_count == max_blocks + 1);
+			valid = nano::work_v1::value (hash, i) > difficulty;
 		}
-		else if (vm.count ("debug_profile_votes"))
+		std::ostringstream oss (valid ? "true" : "false"); // IO forces compiler to not dismiss the variable
+		auto total_time (std::chrono::duration_cast<std::chrono::nanoseconds> (std::chrono::steady_clock::now () - start).count ());
+		uint64_t average (total_time / count);
+		std::cout << "Average validation time: " << std::to_string (average) << " ns (" << std::to_string (static_cast<unsigned> (count * 1e9 / total_time)) << " validations/s)" << std::endl;
+	}
+	else if (vm.count ("debug_opencl"))
+	{
+		nano::network_constants network_constants;
+		bool error (false);
+		nano::opencl_environment environment (error);
+		if (error)
 		{
-			nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
-			nano::network_params dev_params;
-			nano::block_builder builder;
-			size_t num_elections (40000);
-			size_t num_representatives (25);
-			size_t max_votes (num_elections * num_representatives); // 40,000 * 25 = 1,000,000 votes
-			std::cerr << boost::str (boost::format ("Starting pregenerating %1% votes\n") % max_votes);
-			nano::node_flags node_flags;
-			nano::update_flags (node_flags, vm);
-			nano::node_wrapper node_wrapper (nano::unique_path (), data_path, node_flags);
-			auto node = node_wrapper.node;
-
-			nano::block_hash genesis_latest (node->latest (dev_params.ledger.dev_genesis_key.pub));
-			nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
-			// Generating keys
-			std::vector<nano::keypair> keys (num_representatives);
-			nano::uint128_t balance ((node->config.online_weight_minimum.number () / num_representatives) + 1);
-			for (auto i (0); i != num_representatives; ++i)
-			{
-				auto transaction (node->store.tx_begin_write ());
-				genesis_balance = genesis_balance - balance;
-
-				auto send = builder.state ()
-				            .account (dev_params.ledger.dev_genesis_key.pub)
-				            .previous (genesis_latest)
-				            .representative (dev_params.ledger.dev_genesis_key.pub)
-				            .balance (genesis_balance)
-				            .link (keys[i].pub)
-				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
-				            .work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				genesis_latest = send->hash ();
-				node->ledger.process (transaction, *send);
-
-				auto open = builder.state ()
-				            .account (keys[i].pub)
-				            .previous (0)
-				            .representative (keys[i].pub)
-				            .balance (balance)
-				            .link (genesis_latest)
-				            .sign (keys[i].prv, keys[i].pub)
-				            .work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				node->ledger.process (transaction, *open);
-			}
-			// Generating blocks
-			std::deque<std::shared_ptr<nano::block>> blocks;
-			for (auto i (0); i != num_elections; ++i)
-			{
-				genesis_balance = genesis_balance - 1;
-				nano::keypair destination;
-
-				auto send = builder.state ()
-				            .account (dev_params.ledger.dev_genesis_key.pub)
-				            .previous (genesis_latest)
-				            .representative (dev_params.ledger.dev_genesis_key.pub)
-				            .balance (genesis_balance)
-				            .link (destination.pub)
-				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
-				            .work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				genesis_latest = send->hash ();
-				blocks.push_back (std::move (send));
-			}
-			// Generating votes
-			std::deque<std::shared_ptr<nano::vote>> votes;
-			for (auto j (0); j != num_representatives; ++j)
-			{
-				uint64_t sequence (1);
-				for (auto & i : blocks)
-				{
-					auto vote (std::make_shared<nano::vote> (keys[j].pub, keys[j].prv, sequence, std::vector<nano::block_hash> (1, i->hash ())));
-					votes.push_back (vote);
-					sequence++;
-				}
-			}
-			// Processing block & start elections
-			while (!blocks.empty ())
-			{
-				auto block (blocks.front ());
-				node->process_active (block);
-				blocks.pop_front ();
-			}
-			node->block_processor.flush ();
-			// Processing votes
-			std::cerr << boost::str (boost::format ("Starting processing %1% votes\n") % max_votes);
-			auto begin (std::chrono::high_resolution_clock::now ());
-			while (!votes.empty ())
-			{
-				auto vote (votes.front ());
-				auto channel (std::make_shared<nano::transport::channel_loopback> (*node));
-				node->vote_processor.vote (vote, channel);
-				votes.pop_front ();
-			}
-			while (!node->active.empty ())
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (100));
-			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
-			node->stop ();
-			std::cerr << boost::str (boost::format ("%|1$ 12d| us \n%2% votes per second\n") % time % (max_votes * 1000000 / time));
+			std::cout << "Error initializing OpenCL" << std::endl;
+			return -1;
 		}
-		else if (vm.count ("debug_profile_frontiers_confirmation"))
+
+		unsigned short platform (0);
+		auto platform_it = vm.find ("platform");
+		if (platform_it != vm.end ())
 		{
-			nano::force_nano_dev_network ();
-			nano::network_params dev_params;
-			nano::block_builder builder;
-			size_t count (32 * 1024);
-			auto count_it = vm.find ("count");
-			if (count_it != vm.end ())
+			try
 			{
-				try
+				platform = boost::lexical_cast<unsigned short> (platform_it->second.as<std::string> ());
+			}
+			catch (boost::bad_lexical_cast &)
+			{
+				std::cerr << "Invalid platform id\n";
+				return -1;
+			}
+		}
+		unsigned short device (0);
+		auto device_it = vm.find ("device");
+		if (device_it != vm.end ())
+		{
+			try
+			{
+				device = boost::lexical_cast<unsigned short> (device_it->second.as<std::string> ());
+			}
+			catch (boost::bad_lexical_cast &)
+			{
+				std::cerr << "Invalid device id\n";
+				return -1;
+			}
+		}
+		unsigned threads (1024 * 1024);
+		auto threads_it = vm.find ("threads");
+		if (threads_it != vm.end ())
+		{
+			try
+			{
+				threads = boost::lexical_cast<unsigned> (threads_it->second.as<std::string> ());
+			}
+			catch (boost::bad_lexical_cast &)
+			{
+				std::cerr << "Invalid threads count\n";
+				return -1;
+			}
+		}
+		uint64_t difficulty (network_constants.publish_full.base);
+		auto multiplier_it = vm.find ("multiplier");
+		if (multiplier_it != vm.end ())
+		{
+			try
+			{
+				auto multiplier (boost::lexical_cast<double> (multiplier_it->second.as<std::string> ()));
+				difficulty = nano::difficulty::from_multiplier (multiplier, difficulty);
+			}
+			catch (boost::bad_lexical_cast &)
+			{
+				std::cerr << "Invalid multiplier\n";
+				return -1;
+			}
+		}
+		else
+		{
+			auto difficulty_it = vm.find ("difficulty");
+			if (difficulty_it != vm.end ())
+			{
+				if (nano::from_string_hex (difficulty_it->second.as<std::string> (), difficulty))
 				{
-					count = boost::lexical_cast<size_t> (count_it->second.as<std::string> ());
-				}
-				catch (boost::bad_lexical_cast &)
-				{
-					std::cerr << "Invalid count\n";
+					std::cerr << "Invalid difficulty\n";
 					return -1;
 				}
 			}
-			std::cout << boost::str (boost::format ("Starting generating %1% blocks...\n") % (count * 2));
-			boost::asio::io_context io_ctx1;
-			boost::asio::io_context io_ctx2;
-			nano::work_pool work (std::numeric_limits<unsigned>::max ());
-			nano::logging logging;
-			auto path1 (nano::unique_path ());
-			auto path2 (nano::unique_path ());
-			logging.init (path1);
-			std::vector<std::string> config_overrides;
-			auto config (vm.find ("config"));
-			if (config != vm.end ())
-			{
-				config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> ());
-			}
-			nano::daemon_config daemon_config (data_path);
-			auto error = nano::read_node_config_toml (data_path, daemon_config, config_overrides);
-
-			nano::node_config config1 = daemon_config.node;
-			config1.peering_port = 24000;
-
-			nano::node_flags flags;
-			nano::update_flags (flags, vm);
-			flags.disable_lazy_bootstrap = true;
-			flags.disable_legacy_bootstrap = true;
-			flags.disable_wallet_bootstrap = true;
-			flags.disable_bootstrap_listener = true;
-			auto node1 (std::make_shared<nano::node> (io_ctx1, path1, config1, work, flags, 0));
-			nano::block_hash genesis_latest (node1->latest (dev_params.ledger.dev_genesis_key.pub));
-			nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
-			// Generating blocks
-			std::deque<std::shared_ptr<nano::block>> blocks;
-			for (auto i (0); i != count; ++i)
-			{
-				nano::keypair key;
-				genesis_balance = genesis_balance - 1;
-
-				auto send = builder.state ()
-				            .account (dev_params.ledger.dev_genesis_key.pub)
-				            .previous (genesis_latest)
-				            .representative (dev_params.ledger.dev_genesis_key.pub)
-				            .balance (genesis_balance)
-				            .link (key.pub)
-				            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
-				            .work (*work.generate (nano::work_version::work_1, genesis_latest, dev_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				genesis_latest = send->hash ();
-
-				auto open = builder.state ()
-				            .account (key.pub)
-				            .previous (0)
-				            .representative (key.pub)
-				            .balance (1)
-				            .link (genesis_latest)
-				            .sign (key.prv, key.pub)
-				            .work (*work.generate (nano::work_version::work_1, key.pub, dev_params.network.publish_thresholds.epoch_1))
-				            .build ();
-
-				blocks.push_back (std::move (send));
-				blocks.push_back (std::move (open));
-				if (i % 20000 == 0 && i != 0)
-				{
-					std::cout << boost::str (boost::format ("%1% blocks generated\n") % (i * 2));
-				}
-			}
-			node1->start ();
-			nano::thread_runner runner1 (io_ctx1, node1->config.io_threads);
-
-			std::cout << boost::str (boost::format ("Processing %1% blocks\n") % (count * 2));
-			for (auto & block : blocks)
-			{
-				node1->block_processor.add (block);
-			}
-			node1->block_processor.flush ();
-			auto iteration (0);
-			while (node1->ledger.cache.block_count != count * 2 + 1)
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (500));
-				if (++iteration % 60 == 0)
-				{
-					std::cout << boost::str (boost::format ("%1% blocks processed\n") % node1->ledger.cache.block_count);
-				}
-			}
-			// Confirm blocks for node1
-			for (auto & block : blocks)
-			{
-				node1->confirmation_height_processor.add (block);
-			}
-			while (node1->ledger.cache.cemented_count != node1->ledger.cache.block_count)
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (500));
-				if (++iteration % 60 == 0)
-				{
-					std::cout << boost::str (boost::format ("%1% blocks cemented\n") % node1->ledger.cache.cemented_count);
-				}
-			}
-
-			// Start new node
-			nano::node_config config2 = daemon_config.node;
-			config1.peering_port = 24001;
+		}
+		if (!result)
+		{
+			error |= platform >= environment.platforms.size ();
 			if (error)
 			{
-				std::cerr << "\n"
-				          << error.get_message () << std::endl;
-				std::exit (1);
-			}
-			else
-			{
-				config2.frontiers_confirmation = daemon_config.node.frontiers_confirmation;
-				config2.active_elections_size = daemon_config.node.active_elections_size;
+				std::cout << "Not available platform id\n"
+				          << std::endl;
+				return -1;
 			}
 
-			auto node2 (std::make_shared<nano::node> (io_ctx2, path2, config2, work, flags, 1));
-			node2->start ();
-			nano::thread_runner runner2 (io_ctx2, node2->config.io_threads);
-			std::cout << boost::str (boost::format ("Processing %1% blocks (test node)\n") % (count * 2));
-			// Processing block
-			while (!blocks.empty ())
+			error |= device >= environment.platforms[platform].devices.size ();
+			if (error)
 			{
-				auto block (blocks.front ());
-				node2->block_processor.add (block);
-				blocks.pop_front ();
+				std::cout << "Not available device id\n"
+				          << std::endl;
+				return -1;
 			}
-			node2->block_processor.flush ();
-			while (node2->ledger.cache.block_count != count * 2 + 1)
+
+			nano::logger_mt logger;
+			nano::opencl_config config (platform, device, threads);
+			auto opencl (nano::opencl_work::create (true, config, logger));
+			nano::work_pool work_pool (0, std::chrono::nanoseconds (0), opencl ? [&opencl](nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
+				return opencl->generate_work (version_a, root_a, difficulty_a);
+			}
+			                                                                   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+			nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
+			std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x (%5%x from base difficulty %6$#x)\n") % platform % device % threads % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
+			for (uint64_t i (0); true; ++i)
 			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (500));
-				if (++iteration % 60 == 0)
-				{
-					std::cout << boost::str (boost::format ("%1% blocks processed\n") % node2->ledger.cache.block_count);
-				}
+				block.hashables.previous.qwords[0] += 1;
+				auto begin1 (std::chrono::high_resolution_clock::now ());
+				block.block_work_set (*work_pool.generate (nano::work_version::work_1, block.root (), difficulty));
+				auto end1 (std::chrono::high_resolution_clock::now ());
+				std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
 			}
-			// Insert representative
-			std::cout << "Initializing representative\n";
-			auto wallet (node1->wallets.create (nano::random_wallet_id ()));
-			wallet->insert_adhoc (dev_params.ledger.dev_genesis_key.prv);
-			node2->network.merge_peer (node1->network.endpoint ());
-			while (node2->rep_crawler.representative_count () == 0)
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (10));
-				if (++iteration % 500 == 0)
-				{
-					std::cout << "Representative initialization iteration...\n";
-				}
-			}
-			auto begin (std::chrono::high_resolution_clock::now ());
-			std::cout << boost::str (boost::format ("Starting confirming %1% frontiers (test node)\n") % (count + 1));
-			// Wait for full frontiers confirmation
-			while (node2->ledger.cache.cemented_count != node2->ledger.cache.block_count)
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (25));
-				if (++iteration % 1200 == 0)
-				{
-					std::cout << boost::str (boost::format ("%1% blocks confirmed\n") % node2->ledger.cache.cemented_count);
-				}
-			}
-			auto end (std::chrono::high_resolution_clock::now ());
-			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
-			std::cout << boost::str (boost::format ("%|1$ 12d| us \n%2% frontiers per second\n") % time % ((count + 1) * 1000000 / time));
-			io_ctx1.stop ();
-			io_ctx2.stop ();
-			runner1.join ();
-			runner2.join ();
-			node1->stop ();
-			node2->stop ();
 		}
-		else if (vm.count ("debug_random_feed"))
+	}
+	else if (vm.count ("debug_output_last_backtrace_dump"))
+	{
+		if (boost::filesystem::exists ("nano_node_backtrace.dump"))
 		{
-			/*
+			// There is a backtrace, so output the contents
+			std::ifstream ifs ("nano_node_backtrace.dump");
+
+			boost::stacktrace::stacktrace st = boost::stacktrace::stacktrace::from_dump (ifs);
+			std::cout << "Latest crash backtrace:\n"
+			          << st << std::endl;
+		}
+	}
+	else if (vm.count ("debug_generate_crash_report"))
+	{
+		if (boost::filesystem::exists ("nano_node_backtrace.dump"))
+		{
+			// There is a backtrace, so output the contents
+			std::ifstream ifs ("nano_node_backtrace.dump");
+			boost::stacktrace::stacktrace st = boost::stacktrace::stacktrace::from_dump (ifs);
+
+			std::string crash_report_filename = "nano_node_crash_report.txt";
+
+#if defined(_WIN32) || defined(__APPLE__)
+			// Only linux has load addresses, so just write the dump to a readable file.
+			// It's the best we can do to keep consistency.
+			std::ofstream ofs (crash_report_filename);
+			ofs << st;
+#else
+			// Read all the nano node files
+			boost::system::error_code err;
+			auto running_executable_filepath = boost::dll::program_location (err);
+			if (err)
+			{
+				std::cerr << "Error: Could not determine running executable path" << std::endl;
+				return -1;
+			}
+
+			auto num = 0;
+			auto format = boost::format ("nano_node_crash_load_address_dump_%1%.txt");
+			std::vector<address_library_pair> base_addresses;
+
+			// The first one only has the load address
+			uint64_from_hex base_address;
+			std::string line;
+			if (boost::filesystem::exists (boost::str (format % num)))
+			{
+				std::getline (std::ifstream (boost::str (format % num)), line);
+				if (boost::conversion::try_lexical_convert (line, base_address))
+				{
+					base_addresses.emplace_back (base_address.value, running_executable_filepath.string ());
+				}
+			}
+			++num;
+
+			// Now do the rest of the files
+			while (boost::filesystem::exists (boost::str (format % num)))
+			{
+				std::ifstream ifs_dump_filename (boost::str (format % num));
+
+				// 2 lines, the path to the dynamic library followed by the load address
+				std::string dynamic_lib_path;
+				std::getline (ifs_dump_filename, dynamic_lib_path);
+				std::getline (ifs_dump_filename, line);
+
+				if (boost::conversion::try_lexical_convert (line, base_address))
+				{
+					base_addresses.emplace_back (base_address.value, dynamic_lib_path);
+				}
+
+				++num;
+			}
+
+			std::sort (base_addresses.begin (), base_addresses.end ());
+
+			auto address_column_it = vm.find ("address_column");
+			auto column = -1;
+			if (address_column_it != vm.end ())
+			{
+				if (!boost::conversion::try_lexical_convert (address_column_it->second.as<std::string> (), column))
+				{
+					std::cerr << "Error: Invalid address column\n";
+					return -1;
+				}
+			}
+
+			// Extract the addresses from the dump file.
+			std::stringstream stacktrace_ss;
+			stacktrace_ss << st;
+			std::vector<uint64_t> backtrace_addresses;
+			while (std::getline (stacktrace_ss, line))
+			{
+				std::istringstream iss (line);
+				std::vector<std::string> results (std::istream_iterator<std::string>{ iss }, std::istream_iterator<std::string> ());
+
+				if (column != -1)
+				{
+					if (column >= results.size ())
+					{
+						std::cerr << "Error: Address column too high\n";
+						return -1;
+					}
+
+					uint64_from_hex address_hex;
+					if (!boost::conversion::try_lexical_convert (results[column], address_hex))
+					{
+						std::cerr << "Error: Address column does not point to valid addresses\n";
+						return -1;
+					}
+
+					backtrace_addresses.push_back (address_hex.value);
+				}
+				else
+				{
+					for (const auto & text : results)
+					{
+						uint64_from_hex address_hex;
+						if (boost::conversion::try_lexical_convert (text, address_hex))
+						{
+							backtrace_addresses.push_back (address_hex.value);
+							break;
+						}
+					}
+				}
+			}
+
+			// Recreate the crash report with an empty file
+			boost::filesystem::remove (crash_report_filename);
+			{
+				std::ofstream ofs (crash_report_filename);
+				nano::set_secure_perm_file (crash_report_filename);
+			}
+
+			// Hold the results from all addr2line calls, if all fail we can assume that addr2line is not installed,
+			// and inform the user that it needs installing
+			std::vector<int> system_codes;
+
+			auto run_addr2line = [&backtrace_addresses, &base_addresses, &system_codes, &crash_report_filename](bool use_relative_addresses) {
+				for (auto backtrace_address : backtrace_addresses)
+				{
+					// Find the closest address to it
+					for (auto base_address : boost::adaptors::reverse (base_addresses))
+					{
+						if (backtrace_address > base_address.address)
+						{
+							// Addresses need to be in hex for addr2line to work
+							auto address = use_relative_addresses ? backtrace_address - base_address.address : backtrace_address;
+							std::stringstream ss;
+							ss << std::uppercase << std::hex << address;
+
+							// Call addr2line to convert the address into something readable.
+							auto res = std::system (boost::str (boost::format ("addr2line -fCi %1% -e %2% >> %3%") % ss.str () % base_address.library % crash_report_filename).c_str ());
+							system_codes.push_back (res);
+							break;
+						}
+					}
+				}
+			};
+
+			// First run addr2line using absolute addresses
+			run_addr2line (false);
+			{
+				std::ofstream ofs (crash_report_filename, std::ios_base::out | std::ios_base::app);
+				ofs << std::endl
+				    << "Using relative addresses:" << std::endl; // Add an empty line to separate the absolute & relative output
+			}
+
+			// Now run using relative addresses. This will give actual results for other dlls, the results from the nano_node executable.
+			run_addr2line (true);
+
+			if (std::find (system_codes.begin (), system_codes.end (), 0) == system_codes.end ())
+			{
+				std::cerr << "Error: Check that addr2line is installed and that nano_node_crash_load_address_dump_*.txt files exist." << std::endl;
+				return -1;
+			}
+#endif
+			if (result == 0)
+			{
+				std::cout << (boost::format ("%1% created") % crash_report_filename).str () << std::endl;
+			}
+		}
+		else
+		{
+			std::cerr << "Error: nano_node_backtrace.dump could not be found";
+			return -1;
+		}
+	}
+	else if (vm.count ("debug_verify_profile"))
+	{
+		nano::keypair key;
+		nano::uint256_union message;
+		auto signature = nano::sign_message (key.prv, key.pub, message);
+		auto begin (std::chrono::high_resolution_clock::now ());
+		for (auto i (0u); i < 1000; ++i)
+		{
+			nano::validate_message (key.pub, message, signature);
+		}
+		auto end (std::chrono::high_resolution_clock::now ());
+		std::cerr << "Signature verifications " << std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count () << std::endl;
+	}
+	else if (vm.count ("debug_verify_profile_batch"))
+	{
+		nano::keypair key;
+		size_t batch_count (1000);
+		nano::uint256_union message;
+		nano::uint512_union signature (nano::sign_message (key.prv, key.pub, message));
+		std::vector<unsigned char const *> messages (batch_count, message.bytes.data ());
+		std::vector<size_t> lengths (batch_count, sizeof (message));
+		std::vector<unsigned char const *> pub_keys (batch_count, key.pub.bytes.data ());
+		std::vector<unsigned char const *> signatures (batch_count, signature.bytes.data ());
+		std::vector<int> verifications;
+		verifications.resize (batch_count);
+		auto begin (std::chrono::high_resolution_clock::now ());
+		nano::validate_message_batch (messages.data (), lengths.data (), pub_keys.data (), signatures.data (), batch_count, verifications.data ());
+		auto end (std::chrono::high_resolution_clock::now ());
+		std::cerr << "Batch signature verifications " << std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count () << std::endl;
+	}
+	else if (vm.count ("debug_profile_sign"))
+	{
+		std::cerr << "Starting blocks signing profiling\n";
+		while (true)
+		{
+			nano::keypair key;
+			nano::block_hash latest (0);
+			auto begin1 (std::chrono::high_resolution_clock::now ());
+			for (uint64_t balance (0); balance < 1000; ++balance)
+			{
+				nano::send_block send (latest, key.pub, balance, key.prv, key.pub, 0);
+				latest = send.hash ();
+			}
+			auto end1 (std::chrono::high_resolution_clock::now ());
+			std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());
+		}
+	}
+	else if (vm.count ("debug_profile_process"))
+	{
+		nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+		nano::network_params dev_params;
+		nano::block_builder builder;
+		size_t num_accounts (100000);
+		size_t num_iterations (5); // 100,000 * 5 * 2 = 1,000,000 blocks
+		size_t max_blocks (2 * num_accounts * num_iterations + num_accounts * 2); //  1,000,000 + 2 * 100,000 = 1,200,000 blocks
+		std::cout << boost::str (boost::format ("Starting pregenerating %1% blocks\n") % max_blocks);
+		nano::node_flags node_flags;
+		nano::update_flags (node_flags, vm);
+		nano::inactive_node inactive_node (nano::unique_path (), data_path, node_flags);
+		auto node = inactive_node.node;
+
+		nano::block_hash genesis_latest (node->latest (dev_params.ledger.dev_genesis_key.pub));
+		nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
+		// Generating keys
+		std::vector<nano::keypair> keys (num_accounts);
+		std::vector<nano::root> frontiers (num_accounts);
+		std::vector<nano::uint128_t> balances (num_accounts, 1000000000);
+		// Generating blocks
+		std::deque<std::shared_ptr<nano::block>> blocks;
+		for (auto i (0); i != num_accounts; ++i)
+		{
+			genesis_balance = genesis_balance - 1000000000;
+
+			auto send = builder.state ()
+			            .account (dev_params.ledger.dev_genesis_key.pub)
+			            .previous (genesis_latest)
+			            .representative (dev_params.ledger.dev_genesis_key.pub)
+			            .balance (genesis_balance)
+			            .link (keys[i].pub)
+			            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
+			            .work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			genesis_latest = send->hash ();
+			blocks.push_back (std::move (send));
+
+			auto open = builder.state ()
+			            .account (keys[i].pub)
+			            .previous (0)
+			            .representative (keys[i].pub)
+			            .balance (balances[i])
+			            .link (genesis_latest)
+			            .sign (keys[i].prv, keys[i].pub)
+			            .work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			frontiers[i] = open->hash ();
+			blocks.push_back (std::move (open));
+		}
+		for (auto i (0); i != num_iterations; ++i)
+		{
+			for (auto j (0); j != num_accounts; ++j)
+			{
+				size_t other (num_accounts - j - 1);
+				// Sending to other account
+				--balances[j];
+
+				auto send = builder.state ()
+				            .account (keys[j].pub)
+				            .previous (frontiers[j].as_block_hash ())
+				            .representative (keys[j].pub)
+				            .balance (balances[j])
+				            .link (keys[other].pub)
+				            .sign (keys[j].prv, keys[j].pub)
+				            .work (*node->work.generate (nano::work_version::work_1, frontiers[j], node->network_params.network.publish_thresholds.epoch_1))
+				            .build ();
+
+				frontiers[j] = send->hash ();
+				blocks.push_back (std::move (send));
+				// Receiving
+				++balances[other];
+
+				auto receive = builder.state ()
+				               .account (keys[other].pub)
+				               .previous (frontiers[other].as_block_hash ())
+				               .representative (keys[other].pub)
+				               .balance (balances[other])
+				               .link (frontiers[j].as_block_hash ())
+				               .sign (keys[other].prv, keys[other].pub)
+				               .work (*node->work.generate (nano::work_version::work_1, frontiers[other], node->network_params.network.publish_thresholds.epoch_1))
+				               .build ();
+
+				frontiers[other] = receive->hash ();
+				blocks.push_back (std::move (receive));
+			}
+		}
+		// Processing blocks
+		std::cout << boost::str (boost::format ("Starting processing %1% blocks\n") % max_blocks);
+		auto begin (std::chrono::high_resolution_clock::now ());
+		while (!blocks.empty ())
+		{
+			auto block (blocks.front ());
+			node->process_active (block);
+			blocks.pop_front ();
+		}
+		nano::timer<std::chrono::seconds> timer_l (nano::timer_state::started);
+		while (node->ledger.cache.block_count != max_blocks + 1)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (10));
+			// Message each 15 seconds
+			if (timer_l.after_deadline (std::chrono::seconds (15)))
+			{
+				timer_l.restart ();
+				std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked), %3% remaining") % node->ledger.cache.block_count % node->store.unchecked_count (node->store.tx_begin_read ()) % node->block_processor.size ()) << std::endl;
+			}
+		}
+
+		node->block_processor.flush ();
+		auto end (std::chrono::high_resolution_clock::now ());
+		auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
+		node->stop ();
+		std::cout << boost::str (boost::format ("%|1$ 12d| us \n%2% blocks per second\n") % time % (max_blocks * 1000000 / time));
+		release_assert (node->ledger.cache.block_count == max_blocks + 1);
+	}
+	else if (vm.count ("debug_profile_votes"))
+	{
+		nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+		nano::network_params dev_params;
+		nano::block_builder builder;
+		size_t num_elections (40000);
+		size_t num_representatives (25);
+		size_t max_votes (num_elections * num_representatives); // 40,000 * 25 = 1,000,000 votes
+		std::cerr << boost::str (boost::format ("Starting pregenerating %1% votes\n") % max_votes);
+		nano::node_flags node_flags;
+		nano::update_flags (node_flags, vm);
+		nano::node_wrapper node_wrapper (nano::unique_path (), data_path, node_flags);
+		auto node = node_wrapper.node;
+
+		nano::block_hash genesis_latest (node->latest (dev_params.ledger.dev_genesis_key.pub));
+		nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
+		// Generating keys
+		std::vector<nano::keypair> keys (num_representatives);
+		nano::uint128_t balance ((node->config.online_weight_minimum.number () / num_representatives) + 1);
+		for (auto i (0); i != num_representatives; ++i)
+		{
+			auto transaction (node->store.tx_begin_write ());
+			genesis_balance = genesis_balance - balance;
+
+			auto send = builder.state ()
+			            .account (dev_params.ledger.dev_genesis_key.pub)
+			            .previous (genesis_latest)
+			            .representative (dev_params.ledger.dev_genesis_key.pub)
+			            .balance (genesis_balance)
+			            .link (keys[i].pub)
+			            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
+			            .work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			genesis_latest = send->hash ();
+			node->ledger.process (transaction, *send);
+
+			auto open = builder.state ()
+			            .account (keys[i].pub)
+			            .previous (0)
+			            .representative (keys[i].pub)
+			            .balance (balance)
+			            .link (genesis_latest)
+			            .sign (keys[i].prv, keys[i].pub)
+			            .work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			node->ledger.process (transaction, *open);
+		}
+		// Generating blocks
+		std::deque<std::shared_ptr<nano::block>> blocks;
+		for (auto i (0); i != num_elections; ++i)
+		{
+			genesis_balance = genesis_balance - 1;
+			nano::keypair destination;
+
+			auto send = builder.state ()
+			            .account (dev_params.ledger.dev_genesis_key.pub)
+			            .previous (genesis_latest)
+			            .representative (dev_params.ledger.dev_genesis_key.pub)
+			            .balance (genesis_balance)
+			            .link (destination.pub)
+			            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
+			            .work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			genesis_latest = send->hash ();
+			blocks.push_back (std::move (send));
+		}
+		// Generating votes
+		std::deque<std::shared_ptr<nano::vote>> votes;
+		for (auto j (0); j != num_representatives; ++j)
+		{
+			uint64_t sequence (1);
+			for (auto & i : blocks)
+			{
+				auto vote (std::make_shared<nano::vote> (keys[j].pub, keys[j].prv, sequence, std::vector<nano::block_hash> (1, i->hash ())));
+				votes.push_back (vote);
+				sequence++;
+			}
+		}
+		// Processing block & start elections
+		while (!blocks.empty ())
+		{
+			auto block (blocks.front ());
+			node->process_active (block);
+			blocks.pop_front ();
+		}
+		node->block_processor.flush ();
+		// Processing votes
+		std::cerr << boost::str (boost::format ("Starting processing %1% votes\n") % max_votes);
+		auto begin (std::chrono::high_resolution_clock::now ());
+		while (!votes.empty ())
+		{
+			auto vote (votes.front ());
+			auto channel (std::make_shared<nano::transport::channel_loopback> (*node));
+			node->vote_processor.vote (vote, channel);
+			votes.pop_front ();
+		}
+		while (!node->active.empty ())
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (100));
+		}
+		auto end (std::chrono::high_resolution_clock::now ());
+		auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
+		node->stop ();
+		std::cerr << boost::str (boost::format ("%|1$ 12d| us \n%2% votes per second\n") % time % (max_votes * 1000000 / time));
+	}
+	else if (vm.count ("debug_profile_frontiers_confirmation"))
+	{
+		nano::force_nano_dev_network ();
+		nano::network_params dev_params;
+		nano::block_builder builder;
+		size_t count (32 * 1024);
+		auto count_it = vm.find ("count");
+		if (count_it != vm.end ())
+		{
+			try
+			{
+				count = boost::lexical_cast<size_t> (count_it->second.as<std::string> ());
+			}
+			catch (boost::bad_lexical_cast &)
+			{
+				std::cerr << "Invalid count\n";
+				return -1;
+			}
+		}
+		std::cout << boost::str (boost::format ("Starting generating %1% blocks...\n") % (count * 2));
+		boost::asio::io_context io_ctx1;
+		boost::asio::io_context io_ctx2;
+		nano::work_pool work (std::numeric_limits<unsigned>::max ());
+		nano::logging logging;
+		auto path1 (nano::unique_path ());
+		auto path2 (nano::unique_path ());
+		logging.init (path1);
+		std::vector<std::string> config_overrides;
+		auto config (vm.find ("config"));
+		if (config != vm.end ())
+		{
+			config_overrides = nano::config_overrides (config->second.as<std::vector<nano::config_key_value_pair>> ());
+		}
+		nano::daemon_config daemon_config (data_path);
+		auto error = nano::read_node_config_toml (data_path, daemon_config, config_overrides);
+
+		nano::node_config config1 = daemon_config.node;
+		config1.peering_port = 24000;
+
+		nano::node_flags flags;
+		nano::update_flags (flags, vm);
+		flags.disable_lazy_bootstrap = true;
+		flags.disable_legacy_bootstrap = true;
+		flags.disable_wallet_bootstrap = true;
+		flags.disable_bootstrap_listener = true;
+		auto node1 (std::make_shared<nano::node> (io_ctx1, path1, config1, work, flags, 0));
+		nano::block_hash genesis_latest (node1->latest (dev_params.ledger.dev_genesis_key.pub));
+		nano::uint128_t genesis_balance (std::numeric_limits<nano::uint128_t>::max ());
+		// Generating blocks
+		std::deque<std::shared_ptr<nano::block>> blocks;
+		for (auto i (0); i != count; ++i)
+		{
+			nano::keypair key;
+			genesis_balance = genesis_balance - 1;
+
+			auto send = builder.state ()
+			            .account (dev_params.ledger.dev_genesis_key.pub)
+			            .previous (genesis_latest)
+			            .representative (dev_params.ledger.dev_genesis_key.pub)
+			            .balance (genesis_balance)
+			            .link (key.pub)
+			            .sign (dev_params.ledger.dev_genesis_key.prv, dev_params.ledger.dev_genesis_key.pub)
+			            .work (*work.generate (nano::work_version::work_1, genesis_latest, dev_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			genesis_latest = send->hash ();
+
+			auto open = builder.state ()
+			            .account (key.pub)
+			            .previous (0)
+			            .representative (key.pub)
+			            .balance (1)
+			            .link (genesis_latest)
+			            .sign (key.prv, key.pub)
+			            .work (*work.generate (nano::work_version::work_1, key.pub, dev_params.network.publish_thresholds.epoch_1))
+			            .build ();
+
+			blocks.push_back (std::move (send));
+			blocks.push_back (std::move (open));
+			if (i % 20000 == 0 && i != 0)
+			{
+				std::cout << boost::str (boost::format ("%1% blocks generated\n") % (i * 2));
+			}
+		}
+		node1->start ();
+		nano::thread_runner runner1 (io_ctx1, node1->config.io_threads);
+
+		std::cout << boost::str (boost::format ("Processing %1% blocks\n") % (count * 2));
+		for (auto & block : blocks)
+		{
+			node1->block_processor.add (block);
+		}
+		node1->block_processor.flush ();
+		auto iteration (0);
+		while (node1->ledger.cache.block_count != count * 2 + 1)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (500));
+			if (++iteration % 60 == 0)
+			{
+				std::cout << boost::str (boost::format ("%1% blocks processed\n") % node1->ledger.cache.block_count);
+			}
+		}
+		// Confirm blocks for node1
+		for (auto & block : blocks)
+		{
+			node1->confirmation_height_processor.add (block);
+		}
+		while (node1->ledger.cache.cemented_count != node1->ledger.cache.block_count)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (500));
+			if (++iteration % 60 == 0)
+			{
+				std::cout << boost::str (boost::format ("%1% blocks cemented\n") % node1->ledger.cache.cemented_count);
+			}
+		}
+
+		// Start new node
+		nano::node_config config2 = daemon_config.node;
+		config1.peering_port = 24001;
+		if (error)
+		{
+			std::cerr << "\n"
+			          << error.get_message () << std::endl;
+			std::exit (1);
+		}
+		else
+		{
+			config2.frontiers_confirmation = daemon_config.node.frontiers_confirmation;
+			config2.active_elections_size = daemon_config.node.active_elections_size;
+		}
+
+		auto node2 (std::make_shared<nano::node> (io_ctx2, path2, config2, work, flags, 1));
+		node2->start ();
+		nano::thread_runner runner2 (io_ctx2, node2->config.io_threads);
+		std::cout << boost::str (boost::format ("Processing %1% blocks (test node)\n") % (count * 2));
+		// Processing block
+		while (!blocks.empty ())
+		{
+			auto block (blocks.front ());
+			node2->block_processor.add (block);
+			blocks.pop_front ();
+		}
+		node2->block_processor.flush ();
+		while (node2->ledger.cache.block_count != count * 2 + 1)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (500));
+			if (++iteration % 60 == 0)
+			{
+				std::cout << boost::str (boost::format ("%1% blocks processed\n") % node2->ledger.cache.block_count);
+			}
+		}
+		// Insert representative
+		std::cout << "Initializing representative\n";
+		auto wallet (node1->wallets.create (nano::random_wallet_id ()));
+		wallet->insert_adhoc (dev_params.ledger.dev_genesis_key.prv);
+		node2->network.merge_peer (node1->network.endpoint ());
+		while (node2->rep_crawler.representative_count () == 0)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (10));
+			if (++iteration % 500 == 0)
+			{
+				std::cout << "Representative initialization iteration...\n";
+			}
+		}
+		auto begin (std::chrono::high_resolution_clock::now ());
+		std::cout << boost::str (boost::format ("Starting confirming %1% frontiers (test node)\n") % (count + 1));
+		// Wait for full frontiers confirmation
+		while (node2->ledger.cache.cemented_count != node2->ledger.cache.block_count)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (25));
+			if (++iteration % 1200 == 0)
+			{
+				std::cout << boost::str (boost::format ("%1% blocks confirmed\n") % node2->ledger.cache.cemented_count);
+			}
+		}
+		auto end (std::chrono::high_resolution_clock::now ());
+		auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
+		std::cout << boost::str (boost::format ("%|1$ 12d| us \n%2% frontiers per second\n") % time % ((count + 1) * 1000000 / time));
+		io_ctx1.stop ();
+		io_ctx2.stop ();
+		runner1.join ();
+		runner2.join ();
+		node1->stop ();
+		node2->stop ();
+	}
+	else if (vm.count ("debug_random_feed"))
+	{
+		/*
 			 * This command redirects an infinite stream of bytes from the random pool to standard out.
 			 * The result can be fed into various tools for testing RNGs and entropy pools.
 			 *
@@ -1305,731 +1290,731 @@ int main (int argc, char * const * argv)
 			 *
 			 *   ./nano_node --debug_random_feed | dieharder -a -g 200
 			 */
-			nano::raw_key seed;
-			for (;;)
+		nano::raw_key seed;
+		for (;;)
+		{
+			nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
+			std::cout.write (reinterpret_cast<const char *> (seed.bytes.data ()), seed.bytes.size ());
+		}
+	}
+	else if (vm.count ("debug_rpc"))
+	{
+		std::string rpc_input_l;
+		std::ostringstream command_l;
+		while (std::cin >> rpc_input_l)
+		{
+			command_l << rpc_input_l;
+		}
+
+		auto response_handler_l ([](std::string const & response_a) {
+			std::cout << response_a;
+			// Terminate as soon as we have the result, even if background threads (like work generation) are running.
+			std::exit (0);
+		});
+
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		nano::update_flags (node_flags, vm);
+		node_flags.generate_cache.enable_all ();
+		nano::inactive_node inactive_node_l (data_path, node_flags);
+
+		nano::node_rpc_config config;
+		nano::ipc::ipc_server server (*inactive_node_l.node, config);
+		auto handler_l (std::make_shared<nano::json_handler> (*inactive_node_l.node, config, command_l.str (), response_handler_l));
+		handler_l->process_request ();
+	}
+	else if (vm.count ("validate_blocks") || vm.count ("debug_validate_blocks"))
+	{
+		nano::timer<std::chrono::seconds> timer;
+		timer.start ();
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		nano::update_flags (node_flags, vm);
+		node_flags.generate_cache.block_count = true;
+		nano::inactive_node inactive_node (data_path, node_flags);
+		auto node = inactive_node.node;
+		bool const silent (vm.count ("silent"));
+		unsigned threads_count (1);
+		auto threads_it = vm.find ("threads");
+		if (threads_it != vm.end ())
+		{
+			if (!boost::conversion::try_lexical_convert (threads_it->second.as<std::string> (), threads_count))
 			{
-				nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
-				std::cout.write (reinterpret_cast<const char *> (seed.bytes.data ()), seed.bytes.size ());
+				std::cerr << "Invalid threads count\n";
+				return -1;
 			}
 		}
-		else if (vm.count ("debug_rpc"))
-		{
-			std::string rpc_input_l;
-			std::ostringstream command_l;
-			while (std::cin >> rpc_input_l)
+		threads_count = std::max (1u, threads_count);
+		std::vector<std::thread> threads;
+		nano::mutex mutex;
+		nano::condition_variable condition;
+		std::atomic<bool> finished (false);
+		std::deque<std::pair<nano::account, nano::account_info>> accounts;
+		std::atomic<size_t> count (0);
+		std::atomic<uint64_t> block_count (0);
+		std::atomic<uint64_t> errors (0);
+
+		auto print_error_message = [&silent, &errors](std::string const & error_message_a) {
+			if (!silent)
 			{
-				command_l << rpc_input_l;
+				static nano::mutex cerr_mutex;
+				nano::lock_guard<nano::mutex> lock (cerr_mutex);
+				std::cerr << error_message_a;
+			}
+			++errors;
+		};
+
+		auto start_threads = [node, &threads_count, &threads, &mutex, &condition, &finished](const auto & function_a, auto & deque_a) {
+			for (auto i (0U); i < threads_count; ++i)
+			{
+				threads.emplace_back ([&function_a, node, &mutex, &condition, &finished, &deque_a]() {
+					auto transaction (node->store.tx_begin_read ());
+					nano::unique_lock<nano::mutex> lock (mutex);
+					while (!deque_a.empty () || !finished)
+					{
+						while (deque_a.empty () && !finished)
+						{
+							condition.wait (lock);
+						}
+						if (!deque_a.empty ())
+						{
+							auto pair (deque_a.front ());
+							deque_a.pop_front ();
+							lock.unlock ();
+							function_a (node, transaction, pair.first, pair.second);
+							lock.lock ();
+						}
+					}
+				});
+			}
+		};
+
+		auto check_account = [&print_error_message, &silent, &count, &block_count](std::shared_ptr<nano::node> const & node, nano::read_transaction const & transaction, nano::account const & account, nano::account_info const & info) {
+			++count;
+			if (!silent && (count % 20000) == 0)
+			{
+				std::cout << boost::str (boost::format ("%1% accounts validated\n") % count);
+			}
+			nano::confirmation_height_info confirmation_height_info;
+			node->store.confirmation_height_get (transaction, account, confirmation_height_info);
+
+			if (confirmation_height_info.height > info.block_count)
+			{
+				print_error_message (boost::str (boost::format ("Confirmation height %1% greater than block count %2% for account: %3%\n") % confirmation_height_info.height % info.block_count % account.to_account ()));
 			}
 
-			auto response_handler_l ([](std::string const & response_a) {
-				std::cout << response_a;
-				// Terminate as soon as we have the result, even if background threads (like work generation) are running.
-				std::exit (0);
-			});
+			auto hash (info.open_block);
+			nano::block_hash calculated_hash (0);
+			auto block (node->store.block_get (transaction, hash)); // Block data
+			uint64_t height (0);
+			if (node->ledger.pruning && confirmation_height_info.height != 0)
+			{
+				hash = confirmation_height_info.frontier;
+				block = node->store.block_get (transaction, hash);
+				// Iteration until pruned block
+				bool pruned_block (false);
+				while (!pruned_block && !block->previous ().is_zero ())
+				{
+					auto previous_block (node->store.block_get (transaction, block->previous ()));
+					if (previous_block != nullptr)
+					{
+						hash = previous_block->hash ();
+						block = previous_block;
+					}
+					else
+					{
+						pruned_block = true;
+						if (!node->store.pruned_exists (transaction, block->previous ()))
+						{
+							print_error_message (boost::str (boost::format ("Pruned previous block does not exist %1%\n") % block->previous ().to_string ()));
+						}
+					}
+				}
+				calculated_hash = block->previous ();
+				height = block->sideband ().height - 1;
+				if (!node->store.block_or_pruned_exists (transaction, info.open_block))
+				{
+					print_error_message (boost::str (boost::format ("Open block does not exist %1%\n") % info.open_block.to_string ()));
+				}
+			}
+			uint64_t previous_timestamp (0);
+			nano::account calculated_representative (0);
+			while (!hash.is_zero () && block != nullptr)
+			{
+				++block_count;
+				auto const & sideband (block->sideband ());
+				// Check for state & open blocks if account field is correct
+				if (block->type () == nano::block_type::open || block->type () == nano::block_type::state)
+				{
+					if (block->account () != account)
+					{
+						print_error_message (boost::str (boost::format ("Incorrect account field for block %1%\n") % hash.to_string ()));
+					}
+				}
+				// Check if sideband account is correct
+				else if (sideband.account != account)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect sideband account for block %1%\n") % hash.to_string ()));
+				}
+				// Check if previous field is correct
+				if (calculated_hash != block->previous ())
+				{
+					print_error_message (boost::str (boost::format ("Incorrect previous field for block %1%\n") % hash.to_string ()));
+				}
+				// Check if previous & type for open blocks are correct
+				if (height == 0 && !block->previous ().is_zero ())
+				{
+					print_error_message (boost::str (boost::format ("Incorrect previous for open block %1%\n") % hash.to_string ()));
+				}
+				if (height == 0 && block->type () != nano::block_type::open && block->type () != nano::block_type::state)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect type for open block %1%\n") % hash.to_string ()));
+				}
+				// Check if block data is correct (calculating hash)
+				calculated_hash = block->hash ();
+				if (calculated_hash != hash)
+				{
+					print_error_message (boost::str (boost::format ("Invalid data inside block %1% calculated hash: %2%\n") % hash.to_string () % calculated_hash.to_string ()));
+				}
+				// Check if block signature is correct
+				if (validate_message (account, hash, block->block_signature ()))
+				{
+					bool invalid (true);
+					// Epoch blocks
+					if (block->type () == nano::block_type::state)
+					{
+						auto & state_block (static_cast<nano::state_block &> (*block.get ()));
+						nano::amount prev_balance (0);
+						bool error_or_pruned (false);
+						if (!state_block.hashables.previous.is_zero ())
+						{
+							prev_balance = node->ledger.balance_safe (transaction, state_block.hashables.previous, error_or_pruned);
+						}
+						if (node->ledger.is_epoch_link (state_block.hashables.link))
+						{
+							if ((state_block.hashables.balance == prev_balance && !error_or_pruned) || (node->ledger.pruning && error_or_pruned && block->sideband ().details.is_epoch))
+							{
+								invalid = validate_message (node->ledger.epoch_signer (block->link ()), hash, block->block_signature ());
+							}
+						}
+					}
+					if (invalid)
+					{
+						print_error_message (boost::str (boost::format ("Invalid signature for block %1%\n") % hash.to_string ()));
+					}
+				}
+				// Validate block details set in the sideband
+				bool block_details_error = false;
+				if (block->type () != nano::block_type::state)
+				{
+					// Not state
+					block_details_error = sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
+				}
+				else
+				{
+					bool error_or_pruned (false);
+					auto prev_balance (node->ledger.balance_safe (transaction, block->previous (), error_or_pruned));
+					if (!node->ledger.pruning || !error_or_pruned)
+					{
+						if (block->balance () < prev_balance)
+						{
+							// State send
+							block_details_error = !sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
+						}
+						else
+						{
+							if (block->link ().is_zero ())
+							{
+								// State change
+								block_details_error = sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
+							}
+							else if (block->balance () == prev_balance && node->ledger.is_epoch_link (block->link ()))
+							{
+								// State epoch
+								block_details_error = !sideband.details.is_epoch || sideband.details.is_send || sideband.details.is_receive;
+							}
+							else
+							{
+								// State receive
+								block_details_error = !sideband.details.is_receive || sideband.details.is_send || sideband.details.is_epoch;
+								block_details_error |= !node->ledger.block_or_pruned_exists (transaction, block->link ().as_block_hash ());
+							}
+						}
+					}
+					else if (!node->store.pruned_exists (transaction, block->previous ()))
+					{
+						print_error_message (boost::str (boost::format ("Previous pruned block does not exist %1%\n") % block->previous ().to_string ()));
+					}
+				}
+				if (block_details_error)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect sideband block details for block %1%\n") % hash.to_string ()));
+				}
+				// Check link epoch version
+				if (sideband.details.is_receive && (!node->ledger.pruning || !node->store.pruned_exists (transaction, block->link ().as_block_hash ())))
+				{
+					if (sideband.source_epoch != node->store.block_version (transaction, block->link ().as_block_hash ()))
+					{
+						print_error_message (boost::str (boost::format ("Incorrect source epoch for block %1%\n") % hash.to_string ()));
+					}
+				}
+				// Check if block work value is correct
+				if (block->difficulty () < nano::work_threshold (block->work_version (), block->sideband ().details))
+				{
+					print_error_message (boost::str (boost::format ("Invalid work for block %1% value: %2%\n") % hash.to_string () % nano::to_string_hex (block->block_work ())));
+				}
+				// Check if sideband height is correct
+				++height;
+				if (sideband.height != height)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect sideband height for block %1%. Sideband: %2%. Expected: %3%\n") % hash.to_string () % sideband.height % height));
+				}
+				// Check if sideband timestamp is after previous timestamp
+				if (sideband.timestamp < previous_timestamp)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect sideband timestamp for block %1%\n") % hash.to_string ()));
+				}
+				previous_timestamp = sideband.timestamp;
+				// Calculate representative block
+				if (block->type () == nano::block_type::open || block->type () == nano::block_type::change || block->type () == nano::block_type::state)
+				{
+					calculated_representative = block->representative ();
+				}
+				// Retrieving successor block hash
+				hash = node->store.block_successor (transaction, hash);
+				// Retrieving block data
+				if (!hash.is_zero ())
+				{
+					block = node->store.block_get (transaction, hash);
+				}
+			}
+			// Check if required block exists
+			if (!hash.is_zero () && block == nullptr)
+			{
+				print_error_message (boost::str (boost::format ("Required block in account %1% chain was not found in ledger: %2%\n") % account.to_account () % hash.to_string ()));
+			}
+			// Check account block count
+			if (info.block_count != height)
+			{
+				print_error_message (boost::str (boost::format ("Incorrect block count for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % height % info.block_count));
+			}
+			// Check account head block (frontier)
+			if (info.head != calculated_hash)
+			{
+				print_error_message (boost::str (boost::format ("Incorrect frontier for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_hash.to_string () % info.head.to_string ()));
+			}
+			// Check account representative block
+			if (info.representative != calculated_representative)
+			{
+				print_error_message (boost::str (boost::format ("Incorrect representative for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_representative.to_string () % info.representative.to_string ()));
+			}
+		};
 
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			nano::update_flags (node_flags, vm);
-			node_flags.generate_cache.enable_all ();
-			nano::inactive_node inactive_node_l (data_path, node_flags);
+		start_threads (check_account, accounts);
 
-			nano::node_rpc_config config;
-			nano::ipc::ipc_server server (*inactive_node_l.node, config);
-			auto handler_l (std::make_shared<nano::json_handler> (*inactive_node_l.node, config, command_l.str (), response_handler_l));
-			handler_l->process_request ();
-		}
-		else if (vm.count ("validate_blocks") || vm.count ("debug_validate_blocks"))
+		if (!silent)
 		{
-			nano::timer<std::chrono::seconds> timer;
-			timer.start ();
+			std::cout << boost::str (boost::format ("Performing %1% threads blocks hash, signature, work validation...\n") % threads_count);
+		}
+		size_t const accounts_deque_overflow (32 * 1024);
+		auto transaction (node->store.tx_begin_read ());
+		for (auto i (node->store.accounts_begin (transaction)), n (node->store.accounts_end ()); i != n; ++i)
+		{
+			{
+				nano::unique_lock<nano::mutex> lock (mutex);
+				if (accounts.size () > accounts_deque_overflow)
+				{
+					auto wait_ms (250 * accounts.size () / accounts_deque_overflow);
+					const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
+					condition.wait_until (lock, wakeup);
+				}
+				accounts.emplace_back (i->first, i->second);
+			}
+			condition.notify_all ();
+		}
+		{
+			nano::lock_guard<nano::mutex> lock (mutex);
+			finished = true;
+		}
+		condition.notify_all ();
+		for (auto & thread : threads)
+		{
+			thread.join ();
+		}
+		threads.clear ();
+		if (!silent)
+		{
+			std::cout << boost::str (boost::format ("%1% accounts validated\n") % count);
+		}
+
+		// Validate total block count
+		auto ledger_block_count (node->store.block_count (transaction));
+		if (node->flags.enable_pruning)
+		{
+			block_count += 1; // Add disconnected genesis block
+		}
+		if (block_count != ledger_block_count)
+		{
+			print_error_message (boost::str (boost::format ("Incorrect total block count. Blocks validated %1%. Block count in database: %2%\n") % block_count % ledger_block_count));
+		}
+
+		// Validate pending blocks
+		count = 0;
+		finished = false;
+		std::deque<std::pair<nano::pending_key, nano::pending_info>> pending;
+
+		auto check_pending = [&print_error_message, &silent, &count](std::shared_ptr<nano::node> const & node, nano::read_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & info) {
+			++count;
+			if (!silent && (count % 500000) == 0)
+			{
+				std::cout << boost::str (boost::format ("%1% pending blocks validated\n") % count);
+			}
+			// Check block existance
+			auto block (node->store.block_get_no_sideband (transaction, key.hash));
+			bool pruned (false);
+			if (block == nullptr)
+			{
+				pruned = node->ledger.pruning && node->store.pruned_exists (transaction, key.hash);
+				if (!pruned)
+				{
+					print_error_message (boost::str (boost::format ("Pending block does not exist %1%\n") % key.hash.to_string ()));
+				}
+			}
+			else
+			{
+				// Check if pending destination is correct
+				nano::account destination (0);
+				bool previous_pruned = node->ledger.pruning && node->store.pruned_exists (transaction, block->previous ());
+				if (previous_pruned)
+				{
+					block = node->store.block_get (transaction, key.hash);
+				}
+				if (auto state = dynamic_cast<nano::state_block *> (block.get ()))
+				{
+					if (node->ledger.is_send (transaction, *state))
+					{
+						destination = state->hashables.link.as_account ();
+					}
+				}
+				else if (auto send = dynamic_cast<nano::send_block *> (block.get ()))
+				{
+					destination = send->hashables.destination;
+				}
+				else
+				{
+					print_error_message (boost::str (boost::format ("Incorrect type for pending block %1%\n") % key.hash.to_string ()));
+				}
+				if (key.account != destination)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect destination for pending block %1%\n") % key.hash.to_string ()));
+				}
+				// Check if pending source is correct
+				auto account (node->ledger.account (transaction, key.hash));
+				if (info.source != account && !pruned)
+				{
+					print_error_message (boost::str (boost::format ("Incorrect source for pending block %1%\n") % key.hash.to_string ()));
+				}
+				// Check if pending amount is correct
+				if (!pruned && !previous_pruned)
+				{
+					auto amount (node->ledger.amount (transaction, key.hash));
+					if (info.amount != amount)
+					{
+						print_error_message (boost::str (boost::format ("Incorrect amount for pending block %1%\n") % key.hash.to_string ()));
+					}
+				}
+			}
+		};
+
+		start_threads (check_pending, pending);
+
+		size_t const pending_deque_overflow (64 * 1024);
+		for (auto i (node->store.pending_begin (transaction)), n (node->store.pending_end ()); i != n; ++i)
+		{
+			{
+				nano::unique_lock<nano::mutex> lock (mutex);
+				if (pending.size () > pending_deque_overflow)
+				{
+					auto wait_ms (50 * pending.size () / pending_deque_overflow);
+					const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
+					condition.wait_until (lock, wakeup);
+				}
+				pending.emplace_back (i->first, i->second);
+			}
+			condition.notify_all ();
+		}
+		{
+			nano::lock_guard<nano::mutex> lock (mutex);
+			finished = true;
+		}
+		condition.notify_all ();
+		for (auto & thread : threads)
+		{
+			thread.join ();
+		}
+		if (!silent)
+		{
+			std::cout << boost::str (boost::format ("%1% pending blocks validated\n") % count);
+			timer.stop ();
+			std::cout << boost::str (boost::format ("%1% %2% validation time\n") % timer.value ().count () % timer.unit ());
+		}
+		if (errors == 0)
+		{
+			std::cout << "Validation status: Ok\n";
+		}
+		else
+		{
+			std::cout << boost::str (boost::format ("Validation status: Failed\n%1% errors found\n") % errors);
+		}
+	}
+	else if (vm.count ("debug_profile_bootstrap"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		node_flags.read_only = false;
+		nano::update_flags (node_flags, vm);
+		nano::inactive_node node (nano::unique_path (), node_flags);
+		nano::genesis genesis;
+		auto begin (std::chrono::high_resolution_clock::now ());
+		uint64_t block_count (0);
+		size_t count (0);
+		std::deque<nano::unchecked_info> epoch_open_blocks;
+		{
 			auto node_flags = nano::inactive_node_flag_defaults ();
 			nano::update_flags (node_flags, vm);
 			node_flags.generate_cache.block_count = true;
 			nano::inactive_node inactive_node (data_path, node_flags);
-			auto node = inactive_node.node;
-			bool const silent (vm.count ("silent"));
-			unsigned threads_count (1);
-			auto threads_it = vm.find ("threads");
-			if (threads_it != vm.end ())
+			auto source_node = inactive_node.node;
+			auto transaction (source_node->store.tx_begin_read ());
+			block_count = source_node->ledger.cache.block_count;
+			std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
+			for (auto i (source_node->store.accounts_begin (transaction)), n (source_node->store.accounts_end ()); i != n; ++i)
 			{
-				if (!boost::conversion::try_lexical_convert (threads_it->second.as<std::string> (), threads_count))
+				nano::account const & account (i->first);
+				nano::account_info const & info (i->second);
+				auto hash (info.head);
+				while (!hash.is_zero ())
 				{
-					std::cerr << "Invalid threads count\n";
-					return -1;
-				}
-			}
-			threads_count = std::max (1u, threads_count);
-			std::vector<std::thread> threads;
-			nano::mutex mutex;
-			nano::condition_variable condition;
-			std::atomic<bool> finished (false);
-			std::deque<std::pair<nano::account, nano::account_info>> accounts;
-			std::atomic<size_t> count (0);
-			std::atomic<uint64_t> block_count (0);
-			std::atomic<uint64_t> errors (0);
-
-			auto print_error_message = [&silent, &errors](std::string const & error_message_a) {
-				if (!silent)
-				{
-					static nano::mutex cerr_mutex;
-					nano::lock_guard<nano::mutex> lock (cerr_mutex);
-					std::cerr << error_message_a;
-				}
-				++errors;
-			};
-
-			auto start_threads = [node, &threads_count, &threads, &mutex, &condition, &finished](const auto & function_a, auto & deque_a) {
-				for (auto i (0U); i < threads_count; ++i)
-				{
-					threads.emplace_back ([&function_a, node, &mutex, &condition, &finished, &deque_a]() {
-						auto transaction (node->store.tx_begin_read ());
-						nano::unique_lock<nano::mutex> lock (mutex);
-						while (!deque_a.empty () || !finished)
-						{
-							while (deque_a.empty () && !finished)
-							{
-								condition.wait (lock);
-							}
-							if (!deque_a.empty ())
-							{
-								auto pair (deque_a.front ());
-								deque_a.pop_front ();
-								lock.unlock ();
-								function_a (node, transaction, pair.first, pair.second);
-								lock.lock ();
-							}
-						}
-					});
-				}
-			};
-
-			auto check_account = [&print_error_message, &silent, &count, &block_count](std::shared_ptr<nano::node> const & node, nano::read_transaction const & transaction, nano::account const & account, nano::account_info const & info) {
-				++count;
-				if (!silent && (count % 20000) == 0)
-				{
-					std::cout << boost::str (boost::format ("%1% accounts validated\n") % count);
-				}
-				nano::confirmation_height_info confirmation_height_info;
-				node->store.confirmation_height_get (transaction, account, confirmation_height_info);
-
-				if (confirmation_height_info.height > info.block_count)
-				{
-					print_error_message (boost::str (boost::format ("Confirmation height %1% greater than block count %2% for account: %3%\n") % confirmation_height_info.height % info.block_count % account.to_account ()));
-				}
-
-				auto hash (info.open_block);
-				nano::block_hash calculated_hash (0);
-				auto block (node->store.block_get (transaction, hash)); // Block data
-				uint64_t height (0);
-				if (node->ledger.pruning && confirmation_height_info.height != 0)
-				{
-					hash = confirmation_height_info.frontier;
-					block = node->store.block_get (transaction, hash);
-					// Iteration until pruned block
-					bool pruned_block (false);
-					while (!pruned_block && !block->previous ().is_zero ())
-					{
-						auto previous_block (node->store.block_get (transaction, block->previous ()));
-						if (previous_block != nullptr)
-						{
-							hash = previous_block->hash ();
-							block = previous_block;
-						}
-						else
-						{
-							pruned_block = true;
-							if (!node->store.pruned_exists (transaction, block->previous ()))
-							{
-								print_error_message (boost::str (boost::format ("Pruned previous block does not exist %1%\n") % block->previous ().to_string ()));
-							}
-						}
-					}
-					calculated_hash = block->previous ();
-					height = block->sideband ().height - 1;
-					if (!node->store.block_or_pruned_exists (transaction, info.open_block))
-					{
-						print_error_message (boost::str (boost::format ("Open block does not exist %1%\n") % info.open_block.to_string ()));
-					}
-				}
-				uint64_t previous_timestamp (0);
-				nano::account calculated_representative (0);
-				while (!hash.is_zero () && block != nullptr)
-				{
-					++block_count;
-					auto const & sideband (block->sideband ());
-					// Check for state & open blocks if account field is correct
-					if (block->type () == nano::block_type::open || block->type () == nano::block_type::state)
-					{
-						if (block->account () != account)
-						{
-							print_error_message (boost::str (boost::format ("Incorrect account field for block %1%\n") % hash.to_string ()));
-						}
-					}
-					// Check if sideband account is correct
-					else if (sideband.account != account)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect sideband account for block %1%\n") % hash.to_string ()));
-					}
-					// Check if previous field is correct
-					if (calculated_hash != block->previous ())
-					{
-						print_error_message (boost::str (boost::format ("Incorrect previous field for block %1%\n") % hash.to_string ()));
-					}
-					// Check if previous & type for open blocks are correct
-					if (height == 0 && !block->previous ().is_zero ())
-					{
-						print_error_message (boost::str (boost::format ("Incorrect previous for open block %1%\n") % hash.to_string ()));
-					}
-					if (height == 0 && block->type () != nano::block_type::open && block->type () != nano::block_type::state)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect type for open block %1%\n") % hash.to_string ()));
-					}
-					// Check if block data is correct (calculating hash)
-					calculated_hash = block->hash ();
-					if (calculated_hash != hash)
-					{
-						print_error_message (boost::str (boost::format ("Invalid data inside block %1% calculated hash: %2%\n") % hash.to_string () % calculated_hash.to_string ()));
-					}
-					// Check if block signature is correct
-					if (validate_message (account, hash, block->block_signature ()))
-					{
-						bool invalid (true);
-						// Epoch blocks
-						if (block->type () == nano::block_type::state)
-						{
-							auto & state_block (static_cast<nano::state_block &> (*block.get ()));
-							nano::amount prev_balance (0);
-							bool error_or_pruned (false);
-							if (!state_block.hashables.previous.is_zero ())
-							{
-								prev_balance = node->ledger.balance_safe (transaction, state_block.hashables.previous, error_or_pruned);
-							}
-							if (node->ledger.is_epoch_link (state_block.hashables.link))
-							{
-								if ((state_block.hashables.balance == prev_balance && !error_or_pruned) || (node->ledger.pruning && error_or_pruned && block->sideband ().details.is_epoch))
-								{
-									invalid = validate_message (node->ledger.epoch_signer (block->link ()), hash, block->block_signature ());
-								}
-							}
-						}
-						if (invalid)
-						{
-							print_error_message (boost::str (boost::format ("Invalid signature for block %1%\n") % hash.to_string ()));
-						}
-					}
-					// Validate block details set in the sideband
-					bool block_details_error = false;
-					if (block->type () != nano::block_type::state)
-					{
-						// Not state
-						block_details_error = sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
-					}
-					else
-					{
-						bool error_or_pruned (false);
-						auto prev_balance (node->ledger.balance_safe (transaction, block->previous (), error_or_pruned));
-						if (!node->ledger.pruning || !error_or_pruned)
-						{
-							if (block->balance () < prev_balance)
-							{
-								// State send
-								block_details_error = !sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
-							}
-							else
-							{
-								if (block->link ().is_zero ())
-								{
-									// State change
-									block_details_error = sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
-								}
-								else if (block->balance () == prev_balance && node->ledger.is_epoch_link (block->link ()))
-								{
-									// State epoch
-									block_details_error = !sideband.details.is_epoch || sideband.details.is_send || sideband.details.is_receive;
-								}
-								else
-								{
-									// State receive
-									block_details_error = !sideband.details.is_receive || sideband.details.is_send || sideband.details.is_epoch;
-									block_details_error |= !node->ledger.block_or_pruned_exists (transaction, block->link ().as_block_hash ());
-								}
-							}
-						}
-						else if (!node->store.pruned_exists (transaction, block->previous ()))
-						{
-							print_error_message (boost::str (boost::format ("Previous pruned block does not exist %1%\n") % block->previous ().to_string ()));
-						}
-					}
-					if (block_details_error)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect sideband block details for block %1%\n") % hash.to_string ()));
-					}
-					// Check link epoch version
-					if (sideband.details.is_receive && (!node->ledger.pruning || !node->store.pruned_exists (transaction, block->link ().as_block_hash ())))
-					{
-						if (sideband.source_epoch != node->store.block_version (transaction, block->link ().as_block_hash ()))
-						{
-							print_error_message (boost::str (boost::format ("Incorrect source epoch for block %1%\n") % hash.to_string ()));
-						}
-					}
-					// Check if block work value is correct
-					if (block->difficulty () < nano::work_threshold (block->work_version (), block->sideband ().details))
-					{
-						print_error_message (boost::str (boost::format ("Invalid work for block %1% value: %2%\n") % hash.to_string () % nano::to_string_hex (block->block_work ())));
-					}
-					// Check if sideband height is correct
-					++height;
-					if (sideband.height != height)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect sideband height for block %1%. Sideband: %2%. Expected: %3%\n") % hash.to_string () % sideband.height % height));
-					}
-					// Check if sideband timestamp is after previous timestamp
-					if (sideband.timestamp < previous_timestamp)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect sideband timestamp for block %1%\n") % hash.to_string ()));
-					}
-					previous_timestamp = sideband.timestamp;
-					// Calculate representative block
-					if (block->type () == nano::block_type::open || block->type () == nano::block_type::change || block->type () == nano::block_type::state)
-					{
-						calculated_representative = block->representative ();
-					}
-					// Retrieving successor block hash
-					hash = node->store.block_successor (transaction, hash);
 					// Retrieving block data
-					if (!hash.is_zero ())
+					auto block (source_node->store.block_get_no_sideband (transaction, hash));
+					if (block != nullptr)
 					{
-						block = node->store.block_get (transaction, hash);
-					}
-				}
-				// Check if required block exists
-				if (!hash.is_zero () && block == nullptr)
-				{
-					print_error_message (boost::str (boost::format ("Required block in account %1% chain was not found in ledger: %2%\n") % account.to_account () % hash.to_string ()));
-				}
-				// Check account block count
-				if (info.block_count != height)
-				{
-					print_error_message (boost::str (boost::format ("Incorrect block count for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % height % info.block_count));
-				}
-				// Check account head block (frontier)
-				if (info.head != calculated_hash)
-				{
-					print_error_message (boost::str (boost::format ("Incorrect frontier for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_hash.to_string () % info.head.to_string ()));
-				}
-				// Check account representative block
-				if (info.representative != calculated_representative)
-				{
-					print_error_message (boost::str (boost::format ("Incorrect representative for account %1%. Actual: %2%. Expected: %3%\n") % account.to_account () % calculated_representative.to_string () % info.representative.to_string ()));
-				}
-			};
-
-			start_threads (check_account, accounts);
-
-			if (!silent)
-			{
-				std::cout << boost::str (boost::format ("Performing %1% threads blocks hash, signature, work validation...\n") % threads_count);
-			}
-			size_t const accounts_deque_overflow (32 * 1024);
-			auto transaction (node->store.tx_begin_read ());
-			for (auto i (node->store.accounts_begin (transaction)), n (node->store.accounts_end ()); i != n; ++i)
-			{
-				{
-					nano::unique_lock<nano::mutex> lock (mutex);
-					if (accounts.size () > accounts_deque_overflow)
-					{
-						auto wait_ms (250 * accounts.size () / accounts_deque_overflow);
-						const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
-						condition.wait_until (lock, wakeup);
-					}
-					accounts.emplace_back (i->first, i->second);
-				}
-				condition.notify_all ();
-			}
-			{
-				nano::lock_guard<nano::mutex> lock (mutex);
-				finished = true;
-			}
-			condition.notify_all ();
-			for (auto & thread : threads)
-			{
-				thread.join ();
-			}
-			threads.clear ();
-			if (!silent)
-			{
-				std::cout << boost::str (boost::format ("%1% accounts validated\n") % count);
-			}
-
-			// Validate total block count
-			auto ledger_block_count (node->store.block_count (transaction));
-			if (node->flags.enable_pruning)
-			{
-				block_count += 1; // Add disconnected genesis block
-			}
-			if (block_count != ledger_block_count)
-			{
-				print_error_message (boost::str (boost::format ("Incorrect total block count. Blocks validated %1%. Block count in database: %2%\n") % block_count % ledger_block_count));
-			}
-
-			// Validate pending blocks
-			count = 0;
-			finished = false;
-			std::deque<std::pair<nano::pending_key, nano::pending_info>> pending;
-
-			auto check_pending = [&print_error_message, &silent, &count](std::shared_ptr<nano::node> const & node, nano::read_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & info) {
-				++count;
-				if (!silent && (count % 500000) == 0)
-				{
-					std::cout << boost::str (boost::format ("%1% pending blocks validated\n") % count);
-				}
-				// Check block existance
-				auto block (node->store.block_get_no_sideband (transaction, key.hash));
-				bool pruned (false);
-				if (block == nullptr)
-				{
-					pruned = node->ledger.pruning && node->store.pruned_exists (transaction, key.hash);
-					if (!pruned)
-					{
-						print_error_message (boost::str (boost::format ("Pending block does not exist %1%\n") % key.hash.to_string ()));
-					}
-				}
-				else
-				{
-					// Check if pending destination is correct
-					nano::account destination (0);
-					bool previous_pruned = node->ledger.pruning && node->store.pruned_exists (transaction, block->previous ());
-					if (previous_pruned)
-					{
-						block = node->store.block_get (transaction, key.hash);
-					}
-					if (auto state = dynamic_cast<nano::state_block *> (block.get ()))
-					{
-						if (node->ledger.is_send (transaction, *state))
+						++count;
+						if ((count % 500000) == 0)
 						{
-							destination = state->hashables.link.as_account ();
+							std::cout << boost::str (boost::format ("%1% blocks retrieved") % count) << std::endl;
 						}
-					}
-					else if (auto send = dynamic_cast<nano::send_block *> (block.get ()))
-					{
-						destination = send->hashables.destination;
-					}
-					else
-					{
-						print_error_message (boost::str (boost::format ("Incorrect type for pending block %1%\n") % key.hash.to_string ()));
-					}
-					if (key.account != destination)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect destination for pending block %1%\n") % key.hash.to_string ()));
-					}
-					// Check if pending source is correct
-					auto account (node->ledger.account (transaction, key.hash));
-					if (info.source != account && !pruned)
-					{
-						print_error_message (boost::str (boost::format ("Incorrect source for pending block %1%\n") % key.hash.to_string ()));
-					}
-					// Check if pending amount is correct
-					if (!pruned && !previous_pruned)
-					{
-						auto amount (node->ledger.amount (transaction, key.hash));
-						if (info.amount != amount)
-						{
-							print_error_message (boost::str (boost::format ("Incorrect amount for pending block %1%\n") % key.hash.to_string ()));
-						}
-					}
-				}
-			};
-
-			start_threads (check_pending, pending);
-
-			size_t const pending_deque_overflow (64 * 1024);
-			for (auto i (node->store.pending_begin (transaction)), n (node->store.pending_end ()); i != n; ++i)
-			{
-				{
-					nano::unique_lock<nano::mutex> lock (mutex);
-					if (pending.size () > pending_deque_overflow)
-					{
-						auto wait_ms (50 * pending.size () / pending_deque_overflow);
-						const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
-						condition.wait_until (lock, wakeup);
-					}
-					pending.emplace_back (i->first, i->second);
-				}
-				condition.notify_all ();
-			}
-			{
-				nano::lock_guard<nano::mutex> lock (mutex);
-				finished = true;
-			}
-			condition.notify_all ();
-			for (auto & thread : threads)
-			{
-				thread.join ();
-			}
-			if (!silent)
-			{
-				std::cout << boost::str (boost::format ("%1% pending blocks validated\n") % count);
-				timer.stop ();
-				std::cout << boost::str (boost::format ("%1% %2% validation time\n") % timer.value ().count () % timer.unit ());
-			}
-			if (errors == 0)
-			{
-				std::cout << "Validation status: Ok\n";
-			}
-			else
-			{
-				std::cout << boost::str (boost::format ("Validation status: Failed\n%1% errors found\n") % errors);
-			}
-		}
-		else if (vm.count ("debug_profile_bootstrap"))
-		{
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			node_flags.read_only = false;
-			nano::update_flags (node_flags, vm);
-			nano::inactive_node node (nano::unique_path (), node_flags);
-			nano::genesis genesis;
-			auto begin (std::chrono::high_resolution_clock::now ());
-			uint64_t block_count (0);
-			size_t count (0);
-			std::deque<nano::unchecked_info> epoch_open_blocks;
-			{
-				auto node_flags = nano::inactive_node_flag_defaults ();
-				nano::update_flags (node_flags, vm);
-				node_flags.generate_cache.block_count = true;
-				nano::inactive_node inactive_node (data_path, node_flags);
-				auto source_node = inactive_node.node;
-				auto transaction (source_node->store.tx_begin_read ());
-				block_count = source_node->ledger.cache.block_count;
-				std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
-				for (auto i (source_node->store.accounts_begin (transaction)), n (source_node->store.accounts_end ()); i != n; ++i)
-				{
-					nano::account const & account (i->first);
-					nano::account_info const & info (i->second);
-					auto hash (info.head);
-					while (!hash.is_zero ())
-					{
-						// Retrieving block data
-						auto block (source_node->store.block_get_no_sideband (transaction, hash));
-						if (block != nullptr)
-						{
-							++count;
-							if ((count % 500000) == 0)
-							{
-								std::cout << boost::str (boost::format ("%1% blocks retrieved") % count) << std::endl;
-							}
-							nano::unchecked_info unchecked_info (block, account, 0, nano::signature_verification::unknown);
-							node.node->block_processor.add (unchecked_info);
-							if (block->type () == nano::block_type::state && block->previous ().is_zero () && source_node->ledger.is_epoch_link (block->link ()))
-							{
-								// Epoch open blocks can be rejected without processed pending blocks to account, push it later again
-								epoch_open_blocks.push_back (unchecked_info);
-							}
-							// Retrieving previous block hash
-							hash = block->previous ();
-						}
-					}
-				}
-			}
-			nano::timer<std::chrono::seconds> timer_l (nano::timer_state::started);
-			while (node.node->ledger.cache.block_count != block_count)
-			{
-				std::this_thread::sleep_for (std::chrono::milliseconds (500));
-				// Add epoch open blocks again if required
-				if (node.node->block_processor.size () == 0)
-				{
-					for (auto & unchecked_info : epoch_open_blocks)
-					{
+						nano::unchecked_info unchecked_info (block, account, 0, nano::signature_verification::unknown);
 						node.node->block_processor.add (unchecked_info);
+						if (block->type () == nano::block_type::state && block->previous ().is_zero () && source_node->ledger.is_epoch_link (block->link ()))
+						{
+							// Epoch open blocks can be rejected without processed pending blocks to account, push it later again
+							epoch_open_blocks.push_back (unchecked_info);
+						}
+						// Retrieving previous block hash
+						hash = block->previous ();
 					}
 				}
-				// Message each 60 seconds
-				if (timer_l.after_deadline (std::chrono::seconds (60)))
+			}
+		}
+		nano::timer<std::chrono::seconds> timer_l (nano::timer_state::started);
+		while (node.node->ledger.cache.block_count != block_count)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (500));
+			// Add epoch open blocks again if required
+			if (node.node->block_processor.size () == 0)
+			{
+				for (auto & unchecked_info : epoch_open_blocks)
 				{
-					timer_l.restart ();
-					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.cache.block_count % node.node->store.unchecked_count (node.node->store.tx_begin_read ())) << std::endl;
+					node.node->block_processor.add (unchecked_info);
 				}
 			}
-
-			node.node->block_processor.flush ();
-
-			auto end (std::chrono::high_resolution_clock::now ());
-			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
-			auto us_in_second (1000000);
-			auto seconds (time / us_in_second);
-			nano::remove_temporary_directories ();
-			std::cout << boost::str (boost::format ("%|1$ 12d| seconds \n%2% blocks per second") % seconds % (block_count * us_in_second / time)) << std::endl;
-			release_assert (node.node->ledger.cache.block_count == block_count);
-		}
-		else if (vm.count ("debug_peers"))
-		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
-			auto transaction (node->store.tx_begin_read ());
-
-			for (auto i (node->store.peers_begin (transaction)), n (node->store.peers_end ()); i != n; ++i)
+			// Message each 60 seconds
+			if (timer_l.after_deadline (std::chrono::seconds (60)))
 			{
-				std::cout << boost::str (boost::format ("%1%\n") % nano::endpoint (boost::asio::ip::address_v6 (i->first.address_bytes ()), i->first.port ()));
+				timer_l.restart ();
+				std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.cache.block_count % node.node->store.unchecked_count (node.node->store.tx_begin_read ())) << std::endl;
 			}
 		}
-		else if (vm.count ("debug_cemented_block_count"))
+
+		node.node->block_processor.flush ();
+
+		auto end (std::chrono::high_resolution_clock::now ());
+		auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
+		auto us_in_second (1000000);
+		auto seconds (time / us_in_second);
+		nano::remove_temporary_directories ();
+		std::cout << boost::str (boost::format ("%|1$ 12d| seconds \n%2% blocks per second") % seconds % (block_count * us_in_second / time)) << std::endl;
+		release_assert (node.node->ledger.cache.block_count == block_count);
+	}
+	else if (vm.count ("debug_peers"))
+	{
+		auto inactive_node = nano::default_inactive_node (data_path, vm);
+		auto node = inactive_node->node;
+		auto transaction (node->store.tx_begin_read ());
+
+		for (auto i (node->store.peers_begin (transaction)), n (node->store.peers_end ()); i != n; ++i)
 		{
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			node_flags.generate_cache.cemented_count = true;
-			nano::update_flags (node_flags, vm);
-			nano::inactive_node node (data_path, node_flags);
-			std::cout << "Total cemented block count: " << node.node->ledger.cache.cemented_count << std::endl;
-		}
-		else if (vm.count ("debug_prune"))
-		{
-			auto node_flags = nano::inactive_node_flag_defaults ();
-			node_flags.read_only = false;
-			nano::update_flags (node_flags, vm);
-			nano::inactive_node inactive_node (data_path, node_flags);
-			auto node = inactive_node.node;
-			node->ledger_pruning (node_flags.block_processor_batch_size != 0 ? node_flags.block_processor_batch_size : 16 * 1024, true, true);
-		}
-		else if (vm.count ("debug_stacktrace"))
-		{
-			std::cout << boost::stacktrace::stacktrace ();
-		}
-		else if (vm.count ("debug_sys_logging"))
-		{
-#ifdef BOOST_WINDOWS
-			if (!nano::event_log_reg_entry_exists () && !nano::is_windows_elevated ())
-			{
-				std::cerr << "The event log requires the HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\EventLog\\Nano\\Nano registry entry, run again as administator to create it.\n";
-				return 1;
-			}
-#endif
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			inactive_node->node->logger.always_log (nano::severity_level::error, "Testing system logger");
-		}
-		else if (vm.count ("debug_account_versions"))
-		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
-			auto const epoch_count = nano::normalized_epoch (nano::epoch::max) + static_cast<std::underlying_type<nano::epoch>::type> (1);
-			// Cache the accounts in a collection to make searching quicker against unchecked keys. Group by epoch
-			nano::locked<std::vector<boost::unordered_set<nano::account>>> opened_account_versions_shared (epoch_count);
-			using opened_account_versions_t = decltype (opened_account_versions_shared)::value_type;
-			node->store.accounts_for_each_par (
-			[&opened_account_versions_shared, epoch_count](nano::read_transaction const & /*unused*/, nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
-				// First cache locally
-				opened_account_versions_t opened_account_versions_l (epoch_count);
-				for (; i != n; ++i)
-				{
-					auto const & account (i->first);
-					auto const & account_info (i->second);
-
-					// Epoch 0 will be index 0 for instance
-					auto epoch_idx = nano::normalized_epoch (account_info.epoch ());
-					opened_account_versions_l[epoch_idx].emplace (account);
-				}
-				// Now merge
-				auto opened_account_versions = opened_account_versions_shared.lock ();
-				debug_assert (opened_account_versions->size () == opened_account_versions_l.size ());
-				for (auto idx (0); idx < opened_account_versions_l.size (); ++idx)
-				{
-					auto & accounts = opened_account_versions->at (idx);
-					auto const & accounts_l = opened_account_versions_l.at (idx);
-					accounts.insert (accounts_l.begin (), accounts_l.end ());
-				}
-			});
-
-			// Caching in a single set speeds up lookup
-			boost::unordered_set<nano::account> opened_accounts;
-			{
-				auto opened_account_versions = opened_account_versions_shared.lock ();
-				for (auto const & account_version : *opened_account_versions)
-				{
-					opened_accounts.insert (account_version.cbegin (), account_version.cend ());
-				}
-			}
-
-			// Iterate all pending blocks and collect the lowest version for each unopened account
-			nano::locked<boost::unordered_map<nano::account, std::underlying_type_t<nano::epoch>>> unopened_highest_pending_shared;
-			using unopened_highest_pending_t = decltype (unopened_highest_pending_shared)::value_type;
-			node->store.pending_for_each_par (
-			[&unopened_highest_pending_shared, &opened_accounts](nano::read_transaction const & /*unused*/, nano::store_iterator<nano::pending_key, nano::pending_info> i, nano::store_iterator<nano::pending_key, nano::pending_info> n) {
-				// First cache locally
-				unopened_highest_pending_t unopened_highest_pending_l;
-				for (; i != n; ++i)
-				{
-					nano::pending_key const & key (i->first);
-					nano::pending_info const & info (i->second);
-					auto & account = key.account;
-					auto exists = opened_accounts.find (account) != opened_accounts.end ();
-					if (!exists)
-					{
-						// This is an unopened account, store the lowest pending version
-						auto epoch = nano::normalized_epoch (info.epoch);
-						auto & existing_or_new = unopened_highest_pending_l[key.account];
-						existing_or_new = std::max (epoch, existing_or_new);
-					}
-				}
-				// Now merge
-				auto unopened_highest_pending = unopened_highest_pending_shared.lock ();
-				for (auto const & [account, epoch] : unopened_highest_pending_l)
-				{
-					auto & existing_or_new = unopened_highest_pending->operator[] (account);
-					existing_or_new = std::max (epoch, existing_or_new);
-				}
-			});
-
-			auto output_account_version_number = [](auto version, auto num_accounts) {
-				std::cout << "Account version " << version << " num accounts: " << num_accounts << "\n";
-			};
-
-			// Only single-threaded access from now on
-			auto const & opened_account_versions = *opened_account_versions_shared.lock ();
-			auto const & unopened_highest_pending = *unopened_highest_pending_shared.lock ();
-
-			// Output total version counts for the opened accounts
-			std::cout << "Opened accounts:\n";
-			for (auto i = 0u; i < opened_account_versions.size (); ++i)
-			{
-				output_account_version_number (i, opened_account_versions[i].size ());
-			}
-
-			// Accumulate the version numbers for the highest pending epoch for each unopened account.
-			std::vector<size_t> unopened_account_version_totals (epoch_count);
-			for (auto const & [account, epoch] : unopened_highest_pending)
-			{
-				++unopened_account_version_totals[epoch];
-			}
-
-			// Output total version counts for the unopened accounts
-			std::cout << "\nUnopened accounts:\n";
-			for (auto i = 0u; i < unopened_account_version_totals.size (); ++i)
-			{
-				output_account_version_number (i, unopened_account_version_totals[i]);
-			}
-		}
-		else if (vm.count ("debug_unconfirmed_frontiers"))
-		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
-
-			auto unconfirmed_frontiers = node->ledger.unconfirmed_frontiers ();
-			std::cout << "Account: Height delta | Frontier | Confirmed frontier\n";
-			for (auto const & [height_delta, unconfirmed_info] : unconfirmed_frontiers)
-			{
-				std::cout << (boost::format ("%1%: %2% %3% %4%\n") % unconfirmed_info.account.to_account () % height_delta % unconfirmed_info.frontier.to_string () % unconfirmed_info.cemented_frontier.to_string ()).str ();
-			}
-
-			std::cout << "\nNumber of unconfirmed frontiers: " << unconfirmed_frontiers.size () << std::endl;
-		}
-		else if (vm.count ("version"))
-		{
-			std::cout << "Version " << NANO_VERSION_STRING << "\n"
-			          << "Build Info " << BUILD_INFO << std::endl;
-		}
-		else
-		{
-			std::cout << description << std::endl;
-			result = -1;
+			std::cout << boost::str (boost::format ("%1%\n") % nano::endpoint (boost::asio::ip::address_v6 (i->first.address_bytes ()), i->first.port ()));
 		}
 	}
-	return result;
+	else if (vm.count ("debug_cemented_block_count"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		node_flags.generate_cache.cemented_count = true;
+		nano::update_flags (node_flags, vm);
+		nano::inactive_node node (data_path, node_flags);
+		std::cout << "Total cemented block count: " << node.node->ledger.cache.cemented_count << std::endl;
+	}
+	else if (vm.count ("debug_prune"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		node_flags.read_only = false;
+		nano::update_flags (node_flags, vm);
+		nano::inactive_node inactive_node (data_path, node_flags);
+		auto node = inactive_node.node;
+		node->ledger_pruning (node_flags.block_processor_batch_size != 0 ? node_flags.block_processor_batch_size : 16 * 1024, true, true);
+	}
+	else if (vm.count ("debug_stacktrace"))
+	{
+		std::cout << boost::stacktrace::stacktrace ();
+	}
+	else if (vm.count ("debug_sys_logging"))
+	{
+#ifdef BOOST_WINDOWS
+		if (!nano::event_log_reg_entry_exists () && !nano::is_windows_elevated ())
+		{
+			std::cerr << "The event log requires the HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\EventLog\\Nano\\Nano registry entry, run again as administator to create it.\n";
+			return 1;
+		}
+#endif
+		auto inactive_node = nano::default_inactive_node (data_path, vm);
+		inactive_node->node->logger.always_log (nano::severity_level::error, "Testing system logger");
+	}
+	else if (vm.count ("debug_account_versions"))
+	{
+		auto inactive_node = nano::default_inactive_node (data_path, vm);
+		auto node = inactive_node->node;
+		auto const epoch_count = nano::normalized_epoch (nano::epoch::max) + static_cast<std::underlying_type<nano::epoch>::type> (1);
+		// Cache the accounts in a collection to make searching quicker against unchecked keys. Group by epoch
+		nano::locked<std::vector<boost::unordered_set<nano::account>>> opened_account_versions_shared (epoch_count);
+		using opened_account_versions_t = decltype (opened_account_versions_shared)::value_type;
+		node->store.accounts_for_each_par (
+		[&opened_account_versions_shared, epoch_count](nano::read_transaction const & /*unused*/, nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
+			// First cache locally
+			opened_account_versions_t opened_account_versions_l (epoch_count);
+			for (; i != n; ++i)
+			{
+				auto const & account (i->first);
+				auto const & account_info (i->second);
+
+				// Epoch 0 will be index 0 for instance
+				auto epoch_idx = nano::normalized_epoch (account_info.epoch ());
+				opened_account_versions_l[epoch_idx].emplace (account);
+			}
+			// Now merge
+			auto opened_account_versions = opened_account_versions_shared.lock ();
+			debug_assert (opened_account_versions->size () == opened_account_versions_l.size ());
+			for (auto idx (0); idx < opened_account_versions_l.size (); ++idx)
+			{
+				auto & accounts = opened_account_versions->at (idx);
+				auto const & accounts_l = opened_account_versions_l.at (idx);
+				accounts.insert (accounts_l.begin (), accounts_l.end ());
+			}
+		});
+
+		// Caching in a single set speeds up lookup
+		boost::unordered_set<nano::account> opened_accounts;
+		{
+			auto opened_account_versions = opened_account_versions_shared.lock ();
+			for (auto const & account_version : *opened_account_versions)
+			{
+				opened_accounts.insert (account_version.cbegin (), account_version.cend ());
+			}
+		}
+
+		// Iterate all pending blocks and collect the lowest version for each unopened account
+		nano::locked<boost::unordered_map<nano::account, std::underlying_type_t<nano::epoch>>> unopened_highest_pending_shared;
+		using unopened_highest_pending_t = decltype (unopened_highest_pending_shared)::value_type;
+		node->store.pending_for_each_par (
+		[&unopened_highest_pending_shared, &opened_accounts](nano::read_transaction const & /*unused*/, nano::store_iterator<nano::pending_key, nano::pending_info> i, nano::store_iterator<nano::pending_key, nano::pending_info> n) {
+			// First cache locally
+			unopened_highest_pending_t unopened_highest_pending_l;
+			for (; i != n; ++i)
+			{
+				nano::pending_key const & key (i->first);
+				nano::pending_info const & info (i->second);
+				auto & account = key.account;
+				auto exists = opened_accounts.find (account) != opened_accounts.end ();
+				if (!exists)
+				{
+					// This is an unopened account, store the lowest pending version
+					auto epoch = nano::normalized_epoch (info.epoch);
+					auto & existing_or_new = unopened_highest_pending_l[key.account];
+					existing_or_new = std::max (epoch, existing_or_new);
+				}
+			}
+			// Now merge
+			auto unopened_highest_pending = unopened_highest_pending_shared.lock ();
+			for (auto const & [account, epoch] : unopened_highest_pending_l)
+			{
+				auto & existing_or_new = unopened_highest_pending->operator[] (account);
+				existing_or_new = std::max (epoch, existing_or_new);
+			}
+		});
+
+		auto output_account_version_number = [](auto version, auto num_accounts) {
+			std::cout << "Account version " << version << " num accounts: " << num_accounts << "\n";
+		};
+
+		// Only single-threaded access from now on
+		auto const & opened_account_versions = *opened_account_versions_shared.lock ();
+		auto const & unopened_highest_pending = *unopened_highest_pending_shared.lock ();
+
+		// Output total version counts for the opened accounts
+		std::cout << "Opened accounts:\n";
+		for (auto i = 0u; i < opened_account_versions.size (); ++i)
+		{
+			output_account_version_number (i, opened_account_versions[i].size ());
+		}
+
+		// Accumulate the version numbers for the highest pending epoch for each unopened account.
+		std::vector<size_t> unopened_account_version_totals (epoch_count);
+		for (auto const & [account, epoch] : unopened_highest_pending)
+		{
+			++unopened_account_version_totals[epoch];
+		}
+
+		// Output total version counts for the unopened accounts
+		std::cout << "\nUnopened accounts:\n";
+		for (auto i = 0u; i < unopened_account_version_totals.size (); ++i)
+		{
+			output_account_version_number (i, unopened_account_version_totals[i]);
+		}
+	}
+	else if (vm.count ("debug_unconfirmed_frontiers"))
+	{
+		auto inactive_node = nano::default_inactive_node (data_path, vm);
+		auto node = inactive_node->node;
+
+		auto unconfirmed_frontiers = node->ledger.unconfirmed_frontiers ();
+		std::cout << "Account: Height delta | Frontier | Confirmed frontier\n";
+		for (auto const & [height_delta, unconfirmed_info] : unconfirmed_frontiers)
+		{
+			std::cout << (boost::format ("%1%: %2% %3% %4%\n") % unconfirmed_info.account.to_account () % height_delta % unconfirmed_info.frontier.to_string () % unconfirmed_info.cemented_frontier.to_string ()).str ();
+		}
+
+		std::cout << "\nNumber of unconfirmed frontiers: " << unconfirmed_frontiers.size () << std::endl;
+	}
+	else if (vm.count ("version"))
+	{
+		std::cout << "Version " << NANO_VERSION_STRING << "\n"
+		          << "Build Info " << BUILD_INFO << std::endl;
+	}
+	else
+	{
+		std::cout << description << std::endl;
+		return -1;
+	}
+}
+return result;
 }
 
 namespace

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -582,7 +582,7 @@ void nano::active_transactions::request_loop ()
 		}
 		lock.lock ();
 
-		const auto stamp_l = std::chrono::steady_clock::now ();
+		auto const stamp_l = std::chrono::steady_clock::now ();
 
 		// frontiers_confirmation should be above update_active_multiplier to ensure new sorted roots are updated
 		if (should_do_frontiers_confirmation ())
@@ -594,8 +594,8 @@ void nano::active_transactions::request_loop ()
 
 		if (!stopped)
 		{
-			const auto min_sleep_l = std::chrono::milliseconds (node.network_params.network.request_interval_ms / 2);
-			const auto wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
+			auto const min_sleep_l = std::chrono::milliseconds (node.network_params.network.request_interval_ms / 2);
+			auto const wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
 			condition.wait_until (lock, wakeup_l, [&wakeup_l, &stopped = stopped] { return stopped || std::chrono::steady_clock::now () >= wakeup_l; });
 		}
 	}

--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -198,7 +198,7 @@ bool nano::bootstrap_attempt_legacy::confirm_frontiers (nano::unique_lock<nano::
 	auto frontiers_count (frontiers.size ());
 	if (frontiers_count > 0)
 	{
-		const size_t reps_limit = 20;
+		size_t const reps_limit = 20;
 		auto representatives (node->rep_crawler.representatives ());
 		auto reps_weight (node->rep_crawler.total_weight ());
 		auto representatives_copy (representatives);

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -4,14 +4,11 @@
 #include <nano/node/active_transactions.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/election.hpp>
-#include <nano/node/wallet.hpp>
 #include <nano/secure/buffer.hpp>
 
 #include <boost/endian/conversion.hpp>
 #include <boost/pool/pool_alloc.hpp>
 #include <boost/variant/get.hpp>
-
-#include <numeric>
 
 std::bitset<16> constexpr nano::message_header::block_type_mask;
 std::bitset<16> constexpr nano::message_header::count_mask;

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -254,7 +254,7 @@ size_t nano::message_header::payload_length_bytes () const
 }
 
 // MTU - IP header - UDP header
-const size_t nano::message_parser::max_safe_udp_message_size = 508;
+size_t const nano::message_parser::max_safe_udp_message_size = 508;
 
 std::string nano::message_parser::status_string ()
 {

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -379,8 +379,8 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 		// of blocks to retain consistent cementing across all account chains to genesis.
 		while (!error && !pending_writes.empty ())
 		{
-			const auto & pending = pending_writes.front ();
-			const auto & account = pending.account;
+			auto const & pending = pending_writes.front ();
+			auto const & account = pending.account;
 
 			auto write_confirmation_height = [&account, &ledger = ledger, &transaction](uint64_t num_blocks_cemented, uint64_t confirmation_height, nano::block_hash const & confirmed_frontier) {
 #ifndef NDEBUG

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -62,7 +62,7 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 
 			set_next_hash ();
 
-			const auto num_blocks_to_use_unbounded = confirmation_height::unbounded_cutoff;
+			auto const num_blocks_to_use_unbounded = confirmation_height::unbounded_cutoff;
 			auto blocks_within_automatic_unbounded_selection = (ledger.cache.block_count < num_blocks_to_use_unbounded || ledger.cache.block_count - num_blocks_to_use_unbounded < ledger.cache.cemented_count);
 
 			// Don't want to mix up pending writes across different processors

--- a/nano/node/ipc/flatbuffers_handler.cpp
+++ b/nano/node/ipc/flatbuffers_handler.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<flatbuffers::Parser> nano::ipc::flatbuffers_handler::make_flatbu
 		throw nano::error ("Internal IPC error: unable to find api path");
 	}
 
-	const char * include_directories[] = { api_path->string ().c_str (), nullptr };
+	char const * include_directories[] = { api_path->string ().c_str (), nullptr };
 	std::string schemafile;
 	if (!flatbuffers::LoadFile ((*api_path / "nanoapi.fbs").string ().c_str (), false, &schemafile))
 	{
@@ -94,7 +94,7 @@ std::shared_ptr<flatbuffers::Parser> nano::ipc::flatbuffers_handler::make_flatbu
 	return parser;
 }
 
-void nano::ipc::flatbuffers_handler::process_json (const uint8_t * message_buffer_a, size_t buffer_size_a,
+void nano::ipc::flatbuffers_handler::process_json (uint8_t const * message_buffer_a, size_t buffer_size_a,
 std::function<void(std::shared_ptr<std::string> const &)> const & response_handler)
 {
 	try
@@ -107,7 +107,7 @@ std::function<void(std::shared_ptr<std::string> const &)> const & response_handl
 		// Convert request from JSON
 		auto body (std::string (reinterpret_cast<char *> (const_cast<uint8_t *> (message_buffer_a)), buffer_size_a));
 		body += '\0';
-		if (parser->Parse (reinterpret_cast<const char *> (body.data ())))
+		if (parser->Parse (reinterpret_cast<char const *> (body.data ())))
 		{
 			process (parser->builder_.GetBufferPointer (), parser->builder_.GetSize (), [parser = parser, response_handler](std::shared_ptr<flatbuffers::FlatBufferBuilder> const & fbb) {
 				// Convert response to JSON
@@ -144,7 +144,7 @@ std::function<void(std::shared_ptr<std::string> const &)> const & response_handl
 	}
 }
 
-void nano::ipc::flatbuffers_handler::process (const uint8_t * message_buffer_a, size_t buffer_size_a,
+void nano::ipc::flatbuffers_handler::process (uint8_t const * message_buffer_a, size_t buffer_size_a,
 std::function<void(std::shared_ptr<flatbuffers::FlatBufferBuilder> const &)> const & response_handler)
 {
 	auto buffer_l (std::make_shared<flatbuffers::FlatBufferBuilder> ());

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -22,7 +22,7 @@ using ipc_json_handler_no_arg_func_map = std::unordered_map<std::string, std::fu
 ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ();
 auto ipc_json_handler_no_arg_funcs = create_ipc_json_handler_no_arg_func_map ();
 bool block_confirmed (nano::node & node, nano::transaction & transaction, nano::block_hash const & hash, bool include_active, bool include_only_confirmed);
-const char * epoch_as_string (nano::epoch);
+char const * epoch_as_string (nano::epoch);
 }
 
 nano::json_handler::json_handler (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a, std::string const & body_a, std::function<void(std::string const &)> const & response_a, std::function<void()> stop_callback_a) :
@@ -276,7 +276,7 @@ nano::amount nano::json_handler::amount_impl ()
 
 std::shared_ptr<nano::block> nano::json_handler::block_impl (bool signature_work_required)
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	std::shared_ptr<nano::block> result{ nullptr };
 	if (!ec)
 	{
@@ -514,7 +514,7 @@ void nano::json_handler::account_balance ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
+		bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
 		auto balance (node.balance_pending (account, include_only_confirmed));
 		response_l.put ("balance", balance.first.convert_to<std::string> ());
 		response_l.put ("pending", balance.second.convert_to<std::string> ());
@@ -543,7 +543,7 @@ void nano::json_handler::account_create ()
 		auto wallet (rpc_l->wallet_impl ());
 		if (!rpc_l->ec)
 		{
-			const bool generate_work = rpc_l->request.get<bool> ("work", true);
+			bool const generate_work = rpc_l->request.get<bool> ("work", true);
 			nano::account new_key;
 			auto index_text (rpc_l->request.get_optional<std::string> ("index"));
 			if (index_text.is_initialized ())
@@ -599,10 +599,10 @@ void nano::json_handler::account_info ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		const bool representative = request.get<bool> ("representative", false);
-		const bool weight = request.get<bool> ("weight", false);
-		const bool pending = request.get<bool> ("pending", false);
-		const bool include_confirmed = request.get<bool> ("include_confirmed", false);
+		bool const representative = request.get<bool> ("representative", false);
+		bool const weight = request.get<bool> ("weight", false);
+		bool const pending = request.get<bool> ("pending", false);
+		bool const include_confirmed = request.get<bool> ("include_confirmed", false);
 		auto transaction (node.store.tx_begin_read ());
 		auto info (account_info_impl (transaction, account));
 		nano::confirmation_height_info confirmation_height_info;
@@ -901,7 +901,7 @@ void nano::json_handler::accounts_create ()
 		auto count (rpc_l->count_impl ());
 		if (!rpc_l->ec)
 		{
-			const bool generate_work = rpc_l->request.get<bool> ("work", false);
+			bool const generate_work = rpc_l->request.get<bool> ("work", false);
 			boost::property_tree::ptree accounts;
 			for (auto i (0); accounts.size () < count; ++i)
 			{
@@ -943,10 +943,10 @@ void nano::json_handler::accounts_pending ()
 {
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	const bool source = request.get<bool> ("source", false);
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
-	const bool sorting = request.get<bool> ("sorting", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
+	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !sorting); // if simple, response is a list of hashes for each account
 	boost::property_tree::ptree pending;
 	auto transaction (node.store.tx_begin_read ());
@@ -991,13 +991,13 @@ void nano::json_handler::accounts_pending ()
 			{
 				if (source)
 				{
-					peers_l.sort ([](const auto & child1, const auto & child2) -> bool {
+					peers_l.sort ([](auto const & child1, auto const & child2) -> bool {
 						return child1.second.template get<nano::uint128_t> ("amount") > child2.second.template get<nano::uint128_t> ("amount");
 					});
 				}
 				else
 				{
-					peers_l.sort ([](const auto & child1, const auto & child2) -> bool {
+					peers_l.sort ([](auto const & child1, auto const & child2) -> bool {
 						return child1.second.template get<nano::uint128_t> ("") > child2.second.template get<nano::uint128_t> ("");
 					});
 				}
@@ -1147,7 +1147,7 @@ void nano::json_handler::block_confirm ()
 
 void nano::json_handler::blocks ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	boost::property_tree::ptree blocks;
 	auto transaction (node.store.tx_begin_read ());
 	for (boost::property_tree::ptree::value_type & hashes : request.get_child ("hashes"))
@@ -1191,10 +1191,10 @@ void nano::json_handler::blocks ()
 
 void nano::json_handler::blocks_info ()
 {
-	const bool pending = request.get<bool> ("pending", false);
-	const bool source = request.get<bool> ("source", false);
-	const bool json_block_l = request.get<bool> ("json_block", false);
-	const bool include_not_found = request.get<bool> ("include_not_found", false);
+	bool const pending = request.get<bool> ("pending", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
+	bool const include_not_found = request.get<bool> ("include_not_found", false);
 
 	boost::property_tree::ptree blocks;
 	boost::property_tree::ptree blocks_not_found;
@@ -1688,7 +1688,7 @@ void nano::json_handler::bootstrap ()
 {
 	std::string address_text = request.get<std::string> ("address");
 	std::string port_text = request.get<std::string> ("port");
-	const bool bypass_frontier_confirmation = request.get<bool> ("bypass_frontier_confirmation", false);
+	bool const bypass_frontier_confirmation = request.get<bool> ("bypass_frontier_confirmation", false);
 	boost::system::error_code address_ec;
 	auto address (boost::asio::ip::make_address_v6 (address_text, address_ec));
 	if (!address_ec)
@@ -1721,7 +1721,7 @@ void nano::json_handler::bootstrap ()
 
 void nano::json_handler::bootstrap_any ()
 {
-	const bool force = request.get<bool> ("force", false);
+	bool const force = request.get<bool> ("force", false);
 	if (!node.flags.disable_legacy_bootstrap)
 	{
 		std::string bootstrap_id (request.get<std::string> ("id", ""));
@@ -1738,7 +1738,7 @@ void nano::json_handler::bootstrap_any ()
 void nano::json_handler::bootstrap_lazy ()
 {
 	auto hash (hash_impl ());
-	const bool force = request.get<bool> ("force", false);
+	bool const force = request.get<bool> ("force", false);
 	if (!ec)
 	{
 		if (!node.flags.disable_lazy_bootstrap)
@@ -1922,9 +1922,9 @@ void nano::json_handler::confirmation_history ()
 
 void nano::json_handler::confirmation_info ()
 {
-	const bool representatives = request.get<bool> ("representatives", false);
-	const bool contents = request.get<bool> ("contents", true);
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const representatives = request.get<bool> ("representatives", false);
+	bool const contents = request.get<bool> ("contents", true);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	std::string root_text (request.get<std::string> ("root"));
 	nano::qualified_root root;
 	if (!root.decode_hex (root_text))
@@ -2427,7 +2427,7 @@ public:
 void nano::json_handler::account_history ()
 {
 	std::vector<nano::public_key> accounts_to_filter;
-	const auto accounts_filter_node = request.get_child_optional ("account_filter");
+	auto const accounts_filter_node = request.get_child_optional ("account_filter");
 	if (accounts_filter_node.is_initialized ())
 	{
 		for (auto & a : (*accounts_filter_node))
@@ -2598,10 +2598,10 @@ void nano::json_handler::ledger ()
 				ec = nano::error_rpc::invalid_timestamp;
 			}
 		}
-		const bool sorting = request.get<bool> ("sorting", false);
-		const bool representative = request.get<bool> ("representative", false);
-		const bool weight = request.get<bool> ("weight", false);
-		const bool pending = request.get<bool> ("pending", false);
+		bool const sorting = request.get<bool> ("sorting", false);
+		bool const representative = request.get<bool> ("representative", false);
+		bool const weight = request.get<bool> ("weight", false);
+		bool const pending = request.get<bool> ("pending", false);
 		boost::property_tree::ptree accounts;
 		auto transaction (node.store.tx_begin_read ());
 		if (!ec && !sorting) // Simple
@@ -2813,9 +2813,9 @@ void nano::json_handler::password_valid (bool wallet_locked)
 void nano::json_handler::peers ()
 {
 	boost::property_tree::ptree peers_l;
-	const bool peer_details = request.get<bool> ("peer_details", false);
+	bool const peer_details = request.get<bool> ("peer_details", false);
 	auto peers_list (node.network.list (std::numeric_limits<size_t>::max ()));
-	std::sort (peers_list.begin (), peers_list.end (), [](const auto & lhs, const auto & rhs) {
+	std::sort (peers_list.begin (), peers_list.end (), [](auto const & lhs, auto const & rhs) {
 		return lhs->get_endpoint () < rhs->get_endpoint ();
 	});
 	for (auto i (peers_list.begin ()), n (peers_list.end ()); i != n; ++i)
@@ -2853,13 +2853,13 @@ void nano::json_handler::pending ()
 	auto account (account_impl ());
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	const bool source = request.get<bool> ("source", false);
-	const bool min_version = request.get<bool> ("min_version", false);
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
-	const bool sorting = request.get<bool> ("sorting", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const min_version = request.get<bool> ("min_version", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
+	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !min_version && !sorting); // if simple, response is a list of hashes
-	const bool should_sort = sorting && !simple;
+	bool const should_sort = sorting && !simple;
 	if (!ec)
 	{
 		boost::property_tree::ptree peers_l;
@@ -2925,7 +2925,7 @@ void nano::json_handler::pending ()
 			if (source || min_version)
 			{
 				auto mid = hash_ptree_pairs.size () <= count ? hash_ptree_pairs.end () : hash_ptree_pairs.begin () + count;
-				std::partial_sort (hash_ptree_pairs.begin (), mid, hash_ptree_pairs.end (), [](const auto & lhs, const auto & rhs) {
+				std::partial_sort (hash_ptree_pairs.begin (), mid, hash_ptree_pairs.end (), [](auto const & lhs, auto const & rhs) {
 					return lhs.second.template get<nano::uint128_t> ("amount") > rhs.second.template get<nano::uint128_t> ("amount");
 				});
 				for (auto i = 0; i < hash_ptree_pairs.size () && i < count; ++i)
@@ -2936,7 +2936,7 @@ void nano::json_handler::pending ()
 			else
 			{
 				auto mid = hash_amount_pairs.size () <= count ? hash_amount_pairs.end () : hash_amount_pairs.begin () + count;
-				std::partial_sort (hash_amount_pairs.begin (), mid, hash_amount_pairs.end (), [](const auto & lhs, const auto & rhs) {
+				std::partial_sort (hash_amount_pairs.begin (), mid, hash_amount_pairs.end (), [](auto const & lhs, auto const & rhs) {
 					return lhs.second > rhs.second;
 				});
 
@@ -2954,8 +2954,8 @@ void nano::json_handler::pending ()
 void nano::json_handler::pending_exists ()
 {
 	auto hash (hash_impl ());
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
 	if (!ec)
 	{
 		auto transaction (node.store.tx_begin_read ());
@@ -2982,8 +2982,8 @@ void nano::json_handler::pending_exists ()
 void nano::json_handler::process ()
 {
 	node.workers.push_task (create_worker_task ([](std::shared_ptr<nano::json_handler> const & rpc_l) {
-		const bool watch_work_l = rpc_l->request.get<bool> ("watch_work", true);
-		const bool is_async = rpc_l->request.get<bool> ("async", false);
+		bool const watch_work_l = rpc_l->request.get<bool> ("watch_work", true);
+		bool const is_async = rpc_l->request.get<bool> ("async", false);
 		auto block (rpc_l->block_impl (true));
 
 		// State blocks subtype check
@@ -3110,7 +3110,7 @@ void nano::json_handler::process ()
 						}
 						case nano::process_result::fork:
 						{
-							const bool force = rpc_l->request.get<bool> ("force", false);
+							bool const force = rpc_l->request.get<bool> ("force", false);
 							if (force)
 							{
 								rpc_l->node.active.erase (*block);
@@ -3291,7 +3291,7 @@ void nano::json_handler::representatives ()
 	auto count (count_optional_impl ());
 	if (!ec)
 	{
-		const bool sorting = request.get<bool> ("sorting", false);
+		bool const sorting = request.get<bool> ("sorting", false);
 		boost::property_tree::ptree representatives;
 		auto rep_amounts = node.ledger.cache.rep_weights.get_rep_amounts ();
 		if (!sorting) // Simple
@@ -3333,8 +3333,8 @@ void nano::json_handler::representatives ()
 
 void nano::json_handler::representatives_online ()
 {
-	const auto accounts_node = request.get_child_optional ("accounts");
-	const bool weight = request.get<bool> ("weight", false);
+	auto const accounts_node = request.get_child_optional ("accounts");
+	bool const weight = request.get<bool> ("weight", false);
 	std::vector<nano::public_key> accounts_to_filter;
 	if (accounts_node.is_initialized ())
 	{
@@ -3601,7 +3601,7 @@ void nano::json_handler::send ()
 
 void nano::json_handler::sign ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	// Retrieving hash
 	nano::block_hash hash (0);
 	boost::optional<std::string> hash_text (request.get_optional<std::string> ("hash"));
@@ -3922,7 +3922,7 @@ void nano::json_handler::telemetry ()
 
 void nano::json_handler::unchecked ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto count (count_optional_impl ());
 	if (!ec)
 	{
@@ -3961,7 +3961,7 @@ void nano::json_handler::unchecked_clear ()
 
 void nano::json_handler::unchecked_get ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto hash (hash_impl ());
 	if (!ec)
 	{
@@ -3999,7 +3999,7 @@ void nano::json_handler::unchecked_get ()
 
 void nano::json_handler::unchecked_keys ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto count (count_optional_impl ());
 	nano::block_hash key (0);
 	boost::optional<std::string> hash_text (request.get_optional<std::string> ("key"));
@@ -4138,7 +4138,7 @@ void nano::json_handler::wallet_add ()
 			nano::raw_key key;
 			if (!key.decode_hex (key_text))
 			{
-				const bool generate_work = rpc_l->request.get<bool> ("work", true);
+				bool const generate_work = rpc_l->request.get<bool> ("work", true);
 				auto pub (wallet->insert_adhoc (key, generate_work));
 				if (!pub.is_zero ())
 				{
@@ -4479,9 +4479,9 @@ void nano::json_handler::wallet_key_valid ()
 
 void nano::json_handler::wallet_ledger ()
 {
-	const bool representative = request.get<bool> ("representative", false);
-	const bool weight = request.get<bool> ("weight", false);
-	const bool pending = request.get<bool> ("pending", false);
+	bool const representative = request.get<bool> ("representative", false);
+	bool const weight = request.get<bool> ("weight", false);
+	bool const pending = request.get<bool> ("pending", false);
 	uint64_t modified_since (0);
 	boost::optional<std::string> modified_since_text (request.get_optional<std::string> ("modified_since"));
 	if (modified_since_text.is_initialized ())
@@ -4553,10 +4553,10 @@ void nano::json_handler::wallet_pending ()
 	auto wallet (wallet_impl ());
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	const bool source = request.get<bool> ("source", false);
-	const bool min_version = request.get<bool> ("min_version", false);
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const min_version = request.get<bool> ("min_version", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", false);
 	if (!ec)
 	{
 		boost::property_tree::ptree pending;
@@ -5184,7 +5184,7 @@ bool block_confirmed (nano::node & node, nano::transaction & transaction, nano::
 	return is_confirmed;
 }
 
-const char * epoch_as_string (nano::epoch epoch)
+char const * epoch_as_string (nano::epoch epoch)
 {
 	switch (epoch)
 	{

--- a/nano/node/lmdb/lmdb_txn.cpp
+++ b/nano/node/lmdb/lmdb_txn.cpp
@@ -45,7 +45,7 @@ public:
 	}
 
 private:
-	const nano::transaction_impl * transaction_impl;
+	nano::transaction_impl const * transaction_impl;
 };
 }
 

--- a/nano/node/lmdb/lmdb_txn.hpp
+++ b/nano/node/lmdb/lmdb_txn.hpp
@@ -57,7 +57,7 @@ public:
 	mdb_txn_stats (const nano::transaction_impl * transaction_impl_a);
 	bool is_write () const;
 	nano::timer<std::chrono::milliseconds> timer;
-	const nano::transaction_impl * transaction_impl;
+	nano::transaction_impl const * transaction_impl;
 	std::string thread_name;
 
 	// Smart pointer so that we don't need the full definition which causes min/max issues on Windows

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -260,7 +260,7 @@ void nano::network::broadcast_confirm_req (std::shared_ptr<nano::block> const & 
 	 * of "broadcast_confirm_req" will be responsible for calling it again
 	 * if the votes for a block have not arrived in time.
 	 */
-	const size_t max_endpoints = 32;
+	size_t const max_endpoints = 32;
 	nano::random_pool_shuffle (list->begin (), list->end ());
 	if (list->size () > max_endpoints)
 	{
@@ -272,7 +272,7 @@ void nano::network::broadcast_confirm_req (std::shared_ptr<nano::block> const & 
 
 void nano::network::broadcast_confirm_req_base (std::shared_ptr<nano::block> const & block_a, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>> const & endpoints_a, unsigned delay_a, bool resumption)
 {
-	const size_t max_reps = 10;
+	size_t const max_reps = 10;
 	if (!resumption && node.config.logging.network_logging ())
 	{
 		node.logger.try_log (boost::str (boost::format ("Broadcasting confirm req for block %1% to %2% representatives") % block_a->hash ().to_string () % endpoints_a->size ()));

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (re
 		count = rep_crawler.active.size ();
 	}
 
-	const auto sizeof_element = sizeof (decltype (rep_crawler.active)::value_type);
+	auto const sizeof_element = sizeof (decltype (rep_crawler.active)::value_type);
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "active", count, sizeof_element }));
 	return composite;
@@ -332,7 +332,7 @@ node_seq (seq)
 		logger.always_log ("Build information: ", BUILD_INFO);
 		logger.always_log ("Database backend: ", store.vendor_get ());
 
-		const auto network_label = network_params.network.get_current_network_as_string ();
+		auto const network_label = network_params.network.get_current_network_as_string ();
 		logger.always_log ("Active network: ", network_label);
 
 		logger.always_log (boost::str (boost::format ("Work pool running %1% threads %2%") % work.threads.size () % (work.opencl ? "(1 for OpenCL)" : "")));
@@ -352,14 +352,14 @@ node_seq (seq)
 		// First do a pass with a read to see if any writing needs doing, this saves needing to open a write lock (and potentially blocking)
 		auto is_initialized (false);
 		{
-			const auto transaction (store.tx_begin_read ());
+			auto const transaction (store.tx_begin_read ());
 			is_initialized = (store.accounts_begin (transaction) != store.accounts_end ());
 		}
 
 		nano::genesis genesis;
 		if (!is_initialized && !flags.read_only)
 		{
-			const auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers }));
+			auto const transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers }));
 			// Store was empty meaning we just created it, add the genesis block
 			store.initialize (transaction, genesis, ledger.cache);
 		}
@@ -373,7 +373,7 @@ node_seq (seq)
 			{
 				ss << " Beta network may have reset, try clearing database files";
 			}
-			const auto str = ss.str ();
+			auto const str = ss.str ();
 
 			logger.always_log (str);
 			std::cerr << str << std::endl;
@@ -401,9 +401,9 @@ node_seq (seq)
 
 		if ((network_params.network.is_live_network () || network_params.network.is_beta_network ()) && !flags.inactive_node)
 		{
-			const auto bootstrap_weights = get_bootstrap_weights ();
+			auto const bootstrap_weights = get_bootstrap_weights ();
 			// Use bootstrap weights if initial bootstrap is not completed
-			const bool use_bootstrap_weight = ledger.cache.block_count < bootstrap_weights.first;
+			bool const use_bootstrap_weight = ledger.cache.block_count < bootstrap_weights.first;
 			if (use_bootstrap_weight)
 			{
 				ledger.bootstrap_weights = bootstrap_weights.second;
@@ -417,7 +417,7 @@ node_seq (seq)
 			// Drop unchecked blocks if initial bootstrap is completed
 			if (!flags.disable_unchecked_drop && !use_bootstrap_weight && !flags.read_only)
 			{
-				const auto transaction (store.tx_begin_write ({ tables::unchecked }));
+				auto const transaction (store.tx_begin_write ({ tables::unchecked }));
 				store.unchecked_clear (transaction);
 				logger.always_log ("Dropping unchecked blocks");
 			}
@@ -544,10 +544,10 @@ void nano::node::process_fork (nano::transaction const & transaction_a, std::sha
 			auto election = active.insert (ledger_block, boost::none, nano::election_behavior::normal, [this_w, root, root_block_type = block_a->type ()](std::shared_ptr<nano::block> const &) {
 				if (auto this_l = this_w.lock ())
 				{
-					const auto attempt (this_l->bootstrap_initiator.current_attempt ());
+					auto const attempt (this_l->bootstrap_initiator.current_attempt ());
 					if (attempt && attempt->mode == nano::bootstrap_mode::legacy)
 					{
-						const auto transaction (this_l->store.tx_begin_read ());
+						auto const transaction (this_l->store.tx_begin_read ());
 						nano::account account{ 0 };
 						if (root_block_type == nano::block_type::receive || root_block_type == nano::block_type::send || root_block_type == nano::block_type::change || root_block_type == nano::block_type::open)
 						{
@@ -613,7 +613,7 @@ void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 
 nano::process_return nano::node::process (nano::block & block_a)
 {
-	const auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
+	auto const transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
 	auto result (ledger.process (transaction, block_a));
 	return result;
 }
@@ -628,7 +628,7 @@ nano::process_return nano::node::process_local (std::shared_ptr<nano::block> con
 	block_processor.wait_write ();
 	// Process block
 	block_post_events post_events ([& store = store] { return store.tx_begin_read (); });
-	const auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
+	auto const transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
 	return block_processor.process_one (transaction, post_events, info, work_watcher_a, false, nano::block_origin::local);
 }
 
@@ -749,26 +749,26 @@ void nano::node::keepalive_preconfigured (std::vector<std::string> const & peers
 
 nano::block_hash nano::node::latest (nano::account const & account_a)
 {
-	const auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	return ledger.latest (transaction, account_a);
 }
 
 nano::uint128_t nano::node::balance (nano::account const & account_a)
 {
-	const auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	return ledger.account_balance (transaction, account_a);
 }
 
 std::shared_ptr<nano::block> nano::node::block (nano::block_hash const & hash_a)
 {
-	const auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	return store.block_get (transaction, hash_a);
 }
 
 std::pair<nano::uint128_t, nano::uint128_t> nano::node::balance_pending (nano::account const & account_a, bool only_confirmed_a)
 {
 	std::pair<nano::uint128_t, nano::uint128_t> result;
-	const auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	result.first = ledger.account_balance (transaction, account_a, only_confirmed_a);
 	result.second = ledger.account_pending (transaction, account_a, only_confirmed_a);
 	return result;
@@ -781,7 +781,7 @@ nano::uint128_t nano::node::weight (nano::account const & account_a)
 
 nano::block_hash nano::node::rep_block (nano::account const & account_a)
 {
-	const auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	nano::account_info info;
 	nano::block_hash result (0);
 	if (!store.account_get (transaction, account_a, info))
@@ -804,7 +804,7 @@ nano::uint128_t nano::node::minimum_principal_weight (nano::uint128_t const & on
 void nano::node::long_inactivity_cleanup ()
 {
 	bool perform_cleanup = false;
-	const auto transaction (store.tx_begin_write ({ tables::online_weight, tables::peers }));
+	auto const transaction (store.tx_begin_write ({ tables::online_weight, tables::peers }));
 	if (store.online_weight_count (transaction) > 0)
 	{
 		auto i (store.online_weight_begin (transaction));
@@ -863,7 +863,7 @@ void nano::node::ongoing_bootstrap ()
 
 void nano::node::ongoing_peer_store ()
 {
-	const bool stored (network.tcp_channels.store_all (true));
+	bool const stored (network.tcp_channels.store_all (true));
 	network.udp_channels.store_all (!stored);
 	std::weak_ptr<nano::node> node_w (shared_from_this ());
 	workers.add_timed_task (std::chrono::steady_clock::now () + network_params.node.peer_interval, [node_w]() {
@@ -909,7 +909,7 @@ void nano::node::bootstrap_wallet ()
 	std::deque<nano::account> accounts;
 	{
 		nano::lock_guard<nano::mutex> lock (wallets.mutex);
-		const auto transaction (wallets.tx_begin_read ());
+		auto const transaction (wallets.tx_begin_read ());
 		for (auto i (wallets.items.begin ()), n (wallets.items.end ()); i != n && accounts.size () < 128; ++i)
 		{
 			auto & wallet (*i->second);
@@ -931,13 +931,13 @@ void nano::node::unchecked_cleanup ()
 {
 	std::vector<nano::uint128_t> digests;
 	std::deque<nano::unchecked_key> cleaning_list;
-	const auto attempt (bootstrap_initiator.current_attempt ());
-	const bool long_attempt (attempt != nullptr && std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - attempt->attempt_start).count () > config.unchecked_cutoff_time.count ());
+	auto const attempt (bootstrap_initiator.current_attempt ());
+	bool const long_attempt (attempt != nullptr && std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - attempt->attempt_start).count () > config.unchecked_cutoff_time.count ());
 	// Collect old unchecked keys
 	if (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks && !long_attempt)
 	{
-		const auto now (nano::seconds_since_epoch ());
-		const auto transaction (store.tx_begin_read ());
+		auto const now (nano::seconds_since_epoch ());
+		auto const transaction (store.tx_begin_read ());
 		// Max 1M records to clean, max 2 minutes reading to prevent slow i/o systems issues
 		for (auto i (store.unchecked_begin (transaction)), n (store.unchecked_end ()); i != n && cleaning_list.size () < 1024 * 1024 && nano::seconds_since_epoch () - now < 120; ++i)
 		{
@@ -958,7 +958,7 @@ void nano::node::unchecked_cleanup ()
 	while (!cleaning_list.empty ())
 	{
 		size_t deleted_count (0);
-		const auto transaction (store.tx_begin_write ({ tables::unchecked }));
+		auto const transaction (store.tx_begin_write ({ tables::unchecked }));
 		while (deleted_count++ < 2 * 1024 && !cleaning_list.empty ())
 		{
 			auto key (cleaning_list.front ());
@@ -986,7 +986,7 @@ bool nano::node::collect_ledger_pruning_targets (std::deque<nano::block_hash> & 
 {
 	uint64_t read_operations (0);
 	bool finish_transaction (false);
-	const auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	for (auto i (store.confirmation_height_begin (transaction, last_account_a)), n (store.confirmation_height_end ()); i != n && !finish_transaction;)
 	{
 		++read_operations;
@@ -1076,7 +1076,7 @@ void nano::node::ledger_pruning (uint64_t const batch_size_a, bool bootstrap_wei
 			}
 		}
 	}
-	const auto log_message (boost::str (boost::format ("Total recently pruned block count: %1%") % pruned_count));
+	auto const log_message (boost::str (boost::format ("Total recently pruned block count: %1%") % pruned_count));
 	if (!log_to_cout_a)
 	{
 		logger.always_log (log_message);
@@ -1091,7 +1091,7 @@ void nano::node::ongoing_ledger_pruning ()
 {
 	auto bootstrap_weight_reached (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks);
 	ledger_pruning (flags.block_processor_batch_size != 0 ? flags.block_processor_batch_size : 2 * 1024, bootstrap_weight_reached, false);
-	const auto ledger_pruning_interval (bootstrap_weight_reached ? config.max_pruning_age : std::min (config.max_pruning_age, std::chrono::seconds (15 * 60)));
+	auto const ledger_pruning_interval (bootstrap_weight_reached ? config.max_pruning_age : std::min (config.max_pruning_age, std::chrono::seconds (15 * 60)));
 	auto this_l (shared ());
 	workers.add_timed_task (std::chrono::steady_clock::now () + ledger_pruning_interval, [this_l]() {
 		this_l->workers.push_task ([this_l]() {
@@ -1358,7 +1358,7 @@ void nano::node::process_confirmed_data (nano::transaction const & transaction_a
 void nano::node::process_confirmed (nano::election_status const & status_a, uint64_t iteration_a)
 {
 	auto hash (status_a.winner->hash ());
-	const auto num_iters = (config.block_processor_batch_max_time / network_params.node.process_confirmed_interval) * 4;
+	auto const num_iters = (config.block_processor_batch_max_time / network_params.node.process_confirmed_interval) * 4;
 	if (auto block_l = ledger.store.block_get (ledger.store.tx_begin_read (), hash))
 	{
 		confirmation_height_processor.add (block_l);
@@ -1712,7 +1712,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> nano::node::get_bootstrap_weights () const
 {
 	std::unordered_map<nano::account, nano::uint128_t> weights;
-	const uint8_t * weight_buffer = network_params.network.is_live_network () ? nano_bootstrap_weights_live : nano_bootstrap_weights_beta;
+	uint8_t const * weight_buffer = network_params.network.is_live_network () ? nano_bootstrap_weights_live : nano_bootstrap_weights_beta;
 	size_t weight_size = network_params.network.is_live_network () ? nano_bootstrap_weights_live_size : nano_bootstrap_weights_beta_size;
 	nano::bufferstream weight_stream ((const uint8_t *)weight_buffer, weight_size);
 	nano::uint128_union block_height;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1056,7 +1056,7 @@ void nano::node::ledger_pruning (uint64_t const batch_size_a, bool bootstrap_wei
 		if (!pruning_targets.empty () && !stopped)
 		{
 			auto scoped_write_guard = write_database_queue.wait (nano::writer::pruning);
-			const auto write_transaction (store.tx_begin_write ({ tables::blocks, tables::pruned }));
+			auto write_transaction (store.tx_begin_write ({ tables::blocks, tables::pruned }));
 			while (!pruning_targets.empty () && transaction_write_count < batch_size_a && !stopped)
 			{
 				auto const & pruning_hash (pruning_targets.front ());

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -190,7 +190,7 @@ public:
 	nano::active_transactions active;
 	nano::request_aggregator aggregator;
 	nano::wallets wallets;
-	const std::chrono::steady_clock::time_point startup_time;
+	std::chrono::steady_clock::time_point const startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> unresponsive_work_peers{ false };
 	std::atomic<bool> stopped{ false };

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -12,11 +12,11 @@
 
 namespace
 {
-const char * preconfigured_peers_key = "preconfigured_peers";
-const char * signature_checker_threads_key = "signature_checker_threads";
-const char * pow_sleep_interval_key = "pow_sleep_interval";
-const char * default_beta_peer_network = "peering-beta.nano.org";
-const char * default_live_peer_network = "peering.nano.org";
+char const * preconfigured_peers_key = "preconfigured_peers";
+char const * signature_checker_threads_key = "signature_checker_threads";
+char const * pow_sleep_interval_key = "pow_sleep_interval";
+char const * default_beta_peer_network = "peering-beta.nano.org";
+char const * default_live_peer_network = "peering.nano.org";
 const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -17,7 +17,7 @@ char const * signature_checker_threads_key = "signature_checker_threads";
 char const * pow_sleep_interval_key = "pow_sleep_interval";
 char const * default_beta_peer_network = "peering-beta.nano.org";
 char const * default_live_peer_network = "peering.nano.org";
-const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
+std::string const default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 
 nano::node_config::node_config () :

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -120,7 +120,7 @@ __kernel void nano_work(__constant ulong *attempt,
                         __constant uchar *item_a,
                         __constant ulong *difficulty)
 {
-ulong const attempt_l = *attempt + get_global_id(0);
+    ulong const attempt_l = *attempt + get_global_id(0);
     if (blake2b(attempt_l, item_a) >= *difficulty)
         *result_a = attempt_l;
 }

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -120,7 +120,7 @@ __kernel void nano_work(__constant ulong *attempt,
                         __constant uchar *item_a,
                         __constant ulong *difficulty)
 {
-    const ulong attempt_l = *attempt + get_global_id(0);
+ulong const attempt_l = *attempt + get_global_id(0);
     if (blake2b(attempt_l, item_a) >= *difficulty)
         *result_a = attempt_l;
 }

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -68,8 +68,8 @@ public:
 	size_t size ();
 	bool empty ();
 
-	const std::chrono::milliseconds max_delay;
-	const std::chrono::milliseconds small_delay;
+	std::chrono::milliseconds const max_delay;
+	std::chrono::milliseconds const small_delay;
 	size_t const max_channel_requests;
 
 private:

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -70,7 +70,7 @@ public:
 
 	const std::chrono::milliseconds max_delay;
 	const std::chrono::milliseconds small_delay;
-	const size_t max_channel_requests;
+	size_t const max_channel_requests;
 
 private:
 	void run ();

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -221,7 +221,7 @@ bool nano::transport::tcp_channels::store_all (bool clear_peers)
 		nano::lock_guard<nano::mutex> lock (mutex);
 		endpoints.reserve (channels.size ());
 		std::transform (channels.begin (), channels.end (),
-		std::back_inserter (endpoints), [](const auto & channel) { return nano::transport::map_tcp_to_endpoint (channel.endpoint ()); });
+		std::back_inserter (endpoints), [](auto const & channel) { return nano::transport::map_tcp_to_endpoint (channel.endpoint ()); });
 	}
 	bool result (false);
 	if (!endpoints.empty ())
@@ -485,7 +485,7 @@ void nano::transport::tcp_channels::list_below_version (std::vector<std::shared_
 	// clang-format off
 	nano::transform_if (channels.get<random_access_tag> ().begin (), channels.get<random_access_tag> ().end (), std::back_inserter (channels_a),
 		[cutoff_version_a](auto & channel_a) { return channel_a.channel->get_network_version () < cutoff_version_a; },
-		[](const auto & channel) { return channel.channel; });
+		[](auto const & channel) { return channel.channel; });
 	// clang-format on
 }
 
@@ -495,7 +495,7 @@ void nano::transport::tcp_channels::list (std::deque<std::shared_ptr<nano::trans
 	// clang-format off
 	nano::transform_if (channels.get<random_access_tag> ().begin (), channels.get<random_access_tag> ().end (), std::back_inserter (deque_a),
 		[include_temporary_channels_a, minimum_version_a](auto & channel_a) { return channel_a.channel->get_network_version () >= minimum_version_a && (include_temporary_channels_a || !channel_a.channel->temporary); },
-		[](const auto & channel) { return channel.channel; });
+		[](auto const & channel) { return channel.channel; });
 	// clang-format on
 }
 

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -193,7 +193,7 @@ bool nano::transport::udp_channels::store_all (bool clear_peers)
 		nano::lock_guard<nano::mutex> lock (mutex);
 		endpoints.reserve (channels.size ());
 		std::transform (channels.begin (), channels.end (),
-		std::back_inserter (endpoints), [](const auto & channel) { return channel.endpoint (); });
+		std::back_inserter (endpoints), [](auto const & channel) { return channel.endpoint (); });
 	}
 	bool result (false);
 	if (!endpoints.empty ())
@@ -710,7 +710,7 @@ void nano::transport::udp_channels::list_below_version (std::vector<std::shared_
 	// clang-format off
 	nano::transform_if (channels.get<random_access_tag> ().begin (), channels.get<random_access_tag> ().end (), std::back_inserter (channels_a),
 		[cutoff_version_a](auto & channel_a) { return channel_a.channel->get_network_version () < cutoff_version_a; },
-		[](const auto & channel) { return channel.channel; });
+		[](auto const & channel) { return channel.channel; });
 	// clang-format on
 }
 
@@ -720,7 +720,7 @@ void nano::transport::udp_channels::list (std::deque<std::shared_ptr<nano::trans
 	// clang-format off
 	nano::transform_if (channels.get<random_access_tag> ().begin (), channels.get<random_access_tag> ().end (), std::back_inserter (deque_a),
 		[minimum_version_a](auto & channel_a) { return channel_a.channel->get_network_version () >= minimum_version_a; },
-		[](const auto & channel) { return channel.channel; });
+		[](auto const & channel) { return channel.channel; });
 	// clang-format on
 }
 

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -7,8 +7,8 @@
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index_container.hpp>
 
@@ -41,20 +41,22 @@ class vote_spacing final
 		std::chrono::steady_clock::time_point time;
 		nano::block_hash hash;
 	};
-	
+
 	boost::multi_index_container<entry,
 	mi::indexed_by<
-		mi::hashed_non_unique<mi::tag<class tag_root>,
-			mi::member<entry, nano::root, &entry::root>>,
-		mi::ordered_non_unique<mi::tag<class tag_time>,
-			mi::member<entry, std::chrono::steady_clock::time_point, &entry::time>>
-	>>
+	mi::hashed_non_unique<mi::tag<class tag_root>,
+	mi::member<entry, nano::root, &entry::root>>,
+	mi::ordered_non_unique<mi::tag<class tag_time>,
+	mi::member<entry, std::chrono::steady_clock::time_point, &entry::time>>>>
 	recent;
 	std::chrono::milliseconds const delay;
 	void trim ();
+
 public:
 	vote_spacing (std::chrono::milliseconds const & delay) :
-	delay{ delay } {}
+	delay{ delay }
+	{
+	}
 	bool votable (nano::root const & root_a, nano::block_hash const & hash_a) const;
 	void flag (nano::root const & root_a, nano::block_hash const & hash_a);
 	size_t size () const;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1519,7 +1519,7 @@ thread ([this]() {
 	{
 		char const * store_path;
 		mdb_env_get_path (env, &store_path);
-		const boost::filesystem::path path (store_path);
+		boost::filesystem::path const path (store_path);
 		nano::mdb_store::create_backup_file (env, path, node_a.logger);
 	}
 	for (auto & item : items)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -115,9 +115,9 @@ void nano::wallet_store::deterministic_clear (nano::transaction const & transact
 		{
 			case nano::key_type::deterministic:
 			{
-                auto const & key (i->first);
-                erase (transaction_a, key);
-                i = begin (transaction_a, key);
+				auto const & key (i->first);
+				erase (transaction_a, key);
+				i = begin (transaction_a, key);
 				break;
 			}
 			default:
@@ -1633,14 +1633,14 @@ void nano::wallets::reload ()
 	}
 	// Delete non existing wallets from memory
 	std::vector<nano::wallet_id> deleted_items;
-	for (const auto &wallet_id : items)
+	for (const auto & wallet_id : items)
 	{
 		if (stored_items.find (wallet_id.first) == stored_items.end ())
 		{
 			deleted_items.push_back (wallet_id.first);
 		}
 	}
-	for (const auto &wallet_id : deleted_items)
+	for (const auto & wallet_id : deleted_items)
 	{
 		debug_assert (items.find (wallet_id) == items.end ());
 		items.erase (wallet_id);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -941,7 +941,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 		id_mdb_val = nano::mdb_val (id_a->size (), const_cast<char *> (id_a->data ()));
 	}
 
-	auto prepare_send = [&id_mdb_val, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a](const auto & transaction) {
+	auto prepare_send = [&id_mdb_val, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a](auto const & transaction) {
 		auto block_transaction (wallets.node.store.tx_begin_read ());
 		auto error (false);
 		auto cached_block (false);
@@ -1517,7 +1517,7 @@ thread ([this]() {
 	}
 	if (backup_required)
 	{
-		const char * store_path;
+		char const * store_path;
 		mdb_env_get_path (env, &store_path);
 		const boost::filesystem::path path (store_path);
 		nano::mdb_store::create_backup_file (env, path, node_a.logger);
@@ -1633,14 +1633,14 @@ void nano::wallets::reload ()
 	}
 	// Delete non existing wallets from memory
 	std::vector<nano::wallet_id> deleted_items;
-	for (const auto & wallet_id : items)
+	for (auto const & wallet_id : items)
 	{
 		if (stored_items.find (wallet_id.first) == stored_items.end ())
 		{
 			deleted_items.push_back (wallet_id.first);
 		}
 	}
-	for (const auto & wallet_id : deleted_items)
+	for (auto const & wallet_id : deleted_items)
 	{
 		debug_assert (items.find (wallet_id) == items.end ());
 		items.erase (wallet_id);

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -861,7 +861,7 @@ void nano_qt::stats_viewer::refresh_stats ()
 
 			if (type == "traffic_udp" || type == "traffic_tcp")
 			{
-				const std::vector<std::string> units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
+				std::vector<std::string> const units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
 				double bytes = std::stod (value);
 				auto index = bytes == 0 ? 0 : std::min (units.size () - 1, static_cast<size_t> (std::floor (std::log2 (bytes) / 10)));
 				std::string unit = units[index];

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -64,7 +64,7 @@ private:
 	bool stopped{ false };
 	std::deque<std::shared_ptr<nano::rpc_request>> requests;
 	nano::condition_variable condition;
-	const std::string ipc_address;
+	std::string const ipc_address;
 	uint16_t const ipc_port;
 	std::thread thread;
 };

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -65,7 +65,7 @@ private:
 	std::deque<std::shared_ptr<nano::rpc_request>> requests;
 	nano::condition_variable condition;
 	const std::string ipc_address;
-	const uint16_t ipc_port;
+	uint16_t const ipc_port;
 	std::thread thread;
 };
 

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -418,8 +418,8 @@ public:
 	}
 
 	// Must be specialized
-	void * data () const;
-	size_t size () const;
+	[[nodiscard]] void * data () const;
+	[[nodiscard]] size_t size () const;
 	db_val (size_t size_a, void * data_a);
 	void convert_buffer_to_value ();
 
@@ -466,7 +466,7 @@ public:
 	virtual ~store_iterator_impl () = default;
 	virtual nano::store_iterator_impl<T, U> & operator++ () = 0;
 	virtual bool operator== (nano::store_iterator_impl<T, U> const & other_a) const = 0;
-	virtual bool is_end_sentinal () const = 0;
+	[[nodiscard]] virtual bool is_end_sentinal () const = 0;
 	virtual void fill (std::pair<T, U> &) const = 0;
 	nano::store_iterator_impl<T, U> & operator= (nano::store_iterator_impl<T, U> const &) = delete;
 	bool operator== (nano::store_iterator_impl<T, U> const * other_a) const
@@ -551,7 +551,7 @@ class transaction_impl
 {
 public:
 	virtual ~transaction_impl () = default;
-	virtual void * get_handle () const = 0;
+	[[nodiscard]] virtual void * get_handle () const = 0;
 };
 
 class read_transaction_impl : public transaction_impl
@@ -566,14 +566,14 @@ class write_transaction_impl : public transaction_impl
 public:
 	virtual void commit () = 0;
 	virtual void renew () = 0;
-	virtual bool contains (nano::tables table_a) const = 0;
+	[[nodiscard]] virtual bool contains (nano::tables table_a) const = 0;
 };
 
 class transaction
 {
 public:
 	virtual ~transaction () = default;
-	virtual void * get_handle () const = 0;
+	[[nodiscard]] virtual void * get_handle () const = 0;
 };
 
 /**
@@ -584,7 +584,7 @@ class read_transaction final : public transaction
 {
 public:
 	explicit read_transaction (std::unique_ptr<nano::read_transaction_impl> read_transaction_impl);
-	void * get_handle () const override;
+	[[nodiscard]] void * get_handle () const override;
 	void reset () const;
 	void renew () const;
 	void refresh () const;
@@ -601,11 +601,11 @@ class write_transaction final : public transaction
 {
 public:
 	explicit write_transaction (std::unique_ptr<nano::write_transaction_impl> write_transaction_impl);
-	void * get_handle () const override;
+	[[nodiscard]] void * get_handle () const override;
 	void commit ();
 	void renew ();
 	void refresh ();
-	bool contains (nano::tables table_a) const;
+	[[nodiscard]] bool contains (nano::tables table_a) const;
 
 private:
 	std::unique_ptr<nano::write_transaction_impl> impl;
@@ -623,48 +623,48 @@ public:
 	virtual void initialize (nano::write_transaction const &, nano::genesis const &, nano::ledger_cache &) = 0;
 	virtual void block_put (nano::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;
 	virtual void block_raw_put (nano::write_transaction const &, std::vector<uint8_t> const &, nano::block_hash const &) = 0;
-	virtual nano::block_hash block_successor (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual nano::block_hash block_successor (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual void block_successor_clear (nano::write_transaction const &, nano::block_hash const &) = 0;
-	virtual std::shared_ptr<nano::block> block_get (nano::transaction const &, nano::block_hash const &) const = 0;
-	virtual std::shared_ptr<nano::block> block_get_no_sideband (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual std::shared_ptr<nano::block> block_get (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual std::shared_ptr<nano::block> block_get_no_sideband (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual std::shared_ptr<nano::block> block_random (nano::transaction const &) = 0;
 	virtual void block_del (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual bool block_exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual uint64_t block_count (nano::transaction const &) = 0;
 	virtual bool root_exists (nano::transaction const &, nano::root const &) = 0;
-	virtual nano::account block_account (nano::transaction const &, nano::block_hash const &) const = 0;
-	virtual nano::account block_account_calculated (nano::block const &) const = 0;
-	virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &, nano::block_hash const &) const = 0;
-	virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_end () const = 0;
+	[[nodiscard]] virtual nano::account block_account (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual nano::account block_account_calculated (nano::block const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_end () const = 0;
 
 	virtual void frontier_put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) = 0;
-	virtual nano::account frontier_get (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual nano::account frontier_get (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual void frontier_del (nano::write_transaction const &, nano::block_hash const &) = 0;
-	virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &, nano::block_hash const &) const = 0;
-	virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &, nano::block_hash const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_end () const = 0;
 
 	virtual void account_put (nano::write_transaction const &, nano::account const &, nano::account_info const &) = 0;
 	virtual bool account_get (nano::transaction const &, nano::account const &, nano::account_info &) = 0;
 	virtual void account_del (nano::write_transaction const &, nano::account const &) = 0;
 	virtual bool account_exists (nano::transaction const &, nano::account const &) = 0;
 	virtual size_t account_count (nano::transaction const &) = 0;
-	virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &, nano::account const &) const = 0;
-	virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::account, nano::account_info> accounts_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &, nano::account const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::account_info> accounts_end () const = 0;
 
 	virtual void pending_put (nano::write_transaction const &, nano::pending_key const &, nano::pending_info const &) = 0;
 	virtual void pending_del (nano::write_transaction const &, nano::pending_key const &) = 0;
 	virtual bool pending_get (nano::transaction const &, nano::pending_key const &, nano::pending_info &) = 0;
 	virtual bool pending_exists (nano::transaction const &, nano::pending_key const &) = 0;
 	virtual bool pending_any (nano::transaction const &, nano::account const &) = 0;
-	virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &, nano::pending_key const &) const = 0;
-	virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &, nano::pending_key const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_end () const = 0;
 
 	virtual nano::uint128_t block_balance (nano::transaction const &, nano::block_hash const &) = 0;
-	virtual nano::uint128_t block_balance_calculated (std::shared_ptr<nano::block> const &) const = 0;
+	[[nodiscard]] virtual nano::uint128_t block_balance_calculated (std::shared_ptr<nano::block> const &) const = 0;
 	virtual nano::epoch block_version (nano::transaction const &, nano::block_hash const &) = 0;
 
 	virtual void unchecked_clear (nano::write_transaction const &) = 0;
@@ -673,50 +673,50 @@ public:
 	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
 	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
 	virtual size_t unchecked_count (nano::transaction const &) = 0;
 
 	virtual void online_weight_put (nano::write_transaction const &, uint64_t, nano::amount const &) = 0;
 	virtual void online_weight_del (nano::write_transaction const &, uint64_t) = 0;
-	virtual nano::store_iterator<uint64_t, nano::amount> online_weight_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<uint64_t, nano::amount> online_weight_end () const = 0;
-	virtual size_t online_weight_count (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<uint64_t, nano::amount> online_weight_begin (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<uint64_t, nano::amount> online_weight_end () const = 0;
+	[[nodiscard]] virtual size_t online_weight_count (nano::transaction const &) const = 0;
 	virtual void online_weight_clear (nano::write_transaction const &) = 0;
 
 	virtual void version_put (nano::write_transaction const &, int) = 0;
-	virtual int version_get (nano::transaction const &) const = 0;
+	[[nodiscard]] virtual int version_get (nano::transaction const &) const = 0;
 
 	virtual void pruned_put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) = 0;
 	virtual void pruned_del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) = 0;
-	virtual bool pruned_exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	[[nodiscard]] virtual bool pruned_exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 	virtual bool block_or_pruned_exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual nano::block_hash pruned_random (nano::transaction const & transaction_a) = 0;
-	virtual size_t pruned_count (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual size_t pruned_count (nano::transaction const & transaction_a) const = 0;
 	virtual void pruned_clear (nano::write_transaction const &) = 0;
-	virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
-	virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a) const = 0;
-	virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_end () const = 0;
 
 	virtual void peer_put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) = 0;
 	virtual void peer_del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) = 0;
-	virtual bool peer_exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const = 0;
-	virtual size_t peer_count (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual bool peer_exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const = 0;
+	[[nodiscard]] virtual size_t peer_count (nano::transaction const & transaction_a) const = 0;
 	virtual void peer_clear (nano::write_transaction const & transaction_a) = 0;
-	virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_begin (nano::transaction const & transaction_a) const = 0;
-	virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_begin (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_end () const = 0;
 
 	virtual void confirmation_height_put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) = 0;
 	virtual bool confirmation_height_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) = 0;
-	virtual bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	[[nodiscard]] virtual bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
 	virtual void confirmation_height_del (nano::write_transaction const & transaction_a, nano::account const & account_a) = 0;
 	virtual uint64_t confirmation_height_count (nano::transaction const & transaction_a) = 0;
 	virtual void confirmation_height_clear (nano::write_transaction const &, nano::account const &) = 0;
 	virtual void confirmation_height_clear (nano::write_transaction const &) = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const = 0;
 
 	virtual void accounts_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) const = 0;
 	virtual void confirmation_height_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) const = 0;
@@ -727,19 +727,19 @@ public:
 	virtual void frontiers_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const = 0;
 	virtual void final_vote_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const = 0;
 
-	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	[[nodiscard]] virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 
 	virtual bool final_vote_put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
 	virtual std::vector<nano::block_hash> final_vote_get (nano::transaction const & transaction_a, nano::root const & root_a) = 0;
 	virtual void final_vote_del (nano::write_transaction const & transaction_a, nano::root const & root_a) = 0;
-	virtual size_t final_vote_count (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual size_t final_vote_count (nano::transaction const & transaction_a) const = 0;
 	virtual void final_vote_clear (nano::write_transaction const &, nano::root const &) = 0;
 	virtual void final_vote_clear (nano::write_transaction const &) = 0;
-	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const = 0;
-	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a) const = 0;
-	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_end () const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a) const = 0;
+	[[nodiscard]] virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_end () const = 0;
 
-	virtual unsigned max_block_write_batch_num () const = 0;
+	[[nodiscard]] virtual unsigned max_block_write_batch_num () const = 0;
 
 	virtual bool copy_db (boost::filesystem::path const & destination) = 0;
 	virtual void rebuild_db (nano::write_transaction const & transaction_a) = 0;
@@ -748,15 +748,15 @@ public:
 	virtual void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds){};
 	virtual void serialize_memory_stats (boost::property_tree::ptree &) = 0;
 
-	virtual bool init_error () const = 0;
+	[[nodiscard]] virtual bool init_error () const = 0;
 
 	/** Start read-write transaction */
-	virtual nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) = 0;
+	[[nodiscard]] virtual nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) = 0;
 
 	/** Start read-only transaction */
-	virtual nano::read_transaction tx_begin_read () const = 0;
+	[[nodiscard]] virtual nano::read_transaction tx_begin_read () const = 0;
 
-	virtual std::string vendor_get () const = 0;
+	[[nodiscard]] virtual std::string vendor_get () const = 0;
 };
 
 std::unique_ptr<nano::block_store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, bool open_read_only = false, bool add_db_postfix = false, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -418,8 +418,8 @@ public:
 	}
 
 	// Must be specialized
-	[[nodiscard]] void * data () const;
-	[[nodiscard]] size_t size () const;
+	void * data () const;
+	size_t size () const;
 	db_val (size_t size_a, void * data_a);
 	void convert_buffer_to_value ();
 
@@ -466,7 +466,7 @@ public:
 	virtual ~store_iterator_impl () = default;
 	virtual nano::store_iterator_impl<T, U> & operator++ () = 0;
 	virtual bool operator== (nano::store_iterator_impl<T, U> const & other_a) const = 0;
-	[[nodiscard]] virtual bool is_end_sentinal () const = 0;
+	virtual bool is_end_sentinal () const = 0;
 	virtual void fill (std::pair<T, U> &) const = 0;
 	nano::store_iterator_impl<T, U> & operator= (nano::store_iterator_impl<T, U> const &) = delete;
 	bool operator== (nano::store_iterator_impl<T, U> const * other_a) const
@@ -551,7 +551,7 @@ class transaction_impl
 {
 public:
 	virtual ~transaction_impl () = default;
-	[[nodiscard]] virtual void * get_handle () const = 0;
+	virtual void * get_handle () const = 0;
 };
 
 class read_transaction_impl : public transaction_impl
@@ -566,14 +566,14 @@ class write_transaction_impl : public transaction_impl
 public:
 	virtual void commit () = 0;
 	virtual void renew () = 0;
-	[[nodiscard]] virtual bool contains (nano::tables table_a) const = 0;
+	virtual bool contains (nano::tables table_a) const = 0;
 };
 
 class transaction
 {
 public:
 	virtual ~transaction () = default;
-	[[nodiscard]] virtual void * get_handle () const = 0;
+	virtual void * get_handle () const = 0;
 };
 
 /**
@@ -584,7 +584,7 @@ class read_transaction final : public transaction
 {
 public:
 	explicit read_transaction (std::unique_ptr<nano::read_transaction_impl> read_transaction_impl);
-	[[nodiscard]] void * get_handle () const override;
+	void * get_handle () const override;
 	void reset () const;
 	void renew () const;
 	void refresh () const;
@@ -601,11 +601,11 @@ class write_transaction final : public transaction
 {
 public:
 	explicit write_transaction (std::unique_ptr<nano::write_transaction_impl> write_transaction_impl);
-	[[nodiscard]] void * get_handle () const override;
+	void * get_handle () const override;
 	void commit ();
 	void renew ();
 	void refresh ();
-	[[nodiscard]] bool contains (nano::tables table_a) const;
+	bool contains (nano::tables table_a) const;
 
 private:
 	std::unique_ptr<nano::write_transaction_impl> impl;
@@ -623,48 +623,48 @@ public:
 	virtual void initialize (nano::write_transaction const &, nano::genesis const &, nano::ledger_cache &) = 0;
 	virtual void block_put (nano::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;
 	virtual void block_raw_put (nano::write_transaction const &, std::vector<uint8_t> const &, nano::block_hash const &) = 0;
-	[[nodiscard]] virtual nano::block_hash block_successor (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::block_hash block_successor (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual void block_successor_clear (nano::write_transaction const &, nano::block_hash const &) = 0;
-	[[nodiscard]] virtual std::shared_ptr<nano::block> block_get (nano::transaction const &, nano::block_hash const &) const = 0;
-	[[nodiscard]] virtual std::shared_ptr<nano::block> block_get_no_sideband (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual std::shared_ptr<nano::block> block_get (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual std::shared_ptr<nano::block> block_get_no_sideband (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual std::shared_ptr<nano::block> block_random (nano::transaction const &) = 0;
 	virtual void block_del (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual bool block_exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual uint64_t block_count (nano::transaction const &) = 0;
 	virtual bool root_exists (nano::transaction const &, nano::root const &) = 0;
-	[[nodiscard]] virtual nano::account block_account (nano::transaction const &, nano::block_hash const &) const = 0;
-	[[nodiscard]] virtual nano::account block_account_calculated (nano::block const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &, nano::block_hash const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_end () const = 0;
+	virtual nano::account block_account (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::account block_account_calculated (nano::block const &) const = 0;
+	virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::block_hash, block_w_sideband> blocks_end () const = 0;
 
 	virtual void frontier_put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) = 0;
-	[[nodiscard]] virtual nano::account frontier_get (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::account frontier_get (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual void frontier_del (nano::write_transaction const &, nano::block_hash const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &, nano::block_hash const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_end () const = 0;
+	virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_begin (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::store_iterator<nano::block_hash, nano::account> frontiers_end () const = 0;
 
 	virtual void account_put (nano::write_transaction const &, nano::account const &, nano::account_info const &) = 0;
 	virtual bool account_get (nano::transaction const &, nano::account const &, nano::account_info &) = 0;
 	virtual void account_del (nano::write_transaction const &, nano::account const &) = 0;
 	virtual bool account_exists (nano::transaction const &, nano::account const &) = 0;
 	virtual size_t account_count (nano::transaction const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &, nano::account const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::account_info> accounts_end () const = 0;
+	virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &, nano::account const &) const = 0;
+	virtual nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::account, nano::account_info> accounts_end () const = 0;
 
 	virtual void pending_put (nano::write_transaction const &, nano::pending_key const &, nano::pending_info const &) = 0;
 	virtual void pending_del (nano::write_transaction const &, nano::pending_key const &) = 0;
 	virtual bool pending_get (nano::transaction const &, nano::pending_key const &, nano::pending_info &) = 0;
 	virtual bool pending_exists (nano::transaction const &, nano::pending_key const &) = 0;
 	virtual bool pending_any (nano::transaction const &, nano::account const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &, nano::pending_key const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_end () const = 0;
+	virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &, nano::pending_key const &) const = 0;
+	virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::pending_key, nano::pending_info> pending_end () const = 0;
 
 	virtual nano::uint128_t block_balance (nano::transaction const &, nano::block_hash const &) = 0;
-	[[nodiscard]] virtual nano::uint128_t block_balance_calculated (std::shared_ptr<nano::block> const &) const = 0;
+	virtual nano::uint128_t block_balance_calculated (std::shared_ptr<nano::block> const &) const = 0;
 	virtual nano::epoch block_version (nano::transaction const &, nano::block_hash const &) = 0;
 
 	virtual void unchecked_clear (nano::write_transaction const &) = 0;
@@ -673,50 +673,50 @@ public:
 	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
 	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
 	virtual size_t unchecked_count (nano::transaction const &) = 0;
 
 	virtual void online_weight_put (nano::write_transaction const &, uint64_t, nano::amount const &) = 0;
 	virtual void online_weight_del (nano::write_transaction const &, uint64_t) = 0;
-	[[nodiscard]] virtual nano::store_iterator<uint64_t, nano::amount> online_weight_begin (nano::transaction const &) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<uint64_t, nano::amount> online_weight_end () const = 0;
-	[[nodiscard]] virtual size_t online_weight_count (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<uint64_t, nano::amount> online_weight_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<uint64_t, nano::amount> online_weight_end () const = 0;
+	virtual size_t online_weight_count (nano::transaction const &) const = 0;
 	virtual void online_weight_clear (nano::write_transaction const &) = 0;
 
 	virtual void version_put (nano::write_transaction const &, int) = 0;
-	[[nodiscard]] virtual int version_get (nano::transaction const &) const = 0;
+	virtual int version_get (nano::transaction const &) const = 0;
 
 	virtual void pruned_put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) = 0;
 	virtual void pruned_del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) = 0;
-	[[nodiscard]] virtual bool pruned_exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	virtual bool pruned_exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 	virtual bool block_or_pruned_exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual nano::block_hash pruned_random (nano::transaction const & transaction_a) = 0;
-	[[nodiscard]] virtual size_t pruned_count (nano::transaction const & transaction_a) const = 0;
+	virtual size_t pruned_count (nano::transaction const & transaction_a) const = 0;
 	virtual void pruned_clear (nano::write_transaction const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_end () const = 0;
+	virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_end () const = 0;
 
 	virtual void peer_put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) = 0;
 	virtual void peer_del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) = 0;
-	[[nodiscard]] virtual bool peer_exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const = 0;
-	[[nodiscard]] virtual size_t peer_count (nano::transaction const & transaction_a) const = 0;
+	virtual bool peer_exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const = 0;
+	virtual size_t peer_count (nano::transaction const & transaction_a) const = 0;
 	virtual void peer_clear (nano::write_transaction const & transaction_a) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_begin (nano::transaction const & transaction_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_end () const = 0;
+	virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_end () const = 0;
 
 	virtual void confirmation_height_put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) = 0;
 	virtual bool confirmation_height_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) = 0;
-	[[nodiscard]] virtual bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	virtual bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
 	virtual void confirmation_height_del (nano::write_transaction const & transaction_a, nano::account const & account_a) = 0;
 	virtual uint64_t confirmation_height_count (nano::transaction const & transaction_a) = 0;
 	virtual void confirmation_height_clear (nano::write_transaction const &, nano::account const &) = 0;
 	virtual void confirmation_height_clear (nano::write_transaction const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const = 0;
 
 	virtual void accounts_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) const = 0;
 	virtual void confirmation_height_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) const = 0;
@@ -727,19 +727,19 @@ public:
 	virtual void frontiers_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const = 0;
 	virtual void final_vote_for_each_par (std::function<void(nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const = 0;
 
-	[[nodiscard]] virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
+	virtual uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 
 	virtual bool final_vote_put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
 	virtual std::vector<nano::block_hash> final_vote_get (nano::transaction const & transaction_a, nano::root const & root_a) = 0;
 	virtual void final_vote_del (nano::write_transaction const & transaction_a, nano::root const & root_a) = 0;
-	[[nodiscard]] virtual size_t final_vote_count (nano::transaction const & transaction_a) const = 0;
+	virtual size_t final_vote_count (nano::transaction const & transaction_a) const = 0;
 	virtual void final_vote_clear (nano::write_transaction const &, nano::root const &) = 0;
 	virtual void final_vote_clear (nano::write_transaction const &) = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a) const = 0;
-	[[nodiscard]] virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_end () const = 0;
+	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const = 0;
+	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::qualified_root, nano::block_hash> final_vote_end () const = 0;
 
-	[[nodiscard]] virtual unsigned max_block_write_batch_num () const = 0;
+	virtual unsigned max_block_write_batch_num () const = 0;
 
 	virtual bool copy_db (boost::filesystem::path const & destination) = 0;
 	virtual void rebuild_db (nano::write_transaction const & transaction_a) = 0;
@@ -748,15 +748,15 @@ public:
 	virtual void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds){};
 	virtual void serialize_memory_stats (boost::property_tree::ptree &) = 0;
 
-	[[nodiscard]] virtual bool init_error () const = 0;
+	virtual bool init_error () const = 0;
 
 	/** Start read-write transaction */
-	[[nodiscard]] virtual nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) = 0;
+	virtual nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) = 0;
 
 	/** Start read-only transaction */
-	[[nodiscard]] virtual nano::read_transaction tx_begin_read () const = 0;
+	virtual nano::read_transaction tx_begin_read () const = 0;
 
-	[[nodiscard]] virtual std::string vendor_get () const = 0;
+	virtual std::string vendor_get () const = 0;
 };
 
 std::unique_ptr<nano::block_store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, bool open_read_only = false, bool add_db_postfix = false, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -639,7 +639,7 @@ public:
 			final_vote_qualified_roots.push_back (i->first);
 		}
 
-		for (const auto & final_vote_qualified_root : final_vote_qualified_roots)
+		for (auto const & final_vote_qualified_root : final_vote_qualified_roots)
 		{
 			auto const status (del (transaction_a, tables::final_votes, nano::db_val<Val> (final_vote_qualified_root)));
 			release_assert_success (status);
@@ -881,7 +881,7 @@ protected:
 	uint64_t count (nano::transaction const & transaction_a, std::initializer_list<tables> dbs_a) const
 	{
 		uint64_t total_count = 0;
-		for (const auto & db : dbs_a)
+		for (auto const & db : dbs_a)
 		{
 			total_count += count (transaction_a, db);
 		}

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -881,7 +881,7 @@ protected:
 	uint64_t count (nano::transaction const & transaction_a, std::initializer_list<tables> dbs_a) const
 	{
 		uint64_t total_count = 0;
-		for (const auto &db : dbs_a)
+		for (const auto & db : dbs_a)
 		{
 			total_count += count (transaction_a, db);
 		}

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -43,7 +43,7 @@ public:
 	 */
 	void initialize (nano::write_transaction const & transaction_a, nano::genesis const & genesis_a, nano::ledger_cache & ledger_cache_a) override
 	{
-		auto hash_l (genesis_a.hash ());
+		auto const hash_l (genesis_a.hash ());
 		debug_assert (accounts_begin (transaction_a) == accounts_end ());
 		genesis_a.open->sideband_set (nano::block_sideband (network_params.ledger.genesis_account, 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 		block_put (transaction_a, hash_l, *genesis_a.open);
@@ -74,13 +74,13 @@ public:
 	// Converts a block hash to a block height
 	uint64_t block_account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
-		auto block = block_get (transaction_a, hash_a);
+		auto const block = block_get (transaction_a, hash_a);
 		return block->sideband ().height;
 	}
 
 	nano::uint128_t block_balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto block (block_get (transaction_a, hash_a));
+		auto const block (block_get (transaction_a, hash_a));
 		release_assert (block);
 		nano::uint128_t result (block_balance_calculated (block));
 		return result;
@@ -88,7 +88,7 @@ public:
 
 	std::shared_ptr<nano::block> block_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
-		auto value (block_raw_get (transaction_a, hash_a));
+		auto const value (block_raw_get (transaction_a, hash_a));
 		std::shared_ptr<nano::block> result;
 		if (value.size () != 0)
 		{
@@ -108,13 +108,13 @@ public:
 
 	bool block_exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto junk = block_raw_get (transaction_a, hash_a);
+		auto const junk = block_raw_get (transaction_a, hash_a);
 		return junk.size () != 0;
 	}
 
 	std::shared_ptr<nano::block> block_get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
-		auto value (block_raw_get (transaction_a, hash_a));
+		auto const value (block_raw_get (transaction_a, hash_a));
 		std::shared_ptr<nano::block> result;
 		if (value.size () != 0)
 		{
@@ -132,7 +132,7 @@ public:
 
 	nano::account block_account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
-		auto block (block_get (transaction_a, hash_a));
+		auto const block (block_get (transaction_a, hash_a));
 		debug_assert (block != nullptr);
 		return block_account_calculated (*block);
 	}
@@ -175,12 +175,12 @@ public:
 
 	nano::block_hash block_successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
 	{
-		auto value (block_raw_get (transaction_a, hash_a));
+		auto const value (block_raw_get (transaction_a, hash_a));
 		nano::block_hash result;
 		if (value.size () != 0)
 		{
 			debug_assert (value.size () >= result.bytes.size ());
-			auto type = block_type_from_raw (value.data ());
+			auto const type = block_type_from_raw (value.data ());
 			nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()) + block_successor_offset (transaction_a, value.size (), type), result.bytes.size ());
 			auto error (nano::try_read (stream, result.bytes));
 			(void)error;
@@ -195,9 +195,9 @@ public:
 
 	void block_successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto value (block_raw_get (transaction_a, hash_a));
+		auto const value (block_raw_get (transaction_a, hash_a));
 		debug_assert (value.size () != 0);
-		auto type = block_type_from_raw (value.data ());
+		auto const type = block_type_from_raw (value.data ());
 		std::vector<uint8_t> data (static_cast<uint8_t *> (value.data ()), static_cast<uint8_t *> (value.data ()) + value.size ());
 		std::fill_n (data.begin () + block_successor_offset (transaction_a, value.size (), type), sizeof (nano::block_hash), uint8_t{ 0 });
 		block_raw_put (transaction_a, data, hash_a);
@@ -255,9 +255,9 @@ public:
 
 	int version_get (nano::transaction const & transaction_a) const override
 	{
-		nano::uint256_union version_key (1);
+		nano::uint256_union const version_key (1);
 		nano::db_val<Val> data;
-		auto status = get (transaction_a, tables::meta, nano::db_val<Val> (version_key), data);
+		auto const status = get (transaction_a, tables::meta, nano::db_val<Val> (version_key), data);
 		int result (minimum_version);
 		if (success (status))
 		{
@@ -270,13 +270,13 @@ public:
 
 	void block_del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto status = del (transaction_a, tables::blocks, hash_a);
+		auto const status = del (transaction_a, tables::blocks, hash_a);
 		release_assert_success (status);
 	}
 
 	nano::epoch block_version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto block = block_get (transaction_a, hash_a);
+		auto const block = block_get (transaction_a, hash_a);
 		if (block && block->type () == nano::block_type::state)
 		{
 			return block->sideband ().details.epoch;
@@ -287,21 +287,21 @@ public:
 
 	void block_raw_put (nano::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override
 	{
-		nano::db_val<Val> value{ data.size (), (void *)data.data () };
-		auto status = put (transaction_a, tables::blocks, hash_a, value);
+		nano::db_val<Val> const value{ data.size (), (void *)data.data () };
+		auto const status = put (transaction_a, tables::blocks, hash_a, value);
 		release_assert_success (status);
 	}
 
 	void pending_put (nano::write_transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info const & pending_info_a) override
 	{
-		nano::db_val<Val> pending (pending_info_a);
-		auto status = put (transaction_a, tables::pending, key_a, pending);
+		nano::db_val<Val> const pending (pending_info_a);
+		auto const status = put (transaction_a, tables::pending, key_a, pending);
 		release_assert_success (status);
 	}
 
 	void pending_del (nano::write_transaction const & transaction_a, nano::pending_key const & key_a) override
 	{
-		auto status = del (transaction_a, tables::pending, key_a);
+		auto const status = del (transaction_a, tables::pending, key_a);
 		release_assert_success (status);
 	}
 
@@ -309,7 +309,7 @@ public:
 	{
 		nano::db_val<Val> value;
 		nano::db_val<Val> key (key_a);
-		auto status1 = get (transaction_a, tables::pending, key, value);
+		auto const status1 = get (transaction_a, tables::pending, key, value);
 		release_assert (success (status1) || not_found (status1));
 		bool result (true);
 		if (success (status1))
@@ -334,15 +334,15 @@ public:
 
 	void frontier_put (nano::write_transaction const & transaction_a, nano::block_hash const & block_a, nano::account const & account_a) override
 	{
-		nano::db_val<Val> account (account_a);
-		auto status (put (transaction_a, tables::frontiers, block_a, account));
+		nano::db_val<Val> const account (account_a);
+		auto const status (put (transaction_a, tables::frontiers, block_a, account));
 		release_assert_success (status);
 	}
 
 	nano::account frontier_get (nano::transaction const & transaction_a, nano::block_hash const & block_a) const override
 	{
 		nano::db_val<Val> value;
-		auto status (get (transaction_a, tables::frontiers, nano::db_val<Val> (block_a), value));
+		auto const status (get (transaction_a, tables::frontiers, nano::db_val<Val> (block_a), value));
 		release_assert (success (status) || not_found (status));
 		nano::account result (0);
 		if (success (status))
@@ -354,63 +354,63 @@ public:
 
 	void frontier_del (nano::write_transaction const & transaction_a, nano::block_hash const & block_a) override
 	{
-		auto status (del (transaction_a, tables::frontiers, block_a));
+		auto const status (del (transaction_a, tables::frontiers, block_a));
 		release_assert_success (status);
 	}
 
 	void unchecked_put (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a) override
 	{
-		nano::db_val<Val> info (info_a);
-		auto status (put (transaction_a, tables::unchecked, key_a, info));
+		nano::db_val<Val> const info (info_a);
+		auto const status (put (transaction_a, tables::unchecked, key_a, info));
 		release_assert_success (status);
 	}
 
 	void unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
 	{
-		auto status (del (transaction_a, tables::unchecked, key_a));
+		auto const status (del (transaction_a, tables::unchecked, key_a));
 		release_assert_success (status);
 	}
 
 	bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override
 	{
 		nano::db_val<Val> value;
-		auto status (get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
+		auto const status (get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
 		release_assert (success (status) || not_found (status));
 		return (success (status));
 	}
 
 	void unchecked_put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, std::shared_ptr<nano::block> const & block_a) override
 	{
-		nano::unchecked_key key (hash_a, block_a->hash ());
-		nano::unchecked_info info (block_a, block_a->account (), nano::seconds_since_epoch (), nano::signature_verification::unknown);
+		nano::unchecked_key const key (hash_a, block_a->hash ());
+		nano::unchecked_info const info (block_a, block_a->account (), nano::seconds_since_epoch (), nano::signature_verification::unknown);
 		unchecked_put (transaction_a, key, info);
 	}
 
 	void unchecked_clear (nano::write_transaction const & transaction_a) override
 	{
-		auto status = drop (transaction_a, tables::unchecked);
+		auto const status = drop (transaction_a, tables::unchecked);
 		release_assert_success (status);
 	}
 
 	void account_put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::account_info const & info_a) override
 	{
 		// Check we are still in sync with other tables
-		nano::db_val<Val> info (info_a);
-		auto status = put (transaction_a, tables::accounts, account_a, info);
+		nano::db_val<Val> const info (info_a);
+		auto const status = put (transaction_a, tables::accounts, account_a, info);
 		release_assert_success (status);
 	}
 
 	void account_del (nano::write_transaction const & transaction_a, nano::account const & account_a) override
 	{
-		auto status = del (transaction_a, tables::accounts, account_a);
+		auto const status = del (transaction_a, tables::accounts, account_a);
 		release_assert_success (status);
 	}
 
 	bool account_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::account_info & info_a) override
 	{
 		nano::db_val<Val> value;
-		nano::db_val<Val> account (account_a);
-		auto status1 (get (transaction_a, tables::accounts, account, value));
+		nano::db_val<Val> const account (account_a);
+		auto const status1 (get (transaction_a, tables::accounts, account, value));
 		release_assert (success (status1) || not_found (status1));
 		bool result (true);
 		if (success (status1))
@@ -429,14 +429,14 @@ public:
 
 	void online_weight_put (nano::write_transaction const & transaction_a, uint64_t time_a, nano::amount const & amount_a) override
 	{
-		nano::db_val<Val> value (amount_a);
-		auto status (put (transaction_a, tables::online_weight, time_a, value));
+		nano::db_val<Val> const value (amount_a);
+		auto const status (put (transaction_a, tables::online_weight, time_a, value));
 		release_assert_success (status);
 	}
 
 	void online_weight_del (nano::write_transaction const & transaction_a, uint64_t time_a) override
 	{
-		auto status (del (transaction_a, tables::online_weight, time_a));
+		auto const status (del (transaction_a, tables::online_weight, time_a));
 		release_assert_success (status);
 	}
 
@@ -447,19 +447,19 @@ public:
 
 	void online_weight_clear (nano::write_transaction const & transaction_a) override
 	{
-		auto status (drop (transaction_a, tables::online_weight));
+		auto const status (drop (transaction_a, tables::online_weight));
 		release_assert_success (status);
 	}
 
 	void pruned_put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto status = put_key (transaction_a, tables::pruned, hash_a);
+		auto const status = put_key (transaction_a, tables::pruned, hash_a);
 		release_assert_success (status);
 	}
 
 	void pruned_del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override
 	{
-		auto status = del (transaction_a, tables::pruned, hash_a);
+		auto const status = del (transaction_a, tables::pruned, hash_a);
 		release_assert_success (status);
 	}
 
@@ -480,19 +480,19 @@ public:
 
 	void pruned_clear (nano::write_transaction const & transaction_a) override
 	{
-		auto status = drop (transaction_a, tables::pruned);
+		auto const status = drop (transaction_a, tables::pruned);
 		release_assert_success (status);
 	}
 
 	void peer_put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override
 	{
-		auto status = put_key (transaction_a, tables::peers, endpoint_a);
+		auto const status = put_key (transaction_a, tables::peers, endpoint_a);
 		release_assert_success (status);
 	}
 
 	void peer_del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override
 	{
-		auto status (del (transaction_a, tables::peers, endpoint_a));
+		auto const status (del (transaction_a, tables::peers, endpoint_a));
 		release_assert_success (status);
 	}
 
@@ -508,7 +508,7 @@ public:
 
 	void peer_clear (nano::write_transaction const & transaction_a) override
 	{
-		auto status = drop (transaction_a, tables::peers);
+		auto const status = drop (transaction_a, tables::peers);
 		release_assert_success (status);
 	}
 
@@ -532,7 +532,7 @@ public:
 		nano::block_hash hash;
 		nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 		auto existing = make_iterator<nano::block_hash, std::shared_ptr<nano::block>> (transaction_a, tables::blocks, nano::db_val<Val> (hash));
-		auto end (nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> (nullptr));
+		auto const end (nano::store_iterator<nano::block_hash, std::shared_ptr<nano::block>> (nullptr));
 		if (existing == end)
 		{
 			existing = make_iterator<nano::block_hash, std::shared_ptr<nano::block>> (transaction_a, tables::blocks);
@@ -546,7 +546,7 @@ public:
 		nano::block_hash random_hash;
 		nano::random_pool::generate_block (random_hash.bytes.data (), random_hash.bytes.size ());
 		auto existing = make_iterator<nano::block_hash, nano::db_val<Val>> (transaction_a, tables::pruned, nano::db_val<Val> (random_hash));
-		auto end (nano::store_iterator<nano::block_hash, nano::db_val<Val>> (nullptr));
+		auto const end (nano::store_iterator<nano::block_hash, nano::db_val<Val>> (nullptr));
 		if (existing == end)
 		{
 			existing = make_iterator<nano::block_hash, nano::db_val<Val>> (transaction_a, tables::pruned);
@@ -561,15 +561,15 @@ public:
 
 	void confirmation_height_put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override
 	{
-		nano::db_val<Val> confirmation_height_info (confirmation_height_info_a);
-		auto status = put (transaction_a, tables::confirmation_height, account_a, confirmation_height_info);
+		nano::db_val<Val> const confirmation_height_info (confirmation_height_info_a);
+		auto const status = put (transaction_a, tables::confirmation_height, account_a, confirmation_height_info);
 		release_assert_success (status);
 	}
 
 	bool confirmation_height_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override
 	{
 		nano::db_val<Val> value;
-		auto status = get (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a), value);
+		auto const status = get (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a), value);
 		release_assert (success (status) || not_found (status));
 		bool result (true);
 		if (success (status))
@@ -588,7 +588,7 @@ public:
 
 	void confirmation_height_del (nano::write_transaction const & transaction_a, nano::account const & account_a) override
 	{
-		auto status (del (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a)));
+		auto const status (del (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a)));
 		release_assert_success (status);
 	}
 
@@ -618,7 +618,7 @@ public:
 	std::vector<nano::block_hash> final_vote_get (nano::transaction const & transaction_a, nano::root const & root_a) override
 	{
 		std::vector<nano::block_hash> result;
-		nano::qualified_root key_start (root_a.raw, 0);
+		nano::qualified_root const key_start (root_a.raw, 0);
 		for (auto i (final_vote_begin (transaction_a, key_start)), n (final_vote_end ()); i != n && nano::qualified_root (i->first).root () == root_a; ++i)
 		{
 			result.push_back (i->second);
@@ -639,9 +639,9 @@ public:
 			final_vote_qualified_roots.push_back (i->first);
 		}
 
-		for (auto & final_vote_qualified_root : final_vote_qualified_roots)
+		for (const auto & final_vote_qualified_root : final_vote_qualified_roots)
 		{
-			auto status (del (transaction_a, tables::final_votes, nano::db_val<Val> (final_vote_qualified_root)));
+			auto const status (del (transaction_a, tables::final_votes, nano::db_val<Val> (final_vote_qualified_root)));
 			release_assert_success (status);
 		}
 	}
@@ -765,7 +765,7 @@ public:
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->accounts_begin (transaction, start), !is_last ? this->accounts_begin (transaction, end) : this->accounts_end ());
 		});
 	}
@@ -774,7 +774,7 @@ public:
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->confirmation_height_begin (transaction, start), !is_last ? this->confirmation_height_begin (transaction, end) : this->confirmation_height_end ());
 		});
 	}
@@ -787,7 +787,7 @@ public:
 			nano::uint512_union union_end (end);
 			nano::pending_key key_start (union_start.uint256s[0].number (), union_start.uint256s[1].number ());
 			nano::pending_key key_end (union_end.uint256s[0].number (), union_end.uint256s[1].number ());
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->pending_begin (transaction, key_start), !is_last ? this->pending_begin (transaction, key_end) : this->pending_end ());
 		});
 	}
@@ -800,7 +800,7 @@ public:
 			nano::uint512_union union_end (end);
 			nano::unchecked_key key_start (union_start.uint256s[0].number (), union_start.uint256s[1].number ());
 			nano::unchecked_key key_end (union_end.uint256s[0].number (), union_end.uint256s[1].number ());
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->unchecked_begin (transaction, key_start), !is_last ? this->unchecked_begin (transaction, key_end) : this->unchecked_end ());
 		});
 	}
@@ -809,7 +809,7 @@ public:
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->blocks_begin (transaction, start), !is_last ? this->blocks_begin (transaction, end) : this->blocks_end ());
 		});
 	}
@@ -818,7 +818,7 @@ public:
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->pruned_begin (transaction, start), !is_last ? this->pruned_begin (transaction, end) : this->pruned_end ());
 		});
 	}
@@ -827,7 +827,7 @@ public:
 	{
 		parallel_traversal<nano::uint256_t> (
 		[&action_a, this](nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->frontiers_begin (transaction, start), !is_last ? this->frontiers_begin (transaction, end) : this->frontiers_end ());
 		});
 	}
@@ -836,7 +836,7 @@ public:
 	{
 		parallel_traversal<nano::uint512_t> (
 		[&action_a, this](nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
+			auto const transaction (this->tx_begin_read ());
 			action_a (transaction, this->final_vote_begin (transaction, start), !is_last ? this->final_vote_begin (transaction, end) : this->final_vote_end ());
 		});
 	}
@@ -862,7 +862,7 @@ protected:
 	nano::db_val<Val> block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
 	{
 		nano::db_val<Val> result;
-		auto status = get (transaction_a, tables::blocks, hash_a, result);
+		auto const status = get (transaction_a, tables::blocks, hash_a, result);
 		release_assert (success (status) || not_found (status));
 		return result;
 	}
@@ -881,7 +881,7 @@ protected:
 	uint64_t count (nano::transaction const & transaction_a, std::initializer_list<tables> dbs_a) const
 	{
 		uint64_t total_count = 0;
-		for (auto db : dbs_a)
+		for (const auto &db : dbs_a)
 		{
 			total_count += count (transaction_a, db);
 		}
@@ -932,10 +932,10 @@ public:
 	virtual ~block_predecessor_set () = default;
 	void fill_value (nano::block const & block_a)
 	{
-		auto hash (block_a.hash ());
-		auto value (store.block_raw_get (transaction, block_a.previous ()));
+		auto const hash (block_a.hash ());
+		auto const value (store.block_raw_get (transaction, block_a.previous ()));
 		debug_assert (value.size () != 0);
-		auto type = store.block_type_from_raw (value.data ());
+		auto const type = store.block_type_from_raw (value.data ());
 		std::vector<uint8_t> data (static_cast<uint8_t *> (value.data ()), static_cast<uint8_t *> (value.data ()) + value.size ());
 		std::copy (hash.bytes.begin (), hash.bytes.end (), data.begin () + store.block_successor_offset (transaction, value.size (), type));
 		store.block_raw_put (transaction, data, block_a.previous ());

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -373,7 +373,7 @@ address (address_a), network_port (boost::endian::native_to_big (port_a))
 {
 }
 
-const std::array<uint8_t, 16> & nano::endpoint_key::address_bytes () const
+std::array<uint8_t, 16> const & nano::endpoint_key::address_bytes () const
 {
 	return address;
 }
@@ -569,7 +569,7 @@ std::string nano::vote::hashes_string () const
 	return result;
 }
 
-const std::string nano::vote::hash_prefix = "vote ";
+std::string const nano::vote::hash_prefix = "vote ";
 
 nano::block_hash nano::vote::hash () const
 {

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -1,7 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/numbers.hpp>
-#include <nano/secure/blockstore.hpp>
 #include <nano/secure/common.hpp>
 
 #include <crypto/cryptopp/words.h>

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -116,7 +116,7 @@ genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 burn_account (0)
 {
 	nano::link epoch_link_v1;
-	const char * epoch_message_v1 ("epoch v1 block");
+	char const * epoch_message_v1 ("epoch v1 block");
 	strncpy ((char *)epoch_link_v1.bytes.data (), epoch_message_v1, epoch_link_v1.bytes.size ());
 	epochs.add (nano::epoch::epoch_1, genesis_account, epoch_link_v1);
 
@@ -125,7 +125,7 @@ burn_account (0)
 	auto const error (nano_live_epoch_v2_signer.decode_account ("nano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
 	debug_assert (!error);
 	auto epoch_v2_signer (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_epoch_v2_signer);
-	const char * epoch_message_v2 ("epoch v2 block");
+	char const * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);
 }

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -230,7 +230,7 @@ bool nano::account_info::deserialize (nano::stream & stream_a)
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;
@@ -349,20 +349,21 @@ bool nano::unchecked_info::deserialize (nano::stream & stream_a)
 {
 	block = nano::deserialize_block (stream_a);
 	auto error (block == nullptr);
-	if (error) {
-	    return true;
+	if (error)
+	{
+		return true;
 	}
 
-    try
-    {
-        nano::read (stream_a, account.bytes);
-        nano::read (stream_a, modified);
-        nano::read (stream_a, verified);
-    }
-    catch (std::runtime_error const &)
-    {
-        return true;
-    }
+	try
+	{
+		nano::read (stream_a, account.bytes);
+		nano::read (stream_a, modified);
+		nano::read (stream_a, verified);
+	}
+	catch (std::runtime_error const &)
+	{
+		return true;
+	}
 
 	return false;
 }
@@ -689,7 +690,7 @@ bool nano::vote::deserialize (nano::stream & stream_a, nano::block_uniquer * uni
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	if (blocks.empty ())
@@ -832,7 +833,7 @@ bool nano::unchecked_key::deserialize (nano::stream & stream_a)
 	}
 	catch (std::runtime_error const &)
 	{
-	    return true;
+		return true;
 	}
 
 	return false;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -96,8 +96,8 @@ public:
 	bool deserialize (nano::stream &);
 	bool operator== (nano::account_info const &) const;
 	bool operator!= (nano::account_info const &) const;
-	[[nodiscard]] size_t db_size () const;
-	[[nodiscard]] nano::epoch epoch () const;
+	size_t db_size () const;
+	nano::epoch epoch () const;
 	nano::block_hash head{ 0 };
 	nano::account representative{ 0 };
 	nano::block_hash open_block{ 0 };
@@ -116,7 +116,7 @@ class pending_info final
 public:
 	pending_info () = default;
 	pending_info (nano::account const &, nano::amount const &, nano::epoch);
-	[[nodiscard]] size_t db_size () const;
+	size_t db_size () const;
 	bool deserialize (nano::stream &);
 	bool operator== (nano::pending_info const &) const;
 	nano::account source{ 0 };
@@ -130,7 +130,7 @@ public:
 	pending_key (nano::account const &, nano::block_hash const &);
 	bool deserialize (nano::stream &);
 	bool operator== (nano::pending_key const &) const;
-	[[nodiscard]] nano::account const & key () const;
+	nano::account const & key () const;
 	nano::account account{ 0 };
 	nano::block_hash hash{ 0 };
 };
@@ -149,12 +149,12 @@ public:
 	/*
 	 * @return The ipv6 address in network byte order
 	 */
-	[[nodiscard]] const std::array<uint8_t, 16> & address_bytes () const;
+	const std::array<uint8_t, 16> & address_bytes () const;
 
 	/*
 	 * @return The port in host byte order
 	 */
-	[[nodiscard]] uint16_t port () const;
+	uint16_t port () const;
 
 private:
 	// Both stored internally in network byte order
@@ -174,7 +174,7 @@ public:
 	unchecked_key (nano::block_hash const &, nano::block_hash const &);
 	bool deserialize (nano::stream &);
 	bool operator== (nano::unchecked_key const &) const;
-	[[nodiscard]] nano::block_hash const & key () const;
+	nano::block_hash const & key () const;
 	nano::block_hash previous{ 0 };
 	nano::block_hash hash{ 0 };
 };
@@ -250,19 +250,19 @@ public:
 	vote (bool &, nano::stream &, nano::block_type, nano::block_uniquer * = nullptr);
 	vote (nano::account const &, nano::raw_key const &, uint64_t, std::shared_ptr<nano::block> const &);
 	vote (nano::account const &, nano::raw_key const &, uint64_t, std::vector<nano::block_hash> const &);
-	[[nodiscard]] std::string hashes_string () const;
-	[[nodiscard]] nano::block_hash hash () const;
-	[[nodiscard]] nano::block_hash full_hash () const;
+	std::string hashes_string () const;
+	nano::block_hash hash () const;
+	nano::block_hash full_hash () const;
 	bool operator== (nano::vote const &) const;
 	bool operator!= (nano::vote const &) const;
 	void serialize (nano::stream &, nano::block_type) const;
 	void serialize (nano::stream &) const;
 	void serialize_json (boost::property_tree::ptree & tree) const;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
-	[[nodiscard]] bool validate () const;
-	[[nodiscard]] boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> begin () const;
-	[[nodiscard]] boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> end () const;
-	[[nodiscard]] std::string to_json () const;
+	bool validate () const;
+	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> begin () const;
+	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> end () const;
+	std::string to_json () const;
 	// Vote timestamp
 	uint64_t timestamp;
 	// The blocks, or block hashes, that this vote is for
@@ -336,7 +336,7 @@ class genesis final
 {
 public:
 	genesis ();
-	[[nodiscard]] nano::block_hash hash () const;
+	nano::block_hash hash () const;
 	std::shared_ptr<nano::block> open;
 };
 
@@ -350,7 +350,7 @@ public:
 	uint8_t const protocol_version = 0x12;
 
 	/** Minimum accepted protocol version */
-	[[nodiscard]] uint8_t protocol_version_min () const;
+	uint8_t protocol_version_min () const;
 
 private:
 	/* Minimum protocol version we will establish connections to */
@@ -364,8 +364,8 @@ static_assert (std::is_same<std::remove_const_t<decltype (protocol_constants ().
 class ledger_constants
 {
 public:
-	[[nodiscard]] ledger_constants (nano::network_constants & network_constants);
-	[[nodiscard]] ledger_constants (nano::nano_networks network_a);
+	ledger_constants (nano::network_constants & network_constants);
+	ledger_constants (nano::nano_networks network_a);
 	nano::keypair zero_key;
 	nano::keypair dev_genesis_key;
 	nano::account nano_dev_account;
@@ -397,7 +397,7 @@ public:
 class node_constants
 {
 public:
-	[[nodiscard]] node_constants (nano::network_constants & network_constants);
+	node_constants (nano::network_constants & network_constants);
 	std::chrono::seconds period;
 	std::chrono::milliseconds half_period;
 	/** Default maximum idle time for a socket before it's automatically closed */

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -149,7 +149,7 @@ public:
 	/*
 	 * @return The ipv6 address in network byte order
 	 */
-	const std::array<uint8_t, 16> & address_bytes () const;
+	std::array<uint8_t, 16> const & address_bytes () const;
 
 	/*
 	 * @return The port in host byte order

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -79,8 +79,8 @@ class keypair
 {
 public:
 	keypair ();
-	keypair (std::string const &);
-	keypair (nano::raw_key &&);
+	explicit keypair (std::string const &);
+	explicit keypair (nano::raw_key &&);
 	nano::public_key pub;
 	nano::raw_key prv;
 };
@@ -96,8 +96,8 @@ public:
 	bool deserialize (nano::stream &);
 	bool operator== (nano::account_info const &) const;
 	bool operator!= (nano::account_info const &) const;
-	size_t db_size () const;
-	nano::epoch epoch () const;
+	[[nodiscard]] size_t db_size () const;
+	[[nodiscard]] nano::epoch epoch () const;
 	nano::block_hash head{ 0 };
 	nano::account representative{ 0 };
 	nano::block_hash open_block{ 0 };
@@ -116,7 +116,7 @@ class pending_info final
 public:
 	pending_info () = default;
 	pending_info (nano::account const &, nano::amount const &, nano::epoch);
-	size_t db_size () const;
+	[[nodiscard]] size_t db_size () const;
 	bool deserialize (nano::stream &);
 	bool operator== (nano::pending_info const &) const;
 	nano::account source{ 0 };
@@ -130,7 +130,7 @@ public:
 	pending_key (nano::account const &, nano::block_hash const &);
 	bool deserialize (nano::stream &);
 	bool operator== (nano::pending_key const &) const;
-	nano::account const & key () const;
+	[[nodiscard]] nano::account const & key () const;
 	nano::account account{ 0 };
 	nano::block_hash hash{ 0 };
 };
@@ -149,12 +149,12 @@ public:
 	/*
 	 * @return The ipv6 address in network byte order
 	 */
-	const std::array<uint8_t, 16> & address_bytes () const;
+	[[nodiscard]] const std::array<uint8_t, 16> & address_bytes () const;
 
 	/*
 	 * @return The port in host byte order
 	 */
-	uint16_t port () const;
+	[[nodiscard]] uint16_t port () const;
 
 private:
 	// Both stored internally in network byte order
@@ -174,7 +174,7 @@ public:
 	unchecked_key (nano::block_hash const &, nano::block_hash const &);
 	bool deserialize (nano::stream &);
 	bool operator== (nano::unchecked_key const &) const;
-	nano::block_hash const & key () const;
+	[[nodiscard]] nano::block_hash const & key () const;
 	nano::block_hash previous{ 0 };
 	nano::block_hash hash{ 0 };
 };
@@ -250,19 +250,19 @@ public:
 	vote (bool &, nano::stream &, nano::block_type, nano::block_uniquer * = nullptr);
 	vote (nano::account const &, nano::raw_key const &, uint64_t, std::shared_ptr<nano::block> const &);
 	vote (nano::account const &, nano::raw_key const &, uint64_t, std::vector<nano::block_hash> const &);
-	std::string hashes_string () const;
-	nano::block_hash hash () const;
-	nano::block_hash full_hash () const;
+	[[nodiscard]] std::string hashes_string () const;
+	[[nodiscard]] nano::block_hash hash () const;
+	[[nodiscard]] nano::block_hash full_hash () const;
 	bool operator== (nano::vote const &) const;
 	bool operator!= (nano::vote const &) const;
 	void serialize (nano::stream &, nano::block_type) const;
 	void serialize (nano::stream &) const;
 	void serialize_json (boost::property_tree::ptree & tree) const;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
-	bool validate () const;
-	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> begin () const;
-	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> end () const;
-	std::string to_json () const;
+	[[nodiscard]] bool validate () const;
+	[[nodiscard]] boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> begin () const;
+	[[nodiscard]] boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> end () const;
+	[[nodiscard]] std::string to_json () const;
 	// Vote timestamp
 	uint64_t timestamp;
 	// The blocks, or block hashes, that this vote is for
@@ -281,7 +281,7 @@ class vote_uniquer final
 public:
 	using value_type = std::pair<const nano::block_hash, std::weak_ptr<nano::vote>>;
 
-	vote_uniquer (nano::block_uniquer &);
+	explicit vote_uniquer (nano::block_uniquer &);
 	std::shared_ptr<nano::vote> unique (std::shared_ptr<nano::vote> const &);
 	size_t size ();
 
@@ -336,7 +336,7 @@ class genesis final
 {
 public:
 	genesis ();
-	nano::block_hash hash () const;
+	[[nodiscard]] nano::block_hash hash () const;
 	std::shared_ptr<nano::block> open;
 };
 
@@ -350,7 +350,7 @@ public:
 	uint8_t const protocol_version = 0x12;
 
 	/** Minimum accepted protocol version */
-	uint8_t protocol_version_min () const;
+	[[nodiscard]] uint8_t protocol_version_min () const;
 
 private:
 	/* Minimum protocol version we will establish connections to */
@@ -364,8 +364,8 @@ static_assert (std::is_same<std::remove_const_t<decltype (protocol_constants ().
 class ledger_constants
 {
 public:
-	ledger_constants (nano::network_constants & network_constants);
-	ledger_constants (nano::nano_networks network_a);
+	[[nodiscard]] ledger_constants (nano::network_constants & network_constants);
+	[[nodiscard]] ledger_constants (nano::nano_networks network_a);
 	nano::keypair zero_key;
 	nano::keypair dev_genesis_key;
 	nano::account nano_dev_account;
@@ -397,7 +397,7 @@ public:
 class node_constants
 {
 public:
-	node_constants (nano::network_constants & network_constants);
+	[[nodiscard]] node_constants (nano::network_constants & network_constants);
 	std::chrono::seconds period;
 	std::chrono::milliseconds half_period;
 	/** Default maximum idle time for a socket before it's automatically closed */
@@ -422,7 +422,7 @@ public:
 class voting_constants
 {
 public:
-	voting_constants (nano::network_constants & network_constants);
+	explicit voting_constants (nano::network_constants & network_constants);
 	size_t const max_cache;
 	std::chrono::seconds const delay;
 };
@@ -431,7 +431,7 @@ public:
 class portmapping_constants
 {
 public:
-	portmapping_constants (nano::network_constants & network_constants);
+	explicit portmapping_constants (nano::network_constants & network_constants);
 	// Timeouts are primes so they infrequently happen at the same time
 	std::chrono::seconds lease_duration;
 	std::chrono::seconds health_check_period;
@@ -441,7 +441,7 @@ public:
 class bootstrap_constants
 {
 public:
-	bootstrap_constants (nano::network_constants & network_constants);
+	explicit bootstrap_constants (nano::network_constants & network_constants);
 	uint32_t lazy_max_pull_blocks;
 	uint32_t lazy_min_pull_blocks;
 	unsigned frontier_retry_limit;
@@ -458,7 +458,7 @@ public:
 	network_params ();
 
 	/** Populate values based on \p network_a */
-	network_params (nano::nano_networks network_a);
+	explicit network_params (nano::nano_networks network_a);
 
 	std::array<uint8_t, 2> header_magic_number;
 	unsigned kdf_work;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1311,8 +1311,7 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 	if (result == nullptr)
 	{
 		nano::account_info info;
-		auto error (store.account_get (transaction_a, root.as_account (), info));
-		(void)error;
+		[[maybe_unused]] auto const error (store.account_get (transaction_a, root.as_account (), info));
 		debug_assert (!error);
 		result = store.block_get (transaction_a, info.open_block);
 		debug_assert (result != nullptr);
@@ -1323,7 +1322,7 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 bool nano::ledger::block_confirmed (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	auto confirmed (false);
-	auto block = store.block_get (transaction_a, hash_a);
+	auto const block = store.block_get (transaction_a, hash_a);
 	if (block)
 	{
 		nano::confirmation_height_info confirmation_height_info;
@@ -1339,7 +1338,7 @@ uint64_t nano::ledger::pruning_action (nano::write_transaction & transaction_a, 
 	nano::block_hash hash (hash_a);
 	while (!hash.is_zero () && hash != network_params.ledger.genesis_hash)
 	{
-		auto block (store.block_get (transaction_a, hash));
+		auto const block (store.block_get (transaction_a, hash));
 		if (block != nullptr)
 		{
 			store.block_del (transaction_a, hash);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -27,10 +27,10 @@ class ledger final
 {
 public:
 	ledger (nano::block_store &, nano::stat &, nano::generate_cache const & = nano::generate_cache ());
-	nano::account account (nano::transaction const &, nano::block_hash const &) const;
+	[[nodiscard]] nano::account account (nano::transaction const &, nano::block_hash const &) const;
 	nano::account account_safe (nano::transaction const &, nano::block_hash const &, bool &) const;
-	nano::uint128_t amount (nano::transaction const &, nano::account const &);
-	nano::uint128_t amount (nano::transaction const &, nano::block_hash const &);
+	[[nodiscard]] nano::uint128_t amount (nano::transaction const &, nano::account const &);
+	[[nodiscard]] nano::uint128_t amount (nano::transaction const &, nano::block_hash const &);
 	/** Safe for previous block, but block hash_a must exist */
 	nano::uint128_t amount_safe (nano::transaction const &, nano::block_hash const & hash_a, bool &) const;
 	nano::uint128_t balance (nano::transaction const &, nano::block_hash const &) const;
@@ -45,10 +45,10 @@ public:
 	nano::root latest_root (nano::transaction const &, nano::account const &);
 	nano::block_hash representative (nano::transaction const &, nano::block_hash const &);
 	nano::block_hash representative_calculated (nano::transaction const &, nano::block_hash const &);
-	bool block_exists (nano::block_hash const &) const;
-	bool block_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
-	bool block_or_pruned_exists (nano::block_hash const &) const;
-	bool block_confirmed_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
+	[[nodiscard]] bool block_exists (nano::block_hash const &) const;
+	[[nodiscard]] bool block_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
+	[[nodiscard]] bool block_or_pruned_exists (nano::block_hash const &) const;
+	[[nodiscard]] bool block_confirmed_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
 	std::string block_text (char const *);
 	std::string block_text (nano::block_hash const &);
 	bool is_send (nano::transaction const &, nano::state_block const &) const;
@@ -59,7 +59,7 @@ public:
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
 	void update_account (nano::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
-	uint64_t pruning_action (nano::write_transaction &, nano::block_hash const &, uint64_t const);
+	uint64_t pruning_action (nano::write_transaction &, nano::block_hash const &, uint64_t);
 	void dump_account_chain (nano::account const &, std::ostream & = std::cout);
 	bool could_fit (nano::transaction const &, nano::block const &) const;
 	bool dependents_confirmed (nano::transaction const &, nano::block const &) const;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -27,10 +27,10 @@ class ledger final
 {
 public:
 	ledger (nano::block_store &, nano::stat &, nano::generate_cache const & = nano::generate_cache ());
-	[[nodiscard]] nano::account account (nano::transaction const &, nano::block_hash const &) const;
+	nano::account account (nano::transaction const &, nano::block_hash const &) const;
 	nano::account account_safe (nano::transaction const &, nano::block_hash const &, bool &) const;
-	[[nodiscard]] nano::uint128_t amount (nano::transaction const &, nano::account const &);
-	[[nodiscard]] nano::uint128_t amount (nano::transaction const &, nano::block_hash const &);
+	nano::uint128_t amount (nano::transaction const &, nano::account const &);
+	nano::uint128_t amount (nano::transaction const &, nano::block_hash const &);
 	/** Safe for previous block, but block hash_a must exist */
 	nano::uint128_t amount_safe (nano::transaction const &, nano::block_hash const & hash_a, bool &) const;
 	nano::uint128_t balance (nano::transaction const &, nano::block_hash const &) const;
@@ -45,10 +45,10 @@ public:
 	nano::root latest_root (nano::transaction const &, nano::account const &);
 	nano::block_hash representative (nano::transaction const &, nano::block_hash const &);
 	nano::block_hash representative_calculated (nano::transaction const &, nano::block_hash const &);
-	[[nodiscard]] bool block_exists (nano::block_hash const &) const;
-	[[nodiscard]] bool block_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
-	[[nodiscard]] bool block_or_pruned_exists (nano::block_hash const &) const;
-	[[nodiscard]] bool block_confirmed_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
+	bool block_exists (nano::block_hash const &) const;
+	bool block_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
+	bool block_or_pruned_exists (nano::block_hash const &) const;
+	bool block_confirmed_or_pruned_exists (nano::transaction const &, nano::block_hash const &) const;
 	std::string block_text (char const *);
 	std::string block_text (nano::block_hash const &);
 	bool is_send (nano::transaction const &, nano::state_block const &) const;

--- a/nano/secure/network_filter.cpp
+++ b/nano/secure/network_filter.cpp
@@ -13,11 +13,11 @@ items (size_a, nano::uint128_t{ 0 })
 bool nano::network_filter::apply (uint8_t const * bytes_a, size_t count_a, nano::uint128_t * digest_a)
 {
 	// Get hash before locking
-	auto digest (hash (bytes_a, count_a));
+	auto const digest (hash (bytes_a, count_a));
 
 	nano::lock_guard<nano::mutex> lock (mutex);
 	auto & element (get_element (digest));
-	bool existed (element == digest);
+	bool const existed (element == digest);
 	if (!existed)
 	{
 		// Replace likely old element with a new one
@@ -85,7 +85,7 @@ nano::uint128_t & nano::network_filter::get_element (nano::uint128_t const & has
 {
 	debug_assert (!mutex.try_lock ());
 	debug_assert (items.size () > 0);
-	size_t index (hash_a % items.size ());
+	size_t const index (hash_a % items.size ());
 	return items[index];
 }
 

--- a/nano/secure/network_filter.hpp
+++ b/nano/secure/network_filter.hpp
@@ -20,7 +20,7 @@ class network_filter final
 {
 public:
 	network_filter () = delete;
-	network_filter (size_t size_a);
+	explicit network_filter (size_t size_a);
 	/**
 	 * Reads \p count_a bytes starting from \p bytes_a and inserts the siphash digest in the filter.
 	 * @param \p digest_a if given, will be set to the resulting siphash digest

--- a/nano/secure/versioning.hpp
+++ b/nano/secure/versioning.hpp
@@ -12,7 +12,7 @@ class pending_info_v14 final
 public:
 	pending_info_v14 () = default;
 	pending_info_v14 (nano::account const &, nano::amount const &, nano::epoch);
-	size_t db_size () const;
+	[[nodiscard]] size_t db_size () const;
 	bool deserialize (nano::stream &);
 	bool operator== (nano::pending_info_v14 const &) const;
 	nano::account source{ 0 };
@@ -24,7 +24,7 @@ class account_info_v14 final
 public:
 	account_info_v14 () = default;
 	account_info_v14 (nano::block_hash const &, nano::block_hash const &, nano::block_hash const &, nano::amount const &, uint64_t, uint64_t, uint64_t, nano::epoch);
-	size_t db_size () const;
+	[[nodiscard]] size_t db_size () const;
 	nano::block_hash head{ 0 };
 	nano::block_hash rep_block{ 0 };
 	nano::block_hash open_block{ 0 };

--- a/nano/secure/versioning.hpp
+++ b/nano/secure/versioning.hpp
@@ -12,7 +12,7 @@ class pending_info_v14 final
 public:
 	pending_info_v14 () = default;
 	pending_info_v14 (nano::account const &, nano::amount const &, nano::epoch);
-	[[nodiscard]] size_t db_size () const;
+	size_t db_size () const;
 	bool deserialize (nano::stream &);
 	bool operator== (nano::pending_info_v14 const &) const;
 	nano::account source{ 0 };
@@ -24,7 +24,7 @@ class account_info_v14 final
 public:
 	account_info_v14 () = default;
 	account_info_v14 (nano::block_hash const &, nano::block_hash const &, nano::block_hash const &, nano::amount const &, uint64_t, uint64_t, uint64_t, nano::epoch);
-	[[nodiscard]] size_t db_size () const;
+	size_t db_size () const;
 	nano::block_hash head{ 0 };
 	nano::block_hash rep_block{ 0 };
 	nano::block_hash open_block{ 0 };

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1235,7 +1235,7 @@ namespace transport
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.disable_initial_telemetry_requests = true;
-		const auto num_nodes = 4;
+		auto const num_nodes = 4;
 		for (int i = 0; i < num_nodes; ++i)
 		{
 			system.add_node (node_flags);
@@ -1244,7 +1244,7 @@ namespace transport
 		wait_peer_connections (system);
 
 		std::vector<std::thread> threads;
-		const auto num_threads = 4;
+		auto const num_threads = 4;
 
 		std::array<data, num_nodes> node_data{};
 		for (auto i = 0; i < num_nodes; ++i)
@@ -1418,7 +1418,7 @@ TEST (telemetry, many_nodes)
 	node_flags.disable_initial_telemetry_requests = true;
 	node_flags.disable_request_loop = true;
 	// The telemetry responses can timeout if using a large number of nodes under sanitizers, so lower the number.
-	const auto num_nodes = (is_sanitizer_build || nano::running_within_valgrind ()) ? 4 : 10;
+	auto const num_nodes = (is_sanitizer_build || nano::running_within_valgrind ()) ? 4 : 10;
 	for (auto i = 0; i < num_nodes; ++i)
 	{
 		nano::node_config node_config (nano::get_available_port (), system.logging);


### PR DESCRIPTION
I've been manually reviewing the code for some improvements regarding #3099, #3139 and #297. Here are the main changes:

* Added `explicit` to constructors with a single parameter. [Reference](https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html). All of them suggested by `clang-tidy`.
* Some early returns: most make the code considerably easier to read. But they're a bit tricky in reviews so not all are included. Applied manually from `rg 'if \(!error\)'` and `rg 'if \(!result\)'`.
* ~~Added `[[nodiscard]]` to getters and similar functions. [Reference](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nodiscard.html). All of them suggested by `clang-tidy`.~~
* Added `const` to a good chunk of the codebase. I haven't found a way to do this automatically so not all of them are included yet. I've enforced that all of them are in the `T const` order, as it was the most commonly used one. Unfortunately, this can't be checked automatically with `clang-format` [for now](https://bugs.llvm.org/show_bug.cgi?id=34220).
* Removed unused headers. All of them recommended by the CLion IDE.
* Removed `const T` parameters in headers, as they have no effect. [Reference](https://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html). All of them suggested by `clang-tidy`.

I'm not adding more changes related to early returns because there are so many lines modified already and I wanted to keep the PR smaller. If it's too much I can split it up or something. Sorry about that.