### PR TITLE
clear_send_ids in vacuum/snapshot is using wrong txn object

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -9,7 +9,7 @@
 
 namespace
 {
-void reset_confirmation_heights (nano::write_transaction & transaction, nano::block_store & store);
+void reset_confirmation_heights (nano::write_transaction const & transaction, nano::block_store & store);
 bool is_using_rocksdb (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec);
 }
 
@@ -1300,7 +1300,7 @@ std::unique_ptr<nano::inactive_node> nano::default_inactive_node (boost::filesys
 
 namespace
 {
-void reset_confirmation_heights (nano::write_transaction & transaction, nano::block_store & store)
+void reset_confirmation_heights (nano::write_transaction const & transaction, nano::block_store & store)
 {
 	// First do a clean sweep
 	store.confirmation_height_clear (transaction);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -209,7 +209,7 @@ void database_write_lock_error (std::error_code & ec)
 bool copy_database (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, boost::filesystem::path const & output_path, std::error_code & ec)
 {
 	bool success = false;
-	bool needs_to_write = vm.count ("unchecked_clear") || vm.count ("clear_send_ids") || vm.count ("online_weight_clear") || vm.count ("peer_clear") || vm.count ("confirmation_height_clear") || vm.count ("final_vote_clear") || vm.count ("rebuild_database") || vm.count ("vacuum");
+	bool needs_to_write = vm.count ("unchecked_clear") || vm.count ("clear_send_ids") || vm.count ("online_weight_clear") || vm.count ("peer_clear") || vm.count ("confirmation_height_clear") || vm.count ("final_vote_clear") || vm.count ("rebuild_database");
 
 	auto node_flags = nano::inactive_node_flag_defaults ();
 	node_flags.read_only = !needs_to_write;
@@ -217,34 +217,34 @@ bool copy_database (boost::filesystem::path const & data_path, boost::program_op
 	nano::inactive_node node (data_path, node_flags);
 	if (!node.node->init_error ())
 	{
-		auto transaction (node.node->store.tx_begin_write ());
+		auto & store (node.node->store);
 		if (vm.count ("unchecked_clear"))
 		{
-			node.node->store.unchecked_clear (transaction);
+			node.node->store.unchecked_clear (store.tx_begin_write ());
 		}
 		if (vm.count ("clear_send_ids"))
 		{
-			node.node->wallets.clear_send_ids (transaction);
+			node.node->wallets.clear_send_ids (node.node->wallets.tx_begin_write ());
 		}
 		if (vm.count ("online_weight_clear"))
 		{
-			node.node->store.online_weight_clear (transaction);
+			node.node->store.online_weight_clear (store.tx_begin_write ());
 		}
 		if (vm.count ("peer_clear"))
 		{
-			node.node->store.peer_clear (transaction);
+			node.node->store.peer_clear (store.tx_begin_write ());
 		}
 		if (vm.count ("confirmation_height_clear"))
 		{
-			reset_confirmation_heights (transaction, node.node->store);
+			reset_confirmation_heights (store.tx_begin_write (), store);
 		}
 		if (vm.count ("final_vote_clear"))
 		{
-			node.node->store.final_vote_clear (transaction);
+			node.node->store.final_vote_clear (store.tx_begin_write ());
 		}
 		if (vm.count ("rebuild_database"))
 		{
-			node.node->store.rebuild_db (transaction);
+			node.node->store.rebuild_db (store.tx_begin_write ());
 		}
 
 		success = node.node->copy_with_compaction (output_path);


### PR DESCRIPTION
Reverting the `transaction` changes in https://github.com/nanocurrency/nano-node/pull/3130/files (was my fault) which reduces scope of the `transaction` object, but saving a few lines by passing the `transaction` directly as argument to the `*_clear` functions instead. Needed in v21.3 if final votes is going into there.