### PR TITLE
Election scheduler predicates

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1471,51 +1471,51 @@ TEST (active_transactions, fifo)
 	nano::state_block_builder builder;
 	// Construct two pending entries that can be received simultaneously
 	auto send0 = builder.make_block ()
-				.account (nano::dev_genesis_key.pub)
-				.previous (nano::genesis_hash)
-				.representative (nano::dev_genesis_key.pub)
-				.link (key0.pub)
-				.balance (nano::genesis_amount - 1)
-				.sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
-				.work (*system.work.generate (nano::genesis_hash))
-				.build_shared ();
+				 .account (nano::dev_genesis_key.pub)
+				 .previous (nano::genesis_hash)
+				 .representative (nano::dev_genesis_key.pub)
+				 .link (key0.pub)
+				 .balance (nano::genesis_amount - 1)
+				 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+				 .work (*system.work.generate (nano::genesis_hash))
+				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send0).code);
 	nano::blocks_confirm (node, { send0 }, true);
 	ASSERT_TIMELY (1s, node.block_confirmed (send0->hash ()));
 	ASSERT_TIMELY (1s, node.active.empty ());
 	auto send1 = builder.make_block ()
-				.account (nano::dev_genesis_key.pub)
-				.previous (send0->hash ())
-				.representative (nano::dev_genesis_key.pub)
-				.link (key1.pub)
-				.balance (nano::genesis_amount - 2)
-				.sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
-				.work (*system.work.generate (send0->hash ()))
-				.build_shared ();
+				 .account (nano::dev_genesis_key.pub)
+				 .previous (send0->hash ())
+				 .representative (nano::dev_genesis_key.pub)
+				 .link (key1.pub)
+				 .balance (nano::genesis_amount - 2)
+				 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+				 .work (*system.work.generate (send0->hash ()))
+				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	nano::blocks_confirm (node, { send1 }, true);
 	ASSERT_TIMELY (1s, node.block_confirmed (send1->hash ()));
 	ASSERT_TIMELY (1s, node.active.empty ());
 
 	auto receive0 = builder.make_block ()
-				.account (key0.pub)
-				.previous (0)
-				.representative (nano::dev_genesis_key.pub)
-				.link (send0->hash ())
-				.balance (1)
-				.sign (key0.prv, key0.pub)
-				.work (*system.work.generate (key0.pub))
-				.build_shared ();
+					.account (key0.pub)
+					.previous (0)
+					.representative (nano::dev_genesis_key.pub)
+					.link (send0->hash ())
+					.balance (1)
+					.sign (key0.prv, key0.pub)
+					.work (*system.work.generate (key0.pub))
+					.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive0).code);
 	auto receive1 = builder.make_block ()
-				.account (key1.pub)
-				.previous (0)
-				.representative (nano::dev_genesis_key.pub)
-				.link (send1->hash ())
-				.balance (1)
-				.sign (key1.prv, key1.pub)
-				.work (*system.work.generate (key1.pub))
-				.build_shared ();
+					.account (key1.pub)
+					.previous (0)
+					.representative (nano::dev_genesis_key.pub)
+					.link (send1->hash ())
+					.balance (1)
+					.sign (key1.prv, key1.pub)
+					.work (*system.work.generate (key1.pub))
+					.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive1).code);
 	node.scheduler.manual (receive0);
 	// Ensure first transaction becomes active

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1458,3 +1458,73 @@ TEST (active_transactions, vacancy)
 	ASSERT_EQ (1, node.active.vacancy ());
 	ASSERT_EQ (0, node.active.size ());
 }
