### PR TITLE
Fix FreeBSD build error: "Cannot find source file: plat/plat/default/debugging.cpp"

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -10,9 +10,8 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(platform_sources plat/linux/priority.cpp plat/posix/perms.cpp
                        plat/linux/thread_role.cpp plat/linux/debugging.cpp)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  set(platform_sources
-      plat/default/priority.cpp plat/posix/perms.cpp
-      plat/freebsd/thread_role.cpp plat/plat/default/debugging.cpp)
+  set(platform_sources plat/default/priority.cpp plat/posix/perms.cpp
+                       plat/freebsd/thread_role.cpp plat/default/debugging.cpp)
 else()
   error("Unknown platform: ${CMAKE_SYSTEM_NAME}")
 endif()


### PR DESCRIPTION
`cmake` on FreeBSD gives an error. I believe it's a typo in the [CMakeLists.txt](plat/plat/default/debugging.cpp) file:
```
elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
  set(platform_sources
      plat/default/priority.cpp plat/posix/perms.cpp
      plat/freebsd/thread_role.cpp plat/plat/default/debugging.cpp)
else()
```


**Steps to reproduce the issue:**
```
$ cmake .
Generating flatbuffers code for: nanoapi into /root/nano-node/nano/ipc_flatbuffers_lib/generated/flatbuffers
CryptoPP with disabled ASM for Clang 10.0.0
-- Configuring done
CMake Error at nano/lib/CMakeLists.txt:13 (add_library):
  Cannot find source file:

    plat/plat/default/debugging.cpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .ispc


CMake Error at nano/lib/CMakeLists.txt:13 (add_library):
  No SOURCES given to target: nano_lib


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

**Environment**:
```
FreeBSD nanojail 11.2-STABLE FreeBSD 11.2-STABLE #0 r325575+4710c8b6420(HEAD): Fri Feb 14 13:59:19 UTC 2020     root@tnbuild02.tn.ixsystems.com:/freenas-releng/freenas/_BE/objs/freenas-releng/freenas/_BE/os/sys/FreeNAS.amd64  amd64
```
<!--
- OS information  
- (Linux) Kernel (e.g. `uname -a`):
- Node version
- (docker node) docker version 
-->
