### PR TITLE
Moves out confirmation height methods from block store class

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1311,9 +1311,9 @@ TEST (active_transactions, pessimistic_elections)
 	nano::confirmation_height_info key1_confirmation_height_info;
 	{
 		auto transaction = node.store.tx_begin_read ();
-		node.store.confirmation_height_get (transaction, nano::genesis_account, genesis_confirmation_height_info);
+		node.store.confirmation_height.get (transaction, nano::genesis_account, genesis_confirmation_height_info);
 		ASSERT_EQ (2, genesis_confirmation_height_info.height);
-		node.store.confirmation_height_get (transaction, key.pub, key1_confirmation_height_info);
+		node.store.confirmation_height.get (transaction, key.pub, key1_confirmation_height_info);
 		ASSERT_EQ (0, key1_confirmation_height_info.height);
 	}
 
@@ -1333,9 +1333,9 @@ TEST (active_transactions, pessimistic_elections)
 
 	{
 		auto transaction = node.store.tx_begin_read ();
-		node.store.confirmation_height_get (transaction, nano::genesis_account, genesis_confirmation_height_info);
+		node.store.confirmation_height.get (transaction, nano::genesis_account, genesis_confirmation_height_info);
 		ASSERT_EQ (3, genesis_confirmation_height_info.height);
-		node.store.confirmation_height_get (transaction, key.pub, key1_confirmation_height_info);
+		node.store.confirmation_height.get (transaction, key.pub, key1_confirmation_height_info);
 		ASSERT_EQ (0, key1_confirmation_height_info.height);
 	}
 
@@ -1357,9 +1357,9 @@ TEST (active_transactions, pessimistic_elections)
 
 	{
 		auto transaction = node.store.tx_begin_read ();
-		node.store.confirmation_height_get (transaction, nano::genesis_account, genesis_confirmation_height_info);
+		node.store.confirmation_height.get (transaction, nano::genesis_account, genesis_confirmation_height_info);
 		ASSERT_EQ (3, genesis_confirmation_height_info.height);
-		node.store.confirmation_height_get (transaction, key.pub, key1_confirmation_height_info);
+		node.store.confirmation_height.get (transaction, key.pub, key1_confirmation_height_info);
 		ASSERT_EQ (1, key1_confirmation_height_info.height);
 	}
 

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -340,7 +340,7 @@ TEST (block_store, genesis)
 	ASSERT_EQ (info.block_count, 1);
 	// Genesis block should be confirmed by default
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (store->confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 1);
 	ASSERT_EQ (confirmation_height_info.frontier, hash);
 	auto dev_pub_text (nano::dev_genesis_key.pub.to_string ());
@@ -528,7 +528,7 @@ TEST (block_store, frontier_retrieval)
 	nano::account account1 (0);
 	nano::account_info info1 (0, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height_put (transaction, account1, { 0, nano::block_hash (0) });
+	store->confirmation_height.put (transaction, account1, { 0, nano::block_hash (0) });
 	store->account_put (transaction, account1, info1);
 	nano::account_info info2;
 	store->account_get (transaction, account1, info2);
@@ -543,7 +543,7 @@ TEST (block_store, one_account)
 	nano::account account (0);
 	nano::block_hash hash (0);
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height_put (transaction, account, { 20, nano::block_hash (15) });
+	store->confirmation_height.put (transaction, account, { 20, nano::block_hash (15) });
 	store->account_put (transaction, account, { hash, account, hash, 42, 100, 200, nano::epoch::epoch_0 });
 	auto begin (store->accounts_begin (transaction));
 	auto end (store->accounts_end ());
@@ -555,7 +555,7 @@ TEST (block_store, one_account)
 	ASSERT_EQ (100, info.modified);
 	ASSERT_EQ (200, info.block_count);
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (store->confirmation_height_get (transaction, account, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, account, confirmation_height_info));
 	ASSERT_EQ (20, confirmation_height_info.height);
 	ASSERT_EQ (nano::block_hash (15), confirmation_height_info.frontier);
 	++begin;
@@ -595,9 +595,9 @@ TEST (block_store, two_account)
 	nano::account account2 (3);
 	nano::block_hash hash2 (4);
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height_put (transaction, account1, { 20, nano::block_hash (10) });
+	store->confirmation_height.put (transaction, account1, { 20, nano::block_hash (10) });
 	store->account_put (transaction, account1, { hash1, account1, hash1, 42, 100, 300, nano::epoch::epoch_0 });
-	store->confirmation_height_put (transaction, account2, { 30, nano::block_hash (20) });
+	store->confirmation_height.put (transaction, account2, { 30, nano::block_hash (20) });
 	store->account_put (transaction, account2, { hash2, account2, hash2, 84, 200, 400, nano::epoch::epoch_0 });
 	auto begin (store->accounts_begin (transaction));
 	auto end (store->accounts_end ());
@@ -609,7 +609,7 @@ TEST (block_store, two_account)
 	ASSERT_EQ (100, info1.modified);
 	ASSERT_EQ (300, info1.block_count);
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (store->confirmation_height_get (transaction, account1, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, account1, confirmation_height_info));
 	ASSERT_EQ (20, confirmation_height_info.height);
 	ASSERT_EQ (nano::block_hash (10), confirmation_height_info.frontier);
 	++begin;
@@ -620,7 +620,7 @@ TEST (block_store, two_account)
 	ASSERT_EQ (84, info2.balance.number ());
 	ASSERT_EQ (200, info2.modified);
 	ASSERT_EQ (400, info2.block_count);
-	ASSERT_FALSE (store->confirmation_height_get (transaction, account2, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, account2, confirmation_height_info));
 	ASSERT_EQ (30, confirmation_height_info.height);
 	ASSERT_EQ (nano::block_hash (20), confirmation_height_info.frontier);
 	++begin;
@@ -637,9 +637,9 @@ TEST (block_store, latest_find)
 	nano::account account2 (3);
 	nano::block_hash hash2 (4);
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height_put (transaction, account1, { 0, nano::block_hash (0) });
+	store->confirmation_height.put (transaction, account1, { 0, nano::block_hash (0) });
 	store->account_put (transaction, account1, { hash1, account1, hash1, 100, 0, 300, nano::epoch::epoch_0 });
-	store->confirmation_height_put (transaction, account2, { 0, nano::block_hash (0) });
+	store->confirmation_height.put (transaction, account2, { 0, nano::block_hash (0) });
 	store->account_put (transaction, account2, { hash2, account2, hash2, 200, 0, 400, nano::epoch::epoch_0 });
 	auto first (store->accounts_begin (transaction));
 	auto second (store->accounts_begin (transaction));
@@ -689,7 +689,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 		store.initialize (transaction, genesis, ledger.cache);
 		// Lower the database version to the minimum version supported for upgrade.
 		store.version_put (transaction, store.minimum_version);
-		store.confirmation_height_del (transaction, nano::genesis_account);
+		store.confirmation_height.del (transaction, nano::genesis_account);
 		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "accounts_v1", MDB_CREATE, &store.accounts_v1));
 		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks));
 		modify_account_info_to_v14 (store, transaction, nano::genesis_account, 1, nano::genesis_hash);
@@ -764,7 +764,7 @@ TEST (block_store, latest_exists)
 	nano::account two (2);
 	nano::account_info info;
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height_put (transaction, two, { 0, nano::block_hash (0) });
+	store->confirmation_height.put (transaction, two, { 0, nano::block_hash (0) });
 	store->account_put (transaction, two, info);
 	nano::account one (1);
 	ASSERT_FALSE (store->account_exists (transaction, one));
@@ -782,7 +782,7 @@ TEST (block_store, large_iteration)
 		nano::account account;
 		nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
 		accounts1.insert (account);
-		store->confirmation_height_put (transaction, account, { 0, nano::block_hash (0) });
+		store->confirmation_height.put (transaction, account, { 0, nano::block_hash (0) });
 		store->account_put (transaction, account, nano::account_info ());
 	}
 	std::unordered_set<nano::account> accounts2;
@@ -867,7 +867,7 @@ TEST (block_store, account_count)
 		auto transaction (store->tx_begin_write ());
 		ASSERT_EQ (0, store->account_count (transaction));
 		nano::account account (200);
-		store->confirmation_height_put (transaction, account, { 0, nano::block_hash (0) });
+		store->confirmation_height.put (transaction, account, { 0, nano::block_hash (0) });
 		store->account_put (transaction, account, nano::account_info ());
 	}
 	auto transaction (store->tx_begin_read ());
@@ -1287,7 +1287,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		nano::account_info account_info;
 		ASSERT_FALSE (store.account_get (transaction, nano::genesis_account, account_info));
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (store.confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+		ASSERT_FALSE (store.confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 		ASSERT_EQ (confirmation_height_info.height, 1);
 		ASSERT_EQ (confirmation_height_info.frontier, genesis.hash ());
 		// These databases get removed after an upgrade, so readd them
@@ -1302,7 +1302,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send).code);
 		// Lower the database to the previous version
 		store.version_put (transaction, 14);
