### PR TITLE
Fix core test case election.quorum_minimum_confirm_success (#3242)

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -132,6 +132,7 @@ TEST (election, quorum_minimum_confirm_success)
 	node1.process_active (send1);
 	node1.block_processor.flush ();
 	node1.scheduler.activate (nano::dev_genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.flush ();
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -165,6 +165,7 @@ TEST (election, quorum_minimum_confirm_fail)
 	node1.process_active (send1);
 	node1.block_processor.flush ();
 	node1.scheduler.activate (nano::dev_genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.flush ();
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
@@ -235,6 +236,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_EQ (node2.ledger.cache.block_count, 4);
 
 	node1.scheduler.activate (nano::dev_genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.flush ();
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());


### PR DESCRIPTION
The test asks the scheduler to activate an election and then check to see
the election is in the active election container.

However, node.scheduler.activate() is not a blocking operation and the
election activation happens in the background at an unspecified time.

To solve this, the election scheduler can be flushed before checking the
active election container.