### PR TITLE
The build info shows following description: \

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ set(Boost_USE_MULTITHREADED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package(Boost 1.69.0 REQUIRED COMPONENTS filesystem log log_setup thread
+find_package(Boost 1.70.0 REQUIRED COMPONENTS filesystem log log_setup thread
                                               program_options system)
 
 # RocksDB
@@ -569,7 +569,7 @@ if(NANO_FUZZER_TEST)
 endif()
 
 if(NANO_TEST OR RAIBLOCKS_TEST)
-  find_package(Boost 1.69.0 REQUIRED COMPONENTS coroutine context)
+  find_package(Boost 1.70.0 REQUIRED COMPONENTS coroutine context)
   if(WIN32)
     if(MSVC_VERSION)
       if(MSVC_VERSION GREATER_EQUAL 1910)

--- a/cmake/legacyModules/FindBoost.cmake
+++ b/cmake/legacyModules/FindBoost.cmake
@@ -495,7 +495,7 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION _boost_COMPILER_VERSION_MAJOR _boost_COMPILER_VERSION_MINOR)
     if(NOT Boost_VERSION VERSION_LESS 106900)
       # From GCC 5 and clang 4, versioning changes and minor becomes patch.
-      # For those compilers, patch is exclude from compiler tag in Boost 1.69+ library naming.
+      # For those compilers, patch is exclude from compiler tag in Boost 1.70+ library naming.
       if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND _boost_COMPILER_VERSION_MAJOR VERSION_GREATER 4)
         set(_boost_COMPILER_VERSION "${_boost_COMPILER_VERSION_MAJOR}")
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND _boost_COMPILER_VERSION_MAJOR VERSION_GREATER 3)
@@ -1127,7 +1127,7 @@ else()
   # _Boost_COMPONENT_HEADERS.  See the instructions at the top of
   # _Boost_COMPONENT_DEPENDENCIES.
   set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
-    "1.69.0" "1.69"
+    "1.70.0" "1.70" "1.69.0" "1.69"
     "1.68.0" "1.68" "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65"
     "1.64.0" "1.64" "1.63.0" "1.63" "1.62.0" "1.62" "1.61.0" "1.61" "1.60.0" "1.60"
     "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -11,7 +11,7 @@ buildThreads=1
 buildCArgs=()
 buildCXXArgs=()
 buildLDArgs=()
-boostVersion='1.75'
+boostVersion='1.70'
 while getopts 'hmscCkpvB:j:' OPT; do
 	case "${OPT}" in
 	h)
@@ -83,11 +83,6 @@ if [ "${useClang}" = 'true' ]; then
 fi
 
 case "${boostVersion}" in
-1.69)
-	BOOST_BASENAME=boost_1_69_0
-	BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.69.0/${BOOST_BASENAME}.tar.bz2/download
-	BOOST_ARCHIVE_SHA256='8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406'
-	;;
 1.70)
 	BOOST_BASENAME=boost_1_70_0
 	BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.70.0/${BOOST_BASENAME}.tar.bz2/download
@@ -107,7 +102,7 @@ case "${boostVersion}" in
 	BOOST_BASENAME=boost_1_75_0
 	BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.75.0/${BOOST_BASENAME}.tar.bz2/download
 	BOOST_ARCHIVE_SHA256='953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb'
-	;;	
+	;;
 *)
 	echo "Unsupported Boost version: ${boostVersion}" >&2
 	exit 1

--- a/util/build_prep/bootstrap_boost.sh
+++ b/util/build_prep/bootstrap_boost.sh
@@ -11,7 +11,7 @@ buildThreads=1
 buildCArgs=()
 buildCXXArgs=()
 buildLDArgs=()
-boostVersion='1.69'
+boostVersion='1.75'
 while getopts 'hmscCkpvB:j:' OPT; do
 	case "${OPT}" in
 	h)
@@ -103,6 +103,11 @@ case "${boostVersion}" in
 	BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.73.0/${BOOST_BASENAME}.tar.bz2/download
 	BOOST_ARCHIVE_SHA256='4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402'
 	;;
+1.75)
+	BOOST_BASENAME=boost_1_75_0
+	BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.75.0/${BOOST_BASENAME}.tar.bz2/download
+	BOOST_ARCHIVE_SHA256='953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb'
+	;;	
 *)
 	echo "Unsupported Boost version: ${boostVersion}" >&2
 	exit 1

--- a/util/build_prep/centos/prep.sh.in
+++ b/util/build_prep/centos/prep.sh.in
@@ -34,8 +34,8 @@ rm -f ./cmake_install.sh
 		exit 1
 	fi
 
-	if ! version_min 'boost --version' 1.68.999; then
-		echo "boost version too low (1.69.0+ required)" >&2
+	if ! version_min 'boost --version' 1.69.999; then
+		echo "boost version too low (1.70.0+ required)" >&2
 		exit 1
 	fi
 

--- a/util/build_prep/macosx/prep.sh.in
+++ b/util/build_prep/macosx/prep.sh.in
@@ -50,8 +50,8 @@ if ! have boost; then
 	exit 1
 fi
 
-if ! version_min 'boost --version' 1.68.999; then
-	echo "boost version too low (1.69.0+ required)" >&2
+if ! version_min 'boost --version' 1.69.999; then
+	echo "boost version too low (1.70.0+ required)" >&2
 
 	exit 1
 fi

--- a/util/build_prep/ubuntu/prep.sh.in
+++ b/util/build_prep/ubuntu/prep.sh.in
@@ -29,8 +29,8 @@ if ! have boost; then
 	exit 1
 fi
 
-if ! version_min 'boost --version' 1.68.999; then
-	echo "boost version too low (1.69.0+ required)" >&2
+if ! version_min 'boost --version' 1.69.999; then
+	echo "boost version too low (1.70.0+ required)" >&2
 	exit 1
 fi
 boost_dir="$(boost --install-prefix)"


### PR DESCRIPTION
Build Info: 5160073 "GNU C++ version " "5.4.0 20160609" "BOOST 107000" BUILT "Sep  3 2020" \
This file has default set to boostVersion=1.69 which is inconsitent with above build info which shows 1.70. Hence, updating default to latest Boost version to 1.75