### PR TITLE
Extend 'wallet_info' RPC command

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4208,15 +4208,32 @@ void nano::json_handler::wallet_info ()
 		nano::uint128_t balance (0);
 		nano::uint128_t pending (0);
 		uint64_t count (0);
+		uint64_t block_count (0);
+		uint64_t cemented_block_count (0);
 		uint64_t deterministic_count (0);
 		uint64_t adhoc_count (0);
 		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction (node.store.tx_begin_read ());
+
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
-			balance = balance + node.ledger.account_balance (block_transaction, account);
-			pending = pending + node.ledger.account_pending (block_transaction, account);
+
+			nano::account_info account_info{};
+			if (!node.store.account_get (block_transaction, account, account_info))
+			{
+				block_count += account_info.block_count;
+			}
+
+			nano::confirmation_height_info confirmation_info{};
+			if (!node.store.confirmation_height_get (block_transaction, account, confirmation_info))
+			{
+				cemented_block_count += confirmation_info.height;
+			}
+
+			balance += node.ledger.account_balance (block_transaction, account);
+			pending += node.ledger.account_pending (block_transaction, account);
+
 			nano::key_type key_type (wallet->store.key_type (i->second));
 			if (key_type == nano::key_type::deterministic)
 			{
@@ -4226,16 +4243,21 @@ void nano::json_handler::wallet_info ()
 			{
 				adhoc_count++;
 			}
-			count++;
+
+			++count;
 		}
+
 		uint32_t deterministic_index (wallet->store.deterministic_index_get (transaction));
 		response_l.put ("balance", balance.convert_to<std::string> ());
 		response_l.put ("pending", pending.convert_to<std::string> ());
 		response_l.put ("accounts_count", std::to_string (count));
+		response_l.put ("accounts_block_count", std::to_string (block_count));
+		response_l.put ("accounts_cemented_block_count", std::to_string (cemented_block_count));
 		response_l.put ("deterministic_count", std::to_string (deterministic_count));
 		response_l.put ("adhoc_count", std::to_string (adhoc_count));
 		response_l.put ("deterministic_index", std::to_string (deterministic_index));
 	}
+
 	response_errors ();
 }
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4231,7 +4231,7 @@ void nano::json_handler::wallet_info ()
 				cemented_block_count += confirmation_info.height;
 			}
 
