### PR TITLE
Fix for RPC stop command (#3191)

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3760,7 +3760,6 @@ void nano::json_handler::stop ()
 	response_errors ();
 	if (!ec)
 	{
-		node.stop ();
 		stop_callback ();
 	}
 }


### PR DESCRIPTION
The RPC stop command was not working (the node did exit completely)
because the stop callback was never called because the callback was
called after the node was stopped and the stop callback needed the node
to execute.

This commit removes the node stop before the callback and let's the
stop call back execute, which should stop io_ctx after 3 seconds, which
in turn should exit the daemon and the node should be stopped by its
destructor.