### PR TITLE
Qt test wallet status with peer

### DIFF
--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -67,15 +67,14 @@ TEST (wallet, status_with_peer)
 {
 	nano_qt::eventloop_processor processor;
 	nano::system system (2);
-	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
+	auto wallet_l = system.nodes[0]->wallets.create (nano::random_wallet_id ());
 	nano::keypair key;
 	wallet_l->insert_adhoc (key.prv);
-	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub));
+	auto wallet = std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub);
 	wallet->start ();
 	auto wallet_has = [wallet] (nano_qt::status_types status_ty) {
 		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
 	};
-	system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000), 0);
 	// Because of the wallet "vulnerable" message, this won't be the message displayed.
 	// However, it will still be part of the status set.
 	ASSERT_FALSE (wallet_has (nano_qt::status_types::synchronizing));

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -62,6 +62,38 @@ TEST (wallet, DISABLED_status)
 	ASSERT_TRUE (wallet_has (nano_qt::status_types::disconnected));
 }
 
+// this test is modelled on wallet.status but it introduces another node on the network
+TEST (wallet, status_with_peer)
+{
+	nano_qt::eventloop_processor processor;
+	nano::system system (2);
+	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
+	nano::keypair key;
+	wallet_l->insert_adhoc (key.prv);
+	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub));
+	wallet->start ();
+	auto wallet_has = [wallet] (nano_qt::status_types status_ty) {
+		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
+	};
+	system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000), 0);
+	// Because of the wallet "vulnerable" message, this won't be the message displayed.
+	// However, it will still be part of the status set.
+	ASSERT_FALSE (wallet_has (nano_qt::status_types::synchronizing));
+	system.deadline_set (25s);
+	while (!wallet_has (nano_qt::status_types::synchronizing))
+	{
+		test_application->processEvents ();
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	system.nodes[0]->network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (5));
+	while (wallet_has (nano_qt::status_types::synchronizing))
+	{
+		test_application->processEvents ();
+		ASSERT_NO_ERROR (system.poll ());
+	}
+	ASSERT_TRUE (wallet_has (nano_qt::status_types::nominal));
+}
+
 TEST (wallet, startup_balance)
 {
 	nano_qt::eventloop_processor processor;

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -29,7 +29,9 @@ TEST (wallet, construction)
 	ASSERT_EQ (key.to_account (), item1->text ().toStdString ());
 }
 
-TEST (wallet, status)
+// Disabled because it does not work and it is not clearly defined what its behaviour should be:
+// https://github.com/nanocurrency/nano-node/issues/3235
+TEST (wallet, DISABLED_status)
 {
 	nano_qt::eventloop_processor processor;
 	nano::system system (1);


### PR DESCRIPTION
Create a new test, wallet.status_with_peer, modelled on the test case qt_test wallet.status.

The expected behaviour of the test wallet.status is not defined so it cannot be fixed at the moment and we have bigger problems to work on. See #3235

So, I disable test wallet.status and introduce a new test wallet.status_with_peer, which performs a similar test but with defined behaviour.