-		store.confirmation_height_del (transaction, nano::genesis_account);
+		store.confirmation_height.del (transaction, nano::genesis_account);
 		modify_account_info_to_v14 (store, transaction, nano::genesis_account, confirmation_height_info.height, state_send.hash ());
 
 		store.pending.del (transaction, nano::pending_key (nano::genesis_account, state_send.hash ()));
@@ -1328,7 +1328,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		store.account_del (transaction, nano::genesis_account);
 
 		// Confirmation height for the account should be deleted
-		ASSERT_TRUE (mdb_get (store.env.tx (transaction), store.confirmation_height, nano::mdb_val (nano::genesis_account), value));
+		ASSERT_TRUE (mdb_get (store.env.tx (transaction), store.confirmation_height_handle, nano::mdb_val (nano::genesis_account), value));
 	}
 
 	// Now do the upgrade
@@ -1345,7 +1345,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 
 	// Confirmation height should exist
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (store.confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+	ASSERT_FALSE (store.confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 1);
 	ASSERT_EQ (confirmation_height_info.frontier, genesis.hash ());
 
@@ -1403,7 +1403,7 @@ TEST (mdb_block_store, upgrade_v15_v16)
 		store.version_put (transaction, 15);
 		// Confirm the rep weight exists in the database
 		ASSERT_EQ (MDB_SUCCESS, mdb_get (store.env.tx (transaction), store.representation, nano::mdb_val (nano::genesis_account), value));
-		store.confirmation_height_del (transaction, nano::genesis_account);
+		store.confirmation_height.del (transaction, nano::genesis_account);
 	}
 
 	// Now do the upgrade
@@ -1468,7 +1468,7 @@ TEST (mdb_block_store, upgrade_v16_v17)
 		auto transaction (store.tx_begin_read ());
 
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (store.confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+		ASSERT_FALSE (store.confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 		ASSERT_EQ (confirmation_height_info.height, confirmation_height);
 
 		// Check confirmation height frontier is correct
@@ -1903,30 +1903,30 @@ TEST (block_store, confirmation_height)
 	nano::block_hash cemented_frontier3 (5);
 	{
 		auto transaction (store->tx_begin_write ());
-		store->confirmation_height_put (transaction, account1, { 500, cemented_frontier1 });
-		store->confirmation_height_put (transaction, account2, { std::numeric_limits<uint64_t>::max (), cemented_frontier2 });
-		store->confirmation_height_put (transaction, account3, { 10, cemented_frontier3 });
+		store->confirmation_height.put (transaction, account1, { 500, cemented_frontier1 });
+		store->confirmation_height.put (transaction, account2, { std::numeric_limits<uint64_t>::max (), cemented_frontier2 });
+		store->confirmation_height.put (transaction, account3, { 10, cemented_frontier3 });
 
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (store->confirmation_height_get (transaction, account1, confirmation_height_info));
+		ASSERT_FALSE (store->confirmation_height.get (transaction, account1, confirmation_height_info));
 		ASSERT_EQ (confirmation_height_info.height, 500);
 		ASSERT_EQ (confirmation_height_info.frontier, cemented_frontier1);
-		ASSERT_FALSE (store->confirmation_height_get (transaction, account2, confirmation_height_info));
+		ASSERT_FALSE (store->confirmation_height.get (transaction, account2, confirmation_height_info));
 		ASSERT_EQ (confirmation_height_info.height, std::numeric_limits<uint64_t>::max ());
 		ASSERT_EQ (confirmation_height_info.frontier, cemented_frontier2);
-		ASSERT_FALSE (store->confirmation_height_get (transaction, account3, confirmation_height_info));
+		ASSERT_FALSE (store->confirmation_height.get (transaction, account3, confirmation_height_info));
 		ASSERT_EQ (confirmation_height_info.height, 10);
 		ASSERT_EQ (confirmation_height_info.frontier, cemented_frontier3);
 
 		// Check clearing of confirmation heights
-		store->confirmation_height_clear (transaction);
+		store->confirmation_height.clear (transaction);
 	}
 	auto transaction (store->tx_begin_read ());
-	ASSERT_EQ (store->confirmation_height_count (transaction), 0);
+	ASSERT_EQ (store->confirmation_height.count (transaction), 0);
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_TRUE (store->confirmation_height_get (transaction, account1, confirmation_height_info));
-	ASSERT_TRUE (store->confirmation_height_get (transaction, account2, confirmation_height_info));
-	ASSERT_TRUE (store->confirmation_height_get (transaction, account3, confirmation_height_info));
+	ASSERT_TRUE (store->confirmation_height.get (transaction, account1, confirmation_height_info));
+	ASSERT_TRUE (store->confirmation_height.get (transaction, account2, confirmation_height_info));
+	ASSERT_TRUE (store->confirmation_height.get (transaction, account3, confirmation_height_info));
 }
 
 // Test various confirmation height values as well as clearing them
@@ -2124,7 +2124,7 @@ void modify_account_info_to_v14 (nano::mdb_store & store, nano::transaction cons
 
 void modify_confirmation_height_to_v15 (nano::mdb_store & store, nano::transaction const & transaction, nano::account const & account, uint64_t confirmation_height)
 {
-	auto status (mdb_put (store.env.tx (transaction), store.confirmation_height, nano::mdb_val (account), nano::mdb_val (confirmation_height), 0));
+	auto status (mdb_put (store.env.tx (transaction), store.confirmation_height_handle, nano::mdb_val (account), nano::mdb_val (confirmation_height), 0));
 	ASSERT_EQ (status, 0);
 }
 }

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -46,7 +46,7 @@ TEST (confirmation_height, single)
 		nano::confirmation_height_info confirmation_height_info;
 		add_callback_stats (*node);
 		auto transaction = node->store.tx_begin_read ();
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (1, confirmation_height_info.height);
 		ASSERT_EQ (nano::genesis_hash, confirmation_height_info.frontier);
 
@@ -58,7 +58,7 @@ TEST (confirmation_height, single)
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_TRUE (node->ledger.block_confirmed (transaction, send1->hash ()));
-			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (2, confirmation_height_info.height);
 			ASSERT_EQ (send1->hash (), confirmation_height_info.frontier);
 
@@ -132,16 +132,16 @@ TEST (confirmation_height, multiple_accounts)
 			// Check confirmation heights of all the accounts (except genesis) are uninitialized (0),
 			// as we have any just added them to the ledger and not processed any live transactions yet.
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (nano::genesis_hash, confirmation_height_info.frontier);
-			ASSERT_TRUE (node->store.confirmation_height_get (transaction, key1.pub, confirmation_height_info));
+			ASSERT_TRUE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 			ASSERT_EQ (0, confirmation_height_info.height);
 			ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
-			ASSERT_TRUE (node->store.confirmation_height_get (transaction, key2.pub, confirmation_height_info));
+			ASSERT_TRUE (node->store.confirmation_height.get (transaction, key2.pub, confirmation_height_info));
 			ASSERT_EQ (0, confirmation_height_info.height);
 			ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
-			ASSERT_TRUE (node->store.confirmation_height_get (transaction, key3.pub, confirmation_height_info));
+			ASSERT_TRUE (node->store.confirmation_height.get (transaction, key3.pub, confirmation_height_info));
 			ASSERT_EQ (0, confirmation_height_info.height);
 			ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
 		}