+
+// Ensure transactions in excess of capacity are removed in fifo order
+TEST (active_transactions, fifo)
+{
+	nano::system system;
+	nano::node_config config{ nano::get_available_port (), system.logging };
+	config.active_elections_size = 1;
+	auto & node = *system.add_node (config);
+	nano::keypair key0;
+	nano::keypair key1;
+	nano::state_block_builder builder;
+	// Construct two pending entries that can be received simultaneously
+	auto send0 = builder.make_block ()
+				.account (nano::dev_genesis_key.pub)
+				.previous (nano::genesis_hash)
+				.representative (nano::dev_genesis_key.pub)
+				.link (key0.pub)
+				.balance (nano::genesis_amount - 1)
+				.sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+				.work (*system.work.generate (nano::genesis_hash))
+				.build_shared ();
+	ASSERT_EQ (nano::process_result::progress, node.process (*send0).code);
+	nano::blocks_confirm (node, { send0 }, true);
+	ASSERT_TIMELY (1s, node.block_confirmed (send0->hash ()));
+	ASSERT_TIMELY (1s, node.active.empty ());
+	auto send1 = builder.make_block ()
+				.account (nano::dev_genesis_key.pub)
+				.previous (send0->hash ())
+				.representative (nano::dev_genesis_key.pub)
+				.link (key1.pub)
+				.balance (nano::genesis_amount - 2)
+				.sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+				.work (*system.work.generate (send0->hash ()))
+				.build_shared ();
+	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
+	nano::blocks_confirm (node, { send1 }, true);
+	ASSERT_TIMELY (1s, node.block_confirmed (send1->hash ()));
+	ASSERT_TIMELY (1s, node.active.empty ());
+
+	auto receive0 = builder.make_block ()
+				.account (key0.pub)
+				.previous (0)
+				.representative (nano::dev_genesis_key.pub)
+				.link (send0->hash ())
+				.balance (1)
+				.sign (key0.prv, key0.pub)
+				.work (*system.work.generate (key0.pub))
+				.build_shared ();
+	ASSERT_EQ (nano::process_result::progress, node.process (*receive0).code);
+	auto receive1 = builder.make_block ()
+				.account (key1.pub)
+				.previous (0)
+				.representative (nano::dev_genesis_key.pub)
+				.link (send1->hash ())
+				.balance (1)
+				.sign (key1.prv, key1.pub)
+				.work (*system.work.generate (key1.pub))
+				.build_shared ();
+	ASSERT_EQ (nano::process_result::progress, node.process (*receive1).code);
+	node.scheduler.manual (receive0);
+	// Ensure first transaction becomes active
+	ASSERT_TIMELY (1s, node.active.election (receive0->qualified_root ()) != nullptr);
+	node.scheduler.manual (receive1);
+	// Ensure second transaction becomes active
+	ASSERT_TIMELY (1s, node.active.election (receive1->qualified_root ()) != nullptr);
+	// Ensure excess transactions get trimmed
+	ASSERT_TIMELY (1s, node.active.size () == 1);
+	// Ensure the surviving transaction is the least recently inserted
+	ASSERT_TIMELY (1s, node.active.election (receive1->qualified_root ()) != nullptr);
+}

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -142,7 +142,8 @@ TEST (election_scheduler, flush_vacancy)
 				.sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 				.work (*system.work.generate (nano::genesis_hash))
 				.build_shared ();
-	node.scheduler.manual (send);
+	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
+	node.scheduler.activate (nano::dev_genesis_key.pub, node.store.tx_begin_read ());
 	// Ensure this call does not block, even though no elections can be activated.
 	node.scheduler.flush ();
 	ASSERT_EQ (0, node.active.size ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1050,9 +1050,7 @@ void nano::active_transactions::erase_oldest ()
 	if (!roots.empty ())
 	{
 		auto item = roots.get<tag_random_access> ().front ();
-		cleanup_election (lock, item.election->cleanup_info ());
-		roots.get<tag_root> ().erase (item.election->qualified_root);
-		vacancy_update ();
+		cleanup_election (lock, *item.election);
 	}
 }
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -167,6 +167,7 @@ public:
 	std::vector<std::shared_ptr<nano::election>> list_active (size_t = std::numeric_limits<size_t>::max ());
 	void erase (nano::block const &);
 	void erase_hash (nano::block_hash const &);
+	void erase_oldest ();
 	bool empty ();
 	size_t size ();
 	void stop ();

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -94,7 +94,12 @@ bool nano::election_scheduler::priority_queue_predicate () const
 
 bool nano::election_scheduler::manual_queue_predicate () const
 {
-	return node.active.vacancy () > 0 && !manual_queue.empty ();
+	return !manual_queue.empty ();
+}
+
+bool nano::election_scheduler::overfill_predicate () const
+{
+	return node.active.vacancy () < 0;
 }
 
 void nano::election_scheduler::run ()
