### PR TITLE
UPnP leases issue

### DIFF
--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -102,11 +102,6 @@ void nano::port_mapping::refresh_mapping ()
 			{
 				protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
 				node.logger.always_log (boost::str (boost::format ("UPnP %1%:%2% mapped to %3%") % protocol.external_address % config_port_l % node_port_l));
-
-				// Call check mapping loop again before the leasing ends
-				node.workers.add_timed_task (std::chrono::steady_clock::now () + network_params.portmapping.lease_duration - std::chrono::seconds (10), [node_l = node.shared ()] () {
-					node_l->port_mapping.check_mapping_loop ();
-				});
 			}
 			else
 			{

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -58,7 +58,7 @@ void nano::port_mapping::refresh_devices ()
 		std::array<char, 64> local_address_l;
 		local_address_l.fill (0);
 		auto igd_error_l (UPNP_GetValidIGD (upnp_l.devices, &upnp_l.urls, &upnp_l.data, local_address_l.data (), sizeof (local_address_l)));
-		if (check_count % 15 == 0)
+		if (check_count % 15 == 0 || node.config.logging.upnp_details_logging ())
 		{
 			node.logger.always_log (boost::str (boost::format ("UPnP local address: %1%, discovery: %2%, IGD search: %3%") % local_address_l.data () % discover_error_l % igd_error_l));
 			if (node.config.logging.upnp_details_logging ())
@@ -197,7 +197,7 @@ void nano::port_mapping::check_mapping_loop ()
 	}
 	else
 	{
-		if (check_count < 10)
+		if (check_count < 10 || node.config.logging.upnp_details_logging ())
 		{
 			node.logger.always_log (boost::str (boost::format ("UPnP No IGD devices found")));
 		}

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -34,6 +34,20 @@ std::string nano::port_mapping::get_config_port (std::string const & node_port_a
 	return node.config.external_port != 0 ? std::to_string (node.config.external_port) : node_port_a;
 }
 
+std::string nano::port_mapping::to_string ()
+{
+	std::stringstream ss;
+
+	ss << "port_mapping is " << (on ? "on" : "off") << std::endl;
+	for (auto & protocol : protocols)
+	{
+		ss << protocol.to_string () << std::endl;
+	}
+	ss << upnp.to_string ();
+
+	return ss.str ();
+};
+
 void nano::port_mapping::refresh_devices ()
 {
 	if (!network_params.network.is_dev_network ())
@@ -212,6 +226,23 @@ void nano::port_mapping::stop ()
 			}
 		}
 	}
+}
+
+std::string nano::upnp_state::to_string ()
+{
+	std::stringstream ss;
+	ss << "Discovered UPnP devices:" << std::endl;
+	for (UPNPDev * p = devices; p; p = p->pNext)
+	{
+		debug_assert (p->descURL);
+		debug_assert (p->st);
+		debug_assert (p->usn);
+		ss << "  " << p->descURL << std::endl;
+		ss << "  " << p->st << std::endl;
+		ss << "  " << p->usn << std::endl;
+	}
+	ss << "  scope_id: " << std::endl;
+	return ss.str ();
 }
 
 nano::upnp_state::~upnp_state ()

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -170,7 +170,7 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 		}
 		if (node.config.logging.upnp_details_logging ())
 		{
-			node.logger.always_log (boost::str (boost::format ("UPnP %1% mapping verification response: %2%, external ip response: %3%, external ip: %4%, internal ip: %5%, lease: %6%") % protocol.name % verify_port_mapping_error_l % external_ip_error_l % external_address_l.data () % address.to_string () % remaining_mapping_duration_l.data ()));
+			node.logger.always_log (boost::str (boost::format ("UPnP %1% mapping verification response: %2%, external ip response: %3%, external ip: %4%, internal ip: %5%, remaining lease: %6%") % protocol.name % verify_port_mapping_error_l % external_ip_error_l % external_address_l.data () % address.to_string () % remaining_mapping_duration_l.data ()));
 		}
 	}
 	return result_l;

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -94,19 +94,18 @@ void nano::port_mapping::refresh_mapping ()
 		{
 			auto upnp_description = std::string ("Nano Node (") + network_params.network.get_current_network_as_string () + ")";
 			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (network_params.portmapping.lease_duration.count ()).c_str ()));