@@ -163,22 +163,22 @@ TEST (confirmation_height, multiple_accounts)
 		auto transaction = node->store.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
 		ASSERT_FALSE (store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (4, confirmation_height_info.height);
 		ASSERT_EQ (send3.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (4, account_info.block_count);
 		ASSERT_FALSE (store.account_get (transaction, key1.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, key1.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (2, confirmation_height_info.height);
 		ASSERT_EQ (send4.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (3, account_info.block_count);
 		ASSERT_FALSE (store.account_get (transaction, key2.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, key2.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key2.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
 		ASSERT_EQ (send6.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (4, account_info.block_count);
 		ASSERT_FALSE (store.account_get (transaction, key3.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, key3.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key3.pub, confirmation_height_info));
 		ASSERT_EQ (2, confirmation_height_info.height);
 		ASSERT_EQ (receive3->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (2, account_info.block_count);
@@ -259,7 +259,7 @@ TEST (confirmation_height, gap_bootstrap)
 			ASSERT_EQ (unchecked_count, 2);
 
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node1.store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (genesis.hash (), confirmation_height_info.frontier);
 		}
@@ -275,10 +275,10 @@ TEST (confirmation_height, gap_bootstrap)
 			ASSERT_EQ (unchecked_count, 0);
 
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node1.store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node1.store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (genesis.hash (), confirmation_height_info.frontier);
-			ASSERT_TRUE (node1.store.confirmation_height_get (transaction, destination.pub, confirmation_height_info));
+			ASSERT_TRUE (node1.store.confirmation_height.get (transaction, destination.pub, confirmation_height_info));
 			ASSERT_EQ (0, confirmation_height_info.height);
 			ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
 		}
@@ -341,7 +341,7 @@ TEST (confirmation_height, gap_live)
 		{
 			auto transaction = node->store.tx_begin_read ();
 			nano::confirmation_height_info confirmation_height_info;
-			ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+			ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 			ASSERT_EQ (1, confirmation_height_info.height);
 			ASSERT_EQ (nano::genesis_hash, confirmation_height_info.frontier);
 		}
@@ -363,10 +363,10 @@ TEST (confirmation_height, gap_live)
 
 		nano::confirmation_height_info confirmation_height_info;
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive2->hash ()));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (4, confirmation_height_info.height);
 		ASSERT_EQ (send3->hash (), confirmation_height_info.frontier);
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, destination.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, destination.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
 		ASSERT_EQ (receive2->hash (), confirmation_height_info.frontier);
 
@@ -444,13 +444,13 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
 		ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (6, confirmation_height_info.height);
 		ASSERT_EQ (send5.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (7, account_info.block_count);
 
 		ASSERT_FALSE (node->store.account_get (transaction, key1.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, key1.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (5, confirmation_height_info.height);
 		ASSERT_EQ (receive4->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (5, account_info.block_count);
@@ -515,7 +515,7 @@ TEST (confirmation_height, send_receive_self)
 		nano::account_info account_info;
 		ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (7, confirmation_height_info.height);
 		ASSERT_EQ (receive3->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (8, account_info.block_count);
@@ -612,19 +612,19 @@ TEST (confirmation_height, all_block_types)
 		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
 		ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
 		ASSERT_EQ (send1.hash (), confirmation_height_info.frontier);
 		ASSERT_LE (4, account_info.block_count);
 
 		ASSERT_FALSE (node->store.account_get (transaction, key1.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, key1.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (state_send1.hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (6, confirmation_height_info.height);
 		ASSERT_LE (7, account_info.block_count);
 
 		ASSERT_FALSE (node->store.account_get (transaction, key2.pub, account_info));
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, key2.pub, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key2.pub, confirmation_height_info));
 		ASSERT_EQ (7, confirmation_height_info.height);
 		ASSERT_EQ (state_send2->hash (), confirmation_height_info.frontier);
 		ASSERT_LE (8, account_info.block_count);
@@ -683,12 +683,12 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		{
 			auto transaction (node1->store.tx_begin_write ());
 			ASSERT_TRUE (node1->store.block_exists (transaction, publish1.block->hash ()));
-			node1->store.confirmation_height_put (transaction, nano::genesis_account, nano::confirmation_height_info{ 2, send2->hash () });
+			node1->store.confirmation_height.put (transaction, nano::genesis_account, nano::confirmation_height_info{ 2, send2->hash () });
 		}
 		{
 			auto transaction (node2->store.tx_begin_write ());
 			ASSERT_TRUE (node2->store.block_exists (transaction, publish2.block->hash ()));
-			node2->store.confirmation_height_put (transaction, nano::genesis_account, nano::confirmation_height_info{ 2, send2->hash () });
+			node2->store.confirmation_height.put (transaction, nano::genesis_account, nano::confirmation_height_info{ 2, send2->hash () });
 		}
 
 		auto rollback_log_entry = boost::str (boost::format ("Failed to roll back %1%") % send2->hash ().to_string ());
@@ -832,7 +832,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		}
 
 		ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), *send).code);
-		store->confirmation_height_put (store->tx_begin_write (), nano::genesis_account, { 1, nano::genesis_hash });
+		store->confirmation_height.put (store->tx_begin_write (), nano::genesis_account, { 1, nano::genesis_hash });
 
 		nano::confirmation_height_unbounded unbounded_processor (
 		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
@@ -906,7 +906,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 
 		// Reset conditions and test with the bounded processor
 		ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), *open).code);
-		store->confirmation_height_put (store->tx_begin_write (), nano::genesis_account, { 1, nano::genesis_hash });
+		store->confirmation_height.put (store->tx_begin_write (), nano::genesis_account, { 1, nano::genesis_hash });
 
 		nano::confirmation_height_bounded bounded_processor (
 		ledger, write_database_queue, 10ms, logging, logger, stopped, batch_write_size, [] (auto const &) {}, [] (auto const &) {}, [] () { return 0; });
@@ -1241,8 +1241,8 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		// Force some blocks to be cemented so that the cached confirmed info variable is empty
 		{
 			auto transaction (node->store.tx_begin_write ());
-			node->store.confirmation_height_put (transaction, nano::genesis_account, nano::confirmation_height_info{ 3, send1.hash () });
-			node->store.confirmation_height_put (transaction, key1.pub, nano::confirmation_height_info{ 2, receive1.hash () });
+			node->store.confirmation_height.put (transaction, nano::genesis_account, nano::confirmation_height_info{ 3, send1.hash () });
+			node->store.confirmation_height.put (transaction, key1.pub, nano::confirmation_height_info{ 2, receive1.hash () });
 		}
 
 		add_callback_stats (*node);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -61,7 +61,7 @@ TEST (ledger, genesis_balance)
 	ASSERT_LT (nano::seconds_since_epoch () - info.modified, 10);
 	// Genesis block should be confirmed by default
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (store->confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 1);
 	ASSERT_EQ (confirmation_height_info.frontier, genesis.hash ());
 }
@@ -3031,16 +3031,16 @@ TEST (ledger, confirmation_height_not_updated)
 	nano::keypair key;
 	nano::send_block send1 (account_info.head, key.pub, 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (account_info.head));
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (store->confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
 	ASSERT_EQ (genesis.hash (), confirmation_height_info.frontier);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_FALSE (store->confirmation_height_get (transaction, nano::genesis_account, confirmation_height_info));
+	ASSERT_FALSE (store->confirmation_height.get (transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
 	ASSERT_EQ (genesis.hash (), confirmation_height_info.frontier);
 	nano::open_block open1 (send1.hash (), nano::genesis_account, key.pub, key.prv, key.pub, *pool.generate (key.pub));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_TRUE (store->confirmation_height_get (transaction, key.pub, confirmation_height_info));
+	ASSERT_TRUE (store->confirmation_height.get (transaction, key.pub, confirmation_height_info));
 	ASSERT_EQ (0, confirmation_height_info.height);
 	ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
 }
@@ -3219,9 +3219,9 @@ TEST (ledger, dependents_confirmed)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive1));
 	nano::confirmation_height_info height;
-	ASSERT_FALSE (ledger.store.confirmation_height_get (transaction, nano::genesis_account, height));
+	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::genesis_account, height));
 	height.height += 1;
-	ledger.store.confirmation_height_put (transaction, nano::genesis_account, height);
+	ledger.store.confirmation_height.put (transaction, nano::genesis_account, height);
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive1));
 	auto receive2 = builder.state ()
 					.account (key1.pub)
@@ -3234,13 +3234,13 @@ TEST (ledger, dependents_confirmed)
 					.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
-	ASSERT_TRUE (ledger.store.confirmation_height_get (transaction, key1.pub, height));
+	ASSERT_TRUE (ledger.store.confirmation_height.get (transaction, key1.pub, height));
 	height.height += 1;
-	ledger.store.confirmation_height_put (transaction, key1.pub, height);
+	ledger.store.confirmation_height.put (transaction, key1.pub, height);
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
-	ASSERT_FALSE (ledger.store.confirmation_height_get (transaction, nano::genesis_account, height));
+	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::genesis_account, height));
 	height.height += 1;
-	ledger.store.confirmation_height_put (transaction, nano::genesis_account, height);
+	ledger.store.confirmation_height.put (transaction, nano::genesis_account, height);
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive2));
 }
 
@@ -3279,9 +3279,9 @@ TEST (ledger, dependents_confirmed_pruning)
 				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	nano::confirmation_height_info height;
-	ASSERT_FALSE (ledger.store.confirmation_height_get (transaction, nano::genesis_account, height));
+	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::genesis_account, height));
 	height.height = 3;
-	ledger.store.confirmation_height_put (transaction, nano::genesis_account, height);
+	ledger.store.confirmation_height.put (transaction, nano::genesis_account, height);
 	ASSERT_TRUE (ledger.block_confirmed (transaction, send1->hash ()));
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 1));
 	auto receive1 = builder.state ()
@@ -3324,9 +3324,9 @@ TEST (ledger, block_confirmed)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_FALSE (ledger.block_confirmed (transaction, send1->hash ()));
 	nano::confirmation_height_info height;