-			balance += node.ledger.account_balance (block_transaction, account);
+			balance += account_info.balance;
 			pending += node.ledger.account_pending (block_transaction, account);
 
 			nano::key_type key_type (wallet->store.key_type (i->second));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4096,48 +4096,65 @@ TEST (rpc, blocks)
 
 TEST (rpc, wallet_info)
 {
-	nano::system system;
-	auto node = add_ipc_enabled_node (system);
+    nano::system system;
+    nano::node_config node_config (nano::get_available_port (), system.logging);
+    node_config.enable_voting = true;
+	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
-	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
-	nano::account account (system.wallet (0)->deterministic_insert ());
-	{
-		auto transaction (node->wallets.tx_begin_write ());
-		system.wallet (0)->store.erase (transaction, account);
-	}
-	account = system.wallet (0)->deterministic_insert ();
-	scoped_io_thread_name_change scoped_thread_name_io;
-	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
-	nano::rpc_config rpc_config (nano::get_available_port (), true);
-	rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
-	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
-	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
-	rpc.start ();
-	boost::property_tree::ptree request;
-	request.put ("action", "wallet_info");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
-	test_response response (request, rpc.config.port, system.io_ctx);
-	ASSERT_TIMELY (5s, response.status != 0);
-	ASSERT_EQ (200, response.status);
-	std::string balance_text (response.json.get<std::string> ("balance"));
-	ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
-	std::string pending_text (response.json.get<std::string> ("pending"));
-	ASSERT_EQ ("1", pending_text);
-	std::string count_text (response.json.get<std::string> ("accounts_count"));
-	ASSERT_EQ ("3", count_text);
-	std::string block_count_text (response.json.get<std::string> ("accounts_block_count"));
-	ASSERT_EQ ("2", block_count_text);
-	std::string cemented_block_count_text (response.json.get<std::string> ("accounts_cemented_block_count"));
-	ASSERT_EQ ("1", cemented_block_count_text);
-	std::string adhoc_count (response.json.get<std::string> ("adhoc_count"));
-	ASSERT_EQ ("2", adhoc_count);
-	std::string deterministic_count (response.json.get<std::string> ("deterministic_count"));
-	ASSERT_EQ ("1", deterministic_count);
-	std::string index_text (response.json.get<std::string> ("deterministic_index"));
-	ASSERT_EQ ("2", index_text);
+
+	// at first, 1 block and 1 confirmed -- the genesis
+    ASSERT_EQ (1, node->ledger.cache.block_count);
+    ASSERT_EQ (1, node->ledger.cache.cemented_count);
+
+	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
+	// after the send, expect 2 blocks immediately, then 2 confirmed in a timely manner,
+	// and finally 3 blocks and 3 confirmed after the wallet generates the receive block for this send
+    ASSERT_EQ (2, node->ledger.cache.block_count);
+    ASSERT_TIMELY (5s, 2 == node->ledger.cache.cemented_count);
+    ASSERT_TIMELY (5s, 3 == node->ledger.cache.block_count && 3 == node->ledger.cache.cemented_count);
+
+    // do another send to be able to expect some "pending" down below
+    auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
+    ASSERT_EQ (4, node->ledger.cache.block_count);
+
+    nano::account account (system.wallet (0)->deterministic_insert ());
+    {
+        auto transaction (node->wallets.tx_begin_write ());
+        system.wallet (0)->store.erase (transaction, account);
+    }
+    account = system.wallet (0)->deterministic_insert ();
+    scoped_io_thread_name_change scoped_thread_name_io;
+    nano::node_rpc_config node_rpc_config;
+    nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
+    nano::rpc_config rpc_config (nano::get_available_port (), true);
+    rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
+    nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
+    nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
+    rpc.start ();
+    boost::property_tree::ptree request;
+    request.put ("action", "wallet_info");
+    request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+    test_response response (request, rpc.config.port, system.io_ctx);
+    ASSERT_TIMELY (5s, response.status != 0);
+    ASSERT_EQ (200, response.status);
+    std::string balance_text (response.json.get<std::string> ("balance"));
+    ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
+    std::string pending_text (response.json.get<std::string> ("pending"));
+    ASSERT_EQ ("1", pending_text);
+    std::string count_text (response.json.get<std::string> ("accounts_count"));
+    ASSERT_EQ ("3", count_text);
+    std::string block_count_text (response.json.get<std::string> ("accounts_block_count"));
+    ASSERT_EQ ("4", block_count_text);
+    std::string cemented_block_count_text (response.json.get<std::string> ("accounts_cemented_block_count"));
+    ASSERT_EQ ("3", cemented_block_count_text);
+    std::string adhoc_count (response.json.get<std::string> ("adhoc_count"));
+    ASSERT_EQ ("2", adhoc_count);
+    std::string deterministic_count (response.json.get<std::string> ("deterministic_count"));
+    ASSERT_EQ ("1", deterministic_count);
+    std::string index_text (response.json.get<std::string> ("deterministic_index"));
+    ASSERT_EQ ("2", index_text);
 }
 
 TEST (rpc, wallet_balances)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4096,65 +4096,65 @@ TEST (rpc, blocks)
 
 TEST (rpc, wallet_info)
 {
-    nano::system system;
-    nano::node_config node_config (nano::get_available_port (), system.logging);
-    node_config.enable_voting = true;
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.enable_voting = true;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev_genesis_key.prv);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
 
 	// at first, 1 block and 1 confirmed -- the genesis
-    ASSERT_EQ (1, node->ledger.cache.block_count);
-    ASSERT_EQ (1, node->ledger.cache.cemented_count);
+	ASSERT_EQ (1, node->ledger.cache.block_count);
+	ASSERT_EQ (1, node->ledger.cache.cemented_count);
 
 	auto send (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	// after the send, expect 2 blocks immediately, then 2 confirmed in a timely manner,
 	// and finally 3 blocks and 3 confirmed after the wallet generates the receive block for this send
-    ASSERT_EQ (2, node->ledger.cache.block_count);
-    ASSERT_TIMELY (5s, 2 == node->ledger.cache.cemented_count);
-    ASSERT_TIMELY (5s, 3 == node->ledger.cache.block_count && 3 == node->ledger.cache.cemented_count);
+	ASSERT_EQ (2, node->ledger.cache.block_count);
+	ASSERT_TIMELY (5s, 2 == node->ledger.cache.cemented_count);
+	ASSERT_TIMELY (5s, 3 == node->ledger.cache.block_count && 3 == node->ledger.cache.cemented_count);
 
-    // do another send to be able to expect some "pending" down below
-    auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
-    ASSERT_EQ (4, node->ledger.cache.block_count);
+	// do another send to be able to expect some "pending" down below
+	auto send2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key.pub, 1));
+	ASSERT_EQ (4, node->ledger.cache.block_count);
 
