### PR TITLE
Payment notification

### DIFF
--- a/nano/core_test/fakes/websocket_client.hpp
+++ b/nano/core_test/fakes/websocket_client.hpp
@@ -6,6 +6,8 @@
 #include <nano/boost/beast/websocket.hpp>
 #include <nano/node/websocket.hpp>
 
+#include <boost/property_tree/json_parser.hpp>
+
 #include <chrono>
 
 using namespace std::chrono_literals;
@@ -65,6 +67,18 @@ public:
 		});
 		ioc.run_one_for (deadline);
 		return result;
+	}
+
+	boost::property_tree::ptree string_to_json (boost::optional<std::string> const & string_a)
+	{
+		boost::property_tree::ptree event;
+		if (string_a)
+		{
+			std::stringstream stream;
+			stream << string_a.get ();
+			boost::property_tree::read_json (stream, event);
+		}
+		return event;
 	}
 
 private:

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -278,6 +278,27 @@ std::string nano::error_config_messages::message (int ev) const
 	return "Invalid error code";
 }
 
+std::string nano::error_payment_tracking_messages::message (int ev) const
+{
+	switch (static_cast<nano::error_payment_tracking> (ev))
+	{
+		case nano::error_payment_tracking::generic:
+			return "Unknown payment tracking error";
+		case nano::error_payment_tracking::invalid_tracking_policy:
+			return "Invalid or missing tracking policy";
+		case nano::error_payment_tracking::invalid_timeout:
+			return "Invalid or missing timeout";
+		case nano::error_payment_tracking::invalid_minimum_amount:
+			return "Invalid or missing minimum amount for account tracking";
+		case nano::error_payment_tracking::invalid_tracking_account:
+			return "Invalid or missing account for account tracking";
+		case nano::error_payment_tracking::invalid_tracking_block:
+			return "Invalid or missing block for block tracking";
+	}
+
+	return "Invalid error code";
+}
+
 const char * nano::error_conversion::detail::generic_category::name () const noexcept
 {
 	return boost::system::generic_category ().name ();

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -151,6 +151,21 @@ enum class error_config
 	invalid_value,
 	missing_value
 };
+
+/**
+ * Payment tracking option errors.
+ * The error code value is part of the documentation and must thus not be changed.
+ */
+enum class error_payment_tracking
+{
+	generic = 1,
+	invalid_tracking_policy = 2,
+	invalid_timeout = 3,
+	invalid_minimum_amount = 4,
+	invalid_tracking_account = 5,
+	invalid_tracking_block = 6
+};
+
 } // nano namespace
 
 // Convenience macro to implement the standard boilerplate for using std::error_code with enums
@@ -194,6 +209,7 @@ REGISTER_ERROR_CODES (nano, error_blocks);
 REGISTER_ERROR_CODES (nano, error_rpc);
 REGISTER_ERROR_CODES (nano, error_process);
 REGISTER_ERROR_CODES (nano, error_config);