@@ -104,12 +109,16 @@ void nano::election_scheduler::run ()
 	while (!stopped)
 	{
 		condition.wait (lock, [this] () {
-			return stopped || priority_queue_predicate () || manual_queue_predicate ();
+			return stopped || priority_queue_predicate () || manual_queue_predicate () || overfill_predicate ();
 		});
 		debug_assert ((std::this_thread::yield (), true)); // Introduce some random delay in debug builds
 		if (!stopped)
 		{
-			if (manual_queue_predicate ())
+			if (overfill_predicate ())
+			{
+				node.active.erase_oldest ();
+			}
+			else if (manual_queue_predicate ())
 			{
 				auto const [block, previous_balance, election_behavior, confirmation_action] = manual_queue.front ();
 				nano::unique_lock<nano::mutex> lock2 (node.active.mutex);

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -87,6 +87,16 @@ size_t nano::election_scheduler::priority_queue_size () const
 	return priority.size ();
 }
 
+bool nano::election_scheduler::priority_queue_predicate () const
+{
+	return node.active.vacancy () > 0 && !priority.empty ();
+}
+
+bool nano::election_scheduler::manual_queue_predicate () const
+{
+	return node.active.vacancy () > 0 && !manual_queue.empty ();
+}
+
 void nano::election_scheduler::run ()
 {
 	nano::thread_role::set (nano::thread_role::name::election_scheduler);
@@ -94,15 +104,19 @@ void nano::election_scheduler::run ()
 	while (!stopped)
 	{
 		condition.wait (lock, [this] () {
-			auto vacancy = node.active.vacancy ();
-			auto has_vacancy = vacancy > 0;
-			auto available = !priority.empty () || !manual_queue.empty ();
-			return stopped || (has_vacancy && available);
+			return stopped || priority_queue_predicate () || manual_queue_predicate ();
 		});
 		debug_assert ((std::this_thread::yield (), true)); // Introduce some random delay in debug builds
 		if (!stopped)
 		{
-			if (!priority.empty ())
+			if (manual_queue_predicate ())
+			{
+				auto const [block, previous_balance, election_behavior, confirmation_action] = manual_queue.front ();
+				nano::unique_lock<nano::mutex> lock2 (node.active.mutex);
+				node.active.insert_impl (lock2, block, previous_balance, election_behavior, confirmation_action);
+				manual_queue.pop_front ();
+			}
+			else if (priority_queue_predicate ())
 			{
 				auto block = priority.top ();
 				std::shared_ptr<nano::election> election;
@@ -113,15 +127,6 @@ void nano::election_scheduler::run ()
 					election->transition_active ();
 				}
 				priority.pop ();
-				++priority_queued;
-			}
-			if (!manual_queue.empty ())
-			{
-				auto const [block, previous_balance, election_behavior, confirmation_action] = manual_queue.front ();
-				nano::unique_lock<nano::mutex> lock2 (node.active.mutex);
-				node.active.insert_impl (lock2, block, previous_balance, election_behavior, confirmation_action);
-				manual_queue.pop_front ();
-				++manual_queued;
 			}
 			notify ();
 		}

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -38,6 +38,7 @@ private:
 	bool empty_locked () const;
 	bool priority_queue_predicate () const;
 	bool manual_queue_predicate () const;
+	bool overfill_predicate () const;
 	nano::prioritization priority;
 	std::deque<std::tuple<std::shared_ptr<nano::block>, boost::optional<nano::uint128_t>, nano::election_behavior, std::function<void (std::shared_ptr<nano::block>)>>> manual_queue;
 	nano::node & node;

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -36,10 +36,10 @@ public:
 private:
 	void run ();
 	bool empty_locked () const;
+	bool priority_queue_predicate () const;
+	bool manual_queue_predicate () const;
 	nano::prioritization priority;
-	uint64_t priority_queued{ 0 };
 	std::deque<std::tuple<std::shared_ptr<nano::block>, boost::optional<nano::uint128_t>, nano::election_behavior, std::function<void (std::shared_ptr<nano::block>)>>> manual_queue;
-	uint64_t manual_queued{ 0 };
 	nano::node & node;
 	bool stopped;
 	nano::condition_variable condition;


### PR DESCRIPTION
This change simplifies logic in the election scheduler. It extracts predicate functions so identical logic can be checked in the condition_variable wait function and also inside the election_scheduler processing loop. This allows new predicates to be easily added and also eliminates risk of disjoin checks between the loop and the condition variable.