### PR TITLE
Remove frontiers confirmation start only after reaching cemented > hardcoded

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -559,11 +559,10 @@ void nano::active_transactions::confirm_expired_frontiers_pessimistically (nano:
 bool nano::active_transactions::should_do_frontiers_confirmation () const
 {
 	auto pending_confirmation_height_size (confirmation_height_processor.awaiting_processing_size ());
-	auto bootstrap_weight_reached (node.ledger.cache.block_count >= node.ledger.bootstrap_weight_max_blocks);
 	auto disabled_confirmation_mode = (node.config.frontiers_confirmation == nano::frontiers_confirmation_mode::disabled);
 	auto conf_height_capacity_reached = pending_confirmation_height_size > confirmed_frontiers_max_pending_size;
 	auto all_cemented = node.ledger.cache.block_count == node.ledger.cache.cemented_count;
-	return (!disabled_confirmation_mode && (bootstrap_weight_reached || node.ledger.pruning) && !conf_height_capacity_reached && !all_cemented);
+	return (!disabled_confirmation_mode && !conf_height_capacity_reached && !all_cemented);
 }
 
 void nano::active_transactions::request_loop ()


### PR DESCRIPTION
https://github.com/nanocurrency/nano-node/issues/3239