### PR TITLE
Do not repeat core_test in CI

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -47,11 +47,7 @@ run_tests() {
         TIMEOUT_TIME_ARG=""
     fi
 
-    if [ "$(date +%s)" -lt 1625057999 ]; then # June 30 2021 23:59:59 UTC
-        tries=(_initial_ 1 2 3 4 5 6 7 8 9)
-    else
-        tries=(_initial_)
-    fi
+    tries=(_initial_)
 
     for try in "${tries[@]}"; do
         if [ "${try}" != '_initial_' ]; then


### PR DESCRIPTION
Currently we repeat core_test up to 10 times, in the hope that it succeeds.
But that way, we are hiding problems. We should not hide problems, we
should fix them instead.

I am leaving the loop in the script but simply requesting one iteration
only. If we had a need to repeat tests then it is possible that
we may have that need again someday.