### PR TITLE
stop deploying live on latest

### DIFF
--- a/ci/actions/linux/deploy-docker.sh
+++ b/ci/actions/linux/deploy-docker.sh
@@ -6,9 +6,9 @@ scripts="$PWD/ci"
 TRAVIS_BRANCH=$(git branch | cut -f2 -d' ')
 tags=()
 if [ -n "$TRAVIS_TAG" ]; then
-    tags+=("$TRAVIS_TAG" latest)
+    tags+=("$TRAVIS_TAG")
     if [[ "$GITHUB_WORKFLOW" = "Beta" || "$GITHUB_WORKFLOW" = "Test" ]]; then
-        tags+=(latest-including-rc)
+        tags+=(latest latest-including-rc)
     fi
 elif [ -n "$TRAVIS_BRANCH" ]; then
     TRAVIS_TAG=$TRAVIS_BRANCH


### PR DESCRIPTION
closes #3182 
This change would stop deploying docker tag latest on live, instead requiring a version tag, which is already deployed to dockerhub