### PR TITLE
Duplicated foward-reference declaration

### DIFF
--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -228,7 +228,6 @@ void condition_variable::wait (nano::unique_lock<nano::mutex> & lk)
 	cnd.wait (lk);
 	lk.timer.restart ();
 }
-template class unique_lock<nano::mutex>;
 
 nano::mutex * mutex_to_filter{ nullptr };
 nano::mutex mutex_to_filter_mutex;


### PR DESCRIPTION
This was causing a compiling error:
nano/nano-node/nano/lib/locks.cpp:231:16: error: duplicate explicit instantiation of ‘class nano::unique_lock<nano::mutex>’ [-fpermissive]
  231 | template class unique_lock<nano::mutex>;
