### PR TITLE
Fix typeo in FreeBSD CMake path.

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -10,9 +10,8 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(platform_sources plat/linux/priority.cpp plat/posix/perms.cpp
                        plat/linux/thread_role.cpp plat/linux/debugging.cpp)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  set(platform_sources
-      plat/default/priority.cpp plat/posix/perms.cpp
-      plat/freebsd/thread_role.cpp plat/plat/default/debugging.cpp)
+  set(platform_sources plat/default/priority.cpp plat/posix/perms.cpp
+                       plat/freebsd/thread_role.cpp plat/default/debugging.cpp)
 else()
   error("Unknown platform: ${CMAKE_SYSTEM_NAME}")
 endif()


### PR DESCRIPTION
Contribution from @mistakia. This replaces https://github.com/nanocurrency/nano-node/pull/3158 signing the code commit.