### PR TITLE
Fixing test issue found with asan.

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -12,7 +12,7 @@ namespace
 {
 void add_callback_stats (nano::node & node, std::vector<nano::block_hash> * observer_order = nullptr, nano::mutex * mutex = nullptr)
 {
-	node.observers.blocks.add ([& stats = node.stats, observer_order, mutex](nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::amount const &, bool) {
+	node.observers.blocks.add ([&stats = node.stats, observer_order, mutex] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::amount const &, bool) {
 		stats.inc (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out);
 		if (mutex)
 		{
@@ -31,7 +31,7 @@ nano::stat::detail get_stats_detail (nano::confirmation_height_mode mode_a)
 
 TEST (confirmation_height, single)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		auto amount (std::numeric_limits<nano::uint128_t>::max ());
 		nano::system system;
 		nano::node_flags node_flags;
@@ -80,7 +80,7 @@ TEST (confirmation_height, single)
 
 TEST (confirmation_height, multiple_accounts)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -218,7 +218,7 @@ TEST (confirmation_height, multiple_accounts)
 
 TEST (confirmation_height, gap_bootstrap)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -296,7 +296,7 @@ TEST (confirmation_height, gap_bootstrap)
 
 TEST (confirmation_height, gap_live)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -383,7 +383,7 @@ TEST (confirmation_height, gap_live)
 
 TEST (confirmation_height, send_receive_between_2_accounts)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -468,7 +468,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 
 TEST (confirmation_height, send_receive_self)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -531,7 +531,7 @@ TEST (confirmation_height, send_receive_self)
 
 TEST (confirmation_height, all_block_types)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -643,7 +643,7 @@ TEST (confirmation_height, all_block_types)
 /* Bulk of the this test was taken from the node.fork_flip test */
 TEST (confirmation_height, conflict_rollback_cemented)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		boost::iostreams::stream_buffer<nano::stringstream_mt_sink> sb;
 		sb.open (nano::stringstream_mt_sink{});
 		nano::boost_log_cerr_redirect redirect_cerr (&sb);
@@ -735,13 +735,13 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		uint64_t batch_write_size = 2048;
 		std::atomic<bool> stopped{ false };
 		nano::confirmation_height_unbounded unbounded_processor (
-		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [](auto const &) {}, [](auto const &) {}, []() { return 0; });
+		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
 
 		// Processing a block which doesn't exist should bail
 		ASSERT_DEATH_IF_SUPPORTED (unbounded_processor.process (send), "");
 
 		nano::confirmation_height_bounded bounded_processor (
-		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [](auto const &) {}, [](auto const &) {}, []() { return 0; });
+		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
 		// Processing a block which doesn't exist should bail
 		ASSERT_DEATH_IF_SUPPORTED (bounded_processor.process (send), "");
 	}
@@ -749,7 +749,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 
 TEST (confirmation_height, observers)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		auto amount (std::numeric_limits<nano::uint128_t>::max ());
 		nano::system system;
 		nano::node_flags node_flags;
@@ -813,7 +813,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		uint64_t batch_write_size = 2048;
 		std::atomic<bool> stopped{ false };
 		nano::confirmation_height_bounded bounded_processor (
-		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [](auto const &) {}, [](auto const &) {}, []() { return 0; });
+		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
 
 		{
 			// This reads the blocks in the account, but prevents any writes from occuring yet
@@ -832,7 +832,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		store->confirmation_height_put (store->tx_begin_write (), nano::genesis_account, { 1, nano::genesis_hash });
 
 		nano::confirmation_height_unbounded unbounded_processor (
-		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [](auto const &) {}, [](auto const &) {}, []() { return 0; });
+		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
 
 		{
 			// This reads the blocks in the account, but prevents any writes from occuring yet
@@ -886,7 +886,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		uint64_t batch_write_size = 2048;
 		std::atomic<bool> stopped{ false };
 		nano::confirmation_height_unbounded unbounded_processor (
-		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [](auto const &) {}, [](auto const &) {}, []() { return 0; });
+		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
 
 		{
 			// This reads the blocks in the account, but prevents any writes from occuring yet
@@ -906,7 +906,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		store->confirmation_height_put (store->tx_begin_write (), nano::genesis_account, { 1, nano::genesis_hash });
 
 		nano::confirmation_height_bounded bounded_processor (
-		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [](auto const &) {}, [](auto const &) {}, []() { return 0; });
+		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
 
 		{
 			// This reads the blocks in the account, but prevents any writes from occuring yet
@@ -925,7 +925,7 @@ namespace nano
 {
 TEST (confirmation_height, pending_observer_callbacks)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -967,7 +967,7 @@ TEST (confirmation_height, pending_observer_callbacks)
 // The callback and confirmation history should only be updated after confirmation height is set (and not just after voting)
 TEST (confirmation_height, callback_confirmed_history)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.force_use_write_database_queue = true;
@@ -1048,7 +1048,7 @@ namespace nano
 {
 TEST (confirmation_height, dependent_election)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -1099,7 +1099,7 @@ TEST (confirmation_height, dependent_election)
 // This test checks that a receive block with uncemented blocks below cements them too.
 TEST (confirmation_height, cemented_gap_below_receive)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -1184,7 +1184,7 @@ TEST (confirmation_height, cemented_gap_below_receive)
 // is the first write in this chain.
 TEST (confirmation_height, cemented_gap_below_no_cache)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -1267,7 +1267,7 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 
 TEST (confirmation_height, election_winner_details_clearing)
 {
-	auto test_mode = [](nano::confirmation_height_mode mode_a) {
+	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -1437,7 +1437,7 @@ TEST (confirmation_height, pruned_source)
 	std::atomic<bool> stopped{ false };
 	bool first_time{ true };
 	nano::confirmation_height_bounded bounded_processor (
-	ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [&](auto const & cemented_blocks_a) {
+	ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [&] (auto const & cemented_blocks_a) {
 		if (first_time)
 		{
 			// Prune the send
@@ -1445,6 +1445,6 @@ TEST (confirmation_height, pruned_source)
 			ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 2));
 		}
 		first_time = false; },
-	[](auto const &) {}, []() { return 0; });
+	[] (auto const &) {}, [] () { return 0; });
 	bounded_processor.process (open2);
 }

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -803,7 +803,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
+		std::shared_ptr<nano::block> send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, genesis, ledger.cache);
@@ -875,7 +875,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
 		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
-		auto open = std::make_shared<nano::state_block> (key1.pub, 0, 0, nano::Gxrb_ratio, send->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
+		std::shared_ptr<nano::block> open = std::make_shared<nano::state_block> (key1.pub, 0, 0, nano::Gxrb_ratio, send->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, genesis, ledger.cache);
@@ -1423,7 +1423,7 @@ TEST (confirmation_height, pruned_source)
 	auto open1 (std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 100, send1->hash (), key1.prv, key1.pub, *pool.generate (key1.pub)));
 	auto send2 (std::make_shared<nano::state_block> (key1.pub, open1->hash (), key1.pub, 50, key2.pub, key1.prv, key1.pub, *pool.generate (open1->hash ())));
 	auto send3 (std::make_shared<nano::state_block> (key1.pub, send2->hash (), key1.pub, 25, key2.pub, key1.prv, key1.pub, *pool.generate (send2->hash ())));
-	auto open2 (std::make_shared<nano::state_block> (key2.pub, 0, key1.pub, 50, send2->hash (), key2.prv, key2.pub, *pool.generate (key2.pub)));
+	std::shared_ptr<nano::block> open2 = std::make_shared<nano::state_block> (key2.pub, 0, key1.pub, 50, send2->hash (), key2.prv, key2.pub, *pool.generate (key2.pub));
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, genesis, ledger.cache);

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -10,7 +10,7 @@
 
 #include <numeric>
 
-nano::confirmation_height_bounded::confirmation_height_bounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
+nano::confirmation_height_bounded::confirmation_height_bounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, uint64_t & batch_write_size_a, std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void (nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
 ledger (ledger_a),
 write_database_queue (write_database_queue_a),
 batch_separate_pending_min_time (batch_separate_pending_min_time_a),
@@ -186,7 +186,7 @@ void nano::confirmation_height_bounded::process (std::shared_ptr<nano::block> or
 				receive_source_pairs.pop_back ();
 			}
 
-			auto total_pending_write_block_count = std::accumulate (pending_writes.cbegin (), pending_writes.cend (), uint64_t (0), [](uint64_t total, auto const & write_details_a) {
+			auto total_pending_write_block_count = std::accumulate (pending_writes.cbegin (), pending_writes.cend (), uint64_t (0), [] (uint64_t total, auto const & write_details_a) {
 				return total += write_details_a.top_height - write_details_a.bottom_height + 1;
 			});
 
@@ -381,7 +381,7 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 			const auto & pending = pending_writes.front ();
 			const auto & account = pending.account;
 
-			auto write_confirmation_height = [&account, &ledger = ledger, &transaction](uint64_t num_blocks_cemented, uint64_t confirmation_height, nano::block_hash const & confirmed_frontier) {
+			auto write_confirmation_height = [&account, &ledger = ledger, &transaction] (uint64_t num_blocks_cemented, uint64_t confirmation_height, nano::block_hash const & confirmed_frontier) {
 #ifndef NDEBUG
 				// Extra debug checks
 				nano::confirmation_height_info confirmation_height_info;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -30,7 +30,7 @@ awaiting_processing_size_callback (awaiting_processing_size_callback_a)
 // 3 - The last checkpoint hit.
 // 4 - The hash that was passed in originally. Either all checkpoints were exhausted (this can happen when there are many accounts to genesis)
 //     or all other blocks have been processed.
-nano::confirmation_height_bounded::top_and_next_hash nano::confirmation_height_bounded::get_next_block (boost::optional<top_and_next_hash> const & next_in_receive_chain_a, boost::circular_buffer_space_optimized<nano::block_hash> const & checkpoints_a, boost::circular_buffer_space_optimized<receive_source_pair> const & receive_source_pairs, boost::optional<receive_chain_details> & receive_details_a, std::shared_ptr<nano::block> original_block)
+nano::confirmation_height_bounded::top_and_next_hash nano::confirmation_height_bounded::get_next_block (boost::optional<top_and_next_hash> const & next_in_receive_chain_a, boost::circular_buffer_space_optimized<nano::block_hash> const & checkpoints_a, boost::circular_buffer_space_optimized<receive_source_pair> const & receive_source_pairs, boost::optional<receive_chain_details> & receive_details_a, nano::block const & original_block)
 {
 	top_and_next_hash next;
 	if (next_in_receive_chain_a.is_initialized ())
@@ -49,7 +49,7 @@ nano::confirmation_height_bounded::top_and_next_hash nano::confirmation_height_b
 	}
 	else
 	{
-		next = { original_block->hash (), boost::none, 0 };
+		next = { original_block.hash (), boost::none, 0 };
 	}
 
 	return next;
@@ -72,7 +72,7 @@ void nano::confirmation_height_bounded::process (std::shared_ptr<nano::block> or
 	do
 	{
 		boost::optional<receive_chain_details> receive_details;
-		auto hash_to_process = get_next_block (next_in_receive_chain, checkpoints, receive_source_pairs, receive_details, original_block);
+		auto hash_to_process = get_next_block (next_in_receive_chain, checkpoints, receive_source_pairs, receive_details, *original_block);
 		current = hash_to_process.top;
 
 		auto top_level_hash = current;

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -19,10 +19,10 @@ class write_guard;
 class confirmation_height_bounded final
 {
 public:
-	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, std::shared_ptr<nano::block> const &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
+	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
 	void clear_process_vars ();
-	void process ();
+	void process (std::shared_ptr<nano::block> original_block);
 	void cement_blocks (nano::write_guard & scoped_write_guard_a);
 
 private:
@@ -113,7 +113,7 @@ private:
 
 	nano::timer<std::chrono::milliseconds> timer;
 
-	top_and_next_hash get_next_block (boost::optional<top_and_next_hash> const &, boost::circular_buffer_space_optimized<nano::block_hash> const &, boost::circular_buffer_space_optimized<receive_source_pair> const & receive_source_pairs, boost::optional<receive_chain_details> &);
+	top_and_next_hash get_next_block (boost::optional<top_and_next_hash> const &, boost::circular_buffer_space_optimized<nano::block_hash> const &, boost::circular_buffer_space_optimized<receive_source_pair> const & receive_source_pairs, boost::optional<receive_chain_details> &, std::shared_ptr<nano::block> original_block);
 	nano::block_hash get_least_unconfirmed_hash_from_top_level (nano::transaction const &, nano::block_hash const &, nano::account const &, nano::confirmation_height_info const &, uint64_t &);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 	bool iterate (nano::read_transaction const &, uint64_t, nano::block_hash const &, boost::circular_buffer_space_optimized<nano::block_hash> &, nano::block_hash &, nano::block_hash const &, boost::circular_buffer_space_optimized<receive_source_pair> &, nano::account const &);
@@ -124,7 +124,6 @@ private:
 	nano::logging const & logging;
 	nano::logger_mt & logger;
 	std::atomic<bool> & stopped;
-	std::shared_ptr<nano::block> const & original_block;
 	uint64_t & batch_write_size;
 	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -113,7 +113,7 @@ private:
 
 	nano::timer<std::chrono::milliseconds> timer;
 
-	top_and_next_hash get_next_block (boost::optional<top_and_next_hash> const &, boost::circular_buffer_space_optimized<nano::block_hash> const &, boost::circular_buffer_space_optimized<receive_source_pair> const & receive_source_pairs, boost::optional<receive_chain_details> &, std::shared_ptr<nano::block> original_block);
+	top_and_next_hash get_next_block (boost::optional<top_and_next_hash> const &, boost::circular_buffer_space_optimized<nano::block_hash> const &, boost::circular_buffer_space_optimized<receive_source_pair> const & receive_source_pairs, boost::optional<receive_chain_details> &, nano::block const & original_block);
 	nano::block_hash get_least_unconfirmed_hash_from_top_level (nano::transaction const &, nano::block_hash const &, nano::account const &, nano::confirmation_height_info const &, uint64_t &);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 	bool iterate (nano::read_transaction const &, uint64_t, nano::block_hash const &, boost::circular_buffer_space_optimized<nano::block_hash> &, nano::block_hash &, nano::block_hash const &, boost::circular_buffer_space_optimized<receive_source_pair> &, nano::account const &);

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -19,7 +19,7 @@ class write_guard;
 class confirmation_height_bounded final
 {
 public:
-	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
+	confirmation_height_bounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, uint64_t &, std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void (nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
 	void clear_process_vars ();
 	void process (std::shared_ptr<nano::block> original_block);
@@ -125,8 +125,8 @@ private:
 	nano::logger_mt & logger;
 	std::atomic<bool> & stopped;
 	uint64_t & batch_write_size;
-	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
-	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;
+	std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
+	std::function<void (nano::block_hash const &)> notify_block_already_cemented_observers_callback;
 	std::function<uint64_t ()> awaiting_processing_size_callback;
 	nano::network_params network_params;
 

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -18,7 +18,7 @@ write_database_queue (write_database_queue_a),
 unbounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
 bounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
 // clang-format on
-thread ([this, &latch, mode_a]() {
+thread ([this, &latch, mode_a] () {
 	nano::thread_role::set (nano::thread_role::name::confirmation_height_processing);
 	// Do not start running the processing thread until other threads have finished their operations
 	latch.wait ();
@@ -84,7 +84,7 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 		}
 		else
 		{
-			auto lock_and_cleanup = [&lk, this]() {
+			auto lock_and_cleanup = [&lk, this] () {
 				lk.lock ();
 				original_block = nullptr;
 				original_hashes_pending.clear ();
@@ -171,13 +171,13 @@ void nano::confirmation_height_processor::set_next_hash ()
 }
 
 // Not thread-safe, only call before this processor has begun cementing
-void nano::confirmation_height_processor::add_cemented_observer (std::function<void(std::shared_ptr<nano::block> const &)> const & callback_a)
+void nano::confirmation_height_processor::add_cemented_observer (std::function<void (std::shared_ptr<nano::block> const &)> const & callback_a)
 {
 	cemented_observers.push_back (callback_a);
 }
 
 // Not thread-safe, only call before this processor has begun cementing
-void nano::confirmation_height_processor::add_block_already_cemented_observer (std::function<void(nano::block_hash const &)> const & callback_a)
+void nano::confirmation_height_processor::add_block_already_cemented_observer (std::function<void (nano::block_hash const &)> const & callback_a)
 {
 	block_already_cemented_observers.push_back (callback_a);
 }

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -44,8 +44,8 @@ public:
 	bool is_processing_block (nano::block_hash const &) const;
 	nano::block_hash current () const;
 
-	void add_cemented_observer (std::function<void(std::shared_ptr<nano::block> const &)> const &);
-	void add_block_already_cemented_observer (std::function<void(nano::block_hash const &)> const &);
+	void add_cemented_observer (std::function<void (std::shared_ptr<nano::block> const &)> const &);
+	void add_block_already_cemented_observer (std::function<void (nano::block_hash const &)> const &);
 
 private:
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::confirmation_height_processor) };
@@ -84,8 +84,8 @@ private:
 	nano::condition_variable condition;
 	std::atomic<bool> stopped{ false };
 	// No mutex needed for the observers as these should be set up during initialization of the node
-	std::vector<std::function<void(std::shared_ptr<nano::block> const &)>> cemented_observers;
-	std::vector<std::function<void(nano::block_hash const &)>> block_already_cemented_observers;
+	std::vector<std::function<void (std::shared_ptr<nano::block> const &)>> cemented_observers;
+	std::vector<std::function<void (nano::block_hash const &)>> block_already_cemented_observers;
 
 	nano::ledger & ledger;
 	nano::write_database_queue & write_database_queue;

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -8,7 +8,7 @@
 
 #include <numeric>
 
-nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
+nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, uint64_t & batch_write_size_a, std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void (nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
 ledger (ledger_a),
 write_database_queue (write_database_queue_a),
 batch_separate_pending_min_time (batch_separate_pending_min_time_a),
@@ -164,7 +164,7 @@ void nano::confirmation_height_unbounded::process (std::shared_ptr<nano::block> 
 		auto no_pending = awaiting_processing_size_callback () == 0;
 		auto should_output = finished_iterating && (no_pending || min_time_exceeded);
 
-		auto total_pending_write_block_count = std::accumulate (pending_writes.cbegin (), pending_writes.cend (), uint64_t (0), [](uint64_t total, conf_height_details const & receive_details_a) {
+		auto total_pending_write_block_count = std::accumulate (pending_writes.cbegin (), pending_writes.cend (), uint64_t (0), [] (uint64_t total, conf_height_details const & receive_details_a) {
 			return total += receive_details_a.num_blocks_confirmed;
 		});
 		auto force_write = total_pending_write_block_count > batch_write_size;
@@ -412,7 +412,7 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 				std::reverse (pending.block_callback_data.begin (), pending.block_callback_data.end ());
 
 				nano::lock_guard<nano::mutex> guard (block_cache_mutex);
-				std::transform (pending.block_callback_data.begin (), pending.block_callback_data.end (), std::back_inserter (cemented_blocks), [& block_cache = block_cache](auto const & hash_a) {
+				std::transform (pending.block_callback_data.begin (), pending.block_callback_data.end (), std::back_inserter (cemented_blocks), [&block_cache = block_cache] (auto const & hash_a) {
 					debug_assert (block_cache.count (hash_a) == 1);
 					return block_cache.at (hash_a);
 				});

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -8,14 +8,13 @@
 
 #include <numeric>
 
-nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, std::shared_ptr<nano::block> const & original_block_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
+nano::confirmation_height_unbounded::confirmation_height_unbounded (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, std::atomic<bool> & stopped_a, uint64_t & batch_write_size_a, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const & notify_observers_callback_a, std::function<void(nano::block_hash const &)> const & notify_block_already_cemented_observers_callback_a, std::function<uint64_t ()> const & awaiting_processing_size_callback_a) :
 ledger (ledger_a),
 write_database_queue (write_database_queue_a),
 batch_separate_pending_min_time (batch_separate_pending_min_time_a),
 logging (logging_a),
 logger (logger_a),
 stopped (stopped_a),
-original_block (original_block_a),
 batch_write_size (batch_write_size_a),
 notify_observers_callback (notify_observers_callback_a),
 notify_block_already_cemented_observers_callback (notify_block_already_cemented_observers_callback_a),
@@ -23,7 +22,7 @@ awaiting_processing_size_callback (awaiting_processing_size_callback_a)
 {
 }
 
-void nano::confirmation_height_unbounded::process ()
+void nano::confirmation_height_unbounded::process (std::shared_ptr<nano::block> original_block)
 {
 	if (pending_empty ())
 	{
@@ -117,7 +116,7 @@ void nano::confirmation_height_unbounded::process ()
 		auto already_traversed = iterated_height >= block_height;
 		if (!already_traversed)
 		{
-			collect_unconfirmed_receive_and_sources_for_account (block_height, iterated_height, block, current, account, read_transaction, receive_source_pairs, block_callback_datas_required, orig_block_callback_data);
+			collect_unconfirmed_receive_and_sources_for_account (block_height, iterated_height, block, current, account, read_transaction, receive_source_pairs, block_callback_datas_required, orig_block_callback_data, original_block);
 		}
 
 		// Exit early when the processor has been stopped, otherwise this function may take a
@@ -190,7 +189,7 @@ void nano::confirmation_height_unbounded::process ()
 	} while ((!receive_source_pairs.empty () || current != original_block->hash ()) && !stopped);
 }
 
-void nano::confirmation_height_unbounded::collect_unconfirmed_receive_and_sources_for_account (uint64_t block_height_a, uint64_t confirmation_height_a, std::shared_ptr<nano::block> const & block_a, nano::block_hash const & hash_a, nano::account const & account_a, nano::read_transaction const & transaction_a, std::vector<receive_source_pair> & receive_source_pairs_a, std::vector<nano::block_hash> & block_callback_data_a, std::vector<nano::block_hash> & orig_block_callback_data_a)
+void nano::confirmation_height_unbounded::collect_unconfirmed_receive_and_sources_for_account (uint64_t block_height_a, uint64_t confirmation_height_a, std::shared_ptr<nano::block> const & block_a, nano::block_hash const & hash_a, nano::account const & account_a, nano::read_transaction const & transaction_a, std::vector<receive_source_pair> & receive_source_pairs_a, std::vector<nano::block_hash> & block_callback_data_a, std::vector<nano::block_hash> & orig_block_callback_data_a, std::shared_ptr<nano::block> original_block)
 {
 	debug_assert (block_a->hash () == hash_a);
 	auto hash (hash_a);

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -20,7 +20,7 @@ class write_guard;
 class confirmation_height_unbounded final
 {
 public:
-	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
+	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, uint64_t &, std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void (nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
 	void clear_process_vars ();
 	void process (std::shared_ptr<nano::block> original_block);
@@ -104,8 +104,8 @@ private:
 	uint64_t & batch_write_size;
 	nano::logging const & logging;
 
-	std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
-	std::function<void(nano::block_hash const &)> notify_block_already_cemented_observers_callback;
+	std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
+	std::function<void (nano::block_hash const &)> notify_block_already_cemented_observers_callback;
 	std::function<uint64_t ()> awaiting_processing_size_callback;
 
 	friend class confirmation_height_dynamic_algorithm_no_transition_while_pending_Test;

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -20,10 +20,10 @@ class write_guard;
 class confirmation_height_unbounded final
 {
 public:
-	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, std::shared_ptr<nano::block> const & original_block_a, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
+	confirmation_height_unbounded (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, std::atomic<bool> &, uint64_t &, std::function<void(std::vector<std::shared_ptr<nano::block>> const &)> const &, std::function<void(nano::block_hash const &)> const &, std::function<uint64_t ()> const &);
 	bool pending_empty () const;
 	void clear_process_vars ();
-	void process ();
+	void process (std::shared_ptr<nano::block> original_block);
 	void cement_blocks (nano::write_guard &);
 	bool has_iterated_over_block (nano::block_hash const &) const;
 
@@ -92,7 +92,7 @@ private:
 		std::vector<nano::block_hash> const & orig_block_callback_data;
 	};
 
-	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &, std::vector<nano::block_hash> &);
+	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &, std::vector<nano::block_hash> &, std::shared_ptr<nano::block> original_block);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 
 	nano::network_params network_params;
@@ -101,7 +101,6 @@ private:
 	std::chrono::milliseconds batch_separate_pending_min_time;
 	nano::logger_mt & logger;
 	std::atomic<bool> & stopped;
-	std::shared_ptr<nano::block> const & original_block;
 	uint64_t & batch_write_size;
 	nano::logging const & logging;
 


### PR DESCRIPTION
Fixing an issue discovered by asan where confirmation_height_unbounded was holding a reference to a temporary which converted std::shared_ptr<nano::state_block> to std::shared_ptr<nano::block>.