### PR TITLE
Remove full-check for triggering successive active blocks as this is handled by the scheduler.

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -242,10 +242,6 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 		// Next-block activations are only done for blocks with previously active elections
 		bool const was_active{ *election_status_type == nano::election_status_type::active_confirmed_quorum || *election_status_type == nano::election_status_type::active_confirmation_height };
 
-		// Activations are only done if there is not a large amount of active elections, ensuring frontier confirmation takes place
-                //Removed as limiting backlog processing, may need to be reinstated
-		//auto const low_active_elections = [this] { return this->size () < nano::active_transactions::max_active_elections_frontier_insertion / 2; };
-
 		if (cemented_bootstrap_count_reached && was_active)
 		{
 			// Start or vote for the next unconfirmed block

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -243,9 +243,10 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 		bool const was_active{ *election_status_type == nano::election_status_type::active_confirmed_quorum || *election_status_type == nano::election_status_type::active_confirmation_height };
 
 		// Activations are only done if there is not a large amount of active elections, ensuring frontier confirmation takes place
-		auto const low_active_elections = [this] { return this->size () < nano::active_transactions::max_active_elections_frontier_insertion / 2; };
+                //Removed as limiting backlog processing, may need to be reinstated
+		//auto const low_active_elections = [this] { return this->size () < nano::active_transactions::max_active_elections_frontier_insertion / 2; };
 
-		if (cemented_bootstrap_count_reached && was_active && low_active_elections ())
+		if (cemented_bootstrap_count_reached && was_active)
 		{
 			// Start or vote for the next unconfirmed block
 			scheduler.activate (account, transaction);


### PR DESCRIPTION
Current code has a low active election check where if active elections > 500 it doesn’t allow sequential elections along a chain. This patch removes low active election check as this is limiting progression through the backlog (its currently relevant post 2021 spam but might well need to be reimplemented at a later date).