### PR TITLE
Block rebroadcasting changes from V21.3

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -307,7 +307,6 @@ TEST (confirmation_height, gap_live)
 		system.add_node (node_config, node_flags);
 		nano::keypair destination;
 		system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
-		system.wallet (1)->insert_adhoc (destination.prv);
 
 		nano::genesis genesis;
 		auto send1 (std::make_shared<nano::state_block> (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3173,8 +3173,8 @@ TEST (node, epoch_conflict_confirm)
 	ASSERT_EQ (nano::process_result::progress, node0->process (*send).code);
 	ASSERT_EQ (nano::process_result::progress, node0->process (*send2).code);
 	ASSERT_EQ (nano::process_result::progress, node0->process (*open).code);
-	node0->process_active (change);
-	node0->process_active (epoch_open);
+	node0->process_local (change, false);
+	node0->process_local (epoch_open, false);
 	ASSERT_TIMELY (10s, node0->block (change->hash ()) && node0->block (epoch_open->hash ()) && node1->block (change->hash ()) && node1->block (epoch_open->hash ()));
 	// Confirm blocks in node1 to allow generating votes
 	nano::blocks_confirm (*node1, { change, epoch_open }, true /* forced */);
@@ -4503,14 +4503,14 @@ TEST (node, deferred_dependent_elections)
 	            .representative (nano::dev_genesis_key.pub)
 	            .sign (key.prv, key.pub)
 	            .build_shared ();
-	node.process_active (send1);
+	node.process_local (send1);
 	node.block_processor.flush ();
 	auto election_send1 = node.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election_send1);
 
 	// Should process and republish but not start an election for any dependent blocks
-	node.process_active (open);
-	node.process_active (send2);
+	node.process_local (open, false);
+	node.process_local (send2, false);
 	node.block_processor.flush ();
 	ASSERT_TRUE (node.block (open->hash ()));
 	ASSERT_TRUE (node.block (send2->hash ()));
@@ -4521,7 +4521,7 @@ TEST (node, deferred_dependent_elections)
 
 	// Re-processing older blocks with updated work also does not start an election
 	node.work_generate_blocking (*open, open->difficulty () + 1);
-	node.process_active (open);
+	node.process_local (open, false);
 	node.block_processor.flush ();
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 	/// However, work is still updated
@@ -4536,7 +4536,7 @@ TEST (node, deferred_dependent_elections)
 	/// The election was dropped but it's still not possible to restart it
 	node.work_generate_blocking (*open, open->difficulty () + 1);
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
-	node.process_active (open);
+	node.process_local (open, false);
 	node.block_processor.flush ();
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 	/// However, work is still updated
@@ -4575,14 +4575,14 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), receive->hash ()));
 	ASSERT_FALSE (node.block (receive->hash ()));
-	node.process_active (receive);
+	node.process_local (receive, false);
 	node.block_processor.flush ();
 	ASSERT_TRUE (node.block (receive->hash ()));
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 
 	// Processing a fork will also not start an election
 	ASSERT_EQ (nano::process_result::fork, node.process (*fork).code);
-	node.process_active (fork);
+	node.process_local (fork, false);
 	node.block_processor.flush ();
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 
@@ -4592,7 +4592,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_TIMELY (2s, node.active.active (receive->qualified_root ()));
 	node.active.erase (*receive);
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
-	node.process_active (fork);
+	node.process_local (fork, false);
 	node.block_processor.flush ();
 	ASSERT_TRUE (node.active.active (receive->qualified_root ()));
 
@@ -4600,7 +4600,7 @@ TEST (node, deferred_dependent_elections)
 	node.active.erase (*fork);
 	ASSERT_FALSE (node.active.active (fork->qualified_root ()));
 	node.work_generate_blocking (*receive, receive->difficulty () + 1);
-	node.process_active (receive);
+	node.process_local (receive, false);
 	node.block_processor.flush ();
 	ASSERT_TRUE (node.active.active (receive->qualified_root ()));
 }

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -219,7 +219,7 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_EQ (vote->timestamp, existing->second.timestamp);
 	// Ensure the vote, from a local representative, was not broadcast on processing - it should be flooded on generation instead
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// Repeat test with no representative
 	// Erase account from the wallet
@@ -252,7 +252,7 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_EQ (vote2->timestamp, existing2->second.timestamp);
 	// Ensure the vote was broadcast
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_EQ (4, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// Repeat test with a PR in the wallet
 	// Increase the genesis weight again
@@ -286,5 +286,5 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_EQ (vote3->timestamp, existing3->second.timestamp);
 	// Ensure the vote wass not broadcasst
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
-	ASSERT_EQ (3, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_EQ (6, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 }

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -853,6 +853,10 @@ nano::election_insertion_result nano::active_transactions::insert_impl (nano::un
 		// Non-priority elections generate votes when they gain priority in the future
 		if (result.election && result.election->prioritized ())
 		{
+			if (!node.flags.disable_block_processor_republishing)
+			{
+				node.network.flood_block (block_a, nano::buffer_drop_policy::no_limiter_drop);
+			}
 			result.election->generate_votes ();
 		}
 	}

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -360,10 +360,6 @@ void nano::block_processor::process_live (nano::transaction const & transaction_
 	{
 		node.network.flood_block_initial (block_a);
 	}
-	else if (!node.flags.disable_block_processor_republishing)
-	{
-		node.network.flood_block (block_a, nano::buffer_drop_policy::no_limiter_drop);
-	}
 
 	if (node.websocket_server && node.websocket_server->any_subscriber (nano::websocket::topic::new_unconfirmed_block))
 	{

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -515,6 +515,10 @@ void nano::election::generate_votes () const
 {
 	if (node.config.enable_voting && node.wallets.reps ().voting > 0)
 	{
+		if (!node.flags.disable_block_processor_republishing)
+		{
+			node.network.flood_block (status.winner, nano::buffer_drop_policy::no_limiter_drop);
+		}
 		node.active.generator.add (root, winner ()->hash ());
 	}
 }


### PR DESCRIPTION
Rebroadcasting blocks only when an election is prioritized or confirmed. This will focus block propagation on blocks with an open election.  Included in V21.3, creating PR to merge into Develop. https://github.com/nanocurrency/nano-node/pull/3140/commits/c21ec84cfe49bd545198f2cbfa64095bd714e4b8