### PR TITLE
Modernize active_transactions::restart

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1042,9 +1042,8 @@ bool nano::active_transactions::update_difficulty_impl (nano::active_transaction
 	return error;
 }
 
-bool nano::active_transactions::restart (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & block_a)
+void nano::active_transactions::restart (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & block_a)
 {
-	bool error = true;
 	auto hash (block_a->hash ());
 	auto ledger_block (node.store.block_get (transaction_a, hash));
 	if (ledger_block != nullptr && ledger_block->block_work () != block_a->block_work () && !node.block_confirmed_or_being_confirmed (transaction_a, hash))
@@ -1061,17 +1060,14 @@ bool nano::active_transactions::restart (nano::transaction const & transaction_a
 			// Restart election for the upgraded block, previously dropped from elections
 			if (node.ledger.dependents_confirmed (transaction_a, *ledger_block))
 			{
+				node.stats.inc (nano::stat::type::election, nano::stat::detail::election_restart);
 				auto previous_balance = node.ledger.balance (transaction_a, ledger_block->previous ());
-				auto insert_result = insert (ledger_block, previous_balance);
-				if (insert_result.inserted)
-				{
-					error = false;
-					node.stats.inc (nano::stat::type::election, nano::stat::detail::election_restart);
-				}
+				auto block_has_account = ledger_block->type () == nano::block_type::state || ledger_block->type () == nano::block_type::open;
+				auto account = block_has_account ? ledger_block->account () : ledger_block->sideband ().account;
+				activate (account);
 			}
 		}
 	}
-	return error;
 }
 
 double nano::active_transactions::normalized_multiplier (nano::block const & block_a, boost::optional<nano::active_transactions::roots_iterator> const & root_it_a) const

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -172,7 +172,7 @@ public:
 	// Returns false if the election difficulty was updated
 	bool update_difficulty (std::shared_ptr<nano::block> const &, bool);
 	// Returns false if the election was restarted
-	bool restart (nano::transaction const &, std::shared_ptr<nano::block> const &);
+	void restart (nano::transaction const &, std::shared_ptr<nano::block> const &);
 	// Returns a list of elections sorted by difficulty
 	std::vector<std::shared_ptr<nano::election>> list_active (size_t = std::numeric_limits<size_t>::max ());
 	double normalized_multiplier (nano::block const &, boost::optional<roots_iterator> const & = boost::none) const;

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -553,8 +553,9 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 
 void nano::block_processor::process_old (nano::transaction const & transaction_a, std::shared_ptr<nano::block> const & block_a, nano::block_origin const origin_a)
 {
+	node.active.restart (transaction_a, block_a);
 	// First try to update election difficulty, then attempt to restart an election
-	if (!node.active.update_difficulty (block_a, true) || !node.active.restart (transaction_a, block_a))
+	if (!node.active.update_difficulty (block_a, true))
 	{
 		// Let others know about the difficulty update
 		if (origin_a == nano::block_origin::local)


### PR DESCRIPTION
This removes the return value from active_transactions::restart which indicates if the election has been immediately restarted. This is incompatible with the election scheduler that will not immediately start elections.