-	ASSERT_FALSE (ledger.store.confirmation_height_get (transaction, nano::genesis_account, height));
+	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::genesis_account, height));
 	++height.height;
-	ledger.store.confirmation_height_put (transaction, nano::genesis_account, height);
+	ledger.store.confirmation_height.put (transaction, nano::genesis_account, height);
 	ASSERT_TRUE (ledger.block_confirmed (transaction, send1->hash ()));
 }
 
@@ -3404,10 +3404,10 @@ TEST (ledger, cache)
 		{
 			auto transaction (store->tx_begin_write ());
 			nano::confirmation_height_info height;
-			ASSERT_FALSE (ledger.store.confirmation_height_get (transaction, nano::genesis_account, height));
+			ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::genesis_account, height));
 			++height.height;
 			height.frontier = send->hash ();
-			ledger.store.confirmation_height_put (transaction, nano::genesis_account, height);
+			ledger.store.confirmation_height.put (transaction, nano::genesis_account, height);
 			ASSERT_TRUE (ledger.block_confirmed (transaction, send->hash ()));
 			++ledger.cache.cemented_count;
 		}
@@ -3419,10 +3419,10 @@ TEST (ledger, cache)
 		{
 			auto transaction (store->tx_begin_write ());
 			nano::confirmation_height_info height;
-			ledger.store.confirmation_height_get (transaction, key.pub, height);
+			ledger.store.confirmation_height.get (transaction, key.pub, height);
 			height.height += 1;
 			height.frontier = open->hash ();
-			ledger.store.confirmation_height_put (transaction, key.pub, height);
+			ledger.store.confirmation_height.put (transaction, key.pub, height);
 			ASSERT_TRUE (ledger.block_confirmed (transaction, open->hash ()));
 			++ledger.cache.cemented_count;
 		}
@@ -3860,7 +3860,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 		ASSERT_FALSE (store.init_error ());
 
 		// Lower the database to the max version unsupported for upgrades
-		store.confirmation_height_put (transaction, nano::genesis_account, { 2, send->hash () });
+		store.confirmation_height.put (transaction, nano::genesis_account, { 2, send->hash () });
 
 		store.online_weight_put (transaction, 100, nano::amount (2));
 		store.frontier.put (transaction, nano::block_hash (2), nano::account (5));
@@ -3899,7 +3899,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_EQ (rocksdb_store.version_get (rocksdb_transaction), version);
 	ASSERT_EQ (rocksdb_store.frontier.get (rocksdb_transaction, 2), 5);
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (rocksdb_store.confirmation_height_get (rocksdb_transaction, nano::genesis_account, confirmation_height_info));
+	ASSERT_FALSE (rocksdb_store.confirmation_height.get (rocksdb_transaction, nano::genesis_account, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 2);
 	ASSERT_EQ (confirmation_height_info.frontier, send->hash ());
 	ASSERT_TRUE (rocksdb_store.final_vote_get (rocksdb_transaction, nano::root (send->previous ())).size () == 1);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1409,7 +1409,7 @@ int main (int argc, char * const * argv)
 					std::cout << boost::str (boost::format ("%1% accounts validated\n") % count);
 				}
 				nano::confirmation_height_info confirmation_height_info;
