### PR TITLE
Elections/prioritized confirm req

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -188,7 +188,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			}
 			break;
 		case nano::election::state_t::active:
-			if(prioritized_m)
+			if (prioritized_m)
 			{
 				send_confirm_req (solicitor_a);
 			}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -188,7 +188,10 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			}
 			break;
 		case nano::election::state_t::active:
-			send_confirm_req (solicitor_a);
+			if(prioritized_m)
+			{
+				send_confirm_req (solicitor_a);
+			}
 			if (confirmation_request_count > active_request_count_min)
 			{
 				state_change (nano::election::state_t::active, nano::election::state_t::broadcasting);


### PR DESCRIPTION
As elections are started, they are inserted into the active roots as passive, then transition to active after 5 seconds and begin to solicit votes from PR's where a vote has not yet been seen. In V21 the concept of prioritized elections was added that limits vote generation to just the top 5,000 elections in the active roots container. Under some circumstances an election with low PoW could be in the roots container as active after 5 seconds and could result in a node requesting votes even though it has not been prioritized yet.

PR's that receive the requests do not differentiate whether an election is prioritized or not when responding to a vote request, they only check that dependencies are confirmed.

This scenario can then bypass the prioritization so this change limits sending confirm_req messages to only elections that have been prioritized.