### PR TITLE
Resolve issue with inactive votes cache not triggering elections to start

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1485,7 +1485,7 @@ nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_
 {
 	debug_assert (!lock_a.owns_lock ());
 	nano::inactive_cache_status status (previously_a);
-	constexpr unsigned election_start_voters_min{ 5 };
+	const unsigned election_start_voters_min = node.network_params.network.is_dev_network () ? 1 : node.network_params.network.is_beta_network () ? 5 : 15;
 	status.tally = tally_a;
 	if (!previously_a.confirmed && tally_a >= node.online_reps.delta ())
 	{
@@ -1507,11 +1507,8 @@ nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_
 		auto block = node.store.block_get (transaction, hash_a);
 		if (block && status.election_started && !previously_a.election_started && !node.block_confirmed_or_being_confirmed (transaction, hash_a))
 		{
-			if (node.ledger.cache.cemented_count >= node.ledger.bootstrap_weight_max_blocks)
-			{
-				lock_a.lock ();
-				insert_impl (lock_a, block);
-			}
+			lock_a.lock ();
+			insert_impl (lock_a, block);
 		}
 		else if (!block && status.bootstrap_started && !previously_a.bootstrap_started && (!node.ledger.pruning || !node.store.pruned_exists (transaction, hash_a)))
 		{

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1485,7 +1485,7 @@ nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_
 {
 	debug_assert (!lock_a.owns_lock ());
 	nano::inactive_cache_status status (previously_a);
-	const unsigned election_start_voters_min = node.network_params.network.is_dev_network () ? 1 : node.network_params.network.is_beta_network () ? 5 : 15;
+	const unsigned election_start_voters_min = node.network_params.network.is_dev_network () ? 2 : node.network_params.network.is_beta_network () ? 5 : 15;
 	status.tally = tally_a;
 	if (!previously_a.confirmed && tally_a >= node.online_reps.delta ())
 	{


### PR DESCRIPTION
Modifying voter count in inactive cache to trigger an election for different networks. Also removes bootstrap block count check as this can prevent triggering of elections shortly after a release or when a node is near fully bootstrapped.