-				node->store.confirmation_height_get (transaction, account, confirmation_height_info);
+				node->store.confirmation_height.get (transaction, account, confirmation_height_info);
 
 				if (confirmation_height_info.height > info.block_count)
 				{

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -138,7 +138,7 @@ void nano::active_transactions::confirm_prioritized_frontiers (nano::transaction
 					if (!this->confirmation_height_processor.is_processing_block (info.head))
 					{
 						nano::confirmation_height_info confirmation_height_info;
-						this->node.store.confirmation_height_get (transaction_a, cementable_account.account, confirmation_height_info);
+						this->node.store.confirmation_height.get (transaction_a, cementable_account.account, confirmation_height_info);
 
 						if (info.block_count > confirmation_height_info.height)
 						{
@@ -492,7 +492,7 @@ void nano::active_transactions::confirm_expired_frontiers_pessimistically (nano:
 		bool should_delete{ true };
 		if (!node.store.account_get (transaction_a, account, account_info))
 		{
-			node.store.confirmation_height_get (transaction_a, account, confirmation_height_info);
+			node.store.confirmation_height.get (transaction_a, account, confirmation_height_info);
 			if (account_info.block_count > confirmation_height_info.height)
 			{
 				should_delete = false;
@@ -695,7 +695,7 @@ void nano::active_transactions::prioritize_frontiers_for_confirmation (nano::tra
 						if (expired_optimistic_election_infos.get<tag_account> ().count (account) == 0 && !node.store.account_get (transaction_a, account, info))
 						{
 							nano::confirmation_height_info confirmation_height_info;
-							node.store.confirmation_height_get (transaction_a, account, confirmation_height_info);
+							node.store.confirmation_height.get (transaction_a, account, confirmation_height_info);
 							// If it exists in normal priority collection delete from there.
 							auto it = priority_cementable_frontiers.find (account);
 							if (it != priority_cementable_frontiers.end ())
@@ -747,7 +747,7 @@ void nano::active_transactions::prioritize_frontiers_for_confirmation (nano::tra
 				if (expired_optimistic_election_infos.get<tag_account> ().count (account) == 0)
 				{
 					nano::confirmation_height_info confirmation_height_info;
-					node.store.confirmation_height_get (transaction_a, account, confirmation_height_info);
+					node.store.confirmation_height.get (transaction_a, account, confirmation_height_info);
 					auto insert_newed = prioritize_account_for_confirmation (priority_cementable_frontiers, priority_cementable_frontiers_size, account, info, confirmation_height_info.height);
 					if (insert_newed)
 					{

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -349,7 +349,7 @@ void nano::frontier_req_server::next ()
 		}
 		else
 		{
-			for (auto i (connection->node->store.confirmation_height_begin (transaction, current.number () + 1)), n (connection->node->store.confirmation_height_end ()); i != n && accounts.size () != max_size; ++i)
+			for (auto i (connection->node->store.confirmation_height.begin (transaction, current.number () + 1)), n (connection->node->store.confirmation_height.end ()); i != n && accounts.size () != max_size; ++i)
 			{
 				nano::confirmation_height_info const & info (i->second);
 				nano::block_hash const & confirmed_frontier (info.frontier);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -570,18 +570,18 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				if (!account.decode_account (account_str))
 				{
 					nano::confirmation_height_info confirmation_height_info;
-					if (!node.node->store.confirmation_height_get (node.node->store.tx_begin_read (), account, confirmation_height_info))
+					if (!node.node->store.confirmation_height.get (node.node->store.tx_begin_read (), account, confirmation_height_info))
 					{
 						auto transaction (node.node->store.tx_begin_write ());
 						auto conf_height_reset_num = 0;
 						if (account == node.node->network_params.ledger.genesis_account)
 						{
 							conf_height_reset_num = 1;
-							node.node->store.confirmation_height_put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_block });
+							node.node->store.confirmation_height.put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_block });
 						}
 						else
 						{
-							node.node->store.confirmation_height_clear (transaction, account);
+							node.node->store.confirmation_height.clear (transaction, account);
 						}
 
 						std::cout << "Confirmation height of account " << account_str << " is set to " << conf_height_reset_num << std::endl;
@@ -1303,11 +1303,11 @@ namespace
 void reset_confirmation_heights (nano::write_transaction const & transaction, nano::block_store & store)
 {
 	// First do a clean sweep
-	store.confirmation_height_clear (transaction);
+	store.confirmation_height.clear (transaction);
 
 	// Then make sure the confirmation height of the genesis account open block is 1
 	nano::network_params network_params;
-	store.confirmation_height_put (transaction, network_params.ledger.genesis_account, { 1, network_params.ledger.genesis_hash });
+	store.confirmation_height.put (transaction, network_params.ledger.genesis_account, { 1, network_params.ledger.genesis_hash });
 }
 
 bool is_using_rocksdb (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec)

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -121,7 +121,7 @@ void nano::confirmation_height_bounded::process (std::shared_ptr<nano::block> or
 		}
 		else
 		{
-			ledger.store.confirmation_height_get (transaction, account, confirmation_height_info);
+			ledger.store.confirmation_height.get (transaction, account, confirmation_height_info);
 			// This block was added to the confirmation height processor but is already confirmed
 			if (first_iter && confirmation_height_info.height >= block->sideband ().height && current == original_block->hash ())
 			{
@@ -385,19 +385,19 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 #ifndef NDEBUG
 				// Extra debug checks
 				nano::confirmation_height_info confirmation_height_info;
-				ledger.store.confirmation_height_get (transaction, account, confirmation_height_info);
+				ledger.store.confirmation_height.get (transaction, account, confirmation_height_info);
 				auto block (ledger.store.block_get (transaction, confirmed_frontier));
 				debug_assert (block != nullptr);
 				debug_assert (block->sideband ().height == confirmation_height_info.height + num_blocks_cemented);
 #endif
-				ledger.store.confirmation_height_put (transaction, account, nano::confirmation_height_info{ confirmation_height, confirmed_frontier });
+				ledger.store.confirmation_height.put (transaction, account, nano::confirmation_height_info{ confirmation_height, confirmed_frontier });
 				ledger.cache.cemented_count += num_blocks_cemented;
 				ledger.stats.add (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in, num_blocks_cemented);
 				ledger.stats.add (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in, num_blocks_cemented);
 			};
 
 			nano::confirmation_height_info confirmation_height_info;
-			ledger.store.confirmation_height_get (transaction, pending.account, confirmation_height_info);
+			ledger.store.confirmation_height.get (transaction, pending.account, confirmation_height_info);
 
 			// Some blocks need to be cemented at least
 			if (pending.top_height > confirmation_height_info.height)

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -95,7 +95,7 @@ void nano::confirmation_height_unbounded::process (std::shared_ptr<nano::block> 
 		else
 		{
 			nano::confirmation_height_info confirmation_height_info;
-			ledger.store.confirmation_height_get (read_transaction, account, confirmation_height_info);
+			ledger.store.confirmation_height.get (read_transaction, account, confirmation_height_info);
 			confirmation_height = confirmation_height_info.height;
 
 			// This block was added to the confirmation height processor but is already confirmed
@@ -376,7 +376,7 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 		{
 			auto & pending = pending_writes.front ();
 			nano::confirmation_height_info confirmation_height_info;
-			ledger.store.confirmation_height_get (transaction, pending.account, confirmation_height_info);
+			ledger.store.confirmation_height.get (transaction, pending.account, confirmation_height_info);
 			auto confirmation_height = confirmation_height_info.height;
 			if (pending.height > confirmation_height)
 			{
@@ -406,7 +406,7 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 				debug_assert (pending.num_blocks_confirmed == pending.height - confirmation_height);
 				confirmation_height = pending.height;
 				ledger.cache.cemented_count += pending.num_blocks_confirmed;
-				ledger.store.confirmation_height_put (transaction, pending.account, { confirmation_height, pending.hash });
+				ledger.store.confirmation_height.put (transaction, pending.account, { confirmation_height, pending.hash });
 
 				// Reverse it so that the callbacks start from the lowest newly cemented block and move upwards
 				std::reverse (pending.block_callback_data.begin (), pending.block_callback_data.end ());

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -28,7 +28,7 @@ void nano::election_scheduler::activate (nano::account const & account_a, nano::
 	if (!node.store.account_get (transaction, account_a, account_info))
 	{
 		nano::confirmation_height_info conf_info;
-		node.store.confirmation_height_get (transaction, account_a, conf_info);
+		node.store.confirmation_height.get (transaction, account_a, conf_info);
 		if (conf_info.height < account_info.block_count)
 		{
 			debug_assert (conf_info.frontier != account_info.head);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -606,7 +606,7 @@ void nano::json_handler::account_info ()
 		auto transaction (node.store.tx_begin_read ());
 		auto info (account_info_impl (transaction, account));
 		nano::confirmation_height_info confirmation_height_info;
-		node.store.confirmation_height_get (transaction, account, confirmation_height_info);
+		node.store.confirmation_height.get (transaction, account, confirmation_height_info);
 		if (!ec)
 		{
 			response_l.put ("frontier", info.head.to_string ());
@@ -4226,7 +4226,7 @@ void nano::json_handler::wallet_info ()
 			}
 
 			nano::confirmation_height_info confirmation_info{};
-			if (!node.store.confirmation_height_get (block_transaction, account, confirmation_info))
+			if (!node.store.confirmation_height.get (block_transaction, account, confirmation_info))
 			{
 				cemented_block_count += confirmation_info.height;
 			}

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -194,7 +194,7 @@ void nano::mdb_store::open_databases (bool & error_a, nano::transaction const & 
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peers) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pruned", flags, &pruned) != 0;
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "confirmation_height", flags, &confirmation_height) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "confirmation_height", flags, &confirmation_height_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "accounts", flags, &accounts_v0) != 0;
 	accounts = accounts_v0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pending", flags, &pending_v0) != 0;
@@ -313,7 +313,7 @@ void nano::mdb_store::upgrade_v14_to_v15 (nano::write_transaction & transaction_
 		release_assert (rep_block != nullptr);
 		account_infos.emplace_back (account, nano::account_info{ account_info_v14.head, rep_block->representative (), account_info_v14.open_block, account_info_v14.balance, account_info_v14.modified, account_info_v14.block_count, i_account.from_first_database ? nano::epoch::epoch_0 : nano::epoch::epoch_1 });
 		// Move confirmation height from account_info database to its own table
-		mdb_put (env.tx (transaction_a), confirmation_height, nano::mdb_val (account), nano::mdb_val (account_info_v14.confirmation_height), MDB_APPEND);
+		mdb_put (env.tx (transaction_a), confirmation_height_handle, nano::mdb_val (account), nano::mdb_val (account_info_v14.confirmation_height), MDB_APPEND);
 		i_account.from_first_database ? ++account_counters.after_v0 : ++account_counters.after_v1;
 	}
 
@@ -434,7 +434,7 @@ void nano::mdb_store::upgrade_v16_to_v17 (nano::write_transaction const & transa
 	// Set the confirmed frontier for each account in the confirmation height table
 	std::vector<std::pair<nano::account, nano::confirmation_height_info>> confirmation_height_infos;
 	auto num = 0u;
-	for (nano::mdb_iterator<nano::account, uint64_t> i (transaction_a, confirmation_height), n (nano::mdb_iterator<nano::account, uint64_t>{}); i != n; ++i, ++account_info_i, ++num)
+	for (nano::mdb_iterator<nano::account, uint64_t> i (transaction_a, confirmation_height_handle), n (nano::mdb_iterator<nano::account, uint64_t>{}); i != n; ++i, ++account_info_i, ++num)
 	{
 		nano::account account (i->first);
 		uint64_t confirmation_height (i->second);
@@ -491,12 +491,12 @@ void nano::mdb_store::upgrade_v16_to_v17 (nano::write_transaction const & transa
 	}
 
 	// Clear it then append
-	auto status (mdb_drop (env.tx (transaction_a), confirmation_height, 0));
+	auto status (mdb_drop (env.tx (transaction_a), confirmation_height_handle, 0));
 	release_assert_success (*this, status);
 
 	for (auto const & confirmation_height_info_pair : confirmation_height_infos)
 	{
-		mdb_put (env.tx (transaction_a), confirmation_height, nano::mdb_val (confirmation_height_info_pair.first), nano::mdb_val (confirmation_height_info_pair.second), MDB_APPEND);
+		mdb_put (env.tx (transaction_a), confirmation_height_handle, nano::mdb_val (confirmation_height_info_pair.first), nano::mdb_val (confirmation_height_info_pair.second), MDB_APPEND);
 	}
 
 	version_put (transaction_a, 17);
@@ -876,7 +876,7 @@ MDB_dbi nano::mdb_store::table_to_dbi (tables table_a) const
 		case tables::pruned:
 			return pruned;
 		case tables::confirmation_height:
-			return confirmation_height;
+			return confirmation_height_handle;
 		case tables::final_votes:
 			return final_votes;
 		default:
@@ -913,7 +913,7 @@ bool nano::mdb_store::copy_db (boost::filesystem::path const & destination_file)
 void nano::mdb_store::rebuild_db (nano::write_transaction const & transaction_a)
 {
 	// Tables with uint256_union key
-	std::vector<MDB_dbi> tables = { accounts, blocks, pruned, confirmation_height };
+	std::vector<MDB_dbi> tables = { accounts, blocks, pruned, confirmation_height_handle };
 	for (auto const & table : tables)
 	{
 		MDB_dbi temp;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -184,7 +184,7 @@ public:
 	 * Confirmation height of an account, and the hash for the block at that height
 	 * nano::account -> uint64_t, nano::block_hash
 	 */
-	MDB_dbi confirmation_height{ 0 };
+	MDB_dbi confirmation_height_handle{ 0 };
 
 	/*
 	 * Contains block_sideband and block for all block types (legacy send/change/open/receive & state blocks)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -977,7 +977,7 @@ bool nano::node::collect_ledger_pruning_targets (std::deque<nano::block_hash> & 
 	uint64_t read_operations (0);
 	bool finish_transaction (false);
 	auto transaction (store.tx_begin_read ());
-	for (auto i (store.confirmation_height_begin (transaction, last_account_a)), n (store.confirmation_height_end ()); i != n && !finish_transaction;)
+	for (auto i (store.confirmation_height.begin (transaction, last_account_a)), n (store.confirmation_height.end ()); i != n && !finish_transaction;)
 	{
 		++read_operations;
 		auto const & account (i->first);

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -216,7 +216,7 @@ std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr
 				if (block != nullptr)
 				{
 					nano::confirmation_height_info confirmation_height_info;
-					ledger.store.confirmation_height_get (transaction, block->account ().is_zero () ? block->sideband ().account : block->account (), confirmation_height_info);
+					ledger.store.confirmation_height.get (transaction, block->account ().is_zero () ? block->sideband ().account : block->account (), confirmation_height_info);
 					generate_final_vote = (confirmation_height_info.height >= block->sideband ().height);
 				}
 			}
@@ -253,7 +253,7 @@ std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr
 					if (block != nullptr && generate_vote)
 					{
 						nano::confirmation_height_info confirmation_height_info;
-						ledger.store.confirmation_height_get (transaction, block->account ().is_zero () ? block->sideband ().account : block->account (), confirmation_height_info);
+						ledger.store.confirmation_height.get (transaction, block->account ().is_zero () ? block->sideband ().account : block->account (), confirmation_height_info);
 						generate_final_vote = (confirmation_height_info.height >= block->sideband ().height);
 					}
 				}

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -531,7 +531,7 @@ uint64_t nano::rocksdb_store::count (nano::transaction const & transaction_a, ta
 	else if (table_a == tables::confirmation_height)
 	{
 		debug_assert (network_constants ().is_dev_network ());
-		for (auto i (confirmation_height_begin (transaction_a)), n (confirmation_height_end ()); i != n; ++i)
+		for (auto i (confirmation_height.begin (transaction_a)), n (confirmation_height.end ()); i != n; ++i)
 		{
 			++sum;
 		}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -117,9 +117,9 @@ void reset_confirmation_height (nano::block_store & store, nano::account const &
 {
 	auto transaction = store.tx_begin_write ();
 	nano::confirmation_height_info confirmation_height_info;
-	if (!store.confirmation_height_get (transaction, account, confirmation_height_info))
+	if (!store.confirmation_height.get (transaction, account, confirmation_height_info))
 	{
-		store.confirmation_height_clear (transaction, account);
+		store.confirmation_height.clear (transaction, account);
 	}
 }
 
@@ -1274,7 +1274,7 @@ TEST (rpc, frontier)
 			nano::block_hash hash;
 			nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 			source[key.pub] = hash;
-			node->store.confirmation_height_put (transaction, key.pub, { 0, nano::block_hash (0) });
+			node->store.confirmation_height.put (transaction, key.pub, { 0, nano::block_hash (0) });
 			node->store.account_put (transaction, key.pub, nano::account_info (hash, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
 		}
 	}
@@ -1321,7 +1321,7 @@ TEST (rpc, frontier_limited)
 			nano::block_hash hash;
 			nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 			source[key.pub] = hash;
-			node->store.confirmation_height_put (transaction, key.pub, { 0, nano::block_hash (0) });
+			node->store.confirmation_height.put (transaction, key.pub, { 0, nano::block_hash (0) });
 			node->store.account_put (transaction, key.pub, nano::account_info (hash, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
 		}
 	}
@@ -1359,7 +1359,7 @@ TEST (rpc, frontier_startpoint)
 			nano::block_hash hash;
 			nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 			source[key.pub] = hash;
-			node->store.confirmation_height_put (transaction, key.pub, { 0, nano::block_hash (0) });
+			node->store.confirmation_height.put (transaction, key.pub, { 0, nano::block_hash (0) });
 			node->store.account_put (transaction, key.pub, nano::account_info (hash, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
 		}
 	}
@@ -2320,7 +2320,7 @@ TEST (rpc, pending)
 
 	// Sorting with a smaller count than total should give absolute sorted amounts
 	scoped_thread_name_io.reset ();
-	node->store.confirmation_height_put (node->store.tx_begin_write (), nano::dev_genesis_key.pub, { 2, block1->hash () });
+	node->store.confirmation_height.put (node->store.tx_begin_write (), nano::dev_genesis_key.pub, { 2, block1->hash () });
 	auto block2 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 200));
 	auto block3 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 300));
 	auto block4 (system.wallet (0)->send_action (nano::dev_genesis_key.pub, key1.pub, 400));
@@ -4702,7 +4702,7 @@ TEST (rpc, account_info)
 	auto time (nano::seconds_since_epoch ());
 	{
 		auto transaction = node1.store.tx_begin_write ();
-		node1.store.confirmation_height_put (transaction, nano::dev_genesis_key.pub, { 1, genesis.hash () });
+		node1.store.confirmation_height.put (transaction, nano::dev_genesis_key.pub, { 1, genesis.hash () });
 	}
 	scoped_thread_name_io.renew ();
 

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -55,7 +55,8 @@ add_library(
   versioning.cpp
   working.hpp
   store/frontier_store_partial.hpp
-  store/pending_store_partial.hpp)
+  store/pending_store_partial.hpp
+  store/confirmation_height_store_partial.hpp)
 
 target_link_libraries(
   secure

--- a/nano/secure/blockstore.cpp
+++ b/nano/secure/blockstore.cpp
@@ -105,8 +105,9 @@ bool nano::write_transaction::contains (nano::tables table_a) const
 	return impl->contains (table_a);
 }
 
-nano::block_store::block_store (nano::frontier_store & frontier_store_a, nano::pending_store & pending_store_a) :
+nano::block_store::block_store (nano::frontier_store & frontier_store_a, nano::pending_store & pending_store_a, nano::confirmation_height_store & confirmation_height_store_a) :
 	frontier (frontier_store_a),
-	pending (pending_store_a)
+	pending (pending_store_a),
+	confirmation_height (confirmation_height_store_a)
 {
 }

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -653,12 +653,31 @@ public:
 };
 
 /**
+ * Manages confirmation height storage and iteration
+ */
+class confirmation_height_store
+{
+public:
+	virtual void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) = 0;
+	virtual bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) = 0;
+	virtual bool exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	virtual void del (nano::write_transaction const & transaction_a, nano::account const & account_a) = 0;
+	virtual uint64_t count (nano::transaction const & transaction_a) = 0;
+	virtual void clear (nano::write_transaction const &, nano::account const &) = 0;
+	virtual void clear (nano::write_transaction const &) = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> end () const = 0;
+	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) const = 0;
+};
+
+/**
  * Manages block storage and iteration
  */
 class block_store
 {
 public:
-	explicit block_store (nano::frontier_store &, nano::pending_store &);
+	explicit block_store (nano::frontier_store &, nano::pending_store &, nano::confirmation_height_store &);
 	virtual ~block_store () = default;
 	virtual void initialize (nano::write_transaction const &, nano::genesis const &, nano::ledger_cache &) = 0;
 	virtual void block_put (nano::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;
@@ -736,19 +755,9 @@ public:
 	virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_begin (nano::transaction const & transaction_a) const = 0;
 	virtual nano::store_iterator<nano::endpoint_key, nano::no_value> peers_end () const = 0;
 
-	virtual void confirmation_height_put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) = 0;
-	virtual bool confirmation_height_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) = 0;
-	virtual bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
-	virtual void confirmation_height_del (nano::write_transaction const & transaction_a, nano::account const & account_a) = 0;
-	virtual uint64_t confirmation_height_count (nano::transaction const & transaction_a) = 0;
-	virtual void confirmation_height_clear (nano::write_transaction const &, nano::account const &) = 0;
-	virtual void confirmation_height_clear (nano::write_transaction const &) = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const = 0;
-	virtual nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const = 0;
+	confirmation_height_store & confirmation_height;
 
 	virtual void accounts_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) const = 0;
-	virtual void confirmation_height_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) const = 0;
 	virtual void unchecked_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const = 0;
 	virtual void pruned_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const = 0;
 	virtual void blocks_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -6,6 +6,7 @@
 #include <nano/lib/timer.hpp>
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/buffer.hpp>
+#include <nano/secure/store/confirmation_height_store_partial.hpp>
 #include <nano/secure/store/frontier_store_partial.hpp>
 #include <nano/secure/store/pending_store_partial.hpp>
 
@@ -40,6 +41,7 @@ class block_store_partial : public block_store
 	nano::frontier_store_partial<Val, Derived_Store> frontier_store_partial;
 
 	nano::pending_store_partial<Val, Derived_Store> pending_store_partial;
+	nano::confirmation_height_store_partial<Val, Derived_Store> confirmation_height_store_partial;
 
 	friend void release_assert_success<Val, Derived_Store> (block_store_partial<Val, Derived_Store> const & block_store, const int status);
 
@@ -51,11 +53,13 @@ public:
 	friend class nano::frontier_store_partial<Val, Derived_Store>;
 
 	friend class nano::pending_store_partial<Val, Derived_Store>;
+	friend class nano::confirmation_height_store_partial<Val, Derived_Store>;
 
 	block_store_partial () :
-		block_store{ frontier_store_partial, pending_store_partial },
+		block_store{ frontier_store_partial, pending_store_partial, confirmation_height_store_partial },
 		frontier_store_partial{ *this },
-		pending_store_partial{ *this }
+		pending_store_partial{ *this },
+		confirmation_height_store_partial{ *this }
 	{
 	}
 
@@ -70,7 +74,7 @@ public:
 		genesis_a.open->sideband_set (nano::block_sideband (network_params.ledger.genesis_account, 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 		block_put (transaction_a, hash_l, *genesis_a.open);
 		++ledger_cache_a.block_count;
-		confirmation_height_put (transaction_a, network_params.ledger.genesis_account, nano::confirmation_height_info{ 1, genesis_a.hash () });
+		confirmation_height.put (transaction_a, network_params.ledger.genesis_account, nano::confirmation_height_info{ 1, genesis_a.hash () });
 		++ledger_cache_a.cemented_count;
 		ledger_cache_a.final_votes_confirmation_canary = (network_params.ledger.final_votes_canary_account == network_params.ledger.genesis_account && 1 >= network_params.ledger.final_votes_canary_height);
 		account_put (transaction_a, network_params.ledger.genesis_account, { hash_l, network_params.ledger.genesis_account, genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
@@ -249,11 +253,6 @@ public:
 	nano::store_iterator<nano::block_hash, nano::block_w_sideband> blocks_end () const override
 	{
 		return nano::store_iterator<nano::block_hash, nano::block_w_sideband> (nullptr);
-	}
-
-	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_end () const override
-	{
-		return nano::store_iterator<nano::account, nano::confirmation_height_info> (nullptr);
 	}
 
 	nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_end () const override
@@ -496,49 +495,6 @@ public:
 		return existing != end ? existing->first : 0;
 	}
 
-	uint64_t confirmation_height_count (nano::transaction const & transaction_a) override
-	{
-		return count (transaction_a, tables::confirmation_height);
-	}
-
-	void confirmation_height_put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override
-	{
-		nano::db_val<Val> confirmation_height_info (confirmation_height_info_a);
-		auto status = put (transaction_a, tables::confirmation_height, account_a, confirmation_height_info);
-		release_assert_success (*this, status);
-	}
-
-	bool confirmation_height_get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override
-	{
-		nano::db_val<Val> value;
-		auto status = get (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a), value);
-		release_assert (success (status) || not_found (status));
-		bool result (true);
-		if (success (status))
-		{
-			nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
-			result = confirmation_height_info_a.deserialize (stream);
-		}
-		if (result)
-		{
-			confirmation_height_info_a.height = 0;
-			confirmation_height_info_a.frontier = 0;
-		}
-
-		return result;
-	}
-
-	void confirmation_height_del (nano::write_transaction const & transaction_a, nano::account const & account_a) override
-	{
-		auto status (del (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a)));
-		release_assert_success (*this, status);
-	}
-
-	bool confirmation_height_exists (nano::transaction const & transaction_a, nano::account const & account_a) const override
-	{
-		return exists (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a));
-	}
-
 	bool final_vote_put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override
 	{
 		nano::db_val<Val> value;
@@ -598,16 +554,6 @@ public:
 		drop (transaction_a, nano::tables::final_votes);
 	}
 
-	void confirmation_height_clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override
-	{
-		confirmation_height_del (transaction_a, account_a);
-	}
-
-	void confirmation_height_clear (nano::write_transaction const & transaction_a) override
-	{
-		drop (transaction_a, nano::tables::confirmation_height);
-	}
-
 	nano::store_iterator<nano::account, nano::account_info> accounts_begin (nano::transaction const & transaction_a, nano::account const & account_a) const override
 	{
 		return make_iterator<nano::account, nano::account_info> (transaction_a, tables::accounts, nano::db_val<Val> (account_a));
@@ -646,16 +592,6 @@ public:
 	nano::store_iterator<nano::endpoint_key, nano::no_value> peers_begin (nano::transaction const & transaction_a) const override
 	{
 		return make_iterator<nano::endpoint_key, nano::no_value> (transaction_a, tables::peers);
-	}
-
-	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a, nano::account const & account_a) const override
-	{
-		return make_iterator<nano::account, nano::confirmation_height_info> (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a));
-	}
-
-	nano::store_iterator<nano::account, nano::confirmation_height_info> confirmation_height_begin (nano::transaction const & transaction_a) const override
-	{
-		return make_iterator<nano::account, nano::confirmation_height_info> (transaction_a, tables::confirmation_height);
 	}
 
 	nano::store_iterator<nano::block_hash, std::nullptr_t> pruned_begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override
@@ -699,15 +635,6 @@ public:
 		[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
 			auto transaction (this->tx_begin_read ());
 			action_a (transaction, this->accounts_begin (transaction, start), !is_last ? this->accounts_begin (transaction, end) : this->accounts_end ());
-		});
-	}
-
-	void confirmation_height_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override
-	{
-		parallel_traversal<nano::uint256_t> (
-		[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
-			auto transaction (this->tx_begin_read ());
-			action_a (transaction, this->confirmation_height_begin (transaction, start), !is_last ? this->confirmation_height_begin (transaction, end) : this->confirmation_height_end ());
 		});
 	}
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -771,7 +771,7 @@ void nano::ledger::initialize (nano::generate_cache const & generate_cache_a)
 
 	if (generate_cache_a.cemented_count)
 	{
-		store.confirmation_height_for_each_par (
+		store.confirmation_height.for_each_par (
 		[this] (nano::read_transaction const & /*unused*/, nano::store_iterator<nano::account, nano::confirmation_height_info> i, nano::store_iterator<nano::account, nano::confirmation_height_info> n) {
 			uint64_t cemented_count_l (0);
 			for (; i != n; ++i)
@@ -787,7 +787,7 @@ void nano::ledger::initialize (nano::generate_cache const & generate_cache_a)
 
 	// Final votes requirement for confirmation canary block
 	nano::confirmation_height_info confirmation_height_info;
-	if (!store.confirmation_height_get (transaction, network_params.ledger.final_votes_canary_account, confirmation_height_info))
+	if (!store.confirmation_height.get (transaction, network_params.ledger.final_votes_canary_account, confirmation_height_info))
 	{
 		cache.final_votes_confirmation_canary = (confirmation_height_info.height >= network_params.ledger.final_votes_canary_height);
 	}
@@ -821,7 +821,7 @@ nano::uint128_t nano::ledger::account_balance (nano::transaction const & transac
 	if (only_confirmed_a)
 	{
 		nano::confirmation_height_info info;
-		if (!store.confirmation_height_get (transaction_a, account_a, info))
+		if (!store.confirmation_height.get (transaction_a, account_a, info))
 		{
 			result = balance (transaction_a, info.frontier);
 		}
@@ -1044,7 +1044,7 @@ bool nano::ledger::rollback (nano::write_transaction const & transaction_a, nano
 	while (!error && store.block_exists (transaction_a, block_a))
 	{
 		nano::confirmation_height_info confirmation_height_info;
-		store.confirmation_height_get (transaction_a, account_l, confirmation_height_info);
+		store.confirmation_height.get (transaction_a, account_l, confirmation_height_info);
 		if (block_account_height > confirmation_height_info.height)
 		{
 			auto latest_error = store.account_get (transaction_a, account_l, account_info);
@@ -1262,7 +1262,7 @@ void nano::ledger::update_account (nano::write_transaction const & transaction_a
 	}
 	else
 	{
-		debug_assert (!store.confirmation_height_exists (transaction_a, account_a));
+		debug_assert (!store.confirmation_height.exists (transaction_a, account_a));
 		store.account_del (transaction_a, account_a);
 		debug_assert (cache.account_count > 0);
 		--cache.account_count;
@@ -1331,7 +1331,7 @@ bool nano::ledger::block_confirmed (nano::transaction const & transaction_a, nan
 	if (block)
 	{
 		nano::confirmation_height_info confirmation_height_info;
-		store.confirmation_height_get (transaction_a, block->account ().is_zero () ? block->sideband ().account : block->account (), confirmation_height_info);
+		store.confirmation_height.get (transaction_a, block->account ().is_zero () ? block->sideband ().account : block->account (), confirmation_height_info);
 		auto confirmed (confirmation_height_info.height >= block->sideband ().height);
 		return confirmed;
 	}
@@ -1384,7 +1384,7 @@ std::multimap<uint64_t, nano::uncemented_info, std::greater<>> nano::ledger::unc
 			auto const & account_info (i->second);
 
 			nano::confirmation_height_info conf_height_info;
-			this->store.confirmation_height_get (transaction_a, account, conf_height_info);
+			this->store.confirmation_height.get (transaction_a, account, conf_height_info);
 
 			if (account_info.block_count != conf_height_info.height)
 			{
@@ -1454,12 +1454,12 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 			}
 		});
 
-		store.confirmation_height_for_each_par (
+		store.confirmation_height.for_each_par (
 		[&rocksdb_store] (nano::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
-				rocksdb_store->confirmation_height_put (rocksdb_transaction, i->first, i->second);
+				rocksdb_store->confirmation_height.put (rocksdb_transaction, i->first, i->second);
 			}
 		});
 
@@ -1532,9 +1532,9 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 
 		// If confirmation height exists in the lmdb ledger for this account it should exist in the rocksdb ledger
 		nano::confirmation_height_info confirmation_height_info;
-		if (!store.confirmation_height_get (lmdb_transaction, account, confirmation_height_info))
+		if (!store.confirmation_height.get (lmdb_transaction, account, confirmation_height_info))
 		{
-			error |= rocksdb_store->confirmation_height_get (rocksdb_transaction, account, confirmation_height_info);
+			error |= rocksdb_store->confirmation_height.get (rocksdb_transaction, account, confirmation_height_info);
 		}
 	}
 	else

--- a/nano/secure/store/confirmation_height_store_partial.hpp
+++ b/nano/secure/store/confirmation_height_store_partial.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <nano/secure/blockstore_partial.hpp>
+
+namespace
+{
+template <typename T>
+void parallel_traversal (std::function<void (T const &, T const &, bool const)> const & action);
+}
+
+namespace nano
+{
+template <typename Val, typename Derived_Store>
+class block_store_partial;
+
+template <typename Val, typename Derived_Store>
+void release_assert_success (block_store_partial<Val, Derived_Store> const & block_store, const int status);
+
+template <typename Val, typename Derived_Store>
+class confirmation_height_store_partial : public confirmation_height_store
+{
+private:
+	nano::block_store_partial<Val, Derived_Store> & block_store;
+
+	friend void release_assert_success<Val, Derived_Store> (block_store_partial<Val, Derived_Store> const & block_store, const int status);
+
+public:
+	explicit confirmation_height_store_partial (nano::block_store_partial<Val, Derived_Store> & block_store_a) :
+		block_store (block_store_a){};
+
+	void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override
+	{
+		nano::db_val<Val> confirmation_height_info (confirmation_height_info_a);
+		auto status = block_store.put (transaction_a, tables::confirmation_height, account_a, confirmation_height_info);
+		release_assert_success (block_store, status);
+	}
+
+	bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override
+	{
+		nano::db_val<Val> value;
+		auto status = block_store.get (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a), value);
+		release_assert (block_store.success (status) || block_store.not_found (status));
+		bool result (true);
+		if (block_store.success (status))
+		{
+			nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
+			result = confirmation_height_info_a.deserialize (stream);
+		}
+		if (result)
+		{
+			confirmation_height_info_a.height = 0;
+			confirmation_height_info_a.frontier = 0;
+		}
+
+		return result;
+	}
+
+	bool exists (nano::transaction const & transaction_a, nano::account const & account_a) const override
+	{
+		return block_store.exists (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a));
+	}
+
+	void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override
+	{
+		auto status (block_store.del (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a)));
+		release_assert_success (block_store, status);
+	}
+
+	uint64_t count (nano::transaction const & transaction_a) override
+	{
+		return block_store.count (transaction_a, tables::confirmation_height);
+	}
+
+	void clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override
+	{
+		del (transaction_a, account_a);
+	}
+
+	void clear (nano::write_transaction const & transaction_a) override
+	{
+		block_store.drop (transaction_a, nano::tables::confirmation_height);
+	}
+
+	nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override
+	{
+		return block_store.template make_iterator<nano::account, nano::confirmation_height_info> (transaction_a, tables::confirmation_height, nano::db_val<Val> (account_a));
+	}
+
+	nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const override
+	{
+		return block_store.template make_iterator<nano::account, nano::confirmation_height_info> (transaction_a, tables::confirmation_height);
+	}
+
+	nano::store_iterator<nano::account, nano::confirmation_height_info> end () const override
+	{
+		return nano::store_iterator<nano::account, nano::confirmation_height_info> (nullptr);
+	}
+
+	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override
+	{
+		parallel_traversal<nano::uint256_t> (
+		[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
+			auto transaction (this->block_store.tx_begin_read ());
+			action_a (transaction, this->begin (transaction, start), !is_last ? this->begin (transaction, end) : this->end ());
+		});
+	}
+};
+
+}

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -168,7 +168,7 @@ TEST (store, load)
 				{
 					nano::account account;
 					nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
-					system.nodes[0]->store.confirmation_height_put (transaction, account, { 0, nano::block_hash (0) });
+					system.nodes[0]->store.confirmation_height.put (transaction, account, { 0, nano::block_hash (0) });
 					system.nodes[0]->store.account_put (transaction, account, nano::account_info ());
 				}
 			}
@@ -550,13 +550,13 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 		auto & account_info = i->second;
 		auto count = (account != last_keypair.pub) ? 2 : 1;
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.confirmation_height_get (transaction, account, confirmation_height_info));
+		ASSERT_FALSE (node->store.confirmation_height.get (transaction, account, confirmation_height_info));
 		ASSERT_EQ (count, confirmation_height_info.height);
 		ASSERT_EQ (count, account_info.block_count);
 	}
 
 	size_t cemented_count = 0;
-	for (auto i (node->ledger.store.confirmation_height_begin (transaction)), n (node->ledger.store.confirmation_height_end ()); i != n; ++i)
+	for (auto i (node->ledger.store.confirmation_height.begin (transaction)), n (node->ledger.store.confirmation_height.end ()); i != n; ++i)
 	{
 		cemented_count += i->second.height;
 	}
@@ -619,7 +619,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 
 	auto transaction = node->store.tx_begin_read ();
 	size_t cemented_count = 0;
-	for (auto i (node->ledger.store.confirmation_height_begin (transaction)), n (node->ledger.store.confirmation_height_end ()); i != n; ++i)
+	for (auto i (node->ledger.store.confirmation_height.begin (transaction)), n (node->ledger.store.confirmation_height.end ()); i != n; ++i)
 	{
 		cemented_count += i->second.height;
 	}
@@ -701,17 +701,17 @@ TEST (confirmation_height, long_chains)
 	nano::account_info account_info;
 	ASSERT_FALSE (node->store.account_get (transaction, nano::dev_genesis_key.pub, account_info));
 	nano::confirmation_height_info confirmation_height_info;
-	ASSERT_FALSE (node->store.confirmation_height_get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
+	ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev_genesis_key.pub, confirmation_height_info));
 	ASSERT_EQ (num_blocks + 2, confirmation_height_info.height);
 	ASSERT_EQ (num_blocks + 3, account_info.block_count); // Includes the unpocketed send
 
 	ASSERT_FALSE (node->store.account_get (transaction, key1.pub, account_info));
-	ASSERT_FALSE (node->store.confirmation_height_get (transaction, key1.pub, confirmation_height_info));
+	ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 	ASSERT_EQ (num_blocks + 1, confirmation_height_info.height);
 	ASSERT_EQ (num_blocks + 1, account_info.block_count);
 
 	size_t cemented_count = 0;
-	for (auto i (node->ledger.store.confirmation_height_begin (transaction)), n (node->ledger.store.confirmation_height_end ()); i != n; ++i)
+	for (auto i (node->ledger.store.confirmation_height.begin (transaction)), n (node->ledger.store.confirmation_height.end ()); i != n; ++i)
 	{
 		cemented_count += i->second.height;
 	}
@@ -931,7 +931,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 
 	auto transaction = node->store.tx_begin_read ();
 	size_t cemented_count = 0;
-	for (auto i (node->ledger.store.confirmation_height_begin (transaction)), n (node->ledger.store.confirmation_height_end ()); i != n; ++i)
+	for (auto i (node->ledger.store.confirmation_height.begin (transaction)), n (node->ledger.store.confirmation_height.end ()); i != n; ++i)
 	{
 		cemented_count += i->second.height;
 	}
@@ -1061,7 +1061,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 
 	auto transaction = store->tx_begin_read ();
 	size_t cemented_count = 0;
-	for (auto i (store->confirmation_height_begin (transaction)), n (store->confirmation_height_end ()); i != n; ++i)
+	for (auto i (store->confirmation_height.begin (transaction)), n (store->confirmation_height.end ()); i != n; ++i)
 	{
 		cemented_count += i->second.height;
 	}
@@ -1085,7 +1085,7 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	// Clear confirmation height so that the genesis account has the same amount of uncemented blocks as the other frontiers
 	{
 		auto transaction = node->store.tx_begin_write ();
-		node->store.confirmation_height_clear (transaction);
+		node->store.confirmation_height.clear (transaction);
 	}
 
 	{


### PR DESCRIPTION
Moves out the confirmation height functions to a new store class. It is part of issue #3255