### PR TITLE
clang-format check against intial commit

### DIFF
--- a/CL/cl.hpp
+++ b/CL/cl.hpp
@@ -159,7 +159,7 @@
 #include <intrin.h>
 #endif // _MSC_VER
 
-// 
+//
 #if defined(USE_CL_DEVICE_FISSION)
 #include <CL/cl_ext.h>
 #endif
@@ -182,20 +182,19 @@
 #define CL_HPP_NOEXCEPT
 #endif
 
-
 // To avoid accidentally taking ownership of core OpenCL types
 // such as cl_kernel constructors are made explicit
 // under OpenCL 1.2
 #if defined(CL_VERSION_1_2) && !defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 #define __CL_EXPLICIT_CONSTRUCTORS explicit
 #else // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-#define __CL_EXPLICIT_CONSTRUCTORS 
+#define __CL_EXPLICIT_CONSTRUCTORS
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
 // Define deprecated prefixes and suffixes to ensure compilation
 // in case they are not pre-defined
 #if !defined(CL_EXT_PREFIX__VERSION_1_1_DEPRECATED)
-#define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED  
+#define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
 #endif // #if !defined(CL_EXT_PREFIX__VERSION_1_1_DEPRECATED)
 #if !defined(CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED)
 #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
@@ -205,9 +204,9 @@
 #define CL_CALLBACK
 #endif //CL_CALLBACK
 
-#include <utility>
-#include <limits>
 #include <iterator>
+#include <limits>
+#include <utility>
 
 #if defined(__CL_ENABLE_EXCEPTIONS)
 #include <exception>
@@ -219,7 +218,7 @@
 
 #if !defined(__NO_STD_STRING)
 #include <string>
-#endif 
+#endif
 
 #if defined(__ANDROID__) || defined(linux) || defined(__APPLE__) || defined(__MACOSX)
 #include <alloca.h>
@@ -227,37 +226,40 @@
 
 #include <cstring>
 
-
 /*! \namespace cl
  *
  * \brief The OpenCL C++ bindings are defined within this namespace.
  *
  */
-namespace cl {
-
+namespace cl
+{
 class Memory;
 
 /**
  * Deprecated APIs for 1.2
  */
-#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2)) 
-#define __INIT_CL_EXT_FCN_PTR(name) \
-    if(!pfn_##name) { \
-        pfn_##name = (PFN_##name) \
-            clGetExtensionFunctionAddress(#name); \
-        if(!pfn_##name) { \
-        } \
-    }
+#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2))
+#define __INIT_CL_EXT_FCN_PTR(name)            \
+	if (!pfn_##name)                           \
+	{                                          \
+		pfn_##name = (PFN_##name)              \
+		clGetExtensionFunctionAddress (#name); \
+		if (!pfn_##name)                       \
+		{                                      \
+		}                                      \
+	}
 #endif // #if defined(CL_VERSION_1_1)
 
 #if defined(CL_VERSION_1_2)
-#define __INIT_CL_EXT_FCN_PTR_PLATFORM(platform, name) \
-    if(!pfn_##name) { \
-        pfn_##name = (PFN_##name) \
-            clGetExtensionFunctionAddressForPlatform(platform, #name); \
-        if(!pfn_##name) { \
-        } \
-    }
+#define __INIT_CL_EXT_FCN_PTR_PLATFORM(platform, name)              \
+	if (!pfn_##name)                                                \
+	{                                                               \
+		pfn_##name = (PFN_##name)                                   \
+		clGetExtensionFunctionAddressForPlatform (platform, #name); \
+		if (!pfn_##name)                                            \
+		{                                                           \
+		}                                                           \
+	}
 #endif // #if defined(CL_VERSION_1_1)
 
 class Program;
@@ -275,10 +277,11 @@ class Buffer;
 class Error : public std::exception
 {
 private:
-    cl_int err_;
-    const char * errStr_;
+	cl_int err_;
+	const char * errStr_;
+
 public:
-    /*! \brief Create a new CL error exception for a given error code
+	/*! \brief Create a new CL error exception for a given error code
      *  and corresponding message.
      * 
      *  \param err error code value.
@@ -287,30 +290,39 @@ public:
      *                handling of the exception has concluded.  If set, it
      *                will be returned by what().
      */
-    Error(cl_int err, const char * errStr = NULL) : err_(err), errStr_(errStr)
-    {}
+	Error (cl_int err, const char * errStr = NULL) :
+		err_ (err), errStr_ (errStr)
+	{
+	}
 
-    ~Error() throw() {}
+	~Error () throw ()
+	{
+	}
 
-    /*! \brief Get error string associated with exception
+	/*! \brief Get error string associated with exception
      *
      * \return A memory pointer to the error message string.
      */
-    virtual const char * what() const throw ()
-    {
-        if (errStr_ == NULL) {
-            return "empty";
-        }
-        else {
-            return errStr_;
-        }
-    }
+	virtual const char * what () const throw ()
+	{
+		if (errStr_ == NULL)
+		{
+			return "empty";
+		}
+		else
+		{
+			return errStr_;
+		}
+	}
 
-    /*! \brief Get error code associated with exception
+	/*! \brief Get error code associated with exception
      *
      *  \return The error code.
      */
-    cl_int err(void) const { return err_; }
+	cl_int err (void) const
+	{
+		return err_;
+	}
 };
 
 #define __ERR_STR(x) #x
@@ -318,144 +330,141 @@ public:
 #define __ERR_STR(x) NULL
 #endif // __CL_ENABLE_EXCEPTIONS
 
-
 namespace detail
 {
 #if defined(__CL_ENABLE_EXCEPTIONS)
-static inline cl_int errHandler (
-    cl_int err,
-    const char * errStr = NULL)
-{
-    if (err != CL_SUCCESS) {
-        throw Error(err, errStr);
-    }
-    return err;
-}
+	static inline cl_int errHandler (
+	cl_int err,
+	const char * errStr = NULL)
+	{
+		if (err != CL_SUCCESS)
+		{
+			throw Error (err, errStr);
+		}
+		return err;
+	}
 #else
-static inline cl_int errHandler (cl_int err, const char * errStr = NULL)
-{
-    (void) errStr; // suppress unused variable warning
-    return err;
-}
+	static inline cl_int errHandler (cl_int err, const char * errStr = NULL)
+	{
+		(void)errStr; // suppress unused variable warning
+		return err;
+	}
 #endif // __CL_ENABLE_EXCEPTIONS
 }
 
-
-
 //! \cond DOXYGEN_DETAIL
 #if !defined(__CL_USER_OVERRIDE_ERROR_STRINGS)
-#define __GET_DEVICE_INFO_ERR               __ERR_STR(clGetDeviceInfo)
-#define __GET_PLATFORM_INFO_ERR             __ERR_STR(clGetPlatformInfo)
-#define __GET_DEVICE_IDS_ERR                __ERR_STR(clGetDeviceIDs)
-#define __GET_PLATFORM_IDS_ERR              __ERR_STR(clGetPlatformIDs)
-#define __GET_CONTEXT_INFO_ERR              __ERR_STR(clGetContextInfo)
-#define __GET_EVENT_INFO_ERR                __ERR_STR(clGetEventInfo)
-#define __GET_EVENT_PROFILE_INFO_ERR        __ERR_STR(clGetEventProfileInfo)
-#define __GET_MEM_OBJECT_INFO_ERR           __ERR_STR(clGetMemObjectInfo)
-#define __GET_IMAGE_INFO_ERR                __ERR_STR(clGetImageInfo)
-#define __GET_SAMPLER_INFO_ERR              __ERR_STR(clGetSamplerInfo)
-#define __GET_KERNEL_INFO_ERR               __ERR_STR(clGetKernelInfo)
+#define __GET_DEVICE_INFO_ERR __ERR_STR (clGetDeviceInfo)
+#define __GET_PLATFORM_INFO_ERR __ERR_STR (clGetPlatformInfo)
+#define __GET_DEVICE_IDS_ERR __ERR_STR (clGetDeviceIDs)
+#define __GET_PLATFORM_IDS_ERR __ERR_STR (clGetPlatformIDs)
+#define __GET_CONTEXT_INFO_ERR __ERR_STR (clGetContextInfo)
+#define __GET_EVENT_INFO_ERR __ERR_STR (clGetEventInfo)
+#define __GET_EVENT_PROFILE_INFO_ERR __ERR_STR (clGetEventProfileInfo)
+#define __GET_MEM_OBJECT_INFO_ERR __ERR_STR (clGetMemObjectInfo)
+#define __GET_IMAGE_INFO_ERR __ERR_STR (clGetImageInfo)
+#define __GET_SAMPLER_INFO_ERR __ERR_STR (clGetSamplerInfo)
+#define __GET_KERNEL_INFO_ERR __ERR_STR (clGetKernelInfo)
 #if defined(CL_VERSION_1_2)
-#define __GET_KERNEL_ARG_INFO_ERR               __ERR_STR(clGetKernelArgInfo)
+#define __GET_KERNEL_ARG_INFO_ERR __ERR_STR (clGetKernelArgInfo)
 #endif // #if defined(CL_VERSION_1_2)
-#define __GET_KERNEL_WORK_GROUP_INFO_ERR    __ERR_STR(clGetKernelWorkGroupInfo)
-#define __GET_PROGRAM_INFO_ERR              __ERR_STR(clGetProgramInfo)
-#define __GET_PROGRAM_BUILD_INFO_ERR        __ERR_STR(clGetProgramBuildInfo)
-#define __GET_COMMAND_QUEUE_INFO_ERR        __ERR_STR(clGetCommandQueueInfo)
+#define __GET_KERNEL_WORK_GROUP_INFO_ERR __ERR_STR (clGetKernelWorkGroupInfo)
+#define __GET_PROGRAM_INFO_ERR __ERR_STR (clGetProgramInfo)
+#define __GET_PROGRAM_BUILD_INFO_ERR __ERR_STR (clGetProgramBuildInfo)
+#define __GET_COMMAND_QUEUE_INFO_ERR __ERR_STR (clGetCommandQueueInfo)
 
-#define __CREATE_CONTEXT_ERR                __ERR_STR(clCreateContext)
-#define __CREATE_CONTEXT_FROM_TYPE_ERR      __ERR_STR(clCreateContextFromType)
-#define __GET_SUPPORTED_IMAGE_FORMATS_ERR   __ERR_STR(clGetSupportedImageFormats)
+#define __CREATE_CONTEXT_ERR __ERR_STR (clCreateContext)
+#define __CREATE_CONTEXT_FROM_TYPE_ERR __ERR_STR (clCreateContextFromType)
+#define __GET_SUPPORTED_IMAGE_FORMATS_ERR __ERR_STR (clGetSupportedImageFormats)
 
-#define __CREATE_BUFFER_ERR                 __ERR_STR(clCreateBuffer)
-#define __COPY_ERR                          __ERR_STR(cl::copy)
-#define __CREATE_SUBBUFFER_ERR              __ERR_STR(clCreateSubBuffer)
-#define __CREATE_GL_BUFFER_ERR              __ERR_STR(clCreateFromGLBuffer)
-#define __CREATE_GL_RENDER_BUFFER_ERR       __ERR_STR(clCreateFromGLBuffer)
-#define __GET_GL_OBJECT_INFO_ERR            __ERR_STR(clGetGLObjectInfo)
+#define __CREATE_BUFFER_ERR __ERR_STR (clCreateBuffer)
+#define __COPY_ERR __ERR_STR (cl::copy)
+#define __CREATE_SUBBUFFER_ERR __ERR_STR (clCreateSubBuffer)
+#define __CREATE_GL_BUFFER_ERR __ERR_STR (clCreateFromGLBuffer)
+#define __CREATE_GL_RENDER_BUFFER_ERR __ERR_STR (clCreateFromGLBuffer)
+#define __GET_GL_OBJECT_INFO_ERR __ERR_STR (clGetGLObjectInfo)
 #if defined(CL_VERSION_1_2)
-#define __CREATE_IMAGE_ERR                  __ERR_STR(clCreateImage)
-#define __CREATE_GL_TEXTURE_ERR             __ERR_STR(clCreateFromGLTexture)
-#define __IMAGE_DIMENSION_ERR               __ERR_STR(Incorrect image dimensions)
+#define __CREATE_IMAGE_ERR __ERR_STR (clCreateImage)
+#define __CREATE_GL_TEXTURE_ERR __ERR_STR (clCreateFromGLTexture)
+#define __IMAGE_DIMENSION_ERR __ERR_STR (Incorrect image dimensions)
 #endif // #if defined(CL_VERSION_1_2)
-#define __CREATE_SAMPLER_ERR                __ERR_STR(clCreateSampler)
-#define __SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR __ERR_STR(clSetMemObjectDestructorCallback)
+#define __CREATE_SAMPLER_ERR __ERR_STR (clCreateSampler)
+#define __SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR __ERR_STR (clSetMemObjectDestructorCallback)
 
-#define __CREATE_USER_EVENT_ERR             __ERR_STR(clCreateUserEvent)
-#define __SET_USER_EVENT_STATUS_ERR         __ERR_STR(clSetUserEventStatus)
-#define __SET_EVENT_CALLBACK_ERR            __ERR_STR(clSetEventCallback)
-#define __WAIT_FOR_EVENTS_ERR               __ERR_STR(clWaitForEvents)
+#define __CREATE_USER_EVENT_ERR __ERR_STR (clCreateUserEvent)
+#define __SET_USER_EVENT_STATUS_ERR __ERR_STR (clSetUserEventStatus)
+#define __SET_EVENT_CALLBACK_ERR __ERR_STR (clSetEventCallback)
+#define __WAIT_FOR_EVENTS_ERR __ERR_STR (clWaitForEvents)
 
-#define __CREATE_KERNEL_ERR                 __ERR_STR(clCreateKernel)
-#define __SET_KERNEL_ARGS_ERR               __ERR_STR(clSetKernelArg)
-#define __CREATE_PROGRAM_WITH_SOURCE_ERR    __ERR_STR(clCreateProgramWithSource)
-#define __CREATE_PROGRAM_WITH_BINARY_ERR    __ERR_STR(clCreateProgramWithBinary)
+#define __CREATE_KERNEL_ERR __ERR_STR (clCreateKernel)
+#define __SET_KERNEL_ARGS_ERR __ERR_STR (clSetKernelArg)
+#define __CREATE_PROGRAM_WITH_SOURCE_ERR __ERR_STR (clCreateProgramWithSource)
+#define __CREATE_PROGRAM_WITH_BINARY_ERR __ERR_STR (clCreateProgramWithBinary)
 #if defined(CL_VERSION_1_2)
-#define __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR    __ERR_STR(clCreateProgramWithBuiltInKernels)
+#define __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR __ERR_STR (clCreateProgramWithBuiltInKernels)
 #endif // #if defined(CL_VERSION_1_2)
-#define __BUILD_PROGRAM_ERR                 __ERR_STR(clBuildProgram)
+#define __BUILD_PROGRAM_ERR __ERR_STR (clBuildProgram)
 #if defined(CL_VERSION_1_2)
-#define __COMPILE_PROGRAM_ERR                  __ERR_STR(clCompileProgram)
-#define __LINK_PROGRAM_ERR                  __ERR_STR(clLinkProgram)
+#define __COMPILE_PROGRAM_ERR __ERR_STR (clCompileProgram)
+#define __LINK_PROGRAM_ERR __ERR_STR (clLinkProgram)
 #endif // #if defined(CL_VERSION_1_2)
-#define __CREATE_KERNELS_IN_PROGRAM_ERR     __ERR_STR(clCreateKernelsInProgram)
+#define __CREATE_KERNELS_IN_PROGRAM_ERR __ERR_STR (clCreateKernelsInProgram)
 
-#define __CREATE_COMMAND_QUEUE_ERR          __ERR_STR(clCreateCommandQueue)
-#define __SET_COMMAND_QUEUE_PROPERTY_ERR    __ERR_STR(clSetCommandQueueProperty)
-#define __ENQUEUE_READ_BUFFER_ERR           __ERR_STR(clEnqueueReadBuffer)
-#define __ENQUEUE_READ_BUFFER_RECT_ERR      __ERR_STR(clEnqueueReadBufferRect)
-#define __ENQUEUE_WRITE_BUFFER_ERR          __ERR_STR(clEnqueueWriteBuffer)
-#define __ENQUEUE_WRITE_BUFFER_RECT_ERR     __ERR_STR(clEnqueueWriteBufferRect)
-#define __ENQEUE_COPY_BUFFER_ERR            __ERR_STR(clEnqueueCopyBuffer)
-#define __ENQEUE_COPY_BUFFER_RECT_ERR       __ERR_STR(clEnqueueCopyBufferRect)
-#define __ENQUEUE_FILL_BUFFER_ERR           __ERR_STR(clEnqueueFillBuffer)
-#define __ENQUEUE_READ_IMAGE_ERR            __ERR_STR(clEnqueueReadImage)
-#define __ENQUEUE_WRITE_IMAGE_ERR           __ERR_STR(clEnqueueWriteImage)
-#define __ENQUEUE_COPY_IMAGE_ERR            __ERR_STR(clEnqueueCopyImage)
-#define __ENQUEUE_FILL_IMAGE_ERR           __ERR_STR(clEnqueueFillImage)
-#define __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR  __ERR_STR(clEnqueueCopyImageToBuffer)
-#define __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR  __ERR_STR(clEnqueueCopyBufferToImage)
-#define __ENQUEUE_MAP_BUFFER_ERR            __ERR_STR(clEnqueueMapBuffer)
-#define __ENQUEUE_MAP_IMAGE_ERR             __ERR_STR(clEnqueueMapImage)
-#define __ENQUEUE_UNMAP_MEM_OBJECT_ERR      __ERR_STR(clEnqueueUnMapMemObject)
-#define __ENQUEUE_NDRANGE_KERNEL_ERR        __ERR_STR(clEnqueueNDRangeKernel)
-#define __ENQUEUE_TASK_ERR                  __ERR_STR(clEnqueueTask)
-#define __ENQUEUE_NATIVE_KERNEL             __ERR_STR(clEnqueueNativeKernel)
+#define __CREATE_COMMAND_QUEUE_ERR __ERR_STR (clCreateCommandQueue)
+#define __SET_COMMAND_QUEUE_PROPERTY_ERR __ERR_STR (clSetCommandQueueProperty)
+#define __ENQUEUE_READ_BUFFER_ERR __ERR_STR (clEnqueueReadBuffer)
+#define __ENQUEUE_READ_BUFFER_RECT_ERR __ERR_STR (clEnqueueReadBufferRect)
+#define __ENQUEUE_WRITE_BUFFER_ERR __ERR_STR (clEnqueueWriteBuffer)
+#define __ENQUEUE_WRITE_BUFFER_RECT_ERR __ERR_STR (clEnqueueWriteBufferRect)
+#define __ENQEUE_COPY_BUFFER_ERR __ERR_STR (clEnqueueCopyBuffer)
+#define __ENQEUE_COPY_BUFFER_RECT_ERR __ERR_STR (clEnqueueCopyBufferRect)
+#define __ENQUEUE_FILL_BUFFER_ERR __ERR_STR (clEnqueueFillBuffer)
+#define __ENQUEUE_READ_IMAGE_ERR __ERR_STR (clEnqueueReadImage)
+#define __ENQUEUE_WRITE_IMAGE_ERR __ERR_STR (clEnqueueWriteImage)
+#define __ENQUEUE_COPY_IMAGE_ERR __ERR_STR (clEnqueueCopyImage)
+#define __ENQUEUE_FILL_IMAGE_ERR __ERR_STR (clEnqueueFillImage)
+#define __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR __ERR_STR (clEnqueueCopyImageToBuffer)
+#define __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR __ERR_STR (clEnqueueCopyBufferToImage)
+#define __ENQUEUE_MAP_BUFFER_ERR __ERR_STR (clEnqueueMapBuffer)
+#define __ENQUEUE_MAP_IMAGE_ERR __ERR_STR (clEnqueueMapImage)
+#define __ENQUEUE_UNMAP_MEM_OBJECT_ERR __ERR_STR (clEnqueueUnMapMemObject)
+#define __ENQUEUE_NDRANGE_KERNEL_ERR __ERR_STR (clEnqueueNDRangeKernel)
+#define __ENQUEUE_TASK_ERR __ERR_STR (clEnqueueTask)
+#define __ENQUEUE_NATIVE_KERNEL __ERR_STR (clEnqueueNativeKernel)
 #if defined(CL_VERSION_1_2)
-#define __ENQUEUE_MIGRATE_MEM_OBJECTS_ERR   __ERR_STR(clEnqueueMigrateMemObjects)
+#define __ENQUEUE_MIGRATE_MEM_OBJECTS_ERR __ERR_STR (clEnqueueMigrateMemObjects)
 #endif // #if defined(CL_VERSION_1_2)
 
-#define __ENQUEUE_ACQUIRE_GL_ERR            __ERR_STR(clEnqueueAcquireGLObjects)
-#define __ENQUEUE_RELEASE_GL_ERR            __ERR_STR(clEnqueueReleaseGLObjects)
+#define __ENQUEUE_ACQUIRE_GL_ERR __ERR_STR (clEnqueueAcquireGLObjects)
+#define __ENQUEUE_RELEASE_GL_ERR __ERR_STR (clEnqueueReleaseGLObjects)
 
-
-#define __RETAIN_ERR                        __ERR_STR(Retain Object)
-#define __RELEASE_ERR                       __ERR_STR(Release Object)
-#define __FLUSH_ERR                         __ERR_STR(clFlush)
-#define __FINISH_ERR                        __ERR_STR(clFinish)
-#define __VECTOR_CAPACITY_ERR               __ERR_STR(Vector capacity error)
+#define __RETAIN_ERR __ERR_STR (Retain Object)
+#define __RELEASE_ERR __ERR_STR (Release Object)
+#define __FLUSH_ERR __ERR_STR (clFlush)
+#define __FINISH_ERR __ERR_STR (clFinish)
+#define __VECTOR_CAPACITY_ERR __ERR_STR (Vector capacity error)
 
 /**
  * CL 1.2 version that uses device fission.
  */
 #if defined(CL_VERSION_1_2)
-#define __CREATE_SUB_DEVICES                __ERR_STR(clCreateSubDevices)
+#define __CREATE_SUB_DEVICES __ERR_STR (clCreateSubDevices)
 #else
-#define __CREATE_SUB_DEVICES                __ERR_STR(clCreateSubDevicesEXT)
+#define __CREATE_SUB_DEVICES __ERR_STR (clCreateSubDevicesEXT)
 #endif // #if defined(CL_VERSION_1_2)
 
 /**
  * Deprecated APIs for 1.2
  */
-#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2)) 
-#define __ENQUEUE_MARKER_ERR                __ERR_STR(clEnqueueMarker)
-#define __ENQUEUE_WAIT_FOR_EVENTS_ERR       __ERR_STR(clEnqueueWaitForEvents)
-#define __ENQUEUE_BARRIER_ERR               __ERR_STR(clEnqueueBarrier)
-#define __UNLOAD_COMPILER_ERR               __ERR_STR(clUnloadCompiler)
-#define __CREATE_GL_TEXTURE_2D_ERR          __ERR_STR(clCreateFromGLTexture2D)
-#define __CREATE_GL_TEXTURE_3D_ERR          __ERR_STR(clCreateFromGLTexture3D)
-#define __CREATE_IMAGE2D_ERR                __ERR_STR(clCreateImage2D)
-#define __CREATE_IMAGE3D_ERR                __ERR_STR(clCreateImage3D)
+#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2))
+#define __ENQUEUE_MARKER_ERR __ERR_STR (clEnqueueMarker)
+#define __ENQUEUE_WAIT_FOR_EVENTS_ERR __ERR_STR (clEnqueueWaitForEvents)
+#define __ENQUEUE_BARRIER_ERR __ERR_STR (clEnqueueBarrier)
+#define __UNLOAD_COMPILER_ERR __ERR_STR (clUnloadCompiler)
+#define __CREATE_GL_TEXTURE_2D_ERR __ERR_STR (clCreateFromGLTexture2D)
+#define __CREATE_GL_TEXTURE_3D_ERR __ERR_STR (clCreateFromGLTexture3D)
+#define __CREATE_IMAGE2D_ERR __ERR_STR (clCreateImage2D)
+#define __CREATE_IMAGE3D_ERR __ERR_STR (clCreateImage3D)
 #endif // #if defined(CL_VERSION_1_1)
 
 #endif // __CL_USER_OVERRIDE_ERROR_STRINGS
@@ -465,13 +474,13 @@ static inline cl_int errHandler (cl_int err, const char * errStr = NULL)
  * CL 1.2 marker and barrier commands
  */
 #if defined(CL_VERSION_1_2)
-#define __ENQUEUE_MARKER_WAIT_LIST_ERR                __ERR_STR(clEnqueueMarkerWithWaitList)
-#define __ENQUEUE_BARRIER_WAIT_LIST_ERR               __ERR_STR(clEnqueueBarrierWithWaitList)
+#define __ENQUEUE_MARKER_WAIT_LIST_ERR __ERR_STR (clEnqueueMarkerWithWaitList)
+#define __ENQUEUE_BARRIER_WAIT_LIST_ERR __ERR_STR (clEnqueueBarrierWithWaitList)
 #endif // #if defined(CL_VERSION_1_2)
 
 #if !defined(__USE_DEV_STRING) && !defined(__NO_STD_STRING)
 typedef std::string STRING_CLASS;
-#elif !defined(__USE_DEV_STRING) 
+#elif !defined(__USE_DEV_STRING)
 
 /*! \class string
  * \brief Simple string class, that provides a limited subset of std::string
@@ -484,15 +493,17 @@ typedef std::string STRING_CLASS;
 class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED string CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
 {
 private:
-    ::size_t size_;
-    char * str_;
-public:
-    //! \brief Constructs an empty string, allocating no memory.
-    string(void) : size_(0), str_(NULL)
-    {
-    }
+	::size_t size_;
+	char * str_;
 
-    /*! \brief Constructs a string populated from an arbitrary value of
+public:
+	//! \brief Constructs an empty string, allocating no memory.
+	string (void) :
+		size_ (0), str_ (NULL)
+	{
+	}
+
+	/*! \brief Constructs a string populated from an arbitrary value of
      *  specified size.
      * 
      *  An extra '\0' is added, in case none was contained in str.
@@ -503,158 +514,186 @@ public:
      *
      *  \param size the number of characters to copy from str.
      */
-    string(const char * str, ::size_t size) :
-        size_(size),
-        str_(NULL)
-    {
-        if( size > 0 ) {
-            str_ = new char[size_+1];
-            if (str_ != NULL) {
-                memcpy(str_, str, size_  * sizeof(char));
-                str_[size_] = '\0';
-            }
-            else {
-                size_ = 0;
-            }
-        }
-    }
+	string (const char * str, ::size_t size) :
+		size_ (size),
+		str_ (NULL)
+	{
+		if (size > 0)
+		{
+			str_ = new char[size_ + 1];
+			if (str_ != NULL)
+			{
+				memcpy (str_, str, size_ * sizeof (char));
+				str_[size_] = '\0';
+			}
+			else
+			{
+				size_ = 0;
+			}
+		}
+	}
 
-    /*! \brief Constructs a string populated from a null-terminated value.
+	/*! \brief Constructs a string populated from a null-terminated value.
      *
      *  \param str the null-terminated initial value of the string instance.
      *             If NULL, the string is left empty, with a size of 0.
      */
-    string(const char * str) :
-        size_(0),
-        str_(NULL)
-    {
-        if( str ) {
-            size_= ::strlen(str);
-        }
-        if( size_ > 0 ) {
-            str_ = new char[size_ + 1];
-            if (str_ != NULL) {
-                memcpy(str_, str, (size_ + 1) * sizeof(char));
-            }
-        }
-    }
+	string (const char * str) :
+		size_ (0),
+		str_ (NULL)
+	{
+		if (str)
+		{
+			size_ = ::strlen (str);
+		}
+		if (size_ > 0)
+		{
+			str_ = new char[size_ + 1];
+			if (str_ != NULL)
+			{
+				memcpy (str_, str, (size_ + 1) * sizeof (char));
+			}
+		}
+	}
 
-    void resize( ::size_t n )
-    {
-        if( size_ == n ) {
-            return;
-        }
-        if (n == 0) {
-            if( str_ ) {
-                delete [] str_;
-            }
-            str_ = NULL;
-            size_ = 0;
-        } 
-        else {
-            char *newString = new char[n + 1];
-            ::size_t copySize = n;
-            if( size_ < n ) {
-                copySize = size_;
-            }
-            size_ = n;
-            
-            if(str_) {
-                memcpy(newString, str_, (copySize + 1) * sizeof(char));
-            }
-            if( copySize < size_ ) {
-                memset(newString + copySize, 0, size_ - copySize);
-            }
-            newString[size_] = '\0';
+	void resize (::size_t n)
+	{
+		if (size_ == n)
+		{
+			return;
+		}
+		if (n == 0)
+		{
+			if (str_)
+			{
+				delete[] str_;
+			}
+			str_ = NULL;
+			size_ = 0;
+		}
+		else
+		{
+			char * newString = new char[n + 1];
+			::size_t copySize = n;
+			if (size_ < n)
+			{
+				copySize = size_;
+			}
+			size_ = n;
 
-            delete [] str_;
-            str_ = newString;
-        }
-    }
+			if (str_)
+			{
+				memcpy (newString, str_, (copySize + 1) * sizeof (char));
+			}
+			if (copySize < size_)
+			{
+				memset (newString + copySize, 0, size_ - copySize);
+			}
+			newString[size_] = '\0';
 
-    const char& operator[] ( ::size_t pos ) const
-    {
-        return str_[pos];
-    }
+			delete[] str_;
+			str_ = newString;
+		}
+	}
 
-    char& operator[] ( ::size_t pos )
-    {
-        return str_[pos];
-    }
+	const char & operator[] (::size_t pos) const
+	{
+		return str_[pos];
+	}
 
-    /*! \brief Copies the value of another string to this one.
+	char & operator[] (::size_t pos)
+	{
+		return str_[pos];
+	}
+
+	/*! \brief Copies the value of another string to this one.
      *
      *  \param rhs the string to copy.
      *
      *  \returns a reference to the modified instance.
      */
-    string& operator=(const string& rhs)
-    {
-        if (this == &rhs) {
-            return *this;
-        }
+	string & operator= (const string & rhs)
+	{
+		if (this == &rhs)
+		{
+			return *this;
+		}
 
-        if( str_ != NULL ) {
-            delete [] str_;
-            str_ = NULL;
-            size_ = 0;
-        }
+		if (str_ != NULL)
+		{
+			delete[] str_;
+			str_ = NULL;
+			size_ = 0;
+		}
 
-        if (rhs.size_ == 0 || rhs.str_ == NULL) {
-            str_ = NULL;
-            size_ = 0;
-        } 
-        else {
-            str_ = new char[rhs.size_ + 1];
-            size_ = rhs.size_;
-            
-            if (str_ != NULL) {
-                memcpy(str_, rhs.str_, (size_ + 1) * sizeof(char));
-            }
-            else {
-                size_ = 0;
-            }
-        }
+		if (rhs.size_ == 0 || rhs.str_ == NULL)
+		{
+			str_ = NULL;
+			size_ = 0;
+		}
+		else
+		{
+			str_ = new char[rhs.size_ + 1];
+			size_ = rhs.size_;
 
-        return *this;
-    }
+			if (str_ != NULL)
+			{
+				memcpy (str_, rhs.str_, (size_ + 1) * sizeof (char));
+			}
+			else
+			{
+				size_ = 0;
+			}
+		}
 
-    /*! \brief Constructs a string by copying the value of another instance.
+		return *this;
+	}
+
+	/*! \brief Constructs a string by copying the value of another instance.
      *
      *  \param rhs the string to copy.
      */
-    string(const string& rhs) :
-        size_(0),
-        str_(NULL)
-    {
-        *this = rhs;
-    }
+	string (const string & rhs) :
+		size_ (0),
+		str_ (NULL)
+	{
+		*this = rhs;
+	}
 
-    //! \brief Destructor - frees memory used to hold the current value.
-    ~string()
-    {
-        delete[] str_;
-        str_ = NULL;
-    }
-    
-    //! \brief Queries the length of the string, excluding any added '\0's.
-    ::size_t size(void) const   { return size_; }
+	//! \brief Destructor - frees memory used to hold the current value.
+	~string ()
+	{
+		delete[] str_;
+		str_ = NULL;
+	}
 
-    //! \brief Queries the length of the string, excluding any added '\0's.
-    ::size_t length(void) const { return size(); }
+	//! \brief Queries the length of the string, excluding any added '\0's.
+	::size_t size (void) const
+	{
+		return size_;
+	}
 
-    /*! \brief Returns a pointer to the private copy held by this instance,
+	//! \brief Queries the length of the string, excluding any added '\0's.
+	::size_t length (void) const
+	{
+		return size ();
+	}
+
+	/*! \brief Returns a pointer to the private copy held by this instance,
      *  or "" if empty/unset.
      */
-    const char * c_str(void) const { return (str_) ? str_ : "";}
+	const char * c_str (void) const
+	{
+		return (str_) ? str_ : "";
+	}
 };
 typedef cl::string STRING_CLASS;
-#endif // #elif !defined(__USE_DEV_STRING) 
+#endif // #elif !defined(__USE_DEV_STRING)
 
 #if !defined(__USE_DEV_VECTOR) && !defined(__NO_STD_VECTOR)
 #define VECTOR_CLASS std::vector
-#elif !defined(__USE_DEV_VECTOR) 
-#define VECTOR_CLASS cl::vector 
+#elif !defined(__USE_DEV_VECTOR)
+#define VECTOR_CLASS cl::vector
 
 #if !defined(__MAX_DEFAULT_VECTOR_SIZE)
 #define __MAX_DEFAULT_VECTOR_SIZE 10
@@ -686,203 +725,226 @@ template <typename T, unsigned int N = __MAX_DEFAULT_VECTOR_SIZE>
 class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED vector
 {
 private:
-    T data_[N];
-    unsigned int size_;
+	T data_[N];
+	unsigned int size_;
 
 public:
-    //! \brief Constructs an empty vector with no memory allocated.
-    vector() :  
-        size_(static_cast<unsigned int>(0))
-    {}
+	//! \brief Constructs an empty vector with no memory allocated.
+	vector () :
+		size_ (static_cast<unsigned int> (0))
+	{
+	}
 
-    //! \brief Deallocates the vector's memory and destroys all of its elements.
-    ~vector() 
-    {
-        clear();
-    }
+	//! \brief Deallocates the vector's memory and destroys all of its elements.
+	~vector ()
+	{
+		clear ();
+	}
 
-    //! \brief Returns the number of elements currently contained.
-    unsigned int size(void) const
-    {
-        return size_;
-    }
-    
-    /*! \brief Empties the vector of all elements.
+	//! \brief Returns the number of elements currently contained.
+	unsigned int size (void) const
+	{
+		return size_;
+	}
+
+	/*! \brief Empties the vector of all elements.
      *  \note
      *  This does not deallocate memory but will invoke destructors
      *  on contained elements.
      */
-    void clear()
-    {
-        while(!empty()) {
-            pop_back();
-        }
-    }
+	void clear ()
+	{
+		while (!empty ())
+		{
+			pop_back ();
+		}
+	}
 
-    /*! \brief Appends an element after the last valid element.
+	/*! \brief Appends an element after the last valid element.
      * Calling this on a vector that has reached capacity will throw an 
      * exception if exceptions are enabled.
      */
-    void push_back (const T& x)
-    { 
-        if (size() < N) {
-            new (&data_[size_]) T(x);
-            size_++;
-        } else {
-            detail::errHandler(CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
-        }
-    }
+	void push_back (const T & x)
+	{
+		if (size () < N)
+		{
+			new (&data_[size_]) T (x);
+			size_++;
+		}
+		else
+		{
+			detail::errHandler (CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
+		}
+	}
 
-    /*! \brief Removes the last valid element from the vector.
+	/*! \brief Removes the last valid element from the vector.
      * Calling this on an empty vector will throw an exception
      * if exceptions are enabled.
      */
-    void pop_back(void)
-    {
-        if (size_ != 0) {
-            --size_;
-            data_[size_].~T();
-        } else {
-            detail::errHandler(CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
-        }
-    }
+	void pop_back (void)
+	{
+		if (size_ != 0)
+		{
+			--size_;
+			data_[size_].~T ();
+		}
+		else
+		{
+			detail::errHandler (CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
+		}
+	}
 
-    /*! \brief Constructs with a value copied from another.
+	/*! \brief Constructs with a value copied from another.
      *
      *  \param vec the vector to copy.
      */
-    vector(const vector<T, N>& vec) : 
-        size_(vec.size_)
-    {
-        if (size_ != 0) {
-            assign(vec.begin(), vec.end());
-        }
-    } 
+	vector (const vector<T, N> & vec) :
+		size_ (vec.size_)
+	{
+		if (size_ != 0)
+		{
+			assign (vec.begin (), vec.end ());
+		}
+	}
 
-    /*! \brief Constructs with a specified number of initial elements.
+	/*! \brief Constructs with a specified number of initial elements.
      *
      *  \param size number of initial elements.
      *
      *  \param val value of initial elements.
      */
-    vector(unsigned int size, const T& val = T()) :
-        size_(0)
-    {
-        for (unsigned int i = 0; i < size; i++) {
-            push_back(val);
-        }
-    }
+	vector (unsigned int size, const T & val = T ()) :
+		size_ (0)
+	{
+		for (unsigned int i = 0; i < size; i++)
+		{
+			push_back (val);
+		}
+	}
 
-    /*! \brief Overwrites the current content with that copied from another
+	/*! \brief Overwrites the current content with that copied from another
      *         instance.
      *
      *  \param rhs vector to copy.
      *
      *  \returns a reference to this.
      */
-    vector<T, N>& operator=(const vector<T, N>& rhs)
-    {
-        if (this == &rhs) {
-            return *this;
-        }
+	vector<T, N> & operator= (const vector<T, N> & rhs)
+	{
+		if (this == &rhs)
+		{
+			return *this;
+		}
 
-        if (rhs.size_ != 0) {	
-            assign(rhs.begin(), rhs.end());
-        } else {
-            clear();
-        }
+		if (rhs.size_ != 0)
+		{
+			assign (rhs.begin (), rhs.end ());
+		}
+		else
+		{
+			clear ();
+		}
 
-        return *this;
-    }
+		return *this;
+	}
 
-    /*! \brief Tests equality against another instance.
+	/*! \brief Tests equality against another instance.
      *
      *  \param vec the vector against which to compare.
      */
-    bool operator==(vector<T,N> &vec)
-    {
-        if (size() != vec.size()) {
-            return false;
-        }
+	bool operator== (vector<T, N> & vec)
+	{
+		if (size () != vec.size ())
+		{
+			return false;
+		}
 
-        for( unsigned int i = 0; i < size(); ++i ) {
-            if( operator[](i) != vec[i] ) {
-                return false;
-            }
-        }
-        return true;
-    }
-  
-    //! \brief Conversion operator to T*.
-    operator T* ()             { return data_; }
+		for (unsigned int i = 0; i < size (); ++i)
+		{
+			if (operator[] (i) != vec[i])
+			{
+				return false;
+			}
+		}
+		return true;
+	}
 
-    //! \brief Conversion operator to const T*.
-    operator const T* () const { return data_; }
-   
-    //! \brief Tests whether this instance has any elements.
-    bool empty (void) const
-    {
-        return size_==0;
-    }
-  
-    //! \brief Returns the maximum number of elements this instance can hold.
-    unsigned int max_size (void) const
-    {
-        return N;
-    }
+	//! \brief Conversion operator to T*.
+	operator T * ()
+	{
+		return data_;
+	}
 
-    //! \brief Returns the maximum number of elements this instance can hold.
-    unsigned int capacity () const
-    {
-        return N;
-    }
+	//! \brief Conversion operator to const T*.
+	operator const T * () const
+	{
+		return data_;
+	}
 
-    //! \brief Resizes the vector to the given size
-    void resize(unsigned int newSize, T fill = T())
-    {
-        if (newSize > N)
-        {
-            detail::errHandler(CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
-        }
-        else
-        {
-            while (size_ < newSize)
-            {
-                new (&data_[size_]) T(fill);
-                size_++;
-            }
-            while (size_ > newSize)
-            {
-                --size_;
-                data_[size_].~T();
-            }
-        }
-    }
+	//! \brief Tests whether this instance has any elements.
+	bool empty (void) const
+	{
+		return size_ == 0;
+	}
 
-    /*! \brief Returns a reference to a given element.
+	//! \brief Returns the maximum number of elements this instance can hold.
+	unsigned int max_size (void) const
+	{
+		return N;
+	}
+
+	//! \brief Returns the maximum number of elements this instance can hold.
+	unsigned int capacity () const
+	{
+		return N;
+	}
+
+	//! \brief Resizes the vector to the given size
+	void resize (unsigned int newSize, T fill = T ())
+	{
+		if (newSize > N)
+		{
+			detail::errHandler (CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
+		}
+		else
+		{
+			while (size_ < newSize)
+			{
+				new (&data_[size_]) T (fill);
+				size_++;
+			}
+			while (size_ > newSize)
+			{
+				--size_;
+				data_[size_].~T ();
+			}
+		}
+	}
+
+	/*! \brief Returns a reference to a given element.
      *
      *  \param index which element to access.     *
      *  \note
      *  The caller is responsible for ensuring index is >= 0 and < size().
      */
-    T& operator[](int index)
-    {
-        return data_[index];
-    }
-  
-    /*! \brief Returns a const reference to a given element.
+	T & operator[] (int index)
+	{
+		return data_[index];
+	}
+
+	/*! \brief Returns a const reference to a given element.
      *
      *  \param index which element to access.
      *
      *  \note
      *  The caller is responsible for ensuring index is >= 0 and < size().
      */
-    const T& operator[](int index) const
-    {
-        return data_[index];
-    }
-  
-    /*! \brief Assigns elements of the vector based on a source iterator range.
+	const T & operator[] (int index) const
+	{
+		return data_[index];
+	}
+
+	/*! \brief Assigns elements of the vector based on a source iterator range.
      *
      *  \param start Beginning iterator of source range
      *  \param end Enditerator of source range
@@ -890,730 +952,768 @@ public:
      *  \note
      *  Will throw an exception if exceptions are enabled and size exceeded.
      */
-    template<class I>
-    void assign(I start, I end)
-    {
-        clear();   
-        while(start != end) {
-            push_back(*start);
-            start++;
-        }
-    }
+	template <class I>
+	void assign (I start, I end)
+	{
+		clear ();
+		while (start != end)
+		{
+			push_back (*start);
+			start++;
+		}
+	}
 
-    /*! \class iterator
+	/*! \class iterator
      * \brief Const iterator class for vectors
      */
-    class iterator
-    {
-    private:
-        const vector<T,N> *vec_;
-        int index_;
+	class iterator
+	{
+	private:
+		const vector<T, N> * vec_;
+		int index_;
 
-        /**
+		/**
          * Internal iterator constructor to capture reference
          * to the vector it iterates over rather than taking 
          * the vector by copy.
          */
-        iterator (const vector<T,N> &vec, int index) :
-            vec_(&vec)
-        {            
-            if( !vec.empty() ) {
-                index_ = index;
-            } else {
-                index_ = -1;
-            }
-        }
+		iterator (const vector<T, N> & vec, int index) :
+			vec_ (&vec)
+		{
+			if (!vec.empty ())
+			{
+				index_ = index;
+			}
+			else
+			{
+				index_ = -1;
+			}
+		}
 
-    public:
-        iterator(void) : 
-            index_(-1),
-            vec_(NULL)
-        {
-        }
+	public:
+		iterator (void) :
+			index_ (-1),
+			vec_ (NULL)
+		{
+		}
 
-        iterator(const iterator& rhs) :
-            vec_(rhs.vec_),
-            index_(rhs.index_)
-        {
-        }
+		iterator (const iterator & rhs) :
+			vec_ (rhs.vec_),
+			index_ (rhs.index_)
+		{
+		}
 
-        ~iterator(void) {}
+		~iterator (void)
+		{
+		}
 
-        static iterator begin(const cl::vector<T,N> &vec)
-        {
-            iterator i(vec, 0);
+		static iterator begin (const cl::vector<T, N> & vec)
+		{
+			iterator i (vec, 0);
 
-            return i;
-        }
+			return i;
+		}
 
-        static iterator end(const cl::vector<T,N> &vec)
-        {
-            iterator i(vec, vec.size());
+		static iterator end (const cl::vector<T, N> & vec)
+		{
+			iterator i (vec, vec.size ());
 
-            return i;
-        }
-    
-        bool operator==(iterator i)
-        {
-            return ((vec_ == i.vec_) && 
-                    (index_ == i.index_));
-        }
+			return i;
+		}
 
-        bool operator!=(iterator i)
-        {
-            return (!(*this==i));
-        }
+		bool operator== (iterator i)
+		{
+			return ((vec_ == i.vec_) && (index_ == i.index_));
+		}
 
-        iterator& operator++()
-        {
-            ++index_;
-            return *this;
-        }
+		bool operator!= (iterator i)
+		{
+			return (!(*this == i));
+		}
 
-        iterator operator++(int)
-        {
-            iterator retVal(*this);
-            ++index_;
-            return retVal;
-        }
+		iterator & operator++ ()
+		{
+			++index_;
+			return *this;
+		}
 
-        iterator& operator--()
-        {
-            --index_;
-            return *this;
-        }
+		iterator operator++ (int)
+		{
+			iterator retVal (*this);
+			++index_;
+			return retVal;
+		}
 
-        iterator operator--(int)
-        {
-            iterator retVal(*this);
-            --index_;
-            return retVal;
-        }
+		iterator & operator-- ()
+		{
+			--index_;
+			return *this;
+		}
 
-        const T& operator *() const
-        {
-            return (*vec_)[index_];
-        }
-    };
+		iterator operator-- (int)
+		{
+			iterator retVal (*this);
+			--index_;
+			return retVal;
+		}
 
-    iterator begin(void)
-    {
-        return iterator::begin(*this);
-    }
+		const T & operator* () const
+		{
+			return (*vec_)[index_];
+		}
+	};
 
-    iterator begin(void) const
-    {
-        return iterator::begin(*this);
-    }
+	iterator begin (void)
+	{
+		return iterator::begin (*this);
+	}
 
-    iterator end(void)
-    {
-        return iterator::end(*this);
-    }
+	iterator begin (void) const
+	{
+		return iterator::begin (*this);
+	}
 
-    iterator end(void) const
-    {
-        return iterator::end(*this);
-    }
+	iterator end (void)
+	{
+		return iterator::end (*this);
+	}
 
-    T& front(void)
-    {
-        return data_[0];
-    }
+	iterator end (void) const
+	{
+		return iterator::end (*this);
+	}
 
-    T& back(void)
-    {
-        return data_[size_];
-    }
+	T & front (void)
+	{
+		return data_[0];
+	}
 
-    const T& front(void) const
-    {
-        return data_[0];
-    }
+	T & back (void)
+	{
+		return data_[size_];
+	}
 
-    const T& back(void) const
-    {
-        return data_[size_-1];
-    }
+	const T & front (void) const
+	{
+		return data_[0];
+	}
+
+	const T & back (void) const
+	{
+		return data_[size_ - 1];
+	}
 } CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
 #endif // #if !defined(__USE_DEV_VECTOR) && !defined(__NO_STD_VECTOR)
 
-
-
-
-
-namespace detail {
-#define __DEFAULT_NOT_INITIALIZED 1 
+namespace detail
+{
+#define __DEFAULT_NOT_INITIALIZED 1
 #define __DEFAULT_BEING_INITIALIZED 2
 #define __DEFAULT_INITIALIZED 4
 
-    /*
+	/*
      * Compare and exchange primitives are needed for handling of defaults
     */
 
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-    inline int compare_exchange(std::atomic<int> * dest, int exchange, int comparand)
+	inline int compare_exchange (std::atomic<int> * dest, int exchange, int comparand)
 #else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    inline int compare_exchange(volatile int * dest, int exchange, int comparand)
+	inline int compare_exchange (volatile int * dest, int exchange, int comparand)
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    {
+	{
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-        std::atomic_compare_exchange_strong(dest, &comparand, exchange);
-        return comparand;
+		std::atomic_compare_exchange_strong (dest, &comparand, exchange);
+		return comparand;
 #elif _MSC_VER
-        return (int)(_InterlockedCompareExchange(
-            (volatile long*)dest,
-            (long)exchange,
-            (long)comparand));
+		return (int)(_InterlockedCompareExchange (
+		(volatile long *)dest,
+		(long)exchange,
+		(long)comparand));
 #else // !_MSC_VER && !CL_HPP_CPP11_ATOMICS_SUPPORTED
-        return (__sync_val_compare_and_swap(
-            dest,
-            comparand,
-            exchange));
+		return (__sync_val_compare_and_swap (
+		dest,
+		comparand,
+		exchange));
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    }
+	}
 
-    inline void fence() {
+	inline void fence ()
+	{
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-        std::atomic_thread_fence(std::memory_order_seq_cst);
+		std::atomic_thread_fence (std::memory_order_seq_cst);
 #elif _MSC_VER // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-        _ReadWriteBarrier();
+		_ReadWriteBarrier ();
 #else // !_MSC_VER && !CL_HPP_CPP11_ATOMICS_SUPPORTED
-        __sync_synchronize();
+		__sync_synchronize ();
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    }
+	}
 } // namespace detail
 
-    
 /*! \brief class used to interface between C++ and
  *  OpenCL C calls that require arrays of size_t values, whose
  *  size is known statically.
  */
 template <int N>
 class size_t
-{ 
+{
 private:
-    ::size_t data_[N];
+	::size_t data_[N];
 
 public:
-    //! \brief Initialize size_t to all 0s
-    size_t()
-    {
-        for( int i = 0; i < N; ++i ) {
-            data_[i] = 0;
-        }
-    }
+	//! \brief Initialize size_t to all 0s
+	size_t ()
+	{
+		for (int i = 0; i < N; ++i)
+		{
+			data_[i] = 0;
+		}
+	}
 
-    ::size_t& operator[](int index)
-    {
-        return data_[index];
-    }
+	::size_t & operator[] (int index)
+	{
+		return data_[index];
+	}
 
-    const ::size_t& operator[](int index) const
-    {
-        return data_[index];
-    }
+	const ::size_t & operator[] (int index) const
+	{
+		return data_[index];
+	}
 
-    //! \brief Conversion operator to T*.
-    operator ::size_t* ()             { return data_; }
+	//! \brief Conversion operator to T*.
+	operator ::size_t * ()
+	{
+		return data_;
+	}
 
-    //! \brief Conversion operator to const T*.
-    operator const ::size_t* () const { return data_; }
+	//! \brief Conversion operator to const T*.
+	operator const ::size_t * () const
+	{
+		return data_;
+	}
 };
 
-namespace detail {
-
-// Generic getInfoHelper. The final parameter is used to guide overload
-// resolution: the actual parameter passed is an int, which makes this
-// a worse conversion sequence than a specialization that declares the
-// parameter as an int.
-template<typename Functor, typename T>
-inline cl_int getInfoHelper(Functor f, cl_uint name, T* param, long)
+namespace detail
 {
-    return f(name, sizeof(T), param, NULL);
-}
+	// Generic getInfoHelper. The final parameter is used to guide overload
+	// resolution: the actual parameter passed is an int, which makes this
+	// a worse conversion sequence than a specialization that declares the
+	// parameter as an int.
+	template <typename Functor, typename T>
+	inline cl_int getInfoHelper (Functor f, cl_uint name, T * param, long)
+	{
+		return f (name, sizeof (T), param, NULL);
+	}
 
-// Specialized getInfoHelper for VECTOR_CLASS params
-template <typename Func, typename T>
-inline cl_int getInfoHelper(Func f, cl_uint name, VECTOR_CLASS<T>* param, long)
-{
-    ::size_t required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+	// Specialized getInfoHelper for VECTOR_CLASS params
+	template <typename Func, typename T>
+	inline cl_int getInfoHelper (Func f, cl_uint name, VECTOR_CLASS<T> * param, long)
+	{
+		::size_t required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    T* value = (T*) alloca(required);
-    err = f(name, required, value, NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		T * value = (T *)alloca (required);
+		err = f (name, required, value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    param->assign(&value[0], &value[required/sizeof(T)]);
-    return CL_SUCCESS;
-}
+		param->assign (&value[0], &value[required / sizeof (T)]);
+		return CL_SUCCESS;
+	}
 
-/* Specialization for reference-counted types. This depends on the
+	/* Specialization for reference-counted types. This depends on the
  * existence of Wrapper<T>::cl_type, and none of the other types having the
  * cl_type member. Note that simplify specifying the parameter as Wrapper<T>
  * does not work, because when using a derived type (e.g. Context) the generic
  * template will provide a better match.
  */
-template <typename Func, typename T>
-inline cl_int getInfoHelper(Func f, cl_uint name, VECTOR_CLASS<T>* param, int, typename T::cl_type = 0)
-{
-    ::size_t required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+	template <typename Func, typename T>
+	inline cl_int getInfoHelper (Func f, cl_uint name, VECTOR_CLASS<T> * param, int, typename T::cl_type = 0)
+	{
+		::size_t required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    typename T::cl_type * value = (typename T::cl_type *) alloca(required);
-    err = f(name, required, value, NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		typename T::cl_type * value = (typename T::cl_type *)alloca (required);
+		err = f (name, required, value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    ::size_t elements = required / sizeof(typename T::cl_type);
-    param->assign(&value[0], &value[elements]);
-    for (::size_t i = 0; i < elements; i++)
-    {
-        if (value[i] != NULL)
-        {
-            err = (*param)[i].retain();
-            if (err != CL_SUCCESS) {
-                return err;
-            }
-        }
-    }
-    return CL_SUCCESS;
-}
+		::size_t elements = required / sizeof (typename T::cl_type);
+		param->assign (&value[0], &value[elements]);
+		for (::size_t i = 0; i < elements; i++)
+		{
+			if (value[i] != NULL)
+			{
+				err = (*param)[i].retain ();
+				if (err != CL_SUCCESS)
+				{
+					return err;
+				}
+			}
+		}
+		return CL_SUCCESS;
+	}
 
-// Specialized for getInfo<CL_PROGRAM_BINARIES>
-template <typename Func>
-inline cl_int getInfoHelper(Func f, cl_uint name, VECTOR_CLASS<char *>* param, int)
-{
-    cl_int err = f(name, param->size() * sizeof(char *), &(*param)[0], NULL);
+	// Specialized for getInfo<CL_PROGRAM_BINARIES>
+	template <typename Func>
+	inline cl_int getInfoHelper (Func f, cl_uint name, VECTOR_CLASS<char *> * param, int)
+	{
+		cl_int err = f (name, param->size () * sizeof (char *), &(*param)[0], NULL);
 
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    return CL_SUCCESS;
-}
+		return CL_SUCCESS;
+	}
 
-// Specialized GetInfoHelper for STRING_CLASS params
-template <typename Func>
-inline cl_int getInfoHelper(Func f, cl_uint name, STRING_CLASS* param, long)
-{
+	// Specialized GetInfoHelper for STRING_CLASS params
+	template <typename Func>
+	inline cl_int getInfoHelper (Func f, cl_uint name, STRING_CLASS * param, long)
+	{
 #if defined(__NO_STD_VECTOR) || defined(__NO_STD_STRING)
-    ::size_t required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		::size_t required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    char* value = (char*)alloca(required);
-    err = f(name, required, value, NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		char * value = (char *)alloca (required);
+		err = f (name, required, value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    *param = value;
-    return CL_SUCCESS;
-#else 
-    ::size_t required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		*param = value;
+		return CL_SUCCESS;
+#else
+		::size_t required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    // std::string has a constant data member
-    // a char vector does not
-    VECTOR_CLASS<char> value(required);
-    err = f(name, required, value.data(), NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-    if (param) {
-        param->assign(value.begin(), value.end());
-    }
+		// std::string has a constant data member
+		// a char vector does not
+		VECTOR_CLASS<char> value (required);
+		err = f (name, required, value.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
+		if (param)
+		{
+			param->assign (value.begin (), value.end ());
+		}
 #endif
-    return CL_SUCCESS;
-}
+		return CL_SUCCESS;
+	}
 
-// Specialized GetInfoHelper for cl::size_t params
-template <typename Func, ::size_t N>
-inline cl_int getInfoHelper(Func f, cl_uint name, size_t<N>* param, long)
-{
-    ::size_t required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+	// Specialized GetInfoHelper for cl::size_t params
+	template <typename Func, ::size_t N>
+	inline cl_int getInfoHelper (Func f, cl_uint name, size_t<N> * param, long)
+	{
+		::size_t required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    ::size_t* value = (::size_t*) alloca(required);
-    err = f(name, required, value, NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		::size_t * value = (::size_t *)alloca (required);
+		err = f (name, required, value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    for(int i = 0; i < N; ++i) {
-        (*param)[i] = value[i];
-    }
+		for (int i = 0; i < N; ++i)
+		{
+			(*param)[i] = value[i];
+		}
 
-    return CL_SUCCESS;
-}
+		return CL_SUCCESS;
+	}
 
-template<typename T> struct ReferenceHandler;
+	template <typename T>
+	struct ReferenceHandler;
 
-/* Specialization for reference-counted types. This depends on the
+	/* Specialization for reference-counted types. This depends on the
  * existence of Wrapper<T>::cl_type, and none of the other types having the
  * cl_type member. Note that simplify specifying the parameter as Wrapper<T>
  * does not work, because when using a derived type (e.g. Context) the generic
  * template will provide a better match.
  */
-template<typename Func, typename T>
-inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_type = 0)
-{
-    typename T::cl_type value;
-    cl_int err = f(name, sizeof(value), &value, NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-    *param = value;
-    if (value != NULL)
-    {
-        err = param->retain();
-        if (err != CL_SUCCESS) {
-            return err;
-        }
-    }
-    return CL_SUCCESS;
-}
+	template <typename Func, typename T>
+	inline cl_int getInfoHelper (Func f, cl_uint name, T * param, int, typename T::cl_type = 0)
+	{
+		typename T::cl_type value;
+		cl_int err = f (name, sizeof (value), &value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
+		*param = value;
+		if (value != NULL)
+		{
+			err = param->retain ();
+			if (err != CL_SUCCESS)
+			{
+				return err;
+			}
+		}
+		return CL_SUCCESS;
+	}
 
-#define __PARAM_NAME_INFO_1_0(F) \
-    F(cl_platform_info, CL_PLATFORM_PROFILE, STRING_CLASS) \
-    F(cl_platform_info, CL_PLATFORM_VERSION, STRING_CLASS) \
-    F(cl_platform_info, CL_PLATFORM_NAME, STRING_CLASS) \
-    F(cl_platform_info, CL_PLATFORM_VENDOR, STRING_CLASS) \
-    F(cl_platform_info, CL_PLATFORM_EXTENSIONS, STRING_CLASS) \
-    \
-    F(cl_device_info, CL_DEVICE_TYPE, cl_device_type) \
-    F(cl_device_info, CL_DEVICE_VENDOR_ID, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_COMPUTE_UNITS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_WORK_GROUP_SIZE, ::size_t) \
-    F(cl_device_info, CL_DEVICE_MAX_WORK_ITEM_SIZES, VECTOR_CLASS< ::size_t>) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_CLOCK_FREQUENCY, cl_uint) \
-    F(cl_device_info, CL_DEVICE_ADDRESS_BITS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_READ_IMAGE_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_WRITE_IMAGE_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_MEM_ALLOC_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_IMAGE2D_MAX_WIDTH, ::size_t) \
-    F(cl_device_info, CL_DEVICE_IMAGE2D_MAX_HEIGHT, ::size_t) \
-    F(cl_device_info, CL_DEVICE_IMAGE3D_MAX_WIDTH, ::size_t) \
-    F(cl_device_info, CL_DEVICE_IMAGE3D_MAX_HEIGHT, ::size_t) \
-    F(cl_device_info, CL_DEVICE_IMAGE3D_MAX_DEPTH, ::size_t) \
-    F(cl_device_info, CL_DEVICE_IMAGE_SUPPORT, cl_bool) \
-    F(cl_device_info, CL_DEVICE_MAX_PARAMETER_SIZE, ::size_t) \
-    F(cl_device_info, CL_DEVICE_MAX_SAMPLERS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type) \
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint)\
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_MAX_CONSTANT_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_LOCAL_MEM_TYPE, cl_device_local_mem_type) \
-    F(cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_ERROR_CORRECTION_SUPPORT, cl_bool) \
-    F(cl_device_info, CL_DEVICE_PROFILING_TIMER_RESOLUTION, ::size_t) \
-    F(cl_device_info, CL_DEVICE_ENDIAN_LITTLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_AVAILABLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_COMPILER_AVAILABLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_EXECUTION_CAPABILITIES, cl_device_exec_capabilities) \
-    F(cl_device_info, CL_DEVICE_QUEUE_PROPERTIES, cl_command_queue_properties) \
-    F(cl_device_info, CL_DEVICE_PLATFORM, cl_platform_id) \
-    F(cl_device_info, CL_DEVICE_NAME, STRING_CLASS) \
-    F(cl_device_info, CL_DEVICE_VENDOR, STRING_CLASS) \
-    F(cl_device_info, CL_DRIVER_VERSION, STRING_CLASS) \
-    F(cl_device_info, CL_DEVICE_PROFILE, STRING_CLASS) \
-    F(cl_device_info, CL_DEVICE_VERSION, STRING_CLASS) \
-    F(cl_device_info, CL_DEVICE_EXTENSIONS, STRING_CLASS) \
-    \
-    F(cl_context_info, CL_CONTEXT_REFERENCE_COUNT, cl_uint) \
-    F(cl_context_info, CL_CONTEXT_DEVICES, VECTOR_CLASS<Device>) \
-    F(cl_context_info, CL_CONTEXT_PROPERTIES, VECTOR_CLASS<cl_context_properties>) \
-    \
-    F(cl_event_info, CL_EVENT_COMMAND_QUEUE, cl::CommandQueue) \
-    F(cl_event_info, CL_EVENT_COMMAND_TYPE, cl_command_type) \
-    F(cl_event_info, CL_EVENT_REFERENCE_COUNT, cl_uint) \
-    F(cl_event_info, CL_EVENT_COMMAND_EXECUTION_STATUS, cl_int) \
-    \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_QUEUED, cl_ulong) \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_SUBMIT, cl_ulong) \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_START, cl_ulong) \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_END, cl_ulong) \
-    \
-    F(cl_mem_info, CL_MEM_TYPE, cl_mem_object_type) \
-    F(cl_mem_info, CL_MEM_FLAGS, cl_mem_flags) \
-    F(cl_mem_info, CL_MEM_SIZE, ::size_t) \
-    F(cl_mem_info, CL_MEM_HOST_PTR, void*) \
-    F(cl_mem_info, CL_MEM_MAP_COUNT, cl_uint) \
-    F(cl_mem_info, CL_MEM_REFERENCE_COUNT, cl_uint) \
-    F(cl_mem_info, CL_MEM_CONTEXT, cl::Context) \
-    \
-    F(cl_image_info, CL_IMAGE_FORMAT, cl_image_format) \
-    F(cl_image_info, CL_IMAGE_ELEMENT_SIZE, ::size_t) \
-    F(cl_image_info, CL_IMAGE_ROW_PITCH, ::size_t) \
-    F(cl_image_info, CL_IMAGE_SLICE_PITCH, ::size_t) \
-    F(cl_image_info, CL_IMAGE_WIDTH, ::size_t) \
-    F(cl_image_info, CL_IMAGE_HEIGHT, ::size_t) \
-    F(cl_image_info, CL_IMAGE_DEPTH, ::size_t) \
-    \
-    F(cl_sampler_info, CL_SAMPLER_REFERENCE_COUNT, cl_uint) \
-    F(cl_sampler_info, CL_SAMPLER_CONTEXT, cl::Context) \
-    F(cl_sampler_info, CL_SAMPLER_NORMALIZED_COORDS, cl_bool) \
-    F(cl_sampler_info, CL_SAMPLER_ADDRESSING_MODE, cl_addressing_mode) \
-    F(cl_sampler_info, CL_SAMPLER_FILTER_MODE, cl_filter_mode) \
-    \
-    F(cl_program_info, CL_PROGRAM_REFERENCE_COUNT, cl_uint) \
-    F(cl_program_info, CL_PROGRAM_CONTEXT, cl::Context) \
-    F(cl_program_info, CL_PROGRAM_NUM_DEVICES, cl_uint) \
-    F(cl_program_info, CL_PROGRAM_DEVICES, VECTOR_CLASS<Device>) \
-    F(cl_program_info, CL_PROGRAM_SOURCE, STRING_CLASS) \
-    F(cl_program_info, CL_PROGRAM_BINARY_SIZES, VECTOR_CLASS< ::size_t>) \
-    F(cl_program_info, CL_PROGRAM_BINARIES, VECTOR_CLASS<char *>) \
-    \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_STATUS, cl_build_status) \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_OPTIONS, STRING_CLASS) \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_LOG, STRING_CLASS) \
-    \
-    F(cl_kernel_info, CL_KERNEL_FUNCTION_NAME, STRING_CLASS) \
-    F(cl_kernel_info, CL_KERNEL_NUM_ARGS, cl_uint) \
-    F(cl_kernel_info, CL_KERNEL_REFERENCE_COUNT, cl_uint) \
-    F(cl_kernel_info, CL_KERNEL_CONTEXT, cl::Context) \
-    F(cl_kernel_info, CL_KERNEL_PROGRAM, cl::Program) \
-    \
-    F(cl_kernel_work_group_info, CL_KERNEL_WORK_GROUP_SIZE, ::size_t) \
-    F(cl_kernel_work_group_info, CL_KERNEL_COMPILE_WORK_GROUP_SIZE, cl::size_t<3>) \
-    F(cl_kernel_work_group_info, CL_KERNEL_LOCAL_MEM_SIZE, cl_ulong) \
-    \
-    F(cl_command_queue_info, CL_QUEUE_CONTEXT, cl::Context) \
-    F(cl_command_queue_info, CL_QUEUE_DEVICE, cl::Device) \
-    F(cl_command_queue_info, CL_QUEUE_REFERENCE_COUNT, cl_uint) \
-    F(cl_command_queue_info, CL_QUEUE_PROPERTIES, cl_command_queue_properties)
+#define __PARAM_NAME_INFO_1_0(F)                                                      \
+	F (cl_platform_info, CL_PLATFORM_PROFILE, STRING_CLASS)                           \
+	F (cl_platform_info, CL_PLATFORM_VERSION, STRING_CLASS)                           \
+	F (cl_platform_info, CL_PLATFORM_NAME, STRING_CLASS)                              \
+	F (cl_platform_info, CL_PLATFORM_VENDOR, STRING_CLASS)                            \
+	F (cl_platform_info, CL_PLATFORM_EXTENSIONS, STRING_CLASS)                        \
+                                                                                      \
+	F (cl_device_info, CL_DEVICE_TYPE, cl_device_type)                                \
+	F (cl_device_info, CL_DEVICE_VENDOR_ID, cl_uint)                                  \
+	F (cl_device_info, CL_DEVICE_MAX_COMPUTE_UNITS, cl_uint)                          \
+	F (cl_device_info, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, cl_uint)                   \
+	F (cl_device_info, CL_DEVICE_MAX_WORK_GROUP_SIZE, ::size_t)                       \
+	F (cl_device_info, CL_DEVICE_MAX_WORK_ITEM_SIZES, VECTOR_CLASS<::size_t>)         \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, cl_uint)                \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, cl_uint)               \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, cl_uint)                 \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, cl_uint)                \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, cl_uint)               \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, cl_uint)              \
+	F (cl_device_info, CL_DEVICE_MAX_CLOCK_FREQUENCY, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_ADDRESS_BITS, cl_uint)                               \
+	F (cl_device_info, CL_DEVICE_MAX_READ_IMAGE_ARGS, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_MAX_WRITE_IMAGE_ARGS, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_MAX_MEM_ALLOC_SIZE, cl_ulong)                        \
+	F (cl_device_info, CL_DEVICE_IMAGE2D_MAX_WIDTH, ::size_t)                         \
+	F (cl_device_info, CL_DEVICE_IMAGE2D_MAX_HEIGHT, ::size_t)                        \
+	F (cl_device_info, CL_DEVICE_IMAGE3D_MAX_WIDTH, ::size_t)                         \
+	F (cl_device_info, CL_DEVICE_IMAGE3D_MAX_HEIGHT, ::size_t)                        \
+	F (cl_device_info, CL_DEVICE_IMAGE3D_MAX_DEPTH, ::size_t)                         \
+	F (cl_device_info, CL_DEVICE_IMAGE_SUPPORT, cl_bool)                              \
+	F (cl_device_info, CL_DEVICE_MAX_PARAMETER_SIZE, ::size_t)                        \
+	F (cl_device_info, CL_DEVICE_MAX_SAMPLERS, cl_uint)                               \
+	F (cl_device_info, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, cl_uint)                   \
+	F (cl_device_info, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config)               \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type)     \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint)                  \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong)                     \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_SIZE, cl_ulong)                           \
+	F (cl_device_info, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, cl_ulong)                  \
+	F (cl_device_info, CL_DEVICE_MAX_CONSTANT_ARGS, cl_uint)                          \
+	F (cl_device_info, CL_DEVICE_LOCAL_MEM_TYPE, cl_device_local_mem_type)            \
+	F (cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE, cl_ulong)                            \
+	F (cl_device_info, CL_DEVICE_ERROR_CORRECTION_SUPPORT, cl_bool)                   \
+	F (cl_device_info, CL_DEVICE_PROFILING_TIMER_RESOLUTION, ::size_t)                \
+	F (cl_device_info, CL_DEVICE_ENDIAN_LITTLE, cl_bool)                              \
+	F (cl_device_info, CL_DEVICE_AVAILABLE, cl_bool)                                  \
+	F (cl_device_info, CL_DEVICE_COMPILER_AVAILABLE, cl_bool)                         \
+	F (cl_device_info, CL_DEVICE_EXECUTION_CAPABILITIES, cl_device_exec_capabilities) \
+	F (cl_device_info, CL_DEVICE_QUEUE_PROPERTIES, cl_command_queue_properties)       \
+	F (cl_device_info, CL_DEVICE_PLATFORM, cl_platform_id)                            \
+	F (cl_device_info, CL_DEVICE_NAME, STRING_CLASS)                                  \
+	F (cl_device_info, CL_DEVICE_VENDOR, STRING_CLASS)                                \
+	F (cl_device_info, CL_DRIVER_VERSION, STRING_CLASS)                               \
+	F (cl_device_info, CL_DEVICE_PROFILE, STRING_CLASS)                               \
+	F (cl_device_info, CL_DEVICE_VERSION, STRING_CLASS)                               \
+	F (cl_device_info, CL_DEVICE_EXTENSIONS, STRING_CLASS)                            \
+                                                                                      \
+	F (cl_context_info, CL_CONTEXT_REFERENCE_COUNT, cl_uint)                          \
+	F (cl_context_info, CL_CONTEXT_DEVICES, VECTOR_CLASS<Device>)                     \
+	F (cl_context_info, CL_CONTEXT_PROPERTIES, VECTOR_CLASS<cl_context_properties>)   \
+                                                                                      \
+	F (cl_event_info, CL_EVENT_COMMAND_QUEUE, cl::CommandQueue)                       \
+	F (cl_event_info, CL_EVENT_COMMAND_TYPE, cl_command_type)                         \
+	F (cl_event_info, CL_EVENT_REFERENCE_COUNT, cl_uint)                              \
+	F (cl_event_info, CL_EVENT_COMMAND_EXECUTION_STATUS, cl_int)                      \
+                                                                                      \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_QUEUED, cl_ulong)                      \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_SUBMIT, cl_ulong)                      \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_START, cl_ulong)                       \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_END, cl_ulong)                         \
+                                                                                      \
+	F (cl_mem_info, CL_MEM_TYPE, cl_mem_object_type)                                  \
+	F (cl_mem_info, CL_MEM_FLAGS, cl_mem_flags)                                       \
+	F (cl_mem_info, CL_MEM_SIZE, ::size_t)                                            \
+	F (cl_mem_info, CL_MEM_HOST_PTR, void *)                                          \
+	F (cl_mem_info, CL_MEM_MAP_COUNT, cl_uint)                                        \
+	F (cl_mem_info, CL_MEM_REFERENCE_COUNT, cl_uint)                                  \
+	F (cl_mem_info, CL_MEM_CONTEXT, cl::Context)                                      \
+                                                                                      \
+	F (cl_image_info, CL_IMAGE_FORMAT, cl_image_format)                               \
+	F (cl_image_info, CL_IMAGE_ELEMENT_SIZE, ::size_t)                                \
+	F (cl_image_info, CL_IMAGE_ROW_PITCH, ::size_t)                                   \
+	F (cl_image_info, CL_IMAGE_SLICE_PITCH, ::size_t)                                 \
+	F (cl_image_info, CL_IMAGE_WIDTH, ::size_t)                                       \
+	F (cl_image_info, CL_IMAGE_HEIGHT, ::size_t)                                      \
+	F (cl_image_info, CL_IMAGE_DEPTH, ::size_t)                                       \
+                                                                                      \
+	F (cl_sampler_info, CL_SAMPLER_REFERENCE_COUNT, cl_uint)                          \
+	F (cl_sampler_info, CL_SAMPLER_CONTEXT, cl::Context)                              \
+	F (cl_sampler_info, CL_SAMPLER_NORMALIZED_COORDS, cl_bool)                        \
+	F (cl_sampler_info, CL_SAMPLER_ADDRESSING_MODE, cl_addressing_mode)               \
+	F (cl_sampler_info, CL_SAMPLER_FILTER_MODE, cl_filter_mode)                       \
+                                                                                      \
+	F (cl_program_info, CL_PROGRAM_REFERENCE_COUNT, cl_uint)                          \
+	F (cl_program_info, CL_PROGRAM_CONTEXT, cl::Context)                              \
+	F (cl_program_info, CL_PROGRAM_NUM_DEVICES, cl_uint)                              \
+	F (cl_program_info, CL_PROGRAM_DEVICES, VECTOR_CLASS<Device>)                     \
+	F (cl_program_info, CL_PROGRAM_SOURCE, STRING_CLASS)                              \
+	F (cl_program_info, CL_PROGRAM_BINARY_SIZES, VECTOR_CLASS<::size_t>)              \
+	F (cl_program_info, CL_PROGRAM_BINARIES, VECTOR_CLASS<char *>)                    \
+                                                                                      \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_STATUS, cl_build_status)               \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_OPTIONS, STRING_CLASS)                 \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_LOG, STRING_CLASS)                     \
+                                                                                      \
+	F (cl_kernel_info, CL_KERNEL_FUNCTION_NAME, STRING_CLASS)                         \
+	F (cl_kernel_info, CL_KERNEL_NUM_ARGS, cl_uint)                                   \
+	F (cl_kernel_info, CL_KERNEL_REFERENCE_COUNT, cl_uint)                            \
+	F (cl_kernel_info, CL_KERNEL_CONTEXT, cl::Context)                                \
+	F (cl_kernel_info, CL_KERNEL_PROGRAM, cl::Program)                                \
+                                                                                      \
+	F (cl_kernel_work_group_info, CL_KERNEL_WORK_GROUP_SIZE, ::size_t)                \
+	F (cl_kernel_work_group_info, CL_KERNEL_COMPILE_WORK_GROUP_SIZE, cl::size_t<3>)   \
+	F (cl_kernel_work_group_info, CL_KERNEL_LOCAL_MEM_SIZE, cl_ulong)                 \
+                                                                                      \
+	F (cl_command_queue_info, CL_QUEUE_CONTEXT, cl::Context)                          \
+	F (cl_command_queue_info, CL_QUEUE_DEVICE, cl::Device)                            \
+	F (cl_command_queue_info, CL_QUEUE_REFERENCE_COUNT, cl_uint)                      \
+	F (cl_command_queue_info, CL_QUEUE_PROPERTIES, cl_command_queue_properties)
 
 #if defined(CL_VERSION_1_1)
-#define __PARAM_NAME_INFO_1_1(F) \
-    F(cl_context_info, CL_CONTEXT_NUM_DEVICES, cl_uint)\
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint) \
-    F(cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_bool) \
-    F(cl_device_info, CL_DEVICE_OPENCL_C_VERSION, STRING_CLASS) \
-    \
-    F(cl_mem_info, CL_MEM_ASSOCIATED_MEMOBJECT, cl::Memory) \
-    F(cl_mem_info, CL_MEM_OFFSET, ::size_t) \
-    \
-    F(cl_kernel_work_group_info, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, ::size_t) \
-    F(cl_kernel_work_group_info, CL_KERNEL_PRIVATE_MEM_SIZE, cl_ulong) \
-    \
-    F(cl_event_info, CL_EVENT_CONTEXT, cl::Context)
+#define __PARAM_NAME_INFO_1_1(F)                                                          \
+	F (cl_context_info, CL_CONTEXT_NUM_DEVICES, cl_uint)                                  \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint)                    \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint)                      \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint)                      \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint)                     \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config)                   \
+	F (cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config)                     \
+	F (cl_device_info, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_bool)                            \
+	F (cl_device_info, CL_DEVICE_OPENCL_C_VERSION, STRING_CLASS)                          \
+                                                                                          \
+	F (cl_mem_info, CL_MEM_ASSOCIATED_MEMOBJECT, cl::Memory)                              \
+	F (cl_mem_info, CL_MEM_OFFSET, ::size_t)                                              \
+                                                                                          \
+	F (cl_kernel_work_group_info, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, ::size_t) \
+	F (cl_kernel_work_group_info, CL_KERNEL_PRIVATE_MEM_SIZE, cl_ulong)                   \
+                                                                                          \
+	F (cl_event_info, CL_EVENT_CONTEXT, cl::Context)
 #endif // CL_VERSION_1_1
 
-    
 #if defined(CL_VERSION_1_2)
-#define __PARAM_NAME_INFO_1_2(F) \
-    F(cl_image_info, CL_IMAGE_BUFFER, cl::Buffer) \
-    \
-    F(cl_program_info, CL_PROGRAM_NUM_KERNELS, ::size_t) \
-    F(cl_program_info, CL_PROGRAM_KERNEL_NAMES, STRING_CLASS) \
-    \
-    F(cl_program_build_info, CL_PROGRAM_BINARY_TYPE, cl_program_binary_type) \
-    \
-    F(cl_kernel_info, CL_KERNEL_ATTRIBUTES, STRING_CLASS) \
-    \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_ADDRESS_QUALIFIER, cl_kernel_arg_address_qualifier) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_ACCESS_QUALIFIER, cl_kernel_arg_access_qualifier) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_NAME, STRING_CLASS) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_NAME, STRING_CLASS) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_QUALIFIER, cl_kernel_arg_type_qualifier) \
-    \
-    F(cl_device_info, CL_DEVICE_PARENT_DEVICE, cl_device_id) \
-    F(cl_device_info, CL_DEVICE_PARTITION_PROPERTIES, VECTOR_CLASS<cl_device_partition_property>) \
-    F(cl_device_info, CL_DEVICE_PARTITION_TYPE, VECTOR_CLASS<cl_device_partition_property>)  \
-    F(cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, ::size_t) \
-    F(cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain) \
-    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, STRING_CLASS)
+#define __PARAM_NAME_INFO_1_2(F)                                                                   \
+	F (cl_image_info, CL_IMAGE_BUFFER, cl::Buffer)                                                 \
+                                                                                                   \
+	F (cl_program_info, CL_PROGRAM_NUM_KERNELS, ::size_t)                                          \
+	F (cl_program_info, CL_PROGRAM_KERNEL_NAMES, STRING_CLASS)                                     \
+                                                                                                   \
+	F (cl_program_build_info, CL_PROGRAM_BINARY_TYPE, cl_program_binary_type)                      \
+                                                                                                   \
+	F (cl_kernel_info, CL_KERNEL_ATTRIBUTES, STRING_CLASS)                                         \
+                                                                                                   \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_ADDRESS_QUALIFIER, cl_kernel_arg_address_qualifier)       \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_ACCESS_QUALIFIER, cl_kernel_arg_access_qualifier)         \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_NAME, STRING_CLASS)                                  \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_NAME, STRING_CLASS)                                       \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_QUALIFIER, cl_kernel_arg_type_qualifier)             \
+                                                                                                   \
+	F (cl_device_info, CL_DEVICE_PARENT_DEVICE, cl_device_id)                                      \
+	F (cl_device_info, CL_DEVICE_PARTITION_PROPERTIES, VECTOR_CLASS<cl_device_partition_property>) \
+	F (cl_device_info, CL_DEVICE_PARTITION_TYPE, VECTOR_CLASS<cl_device_partition_property>)       \
+	F (cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint)                                         \
+	F (cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, ::size_t)                            \
+	F (cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain)             \
+	F (cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, STRING_CLASS)
 #endif // #if defined(CL_VERSION_1_2)
 
 #if defined(USE_CL_DEVICE_FISSION)
-#define __PARAM_NAME_DEVICE_FISSION(F) \
-    F(cl_device_info, CL_DEVICE_PARENT_DEVICE_EXT, cl_device_id) \
-    F(cl_device_info, CL_DEVICE_PARTITION_TYPES_EXT, VECTOR_CLASS<cl_device_partition_property_ext>) \
-    F(cl_device_info, CL_DEVICE_AFFINITY_DOMAINS_EXT, VECTOR_CLASS<cl_device_partition_property_ext>) \
-    F(cl_device_info, CL_DEVICE_REFERENCE_COUNT_EXT , cl_uint) \
-    F(cl_device_info, CL_DEVICE_PARTITION_STYLE_EXT, VECTOR_CLASS<cl_device_partition_property_ext>)
+#define __PARAM_NAME_DEVICE_FISSION(F)                                                                 \
+	F (cl_device_info, CL_DEVICE_PARENT_DEVICE_EXT, cl_device_id)                                      \
+	F (cl_device_info, CL_DEVICE_PARTITION_TYPES_EXT, VECTOR_CLASS<cl_device_partition_property_ext>)  \
+	F (cl_device_info, CL_DEVICE_AFFINITY_DOMAINS_EXT, VECTOR_CLASS<cl_device_partition_property_ext>) \
+	F (cl_device_info, CL_DEVICE_REFERENCE_COUNT_EXT, cl_uint)                                         \
+	F (cl_device_info, CL_DEVICE_PARTITION_STYLE_EXT, VECTOR_CLASS<cl_device_partition_property_ext>)
 #endif // USE_CL_DEVICE_FISSION
 
-template <typename enum_type, cl_int Name>
-struct param_traits {};
+	template <typename enum_type, cl_int Name>
+	struct param_traits
+	{
+	};
 
 #define __CL_DECLARE_PARAM_TRAITS(token, param_name, T) \
-struct token;                                        \
-template<>                                           \
-struct param_traits<detail:: token,param_name>       \
-{                                                    \
-    enum { value = param_name };                     \
-    typedef T param_type;                            \
-};
+	struct token;                                       \
+	template <>                                         \
+	struct param_traits<detail::token, param_name>      \
+	{                                                   \
+		enum                                            \
+		{                                               \
+			value = param_name                          \
+		};                                              \
+		typedef T param_type;                           \
+	};
 
-__PARAM_NAME_INFO_1_0(__CL_DECLARE_PARAM_TRAITS)
+	__PARAM_NAME_INFO_1_0 (__CL_DECLARE_PARAM_TRAITS)
 #if defined(CL_VERSION_1_1)
-__PARAM_NAME_INFO_1_1(__CL_DECLARE_PARAM_TRAITS)
+	__PARAM_NAME_INFO_1_1 (__CL_DECLARE_PARAM_TRAITS)
 #endif // CL_VERSION_1_1
 #if defined(CL_VERSION_1_2)
-__PARAM_NAME_INFO_1_2(__CL_DECLARE_PARAM_TRAITS)
+	__PARAM_NAME_INFO_1_2 (__CL_DECLARE_PARAM_TRAITS)
 #endif // CL_VERSION_1_1
 
 #if defined(USE_CL_DEVICE_FISSION)
-__PARAM_NAME_DEVICE_FISSION(__CL_DECLARE_PARAM_TRAITS);
+	__PARAM_NAME_DEVICE_FISSION (__CL_DECLARE_PARAM_TRAITS);
 #endif // USE_CL_DEVICE_FISSION
 
 #ifdef CL_PLATFORM_ICD_SUFFIX_KHR
-__CL_DECLARE_PARAM_TRAITS(cl_platform_info, CL_PLATFORM_ICD_SUFFIX_KHR, STRING_CLASS)
+	__CL_DECLARE_PARAM_TRAITS (cl_platform_info, CL_PLATFORM_ICD_SUFFIX_KHR, STRING_CLASS)
 #endif
 
 #ifdef CL_DEVICE_PROFILING_TIMER_OFFSET_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_PROFILING_TIMER_OFFSET_AMD, cl_ulong)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_PROFILING_TIMER_OFFSET_AMD, cl_ulong)
 #endif
 
 #ifdef CL_DEVICE_GLOBAL_FREE_MEMORY_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_GLOBAL_FREE_MEMORY_AMD, VECTOR_CLASS< ::size_t>)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_GLOBAL_FREE_MEMORY_AMD, VECTOR_CLASS<::size_t>)
 #endif
 #ifdef CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_SIMD_WIDTH_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_SIMD_WIDTH_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_SIMD_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_WAVEFRONT_WIDTH_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_WAVEFRONT_WIDTH_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_WAVEFRONT_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_LOCAL_MEM_BANKS_AMD
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_LOCAL_MEM_BANKS_AMD, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_LOCAL_MEM_BANKS_AMD, cl_uint)
 #endif
 
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_REGISTERS_PER_BLOCK_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_REGISTERS_PER_BLOCK_NV, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_REGISTERS_PER_BLOCK_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_WARP_SIZE_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_WARP_SIZE_NV, cl_uint)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_WARP_SIZE_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_GPU_OVERLAP_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_GPU_OVERLAP_NV, cl_bool)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_GPU_OVERLAP_NV, cl_bool)
 #endif
 #ifdef CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV, cl_bool)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV, cl_bool)
 #endif
 #ifdef CL_DEVICE_INTEGRATED_MEMORY_NV
-__CL_DECLARE_PARAM_TRAITS(cl_device_info, CL_DEVICE_INTEGRATED_MEMORY_NV, cl_bool)
+	__CL_DECLARE_PARAM_TRAITS (cl_device_info, CL_DEVICE_INTEGRATED_MEMORY_NV, cl_bool)
 #endif
 
-// Convenience functions
+	// Convenience functions
 
-template <typename Func, typename T>
-inline cl_int
-getInfo(Func f, cl_uint name, T* param)
-{
-    return getInfoHelper(f, name, param, 0);
-}
+	template <typename Func, typename T>
+	inline cl_int
+	getInfo (Func f, cl_uint name, T * param)
+	{
+		return getInfoHelper (f, name, param, 0);
+	}
 
-template <typename Func, typename Arg0>
-struct GetInfoFunctor0
-{
-    Func f_; const Arg0& arg0_;
-    cl_int operator ()(
-        cl_uint param, ::size_t size, void* value, ::size_t* size_ret)
-    { return f_(arg0_, param, size, value, size_ret); }
-};
+	template <typename Func, typename Arg0>
+	struct GetInfoFunctor0
+	{
+		Func f_;
+		const Arg0 & arg0_;
+		cl_int operator() (
+		cl_uint param, ::size_t size, void * value, ::size_t * size_ret)
+		{
+			return f_ (arg0_, param, size, value, size_ret);
+		}
+	};
 
-template <typename Func, typename Arg0, typename Arg1>
-struct GetInfoFunctor1
-{
-    Func f_; const Arg0& arg0_; const Arg1& arg1_;
-    cl_int operator ()(
-        cl_uint param, ::size_t size, void* value, ::size_t* size_ret)
-    { return f_(arg0_, arg1_, param, size, value, size_ret); }
-};
+	template <typename Func, typename Arg0, typename Arg1>
+	struct GetInfoFunctor1
+	{
+		Func f_;
+		const Arg0 & arg0_;
+		const Arg1 & arg1_;
+		cl_int operator() (
+		cl_uint param, ::size_t size, void * value, ::size_t * size_ret)
+		{
+			return f_ (arg0_, arg1_, param, size, value, size_ret);
+		}
+	};
 
-template <typename Func, typename Arg0, typename T>
-inline cl_int
-getInfo(Func f, const Arg0& arg0, cl_uint name, T* param)
-{
-    GetInfoFunctor0<Func, Arg0> f0 = { f, arg0 };
-    return getInfoHelper(f0, name, param, 0);
-}
+	template <typename Func, typename Arg0, typename T>
+	inline cl_int
+	getInfo (Func f, const Arg0 & arg0, cl_uint name, T * param)
+	{
+		GetInfoFunctor0<Func, Arg0> f0 = { f, arg0 };
+		return getInfoHelper (f0, name, param, 0);
+	}
 
-template <typename Func, typename Arg0, typename Arg1, typename T>
-inline cl_int
-getInfo(Func f, const Arg0& arg0, const Arg1& arg1, cl_uint name, T* param)
-{
-    GetInfoFunctor1<Func, Arg0, Arg1> f0 = { f, arg0, arg1 };
-    return getInfoHelper(f0, name, param, 0);
-}
+	template <typename Func, typename Arg0, typename Arg1, typename T>
+	inline cl_int
+	getInfo (Func f, const Arg0 & arg0, const Arg1 & arg1, cl_uint name, T * param)
+	{
+		GetInfoFunctor1<Func, Arg0, Arg1> f0 = { f, arg0, arg1 };
+		return getInfoHelper (f0, name, param, 0);
+	}
 
-template<typename T>
-struct ReferenceHandler
-{ };
+	template <typename T>
+	struct ReferenceHandler
+	{
+	};
 
 #if defined(CL_VERSION_1_2)
-/**
+	/**
  * OpenCL 1.2 devices do have retain/release.
  */
-template <>
-struct ReferenceHandler<cl_device_id>
-{
-    /**
+	template <>
+	struct ReferenceHandler<cl_device_id>
+	{
+		/**
      * Retain the device.
      * \param device A valid device created using createSubDevices
      * \return 
@@ -1622,9 +1722,11 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_RESOURCES
      *   CL_OUT_OF_HOST_MEMORY
      */
-    static cl_int retain(cl_device_id device)
-    { return ::clRetainDevice(device); }
-    /**
+		static cl_int retain (cl_device_id device)
+		{
+			return ::clRetainDevice (device);
+		}
+		/**
      * Retain the device.
      * \param device A valid device created using createSubDevices
      * \return 
@@ -1633,350 +1735,455 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_RESOURCES
      *   CL_OUT_OF_HOST_MEMORY
      */
-    static cl_int release(cl_device_id device)
-    { return ::clReleaseDevice(device); }
-};
+		static cl_int release (cl_device_id device)
+		{
+			return ::clReleaseDevice (device);
+		}
+	};
 #else // #if defined(CL_VERSION_1_2)
-/**
+	/**
  * OpenCL 1.1 devices do not have retain/release.
  */
-template <>
-struct ReferenceHandler<cl_device_id>
-{
-    // cl_device_id does not have retain().
-    static cl_int retain(cl_device_id)
-    { return CL_SUCCESS; }
-    // cl_device_id does not have release().
-    static cl_int release(cl_device_id)
-    { return CL_SUCCESS; }
-};
+	template <>
+	struct ReferenceHandler<cl_device_id>
+	{
+		// cl_device_id does not have retain().
+		static cl_int retain (cl_device_id)
+		{
+			return CL_SUCCESS;
+		}
+		// cl_device_id does not have release().
+		static cl_int release (cl_device_id)
+		{
+			return CL_SUCCESS;
+		}
+	};
 #endif // #if defined(CL_VERSION_1_2)
 
-template <>
-struct ReferenceHandler<cl_platform_id>
-{
-    // cl_platform_id does not have retain().
-    static cl_int retain(cl_platform_id)
-    { return CL_SUCCESS; }
-    // cl_platform_id does not have release().
-    static cl_int release(cl_platform_id)
-    { return CL_SUCCESS; }
-};
+	template <>
+	struct ReferenceHandler<cl_platform_id>
+	{
+		// cl_platform_id does not have retain().
+		static cl_int retain (cl_platform_id)
+		{
+			return CL_SUCCESS;
+		}
+		// cl_platform_id does not have release().
+		static cl_int release (cl_platform_id)
+		{
+			return CL_SUCCESS;
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_context>
-{
-    static cl_int retain(cl_context context)
-    { return ::clRetainContext(context); }
-    static cl_int release(cl_context context)
-    { return ::clReleaseContext(context); }
-};
+	template <>
+	struct ReferenceHandler<cl_context>
+	{
+		static cl_int retain (cl_context context)
+		{
+			return ::clRetainContext (context);
+		}
+		static cl_int release (cl_context context)
+		{
+			return ::clReleaseContext (context);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_command_queue>
-{
-    static cl_int retain(cl_command_queue queue)
-    { return ::clRetainCommandQueue(queue); }
-    static cl_int release(cl_command_queue queue)
-    { return ::clReleaseCommandQueue(queue); }
-};
+	template <>
+	struct ReferenceHandler<cl_command_queue>
+	{
+		static cl_int retain (cl_command_queue queue)
+		{
+			return ::clRetainCommandQueue (queue);
+		}
+		static cl_int release (cl_command_queue queue)
+		{
+			return ::clReleaseCommandQueue (queue);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_mem>
-{
-    static cl_int retain(cl_mem memory)
-    { return ::clRetainMemObject(memory); }
-    static cl_int release(cl_mem memory)
-    { return ::clReleaseMemObject(memory); }
-};
+	template <>
+	struct ReferenceHandler<cl_mem>
+	{
+		static cl_int retain (cl_mem memory)
+		{
+			return ::clRetainMemObject (memory);
+		}
+		static cl_int release (cl_mem memory)
+		{
+			return ::clReleaseMemObject (memory);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_sampler>
-{
-    static cl_int retain(cl_sampler sampler)
-    { return ::clRetainSampler(sampler); }
-    static cl_int release(cl_sampler sampler)
-    { return ::clReleaseSampler(sampler); }
-};
+	template <>
+	struct ReferenceHandler<cl_sampler>
+	{
+		static cl_int retain (cl_sampler sampler)
+		{
+			return ::clRetainSampler (sampler);
+		}
+		static cl_int release (cl_sampler sampler)
+		{
+			return ::clReleaseSampler (sampler);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_program>
-{
-    static cl_int retain(cl_program program)
-    { return ::clRetainProgram(program); }
-    static cl_int release(cl_program program)
-    { return ::clReleaseProgram(program); }
-};
+	template <>
+	struct ReferenceHandler<cl_program>
+	{
+		static cl_int retain (cl_program program)
+		{
+			return ::clRetainProgram (program);
+		}
+		static cl_int release (cl_program program)
+		{
+			return ::clReleaseProgram (program);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_kernel>
-{
-    static cl_int retain(cl_kernel kernel)
-    { return ::clRetainKernel(kernel); }
-    static cl_int release(cl_kernel kernel)
-    { return ::clReleaseKernel(kernel); }
-};
+	template <>
+	struct ReferenceHandler<cl_kernel>
+	{
+		static cl_int retain (cl_kernel kernel)
+		{
+			return ::clRetainKernel (kernel);
+		}
+		static cl_int release (cl_kernel kernel)
+		{
+			return ::clReleaseKernel (kernel);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_event>
-{
-    static cl_int retain(cl_event event)
-    { return ::clRetainEvent(event); }
-    static cl_int release(cl_event event)
-    { return ::clReleaseEvent(event); }
-};
+	template <>
+	struct ReferenceHandler<cl_event>
+	{
+		static cl_int retain (cl_event event)
+		{
+			return ::clRetainEvent (event);
+		}
+		static cl_int release (cl_event event)
+		{
+			return ::clReleaseEvent (event);
+		}
+	};
 
+	// Extracts version number with major in the upper 16 bits, minor in the lower 16
+	static cl_uint getVersion (const char * versionInfo)
+	{
+		int highVersion = 0;
+		int lowVersion = 0;
+		int index = 7;
+		while (versionInfo[index] != '.')
+		{
+			highVersion *= 10;
+			highVersion += versionInfo[index] - '0';
+			++index;
+		}
+		++index;
+		while (versionInfo[index] != ' ' && versionInfo[index] != '\0')
+		{
+			lowVersion *= 10;
+			lowVersion += versionInfo[index] - '0';
+			++index;
+		}
+		return (highVersion << 16) | lowVersion;
+	}
 
-// Extracts version number with major in the upper 16 bits, minor in the lower 16
-static cl_uint getVersion(const char *versionInfo)
-{
-    int highVersion = 0;
-    int lowVersion = 0;
-    int index = 7;
-    while(versionInfo[index] != '.' ) {
-        highVersion *= 10;
-        highVersion += versionInfo[index]-'0';
-        ++index;
-    }
-    ++index;
-    while(versionInfo[index] != ' ' &&  versionInfo[index] != '\0') {
-        lowVersion *= 10;
-        lowVersion += versionInfo[index]-'0';
-        ++index;
-    }
-    return (highVersion << 16) | lowVersion;
-}
+	static cl_uint getPlatformVersion (cl_platform_id platform)
+	{
+		::size_t size = 0;
+		clGetPlatformInfo (platform, CL_PLATFORM_VERSION, 0, NULL, &size);
+		char * versionInfo = (char *)alloca (size);
+		clGetPlatformInfo (platform, CL_PLATFORM_VERSION, size, &versionInfo[0], &size);
+		return getVersion (versionInfo);
+	}
 
-static cl_uint getPlatformVersion(cl_platform_id platform)
-{
-    ::size_t size = 0;
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, 0, NULL, &size);
-    char *versionInfo = (char *) alloca(size);
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, size, &versionInfo[0], &size);
-    return getVersion(versionInfo);
-}
-
-static cl_uint getDevicePlatformVersion(cl_device_id device)
-{
-    cl_platform_id platform;
-    clGetDeviceInfo(device, CL_DEVICE_PLATFORM, sizeof(platform), &platform, NULL);
-    return getPlatformVersion(platform);
-}
+	static cl_uint getDevicePlatformVersion (cl_device_id device)
+	{
+		cl_platform_id platform;
+		clGetDeviceInfo (device, CL_DEVICE_PLATFORM, sizeof (platform), &platform, NULL);
+		return getPlatformVersion (platform);
+	}
 
 #if defined(CL_VERSION_1_2) && defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-static cl_uint getContextPlatformVersion(cl_context context)
-{
-    // The platform cannot be queried directly, so we first have to grab a
-    // device and obtain its context
-    ::size_t size = 0;
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, 0, NULL, &size);
-    if (size == 0)
-        return 0;
-    cl_device_id *devices = (cl_device_id *) alloca(size);
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, size, devices, NULL);
-    return getDevicePlatformVersion(devices[0]);
-}
+	static cl_uint getContextPlatformVersion (cl_context context)
+	{
+		// The platform cannot be queried directly, so we first have to grab a
+		// device and obtain its context
+		::size_t size = 0;
+		clGetContextInfo (context, CL_CONTEXT_DEVICES, 0, NULL, &size);
+		if (size == 0)
+			return 0;
+		cl_device_id * devices = (cl_device_id *)alloca (size);
+		clGetContextInfo (context, CL_CONTEXT_DEVICES, size, devices, NULL);
+		return getDevicePlatformVersion (devices[0]);
+	}
 #endif // #if defined(CL_VERSION_1_2) && defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
-template <typename T>
-class Wrapper
-{
-public:
-    typedef T cl_type;
+	template <typename T>
+	class Wrapper
+	{
+	public:
+		typedef T cl_type;
 
-protected:
-    cl_type object_;
+	protected:
+		cl_type object_;
 
-public:
-    Wrapper() : object_(NULL) { }
+	public:
+		Wrapper () :
+			object_ (NULL)
+		{
+		}
 
-    Wrapper(const cl_type &obj) : object_(obj) { }
+		Wrapper (const cl_type & obj) :
+			object_ (obj)
+		{
+		}
 
-    ~Wrapper()
-    {
-        if (object_ != NULL) { release(); }
-    }
+		~Wrapper ()
+		{
+			if (object_ != NULL)
+			{
+				release ();
+			}
+		}
 
-    Wrapper(const Wrapper<cl_type>& rhs)
-    {
-        object_ = rhs.object_;
-        if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
-    }
-
-#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    Wrapper(Wrapper<cl_type>&& rhs) CL_HPP_NOEXCEPT
-    {
-        object_ = rhs.object_;
-        rhs.object_ = NULL;
-    }
-#endif
-
-    Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
-    {
-        if (this != &rhs) {
-            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-            object_ = rhs.object_;
-            if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
-        }
-        return *this;
-    }
+		Wrapper (const Wrapper<cl_type> & rhs)
+		{
+			object_ = rhs.object_;
+			if (object_ != NULL)
+			{
+				detail::errHandler (retain (), __RETAIN_ERR);
+			}
+		}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    Wrapper<cl_type>& operator = (Wrapper<cl_type>&& rhs)
-    {
-        if (this != &rhs) {
-            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-            object_ = rhs.object_;
-            rhs.object_ = NULL;
-        }
-        return *this;
-    }
+		Wrapper (Wrapper<cl_type> && rhs) CL_HPP_NOEXCEPT
+		{
+			object_ = rhs.object_;
+			rhs.object_ = NULL;
+		}
 #endif
 
-    Wrapper<cl_type>& operator = (const cl_type &rhs)
-    {
-        if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-        object_ = rhs;
-        return *this;
-    }
-
-    cl_type operator ()() const { return object_; }
-
-    cl_type& operator ()() { return object_; }
-
-protected:
-    template<typename Func, typename U>
-    friend inline cl_int getInfoHelper(Func, cl_uint, U*, int, typename U::cl_type);
-
-    cl_int retain() const
-    {
-        return ReferenceHandler<cl_type>::retain(object_);
-    }
-
-    cl_int release() const
-    {
-        return ReferenceHandler<cl_type>::release(object_);
-    }
-};
-
-template <>
-class Wrapper<cl_device_id>
-{
-public:
-    typedef cl_device_id cl_type;
-
-protected:
-    cl_type object_;
-    bool referenceCountable_;
-
-    static bool isReferenceCountable(cl_device_id device)
-    {
-        bool retVal = false;
-        if (device != NULL) {
-            int version = getDevicePlatformVersion(device);
-            if(version > ((1 << 16) + 1)) {
-                retVal = true;
-            }
-        }
-        return retVal;
-    }
-
-public:
-    Wrapper() : object_(NULL), referenceCountable_(false) 
-    { 
-    }
-    
-    Wrapper(const cl_type &obj) : object_(obj), referenceCountable_(false) 
-    {
-        referenceCountable_ = isReferenceCountable(obj); 
-    }
-
-    ~Wrapper()
-    {
-        if (object_ != NULL) { release(); }
-    }
-    
-    Wrapper(const Wrapper<cl_type>& rhs)
-    {
-        object_ = rhs.object_;
-        referenceCountable_ = isReferenceCountable(object_); 
-        if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
-    }
+		Wrapper<cl_type> & operator= (const Wrapper<cl_type> & rhs)
+		{
+			if (this != &rhs)
+			{
+				if (object_ != NULL)
+				{
+					detail::errHandler (release (), __RELEASE_ERR);
+				}
+				object_ = rhs.object_;
+				if (object_ != NULL)
+				{
+					detail::errHandler (retain (), __RETAIN_ERR);
+				}
+			}
+			return *this;
+		}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    Wrapper(Wrapper<cl_type>&& rhs) CL_HPP_NOEXCEPT
-    {
-        object_ = rhs.object_;
-        referenceCountable_ = rhs.referenceCountable_;
-        rhs.object_ = NULL;
-        rhs.referenceCountable_ = false;
-    }
+		Wrapper<cl_type> & operator= (Wrapper<cl_type> && rhs)
+		{
+			if (this != &rhs)
+			{
+				if (object_ != NULL)
+				{
+					detail::errHandler (release (), __RELEASE_ERR);
+				}
+				object_ = rhs.object_;
+				rhs.object_ = NULL;
+			}
+			return *this;
+		}
 #endif
 
-    Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
-    {
-        if (this != &rhs) {
-            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-            object_ = rhs.object_;
-            referenceCountable_ = rhs.referenceCountable_;
-            if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
-        }
-        return *this;
-    }
+		Wrapper<cl_type> & operator= (const cl_type & rhs)
+		{
+			if (object_ != NULL)
+			{
+				detail::errHandler (release (), __RELEASE_ERR);
+			}
+			object_ = rhs;
+			return *this;
+		}
+
+		cl_type operator() () const
+		{
+			return object_;
+		}
+
+		cl_type & operator() ()
+		{
+			return object_;
+		}
+
+	protected:
+		template <typename Func, typename U>
+		friend inline cl_int getInfoHelper (Func, cl_uint, U *, int, typename U::cl_type);
+
+		cl_int retain () const
+		{
+			return ReferenceHandler<cl_type>::retain (object_);
+		}
+
+		cl_int release () const
+		{
+			return ReferenceHandler<cl_type>::release (object_);
+		}
+	};
+
+	template <>
+	class Wrapper<cl_device_id>
+	{
+	public:
+		typedef cl_device_id cl_type;
+
+	protected:
+		cl_type object_;
+		bool referenceCountable_;
+
+		static bool isReferenceCountable (cl_device_id device)
+		{
+			bool retVal = false;
+			if (device != NULL)
+			{
+				int version = getDevicePlatformVersion (device);
+				if (version > ((1 << 16) + 1))
+				{
+					retVal = true;
+				}
+			}
+			return retVal;
+		}
+
+	public:
+		Wrapper () :
+			object_ (NULL), referenceCountable_ (false)
+		{
+		}
+
+		Wrapper (const cl_type & obj) :
+			object_ (obj), referenceCountable_ (false)
+		{
+			referenceCountable_ = isReferenceCountable (obj);
+		}
+
+		~Wrapper ()
+		{
+			if (object_ != NULL)
+			{
+				release ();
+			}
+		}
+
+		Wrapper (const Wrapper<cl_type> & rhs)
+		{
+			object_ = rhs.object_;
+			referenceCountable_ = isReferenceCountable (object_);
+			if (object_ != NULL)
+			{
+				detail::errHandler (retain (), __RETAIN_ERR);
+			}
+		}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    Wrapper<cl_type>& operator = (Wrapper<cl_type>&& rhs)
-    {
-        if (this != &rhs) {
-            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-            object_ = rhs.object_;
-            referenceCountable_ = rhs.referenceCountable_;
-            rhs.object_ = NULL;
-            rhs.referenceCountable_ = false;
-        }
-        return *this;
-    }
+		Wrapper (Wrapper<cl_type> && rhs) CL_HPP_NOEXCEPT
+		{
+			object_ = rhs.object_;
+			referenceCountable_ = rhs.referenceCountable_;
+			rhs.object_ = NULL;
+			rhs.referenceCountable_ = false;
+		}
 #endif
 
-    Wrapper<cl_type>& operator = (const cl_type &rhs)
-    {
-        if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-        object_ = rhs;
-        referenceCountable_ = isReferenceCountable(object_); 
-        return *this;
-    }
+		Wrapper<cl_type> & operator= (const Wrapper<cl_type> & rhs)
+		{
+			if (this != &rhs)
+			{
+				if (object_ != NULL)
+				{
+					detail::errHandler (release (), __RELEASE_ERR);
+				}
+				object_ = rhs.object_;
+				referenceCountable_ = rhs.referenceCountable_;
+				if (object_ != NULL)
+				{
+					detail::errHandler (retain (), __RETAIN_ERR);
+				}
+			}
+			return *this;
+		}
 
-    cl_type operator ()() const { return object_; }
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+		Wrapper<cl_type> & operator= (Wrapper<cl_type> && rhs)
+		{
+			if (this != &rhs)
+			{
+				if (object_ != NULL)
+				{
+					detail::errHandler (release (), __RELEASE_ERR);
+				}
+				object_ = rhs.object_;
+				referenceCountable_ = rhs.referenceCountable_;
+				rhs.object_ = NULL;
+				rhs.referenceCountable_ = false;
+			}
+			return *this;
+		}
+#endif
 
-    cl_type& operator ()() { return object_; }
+		Wrapper<cl_type> & operator= (const cl_type & rhs)
+		{
+			if (object_ != NULL)
+			{
+				detail::errHandler (release (), __RELEASE_ERR);
+			}
+			object_ = rhs;
+			referenceCountable_ = isReferenceCountable (object_);
+			return *this;
+		}
 
-protected:
-    template<typename Func, typename U>
-    friend inline cl_int getInfoHelper(Func, cl_uint, U*, int, typename U::cl_type);
+		cl_type operator() () const
+		{
+			return object_;
+		}
 
-    template<typename Func, typename U>
-    friend inline cl_int getInfoHelper(Func, cl_uint, VECTOR_CLASS<U>*, int, typename U::cl_type);
+		cl_type & operator() ()
+		{
+			return object_;
+		}
 
-    cl_int retain() const
-    {
-        if( referenceCountable_ ) {
-            return ReferenceHandler<cl_type>::retain(object_);
-        }
-        else {
-            return CL_SUCCESS;
-        }
-    }
+	protected:
+		template <typename Func, typename U>
+		friend inline cl_int getInfoHelper (Func, cl_uint, U *, int, typename U::cl_type);
 
-    cl_int release() const
-    {
-        if( referenceCountable_ ) {
-            return ReferenceHandler<cl_type>::release(object_);
-        }
-        else {
-            return CL_SUCCESS;
-        }
-    }
-};
+		template <typename Func, typename U>
+		friend inline cl_int getInfoHelper (Func, cl_uint, VECTOR_CLASS<U> *, int, typename U::cl_type);
+
+		cl_int retain () const
+		{
+			if (referenceCountable_)
+			{
+				return ReferenceHandler<cl_type>::retain (object_);
+			}
+			else
+			{
+				return CL_SUCCESS;
+			}
+		}
+
+		cl_int release () const
+		{
+			if (referenceCountable_)
+			{
+				return ReferenceHandler<cl_type>::release (object_);
+			}
+			else
+			{
+				return CL_SUCCESS;
+			}
+		}
+	};
 
 } // namespace detail
 //! \endcond
@@ -1988,25 +2195,28 @@ protected:
  */
 struct ImageFormat : public cl_image_format
 {
-    //! \brief Default constructor - performs no initialization.
-    ImageFormat(){}
+	//! \brief Default constructor - performs no initialization.
+	ImageFormat ()
+	{
+	}
 
-    //! \brief Initializing constructor.
-    ImageFormat(cl_channel_order order, cl_channel_type type)
-    {
-        image_channel_order = order;
-        image_channel_data_type = type;
-    }
+	//! \brief Initializing constructor.
+	ImageFormat (cl_channel_order order, cl_channel_type type)
+	{
+		image_channel_order = order;
+		image_channel_data_type = type;
+	}
 
-    //! \brief Assignment operator.
-    ImageFormat& operator = (const ImageFormat& rhs)
-    {
-        if (this != &rhs) {
-            this->image_channel_data_type = rhs.image_channel_data_type;
-            this->image_channel_order     = rhs.image_channel_order;
-        }
-        return *this;
-    }
+	//! \brief Assignment operator.
+	ImageFormat & operator= (const ImageFormat & rhs)
+	{
+		if (this != &rhs)
+		{
+			this->image_channel_data_type = rhs.image_channel_data_type;
+			this->image_channel_order = rhs.image_channel_order;
+		}
+		return *this;
+	}
 };
 
 /*! \brief Class interface for cl_device_id.
@@ -2019,108 +2229,122 @@ struct ImageFormat : public cl_image_format
 class Device : public detail::Wrapper<cl_device_id>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Device() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Device () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_device_id.
+	/*! \brief Constructor from cl_device_id.
      * 
      *  This simply copies the device ID value, which is an inexpensive operation.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Device(const cl_device_id &device) : detail::Wrapper<cl_type>(device) { }
+	__CL_EXPLICIT_CONSTRUCTORS Device (const cl_device_id & device) :
+		detail::Wrapper<cl_type> (device)
+	{
+	}
 
-    /*! \brief Returns the first device on the default context.
+	/*! \brief Returns the first device on the default context.
      *
      *  \see Context::getDefault()
      */
-    static Device getDefault(cl_int * err = NULL);
+	static Device getDefault (cl_int * err = NULL);
 
-    /*! \brief Assignment operator from cl_device_id.
+	/*! \brief Assignment operator from cl_device_id.
      * 
      *  This simply copies the device ID value, which is an inexpensive operation.
      */
-    Device& operator = (const cl_device_id& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Device & operator= (const cl_device_id & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Device(const Device& dev) : detail::Wrapper<cl_type>(dev) {}
+	Device (const Device & dev) :
+		detail::Wrapper<cl_type> (dev)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Device& operator = (const Device &dev)
-    {
-        detail::Wrapper<cl_type>::operator=(dev);
-        return *this;
-    }
+	Device & operator= (const Device & dev)
+	{
+		detail::Wrapper<cl_type>::operator= (dev);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Device(Device&& dev) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(dev)) {}
+	Device (Device && dev) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (dev))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Device& operator = (Device &&dev)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(dev));
-        return *this;
-    }
+	Device & operator= (Device && dev)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (dev));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    //! \brief Wrapper for clGetDeviceInfo().
-    template <typename T>
-    cl_int getInfo(cl_device_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetDeviceInfo, object_, name, param),
-            __GET_DEVICE_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetDeviceInfo().
+	template <typename T>
+	cl_int getInfo (cl_device_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetDeviceInfo, object_, name, param),
+		__GET_DEVICE_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetDeviceInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_device_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_device_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetDeviceInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_device_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_device_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /**
+	/**
      * CL 1.2 version
      */
 #if defined(CL_VERSION_1_2)
-    //! \brief Wrapper for clCreateSubDevicesEXT().
-    cl_int createSubDevices(
-        const cl_device_partition_property * properties,
-        VECTOR_CLASS<Device>* devices)
-    {
-        cl_uint n = 0;
-        cl_int err = clCreateSubDevices(object_, properties, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES);
-        }
+	//! \brief Wrapper for clCreateSubDevicesEXT().
+	cl_int createSubDevices (
+	const cl_device_partition_property * properties,
+	VECTOR_CLASS<Device> * devices)
+	{
+		cl_uint n = 0;
+		cl_int err = clCreateSubDevices (object_, properties, 0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES);
+		}
 
-        cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
-        err = clCreateSubDevices(object_, properties, n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES);
-        }
+		cl_device_id * ids = (cl_device_id *)alloca (n * sizeof (cl_device_id));
+		err = clCreateSubDevices (object_, properties, n, ids, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES);
+		}
 
-        devices->assign(&ids[0], &ids[n]);
-        return CL_SUCCESS;
-    }
+		devices->assign (&ids[0], &ids[n]);
+		return CL_SUCCESS;
+	}
 #endif // #if defined(CL_VERSION_1_2)
 
 /**
@@ -2128,36 +2352,37 @@ public:
  */
 #if defined(CL_VERSION_1_1)
 #if defined(USE_CL_DEVICE_FISSION)
-    cl_int createSubDevices(
-        const cl_device_partition_property_ext * properties,
-        VECTOR_CLASS<Device>* devices)
-    {
-        typedef CL_API_ENTRY cl_int 
-            ( CL_API_CALL * PFN_clCreateSubDevicesEXT)(
-                cl_device_id /*in_device*/,
-                const cl_device_partition_property_ext * /* properties */,
-                cl_uint /*num_entries*/,
-                cl_device_id * /*out_devices*/,
-                cl_uint * /*num_devices*/ ) CL_EXT_SUFFIX__VERSION_1_1;
+	cl_int createSubDevices (
+	const cl_device_partition_property_ext * properties,
+	VECTOR_CLASS<Device> * devices)
+	{
+		typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clCreateSubDevicesEXT) (
+		cl_device_id /*in_device*/,
+		const cl_device_partition_property_ext * /* properties */,
+		cl_uint /*num_entries*/,
+		cl_device_id * /*out_devices*/,
+		cl_uint * /*num_devices*/) CL_EXT_SUFFIX__VERSION_1_1;
 
-        static PFN_clCreateSubDevicesEXT pfn_clCreateSubDevicesEXT = NULL;
-        __INIT_CL_EXT_FCN_PTR(clCreateSubDevicesEXT);
+		static PFN_clCreateSubDevicesEXT pfn_clCreateSubDevicesEXT = NULL;
+		__INIT_CL_EXT_FCN_PTR (clCreateSubDevicesEXT);
 
-        cl_uint n = 0;
-        cl_int err = pfn_clCreateSubDevicesEXT(object_, properties, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES);
-        }
+		cl_uint n = 0;
+		cl_int err = pfn_clCreateSubDevicesEXT (object_, properties, 0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES);
+		}
 
-        cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
-        err = pfn_clCreateSubDevicesEXT(object_, properties, n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES);
-        }
+		cl_device_id * ids = (cl_device_id *)alloca (n * sizeof (cl_device_id));
+		err = pfn_clCreateSubDevicesEXT (object_, properties, n, ids, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES);
+		}
 
-        devices->assign(&ids[0], &ids[n]);
-        return CL_SUCCESS;
-    }
+		devices->assign (&ids[0], &ids[n]);
+		return CL_SUCCESS;
+	}
 #endif // #if defined(USE_CL_DEVICE_FISSION)
 #endif // #if defined(CL_VERSION_1_1)
 };
@@ -2172,76 +2397,86 @@ public:
 class Platform : public detail::Wrapper<cl_platform_id>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Platform() : detail::Wrapper<cl_type>()  { }
+	//! \brief Default constructor - initializes to NULL.
+	Platform () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_platform_id.
+	/*! \brief Constructor from cl_platform_id.
      * 
      *  This simply copies the platform ID value, which is an inexpensive operation.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Platform(const cl_platform_id &platform) : detail::Wrapper<cl_type>(platform) { }
+	__CL_EXPLICIT_CONSTRUCTORS Platform (const cl_platform_id & platform) :
+		detail::Wrapper<cl_type> (platform)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_platform_id.
+	/*! \brief Assignment operator from cl_platform_id.
      * 
      *  This simply copies the platform ID value, which is an inexpensive operation.
      */
-    Platform& operator = (const cl_platform_id& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Platform & operator= (const cl_platform_id & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetPlatformInfo().
-    cl_int getInfo(cl_platform_info name, STRING_CLASS* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetPlatformInfo, object_, name, param),
-            __GET_PLATFORM_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetPlatformInfo().
+	cl_int getInfo (cl_platform_info name, STRING_CLASS * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetPlatformInfo, object_, name, param),
+		__GET_PLATFORM_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetPlatformInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_platform_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_platform_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetPlatformInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_platform_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_platform_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*! \brief Gets a list of devices for this platform.
+	/*! \brief Gets a list of devices for this platform.
      * 
      *  Wraps clGetDeviceIDs().
      */
-    cl_int getDevices(
-        cl_device_type type,
-        VECTOR_CLASS<Device>* devices) const
-    {
-        cl_uint n = 0;
-        if( devices == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
-        }
-        cl_int err = ::clGetDeviceIDs(object_, type, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+	cl_int getDevices (
+	cl_device_type type,
+	VECTOR_CLASS<Device> * devices) const
+	{
+		cl_uint n = 0;
+		if (devices == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
+		}
+		cl_int err = ::clGetDeviceIDs (object_, type, 0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
-        err = ::clGetDeviceIDs(object_, type, n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+		cl_device_id * ids = (cl_device_id *)alloca (n * sizeof (cl_device_id));
+		err = ::clGetDeviceIDs (object_, type, n, ids, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        devices->assign(&ids[0], &ids[n]);
-        return CL_SUCCESS;
-    }
+		devices->assign (&ids[0], &ids[n]);
+		return CL_SUCCESS;
+	}
 
 #if defined(USE_DX_INTEROP)
-   /*! \brief Get the list of available D3D10 devices.
+	/*! \brief Get the list of available D3D10 devices.
      *
      *  \param d3d_device_source.
      *
@@ -2264,165 +2499,176 @@ public:
      * other than CL_SUCCESS is generated, then cl::Error exception is
      * generated.
      */
-    cl_int getDevices(
-        cl_d3d10_device_source_khr d3d_device_source,
-        void *                     d3d_object,
-        cl_d3d10_device_set_khr    d3d_device_set,
-        VECTOR_CLASS<Device>* devices) const
-    {
-        typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clGetDeviceIDsFromD3D10KHR)(
-            cl_platform_id platform, 
-            cl_d3d10_device_source_khr d3d_device_source, 
-            void * d3d_object,
-            cl_d3d10_device_set_khr d3d_device_set,
-            cl_uint num_entries,
-            cl_device_id * devices,
-            cl_uint* num_devices);
+	cl_int getDevices (
+	cl_d3d10_device_source_khr d3d_device_source,
+	void * d3d_object,
+	cl_d3d10_device_set_khr d3d_device_set,
+	VECTOR_CLASS<Device> * devices) const
+	{
+		typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clGetDeviceIDsFromD3D10KHR) (
+		cl_platform_id platform,
+		cl_d3d10_device_source_khr d3d_device_source,
+		void * d3d_object,
+		cl_d3d10_device_set_khr d3d_device_set,
+		cl_uint num_entries,
+		cl_device_id * devices,
+		cl_uint * num_devices);
 
-        if( devices == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
-        }
+		if (devices == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
+		}
 
-        static PFN_clGetDeviceIDsFromD3D10KHR pfn_clGetDeviceIDsFromD3D10KHR = NULL;
-        __INIT_CL_EXT_FCN_PTR_PLATFORM(object_, clGetDeviceIDsFromD3D10KHR);
+		static PFN_clGetDeviceIDsFromD3D10KHR pfn_clGetDeviceIDsFromD3D10KHR = NULL;
+		__INIT_CL_EXT_FCN_PTR_PLATFORM (object_, clGetDeviceIDsFromD3D10KHR);
 
-        cl_uint n = 0;
-        cl_int err = pfn_clGetDeviceIDsFromD3D10KHR(
-            object_, 
-            d3d_device_source, 
-            d3d_object,
-            d3d_device_set, 
-            0, 
-            NULL, 
-            &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+		cl_uint n = 0;
+		cl_int err = pfn_clGetDeviceIDsFromD3D10KHR (
+		object_,
+		d3d_device_source,
+		d3d_object,
+		d3d_device_set,
+		0,
+		NULL,
+		&n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        cl_device_id* ids = (cl_device_id*) alloca(n * sizeof(cl_device_id));
-        err = pfn_clGetDeviceIDsFromD3D10KHR(
-            object_, 
-            d3d_device_source, 
-            d3d_object,
-            d3d_device_set,
-            n, 
-            ids, 
-            NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+		cl_device_id * ids = (cl_device_id *)alloca (n * sizeof (cl_device_id));
+		err = pfn_clGetDeviceIDsFromD3D10KHR (
+		object_,
+		d3d_device_source,
+		d3d_object,
+		d3d_device_set,
+		n,
+		ids,
+		NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        devices->assign(&ids[0], &ids[n]);
-        return CL_SUCCESS;
-    }
+		devices->assign (&ids[0], &ids[n]);
+		return CL_SUCCESS;
+	}
 #endif
 
-    /*! \brief Gets a list of available platforms.
+	/*! \brief Gets a list of available platforms.
      * 
      *  Wraps clGetPlatformIDs().
      */
-    static cl_int get(
-        VECTOR_CLASS<Platform>* platforms)
-    {
-        cl_uint n = 0;
+	static cl_int get (
+	VECTOR_CLASS<Platform> * platforms)
+	{
+		cl_uint n = 0;
 
-        if( platforms == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
-        }
+		if (platforms == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
+		}
 
-        cl_int err = ::clGetPlatformIDs(0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-        }
+		cl_int err = ::clGetPlatformIDs (0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+		}
 
-        cl_platform_id* ids = (cl_platform_id*) alloca(
-            n * sizeof(cl_platform_id));
-        err = ::clGetPlatformIDs(n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-        }
+		cl_platform_id * ids = (cl_platform_id *)alloca (
+		n * sizeof (cl_platform_id));
+		err = ::clGetPlatformIDs (n, ids, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+		}
 
-        platforms->assign(&ids[0], &ids[n]);
-        return CL_SUCCESS;
-    }
+		platforms->assign (&ids[0], &ids[n]);
+		return CL_SUCCESS;
+	}
 
-    /*! \brief Gets the first available platform.
+	/*! \brief Gets the first available platform.
      * 
      *  Wraps clGetPlatformIDs(), returning the first result.
      */
-    static cl_int get(
-        Platform * platform)
-    {
-        cl_uint n = 0;
+	static cl_int get (
+	Platform * platform)
+	{
+		cl_uint n = 0;
 
-        if( platform == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
-        }
+		if (platform == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
+		}
 
-        cl_int err = ::clGetPlatformIDs(0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-        }
+		cl_int err = ::clGetPlatformIDs (0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+		}
 
-        cl_platform_id* ids = (cl_platform_id*) alloca(
-            n * sizeof(cl_platform_id));
-        err = ::clGetPlatformIDs(n, ids, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-        }
+		cl_platform_id * ids = (cl_platform_id *)alloca (
+		n * sizeof (cl_platform_id));
+		err = ::clGetPlatformIDs (n, ids, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+		}
 
-        *platform = ids[0];
-        return CL_SUCCESS;
-    }
+		*platform = ids[0];
+		return CL_SUCCESS;
+	}
 
-    /*! \brief Gets the first available platform, returning it by value.
+	/*! \brief Gets the first available platform, returning it by value.
      * 
      *  Wraps clGetPlatformIDs(), returning the first result.
      */
-    static Platform get(
-        cl_int * errResult = NULL)
-    {
-        Platform platform;
-        cl_uint n = 0;
-        cl_int err = ::clGetPlatformIDs(0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-            if (errResult != NULL) {
-                *errResult = err;
-            }
-            return Platform();
-        }
+	static Platform get (
+	cl_int * errResult = NULL)
+	{
+		Platform platform;
+		cl_uint n = 0;
+		cl_int err = ::clGetPlatformIDs (0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+			if (errResult != NULL)
+			{
+				*errResult = err;
+			}
+			return Platform ();
+		}
 
-        cl_platform_id* ids = (cl_platform_id*) alloca(
-            n * sizeof(cl_platform_id));
-        err = ::clGetPlatformIDs(n, ids, NULL);
+		cl_platform_id * ids = (cl_platform_id *)alloca (
+		n * sizeof (cl_platform_id));
+		err = ::clGetPlatformIDs (n, ids, NULL);
 
-        if (err != CL_SUCCESS) {
-            detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-            if (errResult != NULL) {
-                *errResult = err;
-            }
-            return Platform();
-        }
+		if (err != CL_SUCCESS)
+		{
+			detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+			if (errResult != NULL)
+			{
+				*errResult = err;
+			}
+			return Platform ();
+		}
 
-        
-        return Platform(ids[0]);
-    }
+		return Platform (ids[0]);
+	}
 
-    static Platform getDefault( 
-        cl_int *errResult = NULL )
-    {
-        return get(errResult);
-    }
+	static Platform getDefault (
+	cl_int * errResult = NULL)
+	{
+		return get (errResult);
+	}
 
-    
 #if defined(CL_VERSION_1_2)
-    //! \brief Wrapper for clUnloadCompiler().
-    cl_int
-    unloadCompiler()
-    {
-        return ::clUnloadPlatformCompiler(object_);
-    }
+	//! \brief Wrapper for clUnloadCompiler().
+	cl_int
+	unloadCompiler ()
+	{
+		return ::clUnloadPlatformCompiler (object_);
+	}
 #endif // #if defined(CL_VERSION_1_2)
 }; // class Platform
 
@@ -2435,11 +2681,11 @@ public:
  * \note Deprecated for OpenCL 1.2. Use Platform::unloadCompiler instead.
  */
 inline CL_EXT_PREFIX__VERSION_1_1_DEPRECATED cl_int
-UnloadCompiler() CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
+UnloadCompiler () CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
 inline cl_int
-UnloadCompiler()
+UnloadCompiler ()
 {
-    return ::clUnloadCompiler();
+	return ::clUnloadCompiler ();
 }
 #endif // #if defined(CL_VERSION_1_1)
 
@@ -2451,362 +2697,406 @@ UnloadCompiler()
  *
  *  \see cl_context
  */
-class Context 
-    : public detail::Wrapper<cl_context>
+class Context
+	: public detail::Wrapper<cl_context>
 {
 private:
-
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-    static std::atomic<int> default_initialized_;
+	static std::atomic<int> default_initialized_;
 #else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    static volatile int default_initialized_;
+	static volatile int default_initialized_;
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    static Context default_;
-    static volatile cl_int default_error_;
+	static Context default_;
+	static volatile cl_int default_error_;
+
 public:
-    /*! \brief Constructs a context including a list of specified devices.
+	/*! \brief Constructs a context including a list of specified devices.
      *
      *  Wraps clCreateContext().
      */
-    Context(
-        const VECTOR_CLASS<Device>& devices,
-        cl_context_properties* properties = NULL,
-        void (CL_CALLBACK * notifyFptr)(
-            const char *,
-            const void *,
-            ::size_t,
-            void *) = NULL,
-        void* data = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Context (
+	const VECTOR_CLASS<Device> & devices,
+	cl_context_properties * properties = NULL,
+	void (CL_CALLBACK * notifyFptr) (
+	const char *,
+	const void *,
+	::size_t,
+	void *)
+	= NULL,
+	void * data = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        ::size_t numDevices = devices.size();
-        cl_device_id* deviceIDs = (cl_device_id*) alloca(numDevices * sizeof(cl_device_id));
-        for( ::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
+		::size_t numDevices = devices.size ();
+		cl_device_id * deviceIDs = (cl_device_id *)alloca (numDevices * sizeof (cl_device_id));
+		for (::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        object_ = ::clCreateContext(
-            properties, (cl_uint) numDevices,
-            deviceIDs,
-            notifyFptr, data, &error);
+		object_ = ::clCreateContext (
+		properties, (cl_uint)numDevices,
+		deviceIDs,
+		notifyFptr, data, &error);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Context(
-        const Device& device,
-        cl_context_properties* properties = NULL,
-        void (CL_CALLBACK * notifyFptr)(
-            const char *,
-            const void *,
-            ::size_t,
-            void *) = NULL,
-        void* data = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Context (
+	const Device & device,
+	cl_context_properties * properties = NULL,
+	void (CL_CALLBACK * notifyFptr) (
+	const char *,
+	const void *,
+	::size_t,
+	void *)
+	= NULL,
+	void * data = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        cl_device_id deviceID = device();
+		cl_device_id deviceID = device ();
 
-        object_ = ::clCreateContext(
-            properties, 1,
-            &deviceID,
-            notifyFptr, data, &error);
+		object_ = ::clCreateContext (
+		properties, 1,
+		&deviceID,
+		notifyFptr, data, &error);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*! \brief Constructs a context including all or a subset of devices of a specified type.
+	/*! \brief Constructs a context including all or a subset of devices of a specified type.
      *
      *  Wraps clCreateContextFromType().
      */
-    Context(
-        cl_device_type type,
-        cl_context_properties* properties = NULL,
-        void (CL_CALLBACK * notifyFptr)(
-            const char *,
-            const void *,
-            ::size_t,
-            void *) = NULL,
-        void* data = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Context (
+	cl_device_type type,
+	cl_context_properties * properties = NULL,
+	void (CL_CALLBACK * notifyFptr) (
+	const char *,
+	const void *,
+	::size_t,
+	void *)
+	= NULL,
+	void * data = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
 #if !defined(__APPLE__) && !defined(__MACOS)
-        cl_context_properties prop[4] = {CL_CONTEXT_PLATFORM, 0, 0, 0 };
+		cl_context_properties prop[4] = { CL_CONTEXT_PLATFORM, 0, 0, 0 };
 
-        if (properties == NULL) {
-            // Get a valid platform ID as we cannot send in a blank one
-            VECTOR_CLASS<Platform> platforms;
-            error = Platform::get(&platforms);
-            if (error != CL_SUCCESS) {
-                detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
-                if (err != NULL) {
-                    *err = error;
-                }
-                return;
-            }
+		if (properties == NULL)
+		{
+			// Get a valid platform ID as we cannot send in a blank one
+			VECTOR_CLASS<Platform> platforms;
+			error = Platform::get (&platforms);
+			if (error != CL_SUCCESS)
+			{
+				detail::errHandler (error, __CREATE_CONTEXT_FROM_TYPE_ERR);
+				if (err != NULL)
+				{
+					*err = error;
+				}
+				return;
+			}
 
-            // Check the platforms we found for a device of our specified type
-            cl_context_properties platform_id = 0;
-            for (unsigned int i = 0; i < platforms.size(); i++) {
-
-                VECTOR_CLASS<Device> devices;
-
-#if defined(__CL_ENABLE_EXCEPTIONS)
-                try {
-#endif
-
-                    error = platforms[i].getDevices(type, &devices);
+			// Check the platforms we found for a device of our specified type
+			cl_context_properties platform_id = 0;
+			for (unsigned int i = 0; i < platforms.size (); i++)
+			{
+				VECTOR_CLASS<Device> devices;
 
 #if defined(__CL_ENABLE_EXCEPTIONS)
-                } catch (Error) {}
-    // Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
-    // We do error checking next anyway, and can throw there if needed
+				try
+				{
 #endif
 
-                // Only squash CL_SUCCESS and CL_DEVICE_NOT_FOUND
-                if (error != CL_SUCCESS && error != CL_DEVICE_NOT_FOUND) {
-                    detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
-                    if (err != NULL) {
-                        *err = error;
-                    }
-                }
+					error = platforms[i].getDevices (type, &devices);
 
-                if (devices.size() > 0) {
-                    platform_id = (cl_context_properties)platforms[i]();
-                    break;
-                }
-            }
-
-            if (platform_id == 0) {
-                detail::errHandler(CL_DEVICE_NOT_FOUND, __CREATE_CONTEXT_FROM_TYPE_ERR);
-                if (err != NULL) {
-                    *err = CL_DEVICE_NOT_FOUND;
-                }
-                return;
-            }
-
-            prop[1] = platform_id;
-            properties = &prop[0];
-        }
+#if defined(__CL_ENABLE_EXCEPTIONS)
+				}
+				catch (Error)
+				{
+				}
+				// Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
+				// We do error checking next anyway, and can throw there if needed
 #endif
-        object_ = ::clCreateContextFromType(
-            properties, type, notifyFptr, data, &error);
 
-        detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+				// Only squash CL_SUCCESS and CL_DEVICE_NOT_FOUND
+				if (error != CL_SUCCESS && error != CL_DEVICE_NOT_FOUND)
+				{
+					detail::errHandler (error, __CREATE_CONTEXT_FROM_TYPE_ERR);
+					if (err != NULL)
+					{
+						*err = error;
+					}
+				}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+				if (devices.size () > 0)
+				{
+					platform_id = (cl_context_properties)platforms[i]();
+					break;
+				}
+			}
+
+			if (platform_id == 0)
+			{
+				detail::errHandler (CL_DEVICE_NOT_FOUND, __CREATE_CONTEXT_FROM_TYPE_ERR);
+				if (err != NULL)
+				{
+					*err = CL_DEVICE_NOT_FOUND;
+				}
+				return;
+			}
+
+			prop[1] = platform_id;
+			properties = &prop[0];
+		}
+#endif
+		object_ = ::clCreateContextFromType (
+		properties, type, notifyFptr, data, &error);
+
+		detail::errHandler (error, __CREATE_CONTEXT_FROM_TYPE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Context(const Context& ctx) : detail::Wrapper<cl_type>(ctx) {}
+	Context (const Context & ctx) :
+		detail::Wrapper<cl_type> (ctx)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Context& operator = (const Context &ctx)
-    {
-        detail::Wrapper<cl_type>::operator=(ctx);
-        return *this;
-    }
+	Context & operator= (const Context & ctx)
+	{
+		detail::Wrapper<cl_type>::operator= (ctx);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Context(Context&& ctx) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(ctx)) {}
+	Context (Context && ctx) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (ctx))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Context& operator = (Context &&ctx)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(ctx));
-        return *this;
-    }
+	Context & operator= (Context && ctx)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (ctx));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    /*! \brief Returns a singleton context including all devices of CL_DEVICE_TYPE_DEFAULT.
+	/*! \brief Returns a singleton context including all devices of CL_DEVICE_TYPE_DEFAULT.
      *
      *  \note All calls to this function return the same cl_context as the first.
      */
-    static Context getDefault(cl_int * err = NULL) 
-    {
-        int state = detail::compare_exchange(
-            &default_initialized_, 
-            __DEFAULT_BEING_INITIALIZED, __DEFAULT_NOT_INITIALIZED);
-        
-        if (state & __DEFAULT_INITIALIZED) {
-            if (err != NULL) {
-                *err = default_error_;
-            }
-            return default_;
-        }
+	static Context getDefault (cl_int * err = NULL)
+	{
+		int state = detail::compare_exchange (
+		&default_initialized_,
+		__DEFAULT_BEING_INITIALIZED, __DEFAULT_NOT_INITIALIZED);
 
-        if (state & __DEFAULT_BEING_INITIALIZED) {
-              // Assume writes will propagate eventually...
-              while(default_initialized_ != __DEFAULT_INITIALIZED) {
-                  detail::fence();
-              }
+		if (state & __DEFAULT_INITIALIZED)
+		{
+			if (err != NULL)
+			{
+				*err = default_error_;
+			}
+			return default_;
+		}
 
-            if (err != NULL) {
-                *err = default_error_;
-            }
-            return default_;
-        }
+		if (state & __DEFAULT_BEING_INITIALIZED)
+		{
+			// Assume writes will propagate eventually...
+			while (default_initialized_ != __DEFAULT_INITIALIZED)
+			{
+				detail::fence ();
+			}
 
-        cl_int error;
-        default_ = Context(
-            CL_DEVICE_TYPE_DEFAULT,
-            NULL,
-            NULL,
-            NULL,
-            &error);
+			if (err != NULL)
+			{
+				*err = default_error_;
+			}
+			return default_;
+		}
 
-        detail::fence();
+		cl_int error;
+		default_ = Context (
+		CL_DEVICE_TYPE_DEFAULT,
+		NULL,
+		NULL,
+		NULL,
+		&error);
 
-        default_error_ = error;
-        // Assume writes will propagate eventually...
-        default_initialized_ = __DEFAULT_INITIALIZED;
+		detail::fence ();
 
-        detail::fence();
+		default_error_ = error;
+		// Assume writes will propagate eventually...
+		default_initialized_ = __DEFAULT_INITIALIZED;
 
-        if (err != NULL) {
-            *err = default_error_;
-        }
-        return default_;
+		detail::fence ();
 
-    }
+		if (err != NULL)
+		{
+			*err = default_error_;
+		}
+		return default_;
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Context() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Context () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_context - takes ownership.
+	/*! \brief Constructor from cl_context - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_context
      *  into the new Context object.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Context(const cl_context& context) : detail::Wrapper<cl_type>(context) { }
+	__CL_EXPLICIT_CONSTRUCTORS Context (const cl_context & context) :
+		detail::Wrapper<cl_type> (context)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_context - takes ownership.
+	/*! \brief Assignment operator from cl_context - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseContext() on the value previously held by this instance.
      */
-    Context& operator = (const cl_context& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Context & operator= (const cl_context & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetContextInfo().
-    template <typename T>
-    cl_int getInfo(cl_context_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetContextInfo, object_, name, param),
-            __GET_CONTEXT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetContextInfo().
+	template <typename T>
+	cl_int getInfo (cl_context_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetContextInfo, object_, name, param),
+		__GET_CONTEXT_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetContextInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_context_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_context_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetContextInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_context_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_context_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*! \brief Gets a list of supported image formats.
+	/*! \brief Gets a list of supported image formats.
      *  
      *  Wraps clGetSupportedImageFormats().
      */
-    cl_int getSupportedImageFormats(
-        cl_mem_flags flags,
-        cl_mem_object_type type,
-        VECTOR_CLASS<ImageFormat>* formats) const
-    {
-        cl_uint numEntries;
+	cl_int getSupportedImageFormats (
+	cl_mem_flags flags,
+	cl_mem_object_type type,
+	VECTOR_CLASS<ImageFormat> * formats) const
+	{
+		cl_uint numEntries;
 
-        if (!formats) {
-            return CL_SUCCESS;
-        }
+		if (!formats)
+		{
+			return CL_SUCCESS;
+		}
 
-        cl_int err = ::clGetSupportedImageFormats(
-            object_,
-            flags,
-            type,
-            0,
-            NULL,
-            &numEntries);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
-        }
+		cl_int err = ::clGetSupportedImageFormats (
+		object_,
+		flags,
+		type,
+		0,
+		NULL,
+		&numEntries);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
+		}
 
-        if (numEntries > 0) {
-            ImageFormat* value = (ImageFormat*)
-                alloca(numEntries * sizeof(ImageFormat));
-            err = ::clGetSupportedImageFormats(
-                object_,
-                flags,
-                type,
-                numEntries,
-                (cl_image_format*)value,
-                NULL);
-            if (err != CL_SUCCESS) {
-                return detail::errHandler(err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
-            }
+		if (numEntries > 0)
+		{
+			ImageFormat * value = (ImageFormat *)
+			alloca (numEntries * sizeof (ImageFormat));
+			err = ::clGetSupportedImageFormats (
+			object_,
+			flags,
+			type,
+			numEntries,
+			(cl_image_format *)value,
+			NULL);
+			if (err != CL_SUCCESS)
+			{
+				return detail::errHandler (err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
+			}
 
-            formats->assign(&value[0], &value[numEntries]);
-        }
-        else {
-            formats->clear();
-        }
-        return CL_SUCCESS;
-    }
+			formats->assign (&value[0], &value[numEntries]);
+		}
+		else
+		{
+			formats->clear ();
+		}
+		return CL_SUCCESS;
+	}
 };
 
-inline Device Device::getDefault(cl_int * err)
+inline Device Device::getDefault (cl_int * err)
 {
-    cl_int error;
-    Device device;
+	cl_int error;
+	Device device;
 
-    Context context = Context::getDefault(&error);
-    detail::errHandler(error, __CREATE_CONTEXT_ERR);
+	Context context = Context::getDefault (&error);
+	detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-    if (error != CL_SUCCESS) {
-        if (err != NULL) {
-            *err = error;
-        }
-    }
-    else {
-        device = context.getInfo<CL_CONTEXT_DEVICES>()[0];
-        if (err != NULL) {
-            *err = CL_SUCCESS;
-        }
-    }
+	if (error != CL_SUCCESS)
+	{
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+	else
+	{
+		device = context.getInfo<CL_CONTEXT_DEVICES> ()[0];
+		if (err != NULL)
+		{
+			*err = CL_SUCCESS;
+		}
+	}
 
-    return device;
+	return device;
 }
-
 
 #ifdef _WIN32
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
@@ -2818,12 +3108,12 @@ __declspec(selectany) Context Context::default_;
 __declspec(selectany) volatile cl_int Context::default_error_ = CL_SUCCESS;
 #else // !_WIN32
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-__attribute__((weak)) std::atomic<int> Context::default_initialized_;
+__attribute__ ((weak)) std::atomic<int> Context::default_initialized_;
 #else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-__attribute__((weak)) volatile int Context::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
+__attribute__ ((weak)) volatile int Context::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-__attribute__((weak)) Context Context::default_;
-__attribute__((weak)) volatile cl_int Context::default_error_ = CL_SUCCESS;
+__attribute__ ((weak)) Context Context::default_;
+__attribute__ ((weak)) volatile cl_int Context::default_error_ = CL_SUCCESS;
 #endif // !_WIN32
 
 /*! \brief Class interface for cl_event.
@@ -2837,116 +3127,124 @@ __attribute__((weak)) volatile cl_int Context::default_error_ = CL_SUCCESS;
 class Event : public detail::Wrapper<cl_event>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Event() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Event () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_event - takes ownership.
+	/*! \brief Constructor from cl_event - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_event
      *  into the new Event object.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Event(const cl_event& event) : detail::Wrapper<cl_type>(event) { }
+	__CL_EXPLICIT_CONSTRUCTORS Event (const cl_event & event) :
+		detail::Wrapper<cl_type> (event)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_event - takes ownership.
+	/*! \brief Assignment operator from cl_event - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseEvent() on the value previously held by this instance.
      */
-    Event& operator = (const cl_event& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Event & operator= (const cl_event & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetEventInfo().
-    template <typename T>
-    cl_int getInfo(cl_event_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetEventInfo, object_, name, param),
-            __GET_EVENT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetEventInfo().
+	template <typename T>
+	cl_int getInfo (cl_event_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetEventInfo, object_, name, param),
+		__GET_EVENT_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetEventInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_event_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_event_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetEventInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_event_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_event_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    //! \brief Wrapper for clGetEventProfilingInfo().
-    template <typename T>
-    cl_int getProfilingInfo(cl_profiling_info name, T* param) const
-    {
-        return detail::errHandler(detail::getInfo(
-            &::clGetEventProfilingInfo, object_, name, param),
-            __GET_EVENT_PROFILE_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetEventProfilingInfo().
+	template <typename T>
+	cl_int getProfilingInfo (cl_profiling_info name, T * param) const
+	{
+		return detail::errHandler (detail::getInfo (
+								   &::clGetEventProfilingInfo, object_, name, param),
+		__GET_EVENT_PROFILE_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetEventProfilingInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_profiling_info, name>::param_type
-    getProfilingInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_profiling_info, name>::param_type param;
-        cl_int result = getProfilingInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetEventProfilingInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_profiling_info, name>::param_type
+	getProfilingInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_profiling_info, name>::param_type param;
+		cl_int result = getProfilingInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*! \brief Blocks the calling thread until this event completes.
+	/*! \brief Blocks the calling thread until this event completes.
      * 
      *  Wraps clWaitForEvents().
      */
-    cl_int wait() const
-    {
-        return detail::errHandler(
-            ::clWaitForEvents(1, &object_),
-            __WAIT_FOR_EVENTS_ERR);
-    }
+	cl_int wait () const
+	{
+		return detail::errHandler (
+		::clWaitForEvents (1, &object_),
+		__WAIT_FOR_EVENTS_ERR);
+	}
 
 #if defined(CL_VERSION_1_1)
-    /*! \brief Registers a user callback function for a specific command execution status.
+	/*! \brief Registers a user callback function for a specific command execution status.
      *
      *  Wraps clSetEventCallback().
      */
-    cl_int setCallback(
-        cl_int type,
-        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),		
-        void * user_data = NULL)
-    {
-        return detail::errHandler(
-            ::clSetEventCallback(
-                object_,
-                type,
-                pfn_notify,
-                user_data), 
-            __SET_EVENT_CALLBACK_ERR);
-    }
+	cl_int setCallback (
+	cl_int type,
+	void (CL_CALLBACK * pfn_notify) (cl_event, cl_int, void *),
+	void * user_data = NULL)
+	{
+		return detail::errHandler (
+		::clSetEventCallback (
+		object_,
+		type,
+		pfn_notify,
+		user_data),
+		__SET_EVENT_CALLBACK_ERR);
+	}
 #endif
 
-    /*! \brief Blocks the calling thread until every event specified is complete.
+	/*! \brief Blocks the calling thread until every event specified is complete.
      * 
      *  Wraps clWaitForEvents().
      */
-    static cl_int
-    waitForEvents(const VECTOR_CLASS<Event>& events)
-    {
-        return detail::errHandler(
-            ::clWaitForEvents(
-                (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : NULL),
-            __WAIT_FOR_EVENTS_ERR);
-    }
+	static cl_int
+	waitForEvents (const VECTOR_CLASS<Event> & events)
+	{
+		return detail::errHandler (
+		::clWaitForEvents (
+		(cl_uint)events.size (), (events.size () > 0) ? (cl_event *)&events.front () : NULL),
+		__WAIT_FOR_EVENTS_ERR);
+	}
 };
 
 #if defined(CL_VERSION_1_1)
@@ -2957,38 +3255,42 @@ public:
 class UserEvent : public Event
 {
 public:
-    /*! \brief Constructs a user event on a given context.
+	/*! \brief Constructs a user event on a given context.
      *
      *  Wraps clCreateUserEvent().
      */
-    UserEvent(
-        const Context& context,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateUserEvent(
-            context(),
-            &error);
+	UserEvent (
+	const Context & context,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateUserEvent (
+		context (),
+		&error);
 
-        detail::errHandler(error, __CREATE_USER_EVENT_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_USER_EVENT_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    UserEvent() : Event() { }
+	//! \brief Default constructor - initializes to NULL.
+	UserEvent () :
+		Event ()
+	{
+	}
 
-    /*! \brief Sets the execution status of a user event object.
+	/*! \brief Sets the execution status of a user event object.
      *
      *  Wraps clSetUserEventStatus().
      */
-    cl_int setStatus(cl_int status)
-    {
-        return detail::errHandler(
-            ::clSetUserEventStatus(object_,status), 
-            __SET_USER_EVENT_STATUS_ERR);
-    }
+	cl_int setStatus (cl_int status)
+	{
+		return detail::errHandler (
+		::clSetUserEventStatus (object_, status),
+		__SET_USER_EVENT_STATUS_ERR);
+	}
 };
 #endif
 
@@ -2997,12 +3299,12 @@ public:
  *  Wraps clWaitForEvents().
  */
 inline static cl_int
-WaitForEvents(const VECTOR_CLASS<Event>& events)
+WaitForEvents (const VECTOR_CLASS<Event> & events)
 {
-    return detail::errHandler(
-        ::clWaitForEvents(
-            (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : NULL),
-        __WAIT_FOR_EVENTS_ERR);
+	return detail::errHandler (
+	::clWaitForEvents (
+	(cl_uint)events.size (), (events.size () > 0) ? (cl_event *)&events.front () : NULL),
+	__WAIT_FOR_EVENTS_ERR);
 }
 
 /*! \brief Class interface for cl_mem.
@@ -3016,82 +3318,94 @@ WaitForEvents(const VECTOR_CLASS<Event>& events)
 class Memory : public detail::Wrapper<cl_mem>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Memory() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Memory () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_mem
      *  into the new Memory object.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Memory(const cl_mem& memory) : detail::Wrapper<cl_type>(memory) { }
+	__CL_EXPLICIT_CONSTRUCTORS Memory (const cl_mem & memory) :
+		detail::Wrapper<cl_type> (memory)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_mem - takes ownership.
+	/*! \brief Assignment operator from cl_mem - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseMemObject() on the value previously held by this instance.
      */
-    Memory& operator = (const cl_mem& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Memory & operator= (const cl_mem & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Memory(const Memory& mem) : detail::Wrapper<cl_type>(mem) {}
+	Memory (const Memory & mem) :
+		detail::Wrapper<cl_type> (mem)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Memory& operator = (const Memory &mem)
-    {
-        detail::Wrapper<cl_type>::operator=(mem);
-        return *this;
-    }
+	Memory & operator= (const Memory & mem)
+	{
+		detail::Wrapper<cl_type>::operator= (mem);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Memory(Memory&& mem) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(mem)) {}
+	Memory (Memory && mem) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (mem))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Memory& operator = (Memory &&mem)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(mem));
-        return *this;
-    }
+	Memory & operator= (Memory && mem)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (mem));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    //! \brief Wrapper for clGetMemObjectInfo().
-    template <typename T>
-    cl_int getInfo(cl_mem_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetMemObjectInfo, object_, name, param),
-            __GET_MEM_OBJECT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetMemObjectInfo().
+	template <typename T>
+	cl_int getInfo (cl_mem_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetMemObjectInfo, object_, name, param),
+		__GET_MEM_OBJECT_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetMemObjectInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_mem_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_mem_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetMemObjectInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_mem_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_mem_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
 #if defined(CL_VERSION_1_1)
-    /*! \brief Registers a callback function to be called when the memory object
+	/*! \brief Registers a callback function to be called when the memory object
      *         is no longer needed.
      *
      *  Wraps clSetMemObjectDestructorCallback().
@@ -3104,32 +3418,30 @@ public:
      *  The registered callbacks are associated with the underlying cl_mem
      *  value - not the Memory class instance.
      */
-    cl_int setDestructorCallback(
-        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),		
-        void * user_data = NULL)
-    {
-        return detail::errHandler(
-            ::clSetMemObjectDestructorCallback(
-                object_,
-                pfn_notify,
-                user_data), 
-            __SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR);
-    }
+	cl_int setDestructorCallback (
+	void (CL_CALLBACK * pfn_notify) (cl_mem, void *),
+	void * user_data = NULL)
+	{
+		return detail::errHandler (
+		::clSetMemObjectDestructorCallback (
+		object_,
+		pfn_notify,
+		user_data),
+		__SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR);
+	}
 #endif
-
 };
 
 // Pre-declare copy functions
 class Buffer;
-template< typename IteratorType >
-cl_int copy( IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer );
-template< typename IteratorType >
-cl_int copy( const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator );
-template< typename IteratorType >
-cl_int copy( const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer );
-template< typename IteratorType >
-cl_int copy( const CommandQueue &queue, const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator );
-
+template <typename IteratorType>
+cl_int copy (IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer);
+template <typename IteratorType>
+cl_int copy (const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator);
+template <typename IteratorType>
+cl_int copy (const CommandQueue & queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer);
+template <typename IteratorType>
+cl_int copy (const CommandQueue & queue, const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator);
 
 /*! \brief Class interface for Buffer Memory Objects.
  * 
@@ -3140,31 +3452,31 @@ cl_int copy( const CommandQueue &queue, const cl::Buffer &buffer, IteratorType s
 class Buffer : public Memory
 {
 public:
-
-    /*! \brief Constructs a Buffer in a specified context.
+	/*! \brief Constructs a Buffer in a specified context.
      *
      *  Wraps clCreateBuffer().
      *
      *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
      *                  specified.  Note alignment & exclusivity requirements.
      */
-    Buffer(
-        const Context& context,
-        cl_mem_flags flags,
-        ::size_t size,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+	Buffer (
+	const Context & context,
+	cl_mem_flags flags,
+	::size_t size,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateBuffer (context (), flags, size, host_ptr, &error);
 
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*! \brief Constructs a Buffer in the default context.
+	/*! \brief Constructs a Buffer in the default context.
      *
      *  Wraps clCreateBuffer().
      *
@@ -3173,172 +3485,194 @@ public:
      *
      *  \see Context::getDefault()
      */
-    Buffer(
-         cl_mem_flags flags,
-        ::size_t size,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Buffer (
+	cl_mem_flags flags,
+	::size_t size,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        Context context = Context::getDefault(err);
+		Context context = Context::getDefault (err);
 
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+		object_ = ::clCreateBuffer (context (), flags, size, host_ptr, &error);
 
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*!
+	/*!
      * \brief Construct a Buffer from a host container via iterators.
      * IteratorType must be random access.
      * If useHostPtr is specified iterators must represent contiguous data.
      */
-    template< typename IteratorType >
-    Buffer(
-        IteratorType startIterator,
-        IteratorType endIterator,
-        bool readOnly,
-        bool useHostPtr = false,
-        cl_int* err = NULL)
-    {
-        typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-        cl_int error;
+	template <typename IteratorType>
+	Buffer (
+	IteratorType startIterator,
+	IteratorType endIterator,
+	bool readOnly,
+	bool useHostPtr = false,
+	cl_int * err = NULL)
+	{
+		typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+		cl_int error;
 
-        cl_mem_flags flags = 0;
-        if( readOnly ) {
-            flags |= CL_MEM_READ_ONLY;
-        }
-        else {
-            flags |= CL_MEM_READ_WRITE;
-        }
-        if( useHostPtr ) {
-            flags |= CL_MEM_USE_HOST_PTR;
-        }
-        
-        ::size_t size = sizeof(DataType)*(endIterator - startIterator);
+		cl_mem_flags flags = 0;
+		if (readOnly)
+		{
+			flags |= CL_MEM_READ_ONLY;
+		}
+		else
+		{
+			flags |= CL_MEM_READ_WRITE;
+		}
+		if (useHostPtr)
+		{
+			flags |= CL_MEM_USE_HOST_PTR;
+		}
 
-        Context context = Context::getDefault(err);
+		::size_t size = sizeof (DataType) * (endIterator - startIterator);
 
-        if( useHostPtr ) {
-            object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
-        } else {
-            object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
-        }
+		Context context = Context::getDefault (err);
 
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		if (useHostPtr)
+		{
+			object_ = ::clCreateBuffer (context (), flags, size, static_cast<DataType *> (&*startIterator), &error);
+		}
+		else
+		{
+			object_ = ::clCreateBuffer (context (), flags, size, 0, &error);
+		}
 
-        if( !useHostPtr ) {
-            error = cl::copy(startIterator, endIterator, *this);
-            detail::errHandler(error, __CREATE_BUFFER_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-    }
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-    /*!
+		if (!useHostPtr)
+		{
+			error = cl::copy (startIterator, endIterator, *this);
+			detail::errHandler (error, __CREATE_BUFFER_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+	}
+
+	/*!
      * \brief Construct a Buffer from a host container via iterators using a specified context.
      * IteratorType must be random access.
      * If useHostPtr is specified iterators must represent contiguous data.
      */
-    template< typename IteratorType >
-    Buffer(const Context &context, IteratorType startIterator, IteratorType endIterator,
-        bool readOnly, bool useHostPtr = false, cl_int* err = NULL);
+	template <typename IteratorType>
+	Buffer (const Context & context, IteratorType startIterator, IteratorType endIterator,
+	bool readOnly, bool useHostPtr = false, cl_int * err = NULL);
 
-    /*!
+	/*!
     * \brief Construct a Buffer from a host container via iterators using a specified queue.
     * If useHostPtr is specified iterators must represent contiguous data.
     */
-    template< typename IteratorType >
-    Buffer(const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator,
-        bool readOnly, bool useHostPtr = false, cl_int* err = NULL);
+	template <typename IteratorType>
+	Buffer (const CommandQueue & queue, IteratorType startIterator, IteratorType endIterator,
+	bool readOnly, bool useHostPtr = false, cl_int * err = NULL);
 
-    //! \brief Default constructor - initializes to NULL.
-    Buffer() : Memory() { }
+	//! \brief Default constructor - initializes to NULL.
+	Buffer () :
+		Memory ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Buffer(const cl_mem& buffer) : Memory(buffer) { }
+	__CL_EXPLICIT_CONSTRUCTORS Buffer (const cl_mem & buffer) :
+		Memory (buffer)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Buffer& operator = (const cl_mem& rhs)
-    {
-        Memory::operator=(rhs);
-        return *this;
-    }
-    
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
-     * Required for MSVC.
-     */
-    Buffer(const Buffer& buf) : Memory(buf) {}
+	Buffer & operator= (const cl_mem & rhs)
+	{
+		Memory::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer& operator = (const Buffer &buf)
-    {
-        Memory::operator=(buf);
-        return *this;
-    }
-    
+	Buffer (const Buffer & buf) :
+		Memory (buf)
+	{
+	}
+
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+	Buffer & operator= (const Buffer & buf)
+	{
+		Memory::operator= (buf);
+		return *this;
+	}
+
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer(Buffer&& buf) CL_HPP_NOEXCEPT : Memory(std::move(buf)) {}
+	Buffer (Buffer && buf) CL_HPP_NOEXCEPT : Memory (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer& operator = (Buffer &&buf)
-    {
-        Memory::operator=(std::move(buf));
-        return *this;
-    }
+	Buffer & operator= (Buffer && buf)
+	{
+		Memory::operator= (std::move (buf));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
 #if defined(CL_VERSION_1_1)
-    /*! \brief Creates a new buffer object from this.
+	/*! \brief Creates a new buffer object from this.
      *
      *  Wraps clCreateSubBuffer().
      */
-    Buffer createSubBuffer(
-        cl_mem_flags flags,
-        cl_buffer_create_type buffer_create_type,
-        const void * buffer_create_info,
-        cl_int * err = NULL)
-    {
-        Buffer result;
-        cl_int error;
-        result.object_ = ::clCreateSubBuffer(
-            object_, 
-            flags, 
-            buffer_create_type, 
-            buffer_create_info, 
-            &error);
+	Buffer createSubBuffer (
+	cl_mem_flags flags,
+	cl_buffer_create_type buffer_create_type,
+	const void * buffer_create_info,
+	cl_int * err = NULL)
+	{
+		Buffer result;
+		cl_int error;
+		result.object_ = ::clCreateSubBuffer (
+		object_,
+		flags,
+		buffer_create_type,
+		buffer_create_info,
+		&error);
 
-        detail::errHandler(error, __CREATE_SUBBUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_SUBBUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-        return result;
-    }		
+		return result;
+	}
 #endif
 };
 
-#if defined (USE_DX_INTEROP)
+#if defined(USE_DX_INTEROP)
 /*! \brief Class interface for creating OpenCL buffers from ID3D10Buffer's.
  *
  *  This is provided to facilitate interoperability with Direct3D.
@@ -3350,97 +3684,111 @@ public:
 class BufferD3D10 : public Buffer
 {
 public:
-    typedef CL_API_ENTRY cl_mem (CL_API_CALL *PFN_clCreateFromD3D10BufferKHR)(
-    cl_context context, cl_mem_flags flags, ID3D10Buffer*  buffer,
-    cl_int* errcode_ret);
+	typedef CL_API_ENTRY cl_mem (CL_API_CALL * PFN_clCreateFromD3D10BufferKHR) (
+	cl_context context, cl_mem_flags flags, ID3D10Buffer * buffer,
+	cl_int * errcode_ret);
 
-    /*! \brief Constructs a BufferD3D10, in a specified context, from a
+	/*! \brief Constructs a BufferD3D10, in a specified context, from a
      *         given ID3D10Buffer.
      *
      *  Wraps clCreateFromD3D10BufferKHR().
      */
-    BufferD3D10(
-        const Context& context,
-        cl_mem_flags flags,
-        ID3D10Buffer* bufobj,
-        cl_int * err = NULL)
-    {
-        static PFN_clCreateFromD3D10BufferKHR pfn_clCreateFromD3D10BufferKHR = NULL;
+	BufferD3D10 (
+	const Context & context,
+	cl_mem_flags flags,
+	ID3D10Buffer * bufobj,
+	cl_int * err = NULL)
+	{
+		static PFN_clCreateFromD3D10BufferKHR pfn_clCreateFromD3D10BufferKHR = NULL;
 
 #if defined(CL_VERSION_1_2)
-        vector<cl_context_properties> props = context.getInfo<CL_CONTEXT_PROPERTIES>();
-        cl_platform platform = -1;
-        for( int i = 0; i < props.size(); ++i ) {
-            if( props[i] == CL_CONTEXT_PLATFORM ) {
-                platform = props[i+1];
-            }
-        }
-        __INIT_CL_EXT_FCN_PTR_PLATFORM(platform, clCreateFromD3D10BufferKHR);
+		vector<cl_context_properties> props = context.getInfo<CL_CONTEXT_PROPERTIES> ();
+		cl_platform platform = -1;
+		for (int i = 0; i < props.size (); ++i)
+		{
+			if (props[i] == CL_CONTEXT_PLATFORM)
+			{
+				platform = props[i + 1];
+			}
+		}
+		__INIT_CL_EXT_FCN_PTR_PLATFORM (platform, clCreateFromD3D10BufferKHR);
 #endif
 #if defined(CL_VERSION_1_1)
-        __INIT_CL_EXT_FCN_PTR(clCreateFromD3D10BufferKHR);
+		__INIT_CL_EXT_FCN_PTR (clCreateFromD3D10BufferKHR);
 #endif
 
-        cl_int error;
-        object_ = pfn_clCreateFromD3D10BufferKHR(
-            context(),
-            flags,
-            bufobj,
-            &error);
+		cl_int error;
+		object_ = pfn_clCreateFromD3D10BufferKHR (
+		context (),
+		flags,
+		bufobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    BufferD3D10() : Buffer() { }
+	//! \brief Default constructor - initializes to NULL.
+	BufferD3D10 () :
+		Buffer ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS BufferD3D10(const cl_mem& buffer) : Buffer(buffer) { }
+	__CL_EXPLICIT_CONSTRUCTORS BufferD3D10 (const cl_mem & buffer) :
+		Buffer (buffer)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    BufferD3D10& operator = (const cl_mem& rhs)
-    {
-        Buffer::operator=(rhs);
-        return *this;
-    }
+	BufferD3D10 & operator= (const cl_mem & rhs)
+	{
+		Buffer::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    BufferD3D10(const BufferD3D10& buf) : Buffer(buf) {}
+	BufferD3D10 (const BufferD3D10 & buf) :
+		Buffer (buf)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    BufferD3D10& operator = (const BufferD3D10 &buf)
-    {
-        Buffer::operator=(buf);
-        return *this;
-    }
+	BufferD3D10 & operator= (const BufferD3D10 & buf)
+	{
+		Buffer::operator= (buf);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    BufferD3D10(BufferD3D10&& buf) CL_HPP_NOEXCEPT : Buffer(std::move(buf)) {}
+	BufferD3D10 (BufferD3D10 && buf) CL_HPP_NOEXCEPT : Buffer (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    BufferD3D10& operator = (BufferD3D10 &&buf)
-    {
-        Buffer::operator=(std::move(buf));
-        return *this;
-    }
+	BufferD3D10 & operator= (BufferD3D10 && buf)
+	{
+		Buffer::operator= (std::move (buf));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif
@@ -3456,88 +3804,100 @@ public:
 class BufferGL : public Buffer
 {
 public:
-    /*! \brief Constructs a BufferGL in a specified context, from a given
+	/*! \brief Constructs a BufferGL in a specified context, from a given
      *         GL buffer.
      *
      *  Wraps clCreateFromGLBuffer().
      */
-    BufferGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLuint bufobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLBuffer(
-            context(),
-            flags,
-            bufobj,
-            &error);
+	BufferGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLuint bufobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLBuffer (
+		context (),
+		flags,
+		bufobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    BufferGL() : Buffer() { }
+	//! \brief Default constructor - initializes to NULL.
+	BufferGL () :
+		Buffer ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS BufferGL(const cl_mem& buffer) : Buffer(buffer) { }
+	__CL_EXPLICIT_CONSTRUCTORS BufferGL (const cl_mem & buffer) :
+		Buffer (buffer)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    BufferGL& operator = (const cl_mem& rhs)
-    {
-        Buffer::operator=(rhs);
-        return *this;
-    }
+	BufferGL & operator= (const cl_mem & rhs)
+	{
+		Buffer::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    BufferGL(const BufferGL& buf) : Buffer(buf) {}
+	BufferGL (const BufferGL & buf) :
+		Buffer (buf)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    BufferGL& operator = (const BufferGL &buf)
-    {
-        Buffer::operator=(buf);
-        return *this;
-    }
+	BufferGL & operator= (const BufferGL & buf)
+	{
+		Buffer::operator= (buf);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    BufferGL(BufferGL&& buf) CL_HPP_NOEXCEPT : Buffer(std::move(buf)) {}
+	BufferGL (BufferGL && buf) CL_HPP_NOEXCEPT : Buffer (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    BufferGL& operator = (BufferGL &&buf)
-    {
-        Buffer::operator=(std::move(buf));
-        return *this;
-    }
+	BufferGL & operator= (BufferGL && buf)
+	{
+		Buffer::operator= (std::move (buf));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    //! \brief Wrapper for clGetGLObjectInfo().
-    cl_int getObjectInfo(
-        cl_gl_object_type *type,
-        cl_GLuint * gl_object_name)
-    {
-        return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
-            __GET_GL_OBJECT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetGLObjectInfo().
+	cl_int getObjectInfo (
+	cl_gl_object_type * type,
+	cl_GLuint * gl_object_name)
+	{
+		return detail::errHandler (
+		::clGetGLObjectInfo (object_, type, gl_object_name),
+		__GET_GL_OBJECT_INFO_ERR);
+	}
 };
 
 /*! \brief C++ base class for Image Memory objects.
@@ -3549,78 +3909,90 @@ public:
 class Image : public Memory
 {
 protected:
-    //! \brief Default constructor - initializes to NULL.
-    Image() : Memory() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image () :
+		Memory ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Image(const cl_mem& image) : Memory(image) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image (const cl_mem & image) :
+		Memory (image)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image& operator = (const cl_mem& rhs)
-    {
-        Memory::operator=(rhs);
-        return *this;
-    }
+	Image & operator= (const cl_mem & rhs)
+	{
+		Memory::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image(const Image& img) : Memory(img) {}
+	Image (const Image & img) :
+		Memory (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image& operator = (const Image &img)
-    {
-        Memory::operator=(img);
-        return *this;
-    }
+	Image & operator= (const Image & img)
+	{
+		Memory::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image(Image&& img) CL_HPP_NOEXCEPT : Memory(std::move(img)) {}
+	Image (Image && img) CL_HPP_NOEXCEPT : Memory (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image& operator = (Image &&img)
-    {
-        Memory::operator=(std::move(img));
-        return *this;
-    }
+	Image & operator= (Image && img)
+	{
+		Memory::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
 public:
-    //! \brief Wrapper for clGetImageInfo().
-    template <typename T>
-    cl_int getImageInfo(cl_image_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetImageInfo, object_, name, param),
-            __GET_IMAGE_INFO_ERR);
-    }
-    
-    //! \brief Wrapper for clGetImageInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_image_info, name>::param_type
-    getImageInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_image_info, name>::param_type param;
-        cl_int result = getImageInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetImageInfo().
+	template <typename T>
+	cl_int getImageInfo (cl_image_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetImageInfo, object_, name, param),
+		__GET_IMAGE_INFO_ERR);
+	}
+
+	//! \brief Wrapper for clGetImageInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_image_info, name>::param_type
+	getImageInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_image_info, name>::param_type param;
+		cl_int result = getImageInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 };
 
 #if defined(CL_VERSION_1_2)
@@ -3633,86 +4005,96 @@ public:
 class Image1D : public Image
 {
 public:
-    /*! \brief Constructs a 1D Image in a specified context.
+	/*! \brief Constructs a 1D Image in a specified context.
      *
      *  Wraps clCreateImage().
      */
-    Image1D(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        ::size_t width,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE1D,
-            width,
-            0, 0, 0, 0, 0, 0, 0, 0
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            host_ptr, 
-            &error);
+	Image1D (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	::size_t width,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE1D,
+			width,
+			0, 0, 0, 0, 0, 0, 0, 0
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		host_ptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image1D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image1D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Image1D(const cl_mem& image1D) : Image(image1D) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image1D (const cl_mem & image1D) :
+		Image (image1D)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image1D& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image1D & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D(const Image1D& img) : Image(img) {}
+	Image1D (const Image1D & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D& operator = (const Image1D &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image1D & operator= (const Image1D & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D(Image1D&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	Image1D (Image1D && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D& operator = (Image1D &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image1D & operator= (Image1D && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
@@ -3722,74 +4104,84 @@ public:
 class Image1DBuffer : public Image
 {
 public:
-    Image1DBuffer(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        ::size_t width,
-        const Buffer &buffer,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE1D_BUFFER,
-            width,
-            0, 0, 0, 0, 0, 0, 0,
-            buffer()
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            NULL, 
-            &error);
+	Image1DBuffer (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	::size_t width,
+	const Buffer & buffer,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE1D_BUFFER,
+			width,
+			0, 0, 0, 0, 0, 0, 0,
+			buffer ()
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		NULL,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Image1DBuffer() { }
+	Image1DBuffer ()
+	{
+	}
 
-    __CL_EXPLICIT_CONSTRUCTORS Image1DBuffer(const cl_mem& image1D) : Image(image1D) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image1DBuffer (const cl_mem & image1D) :
+		Image (image1D)
+	{
+	}
 
-    Image1DBuffer& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
-    
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	Image1DBuffer & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
+
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer(const Image1DBuffer& img) : Image(img) {}
+	Image1DBuffer (const Image1DBuffer & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer& operator = (const Image1DBuffer &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image1DBuffer & operator= (const Image1DBuffer & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer(Image1DBuffer&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	Image1DBuffer (Image1DBuffer && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer& operator = (Image1DBuffer &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image1DBuffer & operator= (Image1DBuffer && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
@@ -3799,82 +4191,91 @@ public:
 class Image1DArray : public Image
 {
 public:
-    Image1DArray(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        ::size_t arraySize,
-        ::size_t width,
-        ::size_t rowPitch,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE1D_ARRAY,
-            width,
-            0, 0,  // height, depth (unused)
-            arraySize,
-            rowPitch,
-            0, 0, 0, 0
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            host_ptr, 
-            &error);
+	Image1DArray (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	::size_t arraySize,
+	::size_t width,
+	::size_t rowPitch,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE1D_ARRAY,
+			width,
+			0, 0, // height, depth (unused)
+			arraySize,
+			rowPitch,
+			0, 0, 0, 0
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		host_ptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Image1DArray() { }
+	Image1DArray ()
+	{
+	}
 
-    __CL_EXPLICIT_CONSTRUCTORS Image1DArray(const cl_mem& imageArray) : Image(imageArray) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image1DArray (const cl_mem & imageArray) :
+		Image (imageArray)
+	{
+	}
 
-    Image1DArray& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
-    
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	Image1DArray & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
+
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray(const Image1DArray& img) : Image(img) {}
+	Image1DArray (const Image1DArray & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray& operator = (const Image1DArray &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image1DArray & operator= (const Image1DArray & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray(Image1DArray&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	Image1DArray (Image1DArray && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray& operator = (Image1DArray &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image1DArray & operator= (Image1DArray && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if defined(CL_VERSION_1_2)
-
 
 /*! \brief Class interface for 2D Image Memory objects.
  *
@@ -3885,125 +4286,135 @@ public:
 class Image2D : public Image
 {
 public:
-    /*! \brief Constructs a 1D Image in a specified context.
+	/*! \brief Constructs a 1D Image in a specified context.
      *
      *  Wraps clCreateImage().
      */
-    Image2D(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        ::size_t width,
-        ::size_t height,
-        ::size_t row_pitch = 0,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        bool useCreateImage;
+	Image2D (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	::size_t width,
+	::size_t height,
+	::size_t row_pitch = 0,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		bool useCreateImage;
 
 #if defined(CL_VERSION_1_2) && defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-        // Run-time decision based on the actual platform
-        {
-            cl_uint version = detail::getContextPlatformVersion(context());
-            useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
-        }
+		// Run-time decision based on the actual platform
+		{
+			cl_uint version = detail::getContextPlatformVersion (context ());
+			useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
+		}
 #elif defined(CL_VERSION_1_2)
-        useCreateImage = true;
+		useCreateImage = true;
 #else
-        useCreateImage = false;
+		useCreateImage = false;
 #endif
 
 #if defined(CL_VERSION_1_2)
-        if (useCreateImage)
-        {
-            cl_image_desc desc =
-            {
-                CL_MEM_OBJECT_IMAGE2D,
-                width,
-                height,
-                0, 0, // depth, array size (unused)
-                row_pitch,
-                0, 0, 0, 0
-            };
-            object_ = ::clCreateImage(
-                context(),
-                flags,
-                &format,
-                &desc,
-                host_ptr,
-                &error);
+		if (useCreateImage)
+		{
+			cl_image_desc desc = {
+				CL_MEM_OBJECT_IMAGE2D,
+				width,
+				height,
+				0, 0, // depth, array size (unused)
+				row_pitch,
+				0, 0, 0, 0
+			};
+			object_ = ::clCreateImage (
+			context (),
+			flags,
+			&format,
+			&desc,
+			host_ptr,
+			&error);
 
-            detail::errHandler(error, __CREATE_IMAGE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			detail::errHandler (error, __CREATE_IMAGE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 #endif // #if defined(CL_VERSION_1_2)
 #if !defined(CL_VERSION_1_2) || defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-        if (!useCreateImage)
-        {
-            object_ = ::clCreateImage2D(
-                context(), flags,&format, width, height, row_pitch, host_ptr, &error);
+		if (!useCreateImage)
+		{
+			object_ = ::clCreateImage2D (
+			context (), flags, &format, width, height, row_pitch, host_ptr, &error);
 
-            detail::errHandler(error, __CREATE_IMAGE2D_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			detail::errHandler (error, __CREATE_IMAGE2D_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 #endif // #if !defined(CL_VERSION_1_2) || defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-    }
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image2D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image2D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Image2D(const cl_mem& image2D) : Image(image2D) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image2D (const cl_mem & image2D) :
+		Image (image2D)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image2D& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image2D & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D(const Image2D& img) : Image(img) {}
+	Image2D (const Image2D & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D& operator = (const Image2D &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image2D & operator= (const Image2D & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D(Image2D&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	Image2D (Image2D && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D& operator = (Image2D &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image2D & operator= (Image2D && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
-
 
 #if !defined(CL_VERSION_1_2)
 /*! \brief Class interface for GL 2D Image Memory objects.
@@ -4018,82 +4429,93 @@ public:
 class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED Image2DGL CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED : public Image2D
 {
 public:
-    /*! \brief Constructs an Image2DGL in a specified context, from a given
+	/*! \brief Constructs an Image2DGL in a specified context, from a given
      *         GL Texture.
      *
      *  Wraps clCreateFromGLTexture2D().
      */
-    Image2DGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLenum target,
-        cl_GLint  miplevel,
-        cl_GLuint texobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLTexture2D(
-            context(),
-            flags,
-            target,
-            miplevel,
-            texobj,
-            &error);
+	Image2DGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLenum target,
+	cl_GLint miplevel,
+	cl_GLuint texobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLTexture2D (
+		context (),
+		flags,
+		target,
+		miplevel,
+		texobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_TEXTURE_2D_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_GL_TEXTURE_2D_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    }
-    
-    //! \brief Default constructor - initializes to NULL.
-    Image2DGL() : Image2D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image2DGL () :
+		Image2D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Image2DGL(const cl_mem& image) : Image2D(image) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image2DGL (const cl_mem & image) :
+		Image2D (image)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image2DGL& operator = (const cl_mem& rhs)
-    {
-        Image2D::operator=(rhs);
-        return *this;
-    }
+	Image2DGL & operator= (const cl_mem & rhs)
+	{
+		Image2D::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL(const Image2DGL& img) : Image2D(img) {}
+	Image2DGL (const Image2DGL & img) :
+		Image2D (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL& operator = (const Image2DGL &img)
-    {
-        Image2D::operator=(img);
-        return *this;
-    }
+	Image2DGL & operator= (const Image2DGL & img)
+	{
+		Image2D::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL(Image2DGL&& img) CL_HPP_NOEXCEPT : Image2D(std::move(img)) {}
+	Image2DGL (Image2DGL && img) CL_HPP_NOEXCEPT : Image2D (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL& operator = (Image2DGL &&img)
-    {
-        Image2D::operator=(std::move(img));
-        return *this;
-    }
+	Image2DGL & operator= (Image2DGL && img)
+	{
+		Image2D::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if !defined(CL_VERSION_1_2)
@@ -4105,82 +4527,92 @@ public:
 class Image2DArray : public Image
 {
 public:
-    Image2DArray(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        ::size_t arraySize,
-        ::size_t width,
-        ::size_t height,
-        ::size_t rowPitch,
-        ::size_t slicePitch,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE2D_ARRAY,
-            width,
-            height,
-            0,       // depth (unused)
-            arraySize,
-            rowPitch,
-            slicePitch,
-            0, 0, 0
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            host_ptr, 
-            &error);
+	Image2DArray (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	::size_t arraySize,
+	::size_t width,
+	::size_t height,
+	::size_t rowPitch,
+	::size_t slicePitch,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE2D_ARRAY,
+			width,
+			height,
+			0, // depth (unused)
+			arraySize,
+			rowPitch,
+			slicePitch,
+			0, 0, 0
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		host_ptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Image2DArray() { }
+	Image2DArray ()
+	{
+	}
 
-    __CL_EXPLICIT_CONSTRUCTORS Image2DArray(const cl_mem& imageArray) : Image(imageArray) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image2DArray (const cl_mem & imageArray) :
+		Image (imageArray)
+	{
+	}
 
-    Image2DArray& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
-    
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	Image2DArray & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
+
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray(const Image2DArray& img) : Image(img) {}
+	Image2DArray (const Image2DArray & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray& operator = (const Image2DArray &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image2DArray & operator= (const Image2DArray & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray(Image2DArray&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	Image2DArray (Image2DArray && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray& operator = (Image2DArray &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image2DArray & operator= (Image2DArray && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if defined(CL_VERSION_1_2)
@@ -4194,127 +4626,139 @@ public:
 class Image3D : public Image
 {
 public:
-    /*! \brief Constructs a 3D Image in a specified context.
+	/*! \brief Constructs a 3D Image in a specified context.
      *
      *  Wraps clCreateImage().
      */
-    Image3D(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        ::size_t width,
-        ::size_t height,
-        ::size_t depth,
-        ::size_t row_pitch = 0,
-        ::size_t slice_pitch = 0,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        bool useCreateImage;
+	Image3D (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	::size_t width,
+	::size_t height,
+	::size_t depth,
+	::size_t row_pitch = 0,
+	::size_t slice_pitch = 0,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		bool useCreateImage;
 
 #if defined(CL_VERSION_1_2) && defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-        // Run-time decision based on the actual platform
-        {
-            cl_uint version = detail::getContextPlatformVersion(context());
-            useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
-        }
+		// Run-time decision based on the actual platform
+		{
+			cl_uint version = detail::getContextPlatformVersion (context ());
+			useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
+		}
 #elif defined(CL_VERSION_1_2)
-        useCreateImage = true;
+		useCreateImage = true;
 #else
-        useCreateImage = false;
+		useCreateImage = false;
 #endif
 
 #if defined(CL_VERSION_1_2)
-        if (useCreateImage)
-        {
-            cl_image_desc desc =
-            {
-                CL_MEM_OBJECT_IMAGE3D,
-                width,
-                height,
-                depth,
-                0,      // array size (unused)
-                row_pitch,
-                slice_pitch,
-                0, 0, 0
-            };
-            object_ = ::clCreateImage(
-                context(), 
-                flags, 
-                &format, 
-                &desc, 
-                host_ptr, 
-                &error);
+		if (useCreateImage)
+		{
+			cl_image_desc desc = {
+				CL_MEM_OBJECT_IMAGE3D,
+				width,
+				height,
+				depth,
+				0, // array size (unused)
+				row_pitch,
+				slice_pitch,
+				0, 0, 0
+			};
+			object_ = ::clCreateImage (
+			context (),
+			flags,
+			&format,
+			&desc,
+			host_ptr,
+			&error);
 
-            detail::errHandler(error, __CREATE_IMAGE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-#endif  // #if defined(CL_VERSION_1_2)
+			detail::errHandler (error, __CREATE_IMAGE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+#endif // #if defined(CL_VERSION_1_2)
 #if !defined(CL_VERSION_1_2) || defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-        if (!useCreateImage)
-        {
-            object_ = ::clCreateImage3D(
-                context(), flags, &format, width, height, depth, row_pitch,
-                slice_pitch, host_ptr, &error);
+		if (!useCreateImage)
+		{
+			object_ = ::clCreateImage3D (
+			context (), flags, &format, width, height, depth, row_pitch,
+			slice_pitch, host_ptr, &error);
 
-            detail::errHandler(error, __CREATE_IMAGE3D_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			detail::errHandler (error, __CREATE_IMAGE3D_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 #endif // #if !defined(CL_VERSION_1_2) || defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-    }
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image3D() : Image() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image3D () :
+		Image ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Image3D(const cl_mem& image3D) : Image(image3D) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image3D (const cl_mem & image3D) :
+		Image (image3D)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image3D& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image3D & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D(const Image3D& img) : Image(img) {}
+	Image3D (const Image3D & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D& operator = (const Image3D &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image3D & operator= (const Image3D & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D(Image3D&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	Image3D (Image3D && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D& operator = (Image3D &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image3D & operator= (Image3D && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
@@ -4330,81 +4774,93 @@ public:
 class Image3DGL : public Image3D
 {
 public:
-    /*! \brief Constructs an Image3DGL in a specified context, from a given
+	/*! \brief Constructs an Image3DGL in a specified context, from a given
      *         GL Texture.
      *
      *  Wraps clCreateFromGLTexture3D().
      */
-    Image3DGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLenum target,
-        cl_GLint  miplevel,
-        cl_GLuint texobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLTexture3D(
-            context(),
-            flags,
-            target,
-            miplevel,
-            texobj,
-            &error);
+	Image3DGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLenum target,
+	cl_GLint miplevel,
+	cl_GLuint texobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLTexture3D (
+		context (),
+		flags,
+		target,
+		miplevel,
+		texobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_TEXTURE_3D_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_TEXTURE_3D_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image3DGL() : Image3D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image3DGL () :
+		Image3D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Image3DGL(const cl_mem& image) : Image3D(image) { }
+	__CL_EXPLICIT_CONSTRUCTORS Image3DGL (const cl_mem & image) :
+		Image3D (image)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image3DGL& operator = (const cl_mem& rhs)
-    {
-        Image3D::operator=(rhs);
-        return *this;
-    }
+	Image3DGL & operator= (const cl_mem & rhs)
+	{
+		Image3D::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL(const Image3DGL& img) : Image3D(img) {}
+	Image3DGL (const Image3DGL & img) :
+		Image3D (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL& operator = (const Image3DGL &img)
-    {
-        Image3D::operator=(img);
-        return *this;
-    }
+	Image3DGL & operator= (const Image3DGL & img)
+	{
+		Image3D::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL(Image3DGL&& img) CL_HPP_NOEXCEPT : Image3D(std::move(img)) {}
+	Image3DGL (Image3DGL && img) CL_HPP_NOEXCEPT : Image3D (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL& operator = (Image3DGL &&img)
-    {
-        Image3D::operator=(std::move(img));
-        return *this;
-    }
+	Image3DGL & operator= (Image3DGL && img)
+	{
+		Image3D::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if !defined(CL_VERSION_1_2)
@@ -4419,67 +4875,79 @@ public:
 class ImageGL : public Image
 {
 public:
-    ImageGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLenum target,
-        cl_GLint  miplevel,
-        cl_GLuint texobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLTexture(
-            context(), 
-            flags, 
-            target,
-            miplevel,
-            texobj,
-            &error);
+	ImageGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLenum target,
+	cl_GLint miplevel,
+	cl_GLuint texobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLTexture (
+		context (),
+		flags,
+		target,
+		miplevel,
+		texobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_TEXTURE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_TEXTURE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    ImageGL() : Image() { }
+	ImageGL () :
+		Image ()
+	{
+	}
 
-    __CL_EXPLICIT_CONSTRUCTORS ImageGL(const cl_mem& image) : Image(image) { }
+	__CL_EXPLICIT_CONSTRUCTORS ImageGL (const cl_mem & image) :
+		Image (image)
+	{
+	}
 
-    ImageGL& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	ImageGL & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL(const ImageGL& img) : Image(img) {}
+	ImageGL (const ImageGL & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL& operator = (const ImageGL &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	ImageGL & operator= (const ImageGL & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL(ImageGL&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+	ImageGL (ImageGL && img) CL_HPP_NOEXCEPT : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL& operator = (ImageGL &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	ImageGL & operator= (ImageGL && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if defined(CL_VERSION_1_2)
@@ -4492,128 +4960,145 @@ public:
 *
 *  \see Memory
 */
-class BufferRenderGL : 
+class BufferRenderGL :
 #if defined(CL_VERSION_1_2)
-    public ImageGL
+	public ImageGL
 #else // #if defined(CL_VERSION_1_2)
-    public Image2DGL
+	public Image2DGL
 #endif //#if defined(CL_VERSION_1_2)
 {
 public:
-    /*! \brief Constructs a BufferRenderGL in a specified context, from a given
+	/*! \brief Constructs a BufferRenderGL in a specified context, from a given
     *         GL Renderbuffer.
     *
     *  Wraps clCreateFromGLRenderbuffer().
     */
-    BufferRenderGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLuint bufobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLRenderbuffer(
-            context(),
-            flags,
-            bufobj,
-            &error);
+	BufferRenderGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLuint bufobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLRenderbuffer (
+		context (),
+		flags,
+		bufobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_RENDER_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_RENDER_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
+	//! \brief Default constructor - initializes to NULL.
 #if defined(CL_VERSION_1_2)
-    BufferRenderGL() : ImageGL() {};
+	BufferRenderGL () :
+		ImageGL (){};
 #else // #if defined(CL_VERSION_1_2)
-    BufferRenderGL() : Image2DGL() {};
+	BufferRenderGL () :
+		Image2DGL (){};
 #endif //#if defined(CL_VERSION_1_2)
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
     *
     *  See Memory for further details.
     */
 #if defined(CL_VERSION_1_2)
-    __CL_EXPLICIT_CONSTRUCTORS BufferRenderGL(const cl_mem& buffer) : ImageGL(buffer) { }
+	__CL_EXPLICIT_CONSTRUCTORS BufferRenderGL (const cl_mem & buffer) :
+		ImageGL (buffer)
+	{
+	}
 #else // #if defined(CL_VERSION_1_2)
-    __CL_EXPLICIT_CONSTRUCTORS BufferRenderGL(const cl_mem& buffer) : Image2DGL(buffer) { }
+	__CL_EXPLICIT_CONSTRUCTORS BufferRenderGL (const cl_mem & buffer) :
+		Image2DGL (buffer)
+	{
+	}
 #endif //#if defined(CL_VERSION_1_2)
 
-
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
     *
     *  See Memory for further details.
     */
-    BufferRenderGL& operator = (const cl_mem& rhs)
-    {
+	BufferRenderGL & operator= (const cl_mem & rhs)
+	{
 #if defined(CL_VERSION_1_2)
-        ImageGL::operator=(rhs);
+		ImageGL::operator= (rhs);
 #else // #if defined(CL_VERSION_1_2)
-        Image2DGL::operator=(rhs);
+		Image2DGL::operator= (rhs);
 #endif //#if defined(CL_VERSION_1_2)
-        
-        return *this;
-    }
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+		return *this;
+	}
+
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
     * Required for MSVC.
     */
 #if defined(CL_VERSION_1_2)
-    BufferRenderGL(const BufferRenderGL& buf) : ImageGL(buf) {}
+	BufferRenderGL (const BufferRenderGL & buf) :
+		ImageGL (buf)
+	{
+	}
 #else // #if defined(CL_VERSION_1_2)
-    BufferRenderGL(const BufferRenderGL& buf) : Image2DGL(buf) {}
+	BufferRenderGL (const BufferRenderGL & buf) :
+		Image2DGL (buf)
+	{
+	}
 #endif //#if defined(CL_VERSION_1_2)
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    BufferRenderGL& operator = (const BufferRenderGL &rhs)
-    {
+	BufferRenderGL & operator= (const BufferRenderGL & rhs)
+	{
 #if defined(CL_VERSION_1_2)
-        ImageGL::operator=(rhs);
+		ImageGL::operator= (rhs);
 #else // #if defined(CL_VERSION_1_2)
-        Image2DGL::operator=(rhs);
+		Image2DGL::operator= (rhs);
 #endif //#if defined(CL_VERSION_1_2)
-        return *this;
-    }
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
     * Required for MSVC.
     */
 #if defined(CL_VERSION_1_2)
-    BufferRenderGL(BufferRenderGL&& buf) CL_HPP_NOEXCEPT : ImageGL(std::move(buf)) {}
+	BufferRenderGL (BufferRenderGL && buf) CL_HPP_NOEXCEPT : ImageGL (std::move (buf))
+	{
+	}
 #else // #if defined(CL_VERSION_1_2)
-    BufferRenderGL(BufferRenderGL&& buf) CL_HPP_NOEXCEPT : Image2DGL(std::move(buf)) {}
+	BufferRenderGL (BufferRenderGL && buf) CL_HPP_NOEXCEPT : Image2DGL (std::move (buf))
+	{
+	}
 #endif //#if defined(CL_VERSION_1_2)
-    
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    BufferRenderGL& operator = (BufferRenderGL &&buf)
-    {
+	BufferRenderGL & operator= (BufferRenderGL && buf)
+	{
 #if defined(CL_VERSION_1_2)
-        ImageGL::operator=(std::move(buf));
+		ImageGL::operator= (std::move (buf));
 #else // #if defined(CL_VERSION_1_2)
-        Image2DGL::operator=(std::move(buf));
+		Image2DGL::operator= (std::move (buf));
 #endif //#if defined(CL_VERSION_1_2)
-        
-        return *this;
-    }
+
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    //! \brief Wrapper for clGetGLObjectInfo().
-    cl_int getObjectInfo(
-        cl_gl_object_type *type,
-        cl_GLuint * gl_object_name)
-    {
-        return detail::errHandler(
-            ::clGetGLObjectInfo(object_, type, gl_object_name),
-            __GET_GL_OBJECT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetGLObjectInfo().
+	cl_int getObjectInfo (
+	cl_gl_object_type * type,
+	cl_GLuint * gl_object_name)
+	{
+		return detail::errHandler (
+		::clGetGLObjectInfo (object_, type, gl_object_name),
+		__GET_GL_OBJECT_INFO_ERR);
+	}
 };
 
 /*! \brief Class interface for cl_sampler.
@@ -4627,104 +5112,116 @@ public:
 class Sampler : public detail::Wrapper<cl_sampler>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Sampler() { }
+	//! \brief Default constructor - initializes to NULL.
+	Sampler ()
+	{
+	}
 
-    /*! \brief Constructs a Sampler in a specified context.
+	/*! \brief Constructs a Sampler in a specified context.
      *
      *  Wraps clCreateSampler().
      */
-    Sampler(
-        const Context& context,
-        cl_bool normalized_coords,
-        cl_addressing_mode addressing_mode,
-        cl_filter_mode filter_mode,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateSampler(
-            context(), 
-            normalized_coords,
-            addressing_mode,
-            filter_mode,
-            &error);
+	Sampler (
+	const Context & context,
+	cl_bool normalized_coords,
+	cl_addressing_mode addressing_mode,
+	cl_filter_mode filter_mode,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateSampler (
+		context (),
+		normalized_coords,
+		addressing_mode,
+		filter_mode,
+		&error);
 
-        detail::errHandler(error, __CREATE_SAMPLER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_SAMPLER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*! \brief Constructor from cl_sampler - takes ownership.
+	/*! \brief Constructor from cl_sampler - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_sampler
      *  into the new Sampler object.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Sampler(const cl_sampler& sampler) : detail::Wrapper<cl_type>(sampler) { }
+	__CL_EXPLICIT_CONSTRUCTORS Sampler (const cl_sampler & sampler) :
+		detail::Wrapper<cl_type> (sampler)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_sampler - takes ownership.
+	/*! \brief Assignment operator from cl_sampler - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseSampler() on the value previously held by this instance.
      */
-    Sampler& operator = (const cl_sampler& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Sampler & operator= (const cl_sampler & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler(const Sampler& sam) : detail::Wrapper<cl_type>(sam) {}
+	Sampler (const Sampler & sam) :
+		detail::Wrapper<cl_type> (sam)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler& operator = (const Sampler &sam)
-    {
-        detail::Wrapper<cl_type>::operator=(sam);
-        return *this;
-    }
+	Sampler & operator= (const Sampler & sam)
+	{
+		detail::Wrapper<cl_type>::operator= (sam);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler(Sampler&& sam) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(sam)) {}
+	Sampler (Sampler && sam) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (sam))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler& operator = (Sampler &&sam)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(sam));
-        return *this;
-    }
+	Sampler & operator= (Sampler && sam)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (sam));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    //! \brief Wrapper for clGetSamplerInfo().
-    template <typename T>
-    cl_int getInfo(cl_sampler_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetSamplerInfo, object_, name, param),
-            __GET_SAMPLER_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetSamplerInfo().
+	template <typename T>
+	cl_int getInfo (cl_sampler_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetSamplerInfo, object_, name, param),
+		__GET_SAMPLER_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetSamplerInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_sampler_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_sampler_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetSamplerInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_sampler_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_sampler_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 };
 
 class Program;
@@ -4735,49 +5232,54 @@ class Kernel;
 class NDRange
 {
 private:
-    size_t<3> sizes_;
-    cl_uint dimensions_;
+	size_t<3> sizes_;
+	cl_uint dimensions_;
 
 public:
-    //! \brief Default constructor - resulting range has zero dimensions.
-    NDRange()
-        : dimensions_(0)
-    { }
+	//! \brief Default constructor - resulting range has zero dimensions.
+	NDRange () :
+		dimensions_ (0)
+	{
+	}
 
-    //! \brief Constructs one-dimensional range.
-    NDRange(::size_t size0)
-        : dimensions_(1)
-    {
-        sizes_[0] = size0;
-    }
+	//! \brief Constructs one-dimensional range.
+	NDRange (::size_t size0) :
+		dimensions_ (1)
+	{
+		sizes_[0] = size0;
+	}
 
-    //! \brief Constructs two-dimensional range.
-    NDRange(::size_t size0, ::size_t size1)
-        : dimensions_(2)
-    {
-        sizes_[0] = size0;
-        sizes_[1] = size1;
-    }
+	//! \brief Constructs two-dimensional range.
+	NDRange (::size_t size0, ::size_t size1) :
+		dimensions_ (2)
+	{
+		sizes_[0] = size0;
+		sizes_[1] = size1;
+	}
 
-    //! \brief Constructs three-dimensional range.
-    NDRange(::size_t size0, ::size_t size1, ::size_t size2)
-        : dimensions_(3)
-    {
-        sizes_[0] = size0;
-        sizes_[1] = size1;
-        sizes_[2] = size2;
-    }
+	//! \brief Constructs three-dimensional range.
+	NDRange (::size_t size0, ::size_t size1, ::size_t size2) :
+		dimensions_ (3)
+	{
+		sizes_[0] = size0;
+		sizes_[1] = size1;
+		sizes_[2] = size2;
+	}
 
-    /*! \brief Conversion operator to const ::size_t *.
+	/*! \brief Conversion operator to const ::size_t *.
      *  
      *  \returns a pointer to the size of the first dimension.
      */
-    operator const ::size_t*() const { 
-        return (const ::size_t*) sizes_; 
-    }
+	operator const ::size_t * () const
+	{
+		return (const ::size_t *)sizes_;
+	}
 
-    //! \brief Queries the number of dimensions in the range.
-    ::size_t dimensions() const { return dimensions_; }
+	//! \brief Queries the number of dimensions in the range.
+	::size_t dimensions () const
+	{
+		return dimensions_;
+	}
 };
 
 //! \brief A zero-dimensional range.
@@ -4786,26 +5288,38 @@ static const NDRange NullRange;
 //! \brief Local address wrapper for use with Kernel::setArg
 struct LocalSpaceArg
 {
-    ::size_t size_;
+	::size_t size_;
 };
 
-namespace detail {
-
-template <typename T>
-struct KernelArgumentHandler
+namespace detail
 {
-    static ::size_t size(const T&) { return sizeof(T); }
-    static const T* ptr(const T& value) { return &value; }
-};
+	template <typename T>
+	struct KernelArgumentHandler
+	{
+		static ::size_t size (const T &)
+		{
+			return sizeof (T);
+		}
+		static const T * ptr (const T & value)
+		{
+			return &value;
+		}
+	};
 
-template <>
-struct KernelArgumentHandler<LocalSpaceArg>
-{
-    static ::size_t size(const LocalSpaceArg& value) { return value.size_; }
-    static const void* ptr(const LocalSpaceArg&) { return NULL; }
-};
+	template <>
+	struct KernelArgumentHandler<LocalSpaceArg>
+	{
+		static ::size_t size (const LocalSpaceArg & value)
+		{
+			return value.size_;
+		}
+		static const void * ptr (const LocalSpaceArg &)
+		{
+			return NULL;
+		}
+	};
 
-} 
+}
 //! \endcond
 
 /*! __local
@@ -4813,22 +5327,22 @@ struct KernelArgumentHandler<LocalSpaceArg>
  * Deprecated. Replaced with Local.
  */
 inline CL_EXT_PREFIX__VERSION_1_1_DEPRECATED LocalSpaceArg
-__local(::size_t size) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
+__local (::size_t size) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
 inline LocalSpaceArg
-__local(::size_t size)
+__local (::size_t size)
 {
-    LocalSpaceArg ret = { size };
-    return ret;
+	LocalSpaceArg ret = { size };
+	return ret;
 }
 
 /*! Local
  * \brief Helper function for generating LocalSpaceArg objects.
  */
 inline LocalSpaceArg
-Local(::size_t size)
+Local (::size_t size)
 {
-    LocalSpaceArg ret = { size };
-    return ret;
+	LocalSpaceArg ret = { size };
+	return ret;
 }
 
 //class KernelFunctor;
@@ -4844,144 +5358,157 @@ Local(::size_t size)
 class Kernel : public detail::Wrapper<cl_kernel>
 {
 public:
-    inline Kernel(const Program& program, const char* name, cl_int* err = NULL);
+	inline Kernel (const Program & program, const char * name, cl_int * err = NULL);
 
-    //! \brief Default constructor - initializes to NULL.
-    Kernel() { }
+	//! \brief Default constructor - initializes to NULL.
+	Kernel ()
+	{
+	}
 
-    /*! \brief Constructor from cl_kernel - takes ownership.
+	/*! \brief Constructor from cl_kernel - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_kernel
      *  into the new Kernel object.
      */
-    __CL_EXPLICIT_CONSTRUCTORS Kernel(const cl_kernel& kernel) : detail::Wrapper<cl_type>(kernel) { }
+	__CL_EXPLICIT_CONSTRUCTORS Kernel (const cl_kernel & kernel) :
+		detail::Wrapper<cl_type> (kernel)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_kernel - takes ownership.
+	/*! \brief Assignment operator from cl_kernel - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseKernel() on the value previously held by this instance.
      */
-    Kernel& operator = (const cl_kernel& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Kernel & operator= (const cl_kernel & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel(const Kernel& kernel) : detail::Wrapper<cl_type>(kernel) {}
+	Kernel (const Kernel & kernel) :
+		detail::Wrapper<cl_type> (kernel)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel& operator = (const Kernel &kernel)
-    {
-        detail::Wrapper<cl_type>::operator=(kernel);
-        return *this;
-    }
+	Kernel & operator= (const Kernel & kernel)
+	{
+		detail::Wrapper<cl_type>::operator= (kernel);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel(Kernel&& kernel) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(kernel)) {}
+	Kernel (Kernel && kernel) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (kernel))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel& operator = (Kernel &&kernel)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(kernel));
-        return *this;
-    }
+	Kernel & operator= (Kernel && kernel)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (kernel));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    template <typename T>
-    cl_int getInfo(cl_kernel_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetKernelInfo, object_, name, param),
-            __GET_KERNEL_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_kernel_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetKernelInfo, object_, name, param),
+		__GET_KERNEL_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_kernel_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_kernel_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_kernel_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_kernel_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
 #if defined(CL_VERSION_1_2)
-    template <typename T>
-    cl_int getArgInfo(cl_uint argIndex, cl_kernel_arg_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetKernelArgInfo, object_, argIndex, name, param),
-            __GET_KERNEL_ARG_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getArgInfo (cl_uint argIndex, cl_kernel_arg_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetKernelArgInfo, object_, argIndex, name, param),
+		__GET_KERNEL_ARG_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_kernel_arg_info, name>::param_type
-    getArgInfo(cl_uint argIndex, cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_kernel_arg_info, name>::param_type param;
-        cl_int result = getArgInfo(argIndex, name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_kernel_arg_info, name>::param_type
+	getArgInfo (cl_uint argIndex, cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_kernel_arg_info, name>::param_type param;
+		cl_int result = getArgInfo (argIndex, name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 #endif // #if defined(CL_VERSION_1_2)
 
-    template <typename T>
-    cl_int getWorkGroupInfo(
-        const Device& device, cl_kernel_work_group_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-                &::clGetKernelWorkGroupInfo, object_, device(), name, param),
-                __GET_KERNEL_WORK_GROUP_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getWorkGroupInfo (
+	const Device & device, cl_kernel_work_group_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetKernelWorkGroupInfo, object_, device (), name, param),
+		__GET_KERNEL_WORK_GROUP_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_kernel_work_group_info, name>::param_type
-        getWorkGroupInfo(const Device& device, cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-        detail::cl_kernel_work_group_info, name>::param_type param;
-        cl_int result = getWorkGroupInfo(device, name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_kernel_work_group_info, name>::param_type
+	getWorkGroupInfo (const Device & device, cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_kernel_work_group_info, name>::param_type param;
+		cl_int result = getWorkGroupInfo (device, name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    template <typename T>
-    cl_int setArg(cl_uint index, const T &value)
-    {
-        return detail::errHandler(
-            ::clSetKernelArg(
-                object_,
-                index,
-                detail::KernelArgumentHandler<T>::size(value),
-                detail::KernelArgumentHandler<T>::ptr(value)),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	template <typename T>
+	cl_int setArg (cl_uint index, const T & value)
+	{
+		return detail::errHandler (
+		::clSetKernelArg (
+		object_,
+		index,
+		detail::KernelArgumentHandler<T>::size (value),
+		detail::KernelArgumentHandler<T>::ptr (value)),
+		__SET_KERNEL_ARGS_ERR);
+	}
 
-    cl_int setArg(cl_uint index, ::size_t size, const void* argPtr)
-    {
-        return detail::errHandler(
-            ::clSetKernelArg(object_, index, size, argPtr),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	cl_int setArg (cl_uint index, ::size_t size, const void * argPtr)
+	{
+		return detail::errHandler (
+		::clSetKernelArg (object_, index, size, argPtr),
+		__SET_KERNEL_ARGS_ERR);
+	}
 };
 
 /*! \class Program
@@ -4990,104 +5517,108 @@ public:
 class Program : public detail::Wrapper<cl_program>
 {
 public:
-    typedef VECTOR_CLASS<std::pair<const void*, ::size_t> > Binaries;
-    typedef VECTOR_CLASS<std::pair<const char*, ::size_t> > Sources;
+	typedef VECTOR_CLASS<std::pair<const void *, ::size_t>> Binaries;
+	typedef VECTOR_CLASS<std::pair<const char *, ::size_t>> Sources;
 
-    Program(
-        const STRING_CLASS& source,
-        bool build = false,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Program (
+	const STRING_CLASS & source,
+	bool build = false,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        const char * strings = source.c_str();
-        const ::size_t length  = source.size();
+		const char * strings = source.c_str ();
+		const ::size_t length = source.size ();
 
-        Context context = Context::getDefault(err);
+		Context context = Context::getDefault (err);
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)1, &strings, &length, &error);
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)1, &strings, &length, &error);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
-        if (error == CL_SUCCESS && build) {
+		if (error == CL_SUCCESS && build)
+		{
+			error = ::clBuildProgram (
+			object_,
+			0,
+			NULL,
+			"",
+			NULL,
+			NULL);
 
-            error = ::clBuildProgram(
-                object_,
-                0,
-                NULL,
-                "",
-                NULL,
-                NULL);
+			detail::errHandler (error, __BUILD_PROGRAM_ERR);
+		}
 
-            detail::errHandler(error, __BUILD_PROGRAM_ERR);
-        }
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+	Program (
+	const Context & context,
+	const STRING_CLASS & source,
+	bool build = false,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-    Program(
-        const Context& context,
-        const STRING_CLASS& source,
-        bool build = false,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+		const char * strings = source.c_str ();
+		const ::size_t length = source.size ();
 
-        const char * strings = source.c_str();
-        const ::size_t length  = source.size();
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)1, &strings, &length, &error);
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)1, &strings, &length, &error);
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		if (error == CL_SUCCESS && build)
+		{
+			error = ::clBuildProgram (
+			object_,
+			0,
+			NULL,
+			"",
+			NULL,
+			NULL);
 
-        if (error == CL_SUCCESS && build) {
+			detail::errHandler (error, __BUILD_PROGRAM_ERR);
+		}
 
-            error = ::clBuildProgram(
-                object_,
-                0,
-                NULL,
-                "",
-                NULL,
-                NULL);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-            detail::errHandler(error, __BUILD_PROGRAM_ERR);
-        }
+	Program (
+	const Context & context,
+	const Sources & sources,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		const ::size_t n = (::size_t)sources.size ();
+		::size_t * lengths = (::size_t *)alloca (n * sizeof (::size_t));
+		const char ** strings = (const char **)alloca (n * sizeof (const char *));
 
-    Program(
-        const Context& context,
-        const Sources& sources,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+		for (::size_t i = 0; i < n; ++i)
+		{
+			strings[i] = sources[(int)i].first;
+			lengths[i] = sources[(int)i].second;
+		}
 
-        const ::size_t n = (::size_t)sources.size();
-        ::size_t* lengths = (::size_t*) alloca(n * sizeof(::size_t));
-        const char** strings = (const char**) alloca(n * sizeof(const char*));
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)n, strings, lengths, &error);
 
-        for (::size_t i = 0; i < n; ++i) {
-            strings[i] = sources[(int)i].first;
-            lengths[i] = sources[(int)i].second;
-        }
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)n, strings, lengths, &error);
-
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
-
-    /**
+	/**
      * Construct a program object from a list of devices and a per-device list of binaries.
      * \param context A valid OpenCL context in which to construct the program.
      * \param devices A vector of OpenCL device objects for which the program will be created.
@@ -5106,369 +5637,396 @@ public:
      *   CL_INVALID_BINARY if an invalid program binary was encountered for any device. binaryStatus will return specific status for each device.
      *   CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources required by the OpenCL implementation on the host.
      */
-    Program(
-        const Context& context,
-        const VECTOR_CLASS<Device>& devices,
-        const Binaries& binaries,
-        VECTOR_CLASS<cl_int>* binaryStatus = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        
-        const ::size_t numDevices = devices.size();
-        
-        // Catch size mismatch early and return
-        if(binaries.size() != numDevices) {
-            error = CL_INVALID_VALUE;
-            detail::errHandler(error, __CREATE_PROGRAM_WITH_BINARY_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-            return;
-        }
+	Program (
+	const Context & context,
+	const VECTOR_CLASS<Device> & devices,
+	const Binaries & binaries,
+	VECTOR_CLASS<cl_int> * binaryStatus = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        ::size_t* lengths = (::size_t*) alloca(numDevices * sizeof(::size_t));
-        const unsigned char** images = (const unsigned char**) alloca(numDevices * sizeof(const unsigned char**));
+		const ::size_t numDevices = devices.size ();
 
-        for (::size_t i = 0; i < numDevices; ++i) {
-            images[i] = (const unsigned char*)binaries[i].first;
-            lengths[i] = binaries[(int)i].second;
-        }
+		// Catch size mismatch early and return
+		if (binaries.size () != numDevices)
+		{
+			error = CL_INVALID_VALUE;
+			detail::errHandler (error, __CREATE_PROGRAM_WITH_BINARY_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+			return;
+		}
 
-        cl_device_id* deviceIDs = (cl_device_id*) alloca(numDevices * sizeof(cl_device_id));
-        for( ::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
+		::size_t * lengths = (::size_t *)alloca (numDevices * sizeof (::size_t));
+		const unsigned char ** images = (const unsigned char **)alloca (numDevices * sizeof (const unsigned char **));
 
-        if(binaryStatus) {
-            binaryStatus->resize(numDevices);
-        }
-        
-        object_ = ::clCreateProgramWithBinary(
-            context(), (cl_uint) devices.size(),
-            deviceIDs,
-            lengths, images, (binaryStatus != NULL && numDevices > 0)
-               ? &binaryStatus->front()
-               : NULL, &error);
+		for (::size_t i = 0; i < numDevices; ++i)
+		{
+			images[i] = (const unsigned char *)binaries[i].first;
+			lengths[i] = binaries[(int)i].second;
+		}
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_BINARY_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		cl_device_id * deviceIDs = (cl_device_id *)alloca (numDevices * sizeof (cl_device_id));
+		for (::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-    
+		if (binaryStatus)
+		{
+			binaryStatus->resize (numDevices);
+		}
+
+		object_ = ::clCreateProgramWithBinary (
+		context (), (cl_uint)devices.size (),
+		deviceIDs,
+		lengths, images, (binaryStatus != NULL && numDevices > 0) ? &binaryStatus->front () : NULL, &error);
+
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_BINARY_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+
 #if defined(CL_VERSION_1_2)
-    /**
+	/**
      * Create program using builtin kernels.
      * \param kernelNames Semi-colon separated list of builtin kernel names
      */
-    Program(
-        const Context& context,
-        const VECTOR_CLASS<Device>& devices,
-        const STRING_CLASS& kernelNames,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Program (
+	const Context & context,
+	const VECTOR_CLASS<Device> & devices,
+	const STRING_CLASS & kernelNames,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
+		::size_t numDevices = devices.size ();
+		cl_device_id * deviceIDs = (cl_device_id *)alloca (numDevices * sizeof (cl_device_id));
+		for (::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        ::size_t numDevices = devices.size();
-        cl_device_id* deviceIDs = (cl_device_id*) alloca(numDevices * sizeof(cl_device_id));
-        for( ::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
-        
-        object_ = ::clCreateProgramWithBuiltInKernels(
-            context(), 
-            (cl_uint) devices.size(),
-            deviceIDs,
-            kernelNames.c_str(), 
-            &error);
+		object_ = ::clCreateProgramWithBuiltInKernels (
+		context (),
+		(cl_uint)devices.size (),
+		deviceIDs,
+		kernelNames.c_str (),
+		&error);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 #endif // #if defined(CL_VERSION_1_2)
 
-    Program() { }
+	Program ()
+	{
+	}
 
-    __CL_EXPLICIT_CONSTRUCTORS Program(const cl_program& program) : detail::Wrapper<cl_type>(program) { }
+	__CL_EXPLICIT_CONSTRUCTORS Program (const cl_program & program) :
+		detail::Wrapper<cl_type> (program)
+	{
+	}
 
-    Program& operator = (const cl_program& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Program & operator= (const cl_program & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Program(const Program& program) : detail::Wrapper<cl_type>(program) {}
+	Program (const Program & program) :
+		detail::Wrapper<cl_type> (program)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Program& operator = (const Program &program)
-    {
-        detail::Wrapper<cl_type>::operator=(program);
-        return *this;
-    }
+	Program & operator= (const Program & program)
+	{
+		detail::Wrapper<cl_type>::operator= (program);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Program(Program&& program) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(program)) {}
+	Program (Program && program) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (program))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Program& operator = (Program &&program)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(program));
-        return *this;
-    }
+	Program & operator= (Program && program)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (program));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    cl_int build(
-        const VECTOR_CLASS<Device>& devices,
-        const char* options = NULL,
-        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-        void* data = NULL) const
-    {
-        ::size_t numDevices = devices.size();
-        cl_device_id* deviceIDs = (cl_device_id*) alloca(numDevices * sizeof(cl_device_id));
-        for( ::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
+	cl_int build (
+	const VECTOR_CLASS<Device> & devices,
+	const char * options = NULL,
+	void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+	void * data = NULL) const
+	{
+		::size_t numDevices = devices.size ();
+		cl_device_id * deviceIDs = (cl_device_id *)alloca (numDevices * sizeof (cl_device_id));
+		for (::size_t deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        return detail::errHandler(
-            ::clBuildProgram(
-                object_,
-                (cl_uint)
-                devices.size(),
-                deviceIDs,
-                options,
-                notifyFptr,
-                data),
-                __BUILD_PROGRAM_ERR);
-    }
+		return detail::errHandler (
+		::clBuildProgram (
+		object_,
+		(cl_uint)
+		devices.size (),
+		deviceIDs,
+		options,
+		notifyFptr,
+		data),
+		__BUILD_PROGRAM_ERR);
+	}
 
-    cl_int build(
-        const char* options = NULL,
-        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-        void* data = NULL) const
-    {
-        return detail::errHandler(
-            ::clBuildProgram(
-                object_,
-                0,
-                NULL,
-                options,
-                notifyFptr,
-                data),
-                __BUILD_PROGRAM_ERR);
-    }
+	cl_int build (
+	const char * options = NULL,
+	void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+	void * data = NULL) const
+	{
+		return detail::errHandler (
+		::clBuildProgram (
+		object_,
+		0,
+		NULL,
+		options,
+		notifyFptr,
+		data),
+		__BUILD_PROGRAM_ERR);
+	}
 
 #if defined(CL_VERSION_1_2)
-    cl_int compile(
-        const char* options = NULL,
-        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-        void* data = NULL) const
-    {
-        return detail::errHandler(
-            ::clCompileProgram(
-                object_,
-                0,
-                NULL,
-                options,
-                0,
-                NULL,
-                NULL,
-                notifyFptr,
-                data),
-                __COMPILE_PROGRAM_ERR);
-    }
+	cl_int compile (
+	const char * options = NULL,
+	void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+	void * data = NULL) const
+	{
+		return detail::errHandler (
+		::clCompileProgram (
+		object_,
+		0,
+		NULL,
+		options,
+		0,
+		NULL,
+		NULL,
+		notifyFptr,
+		data),
+		__COMPILE_PROGRAM_ERR);
+	}
 #endif
 
-    template <typename T>
-    cl_int getInfo(cl_program_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
-            __GET_PROGRAM_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_program_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetProgramInfo, object_, name, param),
+		__GET_PROGRAM_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_program_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_program_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_program_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_program_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    template <typename T>
-    cl_int getBuildInfo(
-        const Device& device, cl_program_build_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-                &::clGetProgramBuildInfo, object_, device(), name, param),
-                __GET_PROGRAM_BUILD_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getBuildInfo (
+	const Device & device, cl_program_build_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetProgramBuildInfo, object_, device (), name, param),
+		__GET_PROGRAM_BUILD_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_program_build_info, name>::param_type
-    getBuildInfo(const Device& device, cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_program_build_info, name>::param_type param;
-        cl_int result = getBuildInfo(device, name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_program_build_info, name>::param_type
+	getBuildInfo (const Device & device, cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_program_build_info, name>::param_type param;
+		cl_int result = getBuildInfo (device, name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    cl_int createKernels(VECTOR_CLASS<Kernel>* kernels)
-    {
-        cl_uint numKernels;
-        cl_int err = ::clCreateKernelsInProgram(object_, 0, NULL, &numKernels);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
-        }
+	cl_int createKernels (VECTOR_CLASS<Kernel> * kernels)
+	{
+		cl_uint numKernels;
+		cl_int err = ::clCreateKernelsInProgram (object_, 0, NULL, &numKernels);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_KERNELS_IN_PROGRAM_ERR);
+		}
 
-        Kernel* value = (Kernel*) alloca(numKernels * sizeof(Kernel));
-        err = ::clCreateKernelsInProgram(
-            object_, numKernels, (cl_kernel*) value, NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
-        }
+		Kernel * value = (Kernel *)alloca (numKernels * sizeof (Kernel));
+		err = ::clCreateKernelsInProgram (
+		object_, numKernels, (cl_kernel *)value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_KERNELS_IN_PROGRAM_ERR);
+		}
 
-        kernels->assign(&value[0], &value[numKernels]);
-        return CL_SUCCESS;
-    }
+		kernels->assign (&value[0], &value[numKernels]);
+		return CL_SUCCESS;
+	}
 };
 
 #if defined(CL_VERSION_1_2)
-inline Program linkProgram(
-    Program input1,
-    Program input2,
-    const char* options = NULL,
-    void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-    void* data = NULL,
-    cl_int* err = NULL) 
+inline Program linkProgram (
+Program input1,
+Program input2,
+const char * options = NULL,
+void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+void * data = NULL,
+cl_int * err = NULL)
 {
-    cl_int error_local = CL_SUCCESS;
+	cl_int error_local = CL_SUCCESS;
 
-    cl_program programs[2] = { input1(), input2() };
+	cl_program programs[2] = { input1 (), input2 () };
 
-    Context ctx = input1.getInfo<CL_PROGRAM_CONTEXT>(&error_local);
-    if(error_local!=CL_SUCCESS) {
-        detail::errHandler(error_local, __LINK_PROGRAM_ERR);
-    }
+	Context ctx = input1.getInfo<CL_PROGRAM_CONTEXT> (&error_local);
+	if (error_local != CL_SUCCESS)
+	{
+		detail::errHandler (error_local, __LINK_PROGRAM_ERR);
+	}
 
-    cl_program prog = ::clLinkProgram(
-        ctx(),
-        0,
-        NULL,
-        options,
-        2,
-        programs,
-        notifyFptr,
-        data,
-        &error_local);
+	cl_program prog = ::clLinkProgram (
+	ctx (),
+	0,
+	NULL,
+	options,
+	2,
+	programs,
+	notifyFptr,
+	data,
+	&error_local);
 
-    detail::errHandler(error_local,__COMPILE_PROGRAM_ERR);
-    if (err != NULL) {
-        *err = error_local;
-    }
+	detail::errHandler (error_local, __COMPILE_PROGRAM_ERR);
+	if (err != NULL)
+	{
+		*err = error_local;
+	}
 
-    return Program(prog);
+	return Program (prog);
 }
 
-inline Program linkProgram(
-    VECTOR_CLASS<Program> inputPrograms,
-    const char* options = NULL,
-    void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-    void* data = NULL,
-    cl_int* err = NULL) 
+inline Program linkProgram (
+VECTOR_CLASS<Program> inputPrograms,
+const char * options = NULL,
+void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+void * data = NULL,
+cl_int * err = NULL)
 {
-    cl_int error_local = CL_SUCCESS;
+	cl_int error_local = CL_SUCCESS;
 
-    cl_program * programs = (cl_program*) alloca(inputPrograms.size() * sizeof(cl_program));
+	cl_program * programs = (cl_program *)alloca (inputPrograms.size () * sizeof (cl_program));
 
-    if (programs != NULL) {
-        for (unsigned int i = 0; i < inputPrograms.size(); i++) {
-          programs[i] = inputPrograms[i]();
-        }
-    } 
+	if (programs != NULL)
+	{
+		for (unsigned int i = 0; i < inputPrograms.size (); i++)
+		{
+			programs[i] = inputPrograms[i]();
+		}
+	}
 
-    Context ctx;
-    if(inputPrograms.size() > 0) {
-        ctx = inputPrograms[0].getInfo<CL_PROGRAM_CONTEXT>(&error_local);
-        if(error_local!=CL_SUCCESS) {
-            detail::errHandler(error_local, __LINK_PROGRAM_ERR);
-        }
-    }
-    cl_program prog = ::clLinkProgram(
-        ctx(),
-        0,
-        NULL,
-        options,
-        (cl_uint)inputPrograms.size(),
-        programs,
-        notifyFptr,
-        data,
-        &error_local);
+	Context ctx;
+	if (inputPrograms.size () > 0)
+	{
+		ctx = inputPrograms[0].getInfo<CL_PROGRAM_CONTEXT> (&error_local);
+		if (error_local != CL_SUCCESS)
+		{
+			detail::errHandler (error_local, __LINK_PROGRAM_ERR);
+		}
+	}
+	cl_program prog = ::clLinkProgram (
+	ctx (),
+	0,
+	NULL,
+	options,
+	(cl_uint)inputPrograms.size (),
+	programs,
+	notifyFptr,
+	data,
+	&error_local);
 
-    detail::errHandler(error_local,__COMPILE_PROGRAM_ERR);
-    if (err != NULL) {
-        *err = error_local;
-    }
+	detail::errHandler (error_local, __COMPILE_PROGRAM_ERR);
+	if (err != NULL)
+	{
+		*err = error_local;
+	}
 
-    return Program(prog);
+	return Program (prog);
 }
 #endif
 
-template<>
-inline VECTOR_CLASS<char *> cl::Program::getInfo<CL_PROGRAM_BINARIES>(cl_int* err) const
+template <>
+inline VECTOR_CLASS<char *> cl::Program::getInfo<CL_PROGRAM_BINARIES> (cl_int * err) const
 {
-    VECTOR_CLASS< ::size_t> sizes = getInfo<CL_PROGRAM_BINARY_SIZES>();
-    VECTOR_CLASS<char *> binaries;
-    for (VECTOR_CLASS< ::size_t>::iterator s = sizes.begin(); s != sizes.end(); ++s) 
-    {
-        char *ptr = NULL;
-        if (*s != 0) 
-            ptr = new char[*s];
-        binaries.push_back(ptr);
-    }
-    
-    cl_int result = getInfo(CL_PROGRAM_BINARIES, &binaries);
-    if (err != NULL) {
-        *err = result;
-    }
-    return binaries;
+	VECTOR_CLASS<::size_t> sizes = getInfo<CL_PROGRAM_BINARY_SIZES> ();
+	VECTOR_CLASS<char *> binaries;
+	for (VECTOR_CLASS<::size_t>::iterator s = sizes.begin (); s != sizes.end (); ++s)
+	{
+		char * ptr = NULL;
+		if (*s != 0)
+			ptr = new char[*s];
+		binaries.push_back (ptr);
+	}
+
+	cl_int result = getInfo (CL_PROGRAM_BINARIES, &binaries);
+	if (err != NULL)
+	{
+		*err = result;
+	}
+	return binaries;
 }
 
-inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
+inline Kernel::Kernel (const Program & program, const char * name, cl_int * err)
 {
-    cl_int error;
+	cl_int error;
 
-    object_ = ::clCreateKernel(program(), name, &error);
-    detail::errHandler(error, __CREATE_KERNEL_ERR);
+	object_ = ::clCreateKernel (program (), name, &error);
+	detail::errHandler (error, __CREATE_KERNEL_ERR);
 
-    if (err != NULL) {
-        *err = error;
-    }
-
+	if (err != NULL)
+	{
+		*err = error;
+	}
 }
 
 /*! \class CommandQueue
@@ -5478,753 +6036,782 @@ class CommandQueue : public detail::Wrapper<cl_command_queue>
 {
 private:
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-    static std::atomic<int> default_initialized_;
+	static std::atomic<int> default_initialized_;
 #else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    static volatile int default_initialized_;
+	static volatile int default_initialized_;
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-    static CommandQueue default_;
-    static volatile cl_int default_error_;
+	static CommandQueue default_;
+	static volatile cl_int default_error_;
+
 public:
-   CommandQueue(
-        cl_command_queue_properties properties,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	CommandQueue (
+	cl_command_queue_properties properties,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        Context context = Context::getDefault(&error);
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		Context context = Context::getDefault (&error);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-        if (error != CL_SUCCESS) {
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-        else {
-            Device device = context.getInfo<CL_CONTEXT_DEVICES>()[0];
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+		else
+		{
+			Device device = context.getInfo<CL_CONTEXT_DEVICES> ()[0];
 
-            object_ = ::clCreateCommandQueue(
-                context(), device(), properties, &error);
+			object_ = ::clCreateCommandQueue (
+			context (), device (), properties, &error);
 
-            detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-    }
-    /*!
+			detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+	}
+	/*!
     * \brief Constructs a CommandQueue for an implementation defined device in the given context
     */
-    explicit CommandQueue(
-        const Context& context,
-        cl_command_queue_properties properties = 0,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        VECTOR_CLASS<cl::Device> devices;
-        error = context.getInfo(CL_CONTEXT_DEVICES, &devices);
+	explicit CommandQueue (
+	const Context & context,
+	cl_command_queue_properties properties = 0,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		VECTOR_CLASS<cl::Device> devices;
+		error = context.getInfo (CL_CONTEXT_DEVICES, &devices);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-        if (error != CL_SUCCESS)
-        {
-            if (err != NULL) {
-                *err = error;
-            }
-            return;
-        }
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+			return;
+		}
 
-        object_ = ::clCreateCommandQueue(context(), devices[0](), properties, &error);
+		object_ = ::clCreateCommandQueue (context (), devices[0](), properties, &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
 
-        if (err != NULL) {
-            *err = error;
-        }
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    }
+	CommandQueue (
+	const Context & context,
+	const Device & device,
+	cl_command_queue_properties properties = 0,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateCommandQueue (
+		context (), device (), properties, &error);
 
-    CommandQueue(
-        const Context& context,
-        const Device& device,
-        cl_command_queue_properties properties = 0,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateCommandQueue(
-            context(), device(), properties, &error);
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
-
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue(const CommandQueue& queue) : detail::Wrapper<cl_type>(queue) {}
+	CommandQueue (const CommandQueue & queue) :
+		detail::Wrapper<cl_type> (queue)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue& operator = (const CommandQueue &queue)
-    {
-        detail::Wrapper<cl_type>::operator=(queue);
-        return *this;
-    }
+	CommandQueue & operator= (const CommandQueue & queue)
+	{
+		detail::Wrapper<cl_type>::operator= (queue);
+		return *this;
+	}
 
 #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue(CommandQueue&& queue) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(queue)) {}
+	CommandQueue (CommandQueue && queue) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type> (std::move (queue))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue& operator = (CommandQueue &&queue)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(queue));
-        return *this;
-    }
+	CommandQueue & operator= (CommandQueue && queue)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (queue));
+		return *this;
+	}
 #endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
-    static CommandQueue getDefault(cl_int * err = NULL) 
-    {
-        int state = detail::compare_exchange(
-            &default_initialized_, 
-            __DEFAULT_BEING_INITIALIZED, __DEFAULT_NOT_INITIALIZED);
-        
-        if (state & __DEFAULT_INITIALIZED) {
-            if (err != NULL) {
-                *err = default_error_;
-            }
-            return default_;
-        }
+	static CommandQueue getDefault (cl_int * err = NULL)
+	{
+		int state = detail::compare_exchange (
+		&default_initialized_,
+		__DEFAULT_BEING_INITIALIZED, __DEFAULT_NOT_INITIALIZED);
 
-        if (state & __DEFAULT_BEING_INITIALIZED) {
-              // Assume writes will propagate eventually...
-              while(default_initialized_ != __DEFAULT_INITIALIZED) {
-                  detail::fence();
-              }
+		if (state & __DEFAULT_INITIALIZED)
+		{
+			if (err != NULL)
+			{
+				*err = default_error_;
+			}
+			return default_;
+		}
 
-            if (err != NULL) {
-                *err = default_error_;
-            }
-            return default_;
-        }
+		if (state & __DEFAULT_BEING_INITIALIZED)
+		{
+			// Assume writes will propagate eventually...
+			while (default_initialized_ != __DEFAULT_INITIALIZED)
+			{
+				detail::fence ();
+			}
 
-        cl_int error;
+			if (err != NULL)
+			{
+				*err = default_error_;
+			}
+			return default_;
+		}
 
-        Context context = Context::getDefault(&error);
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
+		cl_int error;
 
-        if (error != CL_SUCCESS) {
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-        else {
-            Device device = context.getInfo<CL_CONTEXT_DEVICES>()[0];
+		Context context = Context::getDefault (&error);
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
 
-            default_ = CommandQueue(context, device, 0, &error);
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+		else
+		{
+			Device device = context.getInfo<CL_CONTEXT_DEVICES> ()[0];
 
-            detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			default_ = CommandQueue (context, device, 0, &error);
 
-        detail::fence();
+			detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 
-        default_error_ = error;
-        // Assume writes will propagate eventually...
-        default_initialized_ = __DEFAULT_INITIALIZED;
+		detail::fence ();
 
-        detail::fence();
+		default_error_ = error;
+		// Assume writes will propagate eventually...
+		default_initialized_ = __DEFAULT_INITIALIZED;
 
-        if (err != NULL) {
-            *err = default_error_;
-        }
-        return default_;
+		detail::fence ();
 
-    }
+		if (err != NULL)
+		{
+			*err = default_error_;
+		}
+		return default_;
+	}
 
-    CommandQueue() { }
+	CommandQueue ()
+	{
+	}
 
-    __CL_EXPLICIT_CONSTRUCTORS CommandQueue(const cl_command_queue& commandQueue) : detail::Wrapper<cl_type>(commandQueue) { }
+	__CL_EXPLICIT_CONSTRUCTORS CommandQueue (const cl_command_queue & commandQueue) :
+		detail::Wrapper<cl_type> (commandQueue)
+	{
+	}
 
-    CommandQueue& operator = (const cl_command_queue& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	CommandQueue & operator= (const cl_command_queue & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    template <typename T>
-    cl_int getInfo(cl_command_queue_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-                &::clGetCommandQueueInfo, object_, name, param),
-                __GET_COMMAND_QUEUE_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_command_queue_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetCommandQueueInfo, object_, name, param),
+		__GET_COMMAND_QUEUE_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_command_queue_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_command_queue_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_command_queue_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_command_queue_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    cl_int enqueueReadBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        ::size_t offset,
-        ::size_t size,
-        void* ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueReadBuffer(
-                object_, buffer(), blocking, offset, size,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_READ_BUFFER_ERR);
+	cl_int enqueueReadBuffer (
+	const Buffer & buffer,
+	cl_bool blocking,
+	::size_t offset,
+	::size_t size,
+	void * ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReadBuffer (
+		object_, buffer (), blocking, offset, size,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_READ_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueWriteBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        ::size_t offset,
-        ::size_t size,
-        const void* ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueWriteBuffer(
-                object_, buffer(), blocking, offset, size,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_WRITE_BUFFER_ERR);
+	cl_int enqueueWriteBuffer (
+	const Buffer & buffer,
+	cl_bool blocking,
+	::size_t offset,
+	::size_t size,
+	const void * ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueWriteBuffer (
+		object_, buffer (), blocking, offset, size,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_WRITE_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyBuffer(
-        const Buffer& src,
-        const Buffer& dst,
-        ::size_t src_offset,
-        ::size_t dst_offset,
-        ::size_t size,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyBuffer(
-                object_, src(), dst(), src_offset, dst_offset, size,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQEUE_COPY_BUFFER_ERR);
+	cl_int enqueueCopyBuffer (
+	const Buffer & src,
+	const Buffer & dst,
+	::size_t src_offset,
+	::size_t dst_offset,
+	::size_t size,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyBuffer (
+		object_, src (), dst (), src_offset, dst_offset, size,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQEUE_COPY_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueReadBufferRect(
-        const Buffer& buffer,
-        cl_bool blocking,
-        const size_t<3>& buffer_offset,
-        const size_t<3>& host_offset,
-        const size_t<3>& region,
-        ::size_t buffer_row_pitch,
-        ::size_t buffer_slice_pitch,
-        ::size_t host_row_pitch,
-        ::size_t host_slice_pitch,
-        void *ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueReadBufferRect(
-                object_, 
-                buffer(), 
-                blocking, 
-                (const ::size_t *)buffer_offset,
-                (const ::size_t *)host_offset,
-                (const ::size_t *)region,
-                buffer_row_pitch,
-                buffer_slice_pitch,
-                host_row_pitch,
-                host_slice_pitch,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_READ_BUFFER_RECT_ERR);
+	cl_int enqueueReadBufferRect (
+	const Buffer & buffer,
+	cl_bool blocking,
+	const size_t<3> & buffer_offset,
+	const size_t<3> & host_offset,
+	const size_t<3> & region,
+	::size_t buffer_row_pitch,
+	::size_t buffer_slice_pitch,
+	::size_t host_row_pitch,
+	::size_t host_slice_pitch,
+	void * ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReadBufferRect (
+		object_,
+		buffer (),
+		blocking,
+		(const ::size_t *)buffer_offset,
+		(const ::size_t *)host_offset,
+		(const ::size_t *)region,
+		buffer_row_pitch,
+		buffer_slice_pitch,
+		host_row_pitch,
+		host_slice_pitch,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_READ_BUFFER_RECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueWriteBufferRect(
-        const Buffer& buffer,
-        cl_bool blocking,
-        const size_t<3>& buffer_offset,
-        const size_t<3>& host_offset,
-        const size_t<3>& region,
-        ::size_t buffer_row_pitch,
-        ::size_t buffer_slice_pitch,
-        ::size_t host_row_pitch,
-        ::size_t host_slice_pitch,
-        void *ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueWriteBufferRect(
-                object_, 
-                buffer(), 
-                blocking, 
-                (const ::size_t *)buffer_offset,
-                (const ::size_t *)host_offset,
-                (const ::size_t *)region,
-                buffer_row_pitch,
-                buffer_slice_pitch,
-                host_row_pitch,
-                host_slice_pitch,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_WRITE_BUFFER_RECT_ERR);
+	cl_int enqueueWriteBufferRect (
+	const Buffer & buffer,
+	cl_bool blocking,
+	const size_t<3> & buffer_offset,
+	const size_t<3> & host_offset,
+	const size_t<3> & region,
+	::size_t buffer_row_pitch,
+	::size_t buffer_slice_pitch,
+	::size_t host_row_pitch,
+	::size_t host_slice_pitch,
+	void * ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueWriteBufferRect (
+		object_,
+		buffer (),
+		blocking,
+		(const ::size_t *)buffer_offset,
+		(const ::size_t *)host_offset,
+		(const ::size_t *)region,
+		buffer_row_pitch,
+		buffer_slice_pitch,
+		host_row_pitch,
+		host_slice_pitch,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_WRITE_BUFFER_RECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyBufferRect(
-        const Buffer& src,
-        const Buffer& dst,
-        const size_t<3>& src_origin,
-        const size_t<3>& dst_origin,
-        const size_t<3>& region,
-        ::size_t src_row_pitch,
-        ::size_t src_slice_pitch,
-        ::size_t dst_row_pitch,
-        ::size_t dst_slice_pitch,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferRect(
-                object_, 
-                src(), 
-                dst(), 
-                (const ::size_t *)src_origin, 
-                (const ::size_t *)dst_origin, 
-                (const ::size_t *)region,
-                src_row_pitch,
-                src_slice_pitch,
-                dst_row_pitch,
-                dst_slice_pitch,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQEUE_COPY_BUFFER_RECT_ERR);
+	cl_int enqueueCopyBufferRect (
+	const Buffer & src,
+	const Buffer & dst,
+	const size_t<3> & src_origin,
+	const size_t<3> & dst_origin,
+	const size_t<3> & region,
+	::size_t src_row_pitch,
+	::size_t src_slice_pitch,
+	::size_t dst_row_pitch,
+	::size_t dst_slice_pitch,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyBufferRect (
+		object_,
+		src (),
+		dst (),
+		(const ::size_t *)src_origin,
+		(const ::size_t *)dst_origin,
+		(const ::size_t *)region,
+		src_row_pitch,
+		src_slice_pitch,
+		dst_row_pitch,
+		dst_slice_pitch,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQEUE_COPY_BUFFER_RECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 #if defined(CL_VERSION_1_2)
-    /**
+	/**
      * Enqueue a command to fill a buffer object with a pattern
      * of a given size. The pattern is specified a as vector.
      * \tparam PatternType The datatype of the pattern field. 
      *     The pattern type must be an accepted OpenCL data type.
      */
-    template<typename PatternType>
-    cl_int enqueueFillBuffer(
-        const Buffer& buffer,
-        PatternType pattern,
-        ::size_t offset,
-        ::size_t size,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillBuffer(
-                object_, 
-                buffer(),
-                static_cast<void*>(&pattern),
-                sizeof(PatternType), 
-                offset, 
-                size,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_BUFFER_ERR);
+	template <typename PatternType>
+	cl_int enqueueFillBuffer (
+	const Buffer & buffer,
+	PatternType pattern,
+	::size_t offset,
+	::size_t size,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillBuffer (
+		object_,
+		buffer (),
+		static_cast<void *> (&pattern),
+		sizeof (PatternType),
+		offset,
+		size,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // #if defined(CL_VERSION_1_2)
 
-    cl_int enqueueReadImage(
-        const Image& image,
-        cl_bool blocking,
-        const size_t<3>& origin,
-        const size_t<3>& region,
-        ::size_t row_pitch,
-        ::size_t slice_pitch,
-        void* ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueReadImage(
-                object_, image(), blocking, (const ::size_t *) origin,
-                (const ::size_t *) region, row_pitch, slice_pitch, ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_READ_IMAGE_ERR);
+	cl_int enqueueReadImage (
+	const Image & image,
+	cl_bool blocking,
+	const size_t<3> & origin,
+	const size_t<3> & region,
+	::size_t row_pitch,
+	::size_t slice_pitch,
+	void * ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReadImage (
+		object_, image (), blocking, (const ::size_t *)origin,
+		(const ::size_t *)region, row_pitch, slice_pitch, ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_READ_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueWriteImage(
-        const Image& image,
-        cl_bool blocking,
-        const size_t<3>& origin,
-        const size_t<3>& region,
-        ::size_t row_pitch,
-        ::size_t slice_pitch,
-        void* ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueWriteImage(
-                object_, image(), blocking, (const ::size_t *) origin,
-                (const ::size_t *) region, row_pitch, slice_pitch, ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_WRITE_IMAGE_ERR);
+	cl_int enqueueWriteImage (
+	const Image & image,
+	cl_bool blocking,
+	const size_t<3> & origin,
+	const size_t<3> & region,
+	::size_t row_pitch,
+	::size_t slice_pitch,
+	void * ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueWriteImage (
+		object_, image (), blocking, (const ::size_t *)origin,
+		(const ::size_t *)region, row_pitch, slice_pitch, ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_WRITE_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyImage(
-        const Image& src,
-        const Image& dst,
-        const size_t<3>& src_origin,
-        const size_t<3>& dst_origin,
-        const size_t<3>& region,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyImage(
-                object_, src(), dst(), (const ::size_t *) src_origin,
-                (const ::size_t *)dst_origin, (const ::size_t *) region,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_COPY_IMAGE_ERR);
+	cl_int enqueueCopyImage (
+	const Image & src,
+	const Image & dst,
+	const size_t<3> & src_origin,
+	const size_t<3> & dst_origin,
+	const size_t<3> & region,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyImage (
+		object_, src (), dst (), (const ::size_t *)src_origin,
+		(const ::size_t *)dst_origin, (const ::size_t *)region,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_COPY_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 #if defined(CL_VERSION_1_2)
-    /**
+	/**
      * Enqueue a command to fill an image object with a specified color.
      * \param fillColor is the color to use to fill the image.
      *     This is a four component RGBA floating-point color value if
      *     the image channel data type is not an unnormalized signed or
      *     unsigned data type.
      */
-    cl_int enqueueFillImage(
-        const Image& image,
-        cl_float4 fillColor,
-        const size_t<3>& origin,
-        const size_t<3>& region,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
-                object_, 
-                image(),
-                static_cast<void*>(&fillColor), 
-                (const ::size_t *) origin, 
-                (const ::size_t *) region,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_IMAGE_ERR);
+	cl_int enqueueFillImage (
+	const Image & image,
+	cl_float4 fillColor,
+	const size_t<3> & origin,
+	const size_t<3> & region,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillImage (
+		object_,
+		image (),
+		static_cast<void *> (&fillColor),
+		(const ::size_t *)origin,
+		(const ::size_t *)region,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueue a command to fill an image object with a specified color.
      * \param fillColor is the color to use to fill the image.
      *     This is a four component RGBA signed integer color value if
      *     the image channel data type is an unnormalized signed integer
      *     type.
      */
-    cl_int enqueueFillImage(
-        const Image& image,
-        cl_int4 fillColor,
-        const size_t<3>& origin,
-        const size_t<3>& region,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
-                object_, 
-                image(),
-                static_cast<void*>(&fillColor), 
-                (const ::size_t *) origin, 
-                (const ::size_t *) region,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_IMAGE_ERR);
+	cl_int enqueueFillImage (
+	const Image & image,
+	cl_int4 fillColor,
+	const size_t<3> & origin,
+	const size_t<3> & region,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillImage (
+		object_,
+		image (),
+		static_cast<void *> (&fillColor),
+		(const ::size_t *)origin,
+		(const ::size_t *)region,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueue a command to fill an image object with a specified color.
      * \param fillColor is the color to use to fill the image.
      *     This is a four component RGBA unsigned integer color value if
      *     the image channel data type is an unnormalized unsigned integer
      *     type.
      */
-    cl_int enqueueFillImage(
-        const Image& image,
-        cl_uint4 fillColor,
-        const size_t<3>& origin,
-        const size_t<3>& region,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
-                object_, 
-                image(),
-                static_cast<void*>(&fillColor), 
-                (const ::size_t *) origin, 
-                (const ::size_t *) region,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_IMAGE_ERR);
+	cl_int enqueueFillImage (
+	const Image & image,
+	cl_uint4 fillColor,
+	const size_t<3> & origin,
+	const size_t<3> & region,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillImage (
+		object_,
+		image (),
+		static_cast<void *> (&fillColor),
+		(const ::size_t *)origin,
+		(const ::size_t *)region,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // #if defined(CL_VERSION_1_2)
 
-    cl_int enqueueCopyImageToBuffer(
-        const Image& src,
-        const Buffer& dst,
-        const size_t<3>& src_origin,
-        const size_t<3>& region,
-        ::size_t dst_offset,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyImageToBuffer(
-                object_, src(), dst(), (const ::size_t *) src_origin,
-                (const ::size_t *) region, dst_offset,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR);
+	cl_int enqueueCopyImageToBuffer (
+	const Image & src,
+	const Buffer & dst,
+	const size_t<3> & src_origin,
+	const size_t<3> & region,
+	::size_t dst_offset,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyImageToBuffer (
+		object_, src (), dst (), (const ::size_t *)src_origin,
+		(const ::size_t *)region, dst_offset,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyBufferToImage(
-        const Buffer& src,
-        const Image& dst,
-        ::size_t src_offset,
-        const size_t<3>& dst_origin,
-        const size_t<3>& region,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferToImage(
-                object_, src(), dst(), src_offset,
-                (const ::size_t *) dst_origin, (const ::size_t *) region,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR);
+	cl_int enqueueCopyBufferToImage (
+	const Buffer & src,
+	const Image & dst,
+	::size_t src_offset,
+	const size_t<3> & dst_origin,
+	const size_t<3> & region,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyBufferToImage (
+		object_, src (), dst (), src_offset,
+		(const ::size_t *)dst_origin, (const ::size_t *)region,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    void* enqueueMapBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        cl_map_flags flags,
-        ::size_t offset,
-        ::size_t size,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL,
-        cl_int* err = NULL) const
-    {
-        cl_event tmp;
-        cl_int error;
-        void * result = ::clEnqueueMapBuffer(
-            object_, buffer(), blocking, flags, offset, size,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (event != NULL) ? &tmp : NULL,
-            &error);
+	void * enqueueMapBuffer (
+	const Buffer & buffer,
+	cl_bool blocking,
+	cl_map_flags flags,
+	::size_t offset,
+	::size_t size,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL,
+	cl_int * err = NULL) const
+	{
+		cl_event tmp;
+		cl_int error;
+		void * result = ::clEnqueueMapBuffer (
+		object_, buffer (), blocking, flags, offset, size,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL,
+		&error);
 
-        detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-        if (event != NULL && error == CL_SUCCESS)
-            *event = tmp;
+		detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+		if (event != NULL && error == CL_SUCCESS)
+			*event = tmp;
 
-        return result;
-    }
+		return result;
+	}
 
-    void* enqueueMapImage(
-        const Image& buffer,
-        cl_bool blocking,
-        cl_map_flags flags,
-        const size_t<3>& origin,
-        const size_t<3>& region,
-        ::size_t * row_pitch,
-        ::size_t * slice_pitch,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL,
-        cl_int* err = NULL) const
-    {
-        cl_event tmp;
-        cl_int error;
-        void * result = ::clEnqueueMapImage(
-            object_, buffer(), blocking, flags,
-            (const ::size_t *) origin, (const ::size_t *) region,
-            row_pitch, slice_pitch,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (event != NULL) ? &tmp : NULL,
-            &error);
+	void * enqueueMapImage (
+	const Image & buffer,
+	cl_bool blocking,
+	cl_map_flags flags,
+	const size_t<3> & origin,
+	const size_t<3> & region,
+	::size_t * row_pitch,
+	::size_t * slice_pitch,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL,
+	cl_int * err = NULL) const
+	{
+		cl_event tmp;
+		cl_int error;
+		void * result = ::clEnqueueMapImage (
+		object_, buffer (), blocking, flags,
+		(const ::size_t *)origin, (const ::size_t *)region,
+		row_pitch, slice_pitch,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL,
+		&error);
 
-        detail::errHandler(error, __ENQUEUE_MAP_IMAGE_ERR);
-        if (err != NULL) {
-              *err = error;
-        }
-        if (event != NULL && error == CL_SUCCESS)
-            *event = tmp;
-        return result;
-    }
+		detail::errHandler (error, __ENQUEUE_MAP_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+		if (event != NULL && error == CL_SUCCESS)
+			*event = tmp;
+		return result;
+	}
 
-    cl_int enqueueUnmapMemObject(
-        const Memory& memory,
-        void* mapped_ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueUnmapMemObject(
-                object_, memory(), mapped_ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	cl_int enqueueUnmapMemObject (
+	const Memory & memory,
+	void * mapped_ptr,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueUnmapMemObject (
+		object_, memory (), mapped_ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 #if defined(CL_VERSION_1_2)
-    /**
+	/**
      * Enqueues a marker command which waits for either a list of events to complete, 
      * or all previously enqueued commands to complete.
      *
@@ -6235,26 +6822,26 @@ public:
      * or all previously enqueued commands, queued before this command to command_queue, 
      * have completed.
      */
-    cl_int enqueueMarkerWithWaitList(
-        const VECTOR_CLASS<Event> *events = 0,
-        Event *event = 0)
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueMarkerWithWaitList(
-                object_,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MARKER_WAIT_LIST_ERR);
+	cl_int enqueueMarkerWithWaitList (
+	const VECTOR_CLASS<Event> * events = 0,
+	Event * event = 0)
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueMarkerWithWaitList (
+		object_,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MARKER_WAIT_LIST_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * A synchronization point that enqueues a barrier operation.
      *
      * Enqueues a barrier command which waits for either a list of events to complete, 
@@ -6265,319 +6852,320 @@ public:
      * all events either in the event_wait_list or all previously enqueued commands, queued 
      * before this command to command_queue, have completed.
      */
-    cl_int enqueueBarrierWithWaitList(
-        const VECTOR_CLASS<Event> *events = 0,
-        Event *event = 0)
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueBarrierWithWaitList(
-                object_,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_BARRIER_WAIT_LIST_ERR);
+	cl_int enqueueBarrierWithWaitList (
+	const VECTOR_CLASS<Event> * events = 0,
+	Event * event = 0)
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueBarrierWithWaitList (
+		object_,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_BARRIER_WAIT_LIST_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
-    
-    /**
+		return err;
+	}
+
+	/**
      * Enqueues a command to indicate with which device a set of memory objects
      * should be associated.
      */
-    cl_int enqueueMigrateMemObjects(
-        const VECTOR_CLASS<Memory> &memObjects,
-        cl_mem_migration_flags flags,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL
-        )
-    {
-        cl_event tmp;
-        
-        cl_mem* localMemObjects = static_cast<cl_mem*>(alloca(memObjects.size() * sizeof(cl_mem)));
-        for( int i = 0; i < (int)memObjects.size(); ++i ) {
-            localMemObjects[i] = memObjects[i]();
-        }
+	cl_int enqueueMigrateMemObjects (
+	const VECTOR_CLASS<Memory> & memObjects,
+	cl_mem_migration_flags flags,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL)
+	{
+		cl_event tmp;
 
+		cl_mem * localMemObjects = static_cast<cl_mem *> (alloca (memObjects.size () * sizeof (cl_mem)));
+		for (int i = 0; i < (int)memObjects.size (); ++i)
+		{
+			localMemObjects[i] = memObjects[i]();
+		}
 
-        cl_int err = detail::errHandler(
-            ::clEnqueueMigrateMemObjects(
-                object_, 
-                (cl_uint)memObjects.size(), 
-                static_cast<const cl_mem*>(localMemObjects),
-                flags,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+		cl_int err = detail::errHandler (
+		::clEnqueueMigrateMemObjects (
+		object_,
+		(cl_uint)memObjects.size (),
+		static_cast<const cl_mem *> (localMemObjects),
+		flags,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // #if defined(CL_VERSION_1_2)
 
-    cl_int enqueueNDRangeKernel(
-        const Kernel& kernel,
-        const NDRange& offset,
-        const NDRange& global,
-        const NDRange& local = NullRange,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueNDRangeKernel(
-                object_, kernel(), (cl_uint) global.dimensions(),
-                offset.dimensions() != 0 ? (const ::size_t*) offset : NULL,
-                (const ::size_t*) global,
-                local.dimensions() != 0 ? (const ::size_t*) local : NULL,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_NDRANGE_KERNEL_ERR);
+	cl_int enqueueNDRangeKernel (
+	const Kernel & kernel,
+	const NDRange & offset,
+	const NDRange & global,
+	const NDRange & local = NullRange,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueNDRangeKernel (
+		object_, kernel (), (cl_uint)global.dimensions (),
+		offset.dimensions () != 0 ? (const ::size_t *)offset : NULL,
+		(const ::size_t *)global,
+		local.dimensions () != 0 ? (const ::size_t *)local : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_NDRANGE_KERNEL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueTask(
-        const Kernel& kernel,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueTask(
-                object_, kernel(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_TASK_ERR);
+	cl_int enqueueTask (
+	const Kernel & kernel,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueTask (
+		object_, kernel (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_TASK_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueNativeKernel(
-        void (CL_CALLBACK *userFptr)(void *),
-        std::pair<void*, ::size_t> args,
-        const VECTOR_CLASS<Memory>* mem_objects = NULL,
-        const VECTOR_CLASS<const void*>* mem_locs = NULL,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_mem * mems = (mem_objects != NULL && mem_objects->size() > 0) 
-            ? (cl_mem*) alloca(mem_objects->size() * sizeof(cl_mem))
-            : NULL;
+	cl_int enqueueNativeKernel (
+	void (CL_CALLBACK * userFptr) (void *),
+	std::pair<void *, ::size_t> args,
+	const VECTOR_CLASS<Memory> * mem_objects = NULL,
+	const VECTOR_CLASS<const void *> * mem_locs = NULL,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_mem * mems = (mem_objects != NULL && mem_objects->size () > 0)
+		? (cl_mem *)alloca (mem_objects->size () * sizeof (cl_mem))
+		: NULL;
 
-        if (mems != NULL) {
-            for (unsigned int i = 0; i < mem_objects->size(); i++) {
-                mems[i] = ((*mem_objects)[i])();
-            }
-        }
+		if (mems != NULL)
+		{
+			for (unsigned int i = 0; i < mem_objects->size (); i++)
+			{
+				mems[i] = ((*mem_objects)[i]) ();
+			}
+		}
 
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueNativeKernel(
-                object_, userFptr, args.first, args.second,
-                (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                mems,
-                (mem_locs != NULL && mem_locs->size() > 0) ? (const void **) &mem_locs->front() : NULL,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_NATIVE_KERNEL);
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueNativeKernel (
+		object_, userFptr, args.first, args.second,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		mems,
+		(mem_locs != NULL && mem_locs->size () > 0) ? (const void **)&mem_locs->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_NATIVE_KERNEL);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 /**
  * Deprecated APIs for 1.2
  */
-#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2)) 
-    CL_EXT_PREFIX__VERSION_1_1_DEPRECATED 
-    cl_int enqueueMarker(Event* event = NULL) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueMarker(
-                object_, 
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MARKER_ERR);
+#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2))
+	CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+	cl_int enqueueMarker (Event * event = NULL) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueMarker (
+		object_,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MARKER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-    cl_int enqueueWaitForEvents(const VECTOR_CLASS<Event>& events) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-    {
-        return detail::errHandler(
-            ::clEnqueueWaitForEvents(
-                object_,
-                (cl_uint) events.size(),
-                events.size() > 0 ? (const cl_event*) &events.front() : NULL),
-            __ENQUEUE_WAIT_FOR_EVENTS_ERR);
-    }
+	CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+	cl_int enqueueWaitForEvents (const VECTOR_CLASS<Event> & events) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+	{
+		return detail::errHandler (
+		::clEnqueueWaitForEvents (
+		object_,
+		(cl_uint)events.size (),
+		events.size () > 0 ? (const cl_event *)&events.front () : NULL),
+		__ENQUEUE_WAIT_FOR_EVENTS_ERR);
+	}
 #endif // #if defined(CL_VERSION_1_1)
 
-    cl_int enqueueAcquireGLObjects(
-         const VECTOR_CLASS<Memory>* mem_objects = NULL,
-         const VECTOR_CLASS<Event>* events = NULL,
-         Event* event = NULL) const
-     {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-             ::clEnqueueAcquireGLObjects(
-                 object_,
-                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                 (events != NULL) ? (cl_uint) events->size() : 0,
-                 (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                 (event != NULL) ? &tmp : NULL),
-             __ENQUEUE_ACQUIRE_GL_ERR);
+	cl_int enqueueAcquireGLObjects (
+	const VECTOR_CLASS<Memory> * mem_objects = NULL,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueAcquireGLObjects (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_ACQUIRE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-     }
+		return err;
+	}
 
-    cl_int enqueueReleaseGLObjects(
-         const VECTOR_CLASS<Memory>* mem_objects = NULL,
-         const VECTOR_CLASS<Event>* events = NULL,
-         Event* event = NULL) const
-     {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-             ::clEnqueueReleaseGLObjects(
-                 object_,
-                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                 (events != NULL) ? (cl_uint) events->size() : 0,
-                 (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                 (event != NULL) ? &tmp : NULL),
-             __ENQUEUE_RELEASE_GL_ERR);
+	cl_int enqueueReleaseGLObjects (
+	const VECTOR_CLASS<Memory> * mem_objects = NULL,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReleaseGLObjects (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_RELEASE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-     }
+		return err;
+	}
 
-#if defined (USE_DX_INTEROP)
-typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueAcquireD3D10ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem* mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list, cl_event* event);
-typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem* mem_objects,  cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list, cl_event* event);
+#if defined(USE_DX_INTEROP)
+	typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clEnqueueAcquireD3D10ObjectsKHR) (
+	cl_command_queue command_queue, cl_uint num_objects,
+	const cl_mem * mem_objects, cl_uint num_events_in_wait_list,
+	const cl_event * event_wait_list, cl_event * event);
+	typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clEnqueueReleaseD3D10ObjectsKHR) (
+	cl_command_queue command_queue, cl_uint num_objects,
+	const cl_mem * mem_objects, cl_uint num_events_in_wait_list,
+	const cl_event * event_wait_list, cl_event * event);
 
-    cl_int enqueueAcquireD3D10Objects(
-         const VECTOR_CLASS<Memory>* mem_objects = NULL,
-         const VECTOR_CLASS<Event>* events = NULL,
-         Event* event = NULL) const
-    {
-        static PFN_clEnqueueAcquireD3D10ObjectsKHR pfn_clEnqueueAcquireD3D10ObjectsKHR = NULL;
+	cl_int enqueueAcquireD3D10Objects (
+	const VECTOR_CLASS<Memory> * mem_objects = NULL,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		static PFN_clEnqueueAcquireD3D10ObjectsKHR pfn_clEnqueueAcquireD3D10ObjectsKHR = NULL;
 #if defined(CL_VERSION_1_2)
-        cl_context context = getInfo<CL_QUEUE_CONTEXT>();
-        cl::Device device(getInfo<CL_QUEUE_DEVICE>());
-        cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM>();
-        __INIT_CL_EXT_FCN_PTR_PLATFORM(platform, clEnqueueAcquireD3D10ObjectsKHR);
+		cl_context context = getInfo<CL_QUEUE_CONTEXT> ();
+		cl::Device device (getInfo<CL_QUEUE_DEVICE> ());
+		cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM> ();
+		__INIT_CL_EXT_FCN_PTR_PLATFORM (platform, clEnqueueAcquireD3D10ObjectsKHR);
 #endif
 #if defined(CL_VERSION_1_1)
-        __INIT_CL_EXT_FCN_PTR(clEnqueueAcquireD3D10ObjectsKHR);
+		__INIT_CL_EXT_FCN_PTR (clEnqueueAcquireD3D10ObjectsKHR);
 #endif
-        
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-             pfn_clEnqueueAcquireD3D10ObjectsKHR(
-                 object_,
-                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                 (events != NULL) ? (cl_uint) events->size() : 0,
-                 (events != NULL) ? (cl_event*) &events->front() : NULL,
-                 (event != NULL) ? &tmp : NULL),
-             __ENQUEUE_ACQUIRE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		pfn_clEnqueueAcquireD3D10ObjectsKHR (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_ACQUIRE_GL_ERR);
 
-        return err;
-     }
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-    cl_int enqueueReleaseD3D10Objects(
-         const VECTOR_CLASS<Memory>* mem_objects = NULL,
-         const VECTOR_CLASS<Event>* events = NULL,
-         Event* event = NULL) const
-    {
-        static PFN_clEnqueueReleaseD3D10ObjectsKHR pfn_clEnqueueReleaseD3D10ObjectsKHR = NULL;
+		return err;
+	}
+
+	cl_int enqueueReleaseD3D10Objects (
+	const VECTOR_CLASS<Memory> * mem_objects = NULL,
+	const VECTOR_CLASS<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		static PFN_clEnqueueReleaseD3D10ObjectsKHR pfn_clEnqueueReleaseD3D10ObjectsKHR = NULL;
 #if defined(CL_VERSION_1_2)
-        cl_context context = getInfo<CL_QUEUE_CONTEXT>();
-        cl::Device device(getInfo<CL_QUEUE_DEVICE>());
-        cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM>();
-        __INIT_CL_EXT_FCN_PTR_PLATFORM(platform, clEnqueueReleaseD3D10ObjectsKHR);
+		cl_context context = getInfo<CL_QUEUE_CONTEXT> ();
+		cl::Device device (getInfo<CL_QUEUE_DEVICE> ());
+		cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM> ();
+		__INIT_CL_EXT_FCN_PTR_PLATFORM (platform, clEnqueueReleaseD3D10ObjectsKHR);
 #endif // #if defined(CL_VERSION_1_2)
 #if defined(CL_VERSION_1_1)
-        __INIT_CL_EXT_FCN_PTR(clEnqueueReleaseD3D10ObjectsKHR);
+		__INIT_CL_EXT_FCN_PTR (clEnqueueReleaseD3D10ObjectsKHR);
 #endif // #if defined(CL_VERSION_1_1)
 
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            pfn_clEnqueueReleaseD3D10ObjectsKHR(
-                object_,
-                (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_RELEASE_GL_ERR);
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		pfn_clEnqueueReleaseD3D10ObjectsKHR (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_RELEASE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif
 
 /**
  * Deprecated APIs for 1.2
  */
-#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2)) 
-    CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-    cl_int enqueueBarrier() const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-    {
-        return detail::errHandler(
-            ::clEnqueueBarrier(object_),
-            __ENQUEUE_BARRIER_ERR);
-    }
+#if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS) || (defined(CL_VERSION_1_1) && !defined(CL_VERSION_1_2))
+	CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+	cl_int enqueueBarrier () const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+	{
+		return detail::errHandler (
+		::clEnqueueBarrier (object_),
+		__ENQUEUE_BARRIER_ERR);
+	}
 #endif // #if defined(CL_VERSION_1_1)
 
-    cl_int flush() const
-    {
-        return detail::errHandler(::clFlush(object_), __FLUSH_ERR);
-    }
+	cl_int flush () const
+	{
+		return detail::errHandler (::clFlush (object_), __FLUSH_ERR);
+	}
 
-    cl_int finish() const
-    {
-        return detail::errHandler(::clFinish(object_), __FINISH_ERR);
-    }
+	cl_int finish () const
+	{
+		return detail::errHandler (::clFinish (object_), __FINISH_ERR);
+	}
 };
 
 #ifdef _WIN32
@@ -6590,227 +7178,251 @@ __declspec(selectany) CommandQueue CommandQueue::default_;
 __declspec(selectany) volatile cl_int CommandQueue::default_error_ = CL_SUCCESS;
 #else // !_WIN32
 #ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
-__attribute__((weak)) std::atomic<int> CommandQueue::default_initialized_;
+__attribute__ ((weak)) std::atomic<int> CommandQueue::default_initialized_;
 #else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-__attribute__((weak)) volatile int CommandQueue::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
+__attribute__ ((weak)) volatile int CommandQueue::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
 #endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
-__attribute__((weak)) CommandQueue CommandQueue::default_;
-__attribute__((weak)) volatile cl_int CommandQueue::default_error_ = CL_SUCCESS;
+__attribute__ ((weak)) CommandQueue CommandQueue::default_;
+__attribute__ ((weak)) volatile cl_int CommandQueue::default_error_ = CL_SUCCESS;
 #endif // !_WIN32
 
-template< typename IteratorType >
-Buffer::Buffer(
-    const Context &context,
-    IteratorType startIterator,
-    IteratorType endIterator,
-    bool readOnly,
-    bool useHostPtr,
-    cl_int* err)
+template <typename IteratorType>
+Buffer::Buffer (
+const Context & context,
+IteratorType startIterator,
+IteratorType endIterator,
+bool readOnly,
+bool useHostPtr,
+cl_int * err)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    cl_mem_flags flags = 0;
-    if( readOnly ) {
-        flags |= CL_MEM_READ_ONLY;
-    }
-    else {
-        flags |= CL_MEM_READ_WRITE;
-    }
-    if( useHostPtr ) {
-        flags |= CL_MEM_USE_HOST_PTR;
-    }
-    
-    ::size_t size = sizeof(DataType)*(endIterator - startIterator);
+	cl_mem_flags flags = 0;
+	if (readOnly)
+	{
+		flags |= CL_MEM_READ_ONLY;
+	}
+	else
+	{
+		flags |= CL_MEM_READ_WRITE;
+	}
+	if (useHostPtr)
+	{
+		flags |= CL_MEM_USE_HOST_PTR;
+	}
 
-    if( useHostPtr ) {
-        object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
-    } else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
-    }
+	::size_t size = sizeof (DataType) * (endIterator - startIterator);
 
-    detail::errHandler(error, __CREATE_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
+	if (useHostPtr)
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, static_cast<DataType *> (&*startIterator), &error);
+	}
+	else
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, 0, &error);
+	}
 
-    if( !useHostPtr ) {
-        CommandQueue queue(context, 0, &error);
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+	detail::errHandler (error, __CREATE_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
 
-        error = cl::copy(queue, startIterator, endIterator, *this);
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+	if (!useHostPtr)
+	{
+		CommandQueue queue (context, 0, &error);
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+
+		error = cl::copy (queue, startIterator, endIterator, *this);
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 }
 
-template< typename IteratorType >
-Buffer::Buffer(
-    const CommandQueue &queue,
-    IteratorType startIterator,
-    IteratorType endIterator,
-    bool readOnly,
-    bool useHostPtr,
-    cl_int* err)
+template <typename IteratorType>
+Buffer::Buffer (
+const CommandQueue & queue,
+IteratorType startIterator,
+IteratorType endIterator,
+bool readOnly,
+bool useHostPtr,
+cl_int * err)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    cl_mem_flags flags = 0;
-    if (readOnly) {
-        flags |= CL_MEM_READ_ONLY;
-    }
-    else {
-        flags |= CL_MEM_READ_WRITE;
-    }
-    if (useHostPtr) {
-        flags |= CL_MEM_USE_HOST_PTR;
-    }
+	cl_mem_flags flags = 0;
+	if (readOnly)
+	{
+		flags |= CL_MEM_READ_ONLY;
+	}
+	else
+	{
+		flags |= CL_MEM_READ_WRITE;
+	}
+	if (useHostPtr)
+	{
+		flags |= CL_MEM_USE_HOST_PTR;
+	}
 
-    ::size_t size = sizeof(DataType)*(endIterator - startIterator);
+	::size_t size = sizeof (DataType) * (endIterator - startIterator);
 
-    Context context = queue.getInfo<CL_QUEUE_CONTEXT>();
+	Context context = queue.getInfo<CL_QUEUE_CONTEXT> ();
 
-    if (useHostPtr) {
-        object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
-    }
-    else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
-    }
+	if (useHostPtr)
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, static_cast<DataType *> (&*startIterator), &error);
+	}
+	else
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, 0, &error);
+	}
 
-    detail::errHandler(error, __CREATE_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
+	detail::errHandler (error, __CREATE_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
 
-    if (!useHostPtr) {
-        error = cl::copy(queue, startIterator, endIterator, *this);
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+	if (!useHostPtr)
+	{
+		error = cl::copy (queue, startIterator, endIterator, *this);
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 }
 
-inline cl_int enqueueReadBuffer(
-    const Buffer& buffer,
-    cl_bool blocking,
-    ::size_t offset,
-    ::size_t size,
-    void* ptr,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueReadBuffer (
+const Buffer & buffer,
+cl_bool blocking,
+::size_t offset,
+::size_t size,
+void * ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueReadBuffer(buffer, blocking, offset, size, ptr, events, event);
+	return queue.enqueueReadBuffer (buffer, blocking, offset, size, ptr, events, event);
 }
 
-inline cl_int enqueueWriteBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        ::size_t offset,
-        ::size_t size,
-        const void* ptr,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL)
+inline cl_int enqueueWriteBuffer (
+const Buffer & buffer,
+cl_bool blocking,
+::size_t offset,
+::size_t size,
+const void * ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueWriteBuffer(buffer, blocking, offset, size, ptr, events, event);
+	return queue.enqueueWriteBuffer (buffer, blocking, offset, size, ptr, events, event);
 }
 
-inline void* enqueueMapBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        cl_map_flags flags,
-        ::size_t offset,
-        ::size_t size,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL,
-        cl_int* err = NULL)
+inline void * enqueueMapBuffer (
+const Buffer & buffer,
+cl_bool blocking,
+cl_map_flags flags,
+::size_t offset,
+::size_t size,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL,
+cl_int * err = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
 
-    void * result = ::clEnqueueMapBuffer(
-            queue(), buffer(), blocking, flags, offset, size,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (cl_event*) event,
-            &error);
+	void * result = ::clEnqueueMapBuffer (
+	queue (), buffer (), blocking, flags, offset, size,
+	(events != NULL) ? (cl_uint)events->size () : 0,
+	(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+	(cl_event *)event,
+	&error);
 
-    detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
-    return result;
+	detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
+	return result;
 }
 
-inline cl_int enqueueUnmapMemObject(
-    const Memory& memory,
-    void* mapped_ptr,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueUnmapMemObject (
+const Memory & memory,
+void * mapped_ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    cl_event tmp;
-    cl_int err = detail::errHandler(
-        ::clEnqueueUnmapMemObject(
-            queue(), memory(), mapped_ptr,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	cl_event tmp;
+	cl_int err = detail::errHandler (
+	::clEnqueueUnmapMemObject (
+	queue (), memory (), mapped_ptr,
+	(events != NULL) ? (cl_uint)events->size () : 0,
+	(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+	(event != NULL) ? &tmp : NULL),
+	__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-    if (event != NULL && err == CL_SUCCESS)
-        *event = tmp;
+	if (event != NULL && err == CL_SUCCESS)
+		*event = tmp;
 
-    return err;
+	return err;
 }
 
-inline cl_int enqueueCopyBuffer(
-        const Buffer& src,
-        const Buffer& dst,
-        ::size_t src_offset,
-        ::size_t dst_offset,
-        ::size_t size,
-        const VECTOR_CLASS<Event>* events = NULL,
-        Event* event = NULL)
+inline cl_int enqueueCopyBuffer (
+const Buffer & src,
+const Buffer & dst,
+::size_t src_offset,
+::size_t dst_offset,
+::size_t size,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyBuffer(src, dst, src_offset, dst_offset, size, events, event);
+	return queue.enqueueCopyBuffer (src, dst, src_offset, dst_offset, size, events, event);
 }
 
 /**
@@ -6818,15 +7430,15 @@ inline cl_int enqueueCopyBuffer(
  * Host to Device.
  * Uses default command queue.
  */
-template< typename IteratorType >
-inline cl_int copy( IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer )
+template <typename IteratorType>
+inline cl_int copy (IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS)
-        return error;
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+		return error;
 
-    return cl::copy(queue, startIterator, endIterator, buffer);
+	return cl::copy (queue, startIterator, endIterator, buffer);
 }
 
 /**
@@ -6834,15 +7446,15 @@ inline cl_int copy( IteratorType startIterator, IteratorType endIterator, cl::Bu
  * Device to Host.
  * Uses default command queue.
  */
-template< typename IteratorType >
-inline cl_int copy( const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator )
+template <typename IteratorType>
+inline cl_int copy (const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS)
-        return error;
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+		return error;
 
-    return cl::copy(queue, buffer, startIterator, endIterator);
+	return cl::copy (queue, buffer, startIterator, endIterator);
 }
 
 /**
@@ -6850,38 +7462,39 @@ inline cl_int copy( const cl::Buffer &buffer, IteratorType startIterator, Iterat
  * Host to Device.
  * Uses specified queue.
  */
-template< typename IteratorType >
-inline cl_int copy( const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer )
+template <typename IteratorType>
+inline cl_int copy (const CommandQueue & queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
-    
-    ::size_t length = endIterator-startIterator;
-    ::size_t byteLength = length*sizeof(DataType);
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    DataType *pointer = 
-        static_cast<DataType*>(queue.enqueueMapBuffer(buffer, CL_TRUE, CL_MAP_WRITE, 0, byteLength, 0, 0, &error));
-    // if exceptions enabled, enqueueMapBuffer will throw
-    if( error != CL_SUCCESS ) {
-        return error;
-    }
+	::size_t length = endIterator - startIterator;
+	::size_t byteLength = length * sizeof (DataType);
+
+	DataType * pointer = static_cast<DataType *> (queue.enqueueMapBuffer (buffer, CL_TRUE, CL_MAP_WRITE, 0, byteLength, 0, 0, &error));
+	// if exceptions enabled, enqueueMapBuffer will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 #if defined(_MSC_VER)
-    std::copy(
-        startIterator, 
-        endIterator, 
-        stdext::checked_array_iterator<DataType*>(
-            pointer, length));
+	std::copy (
+	startIterator,
+	endIterator,
+	stdext::checked_array_iterator<DataType *> (
+	pointer, length));
 #else
-    std::copy(startIterator, endIterator, pointer);
+	std::copy (startIterator, endIterator, pointer);
 #endif
-    Event endEvent;
-    error = queue.enqueueUnmapMemObject(buffer, pointer, 0, &endEvent);
-    // if exceptions enabled, enqueueUnmapMemObject will throw
-    if( error != CL_SUCCESS ) { 
-        return error;
-    }
-    endEvent.wait();
-    return CL_SUCCESS;
+	Event endEvent;
+	error = queue.enqueueUnmapMemObject (buffer, pointer, 0, &endEvent);
+	// if exceptions enabled, enqueueUnmapMemObject will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
+	endEvent.wait ();
+	return CL_SUCCESS;
 }
 
 /**
@@ -6889,302 +7502,311 @@ inline cl_int copy( const CommandQueue &queue, IteratorType startIterator, Itera
  * Device to Host.
  * Uses specified queue.
  */
-template< typename IteratorType >
-inline cl_int copy( const CommandQueue &queue, const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator )
+template <typename IteratorType>
+inline cl_int copy (const CommandQueue & queue, const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
-        
-    ::size_t length = endIterator-startIterator;
-    ::size_t byteLength = length*sizeof(DataType);
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    DataType *pointer = 
-        static_cast<DataType*>(queue.enqueueMapBuffer(buffer, CL_TRUE, CL_MAP_READ, 0, byteLength, 0, 0, &error));
-    // if exceptions enabled, enqueueMapBuffer will throw
-    if( error != CL_SUCCESS ) {
-        return error;
-    }
-    std::copy(pointer, pointer + length, startIterator);
-    Event endEvent;
-    error = queue.enqueueUnmapMemObject(buffer, pointer, 0, &endEvent);
-    // if exceptions enabled, enqueueUnmapMemObject will throw
-    if( error != CL_SUCCESS ) { 
-        return error;
-    }
-    endEvent.wait();
-    return CL_SUCCESS;
+	::size_t length = endIterator - startIterator;
+	::size_t byteLength = length * sizeof (DataType);
+
+	DataType * pointer = static_cast<DataType *> (queue.enqueueMapBuffer (buffer, CL_TRUE, CL_MAP_READ, 0, byteLength, 0, 0, &error));
+	// if exceptions enabled, enqueueMapBuffer will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
+	std::copy (pointer, pointer + length, startIterator);
+	Event endEvent;
+	error = queue.enqueueUnmapMemObject (buffer, pointer, 0, &endEvent);
+	// if exceptions enabled, enqueueUnmapMemObject will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
+	endEvent.wait ();
+	return CL_SUCCESS;
 }
 
 #if defined(CL_VERSION_1_1)
-inline cl_int enqueueReadBufferRect(
-    const Buffer& buffer,
-    cl_bool blocking,
-    const size_t<3>& buffer_offset,
-    const size_t<3>& host_offset,
-    const size_t<3>& region,
-    ::size_t buffer_row_pitch,
-    ::size_t buffer_slice_pitch,
-    ::size_t host_row_pitch,
-    ::size_t host_slice_pitch,
-    void *ptr,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueReadBufferRect (
+const Buffer & buffer,
+cl_bool blocking,
+const size_t<3> & buffer_offset,
+const size_t<3> & host_offset,
+const size_t<3> & region,
+::size_t buffer_row_pitch,
+::size_t buffer_slice_pitch,
+::size_t host_row_pitch,
+::size_t host_slice_pitch,
+void * ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueReadBufferRect(
-        buffer, 
-        blocking, 
-        buffer_offset, 
-        host_offset,
-        region,
-        buffer_row_pitch,
-        buffer_slice_pitch,
-        host_row_pitch,
-        host_slice_pitch,
-        ptr, 
-        events, 
-        event);
+	return queue.enqueueReadBufferRect (
+	buffer,
+	blocking,
+	buffer_offset,
+	host_offset,
+	region,
+	buffer_row_pitch,
+	buffer_slice_pitch,
+	host_row_pitch,
+	host_slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueWriteBufferRect(
-    const Buffer& buffer,
-    cl_bool blocking,
-    const size_t<3>& buffer_offset,
-    const size_t<3>& host_offset,
-    const size_t<3>& region,
-    ::size_t buffer_row_pitch,
-    ::size_t buffer_slice_pitch,
-    ::size_t host_row_pitch,
-    ::size_t host_slice_pitch,
-    void *ptr,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueWriteBufferRect (
+const Buffer & buffer,
+cl_bool blocking,
+const size_t<3> & buffer_offset,
+const size_t<3> & host_offset,
+const size_t<3> & region,
+::size_t buffer_row_pitch,
+::size_t buffer_slice_pitch,
+::size_t host_row_pitch,
+::size_t host_slice_pitch,
+void * ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueWriteBufferRect(
-        buffer, 
-        blocking, 
-        buffer_offset, 
-        host_offset,
-        region,
-        buffer_row_pitch,
-        buffer_slice_pitch,
-        host_row_pitch,
-        host_slice_pitch,
-        ptr, 
-        events, 
-        event);
+	return queue.enqueueWriteBufferRect (
+	buffer,
+	blocking,
+	buffer_offset,
+	host_offset,
+	region,
+	buffer_row_pitch,
+	buffer_slice_pitch,
+	host_row_pitch,
+	host_slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyBufferRect(
-    const Buffer& src,
-    const Buffer& dst,
-    const size_t<3>& src_origin,
-    const size_t<3>& dst_origin,
-    const size_t<3>& region,
-    ::size_t src_row_pitch,
-    ::size_t src_slice_pitch,
-    ::size_t dst_row_pitch,
-    ::size_t dst_slice_pitch,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyBufferRect (
+const Buffer & src,
+const Buffer & dst,
+const size_t<3> & src_origin,
+const size_t<3> & dst_origin,
+const size_t<3> & region,
+::size_t src_row_pitch,
+::size_t src_slice_pitch,
+::size_t dst_row_pitch,
+::size_t dst_slice_pitch,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyBufferRect(
-        src,
-        dst,
-        src_origin,
-        dst_origin,
-        region,
-        src_row_pitch,
-        src_slice_pitch,
-        dst_row_pitch,
-        dst_slice_pitch,
-        events, 
-        event);
+	return queue.enqueueCopyBufferRect (
+	src,
+	dst,
+	src_origin,
+	dst_origin,
+	region,
+	src_row_pitch,
+	src_slice_pitch,
+	dst_row_pitch,
+	dst_slice_pitch,
+	events,
+	event);
 }
 #endif
 
-inline cl_int enqueueReadImage(
-    const Image& image,
-    cl_bool blocking,
-    const size_t<3>& origin,
-    const size_t<3>& region,
-    ::size_t row_pitch,
-    ::size_t slice_pitch,
-    void* ptr,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL) 
+inline cl_int enqueueReadImage (
+const Image & image,
+cl_bool blocking,
+const size_t<3> & origin,
+const size_t<3> & region,
+::size_t row_pitch,
+::size_t slice_pitch,
+void * ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueReadImage(
-        image,
-        blocking,
-        origin,
-        region,
-        row_pitch,
-        slice_pitch,
-        ptr,
-        events, 
-        event);
+	return queue.enqueueReadImage (
+	image,
+	blocking,
+	origin,
+	region,
+	row_pitch,
+	slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueWriteImage(
-    const Image& image,
-    cl_bool blocking,
-    const size_t<3>& origin,
-    const size_t<3>& region,
-    ::size_t row_pitch,
-    ::size_t slice_pitch,
-    void* ptr,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueWriteImage (
+const Image & image,
+cl_bool blocking,
+const size_t<3> & origin,
+const size_t<3> & region,
+::size_t row_pitch,
+::size_t slice_pitch,
+void * ptr,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueWriteImage(
-        image,
-        blocking,
-        origin,
-        region,
-        row_pitch,
-        slice_pitch,
-        ptr,
-        events, 
-        event);
+	return queue.enqueueWriteImage (
+	image,
+	blocking,
+	origin,
+	region,
+	row_pitch,
+	slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyImage(
-    const Image& src,
-    const Image& dst,
-    const size_t<3>& src_origin,
-    const size_t<3>& dst_origin,
-    const size_t<3>& region,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyImage (
+const Image & src,
+const Image & dst,
+const size_t<3> & src_origin,
+const size_t<3> & dst_origin,
+const size_t<3> & region,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyImage(
-        src,
-        dst,
-        src_origin,
-        dst_origin,
-        region,
-        events,
-        event);
+	return queue.enqueueCopyImage (
+	src,
+	dst,
+	src_origin,
+	dst_origin,
+	region,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyImageToBuffer(
-    const Image& src,
-    const Buffer& dst,
-    const size_t<3>& src_origin,
-    const size_t<3>& region,
-    ::size_t dst_offset,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyImageToBuffer (
+const Image & src,
+const Buffer & dst,
+const size_t<3> & src_origin,
+const size_t<3> & region,
+::size_t dst_offset,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyImageToBuffer(
-        src,
-        dst,
-        src_origin,
-        region,
-        dst_offset,
-        events,
-        event);
+	return queue.enqueueCopyImageToBuffer (
+	src,
+	dst,
+	src_origin,
+	region,
+	dst_offset,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyBufferToImage(
-    const Buffer& src,
-    const Image& dst,
-    ::size_t src_offset,
-    const size_t<3>& dst_origin,
-    const size_t<3>& region,
-    const VECTOR_CLASS<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyBufferToImage (
+const Buffer & src,
+const Image & dst,
+::size_t src_offset,
+const size_t<3> & dst_origin,
+const size_t<3> & region,
+const VECTOR_CLASS<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyBufferToImage(
-        src,
-        dst,
-        src_offset,
-        dst_origin,
-        region,
-        events,
-        event);
+	return queue.enqueueCopyBufferToImage (
+	src,
+	dst,
+	src_offset,
+	dst_origin,
+	region,
+	events,
+	event);
 }
 
-
-inline cl_int flush(void)
+inline cl_int flush (void)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.flush();
+	return queue.flush ();
 }
 
-inline cl_int finish(void)
+inline cl_int finish (void)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    } 
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-
-    return queue.finish();
+	return queue.finish ();
 }
 
 // Kernel Functor support
@@ -7194,317 +7816,305 @@ inline cl_int finish(void)
 
 struct EnqueueArgs
 {
-    CommandQueue queue_;
-    const NDRange offset_;
-    const NDRange global_;
-    const NDRange local_;
-    VECTOR_CLASS<Event> events_;
+	CommandQueue queue_;
+	const NDRange offset_;
+	const NDRange global_;
+	const NDRange local_;
+	VECTOR_CLASS<Event> events_;
 
-    EnqueueArgs(NDRange global) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
+	EnqueueArgs (NDRange global) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+	}
 
-    }
+	EnqueueArgs (NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    EnqueueArgs(NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
+	EnqueueArgs (NDRange offset, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    }
+	EnqueueArgs (Event e, NDRange global) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(NDRange offset, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
+	EnqueueArgs (Event e, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    }
+	EnqueueArgs (Event e, NDRange offset, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(Event e, NDRange global) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
-        events_.push_back(e);
-    }
+	EnqueueArgs (const VECTOR_CLASS<Event> & events, NDRange global) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(Event e, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
+	EnqueueArgs (const VECTOR_CLASS<Event> & events, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(Event e, NDRange offset, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
+	EnqueueArgs (const VECTOR_CLASS<Event> & events, NDRange offset, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (offset),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(const VECTOR_CLASS<Event> &events, NDRange global) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange),
-      events_(events)
-    {
+	EnqueueArgs (CommandQueue & queue, NDRange global) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    EnqueueArgs(const VECTOR_CLASS<Event> &events, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
+	EnqueueArgs (CommandQueue & queue, NDRange offset, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, Event e, NDRange global) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(const VECTOR_CLASS<Event> &events, NDRange offset, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(offset), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
+	EnqueueArgs (CommandQueue & queue, Event e, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, Event e, NDRange offset, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(CommandQueue &queue, NDRange global) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
+	EnqueueArgs (CommandQueue & queue, const VECTOR_CLASS<Event> & events, NDRange global) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange),
+		events_ (events)
+	{
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, const VECTOR_CLASS<Event> & events, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(CommandQueue &queue, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, NDRange offset, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, Event e, NDRange global) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
-        events_.push_back(e);
-    }
-
-    EnqueueArgs(CommandQueue &queue, Event e, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
-
-    EnqueueArgs(CommandQueue &queue, Event e, NDRange offset, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
-
-    EnqueueArgs(CommandQueue &queue, const VECTOR_CLASS<Event> &events, NDRange global) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange),
-      events_(events)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, const VECTOR_CLASS<Event> &events, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, const VECTOR_CLASS<Event> &events, NDRange offset, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(offset), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
-
-    }
+	EnqueueArgs (CommandQueue & queue, const VECTOR_CLASS<Event> & events, NDRange offset, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (offset),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 };
 
-namespace detail {
-
-class NullType {};
-
-template<int index, typename T0>
-struct SetArg
+namespace detail
 {
-    static void set (Kernel kernel, T0 arg)
-    {
-        kernel.setArg(index, arg);
-    }
-};  
+	class NullType
+	{
+	};
 
-template<int index>
-struct SetArg<index, NullType>
-{
-    static void set (Kernel, NullType)
-    { 
-    }
-};
+	template <int index, typename T0>
+	struct SetArg
+	{
+		static void set (Kernel kernel, T0 arg)
+		{
+			kernel.setArg (index, arg);
+		}
+	};
 
-template <
-   typename T0,   typename T1,   typename T2,   typename T3,
-   typename T4,   typename T5,   typename T6,   typename T7,
-   typename T8,   typename T9,   typename T10,   typename T11,
-   typename T12,   typename T13,   typename T14,   typename T15,
-   typename T16,   typename T17,   typename T18,   typename T19,
-   typename T20,   typename T21,   typename T22,   typename T23,
-   typename T24,   typename T25,   typename T26,   typename T27,
-   typename T28,   typename T29,   typename T30,   typename T31
->
-class KernelFunctorGlobal
-{
-private:
-    Kernel kernel_;
+	template <int index>
+	struct SetArg<index, NullType>
+	{
+		static void set (Kernel, NullType)
+		{
+		}
+	};
 
-public:
-   KernelFunctorGlobal(
-        Kernel kernel) :
-            kernel_(kernel)
-    {}
+	template <
+	typename T0, typename T1, typename T2, typename T3,
+	typename T4, typename T5, typename T6, typename T7,
+	typename T8, typename T9, typename T10, typename T11,
+	typename T12, typename T13, typename T14, typename T15,
+	typename T16, typename T17, typename T18, typename T19,
+	typename T20, typename T21, typename T22, typename T23,
+	typename T24, typename T25, typename T26, typename T27,
+	typename T28, typename T29, typename T30, typename T31>
+	class KernelFunctorGlobal
+	{
+	private:
+		Kernel kernel_;
 
-   KernelFunctorGlobal(
-        const Program& program,
-        const STRING_CLASS name,
-        cl_int * err = NULL) :
-            kernel_(program, name.c_str(), err)
-    {}
+	public:
+		KernelFunctorGlobal (
+		Kernel kernel) :
+			kernel_ (kernel)
+		{
+		}
 
-    Event operator() (
-        const EnqueueArgs& args,
-        T0 t0,
-        T1 t1 = NullType(),
-        T2 t2 = NullType(),
-        T3 t3 = NullType(),
-        T4 t4 = NullType(),
-        T5 t5 = NullType(),
-        T6 t6 = NullType(),
-        T7 t7 = NullType(),
-        T8 t8 = NullType(),
-        T9 t9 = NullType(),
-        T10 t10 = NullType(),
-        T11 t11 = NullType(),
-        T12 t12 = NullType(),
-        T13 t13 = NullType(),
-        T14 t14 = NullType(),
-        T15 t15 = NullType(),
-        T16 t16 = NullType(),
-        T17 t17 = NullType(),
-        T18 t18 = NullType(),
-        T19 t19 = NullType(),
-        T20 t20 = NullType(),
-        T21 t21 = NullType(),
-        T22 t22 = NullType(),
-        T23 t23 = NullType(),
-        T24 t24 = NullType(),
-        T25 t25 = NullType(),
-        T26 t26 = NullType(),
-        T27 t27 = NullType(),
-        T28 t28 = NullType(),
-        T29 t29 = NullType(),
-        T30 t30 = NullType(),
-        T31 t31 = NullType()
-        )
-    {
-        Event event;
-        SetArg<0, T0>::set(kernel_, t0);
-        SetArg<1, T1>::set(kernel_, t1);
-        SetArg<2, T2>::set(kernel_, t2);
-        SetArg<3, T3>::set(kernel_, t3);
-        SetArg<4, T4>::set(kernel_, t4);
-        SetArg<5, T5>::set(kernel_, t5);
-        SetArg<6, T6>::set(kernel_, t6);
-        SetArg<7, T7>::set(kernel_, t7);
-        SetArg<8, T8>::set(kernel_, t8);
-        SetArg<9, T9>::set(kernel_, t9);
-        SetArg<10, T10>::set(kernel_, t10);
-        SetArg<11, T11>::set(kernel_, t11);
-        SetArg<12, T12>::set(kernel_, t12);
-        SetArg<13, T13>::set(kernel_, t13);
-        SetArg<14, T14>::set(kernel_, t14);
-        SetArg<15, T15>::set(kernel_, t15);
-        SetArg<16, T16>::set(kernel_, t16);
-        SetArg<17, T17>::set(kernel_, t17);
-        SetArg<18, T18>::set(kernel_, t18);
-        SetArg<19, T19>::set(kernel_, t19);
-        SetArg<20, T20>::set(kernel_, t20);
-        SetArg<21, T21>::set(kernel_, t21);
-        SetArg<22, T22>::set(kernel_, t22);
-        SetArg<23, T23>::set(kernel_, t23);
-        SetArg<24, T24>::set(kernel_, t24);
-        SetArg<25, T25>::set(kernel_, t25);
-        SetArg<26, T26>::set(kernel_, t26);
-        SetArg<27, T27>::set(kernel_, t27);
-        SetArg<28, T28>::set(kernel_, t28);
-        SetArg<29, T29>::set(kernel_, t29);
-        SetArg<30, T30>::set(kernel_, t30);
-        SetArg<31, T31>::set(kernel_, t31);
-        
-        args.queue_.enqueueNDRangeKernel(
-            kernel_,
-            args.offset_,
-            args.global_,
-            args.local_,
-            &args.events_,
-            &event);
-        
-        return event;
-    }
+		KernelFunctorGlobal (
+		const Program & program,
+		const STRING_CLASS name,
+		cl_int * err = NULL) :
+			kernel_ (program, name.c_str (), err)
+		{
+		}
 
-};
+		Event operator() (
+		const EnqueueArgs & args,
+		T0 t0,
+		T1 t1 = NullType (),
+		T2 t2 = NullType (),
+		T3 t3 = NullType (),
+		T4 t4 = NullType (),
+		T5 t5 = NullType (),
+		T6 t6 = NullType (),
+		T7 t7 = NullType (),
+		T8 t8 = NullType (),
+		T9 t9 = NullType (),
+		T10 t10 = NullType (),
+		T11 t11 = NullType (),
+		T12 t12 = NullType (),
+		T13 t13 = NullType (),
+		T14 t14 = NullType (),
+		T15 t15 = NullType (),
+		T16 t16 = NullType (),
+		T17 t17 = NullType (),
+		T18 t18 = NullType (),
+		T19 t19 = NullType (),
+		T20 t20 = NullType (),
+		T21 t21 = NullType (),
+		T22 t22 = NullType (),
+		T23 t23 = NullType (),
+		T24 t24 = NullType (),
+		T25 t25 = NullType (),
+		T26 t26 = NullType (),
+		T27 t27 = NullType (),
+		T28 t28 = NullType (),
+		T29 t29 = NullType (),
+		T30 t30 = NullType (),
+		T31 t31 = NullType ())
+		{
+			Event event;
+			SetArg<0, T0>::set (kernel_, t0);
+			SetArg<1, T1>::set (kernel_, t1);
+			SetArg<2, T2>::set (kernel_, t2);
+			SetArg<3, T3>::set (kernel_, t3);
+			SetArg<4, T4>::set (kernel_, t4);
+			SetArg<5, T5>::set (kernel_, t5);
+			SetArg<6, T6>::set (kernel_, t6);
+			SetArg<7, T7>::set (kernel_, t7);
+			SetArg<8, T8>::set (kernel_, t8);
+			SetArg<9, T9>::set (kernel_, t9);
+			SetArg<10, T10>::set (kernel_, t10);
+			SetArg<11, T11>::set (kernel_, t11);
+			SetArg<12, T12>::set (kernel_, t12);
+			SetArg<13, T13>::set (kernel_, t13);
+			SetArg<14, T14>::set (kernel_, t14);
+			SetArg<15, T15>::set (kernel_, t15);
+			SetArg<16, T16>::set (kernel_, t16);
+			SetArg<17, T17>::set (kernel_, t17);
+			SetArg<18, T18>::set (kernel_, t18);
+			SetArg<19, T19>::set (kernel_, t19);
+			SetArg<20, T20>::set (kernel_, t20);
+			SetArg<21, T21>::set (kernel_, t21);
+			SetArg<22, T22>::set (kernel_, t22);
+			SetArg<23, T23>::set (kernel_, t23);
+			SetArg<24, T24>::set (kernel_, t24);
+			SetArg<25, T25>::set (kernel_, t25);
+			SetArg<26, T26>::set (kernel_, t26);
+			SetArg<27, T27>::set (kernel_, t27);
+			SetArg<28, T28>::set (kernel_, t28);
+			SetArg<29, T29>::set (kernel_, t29);
+			SetArg<30, T30>::set (kernel_, t30);
+			SetArg<31, T31>::set (kernel_, t31);
 
-//------------------------------------------------------------------------------------------------------
+			args.queue_.enqueueNDRangeKernel (
+			kernel_,
+			args.offset_,
+			args.global_,
+			args.local_,
+			&args.events_,
+			&event);
 
+			return event;
+		}
+	};
 
-template<
+	//------------------------------------------------------------------------------------------------------
+
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -7537,9 +8147,9 @@ template<
 	typename T29,
 	typename T30,
 	typename T31>
-struct functionImplementation_
-{
-	typedef detail::KernelFunctorGlobal<
+	struct functionImplementation_
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -7571,27 +8181,26 @@ struct functionImplementation_
 		T28,
 		T29,
 		T30,
-		T31> FunctorType;
+		T31>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 32))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 32))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -7625,8 +8234,8 @@ struct functionImplementation_
 		T30,
 		T31);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -7659,8 +8268,8 @@ struct functionImplementation_
 		T29 arg29,
 		T30 arg30,
 		T31 arg31)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -7694,12 +8303,10 @@ struct functionImplementation_
 			arg29,
 			arg30,
 			arg31);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -7731,8 +8338,7 @@ template<
 	typename T28,
 	typename T29,
 	typename T30>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -7764,8 +8370,8 @@ struct functionImplementation_
 	T29,
 	T30,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -7797,27 +8403,26 @@ struct functionImplementation_
 		T28,
 		T29,
 		T30,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 31))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 31))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -7850,8 +8455,8 @@ struct functionImplementation_
 		T29,
 		T30);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -7883,8 +8488,8 @@ struct functionImplementation_
 		T28 arg28,
 		T29 arg29,
 		T30 arg30)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -7917,12 +8522,10 @@ struct functionImplementation_
 			arg28,
 			arg29,
 			arg30);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -7953,8 +8556,7 @@ template<
 	typename T27,
 	typename T28,
 	typename T29>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -7986,8 +8588,8 @@ struct functionImplementation_
 	T29,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -8019,27 +8621,26 @@ struct functionImplementation_
 		T28,
 		T29,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 30))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 30))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -8071,8 +8672,8 @@ struct functionImplementation_
 		T28,
 		T29);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -8103,8 +8704,8 @@ struct functionImplementation_
 		T27 arg27,
 		T28 arg28,
 		T29 arg29)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -8136,12 +8737,10 @@ struct functionImplementation_
 			arg27,
 			arg28,
 			arg29);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -8171,8 +8770,7 @@ template<
 	typename T26,
 	typename T27,
 	typename T28>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -8204,8 +8802,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -8237,27 +8835,26 @@ struct functionImplementation_
 		T28,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 29))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 29))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -8288,8 +8885,8 @@ struct functionImplementation_
 		T27,
 		T28);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -8319,8 +8916,8 @@ struct functionImplementation_
 		T26 arg26,
 		T27 arg27,
 		T28 arg28)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -8351,12 +8948,10 @@ struct functionImplementation_
 			arg26,
 			arg27,
 			arg28);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -8385,8 +8980,7 @@ template<
 	typename T25,
 	typename T26,
 	typename T27>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -8418,8 +9012,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -8451,27 +9045,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 28))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 28))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -8501,8 +9094,8 @@ struct functionImplementation_
 		T26,
 		T27);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -8531,8 +9124,8 @@ struct functionImplementation_
 		T25 arg25,
 		T26 arg26,
 		T27 arg27)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -8562,12 +9155,10 @@ struct functionImplementation_
 			arg25,
 			arg26,
 			arg27);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -8595,8 +9186,7 @@ template<
 	typename T24,
 	typename T25,
 	typename T26>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -8628,8 +9218,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -8661,27 +9251,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 27))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 27))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -8710,8 +9299,8 @@ struct functionImplementation_
 		T25,
 		T26);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -8739,8 +9328,8 @@ struct functionImplementation_
 		T24 arg24,
 		T25 arg25,
 		T26 arg26)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -8769,12 +9358,10 @@ struct functionImplementation_
 			arg24,
 			arg25,
 			arg26);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -8801,8 +9388,7 @@ template<
 	typename T23,
 	typename T24,
 	typename T25>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -8834,8 +9420,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -8867,27 +9453,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 26))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 26))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -8915,8 +9500,8 @@ struct functionImplementation_
 		T24,
 		T25);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -8943,8 +9528,8 @@ struct functionImplementation_
 		T23 arg23,
 		T24 arg24,
 		T25 arg25)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -8972,12 +9557,10 @@ struct functionImplementation_
 			arg23,
 			arg24,
 			arg25);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -9003,8 +9586,7 @@ template<
 	typename T22,
 	typename T23,
 	typename T24>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -9036,8 +9618,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -9069,27 +9651,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 25))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 25))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -9116,8 +9697,8 @@ struct functionImplementation_
 		T23,
 		T24);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -9143,8 +9724,8 @@ struct functionImplementation_
 		T22 arg22,
 		T23 arg23,
 		T24 arg24)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -9171,12 +9752,10 @@ struct functionImplementation_
 			arg22,
 			arg23,
 			arg24);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -9201,8 +9780,7 @@ template<
 	typename T21,
 	typename T22,
 	typename T23>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -9234,8 +9812,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -9267,27 +9845,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 24))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 24))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -9313,8 +9890,8 @@ struct functionImplementation_
 		T22,
 		T23);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -9339,8 +9916,8 @@ struct functionImplementation_
 		T21 arg21,
 		T22 arg22,
 		T23 arg23)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -9366,12 +9943,10 @@ struct functionImplementation_
 			arg21,
 			arg22,
 			arg23);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -9395,8 +9970,7 @@ template<
 	typename T20,
 	typename T21,
 	typename T22>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -9428,8 +10002,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -9461,27 +10035,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 23))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 23))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -9506,8 +10079,8 @@ struct functionImplementation_
 		T21,
 		T22);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -9531,8 +10104,8 @@ struct functionImplementation_
 		T20 arg20,
 		T21 arg21,
 		T22 arg22)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -9557,12 +10130,10 @@ struct functionImplementation_
 			arg20,
 			arg21,
 			arg22);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -9585,8 +10156,7 @@ template<
 	typename T19,
 	typename T20,
 	typename T21>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -9618,8 +10188,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -9651,27 +10221,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 22))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 22))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -9695,8 +10264,8 @@ struct functionImplementation_
 		T20,
 		T21);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -9719,8 +10288,8 @@ struct functionImplementation_
 		T19 arg19,
 		T20 arg20,
 		T21 arg21)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -9744,12 +10313,10 @@ struct functionImplementation_
 			arg19,
 			arg20,
 			arg21);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -9771,8 +10338,7 @@ template<
 	typename T18,
 	typename T19,
 	typename T20>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -9804,8 +10370,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -9837,27 +10403,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 21))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 21))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -9880,8 +10445,8 @@ struct functionImplementation_
 		T19,
 		T20);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -9903,8 +10468,8 @@ struct functionImplementation_
 		T18 arg18,
 		T19 arg19,
 		T20 arg20)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -9927,12 +10492,10 @@ struct functionImplementation_
 			arg18,
 			arg19,
 			arg20);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -9953,8 +10516,7 @@ template<
 	typename T17,
 	typename T18,
 	typename T19>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -9986,8 +10548,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -10019,27 +10581,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 20))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 20))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -10061,8 +10622,8 @@ struct functionImplementation_
 		T18,
 		T19);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -10083,8 +10644,8 @@ struct functionImplementation_
 		T17 arg17,
 		T18 arg18,
 		T19 arg19)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -10106,12 +10667,10 @@ struct functionImplementation_
 			arg17,
 			arg18,
 			arg19);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -10131,8 +10690,7 @@ template<
 	typename T16,
 	typename T17,
 	typename T18>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -10164,8 +10722,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -10197,27 +10755,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 19))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 19))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -10238,8 +10795,8 @@ struct functionImplementation_
 		T17,
 		T18);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -10259,8 +10816,8 @@ struct functionImplementation_
 		T16 arg16,
 		T17 arg17,
 		T18 arg18)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -10281,12 +10838,10 @@ struct functionImplementation_
 			arg16,
 			arg17,
 			arg18);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -10305,8 +10860,7 @@ template<
 	typename T15,
 	typename T16,
 	typename T17>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -10338,8 +10892,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -10371,27 +10925,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 18))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 18))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -10411,8 +10964,8 @@ struct functionImplementation_
 		T16,
 		T17);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -10431,8 +10984,8 @@ struct functionImplementation_
 		T15 arg15,
 		T16 arg16,
 		T17 arg17)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -10452,12 +11005,10 @@ struct functionImplementation_
 			arg15,
 			arg16,
 			arg17);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -10475,8 +11026,7 @@ template<
 	typename T14,
 	typename T15,
 	typename T16>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -10508,8 +11058,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -10541,27 +11091,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 17))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 17))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -10580,8 +11129,8 @@ struct functionImplementation_
 		T15,
 		T16);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -10599,8 +11148,8 @@ struct functionImplementation_
 		T14 arg14,
 		T15 arg15,
 		T16 arg16)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -10619,12 +11168,10 @@ struct functionImplementation_
 			arg14,
 			arg15,
 			arg16);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -10641,8 +11188,7 @@ template<
 	typename T13,
 	typename T14,
 	typename T15>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -10674,8 +11220,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -10707,27 +11253,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 16))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 16))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -10745,8 +11290,8 @@ struct functionImplementation_
 		T14,
 		T15);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -10763,8 +11308,8 @@ struct functionImplementation_
 		T13 arg13,
 		T14 arg14,
 		T15 arg15)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -10782,12 +11327,10 @@ struct functionImplementation_
 			arg13,
 			arg14,
 			arg15);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -10803,8 +11346,7 @@ template<
 	typename T12,
 	typename T13,
 	typename T14>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -10836,8 +11378,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -10869,27 +11411,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 15))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 15))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -10906,8 +11447,8 @@ struct functionImplementation_
 		T13,
 		T14);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -10923,8 +11464,8 @@ struct functionImplementation_
 		T12 arg12,
 		T13 arg13,
 		T14 arg14)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -10941,12 +11482,10 @@ struct functionImplementation_
 			arg12,
 			arg13,
 			arg14);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -10961,8 +11500,7 @@ template<
 	typename T11,
 	typename T12,
 	typename T13>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -10994,8 +11532,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11027,27 +11565,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 14))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 14))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11063,8 +11600,8 @@ struct functionImplementation_
 		T12,
 		T13);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11079,8 +11616,8 @@ struct functionImplementation_
 		T11 arg11,
 		T12 arg12,
 		T13 arg13)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11096,12 +11633,10 @@ struct functionImplementation_
 			arg11,
 			arg12,
 			arg13);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11115,8 +11650,7 @@ template<
 	typename T10,
 	typename T11,
 	typename T12>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11148,8 +11682,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11181,27 +11715,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 13))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 13))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11216,8 +11749,8 @@ struct functionImplementation_
 		T11,
 		T12);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11231,8 +11764,8 @@ struct functionImplementation_
 		T10 arg10,
 		T11 arg11,
 		T12 arg12)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11247,12 +11780,10 @@ struct functionImplementation_
 			arg10,
 			arg11,
 			arg12);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11265,8 +11796,7 @@ template<
 	typename T9,
 	typename T10,
 	typename T11>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11298,8 +11828,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11331,27 +11861,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 12))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 12))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11365,8 +11894,8 @@ struct functionImplementation_
 		T10,
 		T11);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11379,8 +11908,8 @@ struct functionImplementation_
 		T9 arg9,
 		T10 arg10,
 		T11 arg11)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11394,12 +11923,10 @@ struct functionImplementation_
 			arg9,
 			arg10,
 			arg11);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11411,8 +11938,7 @@ template<
 	typename T8,
 	typename T9,
 	typename T10>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11444,8 +11970,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11477,27 +12003,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 11))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 11))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11510,8 +12035,8 @@ struct functionImplementation_
 		T9,
 		T10);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11523,8 +12048,8 @@ struct functionImplementation_
 		T8 arg8,
 		T9 arg9,
 		T10 arg10)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11537,12 +12062,10 @@ struct functionImplementation_
 			arg8,
 			arg9,
 			arg10);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11553,8 +12076,7 @@ template<
 	typename T7,
 	typename T8,
 	typename T9>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11586,8 +12108,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11619,27 +12141,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 10))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 10))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11651,8 +12172,8 @@ struct functionImplementation_
 		T8,
 		T9);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11663,8 +12184,8 @@ struct functionImplementation_
 		T7 arg7,
 		T8 arg8,
 		T9 arg9)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11676,12 +12197,10 @@ struct functionImplementation_
 			arg7,
 			arg8,
 			arg9);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11691,8 +12210,7 @@ template<
 	typename T6,
 	typename T7,
 	typename T8>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11724,8 +12242,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11757,27 +12275,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 9))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 9))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11788,8 +12305,8 @@ struct functionImplementation_
 		T7,
 		T8);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11799,8 +12316,8 @@ struct functionImplementation_
 		T6 arg6,
 		T7 arg7,
 		T8 arg8)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11811,12 +12328,10 @@ struct functionImplementation_
 			arg6,
 			arg7,
 			arg8);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11825,8 +12340,7 @@ template<
 	typename T5,
 	typename T6,
 	typename T7>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11858,8 +12372,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -11891,27 +12405,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 8))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 8))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -11921,8 +12434,8 @@ struct functionImplementation_
 		T6,
 		T7);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -11931,8 +12444,8 @@ struct functionImplementation_
 		T5 arg5,
 		T6 arg6,
 		T7 arg7)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -11942,12 +12455,10 @@ struct functionImplementation_
 			arg5,
 			arg6,
 			arg7);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
@@ -11955,8 +12466,7 @@ template<
 	typename T4,
 	typename T5,
 	typename T6>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -11988,8 +12498,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -12021,27 +12531,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 7))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 7))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -12050,8 +12559,8 @@ struct functionImplementation_
 		T5,
 		T6);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
@@ -12059,8 +12568,8 @@ struct functionImplementation_
 		T4 arg4,
 		T5 arg5,
 		T6 arg6)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -12069,20 +12578,17 @@ struct functionImplementation_
 			arg4,
 			arg5,
 			arg6);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
 	typename T3,
 	typename T4,
 	typename T5>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -12114,8 +12620,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -12147,27 +12653,26 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 6))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 6))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
@@ -12175,16 +12680,16 @@ struct functionImplementation_
 		T4,
 		T5);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
 		T3 arg3,
 		T4 arg4,
 		T5 arg5)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
@@ -12192,19 +12697,16 @@ struct functionImplementation_
 			arg3,
 			arg4,
 			arg5);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
 	typename T3,
 	typename T4>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -12236,8 +12738,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -12269,60 +12771,56 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 5))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 5))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
 		T3,
 		T4);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
 		T3 arg3,
 		T4 arg4)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2,
 	typename T3>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	T3,
@@ -12354,8 +12852,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -12387,56 +12885,52 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 4))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 4))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2,
 		T3);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2,
 		T3 arg3)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
 			arg2,
 			arg3);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1,
 	typename T2>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	T2,
 	NullType,
@@ -12468,8 +12962,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		T2,
@@ -12501,52 +12995,48 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 3))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 3))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1,
 		T2);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1,
 		T2 arg2)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1,
 			arg2);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0,
 	typename T1>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	T1,
 	NullType,
 	NullType,
@@ -12578,8 +13068,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		T1,
 		NullType,
@@ -12611,48 +13101,44 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 2))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 2))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0,
 		T1);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0,
 		T1 arg1)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0,
 			arg1);
-	}
+		}
+	};
 
-
-};
-
-template<
+	template <
 	typename T0>
-struct functionImplementation_
-<	T0,
+	struct functionImplementation_<T0,
 	NullType,
 	NullType,
 	NullType,
@@ -12684,8 +13170,8 @@ struct functionImplementation_
 	NullType,
 	NullType,
 	NullType>
-{
-	typedef detail::KernelFunctorGlobal<
+	{
+		typedef detail::KernelFunctorGlobal<
 		T0,
 		NullType,
 		NullType,
@@ -12717,124 +13203,113 @@ struct functionImplementation_
 		NullType,
 		NullType,
 		NullType,
-		NullType> FunctorType;
+		NullType>
+		FunctorType;
 
-    FunctorType functor_;
+		FunctorType functor_;
 
-    functionImplementation_(const FunctorType &functor) :
-        functor_(functor)
-    {
-    
-        #if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 1))
-        // Fail variadic expansion for dev11
-        static_assert(0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
-        #endif
-            
-    }
+		functionImplementation_ (const FunctorType & functor) :
+			functor_ (functor)
+		{
+#if (defined(_WIN32) && defined(_VARIADIC_MAX) && (_VARIADIC_MAX < 1))
+			// Fail variadic expansion for dev11
+			static_assert (0, "Visual Studio has a hard limit of argument count for a std::function expansion. Please define _VARIADIC_MAX to be 10. If you need more arguments than that VC12 and below cannot support it.");
+#endif
+		}
 
-	//! \brief Return type of the functor
-	typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-	//! \brief Function signature of kernel functor with no event dependency.
-	typedef Event type_(
-		const EnqueueArgs&,
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
 		T0);
 
-	Event operator()(
-		const EnqueueArgs& enqueueArgs,
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
 		T0 arg0)
-	{
-		return functor_(
+		{
+			return functor_ (
 			enqueueArgs,
 			arg0);
-	}
-
-
-};
-
-
-
-
+		}
+	};
 
 } // namespace detail
 
 //----------------------------------------------------------------------------------------------
 
 template <
-   typename T0,   typename T1 = detail::NullType,   typename T2 = detail::NullType,
-   typename T3 = detail::NullType,   typename T4 = detail::NullType,
-   typename T5 = detail::NullType,   typename T6 = detail::NullType,
-   typename T7 = detail::NullType,   typename T8 = detail::NullType,
-   typename T9 = detail::NullType,   typename T10 = detail::NullType,
-   typename T11 = detail::NullType,   typename T12 = detail::NullType,
-   typename T13 = detail::NullType,   typename T14 = detail::NullType,
-   typename T15 = detail::NullType,   typename T16 = detail::NullType,
-   typename T17 = detail::NullType,   typename T18 = detail::NullType,
-   typename T19 = detail::NullType,   typename T20 = detail::NullType,
-   typename T21 = detail::NullType,   typename T22 = detail::NullType,
-   typename T23 = detail::NullType,   typename T24 = detail::NullType,
-   typename T25 = detail::NullType,   typename T26 = detail::NullType,
-   typename T27 = detail::NullType,   typename T28 = detail::NullType,
-   typename T29 = detail::NullType,   typename T30 = detail::NullType,
-   typename T31 = detail::NullType
->
-struct make_kernel :
-    public detail::functionImplementation_<
-               T0,   T1,   T2,   T3,
-               T4,   T5,   T6,   T7,
-               T8,   T9,   T10,   T11,
-               T12,   T13,   T14,   T15,
-               T16,   T17,   T18,   T19,
-               T20,   T21,   T22,   T23,
-               T24,   T25,   T26,   T27,
-               T28,   T29,   T30,   T31
-    >
+typename T0, typename T1 = detail::NullType, typename T2 = detail::NullType,
+typename T3 = detail::NullType, typename T4 = detail::NullType,
+typename T5 = detail::NullType, typename T6 = detail::NullType,
+typename T7 = detail::NullType, typename T8 = detail::NullType,
+typename T9 = detail::NullType, typename T10 = detail::NullType,
+typename T11 = detail::NullType, typename T12 = detail::NullType,
+typename T13 = detail::NullType, typename T14 = detail::NullType,
+typename T15 = detail::NullType, typename T16 = detail::NullType,
+typename T17 = detail::NullType, typename T18 = detail::NullType,
+typename T19 = detail::NullType, typename T20 = detail::NullType,
+typename T21 = detail::NullType, typename T22 = detail::NullType,
+typename T23 = detail::NullType, typename T24 = detail::NullType,
+typename T25 = detail::NullType, typename T26 = detail::NullType,
+typename T27 = detail::NullType, typename T28 = detail::NullType,
+typename T29 = detail::NullType, typename T30 = detail::NullType,
+typename T31 = detail::NullType>
+struct make_kernel : public detail::functionImplementation_<
+					 T0, T1, T2, T3,
+					 T4, T5, T6, T7,
+					 T8, T9, T10, T11,
+					 T12, T13, T14, T15,
+					 T16, T17, T18, T19,
+					 T20, T21, T22, T23,
+					 T24, T25, T26, T27,
+					 T28, T29, T30, T31>
 {
 public:
-    typedef detail::KernelFunctorGlobal<             
-               T0,   T1,   T2,   T3,
-               T4,   T5,   T6,   T7,
-               T8,   T9,   T10,   T11,
-               T12,   T13,   T14,   T15,
-               T16,   T17,   T18,   T19,
-               T20,   T21,   T22,   T23,
-               T24,   T25,   T26,   T27,
-               T28,   T29,   T30,   T31
-    > FunctorType;
+	typedef detail::KernelFunctorGlobal<
+	T0, T1, T2, T3,
+	T4, T5, T6, T7,
+	T8, T9, T10, T11,
+	T12, T13, T14, T15,
+	T16, T17, T18, T19,
+	T20, T21, T22, T23,
+	T24, T25, T26, T27,
+	T28, T29, T30, T31>
+	FunctorType;
 
-    make_kernel(
-        const Program& program,
-        const STRING_CLASS name,
-        cl_int * err = NULL) :
-           detail::functionImplementation_<
-                    T0,   T1,   T2,   T3,
-                       T4,   T5,   T6,   T7,
-                       T8,   T9,   T10,   T11,
-                       T12,   T13,   T14,   T15,
-                       T16,   T17,   T18,   T19,
-                       T20,   T21,   T22,   T23,
-                       T24,   T25,   T26,   T27,
-                       T28,   T29,   T30,   T31
-           >(
-            FunctorType(program, name, err)) 
-    {}
+	make_kernel (
+	const Program & program,
+	const STRING_CLASS name,
+	cl_int * err = NULL) :
+		detail::functionImplementation_<
+		T0, T1, T2, T3,
+		T4, T5, T6, T7,
+		T8, T9, T10, T11,
+		T12, T13, T14, T15,
+		T16, T17, T18, T19,
+		T20, T21, T22, T23,
+		T24, T25, T26, T27,
+		T28, T29, T30, T31> (
+		FunctorType (program, name, err))
+	{
+	}
 
-    make_kernel(
-        const Kernel kernel) :
-           detail::functionImplementation_<
-                    T0,   T1,   T2,   T3,
-                       T4,   T5,   T6,   T7,
-                       T8,   T9,   T10,   T11,
-                       T12,   T13,   T14,   T15,
-                       T16,   T17,   T18,   T19,
-                       T20,   T21,   T22,   T23,
-                       T24,   T25,   T26,   T27,
-                       T28,   T29,   T30,   T31
-           >(
-            FunctorType(kernel)) 
-    {}    
+	make_kernel (
+	const Kernel kernel) :
+		detail::functionImplementation_<
+		T0, T1, T2, T3,
+		T4, T5, T6, T7,
+		T8, T9, T10, T11,
+		T12, T13, T14, T15,
+		T16, T17, T18, T19,
+		T20, T21, T22, T23,
+		T24, T25, T26, T27,
+		T28, T29, T30, T31> (
+		FunctorType (kernel))
+	{
+	}
 };
-
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -12922,8 +13397,8 @@ public:
 #undef __PARAM_NAME_DEVICE_FISSION
 #endif // USE_CL_DEVICE_FISSION
 
-#undef __DEFAULT_NOT_INITIALIZED 
-#undef __DEFAULT_BEING_INITIALIZED 
+#undef __DEFAULT_NOT_INITIALIZED
+#undef __DEFAULT_BEING_INITIALIZED
 #undef __DEFAULT_INITIALIZED
 
 #undef CL_HPP_RVALUE_REFERENCES_SUPPORTED

--- a/CL/cl2.hpp
+++ b/CL/cl2.hpp
@@ -176,11 +176,12 @@
     #define CL_HPP_ENABLE_EXCEPTIONS
     #define CL_HPP_TARGET_OPENCL_VERSION 200
    
-    #include <CL/cl2.hpp>
-    #include <iostream>
-    #include <vector>
-    #include <memory>
     #include <algorithm>
+    #include <iostream>
+    #include <memory>
+    #include <vector>
+
+    #include <CL/cl2.hpp>
   
     const int numElements = 32;
   
@@ -345,79 +346,79 @@
  * both and hence work with either version of the bindings.
  */
 #if !defined(CL_HPP_USE_DX_INTEROP) && defined(USE_DX_INTEROP)
-# pragma message("cl2.hpp: USE_DX_INTEROP is deprecated. Define CL_HPP_USE_DX_INTEROP instead")
-# define CL_HPP_USE_DX_INTEROP
+#pragma message("cl2.hpp: USE_DX_INTEROP is deprecated. Define CL_HPP_USE_DX_INTEROP instead")
+#define CL_HPP_USE_DX_INTEROP
 #endif
 #if !defined(CL_HPP_USE_CL_DEVICE_FISSION) && defined(USE_CL_DEVICE_FISSION)
-# pragma message("cl2.hpp: USE_CL_DEVICE_FISSION is deprecated. Define CL_HPP_USE_CL_DEVICE_FISSION instead")
-# define CL_HPP_USE_CL_DEVICE_FISSION
+#pragma message("cl2.hpp: USE_CL_DEVICE_FISSION is deprecated. Define CL_HPP_USE_CL_DEVICE_FISSION instead")
+#define CL_HPP_USE_CL_DEVICE_FISSION
 #endif
 #if !defined(CL_HPP_ENABLE_EXCEPTIONS) && defined(__CL_ENABLE_EXCEPTIONS)
-# pragma message("cl2.hpp: __CL_ENABLE_EXCEPTIONS is deprecated. Define CL_HPP_ENABLE_EXCEPTIONS instead")
-# define CL_HPP_ENABLE_EXCEPTIONS
+#pragma message("cl2.hpp: __CL_ENABLE_EXCEPTIONS is deprecated. Define CL_HPP_ENABLE_EXCEPTIONS instead")
+#define CL_HPP_ENABLE_EXCEPTIONS
 #endif
 #if !defined(CL_HPP_NO_STD_VECTOR) && defined(__NO_STD_VECTOR)
-# pragma message("cl2.hpp: __NO_STD_VECTOR is deprecated. Define CL_HPP_NO_STD_VECTOR instead")
-# define CL_HPP_NO_STD_VECTOR
+#pragma message("cl2.hpp: __NO_STD_VECTOR is deprecated. Define CL_HPP_NO_STD_VECTOR instead")
+#define CL_HPP_NO_STD_VECTOR
 #endif
 #if !defined(CL_HPP_NO_STD_STRING) && defined(__NO_STD_STRING)
-# pragma message("cl2.hpp: __NO_STD_STRING is deprecated. Define CL_HPP_NO_STD_STRING instead")
-# define CL_HPP_NO_STD_STRING
+#pragma message("cl2.hpp: __NO_STD_STRING is deprecated. Define CL_HPP_NO_STD_STRING instead")
+#define CL_HPP_NO_STD_STRING
 #endif
 #if defined(VECTOR_CLASS)
-# pragma message("cl2.hpp: VECTOR_CLASS is deprecated. Alias cl::vector instead")
+#pragma message("cl2.hpp: VECTOR_CLASS is deprecated. Alias cl::vector instead")
 #endif
 #if defined(STRING_CLASS)
-# pragma message("cl2.hpp: STRING_CLASS is deprecated. Alias cl::string instead.")
+#pragma message("cl2.hpp: STRING_CLASS is deprecated. Alias cl::string instead.")
 #endif
 #if !defined(CL_HPP_USER_OVERRIDE_ERROR_STRINGS) && defined(__CL_USER_OVERRIDE_ERROR_STRINGS)
-# pragma message("cl2.hpp: __CL_USER_OVERRIDE_ERROR_STRINGS is deprecated. Define CL_HPP_USER_OVERRIDE_ERROR_STRINGS instead")
-# define CL_HPP_USER_OVERRIDE_ERROR_STRINGS
+#pragma message("cl2.hpp: __CL_USER_OVERRIDE_ERROR_STRINGS is deprecated. Define CL_HPP_USER_OVERRIDE_ERROR_STRINGS instead")
+#define CL_HPP_USER_OVERRIDE_ERROR_STRINGS
 #endif
 
 /* Warn about features that are no longer supported
  */
 #if defined(__USE_DEV_VECTOR)
-# pragma message("cl2.hpp: __USE_DEV_VECTOR is no longer supported. Expect compilation errors")
+#pragma message("cl2.hpp: __USE_DEV_VECTOR is no longer supported. Expect compilation errors")
 #endif
 #if defined(__USE_DEV_STRING)
-# pragma message("cl2.hpp: __USE_DEV_STRING is no longer supported. Expect compilation errors")
+#pragma message("cl2.hpp: __USE_DEV_STRING is no longer supported. Expect compilation errors")
 #endif
 
 /* Detect which version to target */
 #if !defined(CL_HPP_TARGET_OPENCL_VERSION)
-# pragma message("cl2.hpp: CL_HPP_TARGET_OPENCL_VERSION is not defined. It will default to 200 (OpenCL 2.0)")
-# define CL_HPP_TARGET_OPENCL_VERSION 200
+#pragma message("cl2.hpp: CL_HPP_TARGET_OPENCL_VERSION is not defined. It will default to 200 (OpenCL 2.0)")
+#define CL_HPP_TARGET_OPENCL_VERSION 200
 #endif
 #if CL_HPP_TARGET_OPENCL_VERSION != 100 && CL_HPP_TARGET_OPENCL_VERSION != 110 && CL_HPP_TARGET_OPENCL_VERSION != 120 && CL_HPP_TARGET_OPENCL_VERSION != 200
-# pragma message("cl2.hpp: CL_HPP_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120 or 200). It will be set to 200")
-# undef CL_HPP_TARGET_OPENCL_VERSION
-# define CL_HPP_TARGET_OPENCL_VERSION 200
+#pragma message("cl2.hpp: CL_HPP_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120 or 200). It will be set to 200")
+#undef CL_HPP_TARGET_OPENCL_VERSION
+#define CL_HPP_TARGET_OPENCL_VERSION 200
 #endif
 
 #if !defined(CL_HPP_MINIMUM_OPENCL_VERSION)
-# define CL_HPP_MINIMUM_OPENCL_VERSION 200
+#define CL_HPP_MINIMUM_OPENCL_VERSION 200
 #endif
 #if CL_HPP_MINIMUM_OPENCL_VERSION != 100 && CL_HPP_MINIMUM_OPENCL_VERSION != 110 && CL_HPP_MINIMUM_OPENCL_VERSION != 120 && CL_HPP_MINIMUM_OPENCL_VERSION != 200
-# pragma message("cl2.hpp: CL_HPP_MINIMUM_OPENCL_VERSION is not a valid value (100, 110, 120 or 200). It will be set to 100")
-# undef CL_HPP_MINIMUM_OPENCL_VERSION
-# define CL_HPP_MINIMUM_OPENCL_VERSION 100
+#pragma message("cl2.hpp: CL_HPP_MINIMUM_OPENCL_VERSION is not a valid value (100, 110, 120 or 200). It will be set to 100")
+#undef CL_HPP_MINIMUM_OPENCL_VERSION
+#define CL_HPP_MINIMUM_OPENCL_VERSION 100
 #endif
 #if CL_HPP_MINIMUM_OPENCL_VERSION > CL_HPP_TARGET_OPENCL_VERSION
-# error "CL_HPP_MINIMUM_OPENCL_VERSION must not be greater than CL_HPP_TARGET_OPENCL_VERSION"
+#error "CL_HPP_MINIMUM_OPENCL_VERSION must not be greater than CL_HPP_TARGET_OPENCL_VERSION"
 #endif
 
 #if CL_HPP_MINIMUM_OPENCL_VERSION <= 100 && !defined(CL_USE_DEPRECATED_OPENCL_1_0_APIS)
-# define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #endif
 #if CL_HPP_MINIMUM_OPENCL_VERSION <= 110 && !defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-# define CL_USE_DEPRECATED_OPENCL_1_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #endif
 #if CL_HPP_MINIMUM_OPENCL_VERSION <= 120 && !defined(CL_USE_DEPRECATED_OPENCL_1_2_APIS)
-# define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #endif
 #if CL_HPP_MINIMUM_OPENCL_VERSION <= 200 && !defined(CL_USE_DEPRECATED_OPENCL_2_0_APIS)
-# define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 #endif
 
 #ifdef _WIN32
@@ -432,17 +433,17 @@
 
 #if defined(_MSC_VER)
 #include <intrin.h>
-#endif // _MSC_VER 
- 
- // Check for a valid C++ version
+#endif // _MSC_VER
 
-// Need to do both tests here because for some reason __cplusplus is not 
+// Check for a valid C++ version
+
+// Need to do both tests here because for some reason __cplusplus is not
 // updated in visual studio
 #if (!defined(_MSC_VER) && __cplusplus < 201103L) || (defined(_MSC_VER) && _MSC_VER < 1700)
 #error Visual studio 2013 or another C++11-supporting compiler required
 #endif
 
-// 
+//
 #if defined(CL_HPP_USE_CL_DEVICE_FISSION) || defined(CL_HPP_USE_CL_SUB_GROUPS_KHR)
 #include <CL/cl_ext.h>
 #endif
@@ -460,22 +461,22 @@
 #endif
 
 #if defined(_MSC_VER)
-# define CL_HPP_DEFINE_STATIC_MEMBER_ __declspec(selectany)
+#define CL_HPP_DEFINE_STATIC_MEMBER_ __declspec(selectany)
 #else
-# define CL_HPP_DEFINE_STATIC_MEMBER_ __attribute__((weak))
+#define CL_HPP_DEFINE_STATIC_MEMBER_ __attribute__ ((weak))
 #endif // !_MSC_VER
 
 // Define deprecated prefixes and suffixes to ensure compilation
 // in case they are not pre-defined
 #if !defined(CL_EXT_PREFIX__VERSION_1_1_DEPRECATED)
-#define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED  
+#define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
 #endif // #if !defined(CL_EXT_PREFIX__VERSION_1_1_DEPRECATED)
 #if !defined(CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED)
 #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
 #endif // #if !defined(CL_EXT_PREFIX__VERSION_1_1_DEPRECATED)
 
 #if !defined(CL_EXT_PREFIX__VERSION_1_2_DEPRECATED)
-#define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED  
+#define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
 #endif // #if !defined(CL_EXT_PREFIX__VERSION_1_2_DEPRECATED)
 #if !defined(CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED)
 #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
@@ -485,25 +486,25 @@
 #define CL_CALLBACK
 #endif //CL_CALLBACK
 
-#include <utility>
-#include <limits>
-#include <iterator>
-#include <mutex>
 #include <cstring>
 #include <functional>
-
+#include <iterator>
+#include <limits>
+#include <mutex>
+#include <utility>
 
 // Define a size_type to represent a correctly resolved size_t
 #if defined(CL_HPP_ENABLE_SIZE_T_COMPATIBILITY)
-namespace cl {
-    using size_type = ::size_t;
+namespace cl
+{
+using size_type = ::size_t;
 } // namespace cl
 #else // #if defined(CL_HPP_ENABLE_SIZE_T_COMPATIBILITY)
-namespace cl {
-    using size_type = size_t;
+namespace cl
+{
+using size_type = size_t;
 } // namespace cl
 #endif // #if defined(CL_HPP_ENABLE_SIZE_T_COMPATIBILITY)
-
 
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
 #include <exception>
@@ -511,16 +512,18 @@ namespace cl {
 
 #if !defined(CL_HPP_NO_STD_VECTOR)
 #include <vector>
-namespace cl {
-    template < class T, class Alloc = std::allocator<T> >
-    using vector = std::vector<T, Alloc>;
+namespace cl
+{
+template <class T, class Alloc = std::allocator<T>>
+using vector = std::vector<T, Alloc>;
 } // namespace cl
 #endif // #if !defined(CL_HPP_NO_STD_VECTOR)
 
 #if !defined(CL_HPP_NO_STD_STRING)
 #include <string>
-namespace cl {
-    using string = std::string;
+namespace cl
+{
+using string = std::string;
 } // namespace cl
 #endif // #if !defined(CL_HPP_NO_STD_STRING)
 
@@ -528,139 +531,159 @@ namespace cl {
 
 #if !defined(CL_HPP_NO_STD_UNIQUE_PTR)
 #include <memory>
-namespace cl {
-    // Replace unique_ptr and allocate_pointer for internal use
-    // to allow user to replace them
-    template<class T, class D>
-    using pointer = std::unique_ptr<T, D>;
+namespace cl
+{
+// Replace unique_ptr and allocate_pointer for internal use
+// to allow user to replace them
+template <class T, class D>
+using pointer = std::unique_ptr<T, D>;
 } // namespace cl
-#endif 
+#endif
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if !defined(CL_HPP_NO_STD_ARRAY)
 #include <array>
-namespace cl {
-    template < class T, size_type N >
-    using array = std::array<T, N>;
+namespace cl
+{
+template <class T, size_type N>
+using array = std::array<T, N>;
 } // namespace cl
 #endif // #if !defined(CL_HPP_NO_STD_ARRAY)
 
 // Define size_type appropriately to allow backward-compatibility
 // use of the old size_t interface class
 #if defined(CL_HPP_ENABLE_SIZE_T_COMPATIBILITY)
-namespace cl {
-    namespace compatibility {
-        /*! \brief class used to interface between C++ and
+namespace cl
+{
+namespace compatibility
+{
+	/*! \brief class used to interface between C++ and
         *  OpenCL C calls that require arrays of size_t values, whose
         *  size is known statically.
         */
-        template <int N>
-        class size_t
-        {
-        private:
-            size_type data_[N];
+	template <int N>
+	class size_t
+	{
+	private:
+		size_type data_[N];
 
-        public:
-            //! \brief Initialize size_t to all 0s
-            size_t()
-            {
-                for (int i = 0; i < N; ++i) {
-                    data_[i] = 0;
-                }
-            }
+	public:
+		//! \brief Initialize size_t to all 0s
+		size_t ()
+		{
+			for (int i = 0; i < N; ++i)
+			{
+				data_[i] = 0;
+			}
+		}
 
-            size_t(const array<size_type, N> &rhs)
-            {
-                for (int i = 0; i < N; ++i) {
-                    data_[i] = rhs[i];
-                }
-            }
+		size_t (const array<size_type, N> & rhs)
+		{
+			for (int i = 0; i < N; ++i)
+			{
+				data_[i] = rhs[i];
+			}
+		}
 
-            size_type& operator[](int index)
-            {
-                return data_[index];
-            }
+		size_type & operator[] (int index)
+		{
+			return data_[index];
+		}
 
-            const size_type& operator[](int index) const
-            {
-                return data_[index];
-            }
+		const size_type & operator[] (int index) const
+		{
+			return data_[index];
+		}
 
-            //! \brief Conversion operator to T*.
-            operator size_type* ()             { return data_; }
+		//! \brief Conversion operator to T*.
+		operator size_type * ()
+		{
+			return data_;
+		}
 
-            //! \brief Conversion operator to const T*.
-            operator const size_type* () const { return data_; }
+		//! \brief Conversion operator to const T*.
+		operator const size_type * () const
+		{
+			return data_;
+		}
 
-            operator array<size_type, N>() const
-            {
-                array<size_type, N> ret;
+		operator array<size_type, N> () const
+		{
+			array<size_type, N> ret;
 
-                for (int i = 0; i < N; ++i) {
-                    ret[i] = data_[i];
-                }
-                return ret;
-            }
-        };
-    } // namespace compatibility
+			for (int i = 0; i < N; ++i)
+			{
+				ret[i] = data_[i];
+			}
+			return ret;
+		}
+	};
+} // namespace compatibility
 
-    template<int N>
-    using size_t = compatibility::size_t<N>;
+template <int N>
+using size_t = compatibility::size_t<N>;
 } // namespace cl
 #endif // #if defined(CL_HPP_ENABLE_SIZE_T_COMPATIBILITY)
 
 // Helper alias to avoid confusing the macros
-namespace cl {
-    namespace detail {
-        using size_t_array = array<size_type, 3>;
-    } // namespace detail
+namespace cl
+{
+namespace detail
+{
+	using size_t_array = array<size_type, 3>;
+} // namespace detail
 } // namespace cl
-
 
 /*! \namespace cl
  *
  * \brief The OpenCL C++ bindings are defined within this namespace.
  *
  */
-namespace cl {
-    class Memory;
+namespace cl
+{
+class Memory;
 
-#define CL_HPP_INIT_CL_EXT_FCN_PTR_(name) \
-    if (!pfn_##name) {    \
-    pfn_##name = (PFN_##name) \
-    clGetExtensionFunctionAddress(#name); \
-    if (!pfn_##name) {    \
-    } \
-    }
+#define CL_HPP_INIT_CL_EXT_FCN_PTR_(name)      \
+	if (!pfn_##name)                           \
+	{                                          \
+		pfn_##name = (PFN_##name)              \
+		clGetExtensionFunctionAddress (#name); \
+		if (!pfn_##name)                       \
+		{                                      \
+		}                                      \
+	}
 
-#define CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, name) \
-    if (!pfn_##name) {    \
-    pfn_##name = (PFN_##name) \
-    clGetExtensionFunctionAddressForPlatform(platform, #name); \
-    if (!pfn_##name) {    \
-    } \
-    }
+#define CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, name)        \
+	if (!pfn_##name)                                                \
+	{                                                               \
+		pfn_##name = (PFN_##name)                                   \
+		clGetExtensionFunctionAddressForPlatform (platform, #name); \
+		if (!pfn_##name)                                            \
+		{                                                           \
+		}                                                           \
+	}
 
-    class Program;
-    class Device;
-    class Context;
-    class CommandQueue;
-    class DeviceCommandQueue;
-    class Memory;
-    class Buffer;
-    class Pipe;
+class Program;
+class Device;
+class Context;
+class CommandQueue;
+class DeviceCommandQueue;
+class Memory;
+class Buffer;
+class Pipe;
 
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-    /*! \brief Exception class 
+/*! \brief Exception class 
      * 
      *  This may be thrown by API functions when CL_HPP_ENABLE_EXCEPTIONS is defined.
      */
-    class Error : public std::exception
-    {
-    private:
-        cl_int err_;
-        const char * errStr_;
-    public:
-        /*! \brief Create a new CL error exception for a given error code
+class Error : public std::exception
+{
+private:
+	cl_int err_;
+	const char * errStr_;
+
+public:
+	/*! \brief Create a new CL error exception for a given error code
          *  and corresponding message.
          * 
          *  \param err error code value.
@@ -669,752 +692,788 @@ namespace cl {
          *                handling of the exception has concluded.  If set, it
          *                will be returned by what().
          */
-        Error(cl_int err, const char * errStr = NULL) : err_(err), errStr_(errStr)
-        {}
+	Error (cl_int err, const char * errStr = NULL) :
+		err_ (err), errStr_ (errStr)
+	{
+	}
 
-        ~Error() throw() {}
+	~Error () throw ()
+	{
+	}
 
-        /*! \brief Get error string associated with exception
+	/*! \brief Get error string associated with exception
          *
          * \return A memory pointer to the error message string.
          */
-        virtual const char * what() const throw ()
-        {
-            if (errStr_ == NULL) {
-                return "empty";
-            }
-            else {
-                return errStr_;
-            }
-        }
+	virtual const char * what () const throw ()
+	{
+		if (errStr_ == NULL)
+		{
+			return "empty";
+		}
+		else
+		{
+			return errStr_;
+		}
+	}
 
-        /*! \brief Get error code associated with exception
+	/*! \brief Get error code associated with exception
          *
          *  \return The error code.
          */
-        cl_int err(void) const { return err_; }
-    };
+	cl_int err (void) const
+	{
+		return err_;
+	}
+};
 #define CL_HPP_ERR_STR_(x) #x
 #else
 #define CL_HPP_ERR_STR_(x) NULL
 #endif // CL_HPP_ENABLE_EXCEPTIONS
 
-
 namespace detail
 {
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-static inline cl_int errHandler (
-    cl_int err,
-    const char * errStr = NULL)
-{
-    if (err != CL_SUCCESS) {
-        throw Error(err, errStr);
-    }
-    return err;
-}
+	static inline cl_int errHandler (
+	cl_int err,
+	const char * errStr = NULL)
+	{
+		if (err != CL_SUCCESS)
+		{
+			throw Error (err, errStr);
+		}
+		return err;
+	}
 #else
-static inline cl_int errHandler (cl_int err, const char * errStr = NULL)
-{
-    (void) errStr; // suppress unused variable warning
-    return err;
-}
+	static inline cl_int errHandler (cl_int err, const char * errStr = NULL)
+	{
+		(void)errStr; // suppress unused variable warning
+		return err;
+	}
 #endif // CL_HPP_ENABLE_EXCEPTIONS
 }
 
-
-
 //! \cond DOXYGEN_DETAIL
 #if !defined(CL_HPP_USER_OVERRIDE_ERROR_STRINGS)
-#define __GET_DEVICE_INFO_ERR               CL_HPP_ERR_STR_(clGetDeviceInfo)
-#define __GET_PLATFORM_INFO_ERR             CL_HPP_ERR_STR_(clGetPlatformInfo)
-#define __GET_DEVICE_IDS_ERR                CL_HPP_ERR_STR_(clGetDeviceIDs)
-#define __GET_PLATFORM_IDS_ERR              CL_HPP_ERR_STR_(clGetPlatformIDs)
-#define __GET_CONTEXT_INFO_ERR              CL_HPP_ERR_STR_(clGetContextInfo)
-#define __GET_EVENT_INFO_ERR                CL_HPP_ERR_STR_(clGetEventInfo)
-#define __GET_EVENT_PROFILE_INFO_ERR        CL_HPP_ERR_STR_(clGetEventProfileInfo)
-#define __GET_MEM_OBJECT_INFO_ERR           CL_HPP_ERR_STR_(clGetMemObjectInfo)
-#define __GET_IMAGE_INFO_ERR                CL_HPP_ERR_STR_(clGetImageInfo)
-#define __GET_SAMPLER_INFO_ERR              CL_HPP_ERR_STR_(clGetSamplerInfo)
-#define __GET_KERNEL_INFO_ERR               CL_HPP_ERR_STR_(clGetKernelInfo)
+#define __GET_DEVICE_INFO_ERR CL_HPP_ERR_STR_ (clGetDeviceInfo)
+#define __GET_PLATFORM_INFO_ERR CL_HPP_ERR_STR_ (clGetPlatformInfo)
+#define __GET_DEVICE_IDS_ERR CL_HPP_ERR_STR_ (clGetDeviceIDs)
+#define __GET_PLATFORM_IDS_ERR CL_HPP_ERR_STR_ (clGetPlatformIDs)
+#define __GET_CONTEXT_INFO_ERR CL_HPP_ERR_STR_ (clGetContextInfo)
+#define __GET_EVENT_INFO_ERR CL_HPP_ERR_STR_ (clGetEventInfo)
+#define __GET_EVENT_PROFILE_INFO_ERR CL_HPP_ERR_STR_ (clGetEventProfileInfo)
+#define __GET_MEM_OBJECT_INFO_ERR CL_HPP_ERR_STR_ (clGetMemObjectInfo)
+#define __GET_IMAGE_INFO_ERR CL_HPP_ERR_STR_ (clGetImageInfo)
+#define __GET_SAMPLER_INFO_ERR CL_HPP_ERR_STR_ (clGetSamplerInfo)
+#define __GET_KERNEL_INFO_ERR CL_HPP_ERR_STR_ (clGetKernelInfo)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __GET_KERNEL_ARG_INFO_ERR           CL_HPP_ERR_STR_(clGetKernelArgInfo)
+#define __GET_KERNEL_ARG_INFO_ERR CL_HPP_ERR_STR_ (clGetKernelArgInfo)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __GET_KERNEL_WORK_GROUP_INFO_ERR    CL_HPP_ERR_STR_(clGetKernelWorkGroupInfo)
-#define __GET_PROGRAM_INFO_ERR              CL_HPP_ERR_STR_(clGetProgramInfo)
-#define __GET_PROGRAM_BUILD_INFO_ERR        CL_HPP_ERR_STR_(clGetProgramBuildInfo)
-#define __GET_COMMAND_QUEUE_INFO_ERR        CL_HPP_ERR_STR_(clGetCommandQueueInfo)
+#define __GET_KERNEL_WORK_GROUP_INFO_ERR CL_HPP_ERR_STR_ (clGetKernelWorkGroupInfo)
+#define __GET_PROGRAM_INFO_ERR CL_HPP_ERR_STR_ (clGetProgramInfo)
+#define __GET_PROGRAM_BUILD_INFO_ERR CL_HPP_ERR_STR_ (clGetProgramBuildInfo)
+#define __GET_COMMAND_QUEUE_INFO_ERR CL_HPP_ERR_STR_ (clGetCommandQueueInfo)
 
-#define __CREATE_CONTEXT_ERR                CL_HPP_ERR_STR_(clCreateContext)
-#define __CREATE_CONTEXT_FROM_TYPE_ERR      CL_HPP_ERR_STR_(clCreateContextFromType)
-#define __GET_SUPPORTED_IMAGE_FORMATS_ERR   CL_HPP_ERR_STR_(clGetSupportedImageFormats)
+#define __CREATE_CONTEXT_ERR CL_HPP_ERR_STR_ (clCreateContext)
+#define __CREATE_CONTEXT_FROM_TYPE_ERR CL_HPP_ERR_STR_ (clCreateContextFromType)
+#define __GET_SUPPORTED_IMAGE_FORMATS_ERR CL_HPP_ERR_STR_ (clGetSupportedImageFormats)
 
-#define __CREATE_BUFFER_ERR                 CL_HPP_ERR_STR_(clCreateBuffer)
-#define __COPY_ERR                          CL_HPP_ERR_STR_(cl::copy)
-#define __CREATE_SUBBUFFER_ERR              CL_HPP_ERR_STR_(clCreateSubBuffer)
-#define __CREATE_GL_BUFFER_ERR              CL_HPP_ERR_STR_(clCreateFromGLBuffer)
-#define __CREATE_GL_RENDER_BUFFER_ERR       CL_HPP_ERR_STR_(clCreateFromGLBuffer)
-#define __GET_GL_OBJECT_INFO_ERR            CL_HPP_ERR_STR_(clGetGLObjectInfo)
+#define __CREATE_BUFFER_ERR CL_HPP_ERR_STR_ (clCreateBuffer)
+#define __COPY_ERR CL_HPP_ERR_STR_ (cl::copy)
+#define __CREATE_SUBBUFFER_ERR CL_HPP_ERR_STR_ (clCreateSubBuffer)
+#define __CREATE_GL_BUFFER_ERR CL_HPP_ERR_STR_ (clCreateFromGLBuffer)
+#define __CREATE_GL_RENDER_BUFFER_ERR CL_HPP_ERR_STR_ (clCreateFromGLBuffer)
+#define __GET_GL_OBJECT_INFO_ERR CL_HPP_ERR_STR_ (clGetGLObjectInfo)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __CREATE_IMAGE_ERR                  CL_HPP_ERR_STR_(clCreateImage)
-#define __CREATE_GL_TEXTURE_ERR             CL_HPP_ERR_STR_(clCreateFromGLTexture)
-#define __IMAGE_DIMENSION_ERR               CL_HPP_ERR_STR_(Incorrect image dimensions)
+#define __CREATE_IMAGE_ERR CL_HPP_ERR_STR_ (clCreateImage)
+#define __CREATE_GL_TEXTURE_ERR CL_HPP_ERR_STR_ (clCreateFromGLTexture)
+#define __IMAGE_DIMENSION_ERR CL_HPP_ERR_STR_ (Incorrect image dimensions)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR CL_HPP_ERR_STR_(clSetMemObjectDestructorCallback)
+#define __SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR CL_HPP_ERR_STR_ (clSetMemObjectDestructorCallback)
 
-#define __CREATE_USER_EVENT_ERR             CL_HPP_ERR_STR_(clCreateUserEvent)
-#define __SET_USER_EVENT_STATUS_ERR         CL_HPP_ERR_STR_(clSetUserEventStatus)
-#define __SET_EVENT_CALLBACK_ERR            CL_HPP_ERR_STR_(clSetEventCallback)
-#define __WAIT_FOR_EVENTS_ERR               CL_HPP_ERR_STR_(clWaitForEvents)
+#define __CREATE_USER_EVENT_ERR CL_HPP_ERR_STR_ (clCreateUserEvent)
+#define __SET_USER_EVENT_STATUS_ERR CL_HPP_ERR_STR_ (clSetUserEventStatus)
+#define __SET_EVENT_CALLBACK_ERR CL_HPP_ERR_STR_ (clSetEventCallback)
+#define __WAIT_FOR_EVENTS_ERR CL_HPP_ERR_STR_ (clWaitForEvents)
 
-#define __CREATE_KERNEL_ERR                 CL_HPP_ERR_STR_(clCreateKernel)
-#define __SET_KERNEL_ARGS_ERR               CL_HPP_ERR_STR_(clSetKernelArg)
-#define __CREATE_PROGRAM_WITH_SOURCE_ERR    CL_HPP_ERR_STR_(clCreateProgramWithSource)
-#define __CREATE_PROGRAM_WITH_BINARY_ERR    CL_HPP_ERR_STR_(clCreateProgramWithBinary)
+#define __CREATE_KERNEL_ERR CL_HPP_ERR_STR_ (clCreateKernel)
+#define __SET_KERNEL_ARGS_ERR CL_HPP_ERR_STR_ (clSetKernelArg)
+#define __CREATE_PROGRAM_WITH_SOURCE_ERR CL_HPP_ERR_STR_ (clCreateProgramWithSource)
+#define __CREATE_PROGRAM_WITH_BINARY_ERR CL_HPP_ERR_STR_ (clCreateProgramWithBinary)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR    CL_HPP_ERR_STR_(clCreateProgramWithBuiltInKernels)
+#define __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR CL_HPP_ERR_STR_ (clCreateProgramWithBuiltInKernels)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __BUILD_PROGRAM_ERR                 CL_HPP_ERR_STR_(clBuildProgram)
+#define __BUILD_PROGRAM_ERR CL_HPP_ERR_STR_ (clBuildProgram)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __COMPILE_PROGRAM_ERR               CL_HPP_ERR_STR_(clCompileProgram)
-#define __LINK_PROGRAM_ERR                  CL_HPP_ERR_STR_(clLinkProgram)
+#define __COMPILE_PROGRAM_ERR CL_HPP_ERR_STR_ (clCompileProgram)
+#define __LINK_PROGRAM_ERR CL_HPP_ERR_STR_ (clLinkProgram)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __CREATE_KERNELS_IN_PROGRAM_ERR     CL_HPP_ERR_STR_(clCreateKernelsInProgram)
+#define __CREATE_KERNELS_IN_PROGRAM_ERR CL_HPP_ERR_STR_ (clCreateKernelsInProgram)
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-#define __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR          CL_HPP_ERR_STR_(clCreateCommandQueueWithProperties)
-#define __CREATE_SAMPLER_WITH_PROPERTIES_ERR                CL_HPP_ERR_STR_(clCreateSamplerWithProperties)
+#define __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR CL_HPP_ERR_STR_ (clCreateCommandQueueWithProperties)
+#define __CREATE_SAMPLER_WITH_PROPERTIES_ERR CL_HPP_ERR_STR_ (clCreateSamplerWithProperties)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
-#define __SET_COMMAND_QUEUE_PROPERTY_ERR    CL_HPP_ERR_STR_(clSetCommandQueueProperty)
-#define __ENQUEUE_READ_BUFFER_ERR           CL_HPP_ERR_STR_(clEnqueueReadBuffer)
-#define __ENQUEUE_READ_BUFFER_RECT_ERR      CL_HPP_ERR_STR_(clEnqueueReadBufferRect)
-#define __ENQUEUE_WRITE_BUFFER_ERR          CL_HPP_ERR_STR_(clEnqueueWriteBuffer)
-#define __ENQUEUE_WRITE_BUFFER_RECT_ERR     CL_HPP_ERR_STR_(clEnqueueWriteBufferRect)
-#define __ENQEUE_COPY_BUFFER_ERR            CL_HPP_ERR_STR_(clEnqueueCopyBuffer)
-#define __ENQEUE_COPY_BUFFER_RECT_ERR       CL_HPP_ERR_STR_(clEnqueueCopyBufferRect)
-#define __ENQUEUE_FILL_BUFFER_ERR           CL_HPP_ERR_STR_(clEnqueueFillBuffer)
-#define __ENQUEUE_READ_IMAGE_ERR            CL_HPP_ERR_STR_(clEnqueueReadImage)
-#define __ENQUEUE_WRITE_IMAGE_ERR           CL_HPP_ERR_STR_(clEnqueueWriteImage)
-#define __ENQUEUE_COPY_IMAGE_ERR            CL_HPP_ERR_STR_(clEnqueueCopyImage)
-#define __ENQUEUE_FILL_IMAGE_ERR            CL_HPP_ERR_STR_(clEnqueueFillImage)
-#define __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR  CL_HPP_ERR_STR_(clEnqueueCopyImageToBuffer)
-#define __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR  CL_HPP_ERR_STR_(clEnqueueCopyBufferToImage)
-#define __ENQUEUE_MAP_BUFFER_ERR            CL_HPP_ERR_STR_(clEnqueueMapBuffer)
-#define __ENQUEUE_MAP_IMAGE_ERR             CL_HPP_ERR_STR_(clEnqueueMapImage)
-#define __ENQUEUE_UNMAP_MEM_OBJECT_ERR      CL_HPP_ERR_STR_(clEnqueueUnMapMemObject)
-#define __ENQUEUE_NDRANGE_KERNEL_ERR        CL_HPP_ERR_STR_(clEnqueueNDRangeKernel)
-#define __ENQUEUE_NATIVE_KERNEL             CL_HPP_ERR_STR_(clEnqueueNativeKernel)
+#define __SET_COMMAND_QUEUE_PROPERTY_ERR CL_HPP_ERR_STR_ (clSetCommandQueueProperty)
+#define __ENQUEUE_READ_BUFFER_ERR CL_HPP_ERR_STR_ (clEnqueueReadBuffer)
+#define __ENQUEUE_READ_BUFFER_RECT_ERR CL_HPP_ERR_STR_ (clEnqueueReadBufferRect)
+#define __ENQUEUE_WRITE_BUFFER_ERR CL_HPP_ERR_STR_ (clEnqueueWriteBuffer)
+#define __ENQUEUE_WRITE_BUFFER_RECT_ERR CL_HPP_ERR_STR_ (clEnqueueWriteBufferRect)
+#define __ENQEUE_COPY_BUFFER_ERR CL_HPP_ERR_STR_ (clEnqueueCopyBuffer)
+#define __ENQEUE_COPY_BUFFER_RECT_ERR CL_HPP_ERR_STR_ (clEnqueueCopyBufferRect)
+#define __ENQUEUE_FILL_BUFFER_ERR CL_HPP_ERR_STR_ (clEnqueueFillBuffer)
+#define __ENQUEUE_READ_IMAGE_ERR CL_HPP_ERR_STR_ (clEnqueueReadImage)
+#define __ENQUEUE_WRITE_IMAGE_ERR CL_HPP_ERR_STR_ (clEnqueueWriteImage)
+#define __ENQUEUE_COPY_IMAGE_ERR CL_HPP_ERR_STR_ (clEnqueueCopyImage)
+#define __ENQUEUE_FILL_IMAGE_ERR CL_HPP_ERR_STR_ (clEnqueueFillImage)
+#define __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR CL_HPP_ERR_STR_ (clEnqueueCopyImageToBuffer)
+#define __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR CL_HPP_ERR_STR_ (clEnqueueCopyBufferToImage)
+#define __ENQUEUE_MAP_BUFFER_ERR CL_HPP_ERR_STR_ (clEnqueueMapBuffer)
+#define __ENQUEUE_MAP_IMAGE_ERR CL_HPP_ERR_STR_ (clEnqueueMapImage)
+#define __ENQUEUE_UNMAP_MEM_OBJECT_ERR CL_HPP_ERR_STR_ (clEnqueueUnMapMemObject)
+#define __ENQUEUE_NDRANGE_KERNEL_ERR CL_HPP_ERR_STR_ (clEnqueueNDRangeKernel)
+#define __ENQUEUE_NATIVE_KERNEL CL_HPP_ERR_STR_ (clEnqueueNativeKernel)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __ENQUEUE_MIGRATE_MEM_OBJECTS_ERR   CL_HPP_ERR_STR_(clEnqueueMigrateMemObjects)
+#define __ENQUEUE_MIGRATE_MEM_OBJECTS_ERR CL_HPP_ERR_STR_ (clEnqueueMigrateMemObjects)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-#define __ENQUEUE_ACQUIRE_GL_ERR            CL_HPP_ERR_STR_(clEnqueueAcquireGLObjects)
-#define __ENQUEUE_RELEASE_GL_ERR            CL_HPP_ERR_STR_(clEnqueueReleaseGLObjects)
+#define __ENQUEUE_ACQUIRE_GL_ERR CL_HPP_ERR_STR_ (clEnqueueAcquireGLObjects)
+#define __ENQUEUE_RELEASE_GL_ERR CL_HPP_ERR_STR_ (clEnqueueReleaseGLObjects)
 
-#define __CREATE_PIPE_ERR             CL_HPP_ERR_STR_(clCreatePipe)
-#define __GET_PIPE_INFO_ERR           CL_HPP_ERR_STR_(clGetPipeInfo)
+#define __CREATE_PIPE_ERR CL_HPP_ERR_STR_ (clCreatePipe)
+#define __GET_PIPE_INFO_ERR CL_HPP_ERR_STR_ (clGetPipeInfo)
 
-
-#define __RETAIN_ERR                        CL_HPP_ERR_STR_(Retain Object)
-#define __RELEASE_ERR                       CL_HPP_ERR_STR_(Release Object)
-#define __FLUSH_ERR                         CL_HPP_ERR_STR_(clFlush)
-#define __FINISH_ERR                        CL_HPP_ERR_STR_(clFinish)
-#define __VECTOR_CAPACITY_ERR               CL_HPP_ERR_STR_(Vector capacity error)
+#define __RETAIN_ERR CL_HPP_ERR_STR_ (Retain Object)
+#define __RELEASE_ERR CL_HPP_ERR_STR_ (Release Object)
+#define __FLUSH_ERR CL_HPP_ERR_STR_ (clFlush)
+#define __FINISH_ERR CL_HPP_ERR_STR_ (clFinish)
+#define __VECTOR_CAPACITY_ERR CL_HPP_ERR_STR_ (Vector capacity error)
 
 /**
  * CL 1.2 version that uses device fission.
  */
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __CREATE_SUB_DEVICES_ERR            CL_HPP_ERR_STR_(clCreateSubDevices)
+#define __CREATE_SUB_DEVICES_ERR CL_HPP_ERR_STR_ (clCreateSubDevices)
 #else
-#define __CREATE_SUB_DEVICES_ERR            CL_HPP_ERR_STR_(clCreateSubDevicesEXT)
+#define __CREATE_SUB_DEVICES_ERR CL_HPP_ERR_STR_ (clCreateSubDevicesEXT)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
 /**
  * Deprecated APIs for 1.2
  */
 #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-#define __ENQUEUE_MARKER_ERR                CL_HPP_ERR_STR_(clEnqueueMarker)
-#define __ENQUEUE_WAIT_FOR_EVENTS_ERR       CL_HPP_ERR_STR_(clEnqueueWaitForEvents)
-#define __ENQUEUE_BARRIER_ERR               CL_HPP_ERR_STR_(clEnqueueBarrier)
-#define __UNLOAD_COMPILER_ERR               CL_HPP_ERR_STR_(clUnloadCompiler)
-#define __CREATE_GL_TEXTURE_2D_ERR          CL_HPP_ERR_STR_(clCreateFromGLTexture2D)
-#define __CREATE_GL_TEXTURE_3D_ERR          CL_HPP_ERR_STR_(clCreateFromGLTexture3D)
-#define __CREATE_IMAGE2D_ERR                CL_HPP_ERR_STR_(clCreateImage2D)
-#define __CREATE_IMAGE3D_ERR                CL_HPP_ERR_STR_(clCreateImage3D)
+#define __ENQUEUE_MARKER_ERR CL_HPP_ERR_STR_ (clEnqueueMarker)
+#define __ENQUEUE_WAIT_FOR_EVENTS_ERR CL_HPP_ERR_STR_ (clEnqueueWaitForEvents)
+#define __ENQUEUE_BARRIER_ERR CL_HPP_ERR_STR_ (clEnqueueBarrier)
+#define __UNLOAD_COMPILER_ERR CL_HPP_ERR_STR_ (clUnloadCompiler)
+#define __CREATE_GL_TEXTURE_2D_ERR CL_HPP_ERR_STR_ (clCreateFromGLTexture2D)
+#define __CREATE_GL_TEXTURE_3D_ERR CL_HPP_ERR_STR_ (clCreateFromGLTexture3D)
+#define __CREATE_IMAGE2D_ERR CL_HPP_ERR_STR_ (clCreateImage2D)
+#define __CREATE_IMAGE3D_ERR CL_HPP_ERR_STR_ (clCreateImage3D)
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
 /**
  * Deprecated APIs for 2.0
  */
 #if defined(CL_USE_DEPRECATED_OPENCL_1_2_APIS)
-#define __CREATE_COMMAND_QUEUE_ERR          CL_HPP_ERR_STR_(clCreateCommandQueue)
-#define __ENQUEUE_TASK_ERR                  CL_HPP_ERR_STR_(clEnqueueTask)
-#define __CREATE_SAMPLER_ERR                CL_HPP_ERR_STR_(clCreateSampler)
+#define __CREATE_COMMAND_QUEUE_ERR CL_HPP_ERR_STR_ (clCreateCommandQueue)
+#define __ENQUEUE_TASK_ERR CL_HPP_ERR_STR_ (clEnqueueTask)
+#define __CREATE_SAMPLER_ERR CL_HPP_ERR_STR_ (clCreateSampler)
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
 /**
  * CL 1.2 marker and barrier commands
  */
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-#define __ENQUEUE_MARKER_WAIT_LIST_ERR                CL_HPP_ERR_STR_(clEnqueueMarkerWithWaitList)
-#define __ENQUEUE_BARRIER_WAIT_LIST_ERR               CL_HPP_ERR_STR_(clEnqueueBarrierWithWaitList)
+#define __ENQUEUE_MARKER_WAIT_LIST_ERR CL_HPP_ERR_STR_ (clEnqueueMarkerWithWaitList)
+#define __ENQUEUE_BARRIER_WAIT_LIST_ERR CL_HPP_ERR_STR_ (clEnqueueBarrierWithWaitList)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
 #endif // CL_HPP_USER_OVERRIDE_ERROR_STRINGS
 //! \endcond
 
-
-namespace detail {
-
-// Generic getInfoHelper. The final parameter is used to guide overload
-// resolution: the actual parameter passed is an int, which makes this
-// a worse conversion sequence than a specialization that declares the
-// parameter as an int.
-template<typename Functor, typename T>
-inline cl_int getInfoHelper(Functor f, cl_uint name, T* param, long)
+namespace detail
 {
-    return f(name, sizeof(T), param, NULL);
-}
+	// Generic getInfoHelper. The final parameter is used to guide overload
+	// resolution: the actual parameter passed is an int, which makes this
+	// a worse conversion sequence than a specialization that declares the
+	// parameter as an int.
+	template <typename Functor, typename T>
+	inline cl_int getInfoHelper (Functor f, cl_uint name, T * param, long)
+	{
+		return f (name, sizeof (T), param, NULL);
+	}
 
-// Specialized for getInfo<CL_PROGRAM_BINARIES>
-// Assumes that the output vector was correctly resized on the way in
-template <typename Func>
-inline cl_int getInfoHelper(Func f, cl_uint name, vector<vector<unsigned char>>* param, int)
-{
-    if (name != CL_PROGRAM_BINARIES) {
-        return CL_INVALID_VALUE;
-    }
-    if (param) {
-        // Create array of pointers, calculate total size and pass pointer array in
-        size_type numBinaries = param->size();
-        vector<unsigned char*> binariesPointers(numBinaries);
+	// Specialized for getInfo<CL_PROGRAM_BINARIES>
+	// Assumes that the output vector was correctly resized on the way in
+	template <typename Func>
+	inline cl_int getInfoHelper (Func f, cl_uint name, vector<vector<unsigned char>> * param, int)
+	{
+		if (name != CL_PROGRAM_BINARIES)
+		{
+			return CL_INVALID_VALUE;
+		}
+		if (param)
+		{
+			// Create array of pointers, calculate total size and pass pointer array in
+			size_type numBinaries = param->size ();
+			vector<unsigned char *> binariesPointers (numBinaries);
 
-        size_type totalSize = 0;
-        for (size_type i = 0; i < numBinaries; ++i)
-        {
-            binariesPointers[i] = (*param)[i].data();
-            totalSize += (*param)[i].size();
-        }
+			size_type totalSize = 0;
+			for (size_type i = 0; i < numBinaries; ++i)
+			{
+				binariesPointers[i] = (*param)[i].data ();
+				totalSize += (*param)[i].size ();
+			}
 
-        cl_int err = f(name, totalSize, binariesPointers.data(), NULL);
+			cl_int err = f (name, totalSize, binariesPointers.data (), NULL);
 
-        if (err != CL_SUCCESS) {
-            return err;
-        }
-    }
+			if (err != CL_SUCCESS)
+			{
+				return err;
+			}
+		}
 
+		return CL_SUCCESS;
+	}
 
-    return CL_SUCCESS;
-}
+	// Specialized getInfoHelper for vector params
+	template <typename Func, typename T>
+	inline cl_int getInfoHelper (Func f, cl_uint name, vector<T> * param, long)
+	{
+		size_type required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
+		const size_type elements = required / sizeof (T);
 
-// Specialized getInfoHelper for vector params
-template <typename Func, typename T>
-inline cl_int getInfoHelper(Func f, cl_uint name, vector<T>* param, long)
-{
-    size_type required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-    const size_type elements = required / sizeof(T);
+		// Temporary to avoid changing param on an error
+		vector<T> localData (elements);
+		err = f (name, required, localData.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
+		if (param)
+		{
+			*param = std::move (localData);
+		}
 
-    // Temporary to avoid changing param on an error
-    vector<T> localData(elements);
-    err = f(name, required, localData.data(), NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-    if (param) {
-        *param = std::move(localData);
-    }
+		return CL_SUCCESS;
+	}
 
-    return CL_SUCCESS;
-}
-
-/* Specialization for reference-counted types. This depends on the
+	/* Specialization for reference-counted types. This depends on the
  * existence of Wrapper<T>::cl_type, and none of the other types having the
  * cl_type member. Note that simplify specifying the parameter as Wrapper<T>
  * does not work, because when using a derived type (e.g. Context) the generic
  * template will provide a better match.
  */
-template <typename Func, typename T>
-inline cl_int getInfoHelper(
-    Func f, cl_uint name, vector<T>* param, int, typename T::cl_type = 0)
-{
-    size_type required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+	template <typename Func, typename T>
+	inline cl_int getInfoHelper (
+	Func f, cl_uint name, vector<T> * param, int, typename T::cl_type = 0)
+	{
+		size_type required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    const size_type elements = required / sizeof(typename T::cl_type);
+		const size_type elements = required / sizeof (typename T::cl_type);
 
-    vector<typename T::cl_type> value(elements);
-    err = f(name, required, value.data(), NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+		vector<typename T::cl_type> value (elements);
+		err = f (name, required, value.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    if (param) {
-        // Assign to convert CL type to T for each element
-        param->resize(elements);
+		if (param)
+		{
+			// Assign to convert CL type to T for each element
+			param->resize (elements);
 
-        // Assign to param, constructing with retain behaviour
-        // to correctly capture each underlying CL object
-        for (size_type i = 0; i < elements; i++) {
-            (*param)[i] = T(value[i], true);
-        }
-    }
-    return CL_SUCCESS;
-}
+			// Assign to param, constructing with retain behaviour
+			// to correctly capture each underlying CL object
+			for (size_type i = 0; i < elements; i++)
+			{
+				(*param)[i] = T (value[i], true);
+			}
+		}
+		return CL_SUCCESS;
+	}
 
-// Specialized GetInfoHelper for string params
-template <typename Func>
-inline cl_int getInfoHelper(Func f, cl_uint name, string* param, long)
-{
-    size_type required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+	// Specialized GetInfoHelper for string params
+	template <typename Func>
+	inline cl_int getInfoHelper (Func f, cl_uint name, string * param, long)
+	{
+		size_type required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    // std::string has a constant data member
-    // a char vector does not
-    if (required > 0) {
-        vector<char> value(required);
-        err = f(name, required, value.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return err;
-        }
-        if (param) {
-            param->assign(begin(value), prev(end(value)));
-        }
-    }
-    else if (param) {
-        param->assign("");
-    }
-    return CL_SUCCESS;
-}
+		// std::string has a constant data member
+		// a char vector does not
+		if (required > 0)
+		{
+			vector<char> value (required);
+			err = f (name, required, value.data (), NULL);
+			if (err != CL_SUCCESS)
+			{
+				return err;
+			}
+			if (param)
+			{
+				param->assign (begin (value), prev (end (value)));
+			}
+		}
+		else if (param)
+		{
+			param->assign ("");
+		}
+		return CL_SUCCESS;
+	}
 
-// Specialized GetInfoHelper for clsize_t params
-template <typename Func, size_type N>
-inline cl_int getInfoHelper(Func f, cl_uint name, array<size_type, N>* param, long)
-{
-    size_type required;
-    cl_int err = f(name, 0, NULL, &required);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
+	// Specialized GetInfoHelper for clsize_t params
+	template <typename Func, size_type N>
+	inline cl_int getInfoHelper (Func f, cl_uint name, array<size_type, N> * param, long)
+	{
+		size_type required;
+		cl_int err = f (name, 0, NULL, &required);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    size_type elements = required / sizeof(size_type);
-    vector<size_type> value(elements, 0);
+		size_type elements = required / sizeof (size_type);
+		vector<size_type> value (elements, 0);
 
-    err = f(name, required, value.data(), NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-    
-    // Bound the copy with N to prevent overruns
-    // if passed N > than the amount copied
-    if (elements > N) {
-        elements = N;
-    }
-    for (size_type i = 0; i < elements; ++i) {
-        (*param)[i] = value[i];
-    }
+		err = f (name, required, value.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
 
-    return CL_SUCCESS;
-}
+		// Bound the copy with N to prevent overruns
+		// if passed N > than the amount copied
+		if (elements > N)
+		{
+			elements = N;
+		}
+		for (size_type i = 0; i < elements; ++i)
+		{
+			(*param)[i] = value[i];
+		}
 
-template<typename T> struct ReferenceHandler;
+		return CL_SUCCESS;
+	}
 
-/* Specialization for reference-counted types. This depends on the
+	template <typename T>
+	struct ReferenceHandler;
+
+	/* Specialization for reference-counted types. This depends on the
  * existence of Wrapper<T>::cl_type, and none of the other types having the
  * cl_type member. Note that simplify specifying the parameter as Wrapper<T>
  * does not work, because when using a derived type (e.g. Context) the generic
  * template will provide a better match.
  */
-template<typename Func, typename T>
-inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_type = 0)
-{
-    typename T::cl_type value;
-    cl_int err = f(name, sizeof(value), &value, NULL);
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-    *param = value;
-    if (value != NULL)
-    {
-        err = param->retain();
-        if (err != CL_SUCCESS) {
-            return err;
-        }
-    }
-    return CL_SUCCESS;
-}
+	template <typename Func, typename T>
+	inline cl_int getInfoHelper (Func f, cl_uint name, T * param, int, typename T::cl_type = 0)
+	{
+		typename T::cl_type value;
+		cl_int err = f (name, sizeof (value), &value, NULL);
+		if (err != CL_SUCCESS)
+		{
+			return err;
+		}
+		*param = value;
+		if (value != NULL)
+		{
+			err = param->retain ();
+			if (err != CL_SUCCESS)
+			{
+				return err;
+			}
+		}
+		return CL_SUCCESS;
+	}
 
-#define CL_HPP_PARAM_NAME_INFO_1_0_(F) \
-    F(cl_platform_info, CL_PLATFORM_PROFILE, string) \
-    F(cl_platform_info, CL_PLATFORM_VERSION, string) \
-    F(cl_platform_info, CL_PLATFORM_NAME, string) \
-    F(cl_platform_info, CL_PLATFORM_VENDOR, string) \
-    F(cl_platform_info, CL_PLATFORM_EXTENSIONS, string) \
-    \
-    F(cl_device_info, CL_DEVICE_TYPE, cl_device_type) \
-    F(cl_device_info, CL_DEVICE_VENDOR_ID, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_COMPUTE_UNITS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_WORK_GROUP_SIZE, size_type) \
-    F(cl_device_info, CL_DEVICE_MAX_WORK_ITEM_SIZES, cl::vector<size_type>) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_CLOCK_FREQUENCY, cl_uint) \
-    F(cl_device_info, CL_DEVICE_ADDRESS_BITS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_READ_IMAGE_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_WRITE_IMAGE_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_MEM_ALLOC_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_IMAGE2D_MAX_WIDTH, size_type) \
-    F(cl_device_info, CL_DEVICE_IMAGE2D_MAX_HEIGHT, size_type) \
-    F(cl_device_info, CL_DEVICE_IMAGE3D_MAX_WIDTH, size_type) \
-    F(cl_device_info, CL_DEVICE_IMAGE3D_MAX_HEIGHT, size_type) \
-    F(cl_device_info, CL_DEVICE_IMAGE3D_MAX_DEPTH, size_type) \
-    F(cl_device_info, CL_DEVICE_IMAGE_SUPPORT, cl_bool) \
-    F(cl_device_info, CL_DEVICE_MAX_PARAMETER_SIZE, size_type) \
-    F(cl_device_info, CL_DEVICE_MAX_SAMPLERS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type) \
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint)\
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_GLOBAL_MEM_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_MAX_CONSTANT_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_LOCAL_MEM_TYPE, cl_device_local_mem_type) \
-    F(cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE, cl_ulong) \
-    F(cl_device_info, CL_DEVICE_ERROR_CORRECTION_SUPPORT, cl_bool) \
-    F(cl_device_info, CL_DEVICE_PROFILING_TIMER_RESOLUTION, size_type) \
-    F(cl_device_info, CL_DEVICE_ENDIAN_LITTLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_AVAILABLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_COMPILER_AVAILABLE, cl_bool) \
-    F(cl_device_info, CL_DEVICE_EXECUTION_CAPABILITIES, cl_device_exec_capabilities) \
-    F(cl_device_info, CL_DEVICE_PLATFORM, cl_platform_id) \
-    F(cl_device_info, CL_DEVICE_NAME, string) \
-    F(cl_device_info, CL_DEVICE_VENDOR, string) \
-    F(cl_device_info, CL_DRIVER_VERSION, string) \
-    F(cl_device_info, CL_DEVICE_PROFILE, string) \
-    F(cl_device_info, CL_DEVICE_VERSION, string) \
-    F(cl_device_info, CL_DEVICE_EXTENSIONS, string) \
-    \
-    F(cl_context_info, CL_CONTEXT_REFERENCE_COUNT, cl_uint) \
-    F(cl_context_info, CL_CONTEXT_DEVICES, cl::vector<Device>) \
-    F(cl_context_info, CL_CONTEXT_PROPERTIES, cl::vector<cl_context_properties>) \
-    \
-    F(cl_event_info, CL_EVENT_COMMAND_QUEUE, cl::CommandQueue) \
-    F(cl_event_info, CL_EVENT_COMMAND_TYPE, cl_command_type) \
-    F(cl_event_info, CL_EVENT_REFERENCE_COUNT, cl_uint) \
-    F(cl_event_info, CL_EVENT_COMMAND_EXECUTION_STATUS, cl_int) \
-    \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_QUEUED, cl_ulong) \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_SUBMIT, cl_ulong) \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_START, cl_ulong) \
-    F(cl_profiling_info, CL_PROFILING_COMMAND_END, cl_ulong) \
-    \
-    F(cl_mem_info, CL_MEM_TYPE, cl_mem_object_type) \
-    F(cl_mem_info, CL_MEM_FLAGS, cl_mem_flags) \
-    F(cl_mem_info, CL_MEM_SIZE, size_type) \
-    F(cl_mem_info, CL_MEM_HOST_PTR, void*) \
-    F(cl_mem_info, CL_MEM_MAP_COUNT, cl_uint) \
-    F(cl_mem_info, CL_MEM_REFERENCE_COUNT, cl_uint) \
-    F(cl_mem_info, CL_MEM_CONTEXT, cl::Context) \
-    \
-    F(cl_image_info, CL_IMAGE_FORMAT, cl_image_format) \
-    F(cl_image_info, CL_IMAGE_ELEMENT_SIZE, size_type) \
-    F(cl_image_info, CL_IMAGE_ROW_PITCH, size_type) \
-    F(cl_image_info, CL_IMAGE_SLICE_PITCH, size_type) \
-    F(cl_image_info, CL_IMAGE_WIDTH, size_type) \
-    F(cl_image_info, CL_IMAGE_HEIGHT, size_type) \
-    F(cl_image_info, CL_IMAGE_DEPTH, size_type) \
-    F(cl_image_info, CL_IMAGE_ARRAY_SIZE, size_type) \
-    F(cl_image_info, CL_IMAGE_NUM_MIP_LEVELS, cl_uint) \
-    F(cl_image_info, CL_IMAGE_NUM_SAMPLES, cl_uint) \
-    \
-    F(cl_sampler_info, CL_SAMPLER_REFERENCE_COUNT, cl_uint) \
-    F(cl_sampler_info, CL_SAMPLER_CONTEXT, cl::Context) \
-    F(cl_sampler_info, CL_SAMPLER_NORMALIZED_COORDS, cl_bool) \
-    F(cl_sampler_info, CL_SAMPLER_ADDRESSING_MODE, cl_addressing_mode) \
-    F(cl_sampler_info, CL_SAMPLER_FILTER_MODE, cl_filter_mode) \
-    \
-    F(cl_program_info, CL_PROGRAM_REFERENCE_COUNT, cl_uint) \
-    F(cl_program_info, CL_PROGRAM_CONTEXT, cl::Context) \
-    F(cl_program_info, CL_PROGRAM_NUM_DEVICES, cl_uint) \
-    F(cl_program_info, CL_PROGRAM_DEVICES, cl::vector<Device>) \
-    F(cl_program_info, CL_PROGRAM_SOURCE, string) \
-    F(cl_program_info, CL_PROGRAM_BINARY_SIZES, cl::vector<size_type>) \
-    F(cl_program_info, CL_PROGRAM_BINARIES, cl::vector<cl::vector<unsigned char>>) \
-    \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_STATUS, cl_build_status) \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_OPTIONS, string) \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_LOG, string) \
-    \
-    F(cl_kernel_info, CL_KERNEL_FUNCTION_NAME, string) \
-    F(cl_kernel_info, CL_KERNEL_NUM_ARGS, cl_uint) \
-    F(cl_kernel_info, CL_KERNEL_REFERENCE_COUNT, cl_uint) \
-    F(cl_kernel_info, CL_KERNEL_CONTEXT, cl::Context) \
-    F(cl_kernel_info, CL_KERNEL_PROGRAM, cl::Program) \
-    \
-    F(cl_kernel_work_group_info, CL_KERNEL_WORK_GROUP_SIZE, size_type) \
-    F(cl_kernel_work_group_info, CL_KERNEL_COMPILE_WORK_GROUP_SIZE, cl::detail::size_t_array) \
-    F(cl_kernel_work_group_info, CL_KERNEL_LOCAL_MEM_SIZE, cl_ulong) \
-    \
-    F(cl_command_queue_info, CL_QUEUE_CONTEXT, cl::Context) \
-    F(cl_command_queue_info, CL_QUEUE_DEVICE, cl::Device) \
-    F(cl_command_queue_info, CL_QUEUE_REFERENCE_COUNT, cl_uint) \
-    F(cl_command_queue_info, CL_QUEUE_PROPERTIES, cl_command_queue_properties)
+#define CL_HPP_PARAM_NAME_INFO_1_0_(F)                                                         \
+	F (cl_platform_info, CL_PLATFORM_PROFILE, string)                                          \
+	F (cl_platform_info, CL_PLATFORM_VERSION, string)                                          \
+	F (cl_platform_info, CL_PLATFORM_NAME, string)                                             \
+	F (cl_platform_info, CL_PLATFORM_VENDOR, string)                                           \
+	F (cl_platform_info, CL_PLATFORM_EXTENSIONS, string)                                       \
+                                                                                               \
+	F (cl_device_info, CL_DEVICE_TYPE, cl_device_type)                                         \
+	F (cl_device_info, CL_DEVICE_VENDOR_ID, cl_uint)                                           \
+	F (cl_device_info, CL_DEVICE_MAX_COMPUTE_UNITS, cl_uint)                                   \
+	F (cl_device_info, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, cl_uint)                            \
+	F (cl_device_info, CL_DEVICE_MAX_WORK_GROUP_SIZE, size_type)                               \
+	F (cl_device_info, CL_DEVICE_MAX_WORK_ITEM_SIZES, cl::vector<size_type>)                   \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, cl_uint)                         \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, cl_uint)                          \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, cl_uint)                         \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_MAX_CLOCK_FREQUENCY, cl_uint)                                 \
+	F (cl_device_info, CL_DEVICE_ADDRESS_BITS, cl_uint)                                        \
+	F (cl_device_info, CL_DEVICE_MAX_READ_IMAGE_ARGS, cl_uint)                                 \
+	F (cl_device_info, CL_DEVICE_MAX_WRITE_IMAGE_ARGS, cl_uint)                                \
+	F (cl_device_info, CL_DEVICE_MAX_MEM_ALLOC_SIZE, cl_ulong)                                 \
+	F (cl_device_info, CL_DEVICE_IMAGE2D_MAX_WIDTH, size_type)                                 \
+	F (cl_device_info, CL_DEVICE_IMAGE2D_MAX_HEIGHT, size_type)                                \
+	F (cl_device_info, CL_DEVICE_IMAGE3D_MAX_WIDTH, size_type)                                 \
+	F (cl_device_info, CL_DEVICE_IMAGE3D_MAX_HEIGHT, size_type)                                \
+	F (cl_device_info, CL_DEVICE_IMAGE3D_MAX_DEPTH, size_type)                                 \
+	F (cl_device_info, CL_DEVICE_IMAGE_SUPPORT, cl_bool)                                       \
+	F (cl_device_info, CL_DEVICE_MAX_PARAMETER_SIZE, size_type)                                \
+	F (cl_device_info, CL_DEVICE_MAX_SAMPLERS, cl_uint)                                        \
+	F (cl_device_info, CL_DEVICE_MEM_BASE_ADDR_ALIGN, cl_uint)                                 \
+	F (cl_device_info, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, cl_uint)                            \
+	F (cl_device_info, CL_DEVICE_SINGLE_FP_CONFIG, cl_device_fp_config)                        \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, cl_device_mem_cache_type)              \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, cl_uint)                           \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, cl_ulong)                              \
+	F (cl_device_info, CL_DEVICE_GLOBAL_MEM_SIZE, cl_ulong)                                    \
+	F (cl_device_info, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, cl_ulong)                           \
+	F (cl_device_info, CL_DEVICE_MAX_CONSTANT_ARGS, cl_uint)                                   \
+	F (cl_device_info, CL_DEVICE_LOCAL_MEM_TYPE, cl_device_local_mem_type)                     \
+	F (cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE, cl_ulong)                                     \
+	F (cl_device_info, CL_DEVICE_ERROR_CORRECTION_SUPPORT, cl_bool)                            \
+	F (cl_device_info, CL_DEVICE_PROFILING_TIMER_RESOLUTION, size_type)                        \
+	F (cl_device_info, CL_DEVICE_ENDIAN_LITTLE, cl_bool)                                       \
+	F (cl_device_info, CL_DEVICE_AVAILABLE, cl_bool)                                           \
+	F (cl_device_info, CL_DEVICE_COMPILER_AVAILABLE, cl_bool)                                  \
+	F (cl_device_info, CL_DEVICE_EXECUTION_CAPABILITIES, cl_device_exec_capabilities)          \
+	F (cl_device_info, CL_DEVICE_PLATFORM, cl_platform_id)                                     \
+	F (cl_device_info, CL_DEVICE_NAME, string)                                                 \
+	F (cl_device_info, CL_DEVICE_VENDOR, string)                                               \
+	F (cl_device_info, CL_DRIVER_VERSION, string)                                              \
+	F (cl_device_info, CL_DEVICE_PROFILE, string)                                              \
+	F (cl_device_info, CL_DEVICE_VERSION, string)                                              \
+	F (cl_device_info, CL_DEVICE_EXTENSIONS, string)                                           \
+                                                                                               \
+	F (cl_context_info, CL_CONTEXT_REFERENCE_COUNT, cl_uint)                                   \
+	F (cl_context_info, CL_CONTEXT_DEVICES, cl::vector<Device>)                                \
+	F (cl_context_info, CL_CONTEXT_PROPERTIES, cl::vector<cl_context_properties>)              \
+                                                                                               \
+	F (cl_event_info, CL_EVENT_COMMAND_QUEUE, cl::CommandQueue)                                \
+	F (cl_event_info, CL_EVENT_COMMAND_TYPE, cl_command_type)                                  \
+	F (cl_event_info, CL_EVENT_REFERENCE_COUNT, cl_uint)                                       \
+	F (cl_event_info, CL_EVENT_COMMAND_EXECUTION_STATUS, cl_int)                               \
+                                                                                               \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_QUEUED, cl_ulong)                               \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_SUBMIT, cl_ulong)                               \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_START, cl_ulong)                                \
+	F (cl_profiling_info, CL_PROFILING_COMMAND_END, cl_ulong)                                  \
+                                                                                               \
+	F (cl_mem_info, CL_MEM_TYPE, cl_mem_object_type)                                           \
+	F (cl_mem_info, CL_MEM_FLAGS, cl_mem_flags)                                                \
+	F (cl_mem_info, CL_MEM_SIZE, size_type)                                                    \
+	F (cl_mem_info, CL_MEM_HOST_PTR, void *)                                                   \
+	F (cl_mem_info, CL_MEM_MAP_COUNT, cl_uint)                                                 \
+	F (cl_mem_info, CL_MEM_REFERENCE_COUNT, cl_uint)                                           \
+	F (cl_mem_info, CL_MEM_CONTEXT, cl::Context)                                               \
+                                                                                               \
+	F (cl_image_info, CL_IMAGE_FORMAT, cl_image_format)                                        \
+	F (cl_image_info, CL_IMAGE_ELEMENT_SIZE, size_type)                                        \
+	F (cl_image_info, CL_IMAGE_ROW_PITCH, size_type)                                           \
+	F (cl_image_info, CL_IMAGE_SLICE_PITCH, size_type)                                         \
+	F (cl_image_info, CL_IMAGE_WIDTH, size_type)                                               \
+	F (cl_image_info, CL_IMAGE_HEIGHT, size_type)                                              \
+	F (cl_image_info, CL_IMAGE_DEPTH, size_type)                                               \
+	F (cl_image_info, CL_IMAGE_ARRAY_SIZE, size_type)                                          \
+	F (cl_image_info, CL_IMAGE_NUM_MIP_LEVELS, cl_uint)                                        \
+	F (cl_image_info, CL_IMAGE_NUM_SAMPLES, cl_uint)                                           \
+                                                                                               \
+	F (cl_sampler_info, CL_SAMPLER_REFERENCE_COUNT, cl_uint)                                   \
+	F (cl_sampler_info, CL_SAMPLER_CONTEXT, cl::Context)                                       \
+	F (cl_sampler_info, CL_SAMPLER_NORMALIZED_COORDS, cl_bool)                                 \
+	F (cl_sampler_info, CL_SAMPLER_ADDRESSING_MODE, cl_addressing_mode)                        \
+	F (cl_sampler_info, CL_SAMPLER_FILTER_MODE, cl_filter_mode)                                \
+                                                                                               \
+	F (cl_program_info, CL_PROGRAM_REFERENCE_COUNT, cl_uint)                                   \
+	F (cl_program_info, CL_PROGRAM_CONTEXT, cl::Context)                                       \
+	F (cl_program_info, CL_PROGRAM_NUM_DEVICES, cl_uint)                                       \
+	F (cl_program_info, CL_PROGRAM_DEVICES, cl::vector<Device>)                                \
+	F (cl_program_info, CL_PROGRAM_SOURCE, string)                                             \
+	F (cl_program_info, CL_PROGRAM_BINARY_SIZES, cl::vector<size_type>)                        \
+	F (cl_program_info, CL_PROGRAM_BINARIES, cl::vector<cl::vector<unsigned char>>)            \
+                                                                                               \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_STATUS, cl_build_status)                        \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_OPTIONS, string)                                \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_LOG, string)                                    \
+                                                                                               \
+	F (cl_kernel_info, CL_KERNEL_FUNCTION_NAME, string)                                        \
+	F (cl_kernel_info, CL_KERNEL_NUM_ARGS, cl_uint)                                            \
+	F (cl_kernel_info, CL_KERNEL_REFERENCE_COUNT, cl_uint)                                     \
+	F (cl_kernel_info, CL_KERNEL_CONTEXT, cl::Context)                                         \
+	F (cl_kernel_info, CL_KERNEL_PROGRAM, cl::Program)                                         \
+                                                                                               \
+	F (cl_kernel_work_group_info, CL_KERNEL_WORK_GROUP_SIZE, size_type)                        \
+	F (cl_kernel_work_group_info, CL_KERNEL_COMPILE_WORK_GROUP_SIZE, cl::detail::size_t_array) \
+	F (cl_kernel_work_group_info, CL_KERNEL_LOCAL_MEM_SIZE, cl_ulong)                          \
+                                                                                               \
+	F (cl_command_queue_info, CL_QUEUE_CONTEXT, cl::Context)                                   \
+	F (cl_command_queue_info, CL_QUEUE_DEVICE, cl::Device)                                     \
+	F (cl_command_queue_info, CL_QUEUE_REFERENCE_COUNT, cl_uint)                               \
+	F (cl_command_queue_info, CL_QUEUE_PROPERTIES, cl_command_queue_properties)
 
+#define CL_HPP_PARAM_NAME_INFO_1_1_(F)                                                     \
+	F (cl_context_info, CL_CONTEXT_NUM_DEVICES, cl_uint)                                   \
+	F (cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint)                     \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, cl_uint)                         \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint)                      \
+	F (cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint)                        \
+	F (cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config)                    \
+	F (cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config)                      \
+	F (cl_device_info, CL_DEVICE_OPENCL_C_VERSION, string)                                 \
+                                                                                           \
+	F (cl_mem_info, CL_MEM_ASSOCIATED_MEMOBJECT, cl::Memory)                               \
+	F (cl_mem_info, CL_MEM_OFFSET, size_type)                                              \
+                                                                                           \
+	F (cl_kernel_work_group_info, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, size_type) \
+	F (cl_kernel_work_group_info, CL_KERNEL_PRIVATE_MEM_SIZE, cl_ulong)                    \
+                                                                                           \
+	F (cl_event_info, CL_EVENT_CONTEXT, cl::Context)
 
-#define CL_HPP_PARAM_NAME_INFO_1_1_(F) \
-    F(cl_context_info, CL_CONTEXT_NUM_DEVICES, cl_uint)\
-    F(cl_device_info, CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, cl_uint) \
-    F(cl_device_info, CL_DEVICE_DOUBLE_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_HALF_FP_CONFIG, cl_device_fp_config) \
-    F(cl_device_info, CL_DEVICE_OPENCL_C_VERSION, string) \
-    \
-    F(cl_mem_info, CL_MEM_ASSOCIATED_MEMOBJECT, cl::Memory) \
-    F(cl_mem_info, CL_MEM_OFFSET, size_type) \
-    \
-    F(cl_kernel_work_group_info, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, size_type) \
-    F(cl_kernel_work_group_info, CL_KERNEL_PRIVATE_MEM_SIZE, cl_ulong) \
-    \
-    F(cl_event_info, CL_EVENT_CONTEXT, cl::Context)
+#define CL_HPP_PARAM_NAME_INFO_1_2_(F)                                                           \
+	F (cl_program_info, CL_PROGRAM_NUM_KERNELS, size_type)                                       \
+	F (cl_program_info, CL_PROGRAM_KERNEL_NAMES, string)                                         \
+                                                                                                 \
+	F (cl_program_build_info, CL_PROGRAM_BINARY_TYPE, cl_program_binary_type)                    \
+                                                                                                 \
+	F (cl_kernel_info, CL_KERNEL_ATTRIBUTES, string)                                             \
+                                                                                                 \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_ADDRESS_QUALIFIER, cl_kernel_arg_address_qualifier)     \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_ACCESS_QUALIFIER, cl_kernel_arg_access_qualifier)       \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_NAME, string)                                      \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_NAME, string)                                           \
+	F (cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_QUALIFIER, cl_kernel_arg_type_qualifier)           \
+                                                                                                 \
+	F (cl_device_info, CL_DEVICE_PARENT_DEVICE, cl::Device)                                      \
+	F (cl_device_info, CL_DEVICE_PARTITION_PROPERTIES, cl::vector<cl_device_partition_property>) \
+	F (cl_device_info, CL_DEVICE_PARTITION_TYPE, cl::vector<cl_device_partition_property>)       \
+	F (cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint)                                       \
+	F (cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, size_type)                         \
+	F (cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain)           \
+	F (cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, string)
 
-#define CL_HPP_PARAM_NAME_INFO_1_2_(F) \
-    F(cl_program_info, CL_PROGRAM_NUM_KERNELS, size_type) \
-    F(cl_program_info, CL_PROGRAM_KERNEL_NAMES, string) \
-    \
-    F(cl_program_build_info, CL_PROGRAM_BINARY_TYPE, cl_program_binary_type) \
-    \
-    F(cl_kernel_info, CL_KERNEL_ATTRIBUTES, string) \
-    \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_ADDRESS_QUALIFIER, cl_kernel_arg_address_qualifier) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_ACCESS_QUALIFIER, cl_kernel_arg_access_qualifier) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_NAME, string) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_NAME, string) \
-    F(cl_kernel_arg_info, CL_KERNEL_ARG_TYPE_QUALIFIER, cl_kernel_arg_type_qualifier) \
-    \
-    F(cl_device_info, CL_DEVICE_PARENT_DEVICE, cl::Device) \
-    F(cl_device_info, CL_DEVICE_PARTITION_PROPERTIES, cl::vector<cl_device_partition_property>) \
-    F(cl_device_info, CL_DEVICE_PARTITION_TYPE, cl::vector<cl_device_partition_property>)  \
-    F(cl_device_info, CL_DEVICE_REFERENCE_COUNT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, size_type) \
-    F(cl_device_info, CL_DEVICE_PARTITION_AFFINITY_DOMAIN, cl_device_affinity_domain) \
-    F(cl_device_info, CL_DEVICE_BUILT_IN_KERNELS, string)
+#define CL_HPP_PARAM_NAME_INFO_2_0_(F)                                                    \
+	F (cl_device_info, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES, cl_command_queue_properties)   \
+	F (cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES, cl_command_queue_properties) \
+	F (cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE, cl_uint)                 \
+	F (cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE, cl_uint)                       \
+	F (cl_device_info, CL_DEVICE_MAX_ON_DEVICE_QUEUES, cl_uint)                           \
+	F (cl_device_info, CL_DEVICE_MAX_ON_DEVICE_EVENTS, cl_uint)                           \
+	F (cl_device_info, CL_DEVICE_MAX_PIPE_ARGS, cl_uint)                                  \
+	F (cl_device_info, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS, cl_uint)                   \
+	F (cl_device_info, CL_DEVICE_PIPE_MAX_PACKET_SIZE, cl_uint)                           \
+	F (cl_device_info, CL_DEVICE_SVM_CAPABILITIES, cl_device_svm_capabilities)            \
+	F (cl_device_info, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT, cl_uint)            \
+	F (cl_device_info, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT, cl_uint)              \
+	F (cl_device_info, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT, cl_uint)               \
+	F (cl_command_queue_info, CL_QUEUE_SIZE, cl_uint)                                     \
+	F (cl_mem_info, CL_MEM_USES_SVM_POINTER, cl_bool)                                     \
+	F (cl_program_build_info, CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE, size_type)     \
+	F (cl_pipe_info, CL_PIPE_PACKET_SIZE, cl_uint)                                        \
+	F (cl_pipe_info, CL_PIPE_MAX_PACKETS, cl_uint)
 
-#define CL_HPP_PARAM_NAME_INFO_2_0_(F) \
-    F(cl_device_info, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES, cl_command_queue_properties) \
-    F(cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES, cl_command_queue_properties) \
-    F(cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_ON_DEVICE_QUEUES, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_ON_DEVICE_EVENTS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_MAX_PIPE_ARGS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PIPE_MAX_PACKET_SIZE, cl_uint) \
-    F(cl_device_info, CL_DEVICE_SVM_CAPABILITIES, cl_device_svm_capabilities) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT, cl_uint) \
-    F(cl_device_info, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT, cl_uint) \
-    F(cl_command_queue_info, CL_QUEUE_SIZE, cl_uint) \
-    F(cl_mem_info, CL_MEM_USES_SVM_POINTER, cl_bool) \
-    F(cl_program_build_info, CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE, size_type) \
-    F(cl_pipe_info, CL_PIPE_PACKET_SIZE, cl_uint) \
-    F(cl_pipe_info, CL_PIPE_MAX_PACKETS, cl_uint)
+#define CL_HPP_PARAM_NAME_DEVICE_FISSION_(F)                                                         \
+	F (cl_device_info, CL_DEVICE_PARENT_DEVICE_EXT, cl_device_id)                                    \
+	F (cl_device_info, CL_DEVICE_PARTITION_TYPES_EXT, cl::vector<cl_device_partition_property_ext>)  \
+	F (cl_device_info, CL_DEVICE_AFFINITY_DOMAINS_EXT, cl::vector<cl_device_partition_property_ext>) \
+	F (cl_device_info, CL_DEVICE_REFERENCE_COUNT_EXT, cl_uint)                                       \
+	F (cl_device_info, CL_DEVICE_PARTITION_STYLE_EXT, cl::vector<cl_device_partition_property_ext>)
 
-#define CL_HPP_PARAM_NAME_DEVICE_FISSION_(F) \
-    F(cl_device_info, CL_DEVICE_PARENT_DEVICE_EXT, cl_device_id) \
-    F(cl_device_info, CL_DEVICE_PARTITION_TYPES_EXT, cl::vector<cl_device_partition_property_ext>) \
-    F(cl_device_info, CL_DEVICE_AFFINITY_DOMAINS_EXT, cl::vector<cl_device_partition_property_ext>) \
-    F(cl_device_info, CL_DEVICE_REFERENCE_COUNT_EXT , cl_uint) \
-    F(cl_device_info, CL_DEVICE_PARTITION_STYLE_EXT, cl::vector<cl_device_partition_property_ext>)
-
-template <typename enum_type, cl_int Name>
-struct param_traits {};
+	template <typename enum_type, cl_int Name>
+	struct param_traits
+	{
+	};
 
 #define CL_HPP_DECLARE_PARAM_TRAITS_(token, param_name, T) \
-struct token;                                        \
-template<>                                           \
-struct param_traits<detail:: token,param_name>       \
-{                                                    \
-    enum { value = param_name };                     \
-    typedef T param_type;                            \
-};
+	struct token;                                          \
+	template <>                                            \
+	struct param_traits<detail::token, param_name>         \
+	{                                                      \
+		enum                                               \
+		{                                                  \
+			value = param_name                             \
+		};                                                 \
+		typedef T param_type;                              \
+	};
 
-CL_HPP_PARAM_NAME_INFO_1_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_1_0_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-CL_HPP_PARAM_NAME_INFO_1_1_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_1_1_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-CL_HPP_PARAM_NAME_INFO_1_2_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_1_2_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-CL_HPP_PARAM_NAME_INFO_2_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_2_0_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
-
 
 // Flags deprecated in OpenCL 2.0
 #define CL_HPP_PARAM_NAME_INFO_1_0_DEPRECATED_IN_2_0_(F) \
-    F(cl_device_info, CL_DEVICE_QUEUE_PROPERTIES, cl_command_queue_properties)
+	F (cl_device_info, CL_DEVICE_QUEUE_PROPERTIES, cl_command_queue_properties)
 
 #define CL_HPP_PARAM_NAME_INFO_1_1_DEPRECATED_IN_2_0_(F) \
-    F(cl_device_info, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_bool)
+	F (cl_device_info, CL_DEVICE_HOST_UNIFIED_MEMORY, cl_bool)
 
 #define CL_HPP_PARAM_NAME_INFO_1_2_DEPRECATED_IN_2_0_(F) \
-    F(cl_image_info, CL_IMAGE_BUFFER, cl::Buffer)
+	F (cl_image_info, CL_IMAGE_BUFFER, cl::Buffer)
 
 // Include deprecated query flags based on versions
 // Only include deprecated 1.0 flags if 2.0 not active as there is an enum clash
 #if CL_HPP_TARGET_OPENCL_VERSION > 100 && CL_HPP_MINIMUM_OPENCL_VERSION < 200 && CL_HPP_TARGET_OPENCL_VERSION < 200
-CL_HPP_PARAM_NAME_INFO_1_0_DEPRECATED_IN_2_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_1_0_DEPRECATED_IN_2_0_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 110
 #if CL_HPP_TARGET_OPENCL_VERSION > 110 && CL_HPP_MINIMUM_OPENCL_VERSION < 200
-CL_HPP_PARAM_NAME_INFO_1_1_DEPRECATED_IN_2_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_1_1_DEPRECATED_IN_2_0_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
 #if CL_HPP_TARGET_OPENCL_VERSION > 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 200
-CL_HPP_PARAM_NAME_INFO_1_2_DEPRECATED_IN_2_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+	CL_HPP_PARAM_NAME_INFO_1_2_DEPRECATED_IN_2_0_ (CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 200
 
 #if defined(CL_HPP_USE_CL_DEVICE_FISSION)
-CL_HPP_PARAM_NAME_DEVICE_FISSION_(CL_HPP_DECLARE_PARAM_TRAITS_);
+	CL_HPP_PARAM_NAME_DEVICE_FISSION_ (CL_HPP_DECLARE_PARAM_TRAITS_);
 #endif // CL_HPP_USE_CL_DEVICE_FISSION
 
 #ifdef CL_PLATFORM_ICD_SUFFIX_KHR
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_ICD_SUFFIX_KHR, string)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_platform_info, CL_PLATFORM_ICD_SUFFIX_KHR, string)
 #endif
 
 #ifdef CL_DEVICE_PROFILING_TIMER_OFFSET_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_PROFILING_TIMER_OFFSET_AMD, cl_ulong)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_PROFILING_TIMER_OFFSET_AMD, cl_ulong)
 #endif
 
 #ifdef CL_DEVICE_GLOBAL_FREE_MEMORY_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_GLOBAL_FREE_MEMORY_AMD, vector<size_type>)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_GLOBAL_FREE_MEMORY_AMD, vector<size_type>)
 #endif
 #ifdef CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_SIMD_WIDTH_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SIMD_WIDTH_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_SIMD_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_WAVEFRONT_WIDTH_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_WAVEFRONT_WIDTH_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_WAVEFRONT_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD, cl_uint)
 #endif
 #ifdef CL_DEVICE_LOCAL_MEM_BANKS_AMD
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_LOCAL_MEM_BANKS_AMD, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_LOCAL_MEM_BANKS_AMD, cl_uint)
 #endif
 
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_REGISTERS_PER_BLOCK_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_REGISTERS_PER_BLOCK_NV, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_REGISTERS_PER_BLOCK_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_WARP_SIZE_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_WARP_SIZE_NV, cl_uint)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_WARP_SIZE_NV, cl_uint)
 #endif
 #ifdef CL_DEVICE_GPU_OVERLAP_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_GPU_OVERLAP_NV, cl_bool)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_GPU_OVERLAP_NV, cl_bool)
 #endif
 #ifdef CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV, cl_bool)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV, cl_bool)
 #endif
 #ifdef CL_DEVICE_INTEGRATED_MEMORY_NV
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_INTEGRATED_MEMORY_NV, cl_bool)
+	CL_HPP_DECLARE_PARAM_TRAITS_ (cl_device_info, CL_DEVICE_INTEGRATED_MEMORY_NV, cl_bool)
 #endif
 
-// Convenience functions
+	// Convenience functions
 
-template <typename Func, typename T>
-inline cl_int
-getInfo(Func f, cl_uint name, T* param)
-{
-    return getInfoHelper(f, name, param, 0);
-}
+	template <typename Func, typename T>
+	inline cl_int
+	getInfo (Func f, cl_uint name, T * param)
+	{
+		return getInfoHelper (f, name, param, 0);
+	}
 
-template <typename Func, typename Arg0>
-struct GetInfoFunctor0
-{
-    Func f_; const Arg0& arg0_;
-    cl_int operator ()(
-        cl_uint param, size_type size, void* value, size_type* size_ret)
-    { return f_(arg0_, param, size, value, size_ret); }
-};
+	template <typename Func, typename Arg0>
+	struct GetInfoFunctor0
+	{
+		Func f_;
+		const Arg0 & arg0_;
+		cl_int operator() (
+		cl_uint param, size_type size, void * value, size_type * size_ret)
+		{
+			return f_ (arg0_, param, size, value, size_ret);
+		}
+	};
 
-template <typename Func, typename Arg0, typename Arg1>
-struct GetInfoFunctor1
-{
-    Func f_; const Arg0& arg0_; const Arg1& arg1_;
-    cl_int operator ()(
-        cl_uint param, size_type size, void* value, size_type* size_ret)
-    { return f_(arg0_, arg1_, param, size, value, size_ret); }
-};
+	template <typename Func, typename Arg0, typename Arg1>
+	struct GetInfoFunctor1
+	{
+		Func f_;
+		const Arg0 & arg0_;
+		const Arg1 & arg1_;
+		cl_int operator() (
+		cl_uint param, size_type size, void * value, size_type * size_ret)
+		{
+			return f_ (arg0_, arg1_, param, size, value, size_ret);
+		}
+	};
 
-template <typename Func, typename Arg0, typename T>
-inline cl_int
-getInfo(Func f, const Arg0& arg0, cl_uint name, T* param)
-{
-    GetInfoFunctor0<Func, Arg0> f0 = { f, arg0 };
-    return getInfoHelper(f0, name, param, 0);
-}
+	template <typename Func, typename Arg0, typename T>
+	inline cl_int
+	getInfo (Func f, const Arg0 & arg0, cl_uint name, T * param)
+	{
+		GetInfoFunctor0<Func, Arg0> f0 = { f, arg0 };
+		return getInfoHelper (f0, name, param, 0);
+	}
 
-template <typename Func, typename Arg0, typename Arg1, typename T>
-inline cl_int
-getInfo(Func f, const Arg0& arg0, const Arg1& arg1, cl_uint name, T* param)
-{
-    GetInfoFunctor1<Func, Arg0, Arg1> f0 = { f, arg0, arg1 };
-    return getInfoHelper(f0, name, param, 0);
-}
+	template <typename Func, typename Arg0, typename Arg1, typename T>
+	inline cl_int
+	getInfo (Func f, const Arg0 & arg0, const Arg1 & arg1, cl_uint name, T * param)
+	{
+		GetInfoFunctor1<Func, Arg0, Arg1> f0 = { f, arg0, arg1 };
+		return getInfoHelper (f0, name, param, 0);
+	}
 
-
-template<typename T>
-struct ReferenceHandler
-{ };
+	template <typename T>
+	struct ReferenceHandler
+	{
+	};
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-/**
+	/**
  * OpenCL 1.2 devices do have retain/release.
  */
-template <>
-struct ReferenceHandler<cl_device_id>
-{
-    /**
+	template <>
+	struct ReferenceHandler<cl_device_id>
+	{
+		/**
      * Retain the device.
      * \param device A valid device created using createSubDevices
      * \return 
@@ -1423,9 +1482,11 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_RESOURCES
      *   CL_OUT_OF_HOST_MEMORY
      */
-    static cl_int retain(cl_device_id device)
-    { return ::clRetainDevice(device); }
-    /**
+		static cl_int retain (cl_device_id device)
+		{
+			return ::clRetainDevice (device);
+		}
+		/**
      * Retain the device.
      * \param device A valid device created using createSubDevices
      * \return 
@@ -1434,395 +1495,480 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_RESOURCES
      *   CL_OUT_OF_HOST_MEMORY
      */
-    static cl_int release(cl_device_id device)
-    { return ::clReleaseDevice(device); }
-};
+		static cl_int release (cl_device_id device)
+		{
+			return ::clReleaseDevice (device);
+		}
+	};
 #else // CL_HPP_TARGET_OPENCL_VERSION >= 120
-/**
+	/**
  * OpenCL 1.1 devices do not have retain/release.
  */
-template <>
-struct ReferenceHandler<cl_device_id>
-{
-    // cl_device_id does not have retain().
-    static cl_int retain(cl_device_id)
-    { return CL_SUCCESS; }
-    // cl_device_id does not have release().
-    static cl_int release(cl_device_id)
-    { return CL_SUCCESS; }
-};
+	template <>
+	struct ReferenceHandler<cl_device_id>
+	{
+		// cl_device_id does not have retain().
+		static cl_int retain (cl_device_id)
+		{
+			return CL_SUCCESS;
+		}
+		// cl_device_id does not have release().
+		static cl_int release (cl_device_id)
+		{
+			return CL_SUCCESS;
+		}
+	};
 #endif // ! (CL_HPP_TARGET_OPENCL_VERSION >= 120)
 
-template <>
-struct ReferenceHandler<cl_platform_id>
-{
-    // cl_platform_id does not have retain().
-    static cl_int retain(cl_platform_id)
-    { return CL_SUCCESS; }
-    // cl_platform_id does not have release().
-    static cl_int release(cl_platform_id)
-    { return CL_SUCCESS; }
-};
+	template <>
+	struct ReferenceHandler<cl_platform_id>
+	{
+		// cl_platform_id does not have retain().
+		static cl_int retain (cl_platform_id)
+		{
+			return CL_SUCCESS;
+		}
+		// cl_platform_id does not have release().
+		static cl_int release (cl_platform_id)
+		{
+			return CL_SUCCESS;
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_context>
-{
-    static cl_int retain(cl_context context)
-    { return ::clRetainContext(context); }
-    static cl_int release(cl_context context)
-    { return ::clReleaseContext(context); }
-};
+	template <>
+	struct ReferenceHandler<cl_context>
+	{
+		static cl_int retain (cl_context context)
+		{
+			return ::clRetainContext (context);
+		}
+		static cl_int release (cl_context context)
+		{
+			return ::clReleaseContext (context);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_command_queue>
-{
-    static cl_int retain(cl_command_queue queue)
-    { return ::clRetainCommandQueue(queue); }
-    static cl_int release(cl_command_queue queue)
-    { return ::clReleaseCommandQueue(queue); }
-};
+	template <>
+	struct ReferenceHandler<cl_command_queue>
+	{
+		static cl_int retain (cl_command_queue queue)
+		{
+			return ::clRetainCommandQueue (queue);
+		}
+		static cl_int release (cl_command_queue queue)
+		{
+			return ::clReleaseCommandQueue (queue);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_mem>
-{
-    static cl_int retain(cl_mem memory)
-    { return ::clRetainMemObject(memory); }
-    static cl_int release(cl_mem memory)
-    { return ::clReleaseMemObject(memory); }
-};
+	template <>
+	struct ReferenceHandler<cl_mem>
+	{
+		static cl_int retain (cl_mem memory)
+		{
+			return ::clRetainMemObject (memory);
+		}
+		static cl_int release (cl_mem memory)
+		{
+			return ::clReleaseMemObject (memory);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_sampler>
-{
-    static cl_int retain(cl_sampler sampler)
-    { return ::clRetainSampler(sampler); }
-    static cl_int release(cl_sampler sampler)
-    { return ::clReleaseSampler(sampler); }
-};
+	template <>
+	struct ReferenceHandler<cl_sampler>
+	{
+		static cl_int retain (cl_sampler sampler)
+		{
+			return ::clRetainSampler (sampler);
+		}
+		static cl_int release (cl_sampler sampler)
+		{
+			return ::clReleaseSampler (sampler);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_program>
-{
-    static cl_int retain(cl_program program)
-    { return ::clRetainProgram(program); }
-    static cl_int release(cl_program program)
-    { return ::clReleaseProgram(program); }
-};
+	template <>
+	struct ReferenceHandler<cl_program>
+	{
+		static cl_int retain (cl_program program)
+		{
+			return ::clRetainProgram (program);
+		}
+		static cl_int release (cl_program program)
+		{
+			return ::clReleaseProgram (program);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_kernel>
-{
-    static cl_int retain(cl_kernel kernel)
-    { return ::clRetainKernel(kernel); }
-    static cl_int release(cl_kernel kernel)
-    { return ::clReleaseKernel(kernel); }
-};
+	template <>
+	struct ReferenceHandler<cl_kernel>
+	{
+		static cl_int retain (cl_kernel kernel)
+		{
+			return ::clRetainKernel (kernel);
+		}
+		static cl_int release (cl_kernel kernel)
+		{
+			return ::clReleaseKernel (kernel);
+		}
+	};
 
-template <>
-struct ReferenceHandler<cl_event>
-{
-    static cl_int retain(cl_event event)
-    { return ::clRetainEvent(event); }
-    static cl_int release(cl_event event)
-    { return ::clReleaseEvent(event); }
-};
+	template <>
+	struct ReferenceHandler<cl_event>
+	{
+		static cl_int retain (cl_event event)
+		{
+			return ::clRetainEvent (event);
+		}
+		static cl_int release (cl_event event)
+		{
+			return ::clReleaseEvent (event);
+		}
+	};
 
-
-// Extracts version number with major in the upper 16 bits, minor in the lower 16
-static cl_uint getVersion(const vector<char> &versionInfo)
-{
-    int highVersion = 0;
-    int lowVersion = 0;
-    int index = 7;
-    while(versionInfo[index] != '.' ) {
-        highVersion *= 10;
-        highVersion += versionInfo[index]-'0';
-        ++index;
-    }
-    ++index;
-    while(versionInfo[index] != ' ' &&  versionInfo[index] != '\0') {
-        lowVersion *= 10;
-        lowVersion += versionInfo[index]-'0';
-        ++index;
-    }
-    return (highVersion << 16) | lowVersion;
-}
+	// Extracts version number with major in the upper 16 bits, minor in the lower 16
+	static cl_uint getVersion (const vector<char> & versionInfo)
+	{
+		int highVersion = 0;
+		int lowVersion = 0;
+		int index = 7;
+		while (versionInfo[index] != '.')
+		{
+			highVersion *= 10;
+			highVersion += versionInfo[index] - '0';
+			++index;
+		}
+		++index;
+		while (versionInfo[index] != ' ' && versionInfo[index] != '\0')
+		{
+			lowVersion *= 10;
+			lowVersion += versionInfo[index] - '0';
+			++index;
+		}
+		return (highVersion << 16) | lowVersion;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
-static cl_uint getPlatformVersion(cl_platform_id platform)
-{
-    size_type size = 0;
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, 0, NULL, &size);
-    
-    vector<char> versionInfo(size);
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, size, versionInfo.data(), &size);
-    return getVersion(versionInfo);
-}
+	static cl_uint getPlatformVersion (cl_platform_id platform)
+	{
+		size_type size = 0;
+		clGetPlatformInfo (platform, CL_PLATFORM_VERSION, 0, NULL, &size);
 
-static cl_uint getDevicePlatformVersion(cl_device_id device)
-{
-    cl_platform_id platform;
-    clGetDeviceInfo(device, CL_DEVICE_PLATFORM, sizeof(platform), &platform, NULL);
-    return getPlatformVersion(platform);
-}
+		vector<char> versionInfo (size);
+		clGetPlatformInfo (platform, CL_PLATFORM_VERSION, size, versionInfo.data (), &size);
+		return getVersion (versionInfo);
+	}
 
-static cl_uint getContextPlatformVersion(cl_context context)
-{
-    // The platform cannot be queried directly, so we first have to grab a
-    // device and obtain its context
-    size_type size = 0;
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, 0, NULL, &size);
-    if (size == 0)
-        return 0;
-    vector<cl_device_id> devices(size/sizeof(cl_device_id));
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, size, devices.data(), NULL);
-    return getDevicePlatformVersion(devices[0]);
-}
+	static cl_uint getDevicePlatformVersion (cl_device_id device)
+	{
+		cl_platform_id platform;
+		clGetDeviceInfo (device, CL_DEVICE_PLATFORM, sizeof (platform), &platform, NULL);
+		return getPlatformVersion (platform);
+	}
+
+	static cl_uint getContextPlatformVersion (cl_context context)
+	{
+		// The platform cannot be queried directly, so we first have to grab a
+		// device and obtain its context
+		size_type size = 0;
+		clGetContextInfo (context, CL_CONTEXT_DEVICES, 0, NULL, &size);
+		if (size == 0)
+			return 0;
+		vector<cl_device_id> devices (size / sizeof (cl_device_id));
+		clGetContextInfo (context, CL_CONTEXT_DEVICES, size, devices.data (), NULL);
+		return getDevicePlatformVersion (devices[0]);
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
 
-template <typename T>
-class Wrapper
-{
-public:
-    typedef T cl_type;
+	template <typename T>
+	class Wrapper
+	{
+	public:
+		typedef T cl_type;
 
-protected:
-    cl_type object_;
+	protected:
+		cl_type object_;
 
-public:
-    Wrapper() : object_(NULL) { }
-    
-    Wrapper(const cl_type &obj, bool retainObject) : object_(obj) 
-    {
-        if (retainObject) { 
-            detail::errHandler(retain(), __RETAIN_ERR); 
-        }
-    }
+	public:
+		Wrapper () :
+			object_ (NULL)
+		{
+		}
 
-    ~Wrapper()
-    {
-        if (object_ != NULL) { release(); }
-    }
+		Wrapper (const cl_type & obj, bool retainObject) :
+			object_ (obj)
+		{
+			if (retainObject)
+			{
+				detail::errHandler (retain (), __RETAIN_ERR);
+			}
+		}
 
-    Wrapper(const Wrapper<cl_type>& rhs)
-    {
-        object_ = rhs.object_;
-        detail::errHandler(retain(), __RETAIN_ERR);
-    }
+		~Wrapper ()
+		{
+			if (object_ != NULL)
+			{
+				release ();
+			}
+		}
 
-    Wrapper(Wrapper<cl_type>&& rhs) CL_HPP_NOEXCEPT_
-    {
-        object_ = rhs.object_;
-        rhs.object_ = NULL;
-    }
+		Wrapper (const Wrapper<cl_type> & rhs)
+		{
+			object_ = rhs.object_;
+			detail::errHandler (retain (), __RETAIN_ERR);
+		}
 
-    Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
-    {
-        if (this != &rhs) {
-            detail::errHandler(release(), __RELEASE_ERR);
-            object_ = rhs.object_;
-            detail::errHandler(retain(), __RETAIN_ERR);
-        }
-        return *this;
-    }
+		Wrapper (Wrapper<cl_type> && rhs) CL_HPP_NOEXCEPT_
+		{
+			object_ = rhs.object_;
+			rhs.object_ = NULL;
+		}
 
-    Wrapper<cl_type>& operator = (Wrapper<cl_type>&& rhs)
-    {
-        if (this != &rhs) {
-            detail::errHandler(release(), __RELEASE_ERR);
-            object_ = rhs.object_;
-            rhs.object_ = NULL;
-        }
-        return *this;
-    }
+		Wrapper<cl_type> & operator= (const Wrapper<cl_type> & rhs)
+		{
+			if (this != &rhs)
+			{
+				detail::errHandler (release (), __RELEASE_ERR);
+				object_ = rhs.object_;
+				detail::errHandler (retain (), __RETAIN_ERR);
+			}
+			return *this;
+		}
 
-    Wrapper<cl_type>& operator = (const cl_type &rhs)
-    {
-        detail::errHandler(release(), __RELEASE_ERR);
-        object_ = rhs;
-        return *this;
-    }
+		Wrapper<cl_type> & operator= (Wrapper<cl_type> && rhs)
+		{
+			if (this != &rhs)
+			{
+				detail::errHandler (release (), __RELEASE_ERR);
+				object_ = rhs.object_;
+				rhs.object_ = NULL;
+			}
+			return *this;
+		}
 
-    const cl_type& operator ()() const { return object_; }
+		Wrapper<cl_type> & operator= (const cl_type & rhs)
+		{
+			detail::errHandler (release (), __RELEASE_ERR);
+			object_ = rhs;
+			return *this;
+		}
 
-    cl_type& operator ()() { return object_; }
+		const cl_type & operator() () const
+		{
+			return object_;
+		}
 
-    const cl_type get() const { return object_; }
+		cl_type & operator() ()
+		{
+			return object_;
+		}
 
-    cl_type get() { return object_; }
+		const cl_type get () const
+		{
+			return object_;
+		}
 
+		cl_type get ()
+		{
+			return object_;
+		}
 
-protected:
-    template<typename Func, typename U>
-    friend inline cl_int getInfoHelper(Func, cl_uint, U*, int, typename U::cl_type);
+	protected:
+		template <typename Func, typename U>
+		friend inline cl_int getInfoHelper (Func, cl_uint, U *, int, typename U::cl_type);
 
-    cl_int retain() const
-    {
-        if (object_ != nullptr) {
-            return ReferenceHandler<cl_type>::retain(object_);
-        }
-        else {
-            return CL_SUCCESS;
-        }
-    }
+		cl_int retain () const
+		{
+			if (object_ != nullptr)
+			{
+				return ReferenceHandler<cl_type>::retain (object_);
+			}
+			else
+			{
+				return CL_SUCCESS;
+			}
+		}
 
-    cl_int release() const
-    {
-        if (object_ != nullptr) {
-            return ReferenceHandler<cl_type>::release(object_);
-        }
-        else {
-            return CL_SUCCESS;
-        }
-    }
-};
+		cl_int release () const
+		{
+			if (object_ != nullptr)
+			{
+				return ReferenceHandler<cl_type>::release (object_);
+			}
+			else
+			{
+				return CL_SUCCESS;
+			}
+		}
+	};
 
-template <>
-class Wrapper<cl_device_id>
-{
-public:
-    typedef cl_device_id cl_type;
+	template <>
+	class Wrapper<cl_device_id>
+	{
+	public:
+		typedef cl_device_id cl_type;
 
-protected:
-    cl_type object_;
-    bool referenceCountable_;
+	protected:
+		cl_type object_;
+		bool referenceCountable_;
 
-    static bool isReferenceCountable(cl_device_id device)
-    {
-        bool retVal = false;
+		static bool isReferenceCountable (cl_device_id device)
+		{
+			bool retVal = false;
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
-        if (device != NULL) {
-            int version = getDevicePlatformVersion(device);
-            if(version > ((1 << 16) + 1)) {
-                retVal = true;
-            }
-        }
+			if (device != NULL)
+			{
+				int version = getDevicePlatformVersion (device);
+				if (version > ((1 << 16) + 1))
+				{
+					retVal = true;
+				}
+			}
 #else // CL_HPP_MINIMUM_OPENCL_VERSION < 120
-        retVal = true;
+			retVal = true;
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
-        return retVal;
-    }
+			return retVal;
+		}
 
-public:
-    Wrapper() : object_(NULL), referenceCountable_(false) 
-    { 
-    }
-    
-    Wrapper(const cl_type &obj, bool retainObject) : 
-        object_(obj), 
-        referenceCountable_(false) 
-    {
-        referenceCountable_ = isReferenceCountable(obj); 
+	public:
+		Wrapper () :
+			object_ (NULL), referenceCountable_ (false)
+		{
+		}
 
-        if (retainObject) {
-            detail::errHandler(retain(), __RETAIN_ERR);
-        }
-    }
+		Wrapper (const cl_type & obj, bool retainObject) :
+			object_ (obj),
+			referenceCountable_ (false)
+		{
+			referenceCountable_ = isReferenceCountable (obj);
 
-    ~Wrapper()
-    {
-        release();
-    }
-    
-    Wrapper(const Wrapper<cl_type>& rhs)
-    {
-        object_ = rhs.object_;
-        referenceCountable_ = isReferenceCountable(object_); 
-        detail::errHandler(retain(), __RETAIN_ERR);
-    }
+			if (retainObject)
+			{
+				detail::errHandler (retain (), __RETAIN_ERR);
+			}
+		}
 
-    Wrapper(Wrapper<cl_type>&& rhs) CL_HPP_NOEXCEPT_
-    {
-        object_ = rhs.object_;
-        referenceCountable_ = rhs.referenceCountable_;
-        rhs.object_ = NULL;
-        rhs.referenceCountable_ = false;
-    }
+		~Wrapper ()
+		{
+			release ();
+		}
 
-    Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
-    {
-        if (this != &rhs) {
-            detail::errHandler(release(), __RELEASE_ERR);
-            object_ = rhs.object_;
-            referenceCountable_ = rhs.referenceCountable_;
-            detail::errHandler(retain(), __RETAIN_ERR);
-        }
-        return *this;
-    }
+		Wrapper (const Wrapper<cl_type> & rhs)
+		{
+			object_ = rhs.object_;
+			referenceCountable_ = isReferenceCountable (object_);
+			detail::errHandler (retain (), __RETAIN_ERR);
+		}
 
-    Wrapper<cl_type>& operator = (Wrapper<cl_type>&& rhs)
-    {
-        if (this != &rhs) {
-            detail::errHandler(release(), __RELEASE_ERR);
-            object_ = rhs.object_;
-            referenceCountable_ = rhs.referenceCountable_;
-            rhs.object_ = NULL;
-            rhs.referenceCountable_ = false;
-        }
-        return *this;
-    }
+		Wrapper (Wrapper<cl_type> && rhs) CL_HPP_NOEXCEPT_
+		{
+			object_ = rhs.object_;
+			referenceCountable_ = rhs.referenceCountable_;
+			rhs.object_ = NULL;
+			rhs.referenceCountable_ = false;
+		}
 
-    Wrapper<cl_type>& operator = (const cl_type &rhs)
-    {
-        detail::errHandler(release(), __RELEASE_ERR);
-        object_ = rhs;
-        referenceCountable_ = isReferenceCountable(object_); 
-        return *this;
-    }
+		Wrapper<cl_type> & operator= (const Wrapper<cl_type> & rhs)
+		{
+			if (this != &rhs)
+			{
+				detail::errHandler (release (), __RELEASE_ERR);
+				object_ = rhs.object_;
+				referenceCountable_ = rhs.referenceCountable_;
+				detail::errHandler (retain (), __RETAIN_ERR);
+			}
+			return *this;
+		}
 
-    const cl_type& operator ()() const { return object_; }
+		Wrapper<cl_type> & operator= (Wrapper<cl_type> && rhs)
+		{
+			if (this != &rhs)
+			{
+				detail::errHandler (release (), __RELEASE_ERR);
+				object_ = rhs.object_;
+				referenceCountable_ = rhs.referenceCountable_;
+				rhs.object_ = NULL;
+				rhs.referenceCountable_ = false;
+			}
+			return *this;
+		}
 
-    cl_type& operator ()() { return object_; }
+		Wrapper<cl_type> & operator= (const cl_type & rhs)
+		{
+			detail::errHandler (release (), __RELEASE_ERR);
+			object_ = rhs;
+			referenceCountable_ = isReferenceCountable (object_);
+			return *this;
+		}
 
-    const cl_type get() const { return object_; }
+		const cl_type & operator() () const
+		{
+			return object_;
+		}
 
-    cl_type get() { return object_; }
+		cl_type & operator() ()
+		{
+			return object_;
+		}
 
-protected:
-    template<typename Func, typename U>
-    friend inline cl_int getInfoHelper(Func, cl_uint, U*, int, typename U::cl_type);
+		const cl_type get () const
+		{
+			return object_;
+		}
 
-    template<typename Func, typename U>
-    friend inline cl_int getInfoHelper(Func, cl_uint, vector<U>*, int, typename U::cl_type);
+		cl_type get ()
+		{
+			return object_;
+		}
 
-    cl_int retain() const
-    {
-        if( object_ != nullptr && referenceCountable_ ) {
-            return ReferenceHandler<cl_type>::retain(object_);
-        }
-        else {
-            return CL_SUCCESS;
-        }
-    }
+	protected:
+		template <typename Func, typename U>
+		friend inline cl_int getInfoHelper (Func, cl_uint, U *, int, typename U::cl_type);
 
-    cl_int release() const
-    {
-        if (object_ != nullptr && referenceCountable_) {
-            return ReferenceHandler<cl_type>::release(object_);
-        }
-        else {
-            return CL_SUCCESS;
-        }
-    }
-};
+		template <typename Func, typename U>
+		friend inline cl_int getInfoHelper (Func, cl_uint, vector<U> *, int, typename U::cl_type);
 
-template <typename T>
-inline bool operator==(const Wrapper<T> &lhs, const Wrapper<T> &rhs)
-{
-    return lhs() == rhs();
-}
+		cl_int retain () const
+		{
+			if (object_ != nullptr && referenceCountable_)
+			{
+				return ReferenceHandler<cl_type>::retain (object_);
+			}
+			else
+			{
+				return CL_SUCCESS;
+			}
+		}
 
-template <typename T>
-inline bool operator!=(const Wrapper<T> &lhs, const Wrapper<T> &rhs)
-{
-    return !operator==(lhs, rhs);
-}
+		cl_int release () const
+		{
+			if (object_ != nullptr && referenceCountable_)
+			{
+				return ReferenceHandler<cl_type>::release (object_);
+			}
+			else
+			{
+				return CL_SUCCESS;
+			}
+		}
+	};
+
+	template <typename T>
+	inline bool operator== (const Wrapper<T> & lhs, const Wrapper<T> & rhs)
+	{
+		return lhs () == rhs ();
+	}
+
+	template <typename T>
+	inline bool operator!= (const Wrapper<T> & lhs, const Wrapper<T> & rhs)
+	{
+		return !operator== (lhs, rhs);
+	}
 
 } // namespace detail
 //! \endcond
-
 
 using BuildLogType = vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, CL_PROGRAM_BUILD_LOG>::param_type>>;
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
@@ -1832,44 +1978,48 @@ using BuildLogType = vector<std::pair<cl::Device, typename detail::param_traits<
 class BuildError : public Error
 {
 private:
-    BuildLogType buildLogs;
-public:
-    BuildError(cl_int err, const char * errStr, const BuildLogType &vec) : Error(err, errStr), buildLogs(vec)
-    {
-    }
+	BuildLogType buildLogs;
 
-    BuildLogType getBuildLog() const
-    {
-        return buildLogs;
-    }
+public:
+	BuildError (cl_int err, const char * errStr, const BuildLogType & vec) :
+		Error (err, errStr), buildLogs (vec)
+	{
+	}
+
+	BuildLogType getBuildLog () const
+	{
+		return buildLogs;
+	}
 };
-namespace detail {
-    static inline cl_int buildErrHandler(
-        cl_int err,
-        const char * errStr,
-        const BuildLogType &buildLogs)
-    {
-        if (err != CL_SUCCESS) {
-            throw BuildError(err, errStr, buildLogs);
-        }
-        return err;
-    }
+namespace detail
+{
+	static inline cl_int buildErrHandler (
+	cl_int err,
+	const char * errStr,
+	const BuildLogType & buildLogs)
+	{
+		if (err != CL_SUCCESS)
+		{
+			throw BuildError (err, errStr, buildLogs);
+		}
+		return err;
+	}
 } // namespace detail
 
 #else
-namespace detail {
-    static inline cl_int buildErrHandler(
-        cl_int err,
-        const char * errStr,
-        const BuildLogType &buildLogs)
-    {
-        (void)buildLogs; // suppress unused variable warning
-        (void)errStr;
-        return err;
-    }
+namespace detail
+{
+	static inline cl_int buildErrHandler (
+	cl_int err,
+	const char * errStr,
+	const BuildLogType & buildLogs)
+	{
+		(void)buildLogs; // suppress unused variable warning
+		(void)errStr;
+		return err;
+	}
 } // namespace detail
 #endif // #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-
 
 /*! \stuct ImageFormat
  *  \brief Adds constructors and member functions for cl_image_format.
@@ -1878,25 +2028,28 @@ namespace detail {
  */
 struct ImageFormat : public cl_image_format
 {
-    //! \brief Default constructor - performs no initialization.
-    ImageFormat(){}
+	//! \brief Default constructor - performs no initialization.
+	ImageFormat ()
+	{
+	}
 
-    //! \brief Initializing constructor.
-    ImageFormat(cl_channel_order order, cl_channel_type type)
-    {
-        image_channel_order = order;
-        image_channel_data_type = type;
-    }
+	//! \brief Initializing constructor.
+	ImageFormat (cl_channel_order order, cl_channel_type type)
+	{
+		image_channel_order = order;
+		image_channel_data_type = type;
+	}
 
-    //! \brief Assignment operator.
-    ImageFormat& operator = (const ImageFormat& rhs)
-    {
-        if (this != &rhs) {
-            this->image_channel_data_type = rhs.image_channel_data_type;
-            this->image_channel_order     = rhs.image_channel_order;
-        }
-        return *this;
-    }
+	//! \brief Assignment operator.
+	ImageFormat & operator= (const ImageFormat & rhs)
+	{
+		if (this != &rhs)
+		{
+			this->image_channel_data_type = rhs.image_channel_data_type;
+			this->image_channel_order = rhs.image_channel_order;
+		}
+		return *this;
+	}
 };
 
 /*! \brief Class interface for cl_device_id.
@@ -1909,222 +2062,243 @@ struct ImageFormat : public cl_image_format
 class Device : public detail::Wrapper<cl_device_id>
 {
 private:
-    static std::once_flag default_initialized_;
-    static Device default_;
-    static cl_int default_error_;
+	static std::once_flag default_initialized_;
+	static Device default_;
+	static cl_int default_error_;
 
-    /*! \brief Create the default context.
+	/*! \brief Create the default context.
     *
     * This sets @c default_ and @c default_error_. It does not throw
     * @c cl::Error.
     */
-    static void makeDefault();
+	static void makeDefault ();
 
-    /*! \brief Create the default platform from a provided platform.
+	/*! \brief Create the default platform from a provided platform.
     *
     * This sets @c default_. It does not throw
     * @c cl::Error.
     */
-    static void makeDefaultProvided(const Device &p) {
-        default_ = p;
-    }
+	static void makeDefaultProvided (const Device & p)
+	{
+		default_ = p;
+	}
 
 public:
 #ifdef CL_HPP_UNIT_TEST_ENABLE
-    /*! \brief Reset the default.
+	/*! \brief Reset the default.
     *
     * This sets @c default_ to an empty value to support cleanup in
     * the unit test framework.
     * This function is not thread safe.
     */
-    static void unitTestClearDefault() {
-        default_ = Device();
-    }
+	static void unitTestClearDefault ()
+	{
+		default_ = Device ();
+	}
 #endif // #ifdef CL_HPP_UNIT_TEST_ENABLE
 
-    //! \brief Default constructor - initializes to NULL.
-    Device() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Device () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_device_id.
+	/*! \brief Constructor from cl_device_id.
      * 
      *  This simply copies the device ID value, which is an inexpensive operation.
      */
-    explicit Device(const cl_device_id &device, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(device, retainObject) { }
+	explicit Device (const cl_device_id & device, bool retainObject = false) :
+		detail::Wrapper<cl_type> (device, retainObject)
+	{
+	}
 
-    /*! \brief Returns the first device on the default context.
+	/*! \brief Returns the first device on the default context.
      *
      *  \see Context::getDefault()
      */
-    static Device getDefault(
-        cl_int *errResult = NULL)
-    {
-        std::call_once(default_initialized_, makeDefault);
-        detail::errHandler(default_error_);
-        if (errResult != NULL) {
-            *errResult = default_error_;
-        }
-        return default_;
-    }
+	static Device getDefault (
+	cl_int * errResult = NULL)
+	{
+		std::call_once (default_initialized_, makeDefault);
+		detail::errHandler (default_error_);
+		if (errResult != NULL)
+		{
+			*errResult = default_error_;
+		}
+		return default_;
+	}
 
-    /**
+	/**
     * Modify the default device to be used by
     * subsequent operations.
     * Will only set the default if no default was previously created.
     * @return updated default device.
     *         Should be compared to the passed value to ensure that it was updated.
     */
-    static Device setDefault(const Device &default_device)
-    {
-        std::call_once(default_initialized_, makeDefaultProvided, std::cref(default_device));
-        detail::errHandler(default_error_);
-        return default_;
-    }
+	static Device setDefault (const Device & default_device)
+	{
+		std::call_once (default_initialized_, makeDefaultProvided, std::cref (default_device));
+		detail::errHandler (default_error_);
+		return default_;
+	}
 
-    /*! \brief Assignment operator from cl_device_id.
+	/*! \brief Assignment operator from cl_device_id.
      * 
      *  This simply copies the device ID value, which is an inexpensive operation.
      */
-    Device& operator = (const cl_device_id& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Device & operator= (const cl_device_id & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    Device(const Device& dev) : detail::Wrapper<cl_type>(dev) {}
+	Device (const Device & dev) :
+		detail::Wrapper<cl_type> (dev)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    Device& operator = (const Device &dev)
-    {
-        detail::Wrapper<cl_type>::operator=(dev);
-        return *this;
-    }
+	Device & operator= (const Device & dev)
+	{
+		detail::Wrapper<cl_type>::operator= (dev);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    Device(Device&& dev) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(dev)) {}
+	Device (Device && dev) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (dev))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
     * Required for MSVC.
     */
-    Device& operator = (Device &&dev)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(dev));
-        return *this;
-    }
+	Device & operator= (Device && dev)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (dev));
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetDeviceInfo().
-    template <typename T>
-    cl_int getInfo(cl_device_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetDeviceInfo, object_, name, param),
-            __GET_DEVICE_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetDeviceInfo().
+	template <typename T>
+	cl_int getInfo (cl_device_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetDeviceInfo, object_, name, param),
+		__GET_DEVICE_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetDeviceInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_device_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_device_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetDeviceInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_device_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_device_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /**
+	/**
      * CL 1.2 version
      */
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    //! \brief Wrapper for clCreateSubDevices().
-    cl_int createSubDevices(
-        const cl_device_partition_property * properties,
-        vector<Device>* devices)
-    {
-        cl_uint n = 0;
-        cl_int err = clCreateSubDevices(object_, properties, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
-        }
+	//! \brief Wrapper for clCreateSubDevices().
+	cl_int createSubDevices (
+	const cl_device_partition_property * properties,
+	vector<Device> * devices)
+	{
+		cl_uint n = 0;
+		cl_int err = clCreateSubDevices (object_, properties, 0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES_ERR);
+		}
 
-        vector<cl_device_id> ids(n);
-        err = clCreateSubDevices(object_, properties, n, ids.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
-        }
+		vector<cl_device_id> ids (n);
+		err = clCreateSubDevices (object_, properties, n, ids.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES_ERR);
+		}
 
-        // Cannot trivially assign because we need to capture intermediates 
-        // with safe construction
-        if (devices) {
-            devices->resize(ids.size());
+		// Cannot trivially assign because we need to capture intermediates
+		// with safe construction
+		if (devices)
+		{
+			devices->resize (ids.size ());
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < ids.size(); i++) {
-                // We do not need to retain because this device is being created 
-                // by the runtime
-                (*devices)[i] = Device(ids[i], false);
-            }
-        }
+			// Assign to param, constructing with retain behaviour
+			// to correctly capture each underlying CL object
+			for (size_type i = 0; i < ids.size (); i++)
+			{
+				// We do not need to retain because this device is being created
+				// by the runtime
+				(*devices)[i] = Device (ids[i], false);
+			}
+		}
 
-        return CL_SUCCESS;
-    }
+		return CL_SUCCESS;
+	}
 #elif defined(CL_HPP_USE_CL_DEVICE_FISSION)
 
-/**
+	/**
  * CL 1.1 version that uses device fission extension.
  */
-    cl_int createSubDevices(
-        const cl_device_partition_property_ext * properties,
-        vector<Device>* devices)
-    {
-        typedef CL_API_ENTRY cl_int 
-            ( CL_API_CALL * PFN_clCreateSubDevicesEXT)(
-                cl_device_id /*in_device*/,
-                const cl_device_partition_property_ext * /* properties */,
-                cl_uint /*num_entries*/,
-                cl_device_id * /*out_devices*/,
-                cl_uint * /*num_devices*/ ) CL_EXT_SUFFIX__VERSION_1_1;
+	cl_int createSubDevices (
+	const cl_device_partition_property_ext * properties,
+	vector<Device> * devices)
+	{
+		typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clCreateSubDevicesEXT) (
+		cl_device_id /*in_device*/,
+		const cl_device_partition_property_ext * /* properties */,
+		cl_uint /*num_entries*/,
+		cl_device_id * /*out_devices*/,
+		cl_uint * /*num_devices*/) CL_EXT_SUFFIX__VERSION_1_1;
 
-        static PFN_clCreateSubDevicesEXT pfn_clCreateSubDevicesEXT = NULL;
-        CL_HPP_INIT_CL_EXT_FCN_PTR_(clCreateSubDevicesEXT);
+		static PFN_clCreateSubDevicesEXT pfn_clCreateSubDevicesEXT = NULL;
+		CL_HPP_INIT_CL_EXT_FCN_PTR_ (clCreateSubDevicesEXT);
 
-        cl_uint n = 0;
-        cl_int err = pfn_clCreateSubDevicesEXT(object_, properties, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
-        }
+		cl_uint n = 0;
+		cl_int err = pfn_clCreateSubDevicesEXT (object_, properties, 0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES_ERR);
+		}
 
-        vector<cl_device_id> ids(n);
-        err = pfn_clCreateSubDevicesEXT(object_, properties, n, ids.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
-        }
-        // Cannot trivially assign because we need to capture intermediates 
-        // with safe construction
-        if (devices) {
-            devices->resize(ids.size());
+		vector<cl_device_id> ids (n);
+		err = pfn_clCreateSubDevicesEXT (object_, properties, n, ids.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_SUB_DEVICES_ERR);
+		}
+		// Cannot trivially assign because we need to capture intermediates
+		// with safe construction
+		if (devices)
+		{
+			devices->resize (ids.size ());
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < ids.size(); i++) {
-                // We do not need to retain because this device is being created 
-                // by the runtime
-                (*devices)[i] = Device(ids[i], false);
-            }
-        }
-        return CL_SUCCESS;
-    }
+			// Assign to param, constructing with retain behaviour
+			// to correctly capture each underlying CL object
+			for (size_type i = 0; i < ids.size (); i++)
+			{
+				// We do not need to retain because this device is being created
+				// by the runtime
+				(*devices)[i] = Device (ids[i], false);
+			}
+		}
+		return CL_SUCCESS;
+	}
 #endif // defined(CL_HPP_USE_CL_DEVICE_FISSION)
 };
 
@@ -2142,186 +2316,205 @@ CL_HPP_DEFINE_STATIC_MEMBER_ cl_int Device::default_error_ = CL_SUCCESS;
 class Platform : public detail::Wrapper<cl_platform_id>
 {
 private:
-    static std::once_flag default_initialized_;
-    static Platform default_;
-    static cl_int default_error_;
+	static std::once_flag default_initialized_;
+	static Platform default_;
+	static cl_int default_error_;
 
-    /*! \brief Create the default context.
+	/*! \brief Create the default context.
     *
     * This sets @c default_ and @c default_error_. It does not throw
     * @c cl::Error.
     */
-    static void makeDefault() {
-        /* Throwing an exception from a call_once invocation does not do
+	static void makeDefault ()
+	{
+		/* Throwing an exception from a call_once invocation does not do
         * what we wish, so we catch it and save the error.
         */
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        try
+		try
 #endif
-        {
-            // If default wasn't passed ,generate one
-            // Otherwise set it
-            cl_uint n = 0;
+		{
+			// If default wasn't passed ,generate one
+			// Otherwise set it
+			cl_uint n = 0;
 
-            cl_int err = ::clGetPlatformIDs(0, NULL, &n);
-            if (err != CL_SUCCESS) {
-                default_error_ = err;
-                return;
-            }
-            if (n == 0) {
-                default_error_ = CL_INVALID_PLATFORM;
-                return;
-            }
+			cl_int err = ::clGetPlatformIDs (0, NULL, &n);
+			if (err != CL_SUCCESS)
+			{
+				default_error_ = err;
+				return;
+			}
+			if (n == 0)
+			{
+				default_error_ = CL_INVALID_PLATFORM;
+				return;
+			}
 
-            vector<cl_platform_id> ids(n);
-            err = ::clGetPlatformIDs(n, ids.data(), NULL);
-            if (err != CL_SUCCESS) {
-                default_error_ = err;
-                return;
-            }
+			vector<cl_platform_id> ids (n);
+			err = ::clGetPlatformIDs (n, ids.data (), NULL);
+			if (err != CL_SUCCESS)
+			{
+				default_error_ = err;
+				return;
+			}
 
-            default_ = Platform(ids[0]);
-        }
+			default_ = Platform (ids[0]);
+		}
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        catch (cl::Error &e) {
-            default_error_ = e.err();
-        }
+		catch (cl::Error & e)
+		{
+			default_error_ = e.err ();
+		}
 #endif
-    }
+	}
 
-    /*! \brief Create the default platform from a provided platform.
+	/*! \brief Create the default platform from a provided platform.
      *
      * This sets @c default_. It does not throw
      * @c cl::Error.
      */
-    static void makeDefaultProvided(const Platform &p) {
-       default_ = p;
-    }
-    
+	static void makeDefaultProvided (const Platform & p)
+	{
+		default_ = p;
+	}
+
 public:
 #ifdef CL_HPP_UNIT_TEST_ENABLE
-    /*! \brief Reset the default.
+	/*! \brief Reset the default.
     *
     * This sets @c default_ to an empty value to support cleanup in
     * the unit test framework.
     * This function is not thread safe.
     */
-    static void unitTestClearDefault() {
-        default_ = Platform();
-    }
+	static void unitTestClearDefault ()
+	{
+		default_ = Platform ();
+	}
 #endif // #ifdef CL_HPP_UNIT_TEST_ENABLE
 
-    //! \brief Default constructor - initializes to NULL.
-    Platform() : detail::Wrapper<cl_type>()  { }
+	//! \brief Default constructor - initializes to NULL.
+	Platform () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_platform_id.
+	/*! \brief Constructor from cl_platform_id.
      * 
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  This simply copies the platform ID value, which is an inexpensive operation.
      */
-    explicit Platform(const cl_platform_id &platform, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(platform, retainObject) { }
+	explicit Platform (const cl_platform_id & platform, bool retainObject = false) :
+		detail::Wrapper<cl_type> (platform, retainObject)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_platform_id.
+	/*! \brief Assignment operator from cl_platform_id.
      * 
      *  This simply copies the platform ID value, which is an inexpensive operation.
      */
-    Platform& operator = (const cl_platform_id& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Platform & operator= (const cl_platform_id & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    static Platform getDefault(
-        cl_int *errResult = NULL)
-    {
-        std::call_once(default_initialized_, makeDefault);
-        detail::errHandler(default_error_);
-        if (errResult != NULL) {
-            *errResult = default_error_;
-        }
-        return default_;
-    }
+	static Platform getDefault (
+	cl_int * errResult = NULL)
+	{
+		std::call_once (default_initialized_, makeDefault);
+		detail::errHandler (default_error_);
+		if (errResult != NULL)
+		{
+			*errResult = default_error_;
+		}
+		return default_;
+	}
 
-    /**
+	/**
      * Modify the default platform to be used by 
      * subsequent operations.
      * Will only set the default if no default was previously created.
      * @return updated default platform. 
      *         Should be compared to the passed value to ensure that it was updated.
      */
-    static Platform setDefault(const Platform &default_platform)
-    {
-        std::call_once(default_initialized_, makeDefaultProvided, std::cref(default_platform));
-        detail::errHandler(default_error_);
-        return default_;
-    }
+	static Platform setDefault (const Platform & default_platform)
+	{
+		std::call_once (default_initialized_, makeDefaultProvided, std::cref (default_platform));
+		detail::errHandler (default_error_);
+		return default_;
+	}
 
-    //! \brief Wrapper for clGetPlatformInfo().
-    cl_int getInfo(cl_platform_info name, string* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetPlatformInfo, object_, name, param),
-            __GET_PLATFORM_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetPlatformInfo().
+	cl_int getInfo (cl_platform_info name, string * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetPlatformInfo, object_, name, param),
+		__GET_PLATFORM_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetPlatformInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_platform_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_platform_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetPlatformInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_platform_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_platform_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*! \brief Gets a list of devices for this platform.
+	/*! \brief Gets a list of devices for this platform.
      * 
      *  Wraps clGetDeviceIDs().
      */
-    cl_int getDevices(
-        cl_device_type type,
-        vector<Device>* devices) const
-    {
-        cl_uint n = 0;
-        if( devices == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
-        }
-        cl_int err = ::clGetDeviceIDs(object_, type, 0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+	cl_int getDevices (
+	cl_device_type type,
+	vector<Device> * devices) const
+	{
+		cl_uint n = 0;
+		if (devices == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
+		}
+		cl_int err = ::clGetDeviceIDs (object_, type, 0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        vector<cl_device_id> ids(n);
-        err = ::clGetDeviceIDs(object_, type, n, ids.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+		vector<cl_device_id> ids (n);
+		err = ::clGetDeviceIDs (object_, type, n, ids.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        // Cannot trivially assign because we need to capture intermediates 
-        // with safe construction
-        // We must retain things we obtain from the API to avoid releasing
-        // API-owned objects.
-        if (devices) {
-            devices->resize(ids.size());
+		// Cannot trivially assign because we need to capture intermediates
+		// with safe construction
+		// We must retain things we obtain from the API to avoid releasing
+		// API-owned objects.
+		if (devices)
+		{
+			devices->resize (ids.size ());
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < ids.size(); i++) {
-                (*devices)[i] = Device(ids[i], true);
-            }
-        }
-        return CL_SUCCESS;
-    }
+			// Assign to param, constructing with retain behaviour
+			// to correctly capture each underlying CL object
+			for (size_type i = 0; i < ids.size (); i++)
+			{
+				(*devices)[i] = Device (ids[i], true);
+			}
+		}
+		return CL_SUCCESS;
+	}
 
 #if defined(CL_HPP_USE_DX_INTEROP)
-   /*! \brief Get the list of available D3D10 devices.
+	/*! \brief Get the list of available D3D10 devices.
      *
      *  \param d3d_device_source.
      *
@@ -2344,122 +2537,133 @@ public:
      * other than CL_SUCCESS is generated, then cl::Error exception is
      * generated.
      */
-    cl_int getDevices(
-        cl_d3d10_device_source_khr d3d_device_source,
-        void *                     d3d_object,
-        cl_d3d10_device_set_khr    d3d_device_set,
-        vector<Device>* devices) const
-    {
-        typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clGetDeviceIDsFromD3D10KHR)(
-            cl_platform_id platform, 
-            cl_d3d10_device_source_khr d3d_device_source, 
-            void * d3d_object,
-            cl_d3d10_device_set_khr d3d_device_set,
-            cl_uint num_entries,
-            cl_device_id * devices,
-            cl_uint* num_devices);
+	cl_int getDevices (
+	cl_d3d10_device_source_khr d3d_device_source,
+	void * d3d_object,
+	cl_d3d10_device_set_khr d3d_device_set,
+	vector<Device> * devices) const
+	{
+		typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clGetDeviceIDsFromD3D10KHR) (
+		cl_platform_id platform,
+		cl_d3d10_device_source_khr d3d_device_source,
+		void * d3d_object,
+		cl_d3d10_device_set_khr d3d_device_set,
+		cl_uint num_entries,
+		cl_device_id * devices,
+		cl_uint * num_devices);
 
-        if( devices == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
-        }
+		if (devices == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
+		}
 
-        static PFN_clGetDeviceIDsFromD3D10KHR pfn_clGetDeviceIDsFromD3D10KHR = NULL;
-        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(object_, clGetDeviceIDsFromD3D10KHR);
+		static PFN_clGetDeviceIDsFromD3D10KHR pfn_clGetDeviceIDsFromD3D10KHR = NULL;
+		CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_ (object_, clGetDeviceIDsFromD3D10KHR);
 
-        cl_uint n = 0;
-        cl_int err = pfn_clGetDeviceIDsFromD3D10KHR(
-            object_, 
-            d3d_device_source, 
-            d3d_object,
-            d3d_device_set, 
-            0, 
-            NULL, 
-            &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+		cl_uint n = 0;
+		cl_int err = pfn_clGetDeviceIDsFromD3D10KHR (
+		object_,
+		d3d_device_source,
+		d3d_object,
+		d3d_device_set,
+		0,
+		NULL,
+		&n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        vector<cl_device_id> ids(n);
-        err = pfn_clGetDeviceIDsFromD3D10KHR(
-            object_, 
-            d3d_device_source, 
-            d3d_object,
-            d3d_device_set,
-            n, 
-            ids.data(), 
-            NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
-        }
+		vector<cl_device_id> ids (n);
+		err = pfn_clGetDeviceIDsFromD3D10KHR (
+		object_,
+		d3d_device_source,
+		d3d_object,
+		d3d_device_set,
+		n,
+		ids.data (),
+		NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_DEVICE_IDS_ERR);
+		}
 
-        // Cannot trivially assign because we need to capture intermediates 
-        // with safe construction
-        // We must retain things we obtain from the API to avoid releasing
-        // API-owned objects.
-        if (devices) {
-            devices->resize(ids.size());
+		// Cannot trivially assign because we need to capture intermediates
+		// with safe construction
+		// We must retain things we obtain from the API to avoid releasing
+		// API-owned objects.
+		if (devices)
+		{
+			devices->resize (ids.size ());
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < ids.size(); i++) {
-                (*devices)[i] = Device(ids[i], true);
-            }
-        }
-        return CL_SUCCESS;
-    }
+			// Assign to param, constructing with retain behaviour
+			// to correctly capture each underlying CL object
+			for (size_type i = 0; i < ids.size (); i++)
+			{
+				(*devices)[i] = Device (ids[i], true);
+			}
+		}
+		return CL_SUCCESS;
+	}
 #endif
 
-    /*! \brief Gets a list of available platforms.
+	/*! \brief Gets a list of available platforms.
      * 
      *  Wraps clGetPlatformIDs().
      */
-    static cl_int get(
-        vector<Platform>* platforms)
-    {
-        cl_uint n = 0;
+	static cl_int get (
+	vector<Platform> * platforms)
+	{
+		cl_uint n = 0;
 
-        if( platforms == NULL ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
-        }
+		if (platforms == NULL)
+		{
+			return detail::errHandler (CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
+		}
 
-        cl_int err = ::clGetPlatformIDs(0, NULL, &n);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-        }
+		cl_int err = ::clGetPlatformIDs (0, NULL, &n);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+		}
 
-        vector<cl_platform_id> ids(n);
-        err = ::clGetPlatformIDs(n, ids.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
-        }
+		vector<cl_platform_id> ids (n);
+		err = ::clGetPlatformIDs (n, ids.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_PLATFORM_IDS_ERR);
+		}
 
-        if (platforms) {
-            platforms->resize(ids.size());
+		if (platforms)
+		{
+			platforms->resize (ids.size ());
 
-            // Platforms don't reference count
-            for (size_type i = 0; i < ids.size(); i++) {
-                (*platforms)[i] = Platform(ids[i]);
-            }
-        }
-        return CL_SUCCESS;
-    }
+			// Platforms don't reference count
+			for (size_type i = 0; i < ids.size (); i++)
+			{
+				(*platforms)[i] = Platform (ids[i]);
+			}
+		}
+		return CL_SUCCESS;
+	}
 
-    /*! \brief Gets the first available platform.
+	/*! \brief Gets the first available platform.
      * 
      *  Wraps clGetPlatformIDs(), returning the first result.
      */
-    static cl_int get(
-        Platform * platform)
-    {
-        cl_int err;
-        Platform default_platform = Platform::getDefault(&err);
-        if (platform) {
-            *platform = default_platform;
-        }
-        return err;
-    }
+	static cl_int get (
+	Platform * platform)
+	{
+		cl_int err;
+		Platform default_platform = Platform::getDefault (&err);
+		if (platform)
+		{
+			*platform = default_platform;
+		}
+		return err;
+	}
 
-    /*! \brief Gets the first available platform, returning it by value.
+	/*! \brief Gets the first available platform, returning it by value.
      *
      * \return Returns a valid platform if one is available.
      *         If no platform is available will return a null platform.
@@ -2467,31 +2671,31 @@ public:
      * or an error condition occurs.
      * Wraps clGetPlatformIDs(), returning the first result.
      */
-    static Platform get(
-        cl_int * errResult = NULL)
-    {
-        cl_int err;
-        Platform default_platform = Platform::getDefault(&err);
-        if (errResult) {
-            *errResult = err;
-        }
-        return default_platform;
-    }    
-    
+	static Platform get (
+	cl_int * errResult = NULL)
+	{
+		cl_int err;
+		Platform default_platform = Platform::getDefault (&err);
+		if (errResult)
+		{
+			*errResult = err;
+		}
+		return default_platform;
+	}
+
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    //! \brief Wrapper for clUnloadCompiler().
-    cl_int
-    unloadCompiler()
-    {
-        return ::clUnloadPlatformCompiler(object_);
-    }
+	//! \brief Wrapper for clUnloadCompiler().
+	cl_int
+	unloadCompiler ()
+	{
+		return ::clUnloadPlatformCompiler (object_);
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 }; // class Platform
 
 CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag Platform::default_initialized_;
 CL_HPP_DEFINE_STATIC_MEMBER_ Platform Platform::default_;
 CL_HPP_DEFINE_STATIC_MEMBER_ cl_int Platform::default_error_ = CL_SUCCESS;
-
 
 /**
  * Deprecated APIs for 1.2
@@ -2502,11 +2706,11 @@ CL_HPP_DEFINE_STATIC_MEMBER_ cl_int Platform::default_error_ = CL_SUCCESS;
  * \note Deprecated for OpenCL 1.2. Use Platform::unloadCompiler instead.
  */
 inline CL_EXT_PREFIX__VERSION_1_1_DEPRECATED cl_int
-UnloadCompiler() CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
+UnloadCompiler () CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
 inline cl_int
-UnloadCompiler()
+UnloadCompiler ()
 {
-    return ::clUnloadCompiler();
+	return ::clUnloadCompiler ();
 }
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
@@ -2518,398 +2722,439 @@ UnloadCompiler()
  *
  *  \see cl_context
  */
-class Context 
-    : public detail::Wrapper<cl_context>
+class Context
+	: public detail::Wrapper<cl_context>
 {
 private:
-    static std::once_flag default_initialized_;
-    static Context default_;
-    static cl_int default_error_;
+	static std::once_flag default_initialized_;
+	static Context default_;
+	static cl_int default_error_;
 
-    /*! \brief Create the default context from the default device type in the default platform.
+	/*! \brief Create the default context from the default device type in the default platform.
      *
      * This sets @c default_ and @c default_error_. It does not throw
      * @c cl::Error.
      */
-    static void makeDefault() {
-        /* Throwing an exception from a call_once invocation does not do
+	static void makeDefault ()
+	{
+		/* Throwing an exception from a call_once invocation does not do
          * what we wish, so we catch it and save the error.
          */
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        try
+		try
 #endif
-        {
+		{
 #if !defined(__APPLE__) && !defined(__MACOS)
-            const Platform &p = Platform::getDefault();
-            cl_platform_id defaultPlatform = p();
-            cl_context_properties properties[3] = {
-                CL_CONTEXT_PLATFORM, (cl_context_properties)defaultPlatform, 0
-            };
+			const Platform & p = Platform::getDefault ();
+			cl_platform_id defaultPlatform = p ();
+			cl_context_properties properties[3] = {
+				CL_CONTEXT_PLATFORM, (cl_context_properties)defaultPlatform, 0
+			};
 #else // #if !defined(__APPLE__) && !defined(__MACOS)
-            cl_context_properties *properties = nullptr;
+			cl_context_properties * properties = nullptr;
 #endif // #if !defined(__APPLE__) && !defined(__MACOS)
 
-            default_ = Context(
-                CL_DEVICE_TYPE_DEFAULT,
-                properties,
-                NULL,
-                NULL,
-                &default_error_);
-        }
+			default_ = Context (
+			CL_DEVICE_TYPE_DEFAULT,
+			properties,
+			NULL,
+			NULL,
+			&default_error_);
+		}
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        catch (cl::Error &e) {
-            default_error_ = e.err();
-        }
+		catch (cl::Error & e)
+		{
+			default_error_ = e.err ();
+		}
 #endif
-    }
+	}
 
-
-    /*! \brief Create the default context from a provided Context.
+	/*! \brief Create the default context from a provided Context.
      *
      * This sets @c default_. It does not throw
      * @c cl::Error.
      */
-    static void makeDefaultProvided(const Context &c) {
-        default_ = c;
-    }
-    
+	static void makeDefaultProvided (const Context & c)
+	{
+		default_ = c;
+	}
+
 public:
 #ifdef CL_HPP_UNIT_TEST_ENABLE
-    /*! \brief Reset the default.
+	/*! \brief Reset the default.
     *
     * This sets @c default_ to an empty value to support cleanup in
     * the unit test framework.
     * This function is not thread safe.
     */
-    static void unitTestClearDefault() {
-        default_ = Context();
-    }
+	static void unitTestClearDefault ()
+	{
+		default_ = Context ();
+	}
 #endif // #ifdef CL_HPP_UNIT_TEST_ENABLE
 
-    /*! \brief Constructs a context including a list of specified devices.
+	/*! \brief Constructs a context including a list of specified devices.
      *
      *  Wraps clCreateContext().
      */
-    Context(
-        const vector<Device>& devices,
-        cl_context_properties* properties = NULL,
-        void (CL_CALLBACK * notifyFptr)(
-            const char *,
-            const void *,
-            size_type,
-            void *) = NULL,
-        void* data = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Context (
+	const vector<Device> & devices,
+	cl_context_properties * properties = NULL,
+	void (CL_CALLBACK * notifyFptr) (
+	const char *,
+	const void *,
+	size_type,
+	void *)
+	= NULL,
+	void * data = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        size_type numDevices = devices.size();
-        vector<cl_device_id> deviceIDs(numDevices);
+		size_type numDevices = devices.size ();
+		vector<cl_device_id> deviceIDs (numDevices);
 
-        for( size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
+		for (size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        object_ = ::clCreateContext(
-            properties, (cl_uint) numDevices,
-            deviceIDs.data(),
-            notifyFptr, data, &error);
+		object_ = ::clCreateContext (
+		properties, (cl_uint)numDevices,
+		deviceIDs.data (),
+		notifyFptr, data, &error);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Context(
-        const Device& device,
-        cl_context_properties* properties = NULL,
-        void (CL_CALLBACK * notifyFptr)(
-            const char *,
-            const void *,
-            size_type,
-            void *) = NULL,
-        void* data = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Context (
+	const Device & device,
+	cl_context_properties * properties = NULL,
+	void (CL_CALLBACK * notifyFptr) (
+	const char *,
+	const void *,
+	size_type,
+	void *)
+	= NULL,
+	void * data = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        cl_device_id deviceID = device();
+		cl_device_id deviceID = device ();
 
-        object_ = ::clCreateContext(
-            properties, 1,
-            &deviceID,
-            notifyFptr, data, &error);
+		object_ = ::clCreateContext (
+		properties, 1,
+		&deviceID,
+		notifyFptr, data, &error);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
-    
-    /*! \brief Constructs a context including all or a subset of devices of a specified type.
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+
+	/*! \brief Constructs a context including all or a subset of devices of a specified type.
      *
      *  Wraps clCreateContextFromType().
      */
-    Context(
-        cl_device_type type,
-        cl_context_properties* properties = NULL,
-        void (CL_CALLBACK * notifyFptr)(
-            const char *,
-            const void *,
-            size_type,
-            void *) = NULL,
-        void* data = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Context (
+	cl_device_type type,
+	cl_context_properties * properties = NULL,
+	void (CL_CALLBACK * notifyFptr) (
+	const char *,
+	const void *,
+	size_type,
+	void *)
+	= NULL,
+	void * data = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
 #if !defined(__APPLE__) && !defined(__MACOS)
-        cl_context_properties prop[4] = {CL_CONTEXT_PLATFORM, 0, 0, 0 };
+		cl_context_properties prop[4] = { CL_CONTEXT_PLATFORM, 0, 0, 0 };
 
-        if (properties == NULL) {
-            // Get a valid platform ID as we cannot send in a blank one
-            vector<Platform> platforms;
-            error = Platform::get(&platforms);
-            if (error != CL_SUCCESS) {
-                detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
-                if (err != NULL) {
-                    *err = error;
-                }
-                return;
-            }
+		if (properties == NULL)
+		{
+			// Get a valid platform ID as we cannot send in a blank one
+			vector<Platform> platforms;
+			error = Platform::get (&platforms);
+			if (error != CL_SUCCESS)
+			{
+				detail::errHandler (error, __CREATE_CONTEXT_FROM_TYPE_ERR);
+				if (err != NULL)
+				{
+					*err = error;
+				}
+				return;
+			}
 
-            // Check the platforms we found for a device of our specified type
-            cl_context_properties platform_id = 0;
-            for (unsigned int i = 0; i < platforms.size(); i++) {
-
-                vector<Device> devices;
-
-#if defined(CL_HPP_ENABLE_EXCEPTIONS)
-                try {
-#endif
-
-                    error = platforms[i].getDevices(type, &devices);
+			// Check the platforms we found for a device of our specified type
+			cl_context_properties platform_id = 0;
+			for (unsigned int i = 0; i < platforms.size (); i++)
+			{
+				vector<Device> devices;
 
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-                } catch (Error) {}
-    // Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
-    // We do error checking next anyway, and can throw there if needed
+				try
+				{
 #endif
 
-                // Only squash CL_SUCCESS and CL_DEVICE_NOT_FOUND
-                if (error != CL_SUCCESS && error != CL_DEVICE_NOT_FOUND) {
-                    detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
-                    if (err != NULL) {
-                        *err = error;
-                    }
-                }
+					error = platforms[i].getDevices (type, &devices);
 
-                if (devices.size() > 0) {
-                    platform_id = (cl_context_properties)platforms[i]();
-                    break;
-                }
-            }
-
-            if (platform_id == 0) {
-                detail::errHandler(CL_DEVICE_NOT_FOUND, __CREATE_CONTEXT_FROM_TYPE_ERR);
-                if (err != NULL) {
-                    *err = CL_DEVICE_NOT_FOUND;
-                }
-                return;
-            }
-
-            prop[1] = platform_id;
-            properties = &prop[0];
-        }
+#if defined(CL_HPP_ENABLE_EXCEPTIONS)
+				}
+				catch (Error)
+				{
+				}
+				// Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
+				// We do error checking next anyway, and can throw there if needed
 #endif
-        object_ = ::clCreateContextFromType(
-            properties, type, notifyFptr, data, &error);
 
-        detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+				// Only squash CL_SUCCESS and CL_DEVICE_NOT_FOUND
+				if (error != CL_SUCCESS && error != CL_DEVICE_NOT_FOUND)
+				{
+					detail::errHandler (error, __CREATE_CONTEXT_FROM_TYPE_ERR);
+					if (err != NULL)
+					{
+						*err = error;
+					}
+				}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+				if (devices.size () > 0)
+				{
+					platform_id = (cl_context_properties)platforms[i]();
+					break;
+				}
+			}
+
+			if (platform_id == 0)
+			{
+				detail::errHandler (CL_DEVICE_NOT_FOUND, __CREATE_CONTEXT_FROM_TYPE_ERR);
+				if (err != NULL)
+				{
+					*err = CL_DEVICE_NOT_FOUND;
+				}
+				return;
+			}
+
+			prop[1] = platform_id;
+			properties = &prop[0];
+		}
+#endif
+		object_ = ::clCreateContextFromType (
+		properties, type, notifyFptr, data, &error);
+
+		detail::errHandler (error, __CREATE_CONTEXT_FROM_TYPE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Context(const Context& ctx) : detail::Wrapper<cl_type>(ctx) {}
+	Context (const Context & ctx) :
+		detail::Wrapper<cl_type> (ctx)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Context& operator = (const Context &ctx)
-    {
-        detail::Wrapper<cl_type>::operator=(ctx);
-        return *this;
-    }
+	Context & operator= (const Context & ctx)
+	{
+		detail::Wrapper<cl_type>::operator= (ctx);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Context(Context&& ctx) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(ctx)) {}
+	Context (Context && ctx) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (ctx))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Context& operator = (Context &&ctx)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(ctx));
-        return *this;
-    }
+	Context & operator= (Context && ctx)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (ctx));
+		return *this;
+	}
 
-
-    /*! \brief Returns a singleton context including all devices of CL_DEVICE_TYPE_DEFAULT.
+	/*! \brief Returns a singleton context including all devices of CL_DEVICE_TYPE_DEFAULT.
      *
      *  \note All calls to this function return the same cl_context as the first.
      */
-    static Context getDefault(cl_int * err = NULL) 
-    {
-        std::call_once(default_initialized_, makeDefault);
-        detail::errHandler(default_error_);
-        if (err != NULL) {
-            *err = default_error_;
-        }
-        return default_;
-    }
+	static Context getDefault (cl_int * err = NULL)
+	{
+		std::call_once (default_initialized_, makeDefault);
+		detail::errHandler (default_error_);
+		if (err != NULL)
+		{
+			*err = default_error_;
+		}
+		return default_;
+	}
 
-    /**
+	/**
      * Modify the default context to be used by
      * subsequent operations.
      * Will only set the default if no default was previously created.
      * @return updated default context.
      *         Should be compared to the passed value to ensure that it was updated.
      */
-    static Context setDefault(const Context &default_context)
-    {
-        std::call_once(default_initialized_, makeDefaultProvided, std::cref(default_context));
-        detail::errHandler(default_error_);
-        return default_;
-    }
+	static Context setDefault (const Context & default_context)
+	{
+		std::call_once (default_initialized_, makeDefaultProvided, std::cref (default_context));
+		detail::errHandler (default_error_);
+		return default_;
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Context() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Context () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_context - takes ownership.
+	/*! \brief Constructor from cl_context - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_context
      *  into the new Context object.
      */
-    explicit Context(const cl_context& context, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(context, retainObject) { }
+	explicit Context (const cl_context & context, bool retainObject = false) :
+		detail::Wrapper<cl_type> (context, retainObject)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_context - takes ownership.
+	/*! \brief Assignment operator from cl_context - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseContext() on the value previously held by this instance.
      */
-    Context& operator = (const cl_context& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Context & operator= (const cl_context & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetContextInfo().
-    template <typename T>
-    cl_int getInfo(cl_context_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetContextInfo, object_, name, param),
-            __GET_CONTEXT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetContextInfo().
+	template <typename T>
+	cl_int getInfo (cl_context_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetContextInfo, object_, name, param),
+		__GET_CONTEXT_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetContextInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_context_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_context_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetContextInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_context_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_context_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*! \brief Gets a list of supported image formats.
+	/*! \brief Gets a list of supported image formats.
      *  
      *  Wraps clGetSupportedImageFormats().
      */
-    cl_int getSupportedImageFormats(
-        cl_mem_flags flags,
-        cl_mem_object_type type,
-        vector<ImageFormat>* formats) const
-    {
-        cl_uint numEntries;
-        
-        if (!formats) {
-            return CL_SUCCESS;
-        }
+	cl_int getSupportedImageFormats (
+	cl_mem_flags flags,
+	cl_mem_object_type type,
+	vector<ImageFormat> * formats) const
+	{
+		cl_uint numEntries;
 
-        cl_int err = ::clGetSupportedImageFormats(
-           object_, 
-           flags,
-           type, 
-           0, 
-           NULL, 
-           &numEntries);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
-        }
+		if (!formats)
+		{
+			return CL_SUCCESS;
+		}
 
-        if (numEntries > 0) {
-            vector<ImageFormat> value(numEntries);
-            err = ::clGetSupportedImageFormats(
-                object_,
-                flags,
-                type,
-                numEntries,
-                (cl_image_format*)value.data(),
-                NULL);
-            if (err != CL_SUCCESS) {
-                return detail::errHandler(err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
-            }
+		cl_int err = ::clGetSupportedImageFormats (
+		object_,
+		flags,
+		type,
+		0,
+		NULL,
+		&numEntries);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
+		}
 
-            formats->assign(begin(value), end(value));
-        }
-        else {
-            // If no values are being returned, ensure an empty vector comes back
-            formats->clear();
-        }
+		if (numEntries > 0)
+		{
+			vector<ImageFormat> value (numEntries);
+			err = ::clGetSupportedImageFormats (
+			object_,
+			flags,
+			type,
+			numEntries,
+			(cl_image_format *)value.data (),
+			NULL);
+			if (err != CL_SUCCESS)
+			{
+				return detail::errHandler (err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
+			}
 
-        return CL_SUCCESS;
-    }
+			formats->assign (begin (value), end (value));
+		}
+		else
+		{
+			// If no values are being returned, ensure an empty vector comes back
+			formats->clear ();
+		}
+
+		return CL_SUCCESS;
+	}
 };
 
-inline void Device::makeDefault()
+inline void Device::makeDefault ()
 {
-    /* Throwing an exception from a call_once invocation does not do
+	/* Throwing an exception from a call_once invocation does not do
     * what we wish, so we catch it and save the error.
     */
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-    try
+	try
 #endif
-    {
-        cl_int error = 0;
+	{
+		cl_int error = 0;
 
-        Context context = Context::getDefault(&error);
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		Context context = Context::getDefault (&error);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-        if (error != CL_SUCCESS) {
-            default_error_ = error;
-        }
-        else {
-            default_ = context.getInfo<CL_CONTEXT_DEVICES>()[0];
-            default_error_ = CL_SUCCESS;
-        }
-    }
+		if (error != CL_SUCCESS)
+		{
+			default_error_ = error;
+		}
+		else
+		{
+			default_ = context.getInfo<CL_CONTEXT_DEVICES> ()[0];
+			default_error_ = CL_SUCCESS;
+		}
+	}
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-    catch (cl::Error &e) {
-        default_error_ = e.err();
-    }
+	catch (cl::Error & e)
+	{
+		default_error_ = e.err ();
+	}
 #endif
 }
 
@@ -2928,10 +3173,13 @@ CL_HPP_DEFINE_STATIC_MEMBER_ cl_int Context::default_error_ = CL_SUCCESS;
 class Event : public detail::Wrapper<cl_event>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Event() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Event () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_event - takes ownership.
+	/*! \brief Constructor from cl_event - takes ownership.
      * 
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
@@ -2939,109 +3187,113 @@ public:
      *  This effectively transfers ownership of a refcount on the cl_event
      *  into the new Event object.
      */
-    explicit Event(const cl_event& event, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(event, retainObject) { }
+	explicit Event (const cl_event & event, bool retainObject = false) :
+		detail::Wrapper<cl_type> (event, retainObject)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_event - takes ownership.
+	/*! \brief Assignment operator from cl_event - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseEvent() on the value previously held by this instance.
      */
-    Event& operator = (const cl_event& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Event & operator= (const cl_event & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetEventInfo().
-    template <typename T>
-    cl_int getInfo(cl_event_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetEventInfo, object_, name, param),
-            __GET_EVENT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetEventInfo().
+	template <typename T>
+	cl_int getInfo (cl_event_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetEventInfo, object_, name, param),
+		__GET_EVENT_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetEventInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_event_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_event_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetEventInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_event_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_event_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    //! \brief Wrapper for clGetEventProfilingInfo().
-    template <typename T>
-    cl_int getProfilingInfo(cl_profiling_info name, T* param) const
-    {
-        return detail::errHandler(detail::getInfo(
-            &::clGetEventProfilingInfo, object_, name, param),
-            __GET_EVENT_PROFILE_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetEventProfilingInfo().
+	template <typename T>
+	cl_int getProfilingInfo (cl_profiling_info name, T * param) const
+	{
+		return detail::errHandler (detail::getInfo (
+								   &::clGetEventProfilingInfo, object_, name, param),
+		__GET_EVENT_PROFILE_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetEventProfilingInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_profiling_info, name>::param_type
-    getProfilingInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_profiling_info, name>::param_type param;
-        cl_int result = getProfilingInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetEventProfilingInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_profiling_info, name>::param_type
+	getProfilingInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_profiling_info, name>::param_type param;
+		cl_int result = getProfilingInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*! \brief Blocks the calling thread until this event completes.
+	/*! \brief Blocks the calling thread until this event completes.
      * 
      *  Wraps clWaitForEvents().
      */
-    cl_int wait() const
-    {
-        return detail::errHandler(
-            ::clWaitForEvents(1, &object_),
-            __WAIT_FOR_EVENTS_ERR);
-    }
+	cl_int wait () const
+	{
+		return detail::errHandler (
+		::clWaitForEvents (1, &object_),
+		__WAIT_FOR_EVENTS_ERR);
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-    /*! \brief Registers a user callback function for a specific command execution status.
+	/*! \brief Registers a user callback function for a specific command execution status.
      *
      *  Wraps clSetEventCallback().
      */
-    cl_int setCallback(
-        cl_int type,
-        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),		
-        void * user_data = NULL)
-    {
-        return detail::errHandler(
-            ::clSetEventCallback(
-                object_,
-                type,
-                pfn_notify,
-                user_data), 
-            __SET_EVENT_CALLBACK_ERR);
-    }
+	cl_int setCallback (
+	cl_int type,
+	void (CL_CALLBACK * pfn_notify) (cl_event, cl_int, void *),
+	void * user_data = NULL)
+	{
+		return detail::errHandler (
+		::clSetEventCallback (
+		object_,
+		type,
+		pfn_notify,
+		user_data),
+		__SET_EVENT_CALLBACK_ERR);
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 
-    /*! \brief Blocks the calling thread until every event specified is complete.
+	/*! \brief Blocks the calling thread until every event specified is complete.
      * 
      *  Wraps clWaitForEvents().
      */
-    static cl_int
-    waitForEvents(const vector<Event>& events)
-    {
-        return detail::errHandler(
-            ::clWaitForEvents(
-                (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : NULL),
-            __WAIT_FOR_EVENTS_ERR);
-    }
+	static cl_int
+	waitForEvents (const vector<Event> & events)
+	{
+		return detail::errHandler (
+		::clWaitForEvents (
+		(cl_uint)events.size (), (events.size () > 0) ? (cl_event *)&events.front () : NULL),
+		__WAIT_FOR_EVENTS_ERR);
+	}
 };
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
@@ -3052,38 +3304,42 @@ public:
 class UserEvent : public Event
 {
 public:
-    /*! \brief Constructs a user event on a given context.
+	/*! \brief Constructs a user event on a given context.
      *
      *  Wraps clCreateUserEvent().
      */
-    UserEvent(
-        const Context& context,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateUserEvent(
-            context(),
-            &error);
+	UserEvent (
+	const Context & context,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateUserEvent (
+		context (),
+		&error);
 
-        detail::errHandler(error, __CREATE_USER_EVENT_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_USER_EVENT_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    UserEvent() : Event() { }
+	//! \brief Default constructor - initializes to NULL.
+	UserEvent () :
+		Event ()
+	{
+	}
 
-    /*! \brief Sets the execution status of a user event object.
+	/*! \brief Sets the execution status of a user event object.
      *
      *  Wraps clSetUserEventStatus().
      */
-    cl_int setStatus(cl_int status)
-    {
-        return detail::errHandler(
-            ::clSetUserEventStatus(object_,status), 
-            __SET_USER_EVENT_STATUS_ERR);
-    }
+	cl_int setStatus (cl_int status)
+	{
+		return detail::errHandler (
+		::clSetUserEventStatus (object_, status),
+		__SET_USER_EVENT_STATUS_ERR);
+	}
 };
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 
@@ -3092,12 +3348,12 @@ public:
  *  Wraps clWaitForEvents().
  */
 inline static cl_int
-WaitForEvents(const vector<Event>& events)
+WaitForEvents (const vector<Event> & events)
 {
-    return detail::errHandler(
-        ::clWaitForEvents(
-            (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : NULL),
-        __WAIT_FOR_EVENTS_ERR);
+	return detail::errHandler (
+	::clWaitForEvents (
+	(cl_uint)events.size (), (events.size () > 0) ? (cl_event *)&events.front () : NULL),
+	__WAIT_FOR_EVENTS_ERR);
 }
 
 /*! \brief Class interface for cl_mem.
@@ -3111,10 +3367,13 @@ WaitForEvents(const vector<Event>& events)
 class Memory : public detail::Wrapper<cl_mem>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Memory() : detail::Wrapper<cl_type>() { }
+	//! \brief Default constructor - initializes to NULL.
+	Memory () :
+		detail::Wrapper<cl_type> ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      *  Optionally transfer ownership of a refcount on the cl_mem
      *  into the new Memory object.
@@ -3125,74 +3384,81 @@ public:
      *
      *  See Memory for further details.
      */
-    explicit Memory(const cl_mem& memory, bool retainObject) :
-        detail::Wrapper<cl_type>(memory, retainObject) { }
+	explicit Memory (const cl_mem & memory, bool retainObject) :
+		detail::Wrapper<cl_type> (memory, retainObject)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_mem - takes ownership.
+	/*! \brief Assignment operator from cl_mem - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseMemObject() on the value previously held by this instance.
      */
-    Memory& operator = (const cl_mem& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Memory & operator= (const cl_mem & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Memory(const Memory& mem) : detail::Wrapper<cl_type>(mem) {}
+	Memory (const Memory & mem) :
+		detail::Wrapper<cl_type> (mem)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Memory& operator = (const Memory &mem)
-    {
-        detail::Wrapper<cl_type>::operator=(mem);
-        return *this;
-    }
+	Memory & operator= (const Memory & mem)
+	{
+		detail::Wrapper<cl_type>::operator= (mem);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Memory(Memory&& mem) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(mem)) {}
+	Memory (Memory && mem) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (mem))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Memory& operator = (Memory &&mem)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(mem));
-        return *this;
-    }
+	Memory & operator= (Memory && mem)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (mem));
+		return *this;
+	}
 
+	//! \brief Wrapper for clGetMemObjectInfo().
+	template <typename T>
+	cl_int getInfo (cl_mem_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetMemObjectInfo, object_, name, param),
+		__GET_MEM_OBJECT_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetMemObjectInfo().
-    template <typename T>
-    cl_int getInfo(cl_mem_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetMemObjectInfo, object_, name, param),
-            __GET_MEM_OBJECT_INFO_ERR);
-    }
-
-    //! \brief Wrapper for clGetMemObjectInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_mem_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_mem_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetMemObjectInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_mem_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_mem_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-    /*! \brief Registers a callback function to be called when the memory object
+	/*! \brief Registers a callback function to be called when the memory object
      *         is no longer needed.
      *
      *  Wraps clSetMemObjectDestructorCallback().
@@ -3205,122 +3471,113 @@ public:
      *  The registered callbacks are associated with the underlying cl_mem
      *  value - not the Memory class instance.
      */
-    cl_int setDestructorCallback(
-        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),		
-        void * user_data = NULL)
-    {
-        return detail::errHandler(
-            ::clSetMemObjectDestructorCallback(
-                object_,
-                pfn_notify,
-                user_data), 
-            __SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR);
-    }
+	cl_int setDestructorCallback (
+	void (CL_CALLBACK * pfn_notify) (cl_mem, void *),
+	void * user_data = NULL)
+	{
+		return detail::errHandler (
+		::clSetMemObjectDestructorCallback (
+		object_,
+		pfn_notify,
+		user_data),
+		__SET_MEM_OBJECT_DESTRUCTOR_CALLBACK_ERR);
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
-
 };
 
 // Pre-declare copy functions
 class Buffer;
-template< typename IteratorType >
-cl_int copy( IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer );
-template< typename IteratorType >
-cl_int copy( const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator );
-template< typename IteratorType >
-cl_int copy( const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer );
-template< typename IteratorType >
-cl_int copy( const CommandQueue &queue, const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator );
-
+template <typename IteratorType>
+cl_int copy (IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer);
+template <typename IteratorType>
+cl_int copy (const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator);
+template <typename IteratorType>
+cl_int copy (const CommandQueue & queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer);
+template <typename IteratorType>
+cl_int copy (const CommandQueue & queue, const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator);
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 namespace detail
 {
-    class SVMTraitNull
-    {
-    public:
-        static cl_svm_mem_flags getSVMMemFlags()
-        {
-            return 0;
-        }
-    };
+	class SVMTraitNull
+	{
+	public:
+		static cl_svm_mem_flags getSVMMemFlags ()
+		{
+			return 0;
+		}
+	};
 } // namespace detail
 
-template<class Trait = detail::SVMTraitNull>
+template <class Trait = detail::SVMTraitNull>
 class SVMTraitReadWrite
 {
 public:
-    static cl_svm_mem_flags getSVMMemFlags()
-    {
-        return CL_MEM_READ_WRITE |
-            Trait::getSVMMemFlags();
-    }
+	static cl_svm_mem_flags getSVMMemFlags ()
+	{
+		return CL_MEM_READ_WRITE | Trait::getSVMMemFlags ();
+	}
 };
 
-template<class Trait = detail::SVMTraitNull>
+template <class Trait = detail::SVMTraitNull>
 class SVMTraitReadOnly
 {
 public:
-    static cl_svm_mem_flags getSVMMemFlags()
-    {
-        return CL_MEM_READ_ONLY |
-            Trait::getSVMMemFlags();
-    }
+	static cl_svm_mem_flags getSVMMemFlags ()
+	{
+		return CL_MEM_READ_ONLY | Trait::getSVMMemFlags ();
+	}
 };
 
-template<class Trait = detail::SVMTraitNull>
+template <class Trait = detail::SVMTraitNull>
 class SVMTraitWriteOnly
 {
 public:
-    static cl_svm_mem_flags getSVMMemFlags()
-    {
-        return CL_MEM_WRITE_ONLY |
-            Trait::getSVMMemFlags();
-    }
+	static cl_svm_mem_flags getSVMMemFlags ()
+	{
+		return CL_MEM_WRITE_ONLY | Trait::getSVMMemFlags ();
+	}
 };
 
-template<class Trait = SVMTraitReadWrite<>>
+template <class Trait = SVMTraitReadWrite<>>
 class SVMTraitCoarse
 {
 public:
-    static cl_svm_mem_flags getSVMMemFlags()
-    {
-        return Trait::getSVMMemFlags();
-    }
+	static cl_svm_mem_flags getSVMMemFlags ()
+	{
+		return Trait::getSVMMemFlags ();
+	}
 };
 
-template<class Trait = SVMTraitReadWrite<>>
+template <class Trait = SVMTraitReadWrite<>>
 class SVMTraitFine
 {
 public:
-    static cl_svm_mem_flags getSVMMemFlags()
-    {
-        return CL_MEM_SVM_FINE_GRAIN_BUFFER |
-            Trait::getSVMMemFlags();
-    }
+	static cl_svm_mem_flags getSVMMemFlags ()
+	{
+		return CL_MEM_SVM_FINE_GRAIN_BUFFER | Trait::getSVMMemFlags ();
+	}
 };
 
-template<class Trait = SVMTraitReadWrite<>>
+template <class Trait = SVMTraitReadWrite<>>
 class SVMTraitAtomic
 {
 public:
-    static cl_svm_mem_flags getSVMMemFlags()
-    {
-        return
-            CL_MEM_SVM_FINE_GRAIN_BUFFER |
-            CL_MEM_SVM_ATOMICS |
-            Trait::getSVMMemFlags();
-    }
+	static cl_svm_mem_flags getSVMMemFlags ()
+	{
+		return CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS | Trait::getSVMMemFlags ();
+	}
 };
 
 // Pre-declare SVM map function
-template<typename T>
-inline cl_int enqueueMapSVM(
-    T* ptr,
-    cl_bool blocking,
-    cl_map_flags flags,
-    size_type size,
-    const vector<Event>* events = NULL,
-    Event* event = NULL);
+template <typename T>
+inline cl_int enqueueMapSVM (
+T * ptr,
+cl_bool blocking,
+cl_map_flags flags,
+size_type size,
+const vector<Event> * events = NULL,
+Event * event = NULL);
 
 /**
  * STL-like allocator class for managing SVM objects provided for convenience.
@@ -3333,192 +3590,198 @@ inline cl_int enqueueMapSVM(
  * Instead the allocator embeds a Deleter which may be used with unique_ptr and is used
  * with the allocate_shared and allocate_ptr supplied operations.
  */
-template<typename T, class SVMTrait>
-class SVMAllocator {
+template <typename T, class SVMTrait>
+class SVMAllocator
+{
 private:
-    Context context_;
+	Context context_;
 
 public:
-    typedef T value_type;
-    typedef value_type* pointer;
-    typedef const value_type* const_pointer;
-    typedef value_type& reference;
-    typedef const value_type& const_reference;
-    typedef std::size_t size_type;
-    typedef std::ptrdiff_t difference_type;
+	typedef T value_type;
+	typedef value_type * pointer;
+	typedef const value_type * const_pointer;
+	typedef value_type & reference;
+	typedef const value_type & const_reference;
+	typedef std::size_t size_type;
+	typedef std::ptrdiff_t difference_type;
 
-    template<typename U>
-    struct rebind
-    {
-        typedef SVMAllocator<U, SVMTrait> other;
-    };
+	template <typename U>
+	struct rebind
+	{
+		typedef SVMAllocator<U, SVMTrait> other;
+	};
 
-    template<typename U, typename V>
-    friend class SVMAllocator;
+	template <typename U, typename V>
+	friend class SVMAllocator;
 
-    SVMAllocator() :
-        context_(Context::getDefault())
-    {
-    }
+	SVMAllocator () :
+		context_ (Context::getDefault ())
+	{
+	}
 
-    explicit SVMAllocator(cl::Context context) :
-        context_(context)
-    {
-    }
+	explicit SVMAllocator (cl::Context context) :
+		context_ (context)
+	{
+	}
 
+	SVMAllocator (const SVMAllocator & other) :
+		context_ (other.context_)
+	{
+	}
 
-    SVMAllocator(const SVMAllocator &other) :
-        context_(other.context_)
-    {
-    }
+	template <typename U>
+	SVMAllocator (const SVMAllocator<U, SVMTrait> & other) :
+		context_ (other.context_)
+	{
+	}
 
-    template<typename U>
-    SVMAllocator(const SVMAllocator<U, SVMTrait> &other) :
-        context_(other.context_)
-    {
-    }
+	~SVMAllocator ()
+	{
+	}
 
-    ~SVMAllocator()
-    {
-    }
+	pointer address (reference r) CL_HPP_NOEXCEPT_
+	{
+		return std::addressof (r);
+	}
 
-    pointer address(reference r) CL_HPP_NOEXCEPT_
-    {
-        return std::addressof(r);
-    }
+	const_pointer address (const_reference r) CL_HPP_NOEXCEPT_
+	{
+		return std::addressof (r);
+	}
 
-    const_pointer address(const_reference r) CL_HPP_NOEXCEPT_
-    {
-        return std::addressof(r);
-    }
-
-    /**
+	/**
      * Allocate an SVM pointer.
      *
      * If the allocator is coarse-grained, this will take ownership to allow
      * containers to correctly construct data in place. 
      */
-    pointer allocate(
-        size_type size,
-        typename cl::SVMAllocator<void, SVMTrait>::const_pointer = 0)
-    {
-        // Allocate memory with default alignment matching the size of the type
-        void* voidPointer =
-            clSVMAlloc(
-            context_(),
-            SVMTrait::getSVMMemFlags(),
-            size*sizeof(T),
-            sizeof(T));
-        pointer retValue = reinterpret_cast<pointer>(
-            voidPointer);
+	pointer allocate (
+	size_type size,
+	typename cl::SVMAllocator<void, SVMTrait>::const_pointer = 0)
+	{
+		// Allocate memory with default alignment matching the size of the type
+		void * voidPointer = clSVMAlloc (
+		context_ (),
+		SVMTrait::getSVMMemFlags (),
+		size * sizeof (T),
+		sizeof (T));
+		pointer retValue = reinterpret_cast<pointer> (
+		voidPointer);
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        if (!retValue) {
-            std::bad_alloc excep;
-            throw excep;
-        }
+		if (!retValue)
+		{
+			std::bad_alloc excep;
+			throw excep;
+		}
 #endif // #if defined(CL_HPP_ENABLE_EXCEPTIONS)
 
-        // If allocation was coarse-grained then map it
-        if (!(SVMTrait::getSVMMemFlags() & CL_MEM_SVM_FINE_GRAIN_BUFFER)) {
-            cl_int err = enqueueMapSVM(retValue, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, size*sizeof(T));
-            if (err != CL_SUCCESS) {
-                std::bad_alloc excep;
-                throw excep;
-            }
-        }
+		// If allocation was coarse-grained then map it
+		if (!(SVMTrait::getSVMMemFlags () & CL_MEM_SVM_FINE_GRAIN_BUFFER))
+		{
+			cl_int err = enqueueMapSVM (retValue, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, size * sizeof (T));
+			if (err != CL_SUCCESS)
+			{
+				std::bad_alloc excep;
+				throw excep;
+			}
+		}
 
-        // If exceptions disabled, return null pointer from allocator
-        return retValue;
-    }
+		// If exceptions disabled, return null pointer from allocator
+		return retValue;
+	}
 
-    void deallocate(pointer p, size_type)
-    {
-        clSVMFree(context_(), p);
-    }
+	void deallocate (pointer p, size_type)
+	{
+		clSVMFree (context_ (), p);
+	}
 
-    /**
+	/**
      * Return the maximum possible allocation size.
      * This is the minimum of the maximum sizes of all devices in the context.
      */
-    size_type max_size() const CL_HPP_NOEXCEPT_
-    {
-        size_type maxSize = std::numeric_limits<size_type>::max() / sizeof(T);
+	size_type max_size () const CL_HPP_NOEXCEPT_
+	{
+		size_type maxSize = std::numeric_limits<size_type>::max () / sizeof (T);
 
-        for (Device &d : context_.getInfo<CL_CONTEXT_DEVICES>()) {
-            maxSize = std::min(
-                maxSize, 
-                static_cast<size_type>(d.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>()));
-        }
+		for (Device & d : context_.getInfo<CL_CONTEXT_DEVICES> ())
+		{
+			maxSize = std::min (
+			maxSize,
+			static_cast<size_type> (d.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE> ()));
+		}
 
-        return maxSize;
-    }
+		return maxSize;
+	}
 
-    template< class U, class... Args >
-    void construct(U* p, Args&&... args)
-    {
-        new(p)T(args...);
-    }
+	template <class U, class... Args>
+	void construct (U * p, Args &&... args)
+	{
+		new (p) T (args...);
+	}
 
-    template< class U >
-    void destroy(U* p)
-    {
-        p->~U();
-    }
+	template <class U>
+	void destroy (U * p)
+	{
+		p->~U ();
+	}
 
-    /**
+	/**
      * Returns true if the contexts match.
      */
-    inline bool operator==(SVMAllocator const& rhs)
-    {
-        return (context_==rhs.context_);
-    }
+	inline bool operator== (SVMAllocator const & rhs)
+	{
+		return (context_ == rhs.context_);
+	}
 
-    inline bool operator!=(SVMAllocator const& a)
-    {
-        return !operator==(a);
-    }
+	inline bool operator!= (SVMAllocator const & a)
+	{
+		return !operator== (a);
+	}
 }; // class SVMAllocator        return cl::pointer<T>(tmp, detail::Deleter<T, Alloc>{alloc, copies});
 
-
-template<class SVMTrait>
-class SVMAllocator<void, SVMTrait> {
+template <class SVMTrait>
+class SVMAllocator<void, SVMTrait>
+{
 public:
-    typedef void value_type;
-    typedef value_type* pointer;
-    typedef const value_type* const_pointer;
+	typedef void value_type;
+	typedef value_type * pointer;
+	typedef const value_type * const_pointer;
 
-    template<typename U>
-    struct rebind
-    {
-        typedef SVMAllocator<U, SVMTrait> other;
-    };
+	template <typename U>
+	struct rebind
+	{
+		typedef SVMAllocator<U, SVMTrait> other;
+	};
 
-    template<typename U, typename V>
-    friend class SVMAllocator;
+	template <typename U, typename V>
+	friend class SVMAllocator;
 };
 
 #if !defined(CL_HPP_NO_STD_UNIQUE_PTR)
 namespace detail
 {
-    template<class Alloc>
-    class Deleter {
-    private:
-        Alloc alloc_;
-        size_type copies_;
+	template <class Alloc>
+	class Deleter
+	{
+	private:
+		Alloc alloc_;
+		size_type copies_;
 
-    public:
-        typedef typename std::allocator_traits<Alloc>::pointer pointer;
+	public:
+		typedef typename std::allocator_traits<Alloc>::pointer pointer;
 
-        Deleter(const Alloc &alloc, size_type copies) : alloc_{ alloc }, copies_{ copies }
-        {
-        }
+		Deleter (const Alloc & alloc, size_type copies) :
+			alloc_{ alloc }, copies_{ copies }
+		{
+		}
 
-        void operator()(pointer ptr) const {
-            Alloc tmpAlloc{ alloc_ };
-            std::allocator_traits<Alloc>::destroy(tmpAlloc, std::addressof(*ptr));
-            std::allocator_traits<Alloc>::deallocate(tmpAlloc, ptr, copies_);
-        }
-    };
+		void operator() (pointer ptr) const
+		{
+			Alloc tmpAlloc{ alloc_ };
+			std::allocator_traits<Alloc>::destroy (tmpAlloc, std::addressof (*ptr));
+			std::allocator_traits<Alloc>::deallocate (tmpAlloc, ptr, copies_);
+		}
+	};
 } // namespace detail
 
 /**
@@ -3528,69 +3791,70 @@ namespace detail
  * allocated in memory inaccessible to the host.
  */
 template <class T, class Alloc, class... Args>
-cl::pointer<T, detail::Deleter<Alloc>> allocate_pointer(const Alloc &alloc_, Args&&... args)
+cl::pointer<T, detail::Deleter<Alloc>> allocate_pointer (const Alloc & alloc_, Args &&... args)
 {
-    Alloc alloc(alloc_);
-    static const size_t copies = 1;
+	Alloc alloc (alloc_);
+	static const size_t copies = 1;
 
-    // Ensure that creation of the management block and the
-    // object are dealt with separately such that we only provide a deleter
+	// Ensure that creation of the management block and the
+	// object are dealt with separately such that we only provide a deleter
 
-    T* tmp = std::allocator_traits<Alloc>::allocate(alloc, copies);
-    if (!tmp) {
-        std::bad_alloc excep;
-        throw excep;
-    }
-    try {
-        std::allocator_traits<Alloc>::construct(
-            alloc,
-            std::addressof(*tmp),
-            std::forward<Args>(args)...);
+	T * tmp = std::allocator_traits<Alloc>::allocate (alloc, copies);
+	if (!tmp)
+	{
+		std::bad_alloc excep;
+		throw excep;
+	}
+	try
+	{
+		std::allocator_traits<Alloc>::construct (
+		alloc,
+		std::addressof (*tmp),
+		std::forward<Args> (args)...);
 
-        return cl::pointer<T, detail::Deleter<Alloc>>(tmp, detail::Deleter<Alloc>{alloc, copies});
-    }
-    catch (std::bad_alloc b)
-    {
-        std::allocator_traits<Alloc>::deallocate(alloc, tmp, copies);
-        throw;
-    }
+		return cl::pointer<T, detail::Deleter<Alloc>> (tmp, detail::Deleter<Alloc>{ alloc, copies });
+	}
+	catch (std::bad_alloc b)
+	{
+		std::allocator_traits<Alloc>::deallocate (alloc, tmp, copies);
+		throw;
+	}
 }
 
-template< class T, class SVMTrait, class... Args >
-cl::pointer<T, detail::Deleter<SVMAllocator<T, SVMTrait>>> allocate_svm(Args... args)
+template <class T, class SVMTrait, class... Args>
+cl::pointer<T, detail::Deleter<SVMAllocator<T, SVMTrait>>> allocate_svm (Args... args)
 {
-    SVMAllocator<T, SVMTrait> alloc;
-    return cl::allocate_pointer<T>(alloc, args...);
+	SVMAllocator<T, SVMTrait> alloc;
+	return cl::allocate_pointer<T> (alloc, args...);
 }
 
-template< class T, class SVMTrait, class... Args >
-cl::pointer<T, detail::Deleter<SVMAllocator<T, SVMTrait>>> allocate_svm(const cl::Context &c, Args... args)
+template <class T, class SVMTrait, class... Args>
+cl::pointer<T, detail::Deleter<SVMAllocator<T, SVMTrait>>> allocate_svm (const cl::Context & c, Args... args)
 {
-    SVMAllocator<T, SVMTrait> alloc(c);
-    return cl::allocate_pointer<T>(alloc, args...);
+	SVMAllocator<T, SVMTrait> alloc (c);
+	return cl::allocate_pointer<T> (alloc, args...);
 }
 #endif // #if !defined(CL_HPP_NO_STD_UNIQUE_PTR)
 
 /*! \brief Vector alias to simplify contruction of coarse-grained SVM containers.
  * 
  */
-template < class T >
+template <class T>
 using coarse_svm_vector = vector<T, cl::SVMAllocator<int, cl::SVMTraitCoarse<>>>;
 
 /*! \brief Vector alias to simplify contruction of fine-grained SVM containers.
 *
 */
-template < class T >
+template <class T>
 using fine_svm_vector = vector<T, cl::SVMAllocator<int, cl::SVMTraitFine<>>>;
 
 /*! \brief Vector alias to simplify contruction of fine-grained SVM containers that support platform atomics.
 *
 */
-template < class T >
+template <class T>
 using atomic_svm_vector = vector<T, cl::SVMAllocator<int, cl::SVMTraitAtomic<>>>;
 
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-
 
 /*! \brief Class interface for Buffer Memory Objects.
  * 
@@ -3601,31 +3865,31 @@ using atomic_svm_vector = vector<T, cl::SVMAllocator<int, cl::SVMTraitAtomic<>>>
 class Buffer : public Memory
 {
 public:
-
-    /*! \brief Constructs a Buffer in a specified context.
+	/*! \brief Constructs a Buffer in a specified context.
      *
      *  Wraps clCreateBuffer().
      *
      *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
      *                  specified.  Note alignment & exclusivity requirements.
      */
-    Buffer(
-        const Context& context,
-        cl_mem_flags flags,
-        size_type size,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+	Buffer (
+	const Context & context,
+	cl_mem_flags flags,
+	size_type size,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateBuffer (context (), flags, size, host_ptr, &error);
 
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*! \brief Constructs a Buffer in the default context.
+	/*! \brief Constructs a Buffer in the default context.
      *
      *  Wraps clCreateBuffer().
      *
@@ -3634,174 +3898,195 @@ public:
      *
      *  \see Context::getDefault()
      */
-    Buffer(
-         cl_mem_flags flags,
-        size_type size,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Buffer (
+	cl_mem_flags flags,
+	size_type size,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        Context context = Context::getDefault(err);
+		Context context = Context::getDefault (err);
 
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+		object_ = ::clCreateBuffer (context (), flags, size, host_ptr, &error);
 
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*!
+	/*!
      * \brief Construct a Buffer from a host container via iterators.
      * IteratorType must be random access.
      * If useHostPtr is specified iterators must represent contiguous data.
      */
-    template< typename IteratorType >
-    Buffer(
-        IteratorType startIterator,
-        IteratorType endIterator,
-        bool readOnly,
-        bool useHostPtr = false,
-        cl_int* err = NULL)
-    {
-        typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-        cl_int error;
+	template <typename IteratorType>
+	Buffer (
+	IteratorType startIterator,
+	IteratorType endIterator,
+	bool readOnly,
+	bool useHostPtr = false,
+	cl_int * err = NULL)
+	{
+		typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+		cl_int error;
 
-        cl_mem_flags flags = 0;
-        if( readOnly ) {
-            flags |= CL_MEM_READ_ONLY;
-        }
-        else {
-            flags |= CL_MEM_READ_WRITE;
-        }
-        if( useHostPtr ) {
-            flags |= CL_MEM_USE_HOST_PTR;
-        }
-        
-        size_type size = sizeof(DataType)*(endIterator - startIterator);
+		cl_mem_flags flags = 0;
+		if (readOnly)
+		{
+			flags |= CL_MEM_READ_ONLY;
+		}
+		else
+		{
+			flags |= CL_MEM_READ_WRITE;
+		}
+		if (useHostPtr)
+		{
+			flags |= CL_MEM_USE_HOST_PTR;
+		}
 
-        Context context = Context::getDefault(err);
+		size_type size = sizeof (DataType) * (endIterator - startIterator);
 
-        if( useHostPtr ) {
-            object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
-        } else {
-            object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
-        }
+		Context context = Context::getDefault (err);
 
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		if (useHostPtr)
+		{
+			object_ = ::clCreateBuffer (context (), flags, size, static_cast<DataType *> (&*startIterator), &error);
+		}
+		else
+		{
+			object_ = ::clCreateBuffer (context (), flags, size, 0, &error);
+		}
 
-        if( !useHostPtr ) {
-            error = cl::copy(startIterator, endIterator, *this);
-            detail::errHandler(error, __CREATE_BUFFER_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-    }
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-    /*!
+		if (!useHostPtr)
+		{
+			error = cl::copy (startIterator, endIterator, *this);
+			detail::errHandler (error, __CREATE_BUFFER_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+	}
+
+	/*!
      * \brief Construct a Buffer from a host container via iterators using a specified context.
      * IteratorType must be random access.
      * If useHostPtr is specified iterators must represent contiguous data.
      */
-    template< typename IteratorType >
-    Buffer(const Context &context, IteratorType startIterator, IteratorType endIterator,
-        bool readOnly, bool useHostPtr = false, cl_int* err = NULL);
-    
-    /*!
+	template <typename IteratorType>
+	Buffer (const Context & context, IteratorType startIterator, IteratorType endIterator,
+	bool readOnly, bool useHostPtr = false, cl_int * err = NULL);
+
+	/*!
     * \brief Construct a Buffer from a host container via iterators using a specified queue.
     * If useHostPtr is specified iterators must be random access.
     */
-    template< typename IteratorType >
-    Buffer(const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator,
-        bool readOnly, bool useHostPtr = false, cl_int* err = NULL);
+	template <typename IteratorType>
+	Buffer (const CommandQueue & queue, IteratorType startIterator, IteratorType endIterator,
+	bool readOnly, bool useHostPtr = false, cl_int * err = NULL);
 
-    //! \brief Default constructor - initializes to NULL.
-    Buffer() : Memory() { }
+	//! \brief Default constructor - initializes to NULL.
+	Buffer () :
+		Memory ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with earlier versions.
      *
      *  See Memory for further details.
      */
-    explicit Buffer(const cl_mem& buffer, bool retainObject = false) :
-        Memory(buffer, retainObject) { }
+	explicit Buffer (const cl_mem & buffer, bool retainObject = false) :
+		Memory (buffer, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
     *
     *  See Memory for further details.
     */
-    Buffer& operator = (const cl_mem& rhs)
-    {
-        Memory::operator=(rhs);
-        return *this;
-    }
+	Buffer & operator= (const cl_mem & rhs)
+	{
+		Memory::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer(const Buffer& buf) : Memory(buf) {}
+	Buffer (const Buffer & buf) :
+		Memory (buf)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer& operator = (const Buffer &buf)
-    {
-        Memory::operator=(buf);
-        return *this;
-    }
+	Buffer & operator= (const Buffer & buf)
+	{
+		Memory::operator= (buf);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer(Buffer&& buf) CL_HPP_NOEXCEPT_ : Memory(std::move(buf)) {}
+	Buffer (Buffer && buf) CL_HPP_NOEXCEPT_ : Memory (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Buffer& operator = (Buffer &&buf)
-    {
-        Memory::operator=(std::move(buf));
-        return *this;
-    }
+	Buffer & operator= (Buffer && buf)
+	{
+		Memory::operator= (std::move (buf));
+		return *this;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-    /*! \brief Creates a new buffer object from this.
+	/*! \brief Creates a new buffer object from this.
      *
      *  Wraps clCreateSubBuffer().
      */
-    Buffer createSubBuffer(
-        cl_mem_flags flags,
-        cl_buffer_create_type buffer_create_type,
-        const void * buffer_create_info,
-        cl_int * err = NULL)
-    {
-        Buffer result;
-        cl_int error;
-        result.object_ = ::clCreateSubBuffer(
-            object_, 
-            flags, 
-            buffer_create_type, 
-            buffer_create_info, 
-            &error);
+	Buffer createSubBuffer (
+	cl_mem_flags flags,
+	cl_buffer_create_type buffer_create_type,
+	const void * buffer_create_info,
+	cl_int * err = NULL)
+	{
+		Buffer result;
+		cl_int error;
+		result.object_ = ::clCreateSubBuffer (
+		object_,
+		flags,
+		buffer_create_type,
+		buffer_create_info,
+		&error);
 
-        detail::errHandler(error, __CREATE_SUBBUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_SUBBUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-        return result;
-    }		
+		return result;
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 };
 
-#if defined (CL_HPP_USE_DX_INTEROP)
+#if defined(CL_HPP_USE_DX_INTEROP)
 /*! \brief Class interface for creating OpenCL buffers from ID3D10Buffer's.
  *
  *  This is provided to facilitate interoperability with Direct3D.
@@ -3813,100 +4098,111 @@ public:
 class BufferD3D10 : public Buffer
 {
 public:
-   
-
-    /*! \brief Constructs a BufferD3D10, in a specified context, from a
+	/*! \brief Constructs a BufferD3D10, in a specified context, from a
      *         given ID3D10Buffer.
      *
      *  Wraps clCreateFromD3D10BufferKHR().
      */
-    BufferD3D10(
-        const Context& context,
-        cl_mem_flags flags,
-        ID3D10Buffer* bufobj,
-        cl_int * err = NULL) : pfn_clCreateFromD3D10BufferKHR(nullptr)
-    {
-        typedef CL_API_ENTRY cl_mem (CL_API_CALL *PFN_clCreateFromD3D10BufferKHR)(
-            cl_context context, cl_mem_flags flags, ID3D10Buffer*  buffer,
-            cl_int* errcode_ret);
-        PFN_clCreateFromD3D10BufferKHR pfn_clCreateFromD3D10BufferKHR;
+	BufferD3D10 (
+	const Context & context,
+	cl_mem_flags flags,
+	ID3D10Buffer * bufobj,
+	cl_int * err = NULL) :
+		pfn_clCreateFromD3D10BufferKHR (nullptr)
+	{
+		typedef CL_API_ENTRY cl_mem (CL_API_CALL * PFN_clCreateFromD3D10BufferKHR) (
+		cl_context context, cl_mem_flags flags, ID3D10Buffer * buffer,
+		cl_int * errcode_ret);
+		PFN_clCreateFromD3D10BufferKHR pfn_clCreateFromD3D10BufferKHR;
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-        vector<cl_context_properties> props = context.getInfo<CL_CONTEXT_PROPERTIES>();
-        cl_platform platform = -1;
-        for( int i = 0; i < props.size(); ++i ) {
-            if( props[i] == CL_CONTEXT_PLATFORM ) {
-                platform = props[i+1];
-            }
-        }
-        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clCreateFromD3D10BufferKHR);
+		vector<cl_context_properties> props = context.getInfo<CL_CONTEXT_PROPERTIES> ();
+		cl_platform platform = -1;
+		for (int i = 0; i < props.size (); ++i)
+		{
+			if (props[i] == CL_CONTEXT_PLATFORM)
+			{
+				platform = props[i + 1];
+			}
+		}
+		CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_ (platform, clCreateFromD3D10BufferKHR);
 #elif CL_HPP_TARGET_OPENCL_VERSION >= 110
-        CL_HPP_INIT_CL_EXT_FCN_PTR_(clCreateFromD3D10BufferKHR);
+		CL_HPP_INIT_CL_EXT_FCN_PTR_ (clCreateFromD3D10BufferKHR);
 #endif
 
-        cl_int error;
-        object_ = pfn_clCreateFromD3D10BufferKHR(
-            context(),
-            flags,
-            bufobj,
-            &error);
+		cl_int error;
+		object_ = pfn_clCreateFromD3D10BufferKHR (
+		context (),
+		flags,
+		bufobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    BufferD3D10() : Buffer() { }
+	//! \brief Default constructor - initializes to NULL.
+	BufferD3D10 () :
+		Buffer ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with 
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit BufferD3D10(const cl_mem& buffer, bool retainObject = false) : 
-        Buffer(buffer, retainObject) { }
+	explicit BufferD3D10 (const cl_mem & buffer, bool retainObject = false) :
+		Buffer (buffer, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    BufferD3D10& operator = (const cl_mem& rhs)
-    {
-        Buffer::operator=(rhs);
-        return *this;
-    }
+	BufferD3D10 & operator= (const cl_mem & rhs)
+	{
+		Buffer::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    BufferD3D10(const BufferD3D10& buf) : 
-        Buffer(buf) {}
+	BufferD3D10 (const BufferD3D10 & buf) :
+		Buffer (buf)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    BufferD3D10& operator = (const BufferD3D10 &buf)
-    {
-        Buffer::operator=(buf);
-        return *this;
-    }
+	BufferD3D10 & operator= (const BufferD3D10 & buf)
+	{
+		Buffer::operator= (buf);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    BufferD3D10(BufferD3D10&& buf) CL_HPP_NOEXCEPT_ : Buffer(std::move(buf)) {}
+	BufferD3D10 (BufferD3D10 && buf) CL_HPP_NOEXCEPT_ : Buffer (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    BufferD3D10& operator = (BufferD3D10 &&buf)
-    {
-        Buffer::operator=(std::move(buf));
-        return *this;
-    }
+	BufferD3D10 & operator= (BufferD3D10 && buf)
+	{
+		Buffer::operator= (std::move (buf));
+		return *this;
+	}
 };
 #endif
 
@@ -3921,90 +4217,101 @@ public:
 class BufferGL : public Buffer
 {
 public:
-    /*! \brief Constructs a BufferGL in a specified context, from a given
+	/*! \brief Constructs a BufferGL in a specified context, from a given
      *         GL buffer.
      *
      *  Wraps clCreateFromGLBuffer().
      */
-    BufferGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLuint bufobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLBuffer(
-            context(),
-            flags,
-            bufobj,
-            &error);
+	BufferGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLuint bufobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLBuffer (
+		context (),
+		flags,
+		bufobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    BufferGL() : Buffer() { }
+	//! \brief Default constructor - initializes to NULL.
+	BufferGL () :
+		Buffer ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit BufferGL(const cl_mem& buffer, bool retainObject = false) :
-        Buffer(buffer, retainObject) { }
+	explicit BufferGL (const cl_mem & buffer, bool retainObject = false) :
+		Buffer (buffer, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    BufferGL& operator = (const cl_mem& rhs)
-    {
-        Buffer::operator=(rhs);
-        return *this;
-    }
+	BufferGL & operator= (const cl_mem & rhs)
+	{
+		Buffer::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    BufferGL(const BufferGL& buf) : Buffer(buf) {}
+	BufferGL (const BufferGL & buf) :
+		Buffer (buf)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    BufferGL& operator = (const BufferGL &buf)
-    {
-        Buffer::operator=(buf);
-        return *this;
-    }
+	BufferGL & operator= (const BufferGL & buf)
+	{
+		Buffer::operator= (buf);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    BufferGL(BufferGL&& buf) CL_HPP_NOEXCEPT_ : Buffer(std::move(buf)) {}
+	BufferGL (BufferGL && buf) CL_HPP_NOEXCEPT_ : Buffer (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    BufferGL& operator = (BufferGL &&buf)
-    {
-        Buffer::operator=(std::move(buf));
-        return *this;
-    }
+	BufferGL & operator= (BufferGL && buf)
+	{
+		Buffer::operator= (std::move (buf));
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetGLObjectInfo().
-    cl_int getObjectInfo(
-        cl_gl_object_type *type,
-        cl_GLuint * gl_object_name)
-    {
-        return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
-            __GET_GL_OBJECT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetGLObjectInfo().
+	cl_int getObjectInfo (
+	cl_gl_object_type * type,
+	cl_GLuint * gl_object_name)
+	{
+		return detail::errHandler (
+		::clGetGLObjectInfo (object_, type, gl_object_name),
+		__GET_GL_OBJECT_INFO_ERR);
+	}
 };
 
 /*! \brief Class interface for GL Render Buffer Memory Objects.
@@ -4018,90 +4325,101 @@ public:
 class BufferRenderGL : public Buffer
 {
 public:
-    /*! \brief Constructs a BufferRenderGL in a specified context, from a given
+	/*! \brief Constructs a BufferRenderGL in a specified context, from a given
      *         GL Renderbuffer.
      *
      *  Wraps clCreateFromGLRenderbuffer().
      */
-    BufferRenderGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLuint bufobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLRenderbuffer(
-            context(),
-            flags,
-            bufobj,
-            &error);
+	BufferRenderGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLuint bufobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLRenderbuffer (
+		context (),
+		flags,
+		bufobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_RENDER_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_RENDER_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    BufferRenderGL() : Buffer() { }
+	//! \brief Default constructor - initializes to NULL.
+	BufferRenderGL () :
+		Buffer ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with 
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit BufferRenderGL(const cl_mem& buffer, bool retainObject = false) :
-        Buffer(buffer, retainObject) { }
+	explicit BufferRenderGL (const cl_mem & buffer, bool retainObject = false) :
+		Buffer (buffer, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    BufferRenderGL& operator = (const cl_mem& rhs)
-    {
-        Buffer::operator=(rhs);
-        return *this;
-    }
+	BufferRenderGL & operator= (const cl_mem & rhs)
+	{
+		Buffer::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    BufferRenderGL(const BufferRenderGL& buf) : Buffer(buf) {}
+	BufferRenderGL (const BufferRenderGL & buf) :
+		Buffer (buf)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    BufferRenderGL& operator = (const BufferRenderGL &buf)
-    {
-        Buffer::operator=(buf);
-        return *this;
-    }
+	BufferRenderGL & operator= (const BufferRenderGL & buf)
+	{
+		Buffer::operator= (buf);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    BufferRenderGL(BufferRenderGL&& buf) CL_HPP_NOEXCEPT_ : Buffer(std::move(buf)) {}
+	BufferRenderGL (BufferRenderGL && buf) CL_HPP_NOEXCEPT_ : Buffer (std::move (buf))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    BufferRenderGL& operator = (BufferRenderGL &&buf)
-    {
-        Buffer::operator=(std::move(buf));
-        return *this;
-    }
+	BufferRenderGL & operator= (BufferRenderGL && buf)
+	{
+		Buffer::operator= (std::move (buf));
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetGLObjectInfo().
-    cl_int getObjectInfo(
-        cl_gl_object_type *type,
-        cl_GLuint * gl_object_name)
-    {
-        return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
-            __GET_GL_OBJECT_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetGLObjectInfo().
+	cl_int getObjectInfo (
+	cl_gl_object_type * type,
+	cl_GLuint * gl_object_name)
+	{
+		return detail::errHandler (
+		::clGetGLObjectInfo (object_, type, gl_object_name),
+		__GET_GL_OBJECT_INFO_ERR);
+	}
 };
 
 /*! \brief C++ base class for Image Memory objects.
@@ -4113,81 +4431,91 @@ public:
 class Image : public Memory
 {
 protected:
-    //! \brief Default constructor - initializes to NULL.
-    Image() : Memory() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image () :
+		Memory ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image(const cl_mem& image, bool retainObject = false) :
-        Memory(image, retainObject) { }
+	explicit Image (const cl_mem & image, bool retainObject = false) :
+		Memory (image, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image& operator = (const cl_mem& rhs)
-    {
-        Memory::operator=(rhs);
-        return *this;
-    }
+	Image & operator= (const cl_mem & rhs)
+	{
+		Memory::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image(const Image& img) : Memory(img) {}
+	Image (const Image & img) :
+		Memory (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image& operator = (const Image &img)
-    {
-        Memory::operator=(img);
-        return *this;
-    }
+	Image & operator= (const Image & img)
+	{
+		Memory::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image(Image&& img) CL_HPP_NOEXCEPT_ : Memory(std::move(img)) {}
+	Image (Image && img) CL_HPP_NOEXCEPT_ : Memory (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image& operator = (Image &&img)
-    {
-        Memory::operator=(std::move(img));
-        return *this;
-    }
-
+	Image & operator= (Image && img)
+	{
+		Memory::operator= (std::move (img));
+		return *this;
+	}
 
 public:
-    //! \brief Wrapper for clGetImageInfo().
-    template <typename T>
-    cl_int getImageInfo(cl_image_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetImageInfo, object_, name, param),
-            __GET_IMAGE_INFO_ERR);
-    }
-    
-    //! \brief Wrapper for clGetImageInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_image_info, name>::param_type
-    getImageInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_image_info, name>::param_type param;
-        cl_int result = getImageInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetImageInfo().
+	template <typename T>
+	cl_int getImageInfo (cl_image_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetImageInfo, object_, name, param),
+		__GET_IMAGE_INFO_ERR);
+	}
+
+	//! \brief Wrapper for clGetImageInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_image_info, name>::param_type
+	getImageInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_image_info, name>::param_type param;
+		cl_int result = getImageInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 };
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
@@ -4200,90 +4528,98 @@ public:
 class Image1D : public Image
 {
 public:
-    /*! \brief Constructs a 1D Image in a specified context.
+	/*! \brief Constructs a 1D Image in a specified context.
      *
      *  Wraps clCreateImage().
      */
-    Image1D(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        size_type width,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE1D,
-            width,
-            0, 0, 0, 0, 0, 0, 0, 0
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            host_ptr, 
-            &error);
+	Image1D (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	size_type width,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE1D,
+			width,
+			0, 0, 0, 0, 0, 0, 0, 0
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		host_ptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image1D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image1D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image1D(const cl_mem& image1D, bool retainObject = false) :
-        Image(image1D, retainObject) { }
+	explicit Image1D (const cl_mem & image1D, bool retainObject = false) :
+		Image (image1D, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image1D& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image1D & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D(const Image1D& img) : Image(img) {}
+	Image1D (const Image1D & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D& operator = (const Image1D &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image1D & operator= (const Image1D & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D(Image1D&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	Image1D (Image1D && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1D& operator = (Image1D &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
-
+	Image1D & operator= (Image1D && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
 
 /*! \class Image1DBuffer
@@ -4292,82 +4628,90 @@ public:
 class Image1DBuffer : public Image
 {
 public:
-    Image1DBuffer(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        size_type width,
-        const Buffer &buffer,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE1D_BUFFER,
-            width,
-            0, 0, 0, 0, 0, 0, 0,
-            buffer()
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            NULL, 
-            &error);
+	Image1DBuffer (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	size_type width,
+	const Buffer & buffer,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE1D_BUFFER,
+			width,
+			0, 0, 0, 0, 0, 0, 0,
+			buffer ()
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		NULL,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Image1DBuffer() { }
+	Image1DBuffer ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image1DBuffer(const cl_mem& image1D, bool retainObject = false) :
-        Image(image1D, retainObject) { }
+	explicit Image1DBuffer (const cl_mem & image1D, bool retainObject = false) :
+		Image (image1D, retainObject)
+	{
+	}
 
-    Image1DBuffer& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image1DBuffer & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer(const Image1DBuffer& img) : Image(img) {}
+	Image1DBuffer (const Image1DBuffer & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer& operator = (const Image1DBuffer &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image1DBuffer & operator= (const Image1DBuffer & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer(Image1DBuffer&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	Image1DBuffer (Image1DBuffer && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DBuffer& operator = (Image1DBuffer &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
-
+	Image1DBuffer & operator= (Image1DBuffer && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
 
 /*! \class Image1DArray
@@ -4376,90 +4720,96 @@ public:
 class Image1DArray : public Image
 {
 public:
-    Image1DArray(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        size_type arraySize,
-        size_type width,
-        size_type rowPitch,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE1D_ARRAY,
-            width,
-            0, 0,  // height, depth (unused)
-            arraySize,
-            rowPitch,
-            0, 0, 0, 0
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            host_ptr, 
-            &error);
+	Image1DArray (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	size_type arraySize,
+	size_type width,
+	size_type rowPitch,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE1D_ARRAY,
+			width,
+			0, 0, // height, depth (unused)
+			arraySize,
+			rowPitch,
+			0, 0, 0, 0
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		host_ptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Image1DArray() { }
-  
-    /*! \brief Constructor from cl_mem - takes ownership.
+	Image1DArray ()
+	{
+	}
+
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image1DArray(const cl_mem& imageArray, bool retainObject = false) :
-        Image(imageArray, retainObject) { }
+	explicit Image1DArray (const cl_mem & imageArray, bool retainObject = false) :
+		Image (imageArray, retainObject)
+	{
+	}
 
+	Image1DArray & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    Image1DArray& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
-
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray(const Image1DArray& img) : Image(img) {}
+	Image1DArray (const Image1DArray & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray& operator = (const Image1DArray &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image1DArray & operator= (const Image1DArray & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray(Image1DArray&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	Image1DArray (Image1DArray && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image1DArray& operator = (Image1DArray &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
-
+	Image1DArray & operator= (Image1DArray && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-
 
 /*! \brief Class interface for 2D Image Memory objects.
  *
@@ -4470,120 +4820,121 @@ public:
 class Image2D : public Image
 {
 public:
-    /*! \brief Constructs a 2D Image in a specified context.
+	/*! \brief Constructs a 2D Image in a specified context.
      *
      *  Wraps clCreateImage().
      */
-    Image2D(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        size_type width,
-        size_type height,
-        size_type row_pitch = 0,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        bool useCreateImage;
+	Image2D (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	size_type width,
+	size_type height,
+	size_type row_pitch = 0,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		bool useCreateImage;
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
-        // Run-time decision based on the actual platform
-        {
-            cl_uint version = detail::getContextPlatformVersion(context());
-            useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
-        }
+		// Run-time decision based on the actual platform
+		{
+			cl_uint version = detail::getContextPlatformVersion (context ());
+			useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
+		}
 #elif CL_HPP_TARGET_OPENCL_VERSION >= 120
-        useCreateImage = true;
+		useCreateImage = true;
 #else
-        useCreateImage = false;
+		useCreateImage = false;
 #endif
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-        if (useCreateImage)
-        {
-            cl_image_desc desc =
-            {
-                CL_MEM_OBJECT_IMAGE2D,
-                width,
-                height,
-                0, 0, // depth, array size (unused)
-                row_pitch,
-                0, 0, 0, 0
-            };
-            object_ = ::clCreateImage(
-                context(),
-                flags,
-                &format,
-                &desc,
-                host_ptr,
-                &error);
+		if (useCreateImage)
+		{
+			cl_image_desc desc = {
+				CL_MEM_OBJECT_IMAGE2D,
+				width,
+				height,
+				0, 0, // depth, array size (unused)
+				row_pitch,
+				0, 0, 0, 0
+			};
+			object_ = ::clCreateImage (
+			context (),
+			flags,
+			&format,
+			&desc,
+			host_ptr,
+			&error);
 
-            detail::errHandler(error, __CREATE_IMAGE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			detail::errHandler (error, __CREATE_IMAGE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
-        if (!useCreateImage)
-        {
-            object_ = ::clCreateImage2D(
-                context(), flags,&format, width, height, row_pitch, host_ptr, &error);
+		if (!useCreateImage)
+		{
+			object_ = ::clCreateImage2D (
+			context (), flags, &format, width, height, row_pitch, host_ptr, &error);
 
-            detail::errHandler(error, __CREATE_IMAGE2D_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			detail::errHandler (error, __CREATE_IMAGE2D_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
-    }
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /*! \brief Constructs a 2D Image from a buffer.
+	/*! \brief Constructs a 2D Image from a buffer.
     * \note This will share storage with the underlying buffer.
     *
     *  Wraps clCreateImage().
     */
-    Image2D(
-        const Context& context,
-        ImageFormat format,
-        const Buffer &sourceBuffer,
-        size_type width,
-        size_type height,
-        size_type row_pitch = 0,
-        cl_int* err = nullptr)
-    {
-        cl_int error;
+	Image2D (
+	const Context & context,
+	ImageFormat format,
+	const Buffer & sourceBuffer,
+	size_type width,
+	size_type height,
+	size_type row_pitch = 0,
+	cl_int * err = nullptr)
+	{
+		cl_int error;
 
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE2D,
-            width,
-            height,
-            0, 0, // depth, array size (unused)
-            row_pitch,
-            0, 0, 0,
-            // Use buffer as input to image
-            sourceBuffer()
-        };
-        object_ = ::clCreateImage(
-            context(),
-            0, // flags inherited from buffer
-            &format,
-            &desc,
-            nullptr,
-            &error);
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE2D,
+			width,
+			height,
+			0, 0, // depth, array size (unused)
+			row_pitch,
+			0, 0, 0,
+			// Use buffer as input to image
+			sourceBuffer ()
+		};
+		object_ = ::clCreateImage (
+		context (),
+		0, // flags inherited from buffer
+		&format,
+		&desc,
+		nullptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != nullptr) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != nullptr)
+		{
+			*err = error;
+		}
+	}
 #endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /*! \brief Constructs a 2D Image from an image.
+	/*! \brief Constructs a 2D Image from an image.
     * \note This will share storage with the underlying image but may
     *       reinterpret the channel order and type.
     *
@@ -4595,112 +4946,113 @@ public:
     *
     * Wraps clCreateImage().
     */
-    Image2D(
-        const Context& context,
-        cl_channel_order order,
-        const Image &sourceImage,
-        cl_int* err = nullptr)
-    {
-        cl_int error;
+	Image2D (
+	const Context & context,
+	cl_channel_order order,
+	const Image & sourceImage,
+	cl_int * err = nullptr)
+	{
+		cl_int error;
 
-        // Descriptor fields have to match source image
-        size_type sourceWidth = 
-            sourceImage.getImageInfo<CL_IMAGE_WIDTH>();
-        size_type sourceHeight = 
-            sourceImage.getImageInfo<CL_IMAGE_HEIGHT>();
-        size_type sourceRowPitch =
-            sourceImage.getImageInfo<CL_IMAGE_ROW_PITCH>();
-        cl_uint sourceNumMIPLevels =
-            sourceImage.getImageInfo<CL_IMAGE_NUM_MIP_LEVELS>();
-        cl_uint sourceNumSamples =
-            sourceImage.getImageInfo<CL_IMAGE_NUM_SAMPLES>();
-        cl_image_format sourceFormat =
-            sourceImage.getImageInfo<CL_IMAGE_FORMAT>();
+		// Descriptor fields have to match source image
+		size_type sourceWidth = sourceImage.getImageInfo<CL_IMAGE_WIDTH> ();
+		size_type sourceHeight = sourceImage.getImageInfo<CL_IMAGE_HEIGHT> ();
+		size_type sourceRowPitch = sourceImage.getImageInfo<CL_IMAGE_ROW_PITCH> ();
+		cl_uint sourceNumMIPLevels = sourceImage.getImageInfo<CL_IMAGE_NUM_MIP_LEVELS> ();
+		cl_uint sourceNumSamples = sourceImage.getImageInfo<CL_IMAGE_NUM_SAMPLES> ();
+		cl_image_format sourceFormat = sourceImage.getImageInfo<CL_IMAGE_FORMAT> ();
 
-        // Update only the channel order. 
-        // Channel format inherited from source.
-        sourceFormat.image_channel_order = order;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE2D,
-            sourceWidth,
-            sourceHeight,
-            0, 0, // depth (unused), array size (unused)
-            sourceRowPitch,
-            0, // slice pitch (unused)
-            sourceNumMIPLevels,
-            sourceNumSamples,
-            // Use buffer as input to image
-            sourceImage()
-        };
-        object_ = ::clCreateImage(
-            context(),
-            0, // flags should be inherited from mem_object
-            &sourceFormat,
-            &desc,
-            nullptr,
-            &error);
+		// Update only the channel order.
+		// Channel format inherited from source.
+		sourceFormat.image_channel_order = order;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE2D,
+			sourceWidth,
+			sourceHeight,
+			0, 0, // depth (unused), array size (unused)
+			sourceRowPitch,
+			0, // slice pitch (unused)
+			sourceNumMIPLevels,
+			sourceNumSamples,
+			// Use buffer as input to image
+			sourceImage ()
+		};
+		object_ = ::clCreateImage (
+		context (),
+		0, // flags should be inherited from mem_object
+		&sourceFormat,
+		&desc,
+		nullptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != nullptr) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != nullptr)
+		{
+			*err = error;
+		}
+	}
 #endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-    //! \brief Default constructor - initializes to NULL.
-    Image2D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image2D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image2D(const cl_mem& image2D, bool retainObject = false) :
-        Image(image2D, retainObject) { }
+	explicit Image2D (const cl_mem & image2D, bool retainObject = false) :
+		Image (image2D, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image2D& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image2D & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D(const Image2D& img) : Image(img) {}
+	Image2D (const Image2D & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D& operator = (const Image2D &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image2D & operator= (const Image2D & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D(Image2D&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	Image2D (Image2D && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2D& operator = (Image2D &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
-
+	Image2D & operator= (Image2D && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
-
 
 #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 /*! \brief Class interface for GL 2D Image Memory objects.
@@ -4712,88 +5064,98 @@ public:
  *  \see Memory
  *  \note Deprecated for OpenCL 1.2. Please use ImageGL instead.
  */
-class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED Image2DGL : public Image2D 
+class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED Image2DGL : public Image2D
 {
 public:
-    /*! \brief Constructs an Image2DGL in a specified context, from a given
+	/*! \brief Constructs an Image2DGL in a specified context, from a given
      *         GL Texture.
      *
      *  Wraps clCreateFromGLTexture2D().
      */
-    Image2DGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLenum target,
-        cl_GLint  miplevel,
-        cl_GLuint texobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLTexture2D(
-            context(),
-            flags,
-            target,
-            miplevel,
-            texobj,
-            &error);
+	Image2DGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLenum target,
+	cl_GLint miplevel,
+	cl_GLuint texobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLTexture2D (
+		context (),
+		flags,
+		target,
+		miplevel,
+		texobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_TEXTURE_2D_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_GL_TEXTURE_2D_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    }
-    
-    //! \brief Default constructor - initializes to NULL.
-    Image2DGL() : Image2D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image2DGL () :
+		Image2D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image2DGL(const cl_mem& image, bool retainObject = false) : 
-        Image2D(image, retainObject) { }
+	explicit Image2DGL (const cl_mem & image, bool retainObject = false) :
+		Image2D (image, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *c
      *  See Memory for further details.
      */
-    Image2DGL& operator = (const cl_mem& rhs)
-    {
-        Image2D::operator=(rhs);
-        return *this;
-    }
+	Image2DGL & operator= (const cl_mem & rhs)
+	{
+		Image2D::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL(const Image2DGL& img) : Image2D(img) {}
+	Image2DGL (const Image2DGL & img) :
+		Image2D (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL& operator = (const Image2DGL &img)
-    {
-        Image2D::operator=(img);
-        return *this;
-    }
+	Image2DGL & operator= (const Image2DGL & img)
+	{
+		Image2D::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL(Image2DGL&& img) CL_HPP_NOEXCEPT_ : Image2D(std::move(img)) {}
+	Image2DGL (Image2DGL && img) CL_HPP_NOEXCEPT_ : Image2D (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DGL& operator = (Image2DGL &&img)
-    {
-        Image2D::operator=(std::move(img));
-        return *this;
-    }
+	Image2DGL & operator= (Image2DGL && img)
+	{
+		Image2D::operator= (std::move (img));
+		return *this;
+	}
 
 } CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
 #endif // CL_USE_DEPRECATED_OPENCL_1_1_APIS
@@ -4805,88 +5167,98 @@ public:
 class Image2DArray : public Image
 {
 public:
-    Image2DArray(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        size_type arraySize,
-        size_type width,
-        size_type height,
-        size_type rowPitch,
-        size_type slicePitch,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        cl_image_desc desc =
-        {
-            CL_MEM_OBJECT_IMAGE2D_ARRAY,
-            width,
-            height,
-            0,       // depth (unused)
-            arraySize,
-            rowPitch,
-            slicePitch,
-            0, 0, 0
-        };
-        object_ = ::clCreateImage(
-            context(), 
-            flags, 
-            &format, 
-            &desc, 
-            host_ptr, 
-            &error);
+	Image2DArray (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	size_type arraySize,
+	size_type width,
+	size_type height,
+	size_type rowPitch,
+	size_type slicePitch,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		cl_image_desc desc = {
+			CL_MEM_OBJECT_IMAGE2D_ARRAY,
+			width,
+			height,
+			0, // depth (unused)
+			arraySize,
+			rowPitch,
+			slicePitch,
+			0, 0, 0
+		};
+		object_ = ::clCreateImage (
+		context (),
+		flags,
+		&format,
+		&desc,
+		host_ptr,
+		&error);
 
-        detail::errHandler(error, __CREATE_IMAGE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Image2DArray() { }
-    
-    /*! \brief Constructor from cl_mem - takes ownership.
+	Image2DArray ()
+	{
+	}
+
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image2DArray(const cl_mem& imageArray, bool retainObject = false) : Image(imageArray, retainObject) { }
+	explicit Image2DArray (const cl_mem & imageArray, bool retainObject = false) :
+		Image (imageArray, retainObject)
+	{
+	}
 
-    Image2DArray& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image2DArray & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray(const Image2DArray& img) : Image(img) {}
+	Image2DArray (const Image2DArray & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray& operator = (const Image2DArray &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image2DArray & operator= (const Image2DArray & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray(Image2DArray&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	Image2DArray (Image2DArray && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image2DArray& operator = (Image2DArray &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image2DArray & operator= (Image2DArray && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 120
 
@@ -4899,130 +5271,141 @@ public:
 class Image3D : public Image
 {
 public:
-    /*! \brief Constructs a 3D Image in a specified context.
+	/*! \brief Constructs a 3D Image in a specified context.
      *
      *  Wraps clCreateImage().
      */
-    Image3D(
-        const Context& context,
-        cl_mem_flags flags,
-        ImageFormat format,
-        size_type width,
-        size_type height,
-        size_type depth,
-        size_type row_pitch = 0,
-        size_type slice_pitch = 0,
-        void* host_ptr = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        bool useCreateImage;
+	Image3D (
+	const Context & context,
+	cl_mem_flags flags,
+	ImageFormat format,
+	size_type width,
+	size_type height,
+	size_type depth,
+	size_type row_pitch = 0,
+	size_type slice_pitch = 0,
+	void * host_ptr = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		bool useCreateImage;
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120 && CL_HPP_MINIMUM_OPENCL_VERSION < 120
-        // Run-time decision based on the actual platform
-        {
-            cl_uint version = detail::getContextPlatformVersion(context());
-            useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
-        }
+		// Run-time decision based on the actual platform
+		{
+			cl_uint version = detail::getContextPlatformVersion (context ());
+			useCreateImage = (version >= 0x10002); // OpenCL 1.2 or above
+		}
 #elif CL_HPP_TARGET_OPENCL_VERSION >= 120
-        useCreateImage = true;
+		useCreateImage = true;
 #else
-        useCreateImage = false;
+		useCreateImage = false;
 #endif
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-        if (useCreateImage)
-        {
-            cl_image_desc desc =
-            {
-                CL_MEM_OBJECT_IMAGE3D,
-                width,
-                height,
-                depth,
-                0,      // array size (unused)
-                row_pitch,
-                slice_pitch,
-                0, 0, 0
-            };
-            object_ = ::clCreateImage(
-                context(), 
-                flags, 
-                &format, 
-                &desc, 
-                host_ptr, 
-                &error);
+		if (useCreateImage)
+		{
+			cl_image_desc desc = {
+				CL_MEM_OBJECT_IMAGE3D,
+				width,
+				height,
+				depth,
+				0, // array size (unused)
+				row_pitch,
+				slice_pitch,
+				0, 0, 0
+			};
+			object_ = ::clCreateImage (
+			context (),
+			flags,
+			&format,
+			&desc,
+			host_ptr,
+			&error);
 
-            detail::errHandler(error, __CREATE_IMAGE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-#endif  // CL_HPP_TARGET_OPENCL_VERSION >= 120
+			detail::errHandler (error, __CREATE_IMAGE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+#endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
-        if (!useCreateImage)
-        {
-            object_ = ::clCreateImage3D(
-                context(), flags, &format, width, height, depth, row_pitch,
-                slice_pitch, host_ptr, &error);
+		if (!useCreateImage)
+		{
+			object_ = ::clCreateImage3D (
+			context (), flags, &format, width, height, depth, row_pitch,
+			slice_pitch, host_ptr, &error);
 
-            detail::errHandler(error, __CREATE_IMAGE3D_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-        }
+			detail::errHandler (error, __CREATE_IMAGE3D_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
-    }
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image3D() : Image() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image3D () :
+		Image ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image3D(const cl_mem& image3D, bool retainObject = false) : 
-        Image(image3D, retainObject) { }
+	explicit Image3D (const cl_mem & image3D, bool retainObject = false) :
+		Image (image3D, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image3D& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	Image3D & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D(const Image3D& img) : Image(img) {}
+	Image3D (const Image3D & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D& operator = (const Image3D &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	Image3D & operator= (const Image3D & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D(Image3D&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	Image3D (Image3D && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3D& operator = (Image3D &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	Image3D & operator= (Image3D && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
 
 #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
@@ -5037,84 +5420,95 @@ public:
 class Image3DGL : public Image3D
 {
 public:
-    /*! \brief Constructs an Image3DGL in a specified context, from a given
+	/*! \brief Constructs an Image3DGL in a specified context, from a given
      *         GL Texture.
      *
      *  Wraps clCreateFromGLTexture3D().
      */
-    Image3DGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLenum target,
-        cl_GLint  miplevel,
-        cl_GLuint texobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLTexture3D(
-            context(),
-            flags,
-            target,
-            miplevel,
-            texobj,
-            &error);
+	Image3DGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLenum target,
+	cl_GLint miplevel,
+	cl_GLuint texobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLTexture3D (
+		context (),
+		flags,
+		target,
+		miplevel,
+		texobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_TEXTURE_3D_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_TEXTURE_3D_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Image3DGL() : Image3D() { }
+	//! \brief Default constructor - initializes to NULL.
+	Image3DGL () :
+		Image3D ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit Image3DGL(const cl_mem& image, bool retainObject = false) : 
-        Image3D(image, retainObject) { }
+	explicit Image3DGL (const cl_mem & image, bool retainObject = false) :
+		Image3D (image, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Image3DGL& operator = (const cl_mem& rhs)
-    {
-        Image3D::operator=(rhs);
-        return *this;
-    }
+	Image3DGL & operator= (const cl_mem & rhs)
+	{
+		Image3D::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL(const Image3DGL& img) : Image3D(img) {}
+	Image3DGL (const Image3DGL & img) :
+		Image3D (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL& operator = (const Image3DGL &img)
-    {
-        Image3D::operator=(img);
-        return *this;
-    }
+	Image3DGL & operator= (const Image3DGL & img)
+	{
+		Image3D::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL(Image3DGL&& img) CL_HPP_NOEXCEPT_ : Image3D(std::move(img)) {}
+	Image3DGL (Image3DGL && img) CL_HPP_NOEXCEPT_ : Image3D (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Image3DGL& operator = (Image3DGL &&img)
-    {
-        Image3D::operator=(std::move(img));
-        return *this;
-    }
+	Image3DGL & operator= (Image3DGL && img)
+	{
+		Image3D::operator= (std::move (img));
+		return *this;
+	}
 };
 #endif // CL_USE_DEPRECATED_OPENCL_1_1_APIS
 
@@ -5128,78 +5522,87 @@ public:
 class ImageGL : public Image
 {
 public:
-    ImageGL(
-        const Context& context,
-        cl_mem_flags flags,
-        cl_GLenum target,
-        cl_GLint  miplevel,
-        cl_GLuint texobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLTexture(
-            context(), 
-            flags, 
-            target,
-            miplevel,
-            texobj,
-            &error);
+	ImageGL (
+	const Context & context,
+	cl_mem_flags flags,
+	cl_GLenum target,
+	cl_GLint miplevel,
+	cl_GLuint texobj,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		object_ = ::clCreateFromGLTexture (
+		context (),
+		flags,
+		target,
+		miplevel,
+		texobj,
+		&error);
 
-        detail::errHandler(error, __CREATE_GL_TEXTURE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_GL_TEXTURE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    ImageGL() : Image() { }
-    
-    /*! \brief Constructor from cl_mem - takes ownership.
+	ImageGL () :
+		Image ()
+	{
+	}
+
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      *  See Memory for further details.
      */
-    explicit ImageGL(const cl_mem& image, bool retainObject = false) : 
-        Image(image, retainObject) { }
+	explicit ImageGL (const cl_mem & image, bool retainObject = false) :
+		Image (image, retainObject)
+	{
+	}
 
-    ImageGL& operator = (const cl_mem& rhs)
-    {
-        Image::operator=(rhs);
-        return *this;
-    }
+	ImageGL & operator= (const cl_mem & rhs)
+	{
+		Image::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL(const ImageGL& img) : Image(img) {}
+	ImageGL (const ImageGL & img) :
+		Image (img)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL& operator = (const ImageGL &img)
-    {
-        Image::operator=(img);
-        return *this;
-    }
+	ImageGL & operator= (const ImageGL & img)
+	{
+		Image::operator= (img);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL(ImageGL&& img) CL_HPP_NOEXCEPT_ : Image(std::move(img)) {}
+	ImageGL (ImageGL && img) CL_HPP_NOEXCEPT_ : Image (std::move (img))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    ImageGL& operator = (ImageGL &&img)
-    {
-        Image::operator=(std::move(img));
-        return *this;
-    }
+	ImageGL & operator= (ImageGL && img)
+	{
+		Image::operator= (std::move (img));
+		return *this;
+	}
 };
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
-
-
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 /*! \brief Class interface for Pipe Memory Objects.
@@ -5211,8 +5614,7 @@ public:
 class Pipe : public Memory
 {
 public:
-
-    /*! \brief Constructs a Pipe in a specified context.
+	/*! \brief Constructs a Pipe in a specified context.
      *
      * Wraps clCreatePipe().
      * @param context Context in which to create the pipe.
@@ -5221,24 +5623,25 @@ public:
      * @param max_packets Number of packets that may be stored in the pipe.
      *
      */
-    Pipe(
-        const Context& context,
-        cl_uint packet_size,
-        cl_uint max_packets,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Pipe (
+	const Context & context,
+	cl_uint packet_size,
+	cl_uint max_packets,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
-        object_ = ::clCreatePipe(context(), flags, packet_size, max_packets, nullptr, &error);
+		cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
+		object_ = ::clCreatePipe (context (), flags, packet_size, max_packets, nullptr, &error);
 
-        detail::errHandler(error, __CREATE_PIPE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_PIPE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*! \brief Constructs a Pipe in a the default context.
+	/*! \brief Constructs a Pipe in a the default context.
      *
      * Wraps clCreatePipe().
      * @param flags Bitfield. Only CL_MEM_READ_WRITE and CL_MEM_HOST_NO_ACCESS are valid.
@@ -5246,100 +5649,111 @@ public:
      * @param max_packets Number of packets that may be stored in the pipe.
      *
      */
-    Pipe(
-        cl_uint packet_size,
-        cl_uint max_packets,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Pipe (
+	cl_uint packet_size,
+	cl_uint max_packets,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        Context context = Context::getDefault(err);
+		Context context = Context::getDefault (err);
 
-        cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
-        object_ = ::clCreatePipe(context(), flags, packet_size, max_packets, nullptr, &error);
+		cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
+		object_ = ::clCreatePipe (context (), flags, packet_size, max_packets, nullptr, &error);
 
-        detail::errHandler(error, __CREATE_PIPE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_PIPE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    //! \brief Default constructor - initializes to NULL.
-    Pipe() : Memory() { }
+	//! \brief Default constructor - initializes to NULL.
+	Pipe () :
+		Memory ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with earlier versions.
      *
      *  See Memory for further details.
      */
-    explicit Pipe(const cl_mem& pipe, bool retainObject = false) :
-        Memory(pipe, retainObject) { }
+	explicit Pipe (const cl_mem & pipe, bool retainObject = false) :
+		Memory (pipe, retainObject)
+	{
+	}
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
+	/*! \brief Assignment from cl_mem - performs shallow copy.
      *
      *  See Memory for further details.
      */
-    Pipe& operator = (const cl_mem& rhs)
-    {
-        Memory::operator=(rhs);
-        return *this;
-    }
+	Pipe & operator= (const cl_mem & rhs)
+	{
+		Memory::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Pipe(const Pipe& pipe) : Memory(pipe) {}
+	Pipe (const Pipe & pipe) :
+		Memory (pipe)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Pipe& operator = (const Pipe &pipe)
-    {
-        Memory::operator=(pipe);
-        return *this;
-    }
+	Pipe & operator= (const Pipe & pipe)
+	{
+		Memory::operator= (pipe);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Pipe(Pipe&& pipe) CL_HPP_NOEXCEPT_ : Memory(std::move(pipe)) {}
+	Pipe (Pipe && pipe) CL_HPP_NOEXCEPT_ : Memory (std::move (pipe))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Pipe& operator = (Pipe &&pipe)
-    {
-        Memory::operator=(std::move(pipe));
-        return *this;
-    }
+	Pipe & operator= (Pipe && pipe)
+	{
+		Memory::operator= (std::move (pipe));
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetMemObjectInfo().
-    template <typename T>
-    cl_int getInfo(cl_pipe_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetPipeInfo, object_, name, param),
-            __GET_PIPE_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetMemObjectInfo().
+	template <typename T>
+	cl_int getInfo (cl_pipe_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetPipeInfo, object_, name, param),
+		__GET_PIPE_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetMemObjectInfo() that returns by value.
-    template <cl_int name> typename
-        detail::param_traits<detail::cl_pipe_info, name>::param_type
-        getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_pipe_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetMemObjectInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_pipe_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_pipe_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 }; // class Pipe
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
-
 
 /*! \brief Class interface for cl_sampler.
  *
@@ -5352,53 +5766,58 @@ public:
 class Sampler : public detail::Wrapper<cl_sampler>
 {
 public:
-    //! \brief Default constructor - initializes to NULL.
-    Sampler() { }
+	//! \brief Default constructor - initializes to NULL.
+	Sampler ()
+	{
+	}
 
-    /*! \brief Constructs a Sampler in a specified context.
+	/*! \brief Constructs a Sampler in a specified context.
      *
      *  Wraps clCreateSampler().
      */
-    Sampler(
-        const Context& context,
-        cl_bool normalized_coords,
-        cl_addressing_mode addressing_mode,
-        cl_filter_mode filter_mode,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Sampler (
+	const Context & context,
+	cl_bool normalized_coords,
+	cl_addressing_mode addressing_mode,
+	cl_filter_mode filter_mode,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-        cl_sampler_properties sampler_properties[] = {
-            CL_SAMPLER_NORMALIZED_COORDS, normalized_coords,
-            CL_SAMPLER_ADDRESSING_MODE, addressing_mode,
-            CL_SAMPLER_FILTER_MODE, filter_mode,
-            0 };
-        object_ = ::clCreateSamplerWithProperties(
-            context(),
-            sampler_properties,
-            &error);
+		cl_sampler_properties sampler_properties[] = {
+			CL_SAMPLER_NORMALIZED_COORDS, normalized_coords,
+			CL_SAMPLER_ADDRESSING_MODE, addressing_mode,
+			CL_SAMPLER_FILTER_MODE, filter_mode,
+			0
+		};
+		object_ = ::clCreateSamplerWithProperties (
+		context (),
+		sampler_properties,
+		&error);
 
-        detail::errHandler(error, __CREATE_SAMPLER_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_SAMPLER_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #else
-        object_ = ::clCreateSampler(
-            context(),
-            normalized_coords,
-            addressing_mode,
-            filter_mode,
-            &error);
+		object_ = ::clCreateSampler (
+		context (),
+		normalized_coords,
+		addressing_mode,
+		filter_mode,
+		&error);
 
-        detail::errHandler(error, __CREATE_SAMPLER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-#endif        
-    }
+		detail::errHandler (error, __CREATE_SAMPLER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+#endif
+	}
 
-    /*! \brief Constructor from cl_sampler - takes ownership.
+	/*! \brief Constructor from cl_sampler - takes ownership.
      * 
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
@@ -5406,70 +5825,78 @@ public:
      *  This effectively transfers ownership of a refcount on the cl_sampler
      *  into the new Sampler object.
      */
-    explicit Sampler(const cl_sampler& sampler, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(sampler, retainObject) { }
+	explicit Sampler (const cl_sampler & sampler, bool retainObject = false) :
+		detail::Wrapper<cl_type> (sampler, retainObject)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_sampler - takes ownership.
+	/*! \brief Assignment operator from cl_sampler - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseSampler() on the value previously held by this instance.
      */
-    Sampler& operator = (const cl_sampler& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Sampler & operator= (const cl_sampler & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler(const Sampler& sam) : detail::Wrapper<cl_type>(sam) {}
+	Sampler (const Sampler & sam) :
+		detail::Wrapper<cl_type> (sam)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler& operator = (const Sampler &sam)
-    {
-        detail::Wrapper<cl_type>::operator=(sam);
-        return *this;
-    }
+	Sampler & operator= (const Sampler & sam)
+	{
+		detail::Wrapper<cl_type>::operator= (sam);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler(Sampler&& sam) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(sam)) {}
+	Sampler (Sampler && sam) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (sam))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Sampler& operator = (Sampler &&sam)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(sam));
-        return *this;
-    }
+	Sampler & operator= (Sampler && sam)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (sam));
+		return *this;
+	}
 
-    //! \brief Wrapper for clGetSamplerInfo().
-    template <typename T>
-    cl_int getInfo(cl_sampler_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetSamplerInfo, object_, name, param),
-            __GET_SAMPLER_INFO_ERR);
-    }
+	//! \brief Wrapper for clGetSamplerInfo().
+	template <typename T>
+	cl_int getInfo (cl_sampler_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetSamplerInfo, object_, name, param),
+		__GET_SAMPLER_INFO_ERR);
+	}
 
-    //! \brief Wrapper for clGetSamplerInfo() that returns by value.
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_sampler_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_sampler_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	//! \brief Wrapper for clGetSamplerInfo() that returns by value.
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_sampler_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_sampler_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 };
 
 class Program;
@@ -5481,76 +5908,77 @@ class Kernel;
 class NDRange
 {
 private:
-    size_type sizes_[3];
-    cl_uint dimensions_;
+	size_type sizes_[3];
+	cl_uint dimensions_;
 
 public:
-    //! \brief Default constructor - resulting range has zero dimensions.
-    NDRange()
-        : dimensions_(0)
-    {
-        sizes_[0] = 0;
-        sizes_[1] = 0;
-        sizes_[2] = 0;
-    }
+	//! \brief Default constructor - resulting range has zero dimensions.
+	NDRange () :
+		dimensions_ (0)
+	{
+		sizes_[0] = 0;
+		sizes_[1] = 0;
+		sizes_[2] = 0;
+	}
 
-    //! \brief Constructs one-dimensional range.
-    NDRange(size_type size0)
-        : dimensions_(1)
-    {
-        sizes_[0] = size0;
-        sizes_[1] = 1;
-        sizes_[2] = 1;
-    }
+	//! \brief Constructs one-dimensional range.
+	NDRange (size_type size0) :
+		dimensions_ (1)
+	{
+		sizes_[0] = size0;
+		sizes_[1] = 1;
+		sizes_[2] = 1;
+	}
 
-    //! \brief Constructs two-dimensional range.
-    NDRange(size_type size0, size_type size1)
-        : dimensions_(2)
-    {
-        sizes_[0] = size0;
-        sizes_[1] = size1;
-        sizes_[2] = 1;
-    }
+	//! \brief Constructs two-dimensional range.
+	NDRange (size_type size0, size_type size1) :
+		dimensions_ (2)
+	{
+		sizes_[0] = size0;
+		sizes_[1] = size1;
+		sizes_[2] = 1;
+	}
 
-    //! \brief Constructs three-dimensional range.
-    NDRange(size_type size0, size_type size1, size_type size2)
-        : dimensions_(3)
-    {
-        sizes_[0] = size0;
-        sizes_[1] = size1;
-        sizes_[2] = size2;
-    }
+	//! \brief Constructs three-dimensional range.
+	NDRange (size_type size0, size_type size1, size_type size2) :
+		dimensions_ (3)
+	{
+		sizes_[0] = size0;
+		sizes_[1] = size1;
+		sizes_[2] = size2;
+	}
 
-    /*! \brief Conversion operator to const size_type *.
+	/*! \brief Conversion operator to const size_type *.
      *  
      *  \returns a pointer to the size of the first dimension.
      */
-    operator const size_type*() const { 
-        return sizes_; 
-    }
+	operator const size_type * () const
+	{
+		return sizes_;
+	}
 
-    //! \brief Queries the number of dimensions in the range.
-    size_type dimensions() const 
-    { 
-        return dimensions_; 
-    }
+	//! \brief Queries the number of dimensions in the range.
+	size_type dimensions () const
+	{
+		return dimensions_;
+	}
 
-    //! \brief Returns the size of the object in bytes based on the
-    // runtime number of dimensions
-    size_type size() const
-    {
-        return dimensions_*sizeof(size_type);
-    }
+	//! \brief Returns the size of the object in bytes based on the
+	// runtime number of dimensions
+	size_type size () const
+	{
+		return dimensions_ * sizeof (size_type);
+	}
 
-    size_type* get()
-    {
-        return sizes_;
-    }
-    
-    const size_type* get() const
-    {
-        return sizes_;
-    }
+	size_type * get ()
+	{
+		return sizes_;
+	}
+
+	const size_type * get () const
+	{
+		return sizes_;
+	}
 };
 
 //! \brief A zero-dimensional range.
@@ -5559,52 +5987,70 @@ static const NDRange NullRange;
 //! \brief Local address wrapper for use with Kernel::setArg
 struct LocalSpaceArg
 {
-    size_type size_;
+	size_type size_;
 };
 
-namespace detail {
-
-template <typename T, class Enable = void>
-struct KernelArgumentHandler;
-
-// Enable for objects that are not subclasses of memory
-// Pointers, constants etc
-template <typename T>
-struct KernelArgumentHandler<T, typename std::enable_if<!std::is_base_of<cl::Memory, T>::value>::type>
+namespace detail
 {
-    static size_type size(const T&) { return sizeof(T); }
-    static const T* ptr(const T& value) { return &value; }
-};
+	template <typename T, class Enable = void>
+	struct KernelArgumentHandler;
 
-// Enable for subclasses of memory where we want to get a reference to the cl_mem out
-// and pass that in for safety
-template <typename T>
-struct KernelArgumentHandler<T, typename std::enable_if<std::is_base_of<cl::Memory, T>::value>::type>
-{
-    static size_type size(const T&) { return sizeof(cl_mem); }
-    static const cl_mem* ptr(const T& value) { return &(value()); }
-};
+	// Enable for objects that are not subclasses of memory
+	// Pointers, constants etc
+	template <typename T>
+	struct KernelArgumentHandler<T, typename std::enable_if<!std::is_base_of<cl::Memory, T>::value>::type>
+	{
+		static size_type size (const T &)
+		{
+			return sizeof (T);
+		}
+		static const T * ptr (const T & value)
+		{
+			return &value;
+		}
+	};
 
-// Specialization for DeviceCommandQueue defined later
+	// Enable for subclasses of memory where we want to get a reference to the cl_mem out
+	// and pass that in for safety
+	template <typename T>
+	struct KernelArgumentHandler<T, typename std::enable_if<std::is_base_of<cl::Memory, T>::value>::type>
+	{
+		static size_type size (const T &)
+		{
+			return sizeof (cl_mem);
+		}
+		static const cl_mem * ptr (const T & value)
+		{
+			return &(value ());
+		}
+	};
 
-template <>
-struct KernelArgumentHandler<LocalSpaceArg, void>
-{
-    static size_type size(const LocalSpaceArg& value) { return value.size_; }
-    static const void* ptr(const LocalSpaceArg&) { return NULL; }
-};
+	// Specialization for DeviceCommandQueue defined later
 
-} 
+	template <>
+	struct KernelArgumentHandler<LocalSpaceArg, void>
+	{
+		static size_type size (const LocalSpaceArg & value)
+		{
+			return value.size_;
+		}
+		static const void * ptr (const LocalSpaceArg &)
+		{
+			return NULL;
+		}
+	};
+
+}
 //! \endcond
 
 /*! Local
  * \brief Helper function for generating LocalSpaceArg objects.
  */
 inline LocalSpaceArg
-Local(size_type size)
+Local (size_type size)
 {
-    LocalSpaceArg ret = { size };
-    return ret;
+	LocalSpaceArg ret = { size };
+	return ret;
 }
 
 /*! \brief Class interface for cl_kernel.
@@ -5618,12 +6064,14 @@ Local(size_type size)
 class Kernel : public detail::Wrapper<cl_kernel>
 {
 public:
-    inline Kernel(const Program& program, const char* name, cl_int* err = NULL);
+	inline Kernel (const Program & program, const char * name, cl_int * err = NULL);
 
-    //! \brief Default constructor - initializes to NULL.
-    Kernel() { }
+	//! \brief Default constructor - initializes to NULL.
+	Kernel ()
+	{
+	}
 
-    /*! \brief Constructor from cl_kernel - takes ownership.
+	/*! \brief Constructor from cl_kernel - takes ownership.
      * 
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
@@ -5631,227 +6079,238 @@ public:
      *  This effectively transfers ownership of a refcount on the cl_kernel
      *  into the new Kernel object.
      */
-    explicit Kernel(const cl_kernel& kernel, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(kernel, retainObject) { }
+	explicit Kernel (const cl_kernel & kernel, bool retainObject = false) :
+		detail::Wrapper<cl_type> (kernel, retainObject)
+	{
+	}
 
-    /*! \brief Assignment operator from cl_kernel - takes ownership.
+	/*! \brief Assignment operator from cl_kernel - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseKernel() on the value previously held by this instance.
      */
-    Kernel& operator = (const cl_kernel& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Kernel & operator= (const cl_kernel & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel(const Kernel& kernel) : detail::Wrapper<cl_type>(kernel) {}
+	Kernel (const Kernel & kernel) :
+		detail::Wrapper<cl_type> (kernel)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel& operator = (const Kernel &kernel)
-    {
-        detail::Wrapper<cl_type>::operator=(kernel);
-        return *this;
-    }
+	Kernel & operator= (const Kernel & kernel)
+	{
+		detail::Wrapper<cl_type>::operator= (kernel);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel(Kernel&& kernel) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(kernel)) {}
+	Kernel (Kernel && kernel) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (kernel))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Kernel& operator = (Kernel &&kernel)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(kernel));
-        return *this;
-    }
+	Kernel & operator= (Kernel && kernel)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (kernel));
+		return *this;
+	}
 
-    template <typename T>
-    cl_int getInfo(cl_kernel_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetKernelInfo, object_, name, param),
-            __GET_KERNEL_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_kernel_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetKernelInfo, object_, name, param),
+		__GET_KERNEL_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_kernel_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_kernel_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_kernel_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_kernel_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    template <typename T>
-    cl_int getArgInfo(cl_uint argIndex, cl_kernel_arg_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetKernelArgInfo, object_, argIndex, name, param),
-            __GET_KERNEL_ARG_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getArgInfo (cl_uint argIndex, cl_kernel_arg_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetKernelArgInfo, object_, argIndex, name, param),
+		__GET_KERNEL_ARG_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_kernel_arg_info, name>::param_type
-    getArgInfo(cl_uint argIndex, cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_kernel_arg_info, name>::param_type param;
-        cl_int result = getArgInfo(argIndex, name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_kernel_arg_info, name>::param_type
+	getArgInfo (cl_uint argIndex, cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_kernel_arg_info, name>::param_type param;
+		cl_int result = getArgInfo (argIndex, name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-    template <typename T>
-    cl_int getWorkGroupInfo(
-        const Device& device, cl_kernel_work_group_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-                &::clGetKernelWorkGroupInfo, object_, device(), name, param),
-                __GET_KERNEL_WORK_GROUP_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getWorkGroupInfo (
+	const Device & device, cl_kernel_work_group_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetKernelWorkGroupInfo, object_, device (), name, param),
+		__GET_KERNEL_WORK_GROUP_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_kernel_work_group_info, name>::param_type
-        getWorkGroupInfo(const Device& device, cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-        detail::cl_kernel_work_group_info, name>::param_type param;
-        cl_int result = getWorkGroupInfo(device, name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
-    
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_kernel_work_group_info, name>::param_type
+	getWorkGroupInfo (const Device & device, cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_kernel_work_group_info, name>::param_type param;
+		cl_int result = getWorkGroupInfo (device, name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
+
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if defined(CL_HPP_USE_CL_SUB_GROUPS_KHR)
-    cl_int getSubGroupInfo(const cl::Device &dev, cl_kernel_sub_group_info name, const cl::NDRange &range, size_type* param) const
-    {
-        typedef clGetKernelSubGroupInfoKHR_fn PFN_clGetKernelSubGroupInfoKHR;
-        static PFN_clGetKernelSubGroupInfoKHR pfn_clGetKernelSubGroupInfoKHR = NULL;
-        CL_HPP_INIT_CL_EXT_FCN_PTR_(clGetKernelSubGroupInfoKHR);
+	cl_int getSubGroupInfo (const cl::Device & dev, cl_kernel_sub_group_info name, const cl::NDRange & range, size_type * param) const
+	{
+		typedef clGetKernelSubGroupInfoKHR_fn PFN_clGetKernelSubGroupInfoKHR;
+		static PFN_clGetKernelSubGroupInfoKHR pfn_clGetKernelSubGroupInfoKHR = NULL;
+		CL_HPP_INIT_CL_EXT_FCN_PTR_ (clGetKernelSubGroupInfoKHR);
 
-        return detail::errHandler(
-            pfn_clGetKernelSubGroupInfoKHR(object_, dev(), name, range.size(), range.get(), sizeof(size_type), param, nullptr),
-            __GET_KERNEL_ARG_INFO_ERR);
-    }
+		return detail::errHandler (
+		pfn_clGetKernelSubGroupInfoKHR (object_, dev (), name, range.size (), range.get (), sizeof (size_type), param, nullptr),
+		__GET_KERNEL_ARG_INFO_ERR);
+	}
 
-    template <cl_int name>
-        size_type getSubGroupInfo(const cl::Device &dev, const cl::NDRange &range, cl_int* err = NULL) const
-    {
-        size_type param;
-        cl_int result = getSubGroupInfo(dev, name, range, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	size_type getSubGroupInfo (const cl::Device & dev, const cl::NDRange & range, cl_int * err = NULL) const
+	{
+		size_type param;
+		cl_int result = getSubGroupInfo (dev, name, range, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 #endif // #if defined(CL_HPP_USE_CL_SUB_GROUPS_KHR)
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /*! \brief setArg overload taking a shared_ptr type
+	/*! \brief setArg overload taking a shared_ptr type
      */
-    template<typename T, class D>
-    cl_int setArg(cl_uint index, const cl::pointer<T, D> &argPtr)
-    {
-        return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr.get()),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	template <typename T, class D>
+	cl_int setArg (cl_uint index, const cl::pointer<T, D> & argPtr)
+	{
+		return detail::errHandler (
+		::clSetKernelArgSVMPointer (object_, index, argPtr.get ()),
+		__SET_KERNEL_ARGS_ERR);
+	}
 
-    /*! \brief setArg overload taking a vector type.
+	/*! \brief setArg overload taking a vector type.
      */
-    template<typename T, class Alloc>
-    cl_int setArg(cl_uint index, const cl::vector<T, Alloc> &argPtr)
-    {
-        return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr.data()),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	template <typename T, class Alloc>
+	cl_int setArg (cl_uint index, const cl::vector<T, Alloc> & argPtr)
+	{
+		return detail::errHandler (
+		::clSetKernelArgSVMPointer (object_, index, argPtr.data ()),
+		__SET_KERNEL_ARGS_ERR);
+	}
 
-    /*! \brief setArg overload taking a pointer type
+	/*! \brief setArg overload taking a pointer type
      */
-    template<typename T>
-    typename std::enable_if<std::is_pointer<T>::value, cl_int>::type
-        setArg(cl_uint index, const T argPtr)
-    {
-        return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	template <typename T>
+	typename std::enable_if<std::is_pointer<T>::value, cl_int>::type
+	setArg (cl_uint index, const T argPtr)
+	{
+		return detail::errHandler (
+		::clSetKernelArgSVMPointer (object_, index, argPtr),
+		__SET_KERNEL_ARGS_ERR);
+	}
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-    /*! \brief setArg overload taking a POD type
+	/*! \brief setArg overload taking a POD type
      */
-    template <typename T>
-    typename std::enable_if<!std::is_pointer<T>::value, cl_int>::type
-        setArg(cl_uint index, const T &value)
-    {
-        return detail::errHandler(
-            ::clSetKernelArg(
-                object_,
-                index,
-                detail::KernelArgumentHandler<T>::size(value),
-                detail::KernelArgumentHandler<T>::ptr(value)),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	template <typename T>
+	typename std::enable_if<!std::is_pointer<T>::value, cl_int>::type
+	setArg (cl_uint index, const T & value)
+	{
+		return detail::errHandler (
+		::clSetKernelArg (
+		object_,
+		index,
+		detail::KernelArgumentHandler<T>::size (value),
+		detail::KernelArgumentHandler<T>::ptr (value)),
+		__SET_KERNEL_ARGS_ERR);
+	}
 
-    cl_int setArg(cl_uint index, size_type size, const void* argPtr)
-    {
-        return detail::errHandler(
-            ::clSetKernelArg(object_, index, size, argPtr),
-            __SET_KERNEL_ARGS_ERR);
-    }
+	cl_int setArg (cl_uint index, size_type size, const void * argPtr)
+	{
+		return detail::errHandler (
+		::clSetKernelArg (object_, index, size, argPtr),
+		__SET_KERNEL_ARGS_ERR);
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /*!
+	/*!
      * Specify a vector of SVM pointers that the kernel may access in 
      * addition to its arguments.
      */
-    cl_int setSVMPointers(const vector<void*> &pointerList)
-    {
-        return detail::errHandler(
-            ::clSetKernelExecInfo(
-                object_,
-                CL_KERNEL_EXEC_INFO_SVM_PTRS,
-                sizeof(void*)*pointerList.size(),
-                pointerList.data()));
-    }
+	cl_int setSVMPointers (const vector<void *> & pointerList)
+	{
+		return detail::errHandler (
+		::clSetKernelExecInfo (
+		object_,
+		CL_KERNEL_EXEC_INFO_SVM_PTRS,
+		sizeof (void *) * pointerList.size (),
+		pointerList.data ()));
+	}
 
-    /*!
+	/*!
      * Specify a std::array of SVM pointers that the kernel may access in
      * addition to its arguments.
      */
-    template<int ArrayLength>
-    cl_int setSVMPointers(const std::array<void*, ArrayLength> &pointerList)
-    {
-        return detail::errHandler(
-            ::clSetKernelExecInfo(
-                object_,
-                CL_KERNEL_EXEC_INFO_SVM_PTRS,
-                sizeof(void*)*pointerList.size(),
-                pointerList.data()));
-    }
+	template <int ArrayLength>
+	cl_int setSVMPointers (const std::array<void *, ArrayLength> & pointerList)
+	{
+		return detail::errHandler (
+		::clSetKernelExecInfo (
+		object_,
+		CL_KERNEL_EXEC_INFO_SVM_PTRS,
+		sizeof (void *) * pointerList.size (),
+		pointerList.data ()));
+	}
 
-    /*! \brief Enable fine-grained system SVM.
+	/*! \brief Enable fine-grained system SVM.
      *
      * \note It is only possible to enable fine-grained system SVM if all devices
      *       in the context associated with kernel support it.
@@ -5862,60 +6321,58 @@ public:
      *
      * \see clSetKernelExecInfo
      */
-    cl_int enableFineGrainedSystemSVM(bool svmEnabled)
-    {
-        cl_bool svmEnabled_ = svmEnabled ? CL_TRUE : CL_FALSE;
-        return detail::errHandler(
-            ::clSetKernelExecInfo(
-                object_,
-                CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
-                sizeof(cl_bool),
-                &svmEnabled_
-                )
-            );
-    }
-    
-    template<int index, int ArrayLength, class D, typename T0, typename... Ts>
-    void setSVMPointersHelper(std::array<void*, ArrayLength> &pointerList, const pointer<T0, D> &t0, Ts... ts)
-    {
-        pointerList[index] = static_cast<void*>(t0.get());
-        setSVMPointersHelper<index + 1, Ts...>(ts...);
-    }
+	cl_int enableFineGrainedSystemSVM (bool svmEnabled)
+	{
+		cl_bool svmEnabled_ = svmEnabled ? CL_TRUE : CL_FALSE;
+		return detail::errHandler (
+		::clSetKernelExecInfo (
+		object_,
+		CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
+		sizeof (cl_bool),
+		&svmEnabled_));
+	}
 
-    template<int index, int ArrayLength, typename T0, typename... Ts>
-    typename std::enable_if<std::is_pointer<T0>::value, void>::type
-    setSVMPointersHelper(std::array<void*, ArrayLength> &pointerList, T0 t0, Ts... ts)
-    {
-        pointerList[index] = static_cast<void*>(t0);
-        setSVMPointersHelper<index + 1, Ts...>(ts...);
-    }
-    
-    template<int index, int ArrayLength, typename T0, class D>
-    void setSVMPointersHelper(std::array<void*, ArrayLength> &pointerList, const pointer<T0, D> &t0)
-    {
-        pointerList[index] = static_cast<void*>(t0.get());
-    }
+	template <int index, int ArrayLength, class D, typename T0, typename... Ts>
+	void setSVMPointersHelper (std::array<void *, ArrayLength> & pointerList, const pointer<T0, D> & t0, Ts... ts)
+	{
+		pointerList[index] = static_cast<void *> (t0.get ());
+		setSVMPointersHelper<index + 1, Ts...> (ts...);
+	}
 
-    template<int index, int ArrayLength, typename T0>
-    typename std::enable_if<std::is_pointer<T0>::value, void>::type
-    setSVMPointersHelper(std::array<void*, ArrayLength> &pointerList, T0 t0)
-    {
-        pointerList[index] = static_cast<void*>(t0);
-    }
+	template <int index, int ArrayLength, typename T0, typename... Ts>
+	typename std::enable_if<std::is_pointer<T0>::value, void>::type
+	setSVMPointersHelper (std::array<void *, ArrayLength> & pointerList, T0 t0, Ts... ts)
+	{
+		pointerList[index] = static_cast<void *> (t0);
+		setSVMPointersHelper<index + 1, Ts...> (ts...);
+	}
 
-    template<typename T0, typename... Ts>
-    cl_int setSVMPointers(const T0 &t0, Ts... ts)
-    {
-        std::array<void*, 1 + sizeof...(Ts)> pointerList;
+	template <int index, int ArrayLength, typename T0, class D>
+	void setSVMPointersHelper (std::array<void *, ArrayLength> & pointerList, const pointer<T0, D> & t0)
+	{
+		pointerList[index] = static_cast<void *> (t0.get ());
+	}
 
-        setSVMPointersHelper<0, 1 + sizeof...(Ts)>(pointerList, t0, ts...);
-        return detail::errHandler(
-            ::clSetKernelExecInfo(
-            object_,
-            CL_KERNEL_EXEC_INFO_SVM_PTRS,
-            sizeof(void*)*(1 + sizeof...(Ts)),
-            pointerList.data()));
-    }
+	template <int index, int ArrayLength, typename T0>
+	typename std::enable_if<std::is_pointer<T0>::value, void>::type
+	setSVMPointersHelper (std::array<void *, ArrayLength> & pointerList, T0 t0)
+	{
+		pointerList[index] = static_cast<void *> (t0);
+	}
+
+	template <typename T0, typename... Ts>
+	cl_int setSVMPointers (const T0 & t0, Ts... ts)
+	{
+		std::array<void *, 1 + sizeof...(Ts)> pointerList;
+
+		setSVMPointersHelper<0, 1 + sizeof...(Ts)> (pointerList, t0, ts...);
+		return detail::errHandler (
+		::clSetKernelExecInfo (
+		object_,
+		CL_KERNEL_EXEC_INFO_SVM_PTRS,
+		sizeof (void *) * (1 + sizeof...(Ts)),
+		pointerList.data ()));
+	}
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 };
 
@@ -5926,160 +6383,167 @@ class Program : public detail::Wrapper<cl_program>
 {
 public:
 #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-    typedef vector<vector<unsigned char>> Binaries;
-    typedef vector<string> Sources;
+	typedef vector<vector<unsigned char>> Binaries;
+	typedef vector<string> Sources;
 #else // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-    typedef vector<std::pair<const void*, size_type> > Binaries;
-    typedef vector<std::pair<const char*, size_type> > Sources;
+	typedef vector<std::pair<const void *, size_type>> Binaries;
+	typedef vector<std::pair<const char *, size_type>> Sources;
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-    
-    Program(
-        const string& source,
-        bool build = false,
-        cl_int* err = NULL)
-    {
-        cl_int error;
 
-        const char * strings = source.c_str();
-        const size_type length  = source.size();
+	Program (
+	const string & source,
+	bool build = false,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        Context context = Context::getDefault(err);
+		const char * strings = source.c_str ();
+		const size_type length = source.size ();
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)1, &strings, &length, &error);
+		Context context = Context::getDefault (err);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)1, &strings, &length, &error);
 
-        if (error == CL_SUCCESS && build) {
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
-            error = ::clBuildProgram(
-                object_,
-                0,
-                NULL,
+		if (error == CL_SUCCESS && build)
+		{
+			error = ::clBuildProgram (
+			object_,
+			0,
+			NULL,
 #if !defined(CL_HPP_CL_1_2_DEFAULT_BUILD)
-                "-cl-std=CL2.0",
+			"-cl-std=CL2.0",
 #else
-                "",
+			"",
 #endif // #if !defined(CL_HPP_CL_1_2_DEFAULT_BUILD)
-                NULL,
-                NULL);
+			NULL,
+			NULL);
 
-            detail::buildErrHandler(error, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
-        }
+			detail::buildErrHandler (error, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG> ());
+		}
 
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    Program(
-        const Context& context,
-        const string& source,
-        bool build = false,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Program (
+	const Context & context,
+	const string & source,
+	bool build = false,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        const char * strings = source.c_str();
-        const size_type length  = source.size();
+		const char * strings = source.c_str ();
+		const size_type length = source.size ();
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)1, &strings, &length, &error);
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)1, &strings, &length, &error);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
-        if (error == CL_SUCCESS && build) {
-            error = ::clBuildProgram(
-                object_,
-                0,
-                NULL,
+		if (error == CL_SUCCESS && build)
+		{
+			error = ::clBuildProgram (
+			object_,
+			0,
+			NULL,
 #if !defined(CL_HPP_CL_1_2_DEFAULT_BUILD)
-                "-cl-std=CL2.0",
+			"-cl-std=CL2.0",
 #else
-                "",
+			"",
 #endif // #if !defined(CL_HPP_CL_1_2_DEFAULT_BUILD)
-                NULL,
-                NULL);
-            
-            detail::buildErrHandler(error, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
-        }
+			NULL,
+			NULL);
 
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+			detail::buildErrHandler (error, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG> ());
+		}
 
-    /**
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+
+	/**
      * Create a program from a vector of source strings and the default context.
      * Does not compile or link the program.
      */
-    Program(
-        const Sources& sources,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        Context context = Context::getDefault(err);
+	Program (
+	const Sources & sources,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		Context context = Context::getDefault (err);
 
-        const size_type n = (size_type)sources.size();
+		const size_type n = (size_type)sources.size ();
 
-        vector<size_type> lengths(n);
-        vector<const char*> strings(n);
+		vector<size_type> lengths (n);
+		vector<const char *> strings (n);
 
-        for (size_type i = 0; i < n; ++i) {
+		for (size_type i = 0; i < n; ++i)
+		{
 #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-            strings[i] = sources[(int)i].data();
-            lengths[i] = sources[(int)i].length();
+			strings[i] = sources[(int)i].data ();
+			lengths[i] = sources[(int)i].length ();
 #else // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-            strings[i] = sources[(int)i].first;
-            lengths[i] = sources[(int)i].second;
+			strings[i] = sources[(int)i].first;
+			lengths[i] = sources[(int)i].second;
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-        }
+		}
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)n, strings.data(), lengths.data(), &error);
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)n, strings.data (), lengths.data (), &error);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /**
+	/**
      * Create a program from a vector of source strings and a provided context.
      * Does not compile or link the program.
      */
-    Program(
-        const Context& context,
-        const Sources& sources,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Program (
+	const Context & context,
+	const Sources & sources,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        const size_type n = (size_type)sources.size();
+		const size_type n = (size_type)sources.size ();
 
-        vector<size_type> lengths(n);
-        vector<const char*> strings(n);
+		vector<size_type> lengths (n);
+		vector<const char *> strings (n);
 
-        for (size_type i = 0; i < n; ++i) {
+		for (size_type i = 0; i < n; ++i)
+		{
 #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-            strings[i] = sources[(int)i].data();
-            lengths[i] = sources[(int)i].length();
+			strings[i] = sources[(int)i].data ();
+			lengths[i] = sources[(int)i].length ();
 #else // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-            strings[i] = sources[(int)i].first;
-            lengths[i] = sources[(int)i].second;
+			strings[i] = sources[(int)i].first;
+			lengths[i] = sources[(int)i].second;
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-        }
+		}
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)n, strings.data(), lengths.data(), &error);
+		object_ = ::clCreateProgramWithSource (
+		context (), (cl_uint)n, strings.data (), lengths.data (), &error);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /**
+	/**
      * Construct a program object from a list of devices and a per-device list of binaries.
      * \param context A valid OpenCL context in which to construct the program.
      * \param devices A vector of OpenCL device objects for which the program will be created.
@@ -6098,468 +6562,501 @@ public:
      *   CL_INVALID_BINARY if an invalid program binary was encountered for any device. binaryStatus will return specific status for each device.
      *   CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources required by the OpenCL implementation on the host.
      */
-    Program(
-        const Context& context,
-        const vector<Device>& devices,
-        const Binaries& binaries,
-        vector<cl_int>* binaryStatus = NULL,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        
-        const size_type numDevices = devices.size();
-        
-        // Catch size mismatch early and return
-        if(binaries.size() != numDevices) {
-            error = CL_INVALID_VALUE;
-            detail::errHandler(error, __CREATE_PROGRAM_WITH_BINARY_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
-            return;
-        }
+	Program (
+	const Context & context,
+	const vector<Device> & devices,
+	const Binaries & binaries,
+	vector<cl_int> * binaryStatus = NULL,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
+		const size_type numDevices = devices.size ();
 
-        vector<size_type> lengths(numDevices);
-        vector<const unsigned char*> images(numDevices);
+		// Catch size mismatch early and return
+		if (binaries.size () != numDevices)
+		{
+			error = CL_INVALID_VALUE;
+			detail::errHandler (error, __CREATE_PROGRAM_WITH_BINARY_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
+			return;
+		}
+
+		vector<size_type> lengths (numDevices);
+		vector<const unsigned char *> images (numDevices);
 #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-        for (size_type i = 0; i < numDevices; ++i) {
-            images[i] = binaries[i].data();
-            lengths[i] = binaries[(int)i].size();
-        }
+		for (size_type i = 0; i < numDevices; ++i)
+		{
+			images[i] = binaries[i].data ();
+			lengths[i] = binaries[(int)i].size ();
+		}
 #else // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-        for (size_type i = 0; i < numDevices; ++i) {
-            images[i] = (const unsigned char*)binaries[i].first;
-            lengths[i] = binaries[(int)i].second;
-        }
+		for (size_type i = 0; i < numDevices; ++i)
+		{
+			images[i] = (const unsigned char *)binaries[i].first;
+			lengths[i] = binaries[(int)i].second;
+		}
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
-        
-        vector<cl_device_id> deviceIDs(numDevices);
-        for( size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
 
-        if(binaryStatus) {
-            binaryStatus->resize(numDevices);
-        }
-        
-        object_ = ::clCreateProgramWithBinary(
-            context(), (cl_uint) devices.size(),
-            deviceIDs.data(),
-            lengths.data(), images.data(), (binaryStatus != NULL && numDevices > 0)
-               ? &binaryStatus->front()
-               : NULL, &error);
+		vector<cl_device_id> deviceIDs (numDevices);
+		for (size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_BINARY_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		if (binaryStatus)
+		{
+			binaryStatus->resize (numDevices);
+		}
 
-    
+		object_ = ::clCreateProgramWithBinary (
+		context (), (cl_uint)devices.size (),
+		deviceIDs.data (),
+		lengths.data (), images.data (), (binaryStatus != NULL && numDevices > 0) ? &binaryStatus->front () : NULL, &error);
+
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_BINARY_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
+
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    /**
+	/**
      * Create program using builtin kernels.
      * \param kernelNames Semi-colon separated list of builtin kernel names
      */
-    Program(
-        const Context& context,
-        const vector<Device>& devices,
-        const string& kernelNames,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	Program (
+	const Context & context,
+	const vector<Device> & devices,
+	const string & kernelNames,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
+		size_type numDevices = devices.size ();
+		vector<cl_device_id> deviceIDs (numDevices);
+		for (size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        size_type numDevices = devices.size();
-        vector<cl_device_id> deviceIDs(numDevices);
-        for( size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
-        
-        object_ = ::clCreateProgramWithBuiltInKernels(
-            context(), 
-            (cl_uint) devices.size(),
-            deviceIDs.data(),
-            kernelNames.c_str(), 
-            &error);
+		object_ = ::clCreateProgramWithBuiltInKernels (
+		context (),
+		(cl_uint)devices.size (),
+		deviceIDs.data (),
+		kernelNames.c_str (),
+		&error);
 
-        detail::errHandler(error, __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_PROGRAM_WITH_BUILT_IN_KERNELS_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-    Program() { }
-    
+	Program ()
+	{
+	}
 
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      */
-    explicit Program(const cl_program& program, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(program, retainObject) { }
+	explicit Program (const cl_program & program, bool retainObject = false) :
+		detail::Wrapper<cl_type> (program, retainObject)
+	{
+	}
 
-    Program& operator = (const cl_program& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	Program & operator= (const cl_program & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Program(const Program& program) : detail::Wrapper<cl_type>(program) {}
+	Program (const Program & program) :
+		detail::Wrapper<cl_type> (program)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    Program& operator = (const Program &program)
-    {
-        detail::Wrapper<cl_type>::operator=(program);
-        return *this;
-    }
+	Program & operator= (const Program & program)
+	{
+		detail::Wrapper<cl_type>::operator= (program);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Program(Program&& program) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(program)) {}
+	Program (Program && program) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (program))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    Program& operator = (Program &&program)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(program));
-        return *this;
-    }
+	Program & operator= (Program && program)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (program));
+		return *this;
+	}
 
-    cl_int build(
-        const vector<Device>& devices,
-        const char* options = NULL,
-        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-        void* data = NULL) const
-    {
-        size_type numDevices = devices.size();
-        vector<cl_device_id> deviceIDs(numDevices);
-        
-        for( size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
-            deviceIDs[deviceIndex] = (devices[deviceIndex])();
-        }
+	cl_int build (
+	const vector<Device> & devices,
+	const char * options = NULL,
+	void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+	void * data = NULL) const
+	{
+		size_type numDevices = devices.size ();
+		vector<cl_device_id> deviceIDs (numDevices);
 
-        cl_int buildError = ::clBuildProgram(
-            object_,
-            (cl_uint)
-            devices.size(),
-            deviceIDs.data(),
-            options,
-            notifyFptr,
-            data);
+		for (size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex)
+		{
+			deviceIDs[deviceIndex] = (devices[deviceIndex]) ();
+		}
 
-        return detail::buildErrHandler(buildError, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
-    }
+		cl_int buildError = ::clBuildProgram (
+		object_,
+		(cl_uint)
+		devices.size (),
+		deviceIDs.data (),
+		options,
+		notifyFptr,
+		data);
 
-    cl_int build(
-        const char* options = NULL,
-        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-        void* data = NULL) const
-    {
-        cl_int buildError = ::clBuildProgram(
-            object_,
-            0,
-            NULL,
-            options,
-            notifyFptr,
-            data);
+		return detail::buildErrHandler (buildError, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG> ());
+	}
 
+	cl_int build (
+	const char * options = NULL,
+	void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+	void * data = NULL) const
+	{
+		cl_int buildError = ::clBuildProgram (
+		object_,
+		0,
+		NULL,
+		options,
+		notifyFptr,
+		data);
 
-        return detail::buildErrHandler(buildError, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
-    }
+		return detail::buildErrHandler (buildError, __BUILD_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG> ());
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    cl_int compile(
-        const char* options = NULL,
-        void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-        void* data = NULL) const
-    {
-        cl_int error = ::clCompileProgram(
-            object_,
-            0,
-            NULL,
-            options,
-            0,
-            NULL,
-            NULL,
-            notifyFptr,
-            data);
-        return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
-    }
+	cl_int compile (
+	const char * options = NULL,
+	void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+	void * data = NULL) const
+	{
+		cl_int error = ::clCompileProgram (
+		object_,
+		0,
+		NULL,
+		options,
+		0,
+		NULL,
+		NULL,
+		notifyFptr,
+		data);
+		return detail::buildErrHandler (error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG> ());
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-    template <typename T>
-    cl_int getInfo(cl_program_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
-            __GET_PROGRAM_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_program_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (&::clGetProgramInfo, object_, name, param),
+		__GET_PROGRAM_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_program_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_program_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_program_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_program_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    template <typename T>
-    cl_int getBuildInfo(
-        const Device& device, cl_program_build_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-                &::clGetProgramBuildInfo, object_, device(), name, param),
-                __GET_PROGRAM_BUILD_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getBuildInfo (
+	const Device & device, cl_program_build_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetProgramBuildInfo, object_, device (), name, param),
+		__GET_PROGRAM_BUILD_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_program_build_info, name>::param_type
-    getBuildInfo(const Device& device, cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_program_build_info, name>::param_type param;
-        cl_int result = getBuildInfo(device, name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
-    
-    /**
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_program_build_info, name>::param_type
+	getBuildInfo (const Device & device, cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_program_build_info, name>::param_type param;
+		cl_int result = getBuildInfo (device, name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
+
+	/**
      * Build info function that returns a vector of device/info pairs for the specified 
      * info type and for all devices in the program.
      * On an error reading the info for any device, an empty vector of info will be returned.
      */
-    template <cl_int name>
-    vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type>>
-        getBuildInfo(cl_int *err = NULL) const
-    {
-        cl_int result = CL_SUCCESS;
+	template <cl_int name>
+	vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type>>
+	getBuildInfo (cl_int * err = NULL) const
+	{
+		cl_int result = CL_SUCCESS;
 
-        auto devs = getInfo<CL_PROGRAM_DEVICES>(&result);
-        vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type>>
-            devInfo;
+		auto devs = getInfo<CL_PROGRAM_DEVICES> (&result);
+		vector<std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type>>
+		devInfo;
 
-        // If there was an initial error from getInfo return the error
-        if (result != CL_SUCCESS) {
-            if (err != NULL) {
-                *err = result;
-            }
-            return devInfo;
-        }
+		// If there was an initial error from getInfo return the error
+		if (result != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = result;
+			}
+			return devInfo;
+		}
 
-        for (cl::Device d : devs) {
-            typename detail::param_traits<
-                detail::cl_program_build_info, name>::param_type param;
-            result = getBuildInfo(d, name, &param);
-            devInfo.push_back(
-                std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type>
-                (d, param));
-            if (result != CL_SUCCESS) {
-                // On error, leave the loop and return the error code
-                break;
-            }
-        }
-        if (err != NULL) {
-            *err = result;
-        }
-        if (result != CL_SUCCESS) {
-            devInfo.clear();
-        }
-        return devInfo;
-    }
+		for (cl::Device d : devs)
+		{
+			typename detail::param_traits<
+			detail::cl_program_build_info, name>::param_type param;
+			result = getBuildInfo (d, name, &param);
+			devInfo.push_back (
+			std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type> (d, param));
+			if (result != CL_SUCCESS)
+			{
+				// On error, leave the loop and return the error code
+				break;
+			}
+		}
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		if (result != CL_SUCCESS)
+		{
+			devInfo.clear ();
+		}
+		return devInfo;
+	}
 
-    cl_int createKernels(vector<Kernel>* kernels)
-    {
-        cl_uint numKernels;
-        cl_int err = ::clCreateKernelsInProgram(object_, 0, NULL, &numKernels);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
-        }
+	cl_int createKernels (vector<Kernel> * kernels)
+	{
+		cl_uint numKernels;
+		cl_int err = ::clCreateKernelsInProgram (object_, 0, NULL, &numKernels);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_KERNELS_IN_PROGRAM_ERR);
+		}
 
-        vector<cl_kernel> value(numKernels);
-        
-        err = ::clCreateKernelsInProgram(
-            object_, numKernels, value.data(), NULL);
-        if (err != CL_SUCCESS) {
-            return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
-        }
+		vector<cl_kernel> value (numKernels);
 
-        if (kernels) {
-            kernels->resize(value.size());
+		err = ::clCreateKernelsInProgram (
+		object_, numKernels, value.data (), NULL);
+		if (err != CL_SUCCESS)
+		{
+			return detail::errHandler (err, __CREATE_KERNELS_IN_PROGRAM_ERR);
+		}
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < value.size(); i++) {
-                // We do not need to retain because this kernel is being created 
-                // by the runtime
-                (*kernels)[i] = Kernel(value[i], false);
-            }
-        }
-        return CL_SUCCESS;
-    }
+		if (kernels)
+		{
+			kernels->resize (value.size ());
+
+			// Assign to param, constructing with retain behaviour
+			// to correctly capture each underlying CL object
+			for (size_type i = 0; i < value.size (); i++)
+			{
+				// We do not need to retain because this kernel is being created
+				// by the runtime
+				(*kernels)[i] = Kernel (value[i], false);
+			}
+		}
+		return CL_SUCCESS;
+	}
 };
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-inline Program linkProgram(
-    Program input1,
-    Program input2,
-    const char* options = NULL,
-    void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-    void* data = NULL,
-    cl_int* err = NULL) 
+inline Program linkProgram (
+Program input1,
+Program input2,
+const char * options = NULL,
+void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+void * data = NULL,
+cl_int * err = NULL)
 {
-    cl_int error_local = CL_SUCCESS;
+	cl_int error_local = CL_SUCCESS;
 
-    cl_program programs[2] = { input1(), input2() };
+	cl_program programs[2] = { input1 (), input2 () };
 
-    Context ctx = input1.getInfo<CL_PROGRAM_CONTEXT>(&error_local);
-    if(error_local!=CL_SUCCESS) {
-        detail::errHandler(error_local, __LINK_PROGRAM_ERR);
-    }
+	Context ctx = input1.getInfo<CL_PROGRAM_CONTEXT> (&error_local);
+	if (error_local != CL_SUCCESS)
+	{
+		detail::errHandler (error_local, __LINK_PROGRAM_ERR);
+	}
 
-    cl_program prog = ::clLinkProgram(
-        ctx(),
-        0,
-        NULL,
-        options,
-        2,
-        programs,
-        notifyFptr,
-        data,
-        &error_local);
+	cl_program prog = ::clLinkProgram (
+	ctx (),
+	0,
+	NULL,
+	options,
+	2,
+	programs,
+	notifyFptr,
+	data,
+	&error_local);
 
-    detail::errHandler(error_local,__COMPILE_PROGRAM_ERR);
-    if (err != NULL) {
-        *err = error_local;
-    }
+	detail::errHandler (error_local, __COMPILE_PROGRAM_ERR);
+	if (err != NULL)
+	{
+		*err = error_local;
+	}
 
-    return Program(prog);
+	return Program (prog);
 }
 
-inline Program linkProgram(
-    vector<Program> inputPrograms,
-    const char* options = NULL,
-    void (CL_CALLBACK * notifyFptr)(cl_program, void *) = NULL,
-    void* data = NULL,
-    cl_int* err = NULL) 
+inline Program linkProgram (
+vector<Program> inputPrograms,
+const char * options = NULL,
+void (CL_CALLBACK * notifyFptr) (cl_program, void *) = NULL,
+void * data = NULL,
+cl_int * err = NULL)
 {
-    cl_int error_local = CL_SUCCESS;
+	cl_int error_local = CL_SUCCESS;
 
-    vector<cl_program> programs(inputPrograms.size());
+	vector<cl_program> programs (inputPrograms.size ());
 
-    for (unsigned int i = 0; i < inputPrograms.size(); i++) {
-        programs[i] = inputPrograms[i]();
-    }
-    
-    Context ctx;
-    if(inputPrograms.size() > 0) {
-        ctx = inputPrograms[0].getInfo<CL_PROGRAM_CONTEXT>(&error_local);
-        if(error_local!=CL_SUCCESS) {
-            detail::errHandler(error_local, __LINK_PROGRAM_ERR);
-        }
-    }
-    cl_program prog = ::clLinkProgram(
-        ctx(),
-        0,
-        NULL,
-        options,
-        (cl_uint)inputPrograms.size(),
-        programs.data(),
-        notifyFptr,
-        data,
-        &error_local);
+	for (unsigned int i = 0; i < inputPrograms.size (); i++)
+	{
+		programs[i] = inputPrograms[i]();
+	}
 
-    detail::errHandler(error_local,__COMPILE_PROGRAM_ERR);
-    if (err != NULL) {
-        *err = error_local;
-    }
+	Context ctx;
+	if (inputPrograms.size () > 0)
+	{
+		ctx = inputPrograms[0].getInfo<CL_PROGRAM_CONTEXT> (&error_local);
+		if (error_local != CL_SUCCESS)
+		{
+			detail::errHandler (error_local, __LINK_PROGRAM_ERR);
+		}
+	}
+	cl_program prog = ::clLinkProgram (
+	ctx (),
+	0,
+	NULL,
+	options,
+	(cl_uint)inputPrograms.size (),
+	programs.data (),
+	notifyFptr,
+	data,
+	&error_local);
 
-    return Program(prog, false);
+	detail::errHandler (error_local, __COMPILE_PROGRAM_ERR);
+	if (err != NULL)
+	{
+		*err = error_local;
+	}
+
+	return Program (prog, false);
 }
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
 // Template specialization for CL_PROGRAM_BINARIES
 template <>
-inline cl_int cl::Program::getInfo(cl_program_info name, vector<vector<unsigned char>>* param) const
+inline cl_int cl::Program::getInfo (cl_program_info name, vector<vector<unsigned char>> * param) const
 {
-    if (name != CL_PROGRAM_BINARIES) {
-        return CL_INVALID_VALUE;
-    }
-    if (param) {
-        // Resize the parameter array appropriately for each allocation
-        // and pass down to the helper
+	if (name != CL_PROGRAM_BINARIES)
+	{
+		return CL_INVALID_VALUE;
+	}
+	if (param)
+	{
+		// Resize the parameter array appropriately for each allocation
+		// and pass down to the helper
 
-        vector<size_type> sizes = getInfo<CL_PROGRAM_BINARY_SIZES>();
-        size_type numBinaries = sizes.size();
+		vector<size_type> sizes = getInfo<CL_PROGRAM_BINARY_SIZES> ();
+		size_type numBinaries = sizes.size ();
 
-        // Resize the parameter array and constituent arrays
-        param->resize(numBinaries);
-        for (int i = 0; i < numBinaries; ++i) {
-            (*param)[i].resize(sizes[i]);
-        }
+		// Resize the parameter array and constituent arrays
+		param->resize (numBinaries);
+		for (int i = 0; i < numBinaries; ++i)
+		{
+			(*param)[i].resize (sizes[i]);
+		}
 
-        return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
-            __GET_PROGRAM_INFO_ERR);
-    }
+		return detail::errHandler (
+		detail::getInfo (&::clGetProgramInfo, object_, name, param),
+		__GET_PROGRAM_INFO_ERR);
+	}
 
-    return CL_SUCCESS;
+	return CL_SUCCESS;
 }
 
-template<>
-inline vector<vector<unsigned char>> cl::Program::getInfo<CL_PROGRAM_BINARIES>(cl_int* err) const
+template <>
+inline vector<vector<unsigned char>> cl::Program::getInfo<CL_PROGRAM_BINARIES> (cl_int * err) const
 {
-    vector<vector<unsigned char>> binariesVectors;
+	vector<vector<unsigned char>> binariesVectors;
 
-    cl_int result = getInfo(CL_PROGRAM_BINARIES, &binariesVectors);
-    if (err != NULL) {
-        *err = result;
-    }
-    return binariesVectors;
+	cl_int result = getInfo (CL_PROGRAM_BINARIES, &binariesVectors);
+	if (err != NULL)
+	{
+		*err = result;
+	}
+	return binariesVectors;
 }
 
-inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
+inline Kernel::Kernel (const Program & program, const char * name, cl_int * err)
 {
-    cl_int error;
+	cl_int error;
 
-    object_ = ::clCreateKernel(program(), name, &error);
-    detail::errHandler(error, __CREATE_KERNEL_ERR);
+	object_ = ::clCreateKernel (program (), name, &error);
+	detail::errHandler (error, __CREATE_KERNEL_ERR);
 
-    if (err != NULL) {
-        *err = error;
-    }
-
+	if (err != NULL)
+	{
+		*err = error;
+	}
 }
 
 enum class QueueProperties : cl_command_queue_properties
 {
-    None = 0,
-    Profiling = CL_QUEUE_PROFILING_ENABLE,
-    OutOfOrder = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+	None = 0,
+	Profiling = CL_QUEUE_PROFILING_ENABLE,
+	OutOfOrder = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
 };
 
-QueueProperties operator|(QueueProperties lhs, QueueProperties rhs)
+QueueProperties operator| (QueueProperties lhs, QueueProperties rhs)
 {
-    return static_cast<QueueProperties>(static_cast<cl_command_queue_properties>(lhs) | static_cast<cl_command_queue_properties>(rhs));
+	return static_cast<QueueProperties> (static_cast<cl_command_queue_properties> (lhs) | static_cast<cl_command_queue_properties> (rhs));
 }
 
 /*! \class CommandQueue
@@ -6568,606 +7065,647 @@ QueueProperties operator|(QueueProperties lhs, QueueProperties rhs)
 class CommandQueue : public detail::Wrapper<cl_command_queue>
 {
 private:
-    static std::once_flag default_initialized_;
-    static CommandQueue default_;
-    static cl_int default_error_;
+	static std::once_flag default_initialized_;
+	static CommandQueue default_;
+	static cl_int default_error_;
 
-    /*! \brief Create the default command queue returned by @ref getDefault.
+	/*! \brief Create the default command queue returned by @ref getDefault.
      *
      * It sets default_error_ to indicate success or failure. It does not throw
      * @c cl::Error.
      */
-    static void makeDefault()
-    {
-        /* We don't want to throw an error from this function, so we have to
+	static void makeDefault ()
+	{
+		/* We don't want to throw an error from this function, so we have to
          * catch and set the error flag.
          */
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        try
+		try
 #endif
-        {
-            int error;
-            Context context = Context::getDefault(&error);
+		{
+			int error;
+			Context context = Context::getDefault (&error);
 
-            if (error != CL_SUCCESS) {
-                default_error_ = error;
-            }
-            else {
-                Device device = Device::getDefault();
-                default_ = CommandQueue(context, device, 0, &default_error_);
-            }
-        }
+			if (error != CL_SUCCESS)
+			{
+				default_error_ = error;
+			}
+			else
+			{
+				Device device = Device::getDefault ();
+				default_ = CommandQueue (context, device, 0, &default_error_);
+			}
+		}
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-        catch (cl::Error &e) {
-            default_error_ = e.err();
-        }
+		catch (cl::Error & e)
+		{
+			default_error_ = e.err ();
+		}
 #endif
-    }
+	}
 
-    /*! \brief Create the default command queue.
+	/*! \brief Create the default command queue.
      *
      * This sets @c default_. It does not throw
      * @c cl::Error.
      */
-    static void makeDefaultProvided(const CommandQueue &c) {
-        default_ = c;
-    }
+	static void makeDefaultProvided (const CommandQueue & c)
+	{
+		default_ = c;
+	}
 
 public:
 #ifdef CL_HPP_UNIT_TEST_ENABLE
-    /*! \brief Reset the default.
+	/*! \brief Reset the default.
     *
     * This sets @c default_ to an empty value to support cleanup in
     * the unit test framework.
     * This function is not thread safe.
     */
-    static void unitTestClearDefault() {
-        default_ = CommandQueue();
-    }
+	static void unitTestClearDefault ()
+	{
+		default_ = CommandQueue ();
+	}
 #endif // #ifdef CL_HPP_UNIT_TEST_ENABLE
-        
 
-    /*!
+	/*!
      * \brief Constructs a CommandQueue based on passed properties.
      * Will return an CL_INVALID_QUEUE_PROPERTIES error if CL_QUEUE_ON_DEVICE is specified.
      */
-   CommandQueue(
-        cl_command_queue_properties properties,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	CommandQueue (
+	cl_command_queue_properties properties,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        Context context = Context::getDefault(&error);
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		Context context = Context::getDefault (&error);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-        if (error != CL_SUCCESS) {
-            if (err != NULL) {
-                *err = error;
-            }
-        }
-        else {
-            Device device = context.getInfo<CL_CONTEXT_DEVICES>()[0];
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+		else
+		{
+			Device device = context.getInfo<CL_CONTEXT_DEVICES> ()[0];
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-            cl_queue_properties queue_properties[] = {
-                CL_QUEUE_PROPERTIES, properties, 0 };
-            if ((properties & CL_QUEUE_ON_DEVICE) == 0) {
-                object_ = ::clCreateCommandQueueWithProperties(
-                    context(), device(), queue_properties, &error);
-            }
-            else {
-                error = CL_INVALID_QUEUE_PROPERTIES;
-            }
+			cl_queue_properties queue_properties[] = {
+				CL_QUEUE_PROPERTIES, properties, 0
+			};
+			if ((properties & CL_QUEUE_ON_DEVICE) == 0)
+			{
+				object_ = ::clCreateCommandQueueWithProperties (
+				context (), device (), queue_properties, &error);
+			}
+			else
+			{
+				error = CL_INVALID_QUEUE_PROPERTIES;
+			}
 
-            detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
+			detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
 #else
-            object_ = ::clCreateCommandQueue(
-                context(), device(), properties, &error);
+			object_ = ::clCreateCommandQueue (
+			context (), device (), properties, &error);
 
-            detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
+			detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
 #endif
-        }
-    }
+		}
+	}
 
-   /*!
+	/*!
     * \brief Constructs a CommandQueue based on passed properties.
     * Will return an CL_INVALID_QUEUE_PROPERTIES error if CL_QUEUE_ON_DEVICE is specified.
     */
-   CommandQueue(
-       QueueProperties properties,
-       cl_int* err = NULL)
-   {
-       cl_int error;
+	CommandQueue (
+	QueueProperties properties,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-       Context context = Context::getDefault(&error);
-       detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		Context context = Context::getDefault (&error);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-       if (error != CL_SUCCESS) {
-           if (err != NULL) {
-               *err = error;
-           }
-       }
-       else {
-           Device device = context.getInfo<CL_CONTEXT_DEVICES>()[0];
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+		}
+		else
+		{
+			Device device = context.getInfo<CL_CONTEXT_DEVICES> ()[0];
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-           cl_queue_properties queue_properties[] = {
-               CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
+			cl_queue_properties queue_properties[] = {
+				CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties> (properties), 0
+			};
 
-           object_ = ::clCreateCommandQueueWithProperties(
-               context(), device(), queue_properties, &error);
+			object_ = ::clCreateCommandQueueWithProperties (
+			context (), device (), queue_properties, &error);
 
-
-           detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-           if (err != NULL) {
-               *err = error;
-           }
+			detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
 #else
-           object_ = ::clCreateCommandQueue(
-               context(), device(), static_cast<cl_command_queue_properties>(properties), &error);
+			object_ = ::clCreateCommandQueue (
+			context (), device (), static_cast<cl_command_queue_properties> (properties), &error);
 
-           detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-           if (err != NULL) {
-               *err = error;
-           }
+			detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+			if (err != NULL)
+			{
+				*err = error;
+			}
 #endif
-       }
-   }
+		}
+	}
 
-    /*!
+	/*!
      * \brief Constructs a CommandQueue for an implementation defined device in the given context
      * Will return an CL_INVALID_QUEUE_PROPERTIES error if CL_QUEUE_ON_DEVICE is specified.
      */
-    explicit CommandQueue(
-        const Context& context,
-        cl_command_queue_properties properties = 0,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        vector<cl::Device> devices;
-        error = context.getInfo(CL_CONTEXT_DEVICES, &devices);
+	explicit CommandQueue (
+	const Context & context,
+	cl_command_queue_properties properties = 0,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		vector<cl::Device> devices;
+		error = context.getInfo (CL_CONTEXT_DEVICES, &devices);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-        if (error != CL_SUCCESS)
-        {
-            if (err != NULL) {
-                *err = error;
-            }
-            return;
-        }
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+			return;
+		}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, properties, 0 };
-        if ((properties & CL_QUEUE_ON_DEVICE) == 0) {
-            object_ = ::clCreateCommandQueueWithProperties(
-                context(), devices[0](), queue_properties, &error);
-        }
-        else {
-            error = CL_INVALID_QUEUE_PROPERTIES;
-        }
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, properties, 0
+		};
+		if ((properties & CL_QUEUE_ON_DEVICE) == 0)
+		{
+			object_ = ::clCreateCommandQueueWithProperties (
+			context (), devices[0](), queue_properties, &error);
+		}
+		else
+		{
+			error = CL_INVALID_QUEUE_PROPERTIES;
+		}
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #else
-        object_ = ::clCreateCommandQueue(
-            context(), devices[0](), properties, &error);
+		object_ = ::clCreateCommandQueue (
+		context (), devices[0](), properties, &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #endif
+	}
 
-    }
-
-    /*!
+	/*!
     * \brief Constructs a CommandQueue for an implementation defined device in the given context
     * Will return an CL_INVALID_QUEUE_PROPERTIES error if CL_QUEUE_ON_DEVICE is specified.
     */
-    explicit CommandQueue(
-        const Context& context,
-        QueueProperties properties,
-        cl_int* err = NULL)
-    {
-        cl_int error;
-        vector<cl::Device> devices;
-        error = context.getInfo(CL_CONTEXT_DEVICES, &devices);
+	explicit CommandQueue (
+	const Context & context,
+	QueueProperties properties,
+	cl_int * err = NULL)
+	{
+		cl_int error;
+		vector<cl::Device> devices;
+		error = context.getInfo (CL_CONTEXT_DEVICES, &devices);
 
-        detail::errHandler(error, __CREATE_CONTEXT_ERR);
+		detail::errHandler (error, __CREATE_CONTEXT_ERR);
 
-        if (error != CL_SUCCESS)
-        {
-            if (err != NULL) {
-                *err = error;
-            }
-            return;
-        }
+		if (error != CL_SUCCESS)
+		{
+			if (err != NULL)
+			{
+				*err = error;
+			}
+			return;
+		}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
-            context(), devices[0](), queue_properties, &error);
-       
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties> (properties), 0
+		};
+		object_ = ::clCreateCommandQueueWithProperties (
+		context (), devices[0](), queue_properties, &error);
+
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #else
-        object_ = ::clCreateCommandQueue(
-            context(), devices[0](), static_cast<cl_command_queue_properties>(properties), &error);
+		object_ = ::clCreateCommandQueue (
+		context (), devices[0](), static_cast<cl_command_queue_properties> (properties), &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #endif
+	}
 
-    }
-
-    /*!
+	/*!
      * \brief Constructs a CommandQueue for a passed device and context
      * Will return an CL_INVALID_QUEUE_PROPERTIES error if CL_QUEUE_ON_DEVICE is specified.
      */
-    CommandQueue(
-        const Context& context,
-        const Device& device,
-        cl_command_queue_properties properties = 0,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	CommandQueue (
+	const Context & context,
+	const Device & device,
+	cl_command_queue_properties properties = 0,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, properties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
-            context(), device(), queue_properties, &error);
-        
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, properties, 0
+		};
+		object_ = ::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error);
+
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #else
-        object_ = ::clCreateCommandQueue(
-            context(), device(), properties, &error);
+		object_ = ::clCreateCommandQueue (
+		context (), device (), properties, &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #endif
-    }
+	}
 
-    /*!
+	/*!
      * \brief Constructs a CommandQueue for a passed device and context
      * Will return an CL_INVALID_QUEUE_PROPERTIES error if CL_QUEUE_ON_DEVICE is specified.
      */
-    CommandQueue(
-        const Context& context,
-        const Device& device,
-        QueueProperties properties,
-        cl_int* err = NULL)
-    {
-            cl_int error;
+	CommandQueue (
+	const Context & context,
+	const Device & device,
+	QueueProperties properties,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-            cl_queue_properties queue_properties[] = {
-                CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
-                context(), device(), queue_properties, &error);
-      
-            detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties> (properties), 0
+		};
+		object_ = ::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error);
+
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #else
-            object_ = ::clCreateCommandQueue(
-                context(), device(), static_cast<cl_command_queue_properties>(properties), &error);
+		object_ = ::clCreateCommandQueue (
+		context (), device (), static_cast<cl_command_queue_properties> (properties), &error);
 
-            detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
-            if (err != NULL) {
-                *err = error;
-            }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 #endif
-        }
+	}
 
-    static CommandQueue getDefault(cl_int * err = NULL) 
-    {
-        std::call_once(default_initialized_, makeDefault);
+	static CommandQueue getDefault (cl_int * err = NULL)
+	{
+		std::call_once (default_initialized_, makeDefault);
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-        detail::errHandler(default_error_, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		detail::errHandler (default_error_, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
 #else // CL_HPP_TARGET_OPENCL_VERSION >= 200
-        detail::errHandler(default_error_, __CREATE_COMMAND_QUEUE_ERR);
+		detail::errHandler (default_error_, __CREATE_COMMAND_QUEUE_ERR);
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
-        if (err != NULL) {
-            *err = default_error_;
-        }
-        return default_;
-    }
+		if (err != NULL)
+		{
+			*err = default_error_;
+		}
+		return default_;
+	}
 
-    /**
+	/**
      * Modify the default command queue to be used by
      * subsequent operations.
      * Will only set the default if no default was previously created.
      * @return updated default command queue.
      *         Should be compared to the passed value to ensure that it was updated.
      */
-    static CommandQueue setDefault(const CommandQueue &default_queue)
-    {
-        std::call_once(default_initialized_, makeDefaultProvided, std::cref(default_queue));
-        detail::errHandler(default_error_);
-        return default_;
-    }
+	static CommandQueue setDefault (const CommandQueue & default_queue)
+	{
+		std::call_once (default_initialized_, makeDefaultProvided, std::cref (default_queue));
+		detail::errHandler (default_error_);
+		return default_;
+	}
 
-    CommandQueue() { }
+	CommandQueue ()
+	{
+	}
 
-
-    /*! \brief Constructor from cl_mem - takes ownership.
+	/*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
      *                     Defaults to false to maintain compatibility with
      *                     earlier versions.
      */
-    explicit CommandQueue(const cl_command_queue& commandQueue, bool retainObject = false) : 
-        detail::Wrapper<cl_type>(commandQueue, retainObject) { }
+	explicit CommandQueue (const cl_command_queue & commandQueue, bool retainObject = false) :
+		detail::Wrapper<cl_type> (commandQueue, retainObject)
+	{
+	}
 
-    CommandQueue& operator = (const cl_command_queue& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	CommandQueue & operator= (const cl_command_queue & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue(const CommandQueue& queue) : detail::Wrapper<cl_type>(queue) {}
+	CommandQueue (const CommandQueue & queue) :
+		detail::Wrapper<cl_type> (queue)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue& operator = (const CommandQueue &queue)
-    {
-        detail::Wrapper<cl_type>::operator=(queue);
-        return *this;
-    }
+	CommandQueue & operator= (const CommandQueue & queue)
+	{
+		detail::Wrapper<cl_type>::operator= (queue);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue(CommandQueue&& queue) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(queue)) {}
+	CommandQueue (CommandQueue && queue) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (queue))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    CommandQueue& operator = (CommandQueue &&queue)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(queue));
-        return *this;
-    }
+	CommandQueue & operator= (CommandQueue && queue)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (queue));
+		return *this;
+	}
 
-    template <typename T>
-    cl_int getInfo(cl_command_queue_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-                &::clGetCommandQueueInfo, object_, name, param),
-                __GET_COMMAND_QUEUE_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_command_queue_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetCommandQueueInfo, object_, name, param),
+		__GET_COMMAND_QUEUE_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-    detail::param_traits<detail::cl_command_queue_info, name>::param_type
-    getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_command_queue_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_command_queue_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_command_queue_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    cl_int enqueueReadBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        size_type offset,
-        size_type size,
-        void* ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueReadBuffer(
-                object_, buffer(), blocking, offset, size,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_READ_BUFFER_ERR);
+	cl_int enqueueReadBuffer (
+	const Buffer & buffer,
+	cl_bool blocking,
+	size_type offset,
+	size_type size,
+	void * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReadBuffer (
+		object_, buffer (), blocking, offset, size,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_READ_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueWriteBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        size_type offset,
-        size_type size,
-        const void* ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueWriteBuffer(
-                object_, buffer(), blocking, offset, size,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_WRITE_BUFFER_ERR);
+	cl_int enqueueWriteBuffer (
+	const Buffer & buffer,
+	cl_bool blocking,
+	size_type offset,
+	size_type size,
+	const void * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueWriteBuffer (
+		object_, buffer (), blocking, offset, size,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_WRITE_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyBuffer(
-        const Buffer& src,
-        const Buffer& dst,
-        size_type src_offset,
-        size_type dst_offset,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyBuffer(
-                object_, src(), dst(), src_offset, dst_offset, size,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQEUE_COPY_BUFFER_ERR);
+	cl_int enqueueCopyBuffer (
+	const Buffer & src,
+	const Buffer & dst,
+	size_type src_offset,
+	size_type dst_offset,
+	size_type size,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyBuffer (
+		object_, src (), dst (), src_offset, dst_offset, size,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQEUE_COPY_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueReadBufferRect(
-        const Buffer& buffer,
-        cl_bool blocking,
-        const array<size_type, 3>& buffer_offset,
-        const array<size_type, 3>& host_offset,
-        const array<size_type, 3>& region,
-        size_type buffer_row_pitch,
-        size_type buffer_slice_pitch,
-        size_type host_row_pitch,
-        size_type host_slice_pitch,
-        void *ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueReadBufferRect(
-                object_, 
-                buffer(), 
-                blocking,
-                buffer_offset.data(),
-                host_offset.data(),
-                region.data(),
-                buffer_row_pitch,
-                buffer_slice_pitch,
-                host_row_pitch,
-                host_slice_pitch,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_READ_BUFFER_RECT_ERR);
+	cl_int enqueueReadBufferRect (
+	const Buffer & buffer,
+	cl_bool blocking,
+	const array<size_type, 3> & buffer_offset,
+	const array<size_type, 3> & host_offset,
+	const array<size_type, 3> & region,
+	size_type buffer_row_pitch,
+	size_type buffer_slice_pitch,
+	size_type host_row_pitch,
+	size_type host_slice_pitch,
+	void * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReadBufferRect (
+		object_,
+		buffer (),
+		blocking,
+		buffer_offset.data (),
+		host_offset.data (),
+		region.data (),
+		buffer_row_pitch,
+		buffer_slice_pitch,
+		host_row_pitch,
+		host_slice_pitch,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_READ_BUFFER_RECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueWriteBufferRect(
-        const Buffer& buffer,
-        cl_bool blocking,
-        const array<size_type, 3>& buffer_offset,
-        const array<size_type, 3>& host_offset,
-        const array<size_type, 3>& region,
-        size_type buffer_row_pitch,
-        size_type buffer_slice_pitch,
-        size_type host_row_pitch,
-        size_type host_slice_pitch,
-        void *ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueWriteBufferRect(
-                object_, 
-                buffer(), 
-                blocking,
-                buffer_offset.data(),
-                host_offset.data(),
-                region.data(),
-                buffer_row_pitch,
-                buffer_slice_pitch,
-                host_row_pitch,
-                host_slice_pitch,
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_WRITE_BUFFER_RECT_ERR);
+	cl_int enqueueWriteBufferRect (
+	const Buffer & buffer,
+	cl_bool blocking,
+	const array<size_type, 3> & buffer_offset,
+	const array<size_type, 3> & host_offset,
+	const array<size_type, 3> & region,
+	size_type buffer_row_pitch,
+	size_type buffer_slice_pitch,
+	size_type host_row_pitch,
+	size_type host_slice_pitch,
+	void * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueWriteBufferRect (
+		object_,
+		buffer (),
+		blocking,
+		buffer_offset.data (),
+		host_offset.data (),
+		region.data (),
+		buffer_row_pitch,
+		buffer_slice_pitch,
+		host_row_pitch,
+		host_slice_pitch,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_WRITE_BUFFER_RECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyBufferRect(
-        const Buffer& src,
-        const Buffer& dst,
-        const array<size_type, 3>& src_origin,
-        const array<size_type, 3>& dst_origin,
-        const array<size_type, 3>& region,
-        size_type src_row_pitch,
-        size_type src_slice_pitch,
-        size_type dst_row_pitch,
-        size_type dst_slice_pitch,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferRect(
-                object_, 
-                src(), 
-                dst(), 
-                src_origin.data(),
-                dst_origin.data(),
-                region.data(),
-                src_row_pitch,
-                src_slice_pitch,
-                dst_row_pitch,
-                dst_slice_pitch,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQEUE_COPY_BUFFER_RECT_ERR);
+	cl_int enqueueCopyBufferRect (
+	const Buffer & src,
+	const Buffer & dst,
+	const array<size_type, 3> & src_origin,
+	const array<size_type, 3> & dst_origin,
+	const array<size_type, 3> & region,
+	size_type src_row_pitch,
+	size_type src_slice_pitch,
+	size_type dst_row_pitch,
+	size_type dst_slice_pitch,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyBufferRect (
+		object_,
+		src (),
+		dst (),
+		src_origin.data (),
+		dst_origin.data (),
+		region.data (),
+		src_row_pitch,
+		src_slice_pitch,
+		dst_row_pitch,
+		dst_slice_pitch,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQEUE_COPY_BUFFER_RECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    /**
+	/**
      * Enqueue a command to fill a buffer object with a pattern
      * of a given size. The pattern is specified as a vector type.
      * \tparam PatternType The datatype of the pattern field. 
@@ -7178,539 +7716,539 @@ public:
      * \tparam size Is the size in bytes of the region to fill.
      *     This must be a multiple of the pattern size.
      */
-    template<typename PatternType>
-    cl_int enqueueFillBuffer(
-        const Buffer& buffer,
-        PatternType pattern,
-        size_type offset,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillBuffer(
-                object_, 
-                buffer(),
-                static_cast<void*>(&pattern),
-                sizeof(PatternType), 
-                offset, 
-                size,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_BUFFER_ERR);
+	template <typename PatternType>
+	cl_int enqueueFillBuffer (
+	const Buffer & buffer,
+	PatternType pattern,
+	size_type offset,
+	size_type size,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillBuffer (
+		object_,
+		buffer (),
+		static_cast<void *> (&pattern),
+		sizeof (PatternType),
+		offset,
+		size,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-    cl_int enqueueReadImage(
-        const Image& image,
-        cl_bool blocking,
-        const array<size_type, 3>& origin,
-        const array<size_type, 3>& region,
-        size_type row_pitch,
-        size_type slice_pitch,
-        void* ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueReadImage(
-                object_, 
-                image(), 
-                blocking, 
-                origin.data(),
-                region.data(), 
-                row_pitch, 
-                slice_pitch, 
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_READ_IMAGE_ERR);
+	cl_int enqueueReadImage (
+	const Image & image,
+	cl_bool blocking,
+	const array<size_type, 3> & origin,
+	const array<size_type, 3> & region,
+	size_type row_pitch,
+	size_type slice_pitch,
+	void * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReadImage (
+		object_,
+		image (),
+		blocking,
+		origin.data (),
+		region.data (),
+		row_pitch,
+		slice_pitch,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_READ_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueWriteImage(
-        const Image& image,
-        cl_bool blocking,
-        const array<size_type, 3>& origin,
-        const array<size_type, 3>& region,
-        size_type row_pitch,
-        size_type slice_pitch,
-        void* ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueWriteImage(
-                object_, 
-                image(), 
-                blocking, 
-                origin.data(),
-                region.data(), 
-                row_pitch, 
-                slice_pitch, 
-                ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_WRITE_IMAGE_ERR);
+	cl_int enqueueWriteImage (
+	const Image & image,
+	cl_bool blocking,
+	const array<size_type, 3> & origin,
+	const array<size_type, 3> & region,
+	size_type row_pitch,
+	size_type slice_pitch,
+	void * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueWriteImage (
+		object_,
+		image (),
+		blocking,
+		origin.data (),
+		region.data (),
+		row_pitch,
+		slice_pitch,
+		ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_WRITE_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyImage(
-        const Image& src,
-        const Image& dst,
-        const array<size_type, 3>& src_origin,
-        const array<size_type, 3>& dst_origin,
-        const array<size_type, 3>& region,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyImage(
-                object_, 
-                src(), 
-                dst(), 
-                src_origin.data(),
-                dst_origin.data(), 
-                region.data(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_COPY_IMAGE_ERR);
+	cl_int enqueueCopyImage (
+	const Image & src,
+	const Image & dst,
+	const array<size_type, 3> & src_origin,
+	const array<size_type, 3> & dst_origin,
+	const array<size_type, 3> & region,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyImage (
+		object_,
+		src (),
+		dst (),
+		src_origin.data (),
+		dst_origin.data (),
+		region.data (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_COPY_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    /**
+	/**
      * Enqueue a command to fill an image object with a specified color.
      * \param fillColor is the color to use to fill the image.
      *     This is a four component RGBA floating-point color value if
      *     the image channel data type is not an unnormalized signed or
      *     unsigned data type.
      */
-    cl_int enqueueFillImage(
-        const Image& image,
-        cl_float4 fillColor,
-        const array<size_type, 3>& origin,
-        const array<size_type, 3>& region,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
-                object_, 
-                image(),
-                static_cast<void*>(&fillColor), 
-                origin.data(),
-                region.data(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_IMAGE_ERR);
+	cl_int enqueueFillImage (
+	const Image & image,
+	cl_float4 fillColor,
+	const array<size_type, 3> & origin,
+	const array<size_type, 3> & region,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillImage (
+		object_,
+		image (),
+		static_cast<void *> (&fillColor),
+		origin.data (),
+		region.data (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueue a command to fill an image object with a specified color.
      * \param fillColor is the color to use to fill the image.
      *     This is a four component RGBA signed integer color value if
      *     the image channel data type is an unnormalized signed integer
      *     type.
      */
-    cl_int enqueueFillImage(
-        const Image& image,
-        cl_int4 fillColor,
-        const array<size_type, 3>& origin,
-        const array<size_type, 3>& region,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
-                object_, 
-                image(),
-                static_cast<void*>(&fillColor), 
-                origin.data(),
-                region.data(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_IMAGE_ERR);
+	cl_int enqueueFillImage (
+	const Image & image,
+	cl_int4 fillColor,
+	const array<size_type, 3> & origin,
+	const array<size_type, 3> & region,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillImage (
+		object_,
+		image (),
+		static_cast<void *> (&fillColor),
+		origin.data (),
+		region.data (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueue a command to fill an image object with a specified color.
      * \param fillColor is the color to use to fill the image.
      *     This is a four component RGBA unsigned integer color value if
      *     the image channel data type is an unnormalized unsigned integer
      *     type.
      */
-    cl_int enqueueFillImage(
-        const Image& image,
-        cl_uint4 fillColor,
-        const array<size_type, 3>& origin,
-        const array<size_type, 3>& region,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
-                object_, 
-                image(),
-                static_cast<void*>(&fillColor), 
-                origin.data(),
-                region.data(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-                __ENQUEUE_FILL_IMAGE_ERR);
+	cl_int enqueueFillImage (
+	const Image & image,
+	cl_uint4 fillColor,
+	const array<size_type, 3> & origin,
+	const array<size_type, 3> & region,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueFillImage (
+		object_,
+		image (),
+		static_cast<void *> (&fillColor),
+		origin.data (),
+		region.data (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_FILL_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-    cl_int enqueueCopyImageToBuffer(
-        const Image& src,
-        const Buffer& dst,
-        const array<size_type, 3>& src_origin,
-        const array<size_type, 3>& region,
-        size_type dst_offset,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyImageToBuffer(
-                object_, 
-                src(), 
-                dst(), 
-                src_origin.data(),
-                region.data(), 
-                dst_offset,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR);
+	cl_int enqueueCopyImageToBuffer (
+	const Image & src,
+	const Buffer & dst,
+	const array<size_type, 3> & src_origin,
+	const array<size_type, 3> & region,
+	size_type dst_offset,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyImageToBuffer (
+		object_,
+		src (),
+		dst (),
+		src_origin.data (),
+		region.data (),
+		dst_offset,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    cl_int enqueueCopyBufferToImage(
-        const Buffer& src,
-        const Image& dst,
-        size_type src_offset,
-        const array<size_type, 3>& dst_origin,
-        const array<size_type, 3>& region,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferToImage(
-                object_, 
-                src(), 
-                dst(), 
-                src_offset,
-                dst_origin.data(), 
-                region.data(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR);
+	cl_int enqueueCopyBufferToImage (
+	const Buffer & src,
+	const Image & dst,
+	size_type src_offset,
+	const array<size_type, 3> & dst_origin,
+	const array<size_type, 3> & region,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueCopyBufferToImage (
+		object_,
+		src (),
+		dst (),
+		src_offset,
+		dst_origin.data (),
+		region.data (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    void* enqueueMapBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        cl_map_flags flags,
-        size_type offset,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL,
-        cl_int* err = NULL) const
-    {
-        cl_event tmp;
-        cl_int error;
-        void * result = ::clEnqueueMapBuffer(
-            object_, buffer(), blocking, flags, offset, size,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (event != NULL) ? &tmp : NULL,
-            &error);
+	void * enqueueMapBuffer (
+	const Buffer & buffer,
+	cl_bool blocking,
+	cl_map_flags flags,
+	size_type offset,
+	size_type size,
+	const vector<Event> * events = NULL,
+	Event * event = NULL,
+	cl_int * err = NULL) const
+	{
+		cl_event tmp;
+		cl_int error;
+		void * result = ::clEnqueueMapBuffer (
+		object_, buffer (), blocking, flags, offset, size,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL,
+		&error);
 
-        detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-        if (event != NULL && error == CL_SUCCESS)
-            *event = tmp;
+		detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+		if (event != NULL && error == CL_SUCCESS)
+			*event = tmp;
 
-        return result;
-    }
+		return result;
+	}
 
-    void* enqueueMapImage(
-        const Image& buffer,
-        cl_bool blocking,
-        cl_map_flags flags,
-        const array<size_type, 3>& origin,
-        const array<size_type, 3>& region,
-        size_type * row_pitch,
-        size_type * slice_pitch,
-        const vector<Event>* events = NULL,
-        Event* event = NULL,
-        cl_int* err = NULL) const
-    {
-        cl_event tmp;
-        cl_int error;
-        void * result = ::clEnqueueMapImage(
-            object_, buffer(), blocking, flags,
-            origin.data(), 
-            region.data(),
-            row_pitch, slice_pitch,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (event != NULL) ? &tmp : NULL,
-            &error);
+	void * enqueueMapImage (
+	const Image & buffer,
+	cl_bool blocking,
+	cl_map_flags flags,
+	const array<size_type, 3> & origin,
+	const array<size_type, 3> & region,
+	size_type * row_pitch,
+	size_type * slice_pitch,
+	const vector<Event> * events = NULL,
+	Event * event = NULL,
+	cl_int * err = NULL) const
+	{
+		cl_event tmp;
+		cl_int error;
+		void * result = ::clEnqueueMapImage (
+		object_, buffer (), blocking, flags,
+		origin.data (),
+		region.data (),
+		row_pitch, slice_pitch,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL,
+		&error);
 
-        detail::errHandler(error, __ENQUEUE_MAP_IMAGE_ERR);
-        if (err != NULL) {
-              *err = error;
-        }
-        if (event != NULL && error == CL_SUCCESS)
-            *event = tmp;
-        return result;
-    }
+		detail::errHandler (error, __ENQUEUE_MAP_IMAGE_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+		if (event != NULL && error == CL_SUCCESS)
+			*event = tmp;
+		return result;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /**
+	/**
      * Enqueues a command that will allow the host to update a region of a coarse-grained SVM buffer.
      * This variant takes a raw SVM pointer.
      */
-    template<typename T>
-    cl_int enqueueMapSVM(
-        T* ptr,
-        cl_bool blocking,
-        cl_map_flags flags,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
-            object_, blocking, flags, static_cast<void*>(ptr), size,
-            (events != NULL) ? (cl_uint)events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MAP_BUFFER_ERR);
+	template <typename T>
+	cl_int enqueueMapSVM (
+	T * ptr,
+	cl_bool blocking,
+	cl_map_flags flags,
+	size_type size,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (::clEnqueueSVMMap (
+										 object_, blocking, flags, static_cast<void *> (ptr), size,
+										 (events != NULL) ? (cl_uint)events->size () : 0,
+										 (events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+										 (event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MAP_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-
-    /**
+	/**
      * Enqueues a command that will allow the host to update a region of a coarse-grained SVM buffer.
      * This variant takes a cl::pointer instance.
      */
-    template<typename T, class D>
-    cl_int enqueueMapSVM(
-        cl::pointer<T, D> &ptr,
-        cl_bool blocking,
-        cl_map_flags flags,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
-            object_, blocking, flags, static_cast<void*>(ptr.get()), size,
-            (events != NULL) ? (cl_uint)events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MAP_BUFFER_ERR);
+	template <typename T, class D>
+	cl_int enqueueMapSVM (
+	cl::pointer<T, D> & ptr,
+	cl_bool blocking,
+	cl_map_flags flags,
+	size_type size,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (::clEnqueueSVMMap (
+										 object_, blocking, flags, static_cast<void *> (ptr.get ()), size,
+										 (events != NULL) ? (cl_uint)events->size () : 0,
+										 (events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+										 (event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MAP_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueues a command that will allow the host to update a region of a coarse-grained SVM buffer.
      * This variant takes a cl::vector instance.
      */
-    template<typename T, class Alloc>
-    cl_int enqueueMapSVM(
-        cl::vector<T, Alloc> &container,
-        cl_bool blocking,
-        cl_map_flags flags,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
-            object_, blocking, flags, static_cast<void*>(container.data()), container.size(),
-            (events != NULL) ? (cl_uint)events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MAP_BUFFER_ERR);
+	template <typename T, class Alloc>
+	cl_int enqueueMapSVM (
+	cl::vector<T, Alloc> & container,
+	cl_bool blocking,
+	cl_map_flags flags,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (::clEnqueueSVMMap (
+										 object_, blocking, flags, static_cast<void *> (container.data ()), container.size (),
+										 (events != NULL) ? (cl_uint)events->size () : 0,
+										 (events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+										 (event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MAP_BUFFER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-    cl_int enqueueUnmapMemObject(
-        const Memory& memory,
-        void* mapped_ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueUnmapMemObject(
-                object_, memory(), mapped_ptr,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	cl_int enqueueUnmapMemObject (
+	const Memory & memory,
+	void * mapped_ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueUnmapMemObject (
+		object_, memory (), mapped_ptr,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
-
+		return err;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    /**
+	/**
      * Enqueues a command that will release a coarse-grained SVM buffer back to the OpenCL runtime.
      * This variant takes a raw SVM pointer.
      */
-    template<typename T>
-    cl_int enqueueUnmapSVM(
-        T* ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
-            object_, static_cast<void*>(ptr),
-            (events != NULL) ? (cl_uint)events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	template <typename T>
+	cl_int enqueueUnmapSVM (
+	T * ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueSVMUnmap (
+		object_, static_cast<void *> (ptr),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueues a command that will release a coarse-grained SVM buffer back to the OpenCL runtime.
      * This variant takes a cl::pointer instance.
      */
-    template<typename T, class D>
-    cl_int enqueueUnmapSVM(
-        cl::pointer<T, D> &ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
-            object_, static_cast<void*>(ptr.get()),
-            (events != NULL) ? (cl_uint)events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	template <typename T, class D>
+	cl_int enqueueUnmapSVM (
+	cl::pointer<T, D> & ptr,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueSVMUnmap (
+		object_, static_cast<void *> (ptr.get ()),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * Enqueues a command that will release a coarse-grained SVM buffer back to the OpenCL runtime.
      * This variant takes a cl::vector instance.
      */
-    template<typename T, class Alloc>
-    cl_int enqueueUnmapSVM(
-        cl::vector<T, Alloc> &container,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
-            object_, static_cast<void*>(container.data()),
-            (events != NULL) ? (cl_uint)events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-            (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	template <typename T, class Alloc>
+	cl_int enqueueUnmapSVM (
+	cl::vector<T, Alloc> & container,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueSVMUnmap (
+		object_, static_cast<void *> (container.data ()),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-    /**
+	/**
      * Enqueues a marker command which waits for either a list of events to complete, 
      * or all previously enqueued commands to complete.
      *
@@ -7721,26 +8259,26 @@ public:
      * or all previously enqueued commands, queued before this command to command_queue, 
      * have completed.
      */
-    cl_int enqueueMarkerWithWaitList(
-        const vector<Event> *events = 0,
-        Event *event = 0)
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueMarkerWithWaitList(
-                object_,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MARKER_WAIT_LIST_ERR);
+	cl_int enqueueMarkerWithWaitList (
+	const vector<Event> * events = 0,
+	Event * event = 0)
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueMarkerWithWaitList (
+		object_,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MARKER_WAIT_LIST_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    /**
+	/**
      * A synchronization point that enqueues a barrier operation.
      *
      * Enqueues a barrier command which waits for either a list of events to complete, 
@@ -7751,338 +8289,338 @@ public:
      * all events either in the event_wait_list or all previously enqueued commands, queued 
      * before this command to command_queue, have completed.
      */
-    cl_int enqueueBarrierWithWaitList(
-        const vector<Event> *events = 0,
-        Event *event = 0)
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueBarrierWithWaitList(
-                object_,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_BARRIER_WAIT_LIST_ERR);
+	cl_int enqueueBarrierWithWaitList (
+	const vector<Event> * events = 0,
+	Event * event = 0)
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueBarrierWithWaitList (
+		object_,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_BARRIER_WAIT_LIST_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
-    
-    /**
+		return err;
+	}
+
+	/**
      * Enqueues a command to indicate with which device a set of memory objects
      * should be associated.
      */
-    cl_int enqueueMigrateMemObjects(
-        const vector<Memory> &memObjects,
-        cl_mem_migration_flags flags,
-        const vector<Event>* events = NULL,
-        Event* event = NULL
-        )
-    {
-        cl_event tmp;
-        
-        vector<cl_mem> localMemObjects(memObjects.size());
+	cl_int enqueueMigrateMemObjects (
+	const vector<Memory> & memObjects,
+	cl_mem_migration_flags flags,
+	const vector<Event> * events = NULL,
+	Event * event = NULL)
+	{
+		cl_event tmp;
 
-        for( int i = 0; i < (int)memObjects.size(); ++i ) {
-            localMemObjects[i] = memObjects[i]();
-        }
+		vector<cl_mem> localMemObjects (memObjects.size ());
 
+		for (int i = 0; i < (int)memObjects.size (); ++i)
+		{
+			localMemObjects[i] = memObjects[i]();
+		}
 
-        cl_int err = detail::errHandler(
-            ::clEnqueueMigrateMemObjects(
-                object_, 
-                (cl_uint)memObjects.size(), 
-                localMemObjects.data(),
-                flags,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+		cl_int err = detail::errHandler (
+		::clEnqueueMigrateMemObjects (
+		object_,
+		(cl_uint)memObjects.size (),
+		localMemObjects.data (),
+		flags,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 
-    cl_int enqueueNDRangeKernel(
-        const Kernel& kernel,
-        const NDRange& offset,
-        const NDRange& global,
-        const NDRange& local = NullRange,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueNDRangeKernel(
-                object_, kernel(), (cl_uint) global.dimensions(),
-                offset.dimensions() != 0 ? (const size_type*) offset : NULL,
-                (const size_type*) global,
-                local.dimensions() != 0 ? (const size_type*) local : NULL,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_NDRANGE_KERNEL_ERR);
+	cl_int enqueueNDRangeKernel (
+	const Kernel & kernel,
+	const NDRange & offset,
+	const NDRange & global,
+	const NDRange & local = NullRange,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueNDRangeKernel (
+		object_, kernel (), (cl_uint)global.dimensions (),
+		offset.dimensions () != 0 ? (const size_type *)offset : NULL,
+		(const size_type *)global,
+		local.dimensions () != 0 ? (const size_type *)local : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_NDRANGE_KERNEL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
 #if defined(CL_USE_DEPRECATED_OPENCL_1_2_APIS)
-    CL_EXT_PREFIX__VERSION_1_2_DEPRECATED cl_int enqueueTask(
-        const Kernel& kernel,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED const
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueTask(
-                object_, kernel(),
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_TASK_ERR);
+	CL_EXT_PREFIX__VERSION_1_2_DEPRECATED cl_int enqueueTask (
+	const Kernel & kernel,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueTask (
+		object_, kernel (),
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_TASK_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_2_APIS)
 
-    cl_int enqueueNativeKernel(
-        void (CL_CALLBACK *userFptr)(void *),
-        std::pair<void*, size_type> args,
-        const vector<Memory>* mem_objects = NULL,
-        const vector<const void*>* mem_locs = NULL,
-        const vector<Event>* events = NULL,
-        Event* event = NULL) const
-    {
-        size_type elements = 0;
-        if (mem_objects != NULL) {
-            elements = mem_objects->size();
-        }
-        vector<cl_mem> mems(elements);
-        for (unsigned int i = 0; i < elements; i++) {
-            mems[i] = ((*mem_objects)[i])();
-        }
-        
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueNativeKernel(
-                object_, userFptr, args.first, args.second,
-                (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                mems.data(),
-                (mem_locs != NULL && mem_locs->size() > 0) ? (const void **) &mem_locs->front() : NULL,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_NATIVE_KERNEL);
+	cl_int enqueueNativeKernel (
+	void (CL_CALLBACK * userFptr) (void *),
+	std::pair<void *, size_type> args,
+	const vector<Memory> * mem_objects = NULL,
+	const vector<const void *> * mem_locs = NULL,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		size_type elements = 0;
+		if (mem_objects != NULL)
+		{
+			elements = mem_objects->size ();
+		}
+		vector<cl_mem> mems (elements);
+		for (unsigned int i = 0; i < elements; i++)
+		{
+			mems[i] = ((*mem_objects)[i]) ();
+		}
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueNativeKernel (
+		object_, userFptr, args.first, args.second,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		mems.data (),
+		(mem_locs != NULL && mem_locs->size () > 0) ? (const void **)&mem_locs->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_NATIVE_KERNEL);
 
-        return err;
-    }
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
+
+		return err;
+	}
 
 /**
  * Deprecated APIs for 1.2
  */
 #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-    CL_EXT_PREFIX__VERSION_1_1_DEPRECATED 
-    cl_int enqueueMarker(Event* event = NULL) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-    {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            ::clEnqueueMarker(
-                object_, 
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_MARKER_ERR);
+	CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+	cl_int enqueueMarker (Event * event = NULL) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueMarker (
+		object_,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_MARKER_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 
-    CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-    cl_int enqueueWaitForEvents(const vector<Event>& events) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-    {
-        return detail::errHandler(
-            ::clEnqueueWaitForEvents(
-                object_,
-                (cl_uint) events.size(),
-                events.size() > 0 ? (const cl_event*) &events.front() : NULL),
-            __ENQUEUE_WAIT_FOR_EVENTS_ERR);
-    }
+	CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+	cl_int enqueueWaitForEvents (const vector<Event> & events) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+	{
+		return detail::errHandler (
+		::clEnqueueWaitForEvents (
+		object_,
+		(cl_uint)events.size (),
+		events.size () > 0 ? (const cl_event *)&events.front () : NULL),
+		__ENQUEUE_WAIT_FOR_EVENTS_ERR);
+	}
 #endif // defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
-    cl_int enqueueAcquireGLObjects(
-         const vector<Memory>* mem_objects = NULL,
-         const vector<Event>* events = NULL,
-         Event* event = NULL) const
-     {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-             ::clEnqueueAcquireGLObjects(
-                 object_,
-                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                 (events != NULL) ? (cl_uint) events->size() : 0,
-                 (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                 (event != NULL) ? &tmp : NULL),
-             __ENQUEUE_ACQUIRE_GL_ERR);
+	cl_int enqueueAcquireGLObjects (
+	const vector<Memory> * mem_objects = NULL,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueAcquireGLObjects (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_ACQUIRE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-     }
+		return err;
+	}
 
-    cl_int enqueueReleaseGLObjects(
-         const vector<Memory>* mem_objects = NULL,
-         const vector<Event>* events = NULL,
-         Event* event = NULL) const
-     {
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-             ::clEnqueueReleaseGLObjects(
-                 object_,
-                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                 (events != NULL) ? (cl_uint) events->size() : 0,
-                 (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                 (event != NULL) ? &tmp : NULL),
-             __ENQUEUE_RELEASE_GL_ERR);
+	cl_int enqueueReleaseGLObjects (
+	const vector<Memory> * mem_objects = NULL,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		::clEnqueueReleaseGLObjects (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_RELEASE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-     }
+		return err;
+	}
 
-#if defined (CL_HPP_USE_DX_INTEROP)
-typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueAcquireD3D10ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem* mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list, cl_event* event);
-typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem* mem_objects,  cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list, cl_event* event);
+#if defined(CL_HPP_USE_DX_INTEROP)
+	typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clEnqueueAcquireD3D10ObjectsKHR) (
+	cl_command_queue command_queue, cl_uint num_objects,
+	const cl_mem * mem_objects, cl_uint num_events_in_wait_list,
+	const cl_event * event_wait_list, cl_event * event);
+	typedef CL_API_ENTRY cl_int (CL_API_CALL * PFN_clEnqueueReleaseD3D10ObjectsKHR) (
+	cl_command_queue command_queue, cl_uint num_objects,
+	const cl_mem * mem_objects, cl_uint num_events_in_wait_list,
+	const cl_event * event_wait_list, cl_event * event);
 
-    cl_int enqueueAcquireD3D10Objects(
-         const vector<Memory>* mem_objects = NULL,
-         const vector<Event>* events = NULL,
-         Event* event = NULL) const
-    {
-        static PFN_clEnqueueAcquireD3D10ObjectsKHR pfn_clEnqueueAcquireD3D10ObjectsKHR = NULL;
+	cl_int enqueueAcquireD3D10Objects (
+	const vector<Memory> * mem_objects = NULL,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		static PFN_clEnqueueAcquireD3D10ObjectsKHR pfn_clEnqueueAcquireD3D10ObjectsKHR = NULL;
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-        cl_context context = getInfo<CL_QUEUE_CONTEXT>();
-        cl::Device device(getInfo<CL_QUEUE_DEVICE>());
-        cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM>();
-        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clEnqueueAcquireD3D10ObjectsKHR);
+		cl_context context = getInfo<CL_QUEUE_CONTEXT> ();
+		cl::Device device (getInfo<CL_QUEUE_DEVICE> ());
+		cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM> ();
+		CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_ (platform, clEnqueueAcquireD3D10ObjectsKHR);
 #endif
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-        CL_HPP_INIT_CL_EXT_FCN_PTR_(clEnqueueAcquireD3D10ObjectsKHR);
+		CL_HPP_INIT_CL_EXT_FCN_PTR_ (clEnqueueAcquireD3D10ObjectsKHR);
 #endif
-        
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-             pfn_clEnqueueAcquireD3D10ObjectsKHR(
-                 object_,
-                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                 (events != NULL) ? (cl_uint) events->size() : 0,
-                 (events != NULL) ? (cl_event*) &events->front() : NULL,
-                 (event != NULL) ? &tmp : NULL),
-             __ENQUEUE_ACQUIRE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		pfn_clEnqueueAcquireD3D10ObjectsKHR (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_ACQUIRE_GL_ERR);
 
-        return err;
-     }
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-    cl_int enqueueReleaseD3D10Objects(
-         const vector<Memory>* mem_objects = NULL,
-         const vector<Event>* events = NULL,
-         Event* event = NULL) const
-    {
-        static PFN_clEnqueueReleaseD3D10ObjectsKHR pfn_clEnqueueReleaseD3D10ObjectsKHR = NULL;
+		return err;
+	}
+
+	cl_int enqueueReleaseD3D10Objects (
+	const vector<Memory> * mem_objects = NULL,
+	const vector<Event> * events = NULL,
+	Event * event = NULL) const
+	{
+		static PFN_clEnqueueReleaseD3D10ObjectsKHR pfn_clEnqueueReleaseD3D10ObjectsKHR = NULL;
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
-        cl_context context = getInfo<CL_QUEUE_CONTEXT>();
-        cl::Device device(getInfo<CL_QUEUE_DEVICE>());
-        cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM>();
-        CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, clEnqueueReleaseD3D10ObjectsKHR);
+		cl_context context = getInfo<CL_QUEUE_CONTEXT> ();
+		cl::Device device (getInfo<CL_QUEUE_DEVICE> ());
+		cl_platform_id platform = device.getInfo<CL_DEVICE_PLATFORM> ();
+		CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_ (platform, clEnqueueReleaseD3D10ObjectsKHR);
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-        CL_HPP_INIT_CL_EXT_FCN_PTR_(clEnqueueReleaseD3D10ObjectsKHR);
+		CL_HPP_INIT_CL_EXT_FCN_PTR_ (clEnqueueReleaseD3D10ObjectsKHR);
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 
-        cl_event tmp;
-        cl_int err = detail::errHandler(
-            pfn_clEnqueueReleaseD3D10ObjectsKHR(
-                object_,
-                (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
-                (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-                (event != NULL) ? &tmp : NULL),
-            __ENQUEUE_RELEASE_GL_ERR);
+		cl_event tmp;
+		cl_int err = detail::errHandler (
+		pfn_clEnqueueReleaseD3D10ObjectsKHR (
+		object_,
+		(mem_objects != NULL) ? (cl_uint)mem_objects->size () : 0,
+		(mem_objects != NULL && mem_objects->size () > 0) ? (const cl_mem *)&mem_objects->front () : NULL,
+		(events != NULL) ? (cl_uint)events->size () : 0,
+		(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+		(event != NULL) ? &tmp : NULL),
+		__ENQUEUE_RELEASE_GL_ERR);
 
-        if (event != NULL && err == CL_SUCCESS)
-            *event = tmp;
+		if (event != NULL && err == CL_SUCCESS)
+			*event = tmp;
 
-        return err;
-    }
+		return err;
+	}
 #endif
 
 /**
  * Deprecated APIs for 1.2
  */
 #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
-    CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-    cl_int enqueueBarrier() const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-    {
-        return detail::errHandler(
-            ::clEnqueueBarrier(object_),
-            __ENQUEUE_BARRIER_ERR);
-    }
+	CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+	cl_int enqueueBarrier () const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+	{
+		return detail::errHandler (
+		::clEnqueueBarrier (object_),
+		__ENQUEUE_BARRIER_ERR);
+	}
 #endif // CL_USE_DEPRECATED_OPENCL_1_1_APIS
 
-    cl_int flush() const
-    {
-        return detail::errHandler(::clFlush(object_), __FLUSH_ERR);
-    }
+	cl_int flush () const
+	{
+		return detail::errHandler (::clFlush (object_), __FLUSH_ERR);
+	}
 
-    cl_int finish() const
-    {
-        return detail::errHandler(::clFinish(object_), __FINISH_ERR);
-    }
+	cl_int finish () const
+	{
+		return detail::errHandler (::clFinish (object_), __FINISH_ERR);
+	}
 }; // CommandQueue
 
 CL_HPP_DEFINE_STATIC_MEMBER_ std::once_flag CommandQueue::default_initialized_;
 CL_HPP_DEFINE_STATIC_MEMBER_ CommandQueue CommandQueue::default_;
 CL_HPP_DEFINE_STATIC_MEMBER_ cl_int CommandQueue::default_error_ = CL_SUCCESS;
 
-
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 enum class DeviceQueueProperties : cl_command_queue_properties
 {
-    None = 0,
-    Profiling = CL_QUEUE_PROFILING_ENABLE,
+	None = 0,
+	Profiling = CL_QUEUE_PROFILING_ENABLE,
 };
 
-DeviceQueueProperties  operator|(DeviceQueueProperties  lhs, DeviceQueueProperties  rhs)
+DeviceQueueProperties operator| (DeviceQueueProperties lhs, DeviceQueueProperties rhs)
 {
-    return static_cast<DeviceQueueProperties>(static_cast<cl_command_queue_properties>(lhs) | static_cast<cl_command_queue_properties>(rhs));
+	return static_cast<DeviceQueueProperties> (static_cast<cl_command_queue_properties> (lhs) | static_cast<cl_command_queue_properties> (rhs));
 }
 
 /*! \class DeviceCommandQueue
@@ -8091,421 +8629,462 @@ DeviceQueueProperties  operator|(DeviceQueueProperties  lhs, DeviceQueueProperti
 class DeviceCommandQueue : public detail::Wrapper<cl_command_queue>
 {
 public:
-
-    /*!
+	/*!
      * Trivial empty constructor to create a null queue.
      */
-    DeviceCommandQueue() { }
+	DeviceCommandQueue ()
+	{
+	}
 
-    /*!
+	/*!
      * Default construct device command queue on default context and device
      */
-    DeviceCommandQueue(DeviceQueueProperties properties, cl_int* err = NULL)
-    {
-        cl_int error;
-        cl::Context context = cl::Context::getDefault();
-        cl::Device device = cl::Device::getDefault();
+	DeviceCommandQueue (DeviceQueueProperties properties, cl_int * err = NULL)
+	{
+		cl_int error;
+		cl::Context context = cl::Context::getDefault ();
+		cl::Device device = cl::Device::getDefault ();
 
-        cl_command_queue_properties mergedProperties =
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties>(properties);
+		cl_command_queue_properties mergedProperties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties> (properties);
 
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, mergedProperties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
-            context(), device(), queue_properties, &error);
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, mergedProperties, 0
+		};
+		object_ = ::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*!
+	/*!
      * Create a device command queue for a specified device in the passed context.
      */
-    DeviceCommandQueue(
-        const Context& context,
-        const Device& device,
-        DeviceQueueProperties properties = DeviceQueueProperties::None,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	DeviceCommandQueue (
+	const Context & context,
+	const Device & device,
+	DeviceQueueProperties properties = DeviceQueueProperties::None,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        cl_command_queue_properties mergedProperties =
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties>(properties);
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, mergedProperties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
-            context(), device(), queue_properties, &error);
+		cl_command_queue_properties mergedProperties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties> (properties);
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, mergedProperties, 0
+		};
+		object_ = ::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*!
+	/*!
      * Create a device command queue for a specified device in the passed context.
      */
-    DeviceCommandQueue(
-        const Context& context,
-        const Device& device,
-        cl_uint queueSize,
-        DeviceQueueProperties properties = DeviceQueueProperties::None,
-        cl_int* err = NULL)
-    {
-        cl_int error;
+	DeviceCommandQueue (
+	const Context & context,
+	const Device & device,
+	cl_uint queueSize,
+	DeviceQueueProperties properties = DeviceQueueProperties::None,
+	cl_int * err = NULL)
+	{
+		cl_int error;
 
-        cl_command_queue_properties mergedProperties =
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties>(properties);
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, mergedProperties,
-            CL_QUEUE_SIZE, queueSize, 
-            0 };
-        object_ = ::clCreateCommandQueueWithProperties(
-            context(), device(), queue_properties, &error);
+		cl_command_queue_properties mergedProperties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties> (properties);
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, mergedProperties,
+			CL_QUEUE_SIZE, queueSize,
+			0
+		};
+		object_ = ::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 
-    /*! \brief Constructor from cl_command_queue - takes ownership.
+	/*! \brief Constructor from cl_command_queue - takes ownership.
     *
     * \param retainObject will cause the constructor to retain its cl object.
     *                     Defaults to false to maintain compatibility with
     *                     earlier versions.
     */
-    explicit DeviceCommandQueue(const cl_command_queue& commandQueue, bool retainObject = false) :
-        detail::Wrapper<cl_type>(commandQueue, retainObject) { }
+	explicit DeviceCommandQueue (const cl_command_queue & commandQueue, bool retainObject = false) :
+		detail::Wrapper<cl_type> (commandQueue, retainObject)
+	{
+	}
 
-    DeviceCommandQueue& operator = (const cl_command_queue& rhs)
-    {
-        detail::Wrapper<cl_type>::operator=(rhs);
-        return *this;
-    }
+	DeviceCommandQueue & operator= (const cl_command_queue & rhs)
+	{
+		detail::Wrapper<cl_type>::operator= (rhs);
+		return *this;
+	}
 
-    /*! \brief Copy constructor to forward copy to the superclass correctly.
+	/*! \brief Copy constructor to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    DeviceCommandQueue(const DeviceCommandQueue& queue) : detail::Wrapper<cl_type>(queue) {}
+	DeviceCommandQueue (const DeviceCommandQueue & queue) :
+		detail::Wrapper<cl_type> (queue)
+	{
+	}
 
-    /*! \brief Copy assignment to forward copy to the superclass correctly.
+	/*! \brief Copy assignment to forward copy to the superclass correctly.
      * Required for MSVC.
      */
-    DeviceCommandQueue& operator = (const DeviceCommandQueue &queue)
-    {
-        detail::Wrapper<cl_type>::operator=(queue);
-        return *this;
-    }
+	DeviceCommandQueue & operator= (const DeviceCommandQueue & queue)
+	{
+		detail::Wrapper<cl_type>::operator= (queue);
+		return *this;
+	}
 
-    /*! \brief Move constructor to forward move to the superclass correctly.
+	/*! \brief Move constructor to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    DeviceCommandQueue(DeviceCommandQueue&& queue) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type>(std::move(queue)) {}
+	DeviceCommandQueue (DeviceCommandQueue && queue) CL_HPP_NOEXCEPT_ : detail::Wrapper<cl_type> (std::move (queue))
+	{
+	}
 
-    /*! \brief Move assignment to forward move to the superclass correctly.
+	/*! \brief Move assignment to forward move to the superclass correctly.
      * Required for MSVC.
      */
-    DeviceCommandQueue& operator = (DeviceCommandQueue &&queue)
-    {
-        detail::Wrapper<cl_type>::operator=(std::move(queue));
-        return *this;
-    }
+	DeviceCommandQueue & operator= (DeviceCommandQueue && queue)
+	{
+		detail::Wrapper<cl_type>::operator= (std::move (queue));
+		return *this;
+	}
 
-    template <typename T>
-    cl_int getInfo(cl_command_queue_info name, T* param) const
-    {
-        return detail::errHandler(
-            detail::getInfo(
-            &::clGetCommandQueueInfo, object_, name, param),
-            __GET_COMMAND_QUEUE_INFO_ERR);
-    }
+	template <typename T>
+	cl_int getInfo (cl_command_queue_info name, T * param) const
+	{
+		return detail::errHandler (
+		detail::getInfo (
+		&::clGetCommandQueueInfo, object_, name, param),
+		__GET_COMMAND_QUEUE_INFO_ERR);
+	}
 
-    template <cl_int name> typename
-        detail::param_traits<detail::cl_command_queue_info, name>::param_type
-        getInfo(cl_int* err = NULL) const
-    {
-        typename detail::param_traits<
-            detail::cl_command_queue_info, name>::param_type param;
-        cl_int result = getInfo(name, &param);
-        if (err != NULL) {
-            *err = result;
-        }
-        return param;
-    }
+	template <cl_int name>
+	typename detail::param_traits<detail::cl_command_queue_info, name>::param_type
+	getInfo (cl_int * err = NULL) const
+	{
+		typename detail::param_traits<
+		detail::cl_command_queue_info, name>::param_type param;
+		cl_int result = getInfo (name, &param);
+		if (err != NULL)
+		{
+			*err = result;
+		}
+		return param;
+	}
 
-    /*!
+	/*!
     * Create a new default device command queue for the default device,
     * in the default context and of the default size.
     * If there is already a default queue for the specified device this
     * function will return the pre-existing queue.
     */
-    static DeviceCommandQueue makeDefault(
-        cl_int *err = nullptr)
-    {
-        cl_int error;
-        cl::Context context = cl::Context::getDefault();
-        cl::Device device = cl::Device::getDefault();
+	static DeviceCommandQueue makeDefault (
+	cl_int * err = nullptr)
+	{
+		cl_int error;
+		cl::Context context = cl::Context::getDefault ();
+		cl::Device device = cl::Device::getDefault ();
 
-        cl_command_queue_properties properties =
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT;
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, properties,
-            0 };
-        DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
-            context(), device(), queue_properties, &error));
+		cl_command_queue_properties properties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT;
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, properties,
+			0
+		};
+		DeviceCommandQueue deviceQueue (
+		::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error));
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-        return deviceQueue;
-    }
+		return deviceQueue;
+	}
 
-    /*!
+	/*!
     * Create a new default device command queue for the specified device
     * and of the default size.
     * If there is already a default queue for the specified device this
     * function will return the pre-existing queue.
     */
-    static DeviceCommandQueue makeDefault(
-        const Context &context, const Device &device, cl_int *err = nullptr)
-    {
-        cl_int error;
+	static DeviceCommandQueue makeDefault (
+	const Context & context, const Device & device, cl_int * err = nullptr)
+	{
+		cl_int error;
 
-        cl_command_queue_properties properties =
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT;
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, properties,
-            0 };
-        DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
-            context(), device(), queue_properties, &error));
+		cl_command_queue_properties properties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT;
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, properties,
+			0
+		};
+		DeviceCommandQueue deviceQueue (
+		::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error));
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-        return deviceQueue;
-    }
+		return deviceQueue;
+	}
 
-    /*!
+	/*!
      * Create a new default device command queue for the specified device 
      * and of the requested size in bytes.
      * If there is already a default queue for the specified device this
      * function will return the pre-existing queue.
      */
-    static DeviceCommandQueue makeDefault(
-        const Context &context, const Device &device, cl_uint queueSize, cl_int *err = nullptr)
-    {
-        cl_int error;
+	static DeviceCommandQueue makeDefault (
+	const Context & context, const Device & device, cl_uint queueSize, cl_int * err = nullptr)
+	{
+		cl_int error;
 
-        cl_command_queue_properties properties =
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT;
-        cl_queue_properties queue_properties[] = {
-            CL_QUEUE_PROPERTIES, properties,
-            CL_QUEUE_SIZE, queueSize,
-            0 };
-        DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
-                context(), device(), queue_properties, &error));
+		cl_command_queue_properties properties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT;
+		cl_queue_properties queue_properties[] = {
+			CL_QUEUE_PROPERTIES, properties,
+			CL_QUEUE_SIZE, queueSize,
+			0
+		};
+		DeviceCommandQueue deviceQueue (
+		::clCreateCommandQueueWithProperties (
+		context (), device (), queue_properties, &error));
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+		detail::errHandler (error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
 
-        return deviceQueue;
-    }
+		return deviceQueue;
+	}
 }; // DeviceCommandQueue
 
 namespace detail
 {
-    // Specialization for device command queue
-    template <>
-    struct KernelArgumentHandler<cl::DeviceCommandQueue, void>
-    {
-        static size_type size(const cl::DeviceCommandQueue&) { return sizeof(cl_command_queue); }
-        static const cl_command_queue* ptr(const cl::DeviceCommandQueue& value) { return &(value()); }
-    };
+	// Specialization for device command queue
+	template <>
+	struct KernelArgumentHandler<cl::DeviceCommandQueue, void>
+	{
+		static size_type size (const cl::DeviceCommandQueue &)
+		{
+			return sizeof (cl_command_queue);
+		}
+		static const cl_command_queue * ptr (const cl::DeviceCommandQueue & value)
+		{
+			return &(value ());
+		}
+	};
 } // namespace detail
 
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-
-template< typename IteratorType >
-Buffer::Buffer(
-    const Context &context,
-    IteratorType startIterator,
-    IteratorType endIterator,
-    bool readOnly,
-    bool useHostPtr,
-    cl_int* err)
+template <typename IteratorType>
+Buffer::Buffer (
+const Context & context,
+IteratorType startIterator,
+IteratorType endIterator,
+bool readOnly,
+bool useHostPtr,
+cl_int * err)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    cl_mem_flags flags = 0;
-    if( readOnly ) {
-        flags |= CL_MEM_READ_ONLY;
-    }
-    else {
-        flags |= CL_MEM_READ_WRITE;
-    }
-    if( useHostPtr ) {
-        flags |= CL_MEM_USE_HOST_PTR;
-    }
-    
-    size_type size = sizeof(DataType)*(endIterator - startIterator);
+	cl_mem_flags flags = 0;
+	if (readOnly)
+	{
+		flags |= CL_MEM_READ_ONLY;
+	}
+	else
+	{
+		flags |= CL_MEM_READ_WRITE;
+	}
+	if (useHostPtr)
+	{
+		flags |= CL_MEM_USE_HOST_PTR;
+	}
 
-    if( useHostPtr ) {
-        object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
-    } else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
-    }
+	size_type size = sizeof (DataType) * (endIterator - startIterator);
 
-    detail::errHandler(error, __CREATE_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
+	if (useHostPtr)
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, static_cast<DataType *> (&*startIterator), &error);
+	}
+	else
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, 0, &error);
+	}
 
-    if( !useHostPtr ) {
-        CommandQueue queue(context, 0, &error);
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
+	detail::errHandler (error, __CREATE_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
 
-        error = cl::copy(queue, startIterator, endIterator, *this);
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+	if (!useHostPtr)
+	{
+		CommandQueue queue (context, 0, &error);
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+
+		error = cl::copy (queue, startIterator, endIterator, *this);
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 }
 
-template< typename IteratorType >
-Buffer::Buffer(
-    const CommandQueue &queue,
-    IteratorType startIterator,
-    IteratorType endIterator,
-    bool readOnly,
-    bool useHostPtr,
-    cl_int* err)
+template <typename IteratorType>
+Buffer::Buffer (
+const CommandQueue & queue,
+IteratorType startIterator,
+IteratorType endIterator,
+bool readOnly,
+bool useHostPtr,
+cl_int * err)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    cl_mem_flags flags = 0;
-    if (readOnly) {
-        flags |= CL_MEM_READ_ONLY;
-    }
-    else {
-        flags |= CL_MEM_READ_WRITE;
-    }
-    if (useHostPtr) {
-        flags |= CL_MEM_USE_HOST_PTR;
-    }
+	cl_mem_flags flags = 0;
+	if (readOnly)
+	{
+		flags |= CL_MEM_READ_ONLY;
+	}
+	else
+	{
+		flags |= CL_MEM_READ_WRITE;
+	}
+	if (useHostPtr)
+	{
+		flags |= CL_MEM_USE_HOST_PTR;
+	}
 
-    size_type size = sizeof(DataType)*(endIterator - startIterator);
+	size_type size = sizeof (DataType) * (endIterator - startIterator);
 
-    Context context = queue.getInfo<CL_QUEUE_CONTEXT>();
+	Context context = queue.getInfo<CL_QUEUE_CONTEXT> ();
 
-    if (useHostPtr) {
-        object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
-    }
-    else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
-    }
+	if (useHostPtr)
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, static_cast<DataType *> (&*startIterator), &error);
+	}
+	else
+	{
+		object_ = ::clCreateBuffer (context (), flags, size, 0, &error);
+	}
 
-    detail::errHandler(error, __CREATE_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
+	detail::errHandler (error, __CREATE_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
 
-    if (!useHostPtr) {
-        error = cl::copy(queue, startIterator, endIterator, *this);
-        detail::errHandler(error, __CREATE_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
+	if (!useHostPtr)
+	{
+		error = cl::copy (queue, startIterator, endIterator, *this);
+		detail::errHandler (error, __CREATE_BUFFER_ERR);
+		if (err != NULL)
+		{
+			*err = error;
+		}
+	}
 }
 
-inline cl_int enqueueReadBuffer(
-    const Buffer& buffer,
-    cl_bool blocking,
-    size_type offset,
-    size_type size,
-    void* ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueReadBuffer (
+const Buffer & buffer,
+cl_bool blocking,
+size_type offset,
+size_type size,
+void * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueReadBuffer(buffer, blocking, offset, size, ptr, events, event);
+	return queue.enqueueReadBuffer (buffer, blocking, offset, size, ptr, events, event);
 }
 
-inline cl_int enqueueWriteBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        size_type offset,
-        size_type size,
-        const void* ptr,
-        const vector<Event>* events = NULL,
-        Event* event = NULL)
+inline cl_int enqueueWriteBuffer (
+const Buffer & buffer,
+cl_bool blocking,
+size_type offset,
+size_type size,
+const void * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueWriteBuffer(buffer, blocking, offset, size, ptr, events, event);
+	return queue.enqueueWriteBuffer (buffer, blocking, offset, size, ptr, events, event);
 }
 
-inline void* enqueueMapBuffer(
-        const Buffer& buffer,
-        cl_bool blocking,
-        cl_map_flags flags,
-        size_type offset,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL,
-        cl_int* err = NULL)
+inline void * enqueueMapBuffer (
+const Buffer & buffer,
+cl_bool blocking,
+cl_map_flags flags,
+size_type offset,
+size_type size,
+const vector<Event> * events = NULL,
+Event * event = NULL,
+cl_int * err = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
 
-    void * result = ::clEnqueueMapBuffer(
-            queue(), buffer(), blocking, flags, offset, size,
-            (events != NULL) ? (cl_uint) events->size() : 0,
-            (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (cl_event*) event,
-            &error);
+	void * result = ::clEnqueueMapBuffer (
+	queue (), buffer (), blocking, flags, offset, size,
+	(events != NULL) ? (cl_uint)events->size () : 0,
+	(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+	(cl_event *)event,
+	&error);
 
-    detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    if (err != NULL) {
-        *err = error;
-    }
-    return result;
+	detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	if (err != NULL)
+	{
+		*err = error;
+	}
+	return result;
 }
-
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 /**
@@ -8513,23 +9092,24 @@ inline void* enqueueMapBuffer(
  * update a region of a coarse-grained SVM buffer.
  * This variant takes a raw SVM pointer.
  */
-template<typename T>
-inline cl_int enqueueMapSVM(
-    T* ptr,
-    cl_bool blocking,
-    cl_map_flags flags,
-    size_type size,
-    const vector<Event>* events,
-    Event* event)
+template <typename T>
+inline cl_int enqueueMapSVM (
+T * ptr,
+cl_bool blocking,
+cl_map_flags flags,
+size_type size,
+const vector<Event> * events,
+Event * event)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+	{
+		return detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	}
 
-    return queue.enqueueMapSVM(
-        ptr, blocking, flags, size, events, event);
+	return queue.enqueueMapSVM (
+	ptr, blocking, flags, size, events, event);
 }
 
 /**
@@ -8537,23 +9117,24 @@ inline cl_int enqueueMapSVM(
  * update a region of a coarse-grained SVM buffer.
  * This variant takes a cl::pointer instance.
  */
-template<typename T, class D>
-inline cl_int enqueueMapSVM(
-    cl::pointer<T, D> ptr,
-    cl_bool blocking,
-    cl_map_flags flags,
-    size_type size,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+template <typename T, class D>
+inline cl_int enqueueMapSVM (
+cl::pointer<T, D> ptr,
+cl_bool blocking,
+cl_map_flags flags,
+size_type size,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+	{
+		return detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	}
 
-    return queue.enqueueMapSVM(
-        ptr, blocking, flags, size, events, event);
+	return queue.enqueueMapSVM (
+	ptr, blocking, flags, size, events, event);
 }
 
 /**
@@ -8561,52 +9142,54 @@ inline cl_int enqueueMapSVM(
  * update a region of a coarse-grained SVM buffer.
  * This variant takes a cl::vector instance.
  */
-template<typename T, class Alloc>
-inline cl_int enqueueMapSVM(
-    cl::vector<T, Alloc> container,
-    cl_bool blocking,
-    cl_map_flags flags,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+template <typename T, class Alloc>
+inline cl_int enqueueMapSVM (
+cl::vector<T, Alloc> container,
+cl_bool blocking,
+cl_map_flags flags,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+	{
+		return detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	}
 
-    return queue.enqueueMapSVM(
-        container, blocking, flags, events, event);
+	return queue.enqueueMapSVM (
+	container, blocking, flags, events, event);
 }
 
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-inline cl_int enqueueUnmapMemObject(
-    const Memory& memory,
-    void* mapped_ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueUnmapMemObject (
+const Memory & memory,
+void * mapped_ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	detail::errHandler (error, __ENQUEUE_MAP_BUFFER_ERR);
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    cl_event tmp;
-    cl_int err = detail::errHandler(
-        ::clEnqueueUnmapMemObject(
-        queue(), memory(), mapped_ptr,
-        (events != NULL) ? (cl_uint)events->size() : 0,
-        (events != NULL && events->size() > 0) ? (cl_event*)&events->front() : NULL,
-        (event != NULL) ? &tmp : NULL),
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	cl_event tmp;
+	cl_int err = detail::errHandler (
+	::clEnqueueUnmapMemObject (
+	queue (), memory (), mapped_ptr,
+	(events != NULL) ? (cl_uint)events->size () : 0,
+	(events != NULL && events->size () > 0) ? (cl_event *)&events->front () : NULL,
+	(event != NULL) ? &tmp : NULL),
+	__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
-    if (event != NULL && err == CL_SUCCESS)
-        *event = tmp;
+	if (event != NULL && err == CL_SUCCESS)
+		*event = tmp;
 
-    return err;
+	return err;
 }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
@@ -8615,21 +9198,21 @@ inline cl_int enqueueUnmapMemObject(
  * SVM buffer back to the OpenCL runtime.
  * This variant takes a raw SVM pointer.
  */
-template<typename T>
-inline cl_int enqueueUnmapSVM(
-    T* ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+template <typename T>
+inline cl_int enqueueUnmapSVM (
+T * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+	{
+		return detail::errHandler (error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	}
 
-    return detail::errHandler(queue.enqueueUnmapSVM(ptr, events, event), 
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
-
+	return detail::errHandler (queue.enqueueUnmapSVM (ptr, events, event),
+	__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 }
 
 /**
@@ -8637,20 +9220,21 @@ inline cl_int enqueueUnmapSVM(
  * SVM buffer back to the OpenCL runtime.
  * This variant takes a cl::pointer instance.
  */
-template<typename T, class D>
-inline cl_int enqueueUnmapSVM(
-    cl::pointer<T, D> &ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+template <typename T, class D>
+inline cl_int enqueueUnmapSVM (
+cl::pointer<T, D> & ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+	{
+		return detail::errHandler (error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	}
 
-    return detail::errHandler(queue.enqueueUnmapSVM(ptr, events, event),
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	return detail::errHandler (queue.enqueueUnmapSVM (ptr, events, event),
+	__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 }
 
 /**
@@ -8658,41 +9242,43 @@ inline cl_int enqueueUnmapSVM(
  * SVM buffer back to the OpenCL runtime.
  * This variant takes a cl::vector instance.
  */
-template<typename T, class Alloc>
-inline cl_int enqueueUnmapSVM(
-    cl::vector<T, Alloc> &container,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+template <typename T, class Alloc>
+inline cl_int enqueueUnmapSVM (
+cl::vector<T, Alloc> & container,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS) {
-        return detail::errHandler(error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
-    }
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+	{
+		return detail::errHandler (error, __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	}
 
-    return detail::errHandler(queue.enqueueUnmapSVM(container, events, event),
-        __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
+	return detail::errHandler (queue.enqueueUnmapSVM (container, events, event),
+	__ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 }
 
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-inline cl_int enqueueCopyBuffer(
-        const Buffer& src,
-        const Buffer& dst,
-        size_type src_offset,
-        size_type dst_offset,
-        size_type size,
-        const vector<Event>* events = NULL,
-        Event* event = NULL)
+inline cl_int enqueueCopyBuffer (
+const Buffer & src,
+const Buffer & dst,
+size_type src_offset,
+size_type dst_offset,
+size_type size,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyBuffer(src, dst, src_offset, dst_offset, size, events, event);
+	return queue.enqueueCopyBuffer (src, dst, src_offset, dst_offset, size, events, event);
 }
 
 /**
@@ -8700,15 +9286,15 @@ inline cl_int enqueueCopyBuffer(
  * Host to Device.
  * Uses default command queue.
  */
-template< typename IteratorType >
-inline cl_int copy( IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer )
+template <typename IteratorType>
+inline cl_int copy (IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS)
-        return error;
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+		return error;
 
-    return cl::copy(queue, startIterator, endIterator, buffer);
+	return cl::copy (queue, startIterator, endIterator, buffer);
 }
 
 /**
@@ -8716,15 +9302,15 @@ inline cl_int copy( IteratorType startIterator, IteratorType endIterator, cl::Bu
  * Device to Host.
  * Uses default command queue.
  */
-template< typename IteratorType >
-inline cl_int copy( const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator )
+template <typename IteratorType>
+inline cl_int copy (const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
-    if (error != CL_SUCCESS)
-        return error;
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
+	if (error != CL_SUCCESS)
+		return error;
 
-    return cl::copy(queue, buffer, startIterator, endIterator);
+	return cl::copy (queue, buffer, startIterator, endIterator);
 }
 
 /**
@@ -8732,38 +9318,39 @@ inline cl_int copy( const cl::Buffer &buffer, IteratorType startIterator, Iterat
  * Host to Device.
  * Uses specified queue.
  */
-template< typename IteratorType >
-inline cl_int copy( const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer &buffer )
+template <typename IteratorType>
+inline cl_int copy (const CommandQueue & queue, IteratorType startIterator, IteratorType endIterator, cl::Buffer & buffer)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
-    
-    size_type length = endIterator-startIterator;
-    size_type byteLength = length*sizeof(DataType);
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    DataType *pointer = 
-        static_cast<DataType*>(queue.enqueueMapBuffer(buffer, CL_TRUE, CL_MAP_WRITE, 0, byteLength, 0, 0, &error));
-    // if exceptions enabled, enqueueMapBuffer will throw
-    if( error != CL_SUCCESS ) {
-        return error;
-    }
+	size_type length = endIterator - startIterator;
+	size_type byteLength = length * sizeof (DataType);
+
+	DataType * pointer = static_cast<DataType *> (queue.enqueueMapBuffer (buffer, CL_TRUE, CL_MAP_WRITE, 0, byteLength, 0, 0, &error));
+	// if exceptions enabled, enqueueMapBuffer will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 #if defined(_MSC_VER)
-    std::copy(
-        startIterator, 
-        endIterator, 
-        stdext::checked_array_iterator<DataType*>(
-            pointer, length));
+	std::copy (
+	startIterator,
+	endIterator,
+	stdext::checked_array_iterator<DataType *> (
+	pointer, length));
 #else
-    std::copy(startIterator, endIterator, pointer);
+	std::copy (startIterator, endIterator, pointer);
 #endif
-    Event endEvent;
-    error = queue.enqueueUnmapMemObject(buffer, pointer, 0, &endEvent);
-    // if exceptions enabled, enqueueUnmapMemObject will throw
-    if( error != CL_SUCCESS ) { 
-        return error;
-    }
-    endEvent.wait();
-    return CL_SUCCESS;
+	Event endEvent;
+	error = queue.enqueueUnmapMemObject (buffer, pointer, 0, &endEvent);
+	// if exceptions enabled, enqueueUnmapMemObject will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
+	endEvent.wait ();
+	return CL_SUCCESS;
 }
 
 /**
@@ -8771,664 +9358,662 @@ inline cl_int copy( const CommandQueue &queue, IteratorType startIterator, Itera
  * Device to Host.
  * Uses specified queue.
  */
-template< typename IteratorType >
-inline cl_int copy( const CommandQueue &queue, const cl::Buffer &buffer, IteratorType startIterator, IteratorType endIterator )
+template <typename IteratorType>
+inline cl_int copy (const CommandQueue & queue, const cl::Buffer & buffer, IteratorType startIterator, IteratorType endIterator)
 {
-    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
-    cl_int error;
-        
-    size_type length = endIterator-startIterator;
-    size_type byteLength = length*sizeof(DataType);
+	typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+	cl_int error;
 
-    DataType *pointer = 
-        static_cast<DataType*>(queue.enqueueMapBuffer(buffer, CL_TRUE, CL_MAP_READ, 0, byteLength, 0, 0, &error));
-    // if exceptions enabled, enqueueMapBuffer will throw
-    if( error != CL_SUCCESS ) {
-        return error;
-    }
-    std::copy(pointer, pointer + length, startIterator);
-    Event endEvent;
-    error = queue.enqueueUnmapMemObject(buffer, pointer, 0, &endEvent);
-    // if exceptions enabled, enqueueUnmapMemObject will throw
-    if( error != CL_SUCCESS ) { 
-        return error;
-    }
-    endEvent.wait();
-    return CL_SUCCESS;
+	size_type length = endIterator - startIterator;
+	size_type byteLength = length * sizeof (DataType);
+
+	DataType * pointer = static_cast<DataType *> (queue.enqueueMapBuffer (buffer, CL_TRUE, CL_MAP_READ, 0, byteLength, 0, 0, &error));
+	// if exceptions enabled, enqueueMapBuffer will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
+	std::copy (pointer, pointer + length, startIterator);
+	Event endEvent;
+	error = queue.enqueueUnmapMemObject (buffer, pointer, 0, &endEvent);
+	// if exceptions enabled, enqueueUnmapMemObject will throw
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
+	endEvent.wait ();
+	return CL_SUCCESS;
 }
-
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 /**
  * Blocking SVM map operation - performs a blocking map underneath.
  */
-template<typename T, class Alloc>
-inline cl_int mapSVM(cl::vector<T, Alloc> &container)
+template <typename T, class Alloc>
+inline cl_int mapSVM (cl::vector<T, Alloc> & container)
 {
-    return enqueueMapSVM(container, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE);
+	return enqueueMapSVM (container, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE);
 }
 
 /**
 * Blocking SVM map operation - performs a blocking map underneath.
 */
-template<typename T, class Alloc>
-inline cl_int unmapSVM(cl::vector<T, Alloc> &container)
+template <typename T, class Alloc>
+inline cl_int unmapSVM (cl::vector<T, Alloc> & container)
 {
-    return enqueueUnmapSVM(container);
+	return enqueueUnmapSVM (container);
 }
 
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 110
-inline cl_int enqueueReadBufferRect(
-    const Buffer& buffer,
-    cl_bool blocking,
-    const array<size_type, 3>& buffer_offset,
-    const array<size_type, 3>& host_offset,
-    const array<size_type, 3>& region,
-    size_type buffer_row_pitch,
-    size_type buffer_slice_pitch,
-    size_type host_row_pitch,
-    size_type host_slice_pitch,
-    void *ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueReadBufferRect (
+const Buffer & buffer,
+cl_bool blocking,
+const array<size_type, 3> & buffer_offset,
+const array<size_type, 3> & host_offset,
+const array<size_type, 3> & region,
+size_type buffer_row_pitch,
+size_type buffer_slice_pitch,
+size_type host_row_pitch,
+size_type host_slice_pitch,
+void * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueReadBufferRect(
-        buffer, 
-        blocking, 
-        buffer_offset, 
-        host_offset,
-        region,
-        buffer_row_pitch,
-        buffer_slice_pitch,
-        host_row_pitch,
-        host_slice_pitch,
-        ptr, 
-        events, 
-        event);
+	return queue.enqueueReadBufferRect (
+	buffer,
+	blocking,
+	buffer_offset,
+	host_offset,
+	region,
+	buffer_row_pitch,
+	buffer_slice_pitch,
+	host_row_pitch,
+	host_slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueWriteBufferRect(
-    const Buffer& buffer,
-    cl_bool blocking,
-    const array<size_type, 3>& buffer_offset,
-    const array<size_type, 3>& host_offset,
-    const array<size_type, 3>& region,
-    size_type buffer_row_pitch,
-    size_type buffer_slice_pitch,
-    size_type host_row_pitch,
-    size_type host_slice_pitch,
-    void *ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueWriteBufferRect (
+const Buffer & buffer,
+cl_bool blocking,
+const array<size_type, 3> & buffer_offset,
+const array<size_type, 3> & host_offset,
+const array<size_type, 3> & region,
+size_type buffer_row_pitch,
+size_type buffer_slice_pitch,
+size_type host_row_pitch,
+size_type host_slice_pitch,
+void * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueWriteBufferRect(
-        buffer, 
-        blocking, 
-        buffer_offset, 
-        host_offset,
-        region,
-        buffer_row_pitch,
-        buffer_slice_pitch,
-        host_row_pitch,
-        host_slice_pitch,
-        ptr, 
-        events, 
-        event);
+	return queue.enqueueWriteBufferRect (
+	buffer,
+	blocking,
+	buffer_offset,
+	host_offset,
+	region,
+	buffer_row_pitch,
+	buffer_slice_pitch,
+	host_row_pitch,
+	host_slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyBufferRect(
-    const Buffer& src,
-    const Buffer& dst,
-    const array<size_type, 3>& src_origin,
-    const array<size_type, 3>& dst_origin,
-    const array<size_type, 3>& region,
-    size_type src_row_pitch,
-    size_type src_slice_pitch,
-    size_type dst_row_pitch,
-    size_type dst_slice_pitch,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyBufferRect (
+const Buffer & src,
+const Buffer & dst,
+const array<size_type, 3> & src_origin,
+const array<size_type, 3> & dst_origin,
+const array<size_type, 3> & region,
+size_type src_row_pitch,
+size_type src_slice_pitch,
+size_type dst_row_pitch,
+size_type dst_slice_pitch,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyBufferRect(
-        src,
-        dst,
-        src_origin,
-        dst_origin,
-        region,
-        src_row_pitch,
-        src_slice_pitch,
-        dst_row_pitch,
-        dst_slice_pitch,
-        events, 
-        event);
+	return queue.enqueueCopyBufferRect (
+	src,
+	dst,
+	src_origin,
+	dst_origin,
+	region,
+	src_row_pitch,
+	src_slice_pitch,
+	dst_row_pitch,
+	dst_slice_pitch,
+	events,
+	event);
 }
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 
-inline cl_int enqueueReadImage(
-    const Image& image,
-    cl_bool blocking,
-    const array<size_type, 3>& origin,
-    const array<size_type, 3>& region,
-    size_type row_pitch,
-    size_type slice_pitch,
-    void* ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL) 
+inline cl_int enqueueReadImage (
+const Image & image,
+cl_bool blocking,
+const array<size_type, 3> & origin,
+const array<size_type, 3> & region,
+size_type row_pitch,
+size_type slice_pitch,
+void * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueReadImage(
-        image,
-        blocking,
-        origin,
-        region,
-        row_pitch,
-        slice_pitch,
-        ptr,
-        events, 
-        event);
+	return queue.enqueueReadImage (
+	image,
+	blocking,
+	origin,
+	region,
+	row_pitch,
+	slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueWriteImage(
-    const Image& image,
-    cl_bool blocking,
-    const array<size_type, 3>& origin,
-    const array<size_type, 3>& region,
-    size_type row_pitch,
-    size_type slice_pitch,
-    void* ptr,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueWriteImage (
+const Image & image,
+cl_bool blocking,
+const array<size_type, 3> & origin,
+const array<size_type, 3> & region,
+size_type row_pitch,
+size_type slice_pitch,
+void * ptr,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueWriteImage(
-        image,
-        blocking,
-        origin,
-        region,
-        row_pitch,
-        slice_pitch,
-        ptr,
-        events, 
-        event);
+	return queue.enqueueWriteImage (
+	image,
+	blocking,
+	origin,
+	region,
+	row_pitch,
+	slice_pitch,
+	ptr,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyImage(
-    const Image& src,
-    const Image& dst,
-    const array<size_type, 3>& src_origin,
-    const array<size_type, 3>& dst_origin,
-    const array<size_type, 3>& region,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyImage (
+const Image & src,
+const Image & dst,
+const array<size_type, 3> & src_origin,
+const array<size_type, 3> & dst_origin,
+const array<size_type, 3> & region,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyImage(
-        src,
-        dst,
-        src_origin,
-        dst_origin,
-        region,
-        events,
-        event);
+	return queue.enqueueCopyImage (
+	src,
+	dst,
+	src_origin,
+	dst_origin,
+	region,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyImageToBuffer(
-    const Image& src,
-    const Buffer& dst,
-    const array<size_type, 3>& src_origin,
-    const array<size_type, 3>& region,
-    size_type dst_offset,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyImageToBuffer (
+const Image & src,
+const Buffer & dst,
+const array<size_type, 3> & src_origin,
+const array<size_type, 3> & region,
+size_type dst_offset,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyImageToBuffer(
-        src,
-        dst,
-        src_origin,
-        region,
-        dst_offset,
-        events,
-        event);
+	return queue.enqueueCopyImageToBuffer (
+	src,
+	dst,
+	src_origin,
+	region,
+	dst_offset,
+	events,
+	event);
 }
 
-inline cl_int enqueueCopyBufferToImage(
-    const Buffer& src,
-    const Image& dst,
-    size_type src_offset,
-    const array<size_type, 3>& dst_origin,
-    const array<size_type, 3>& region,
-    const vector<Event>* events = NULL,
-    Event* event = NULL)
+inline cl_int enqueueCopyBufferToImage (
+const Buffer & src,
+const Image & dst,
+size_type src_offset,
+const array<size_type, 3> & dst_origin,
+const array<size_type, 3> & region,
+const vector<Event> * events = NULL,
+Event * event = NULL)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.enqueueCopyBufferToImage(
-        src,
-        dst,
-        src_offset,
-        dst_origin,
-        region,
-        events,
-        event);
+	return queue.enqueueCopyBufferToImage (
+	src,
+	dst,
+	src_offset,
+	dst_origin,
+	region,
+	events,
+	event);
 }
 
-
-inline cl_int flush(void)
+inline cl_int flush (void)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    }
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-    return queue.flush();
+	return queue.flush ();
 }
 
-inline cl_int finish(void)
+inline cl_int finish (void)
 {
-    cl_int error;
-    CommandQueue queue = CommandQueue::getDefault(&error);
+	cl_int error;
+	CommandQueue queue = CommandQueue::getDefault (&error);
 
-    if (error != CL_SUCCESS) {
-        return error;
-    } 
+	if (error != CL_SUCCESS)
+	{
+		return error;
+	}
 
-
-    return queue.finish();
+	return queue.finish ();
 }
 
 class EnqueueArgs
 {
 private:
-    CommandQueue queue_;
-    const NDRange offset_;
-    const NDRange global_;
-    const NDRange local_;
-    vector<Event> events_;
+	CommandQueue queue_;
+	const NDRange offset_;
+	const NDRange global_;
+	const NDRange local_;
+	vector<Event> events_;
 
-    template<typename... Ts>
-    friend class KernelFunctor;
+	template <typename... Ts>
+	friend class KernelFunctor;
 
 public:
-    EnqueueArgs(NDRange global) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
+	EnqueueArgs (NDRange global) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+	}
 
-    }
+	EnqueueArgs (NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    EnqueueArgs(NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
+	EnqueueArgs (NDRange offset, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    }
+	EnqueueArgs (Event e, NDRange global) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(NDRange offset, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
+	EnqueueArgs (Event e, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    }
+	EnqueueArgs (Event e, NDRange offset, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(Event e, NDRange global) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
-        events_.push_back(e);
-    }
+	EnqueueArgs (const vector<Event> & events, NDRange global) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(Event e, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
+	EnqueueArgs (const vector<Event> & events, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(Event e, NDRange offset, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
+	EnqueueArgs (const vector<Event> & events, NDRange offset, NDRange global, NDRange local) :
+		queue_ (CommandQueue::getDefault ()),
+		offset_ (offset),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(const vector<Event> &events, NDRange global) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange),
-      events_(events)
-    {
+	EnqueueArgs (CommandQueue & queue, NDRange global) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    EnqueueArgs(const vector<Event> &events, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(NullRange), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
+	EnqueueArgs (CommandQueue & queue, NDRange offset, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, Event e, NDRange global) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(const vector<Event> &events, NDRange offset, NDRange global, NDRange local) : 
-      queue_(CommandQueue::getDefault()),
-      offset_(offset), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
+	EnqueueArgs (CommandQueue & queue, Event e, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, Event e, NDRange offset, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (offset),
+		global_ (global),
+		local_ (local)
+	{
+		events_.push_back (e);
+	}
 
-    EnqueueArgs(CommandQueue &queue, NDRange global) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
+	EnqueueArgs (CommandQueue & queue, const vector<Event> & events, NDRange global) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (NullRange),
+		events_ (events)
+	{
+	}
 
-    }
+	EnqueueArgs (CommandQueue & queue, const vector<Event> & events, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (NullRange),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 
-    EnqueueArgs(CommandQueue &queue, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, NDRange offset, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, Event e, NDRange global) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange)
-    {
-        events_.push_back(e);
-    }
-
-    EnqueueArgs(CommandQueue &queue, Event e, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
-
-    EnqueueArgs(CommandQueue &queue, Event e, NDRange offset, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(offset), 
-      global_(global),
-      local_(local)
-    {
-        events_.push_back(e);
-    }
-
-    EnqueueArgs(CommandQueue &queue, const vector<Event> &events, NDRange global) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(NullRange),
-      events_(events)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, const vector<Event> &events, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(NullRange), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
-
-    }
-
-    EnqueueArgs(CommandQueue &queue, const vector<Event> &events, NDRange offset, NDRange global, NDRange local) : 
-      queue_(queue),
-      offset_(offset), 
-      global_(global),
-      local_(local),
-      events_(events)
-    {
-
-    }
+	EnqueueArgs (CommandQueue & queue, const vector<Event> & events, NDRange offset, NDRange global, NDRange local) :
+		queue_ (queue),
+		offset_ (offset),
+		global_ (global),
+		local_ (local),
+		events_ (events)
+	{
+	}
 };
 
-
 //----------------------------------------------------------------------------------------------
-
 
 /**
  * Type safe kernel functor.
  * 
  */
-template<typename... Ts>
+template <typename... Ts>
 class KernelFunctor
 {
 private:
-    Kernel kernel_;
+	Kernel kernel_;
 
-    template<int index, typename T0, typename... T1s>
-    void setArgs(T0&& t0, T1s&&... t1s)
-    {
-        kernel_.setArg(index, t0);
-        setArgs<index + 1, T1s...>(std::forward<T1s>(t1s)...);
-    }
+	template <int index, typename T0, typename... T1s>
+	void setArgs (T0 && t0, T1s &&... t1s)
+	{
+		kernel_.setArg (index, t0);
+		setArgs<index + 1, T1s...> (std::forward<T1s> (t1s)...);
+	}
 
-    template<int index, typename T0>
-    void setArgs(T0&& t0)
-    {
-        kernel_.setArg(index, t0);
-    }
+	template <int index, typename T0>
+	void setArgs (T0 && t0)
+	{
+		kernel_.setArg (index, t0);
+	}
 
-    template<int index>
-    void setArgs()
-    {
-    }
-
+	template <int index>
+	void setArgs ()
+	{
+	}
 
 public:
-    KernelFunctor(Kernel kernel) : kernel_(kernel)
-    {}
+	KernelFunctor (Kernel kernel) :
+		kernel_ (kernel)
+	{
+	}
 
-    KernelFunctor(
-        const Program& program,
-        const string name,
-        cl_int * err = NULL) :
-        kernel_(program, name.c_str(), err)
-    {}
+	KernelFunctor (
+	const Program & program,
+	const string name,
+	cl_int * err = NULL) :
+		kernel_ (program, name.c_str (), err)
+	{
+	}
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    /**
+	/**
      * Enqueue kernel.
      * @param args Launch parameters of the kernel.
      * @param t0... List of kernel arguments based on the template type of the functor.
      */
-    Event operator() (
-        const EnqueueArgs& args,
-        Ts... ts)
-    {
-        Event event;
-        setArgs<0>(std::forward<Ts>(ts)...);
-        
-        args.queue_.enqueueNDRangeKernel(
-            kernel_,
-            args.offset_,
-            args.global_,
-            args.local_,
-            &args.events_,
-            &event);
+	Event operator() (
+	const EnqueueArgs & args,
+	Ts... ts)
+	{
+		Event event;
+		setArgs<0> (std::forward<Ts> (ts)...);
 
-        return event;
-    }
+		args.queue_.enqueueNDRangeKernel (
+		kernel_,
+		args.offset_,
+		args.global_,
+		args.local_,
+		&args.events_,
+		&event);
 
-    /**
+		return event;
+	}
+
+	/**
     * Enqueue kernel with support for error code.
     * @param args Launch parameters of the kernel.
     * @param t0... List of kernel arguments based on the template type of the functor.
     * @param error Out parameter returning the error code from the execution.
     */
-    Event operator() (
-        const EnqueueArgs& args,
-        Ts... ts,
-        cl_int &error)
-    {
-        Event event;
-        setArgs<0>(std::forward<Ts>(ts)...);
+	Event operator() (
+	const EnqueueArgs & args,
+	Ts... ts,
+	cl_int & error)
+	{
+		Event event;
+		setArgs<0> (std::forward<Ts> (ts)...);
 
-        error = args.queue_.enqueueNDRangeKernel(
-            kernel_,
-            args.offset_,
-            args.global_,
-            args.local_,
-            &args.events_,
-            &event);
-        
-        return event;
-    }
+		error = args.queue_.enqueueNDRangeKernel (
+		kernel_,
+		args.offset_,
+		args.global_,
+		args.local_,
+		&args.events_,
+		&event);
+
+		return event;
+	}
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
-    cl_int setSVMPointers(const vector<void*> &pointerList)
-    {
-        return kernel_.setSVMPointers(pointerList);
-    }
+	cl_int setSVMPointers (const vector<void *> & pointerList)
+	{
+		return kernel_.setSVMPointers (pointerList);
+	}
 
-    template<typename T0, typename... T1s>
-    cl_int setSVMPointers(const T0 &t0, T1s... ts)
-    {
-        return kernel_.setSVMPointers(t0, ts...);
-    }
+	template <typename T0, typename... T1s>
+	cl_int setSVMPointers (const T0 & t0, T1s... ts)
+	{
+		return kernel_.setSVMPointers (t0, ts...);
+	}
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
-    Kernel getKernel()
-    {
-        return kernel_;
-    }
+	Kernel getKernel ()
+	{
+		return kernel_;
+	}
 };
 
-namespace compatibility {
-    /**
+namespace compatibility
+{
+	/**
      * Backward compatibility class to ensure that cl.hpp code works with cl2.hpp.
      * Please use KernelFunctor directly.
      */
-    template<typename... Ts>
-    struct make_kernel
-    {
-        typedef KernelFunctor<Ts...> FunctorType;
+	template <typename... Ts>
+	struct make_kernel
+	{
+		typedef KernelFunctor<Ts...> FunctorType;
 
-        FunctorType functor_;
+		FunctorType functor_;
 
-        make_kernel(
-            const Program& program,
-            const string name,
-            cl_int * err = NULL) :
-            functor_(FunctorType(program, name, err))
-        {}
+		make_kernel (
+		const Program & program,
+		const string name,
+		cl_int * err = NULL) :
+			functor_ (FunctorType (program, name, err))
+		{
+		}
 
-        make_kernel(
-            const Kernel kernel) :
-            functor_(FunctorType(kernel))
-        {}
+		make_kernel (
+		const Kernel kernel) :
+			functor_ (FunctorType (kernel))
+		{
+		}
 
-        //! \brief Return type of the functor
-        typedef Event result_type;
+		//! \brief Return type of the functor
+		typedef Event result_type;
 
-        //! \brief Function signature of kernel functor with no event dependency.
-        typedef Event type_(
-            const EnqueueArgs&,
-            Ts...);
+		//! \brief Function signature of kernel functor with no event dependency.
+		typedef Event type_ (
+		const EnqueueArgs &,
+		Ts...);
 
-        Event operator()(
-            const EnqueueArgs& enqueueArgs,
-            Ts... args)
-        {
-            return functor_(
-                enqueueArgs, args...);
-        }
-    };
+		Event operator() (
+		const EnqueueArgs & enqueueArgs,
+		Ts... args)
+		{
+			return functor_ (
+			enqueueArgs, args...);
+		}
+	};
 } // namespace compatibility
-
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/ci/check-commit-format.sh
+++ b/ci/check-commit-format.sh
@@ -4,9 +4,9 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 "${REPO_ROOT}/ci/update-clang-format"
 
-RESULT=$(python $REPO_ROOT/ci/git-clang-format.py --diff -f --commit HEAD~1 --extensions "hpp,cpp")
+RESULT=$(python $REPO_ROOT/ci/git-clang-format.py --diff -f --commit e387c89 --extensions "hpp,cpp")
 if [ "$RESULT" != "no modified files to format" ] && [ "$RESULT" != "clang-format did not modify any files" ]; then
-    python $REPO_ROOT/ci/git-clang-format.py --diff -f --commit HEAD~1 --extensions "hpp,cpp"
+    python $REPO_ROOT/ci/git-clang-format.py --diff -f --commit e387c89 --extensions "hpp,cpp"
     echo
     echo "Code formatting differs from expected - please run ci/clang-format-all.sh"
     exit 1

--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -5,4 +5,4 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 ./ci/update-clang-format
-find nano -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format -i
+python ci/git-clang-format.py -f --commit e387c89 --extensions "hpp,cpp"


### PR DESCRIPTION
Instead of checking clang-format against files changed over HEAD~1 this goes clear back to the initial commit showing any changes.
Also included were two changes required to pass