+REGISTER_ERROR_CODES (nano, error_payment_tracking);
 
 /* boost->std error_code bridge */
 namespace nano

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -140,6 +140,8 @@ add_library(
   websocket.cpp
   websocketconfig.hpp
   websocketconfig.cpp
+  websocket_payment_tracking.hpp
+  websocket_payment_tracking.cpp
   write_database_queue.hpp
   write_database_queue.cpp
   xorshift.hpp)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -135,8 +135,10 @@ node_seq (seq)
 		if (config.websocket_config.enabled)
 		{
 			auto endpoint_l (nano::tcp_endpoint (boost::asio::ip::make_address_v6 (config.websocket_config.address), config.websocket_config.port));
-			websocket_payment_validator = std::make_shared<nano::websocket::payment_validator> (*this);
-			websocket_server = std::make_shared<nano::websocket::listener> (websocket_payment_validator, logger, wallets, io_ctx, endpoint_l);
+			auto validator_l (std::make_unique<nano::websocket::payment_validator> (io_ctx, worker, ledger, logger, [this](std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a) {
+				this->process_local (block_a, work_watcher_a);
+			}));
+			websocket_server = std::make_shared<nano::websocket::listener> (std::move (validator_l), logger, wallets, io_ctx, endpoint_l);
 			this->websocket_server->run ();
 		}
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -135,7 +135,7 @@ node_seq (seq)
 		if (config.websocket_config.enabled)
 		{
 			auto endpoint_l (nano::tcp_endpoint (boost::asio::ip::make_address_v6 (config.websocket_config.address), config.websocket_config.port));
-			auto validator_l (std::make_unique<nano::websocket::payment_validator> (io_ctx, worker, ledger, logger, [this](std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a) {
+			auto validator_l (std::make_unique<nano::websocket::payment_validator> (io_ctx, workers, ledger, logger, [this](std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a) {
 				this->process_local (block_a, work_watcher_a);
 			}));
 			websocket_server = std::make_shared<nano::websocket::listener> (std::move (validator_l), logger, wallets, io_ctx, endpoint_l);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -45,6 +45,7 @@ namespace nano
 namespace websocket
 {
 	class listener;
+	class payment_validator;
 }
 class node;
 class telemetry;
@@ -156,6 +157,7 @@ public:
 	nano::node_config config;
 	nano::stat stats;
 	nano::thread_pool workers;
+	std::shared_ptr<nano::websocket::payment_validator> websocket_payment_validator;
 	std::shared_ptr<nano::websocket::listener> websocket_server;
 	nano::node_flags flags;
 	nano::work_pool & work;

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -160,7 +160,7 @@ namespace websocket
 		std::string tracked_account;
 
 		/** Set only if tracking a block */
-		std::shared_ptr<nano::state_block> tracked_block;
+		std::unique_ptr<nano::state_block> tracked_block;
 
 		/** Tracking a block also means publishing it. With this flag enabled, work is watched. */
 		bool watch_work{ false };
@@ -329,7 +329,7 @@ namespace websocket
 	class listener final : public std::enable_shared_from_this<listener>
 	{
 	public:
-		listener (std::shared_ptr<nano::websocket::payment_validator> const & payment_validator_a, nano::logger_mt & logger_a, nano::wallets & wallets_a, boost::asio::io_context & io_ctx_a, boost::asio::ip::tcp::endpoint endpoint_a);
+		listener (std::unique_ptr<nano::websocket::payment_validator> payment_validator_a, nano::logger_mt & logger_a, nano::wallets & wallets_a, boost::asio::io_context & io_ctx_a, boost::asio::ip::tcp::endpoint endpoint_a);
 
 		/** Start accepting connections */
 		void run ();
@@ -338,6 +338,12 @@ namespace websocket
 
 		/** Close all websocket sessions and stop listening for new connections */
 		void stop ();
+
+		/** Returns true if the websocket server has stopped */
+		bool is_stopped () const
+		{
+			return stopped;
+		}
 
 		/** Broadcast block confirmation. The content of the message depends on subscription options (such as "include_block") */
 		void broadcast_confirmation (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, nano::amount const & amount_a, std::string const & subtype, nano::election_status const & election_status_a);
@@ -361,9 +367,9 @@ namespace websocket
 			return wallets;
 		}
 
-		std::shared_ptr<nano::websocket::payment_validator> get_payment_validator ()
+		nano::websocket::payment_validator & get_payment_validator ()
 		{
-			return payment_validator;
+			return *payment_validator;
 		}
 
 		/**
@@ -392,7 +398,7 @@ namespace websocket
 		/** Removes from subscription count of a specific topic*/
 		void decrease_subscriber_count (nano::websocket::topic const & topic_a);
 
-		std::shared_ptr<nano::websocket::payment_validator> payment_validator;
+		std::unique_ptr<nano::websocket::payment_validator> payment_validator;
 		nano::logger_mt & logger;
 		nano::wallets & wallets;
 		boost::asio::ip::tcp::acceptor acceptor;

--- a/nano/node/websocket_payment_tracking.cpp
+++ b/nano/node/websocket_payment_tracking.cpp
@@ -145,7 +145,7 @@ void nano::websocket::payment_validator::check_payment (nano::account const & de
 	}
 }
 
-void nano::websocket::payment_validator::publish_block (std::shared_ptr<nano::block> block_a, bool const work_watcher_a)
+void nano::websocket::payment_validator::publish_block (std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a)
 {
 	// Delegate to worker thread, as publishing the block involves a write transaction
 	worker.push_task ([publish_handler = publish_handler, block_a, work_watcher_a]() {

--- a/nano/node/websocket_payment_tracking.cpp
+++ b/nano/node/websocket_payment_tracking.cpp
@@ -1,0 +1,192 @@
+#include <nano/lib/config.hpp>
+#include <nano/lib/logger_mt.hpp>
+#include <nano/node/common.hpp>
+#include <nano/node/node.hpp>
+#include <nano/node/websocket.hpp>
+#include <nano/node/websocket_payment_tracking.hpp>
+#include <nano/secure/blockstore.hpp>
+#include <nano/secure/ledger.hpp>
+
+void nano::websocket::payment_tracker::track (nano::websocket::payment_tracking_options const & options_a)
+{
+	auto tracked_l = tracked_accounts.lock ();
+	std::chrono::seconds track_until (nano::seconds_since_epoch () + options_a.max_tracking_duration.count ());
+
+	// Add or update tracking information
+	tracked_l->erase (options_a.tracked_account);
+	tracked_l->try_emplace (options_a.tracked_account, options_a.id, options_a.tracked_block, options_a.minimum_amount, options_a.tracking_policy, track_until);
+}
+
+void nano::websocket::payment_tracker::untrack (std::string const & account_a)
+{
+	auto tracked_l = tracked_accounts.lock ();
+	tracked_l->erase (account_a);
+}
+
+void nano::websocket::payment_tracker::for_each (std::function<void(std::string const &, nano::websocket::payment_tracker::payment_tracking_info const &)> callback_a)
+{
+	// The callback may make changes to the tracked map (in order to untrack), so we take a snapshot.
+	// This also enables us to quickly release the lock before the callbacks do their processing.
+	std::unordered_map<std::string, payment_tracking_info> currently_tracked_l;
+	{
+		auto tracked_l = tracked_accounts.lock ();
+		currently_tracked_l = *tracked_l;
+	}
+
+	for (auto item : currently_tracked_l)
+	{
+		callback_a (item.first, item.second);
+	}
+}
+
+std::optional<nano::websocket::payment_tracker::payment_tracking_info> nano::websocket::payment_tracker::get_tracking_info (std::string const & account_a)
+{
+	auto tracked_l = tracked_accounts.lock ();
+	auto const & match_l = tracked_l->find (account_a);
+	if (match_l != tracked_l->end ())
+	{
+		return std::optional<nano::websocket::payment_tracker::payment_tracking_info> (match_l->second);
+	}
+	return std::nullopt;
+}
+
+bool nano::websocket::payment_tracker::update_partial_payment_amount (std::string const & account_a, nano::amount const & amount_a)
+{
+	auto different_amount_l (false);
+	auto tracked_l = tracked_accounts.lock ();
+	auto const & match_l = tracked_l->find (account_a);
+	if (match_l != tracked_l->end ())
+	{
+		different_amount_l = match_l->second.last_sent_partial_amount != amount_a;
+		if (different_amount_l)
+		{
+			match_l->second.last_sent_partial_amount = amount_a;
+		}
+	}
+
+	return different_amount_l;
+}
+
+nano::websocket::payment_validator::payment_validator (nano::node & node_a) :
+node (node_a), payment_tracker_timer (node.io_ctx)
+{
+	ongoing_payment_tracking ();
+}
+
+void nano::websocket::payment_validator::check_payment (nano::account const & destination_account_a, nano::block_hash const & block_hash_a, std::shared_ptr<nano::websocket::session> const & session_a)
+{
+	auto account_string_l (destination_account_a.to_account ());
+	auto tracking_info_l (session_a->get_payment_tracker ().get_tracking_info (account_string_l));
+	if (tracking_info_l)
+	{
+		nano::websocket::message_builder builder_l;
+		nano::amount pending_l (0);
+		nano::amount balance_l (0);
+
+		auto tx_read_l (node.ledger.store.tx_begin_read ());
+		nano::confirmation_height_info confirmation_height_info_l;
+		std::optional<std::reference_wrapper<nano::confirmation_height_info>> optional_confirmation_height_info_l{ std::nullopt };
+
+		// Get confirmed balance if available
+		if (!node.ledger.store.confirmation_height_get (tx_read_l, destination_account_a, confirmation_height_info_l))
+		{
+			balance_l = node.ledger.balance (tx_read_l, confirmation_height_info_l.frontier);
+		}
+
+		// Sum up pending entries where the source send block is confirmed
+		pending_l = node.ledger.account_pending_confirmed (tx_read_l, destination_account_a);
+
+		if (tracking_info_l->tracking_policy == nano::websocket::payment_tracker::policy::account)
+		{
+			// Total confirmed balance
+			nano::amount total_balance_l (pending_l.number () + balance_l.number ());
+
+			if (total_balance_l.number () >= tracking_info_l->minimum_amount.number ())
+			{
+				auto notification = builder_l.payment_notification (*tracking_info_l, destination_account_a, balance_l, pending_l, optional_confirmation_height_info_l, false);
+				session_a->write (notification);
+				session_a->get_payment_tracker ().untrack (destination_account_a.to_account ());
+
+				node.logger.always_log ("Websocket: sent payment notification for account: ", account_string_l);
+			}
+			else if (!total_balance_l.number ().is_zero ())
+			{
+				// Send partial payment notification if the amount is different than last time
+				if (session_a->get_payment_tracker ().update_partial_payment_amount (destination_account_a.to_account (), total_balance_l))
+				{
+					auto notification = builder_l.payment_notification (*tracking_info_l, destination_account_a, balance_l, pending_l, optional_confirmation_height_info_l, true);
+					session_a->write (notification);
+
+					node.logger.always_log ("Websocket: sent partial payment notification for account: ", account_string_l);
+				}
+			}
+		}
+		else if (tracking_info_l->tracking_policy == nano::websocket::payment_tracker::policy::block)
+		{
+			if (node.ledger.block_confirmed (tx_read_l, block_hash_a) || (node.ledger.pruning && node.ledger.store.pruned_exists (tx_read_l, block_hash_a)))
+			{
+				auto notification_l = builder_l.payment_notification (*tracking_info_l, destination_account_a, balance_l, pending_l, optional_confirmation_height_info_l, false);
+				session_a->write (notification_l);
+				session_a->get_payment_tracker ().untrack (destination_account_a.to_account ());
+
+				node.logger.always_log ("Websocket: sent payment notification for account: ", account_string_l, ", tracking block hash: ", block_hash_a.to_string ());
+			}
+		}
+		else
+		{
+			debug_assert (false);
+		}
+	}
+}
+
+void nano::websocket::payment_validator::publish_block (std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a)
+{
+	// Delegate to worker thread, as publishing the block involves a write transaction
+	node.worker.push_task ([node = node.shared (), block_a, work_watcher_a]() {
+		node->process_local (block_a, work_watcher_a);
+	});
+}
+
+void nano::websocket::payment_validator::ongoing_payment_tracking ()
+{
+	static nano::network_constants network_constants;
+	payment_tracker_timer.expires_from_now (network_constants.is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (5));
+	payment_tracker_timer.async_wait ([this](const boost::system::error_code & ec) {
+		if (!node.stopped && !ec)
+		{
+			auto sessions_l (node.websocket_server->find_sessions (nano::websocket::topic::payment));
+			for (auto & session_ptr : sessions_l)
+			{
+				std::vector<std::string> timed_out_l;
+				session_ptr->get_payment_tracker ().for_each ([this, &timed_out_l, &session_ptr](std::string const & account_a, nano::websocket::payment_tracker::payment_tracking_info const & tracking_info_l) {
+					nano::account destination_account_l;
+					destination_account_l.decode_account (account_a);
+
+					if (nano::seconds_since_epoch () > tracking_info_l.track_until.count ())
+					{
+						timed_out_l.push_back (account_a);
+					}
+					else
+					{
+						nano::block_hash block_hash_l;
+						if (tracking_info_l.tracked_block)
+						{
+							block_hash_l = tracking_info_l.tracked_block->hash ();
+						}
+
+						check_payment (destination_account_l, block_hash_l, session_ptr);
+					}
+				});
+
+				// Remove timed-out trackings
+				for (auto const & account : timed_out_l)
+				{
+					node.logger.always_log ("Websocket: payment tracking timed out for account: ", account);
+					session_ptr->get_payment_tracker ().untrack (account);
+				}
+			}
+
+			ongoing_payment_tracking ();
+		}
+	});
+}

--- a/nano/node/websocket_payment_tracking.cpp
+++ b/nano/node/websocket_payment_tracking.cpp
@@ -152,9 +152,9 @@ void nano::websocket::payment_validator::ongoing_payment_tracking ()
 	static nano::network_constants network_constants;
 	payment_tracker_timer.expires_from_now (network_constants.is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (5));
 	payment_tracker_timer.async_wait ([this](const boost::system::error_code & ec) {
-		if (!node.stopped && !ec)
+		if (!this->node.stopped && !ec)
 		{
-			auto sessions_l (node.websocket_server->find_sessions (nano::websocket::topic::payment));
+			auto sessions_l (this->node.websocket_server->find_sessions (nano::websocket::topic::payment));
 			for (auto & session_ptr : sessions_l)
 			{
 				std::vector<std::string> timed_out_l;
@@ -174,19 +174,19 @@ void nano::websocket::payment_validator::ongoing_payment_tracking ()
 							block_hash_l = tracking_info_l.tracked_block->hash ();
 						}
 
-						check_payment (destination_account_l, block_hash_l, session_ptr);
+						this->check_payment (destination_account_l, block_hash_l, session_ptr);
 					}
 				});
 
 				// Remove timed-out trackings
 				for (auto const & account : timed_out_l)
 				{
-					node.logger.always_log ("Websocket: payment tracking timed out for account: ", account);
+					this->node.logger.always_log ("Websocket: payment tracking timed out for account: ", account);
 					session_ptr->get_payment_tracker ().untrack (account);
 				}
 			}
 
-			ongoing_payment_tracking ();
+			this->ongoing_payment_tracking ();
 		}
 	});
 }

--- a/nano/node/websocket_payment_tracking.cpp
+++ b/nano/node/websocket_payment_tracking.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/config.hpp>
 #include <nano/lib/logger_mt.hpp>
-#include <nano/lib/worker.hpp>
+#include <nano/lib/threading.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/websocket.hpp>
@@ -74,7 +74,7 @@ bool nano::websocket::payment_tracker::update_partial_payment_amount (std::strin
 	return different_amount_l;
 }
 
-nano::websocket::payment_validator::payment_validator (boost::asio::io_context & io_ctx_a, nano::worker & worker_a, nano::ledger & ledger_a, nano::logger_mt & logger_a, std::function<void(std::shared_ptr<nano::block> const &, bool const)> publish_handler_a) :
+nano::websocket::payment_validator::payment_validator (boost::asio::io_context & io_ctx_a, nano::thread_pool & worker_a, nano::ledger & ledger_a, nano::logger_mt & logger_a, std::function<void(std::shared_ptr<nano::block> const &, bool const)> publish_handler_a) :
 worker (worker_a), ledger (ledger_a), logger (logger_a), publish_handler (publish_handler_a), payment_tracker_timer (io_ctx_a)
 {
 }

--- a/nano/node/websocket_payment_tracking.cpp
+++ b/nano/node/websocket_payment_tracking.cpp
@@ -100,7 +100,7 @@ void nano::websocket::payment_validator::check_payment (nano::account const & de
 		}
 
 		// Sum up pending entries where the source send block is confirmed
-		pending_l = ledger.account_pending_confirmed (tx_read_l, destination_account_a);
+		pending_l = ledger.account_pending (tx_read_l, destination_account_a, true);
 
 		if (tracking_info_l->tracking_policy == nano::websocket::payment_tracker::policy::account)
 		{

--- a/nano/node/websocket_payment_tracking.hpp
+++ b/nano/node/websocket_payment_tracking.hpp
@@ -15,7 +15,7 @@ namespace nano
 {
 class ledger;
 class logger_mt;
-class worker;
+class thread_pool;
 }
 
 namespace nano::websocket
@@ -94,7 +94,7 @@ private:
 class payment_validator final
 {
 public:
-	payment_validator (boost::asio::io_context & io_ctx_a, nano::worker & worker_a, nano::ledger & ledger_a, nano::logger_mt & logger_a, std::function<void(std::shared_ptr<nano::block> const &, bool const)> publish_handler_a);
+	payment_validator (boost::asio::io_context & io_ctx_a, nano::thread_pool & worker_a, nano::ledger & ledger_a, nano::logger_mt & logger_a, std::function<void(std::shared_ptr<nano::block> const &, bool const)> publish_handler_a);
 
 	/** Starts ongoing payment tracking */
 	void start (std::shared_ptr<nano::websocket::listener> const & websocket_server_a);
@@ -106,7 +106,7 @@ public:
 	void publish_block (std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a);
 
 private:
-	nano::worker & worker;
+	nano::thread_pool & worker;
 	std::shared_ptr<nano::websocket::listener> websocket_server;
 	nano::ledger & ledger;
 	nano::logger_mt & logger;

--- a/nano/node/websocket_payment_tracking.hpp
+++ b/nano/node/websocket_payment_tracking.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/errors.hpp>
+#include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+
+#include <boost/asio/steady_timer.hpp>
+
+#include <memory>
+#include <string>
+
+namespace nano
+{
+class node;
+}
+
+namespace nano::websocket
+{
+class session;
+class payment_tracking_options;
+
+/** Per-session tracking of payment destination accounts. This class is thread-safe. */
+class payment_tracker
+{
+public:
+	/** Payment tracking policies */
+	enum policy
+	{
+		invalid,
+		/** Track total balance of an account (account per payment use-case) */
+		account,
+		/** Track confirmation of a send state block (hand-off use-case) */
+		block
+	};
+
+	/** Tracking info based on payment subscription options */
+	class payment_tracking_info
+	{
+	public:
+		payment_tracking_info (std::string id_a, std::shared_ptr<nano::state_block> const & tracked_block_a, nano::amount const & minimum_amount_a, nano::websocket::payment_tracker::policy tracking_policy_a, std::chrono::seconds track_until_a) :
+		id (id_a), tracked_block (tracked_block_a), minimum_amount (minimum_amount_a), last_sent_partial_amount (0), tracking_policy (tracking_policy_a), track_until (track_until_a)
+		{
+		}
+
+		/** The id provided through the Websocket subscription. This can be used by external systems to match up payment notifications. */
+		std::string id;
+
+		/** Tracked block, if any */
+		std::shared_ptr<nano::state_block> tracked_block;
+
+		/** The minimum amount required for a payment notification to be sent */
+		nano::amount minimum_amount;
+
+		/** If there's a partial payment (below minimum amount), we send a partial_payment notification. This is only done once per partial amount. */
+		nano::amount last_sent_partial_amount;
+
+		/** The requested tracking policy */
+		nano::websocket::payment_tracker::policy tracking_policy;
+
+		/** Tracking until this many seconds since epoch */
+		std::chrono::seconds track_until;
+	};
+
+	/** Start tracking a destination account based on websocket options for the payment subscription */
+	void track (nano::websocket::payment_tracking_options const & options_a);
+
+	/** Stop tracking this destination account */
+	void untrack (std::string const & account_a);
+
+	/**
+	 * Update the last-sent partial payment amount
+	 * @param account_a Account being tracked
+	 * @param amount_a The current total balance
+	 * @return true if the amount is different from what is previously recorded. This causes a partial_payment message to be sent.
+	 */
+	bool update_partial_payment_amount (std::string const & account_a, nano::amount const & amount_a);
+
+	/** Get tracking info for the given account, if available */
+	std::optional<payment_tracking_info> get_tracking_info (std::string const & account_a);
+
+	/** For each tracked account by this session, invoke \p callback_a */
+	void for_each (std::function<void(std::string const &, payment_tracking_info const &)> callback_a);
+
+private:
+	nano::locked<std::unordered_map<std::string, payment_tracking_info>> tracked_accounts;
+};
+
+/** Interacts with the node to hand off send blocks, and queries the ledger for confirmation status and balances */
+class payment_validator
+{
+public:
+	/** Starts ongoing payment tracking */
+	payment_validator (nano::node & node_a);
+
+	/** Check if the payment conditions are met, and if so, send notification to websocket client */
+	void check_payment (nano::account const & destination_account_a, nano::block_hash const & block_hash_a, std::shared_ptr<nano::websocket::session> const & session_a);
+
+	/** Publish a send state block to the network */
+	void publish_block (std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a);
+
+private:
+	nano::node & node;
+	boost::asio::steady_timer payment_tracker_timer;
+
+	/** Periodically check tracked payments to handle cases where clients miss notifications or resubscribes. */
+	void ongoing_payment_tracking ();
+};
+}

--- a/nano/node/websocket_payment_tracking.hpp
+++ b/nano/node/websocket_payment_tracking.hpp
@@ -15,7 +15,6 @@ namespace nano
 {
 class ledger;
 class logger_mt;
-class node;
 class worker;
 }
 
@@ -104,7 +103,7 @@ public:
 	void check_payment (nano::account const & destination_account_a, nano::block_hash const & block_hash_a, std::shared_ptr<nano::websocket::session> const & session_a);
 
 	/** Publish a send state block to the network */
-	void publish_block (std::shared_ptr<nano::block> block_a, bool const work_watcher_a);
+	void publish_block (std::shared_ptr<nano::block> const & block_a, bool const work_watcher_a);
 
 private:
 	nano::worker & worker;


### PR DESCRIPTION
This PR attempts to provide an easy and reliable way to get payment notifications, through a Websocket subscription. It's an alternative to block confirmation/pending/balance checks, and supports single-use accounts and block hand-off.

Preliminary documentation: https://github.com/cryptocode/notes/wiki/Websocket-Payment-Tracking

 It adds ledger functionality similar to #3022 - will move this PR to those ledger functions once they're merged.