-			if (node.config.logging.upnp_details_logging ())
-			{
-				node.logger.always_log (boost::str (boost::format ("UPnP %1% port mapping response: %2%") % protocol.name % add_port_mapping_error_l));
-			}
+
 			if (add_port_mapping_error_l == UPNPCOMMAND_SUCCESS)
 			{
 				protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
-				node.logger.always_log (boost::str (boost::format ("UPnP %1%:%2% mapped to %3%") % protocol.external_address % config_port_l % node_port_l));
+				auto fmt = boost::format ("UPnP %1% %2%:%3% mapped to %4%") % protocol.name % protocol.external_address % config_port_l % node_port_l;
+				node.logger.always_log (boost::str (fmt));
 			}
 			else
 			{
 				protocol.external_port = 0;
-				node.logger.always_log (boost::str (boost::format ("UPnP failed %1%: %2%") % add_port_mapping_error_l % strupnperror (add_port_mapping_error_l)));
+				auto fmt = boost::format ("UPnP %1% %2%:%3% FAILED") % protocol.name % add_port_mapping_error_l % strupnperror (add_port_mapping_error_l);
+				node.logger.always_log (boost::str (fmt));
 			}
 		}
 	}

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -7,6 +7,14 @@
 #include <boost/format.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 
+std::string nano::mapping_protocol::to_string ()
+{
+	std::stringstream ss;
+	ss << name << " " << external_address << ":" << external_port;
+	ss << (enabled ? " (enabled)" : " (disabled)");
+	return ss.str ();
+};
+
 nano::port_mapping::port_mapping (nano::node & node_a) :
 	node (node_a),
 	protocols ({ { { "TCP", boost::asio::ip::address_v4::any (), 0, true }, { "UDP", boost::asio::ip::address_v4::any (), 0, !node_a.flags.disable_udp } } })

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -17,6 +17,7 @@ public:
 	boost::asio::ip::address_v4 external_address;
 	uint16_t external_port;
 	bool enabled;
+	std::string to_string ();
 };
 
 /** Collection of discovered UPnP devices and state*/

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -27,6 +27,7 @@ public:
 	upnp_state () = default;
 	~upnp_state ();
 	upnp_state & operator= (upnp_state &&);
+	std::string to_string ();
 
 	/** List of discovered UPnP devices */
 	UPNPDev * devices{ nullptr };
@@ -45,6 +46,7 @@ public:
 	void stop ();
 	void refresh_devices ();
 	nano::endpoint external_address ();
+	std::string to_string ();
 
 private:
 	/** Add port mappings for the node port (not RPC). Refresh when the lease ends. */

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -51,7 +51,7 @@ private:
 	/** Check occasionally to refresh in case router loses mapping */
 	void check_mapping_loop ();
 	/** Returns false if mapping still exists */
-	bool check_mapping ();
+	bool check_lost_or_old_mapping ();
 	std::string get_config_port (std::string const &);
 	upnp_state upnp;
 	nano::node & node;


### PR DESCRIPTION
This PR is intended to address the proposed changes on #3295 proposed by https://github.com/sudokai0

1. changed check_mapping() name to check_lost_or_old_mapping(), so it reflects better what it does;
2. changed call to the refresh_mapping() in the end of the lease time to call its parent loop instead of itself;
3. inverted the return logic so it returns true only if there is a protocol that evaluates to an error or old leasing time. In check_lost_or_old_mapping() there is a loop over the protocols and the former implementation was setting the return to false for the first protocol found ok, preventing others (in case there were any other) to get updated;
4. fixed the logic for calling refresh_mapping().