-    nano::account account (system.wallet (0)->deterministic_insert ());
-    {
-        auto transaction (node->wallets.tx_begin_write ());
-        system.wallet (0)->store.erase (transaction, account);
-    }
-    account = system.wallet (0)->deterministic_insert ();
-    scoped_io_thread_name_change scoped_thread_name_io;
-    nano::node_rpc_config node_rpc_config;
-    nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
-    nano::rpc_config rpc_config (nano::get_available_port (), true);
-    rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
-    nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
-    nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
-    rpc.start ();
-    boost::property_tree::ptree request;
-    request.put ("action", "wallet_info");
-    request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
-    test_response response (request, rpc.config.port, system.io_ctx);
-    ASSERT_TIMELY (5s, response.status != 0);
-    ASSERT_EQ (200, response.status);
-    std::string balance_text (response.json.get<std::string> ("balance"));
-    ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
-    std::string pending_text (response.json.get<std::string> ("pending"));
-    ASSERT_EQ ("1", pending_text);
-    std::string count_text (response.json.get<std::string> ("accounts_count"));
-    ASSERT_EQ ("3", count_text);
-    std::string block_count_text (response.json.get<std::string> ("accounts_block_count"));
-    ASSERT_EQ ("4", block_count_text);
-    std::string cemented_block_count_text (response.json.get<std::string> ("accounts_cemented_block_count"));
-    ASSERT_EQ ("3", cemented_block_count_text);
-    std::string adhoc_count (response.json.get<std::string> ("adhoc_count"));
-    ASSERT_EQ ("2", adhoc_count);
-    std::string deterministic_count (response.json.get<std::string> ("deterministic_count"));
-    ASSERT_EQ ("1", deterministic_count);
-    std::string index_text (response.json.get<std::string> ("deterministic_index"));
-    ASSERT_EQ ("2", index_text);
+	nano::account account (system.wallet (0)->deterministic_insert ());
+	{
+		auto transaction (node->wallets.tx_begin_write ());
+		system.wallet (0)->store.erase (transaction, account);
+	}
+	account = system.wallet (0)->deterministic_insert ();
+	scoped_io_thread_name_change scoped_thread_name_io;
+	nano::node_rpc_config node_rpc_config;
+	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
+	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
+	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_info");
+	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	test_response response (request, rpc.config.port, system.io_ctx);
+	ASSERT_TIMELY (5s, response.status != 0);
+	ASSERT_EQ (200, response.status);
+	std::string balance_text (response.json.get<std::string> ("balance"));
+	ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
+	std::string pending_text (response.json.get<std::string> ("pending"));
+	ASSERT_EQ ("1", pending_text);
+	std::string count_text (response.json.get<std::string> ("accounts_count"));
+	ASSERT_EQ ("3", count_text);
+	std::string block_count_text (response.json.get<std::string> ("accounts_block_count"));
+	ASSERT_EQ ("4", block_count_text);
+	std::string cemented_block_count_text (response.json.get<std::string> ("accounts_cemented_block_count"));
+	ASSERT_EQ ("3", cemented_block_count_text);
+	std::string adhoc_count (response.json.get<std::string> ("adhoc_count"));
+	ASSERT_EQ ("2", adhoc_count);
+	std::string deterministic_count (response.json.get<std::string> ("deterministic_count"));
+	ASSERT_EQ ("1", deterministic_count);
+	std::string index_text (response.json.get<std::string> ("deterministic_index"));
+	ASSERT_EQ ("2", index_text);
 }
 
 TEST (rpc, wallet_balances)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4128,6 +4128,10 @@ TEST (rpc, wallet_info)
 	ASSERT_EQ ("1", pending_text);
 	std::string count_text (response.json.get<std::string> ("accounts_count"));
 	ASSERT_EQ ("3", count_text);
+	std::string block_count_text (response.json.get<std::string> ("accounts_block_count"));
+	ASSERT_EQ ("2", block_count_text);
+	std::string cemented_block_count_text (response.json.get<std::string> ("accounts_cemented_block_count"));
+	ASSERT_EQ ("1", cemented_block_count_text);
 	std::string adhoc_count (response.json.get<std::string> ("adhoc_count"));
 	ASSERT_EQ ("2", adhoc_count);
 	std::string deterministic_count (response.json.get<std::string> ("deterministic_count"));


### PR DESCRIPTION
This PR adds two new keys to the response of the `wallet_info` RPC command:
- accounts_block_count
- accounts_cemented_block_count
