### PR TITLE
Adjust active_transactions.pessimistic_elections & network.last_contacted

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1396,7 +1396,7 @@ TEST (active_transactions, pessimistic_elections)
 	}
 
 	// Wait until activation of destination account is done.
-	ASSERT_TIMELY (10s, node.active.active (send2->qualified_root ()));
+	ASSERT_TIMELY (10s, node.active.active (open->qualified_root ()));
 
 	// Election count should not increase, but the elections should be marked as started for that account afterwards
 	ASSERT_EQ (election_started_it->election_started, false);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -135,7 +135,9 @@ TEST (network, last_contacted)
 	nano::system system (1);
 	auto node0 = system.nodes[0];
 	ASSERT_EQ (0, node0->network.size ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	nano::node_config node1_config (nano::get_available_port (), system.logging);
+	node1_config.tcp_incoming_connections_max = 0; // Prevent ephemeral node1->node0 channel repacement with incoming connection
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node1_config, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto channel1 = nano::establish_tcp (system, *node1, node0->network.endpoint ());
@@ -149,17 +151,8 @@ TEST (network, last_contacted)
 	node1->network.send_keepalive (channel1);
 	ASSERT_TIMELY (3s, node0->stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) > keepalive_count);
 	ASSERT_EQ (node0->network.size (), 1);
-	// Precision of last_packet_received is 1 second, repeat keepalive if nessesary
-	ASSERT_NO_ERROR (system.poll_until_true (1s, [&node1, &channel1, &channel2, timestamp_before_keepalive] {
-		auto timestamp_after_keepalive = channel2->get_last_packet_received ();
-		EXPECT_GE (timestamp_after_keepalive, timestamp_before_keepalive);
-		bool greater_timestamp (timestamp_after_keepalive > timestamp_before_keepalive);
-		if (!greater_timestamp)
-		{
-			node1->network.send_keepalive (channel1);
-		}
-		return greater_timestamp;
-	}));
+	auto timestamp_after_keepalive = channel2->get_last_packet_received ();
+	ASSERT_GT (timestamp_after_keepalive, timestamp_before_keepalive);
 }
 
 TEST (network, multi_keepalive)


### PR DESCRIPTION
* active_transactions.pessimistic_elections - Follow test commentary
* network.last_contacted - Prevent ephemeral node1->node0 channel repacement with incoming connection