### PR TITLE
Unchecked store break up

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -356,14 +356,14 @@ TEST (bootstrap, simple)
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
-	auto block2 (store->unchecked_get (transaction, block1->previous ()));
+	auto block2 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_TRUE (block2.empty ());
-	store->unchecked_put (transaction, block1->previous (), block1);
-	auto block3 (store->unchecked_get (transaction, block1->previous ()));
+	store->unchecked.put (transaction, block1->previous (), block1);
+	auto block3 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_FALSE (block3.empty ());
 	ASSERT_EQ (*block1, *(block3[0].block));
-	store->unchecked_del (transaction, nano::unchecked_key (block1->previous (), block1->hash ()));
-	auto block4 (store->unchecked_get (transaction, block1->previous ()));
+	store->unchecked.del (transaction, nano::unchecked_key (block1->previous (), block1->hash ()));
+	auto block4 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_TRUE (block4.empty ());
 }
 
@@ -379,13 +379,13 @@ TEST (unchecked, multiple)
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
-	auto block2 (store->unchecked_get (transaction, block1->previous ()));
+	auto block2 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_TRUE (block2.empty ());
-	store->unchecked_put (transaction, block1->previous (), block1);
-	store->unchecked_put (transaction, block1->source (), block1);
-	auto block3 (store->unchecked_get (transaction, block1->previous ()));
+	store->unchecked.put (transaction, block1->previous (), block1);
+	store->unchecked.put (transaction, block1->source (), block1);
+	auto block3 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_FALSE (block3.empty ());
-	auto block4 (store->unchecked_get (transaction, block1->source ()));
+	auto block4 (store->unchecked.get (transaction, block1->source ()));
 	ASSERT_FALSE (block4.empty ());
 }
 
@@ -396,11 +396,11 @@ TEST (unchecked, double_put)
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
-	auto block2 (store->unchecked_get (transaction, block1->previous ()));
+	auto block2 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_TRUE (block2.empty ());
-	store->unchecked_put (transaction, block1->previous (), block1);
-	store->unchecked_put (transaction, block1->previous (), block1);
-	auto block3 (store->unchecked_get (transaction, block1->previous ()));
+	store->unchecked.put (transaction, block1->previous (), block1);
+	store->unchecked.put (transaction, block1->previous (), block1);
+	auto block3 (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_EQ (block3.size (), 1);
 }
 
@@ -414,20 +414,20 @@ TEST (unchecked, multiple_get)
 	auto block3 (std::make_shared<nano::send_block> (5, 1, 2, nano::keypair ().prv, 4, 5));
 	{
 		auto transaction (store->tx_begin_write ());
-		store->unchecked_put (transaction, block1->previous (), block1); // unchecked1
-		store->unchecked_put (transaction, block1->hash (), block1); // unchecked2
-		store->unchecked_put (transaction, block2->previous (), block2); // unchecked3
-		store->unchecked_put (transaction, block1->previous (), block2); // unchecked1
-		store->unchecked_put (transaction, block1->hash (), block2); // unchecked2
-		store->unchecked_put (transaction, block3->previous (), block3);
-		store->unchecked_put (transaction, block3->hash (), block3); // unchecked4
-		store->unchecked_put (transaction, block1->previous (), block3); // unchecked1
+		store->unchecked.put (transaction, block1->previous (), block1); // unchecked1
+		store->unchecked.put (transaction, block1->hash (), block1); // unchecked2
+		store->unchecked.put (transaction, block2->previous (), block2); // unchecked3
+		store->unchecked.put (transaction, block1->previous (), block2); // unchecked1
+		store->unchecked.put (transaction, block1->hash (), block2); // unchecked2
+		store->unchecked.put (transaction, block3->previous (), block3);
+		store->unchecked.put (transaction, block3->hash (), block3); // unchecked4
+		store->unchecked.put (transaction, block1->previous (), block3); // unchecked1
 	}
 	auto transaction (store->tx_begin_read ());
-	auto unchecked_count (store->unchecked_count (transaction));
+	auto unchecked_count (store->unchecked.count (transaction));
 	ASSERT_EQ (unchecked_count, 8);
 	std::vector<nano::block_hash> unchecked1;
-	auto unchecked1_blocks (store->unchecked_get (transaction, block1->previous ()));
+	auto unchecked1_blocks (store->unchecked.get (transaction, block1->previous ()));
 	ASSERT_EQ (unchecked1_blocks.size (), 3);
 	for (auto & i : unchecked1_blocks)
 	{
@@ -437,7 +437,7 @@ TEST (unchecked, multiple_get)
 	ASSERT_TRUE (std::find (unchecked1.begin (), unchecked1.end (), block2->hash ()) != unchecked1.end ());
 	ASSERT_TRUE (std::find (unchecked1.begin (), unchecked1.end (), block3->hash ()) != unchecked1.end ());
 	std::vector<nano::block_hash> unchecked2;
-	auto unchecked2_blocks (store->unchecked_get (transaction, block1->hash ()));
+	auto unchecked2_blocks (store->unchecked.get (transaction, block1->hash ()));
 	ASSERT_EQ (unchecked2_blocks.size (), 2);
 	for (auto & i : unchecked2_blocks)
 	{
@@ -445,13 +445,13 @@ TEST (unchecked, multiple_get)
 	}
 	ASSERT_TRUE (std::find (unchecked2.begin (), unchecked2.end (), block1->hash ()) != unchecked2.end ());
 	ASSERT_TRUE (std::find (unchecked2.begin (), unchecked2.end (), block2->hash ()) != unchecked2.end ());
-	auto unchecked3 (store->unchecked_get (transaction, block2->previous ()));
+	auto unchecked3 (store->unchecked.get (transaction, block2->previous ()));
 	ASSERT_EQ (unchecked3.size (), 1);
 	ASSERT_EQ (unchecked3[0].block->hash (), block2->hash ());
-	auto unchecked4 (store->unchecked_get (transaction, block3->hash ()));
+	auto unchecked4 (store->unchecked.get (transaction, block3->hash ()));
 	ASSERT_EQ (unchecked4.size (), 1);
 	ASSERT_EQ (unchecked4[0].block->hash (), block3->hash ());
-	auto unchecked5 (store->unchecked_get (transaction, block2->hash ()));
+	auto unchecked5 (store->unchecked.get (transaction, block2->hash ()));
 	ASSERT_EQ (unchecked5.size (), 0);
 }
 
@@ -484,8 +484,8 @@ TEST (block_store, empty_bootstrap)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_read ());
-	auto begin (store->unchecked_begin (transaction));
-	auto end (store->unchecked_end ());
+	auto begin (store->unchecked.begin (transaction));
+	auto end (store->unchecked.end ());
 	ASSERT_EQ (end, begin);
 }
 
@@ -496,13 +496,13 @@ TEST (block_store, one_bootstrap)
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
-	store->unchecked_put (transaction, block1->hash (), block1);
-	auto begin (store->unchecked_begin (transaction));
-	auto end (store->unchecked_end ());
+	store->unchecked.put (transaction, block1->hash (), block1);
+	auto begin (store->unchecked.begin (transaction));
+	auto end (store->unchecked.end ());
 	ASSERT_NE (end, begin);
 	auto hash1 (begin->first.key ());
 	ASSERT_EQ (block1->hash (), hash1);
-	auto blocks (store->unchecked_get (transaction, hash1));
+	auto blocks (store->unchecked.get (transaction, hash1));
 	ASSERT_EQ (1, blocks.size ());
 	auto block2 (blocks[0].block);
 	ASSERT_EQ (*block1, *block2);
@@ -935,33 +935,33 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	auto send2 (std::make_shared<nano::send_block> (1, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	ASSERT_NE (send1->hash (), send2->hash ());
-	store.unchecked_put (transaction, send1->hash (), send1);
-	store.unchecked_put (transaction, send1->hash (), send2);
+	store.unchecked.put (transaction, send1->hash (), send1);
+	store.unchecked.put (transaction, send1->hash (), send2);
 	{
-		auto iterator1 (store.unchecked_begin (transaction));
+		auto iterator1 (store.unchecked.begin (transaction));
 		++iterator1;
-		ASSERT_EQ (store.unchecked_end (), iterator1);
+		ASSERT_EQ (store.unchecked.end (), iterator1);
 	}
 	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 0));
 	mdb_dbi_close (store.env, store.unchecked_handle);
 	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_handle));
-	store.unchecked_put (transaction, send1->hash (), send1);
-	store.unchecked_put (transaction, send1->hash (), send2);
+	store.unchecked.put (transaction, send1->hash (), send1);
+	store.unchecked.put (transaction, send1->hash (), send2);
 	{
-		auto iterator1 (store.unchecked_begin (transaction));
+		auto iterator1 (store.unchecked.begin (transaction));
 		++iterator1;
-		ASSERT_EQ (store.unchecked_end (), iterator1);
+		ASSERT_EQ (store.unchecked.end (), iterator1);
 	}
 	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 1));
 	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_handle));
-	store.unchecked_put (transaction, send1->hash (), send1);
-	store.unchecked_put (transaction, send1->hash (), send2);
+	store.unchecked.put (transaction, send1->hash (), send1);
+	store.unchecked.put (transaction, send1->hash (), send2);
 	{
-		auto iterator1 (store.unchecked_begin (transaction));
+		auto iterator1 (store.unchecked.begin (transaction));
 		++iterator1;
-		ASSERT_NE (store.unchecked_end (), iterator1);
+		ASSERT_NE (store.unchecked.end (), iterator1);
 		++iterator1;
-		ASSERT_EQ (store.unchecked_end (), iterator1);
+		ASSERT_EQ (store.unchecked.end (), iterator1);
 	}
 }
 
@@ -2048,9 +2048,9 @@ TEST (rocksdb_block_store, tombstone_count)
 		ASSERT_TRUE (!store->init_error ());
 		auto transaction = store->tx_begin_write ();
 		auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
-		store->unchecked_put (transaction, block1->previous (), block1);
+		store->unchecked.put (transaction, block1->previous (), block1);
 		ASSERT_EQ (store->tombstone_map.at (nano::tables::unchecked).num_since_last_flush.load (), 0);
-		store->unchecked_del (transaction, nano::unchecked_key (block1->previous (), block1->hash ()));
+		store->unchecked.del (transaction, nano::unchecked_key (block1->previous (), block1->hash ()));
 		ASSERT_EQ (store->tombstone_map.at (nano::tables::unchecked).num_since_last_flush.load (), 1);
 	}
 }

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -930,8 +930,8 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 	nano::logger_mt logger;
 	nano::mdb_store store (logger, path);
 	auto transaction (store.tx_begin_write ());
-	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked, 1));
-	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked));
+	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 1));
+	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked_handle));
 	auto send1 (std::make_shared<nano::send_block> (0, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	auto send2 (std::make_shared<nano::send_block> (1, 0, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, 0));
 	ASSERT_NE (send1->hash (), send2->hash ());
@@ -942,9 +942,9 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 		++iterator1;
 		ASSERT_EQ (store.unchecked_end (), iterator1);
 	}
-	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked, 0));
-	mdb_dbi_close (store.env, store.unchecked);
-	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked));
+	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 0));
+	mdb_dbi_close (store.env, store.unchecked_handle);
+	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_handle));
 	store.unchecked_put (transaction, send1->hash (), send1);
 	store.unchecked_put (transaction, send1->hash (), send2);
 	{
@@ -952,8 +952,8 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 		++iterator1;
 		ASSERT_EQ (store.unchecked_end (), iterator1);
 	}
-	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked, 1));
-	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked));
+	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 1));
+	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_handle));
 	store.unchecked_put (transaction, send1->hash (), send1);
 	store.unchecked_put (transaction, send1->hash (), send2);
 	{

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -690,10 +690,10 @@ TEST (mdb_block_store, supported_version_upgrades)
 		// Lower the database version to the minimum version supported for upgrade.
 		store.version_put (transaction, store.minimum_version);
 		store.confirmation_height.del (transaction, nano::genesis_account);
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "accounts_v1", MDB_CREATE, &store.accounts_v1));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "accounts_v1", MDB_CREATE, &store.accounts_v1_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks_handle));
 		modify_account_info_to_v14 (store, transaction, nano::genesis_account, 1, nano::genesis_hash);
-		write_block_w_sideband_v18 (store, store.open_blocks, transaction, *nano::genesis ().open);
+		write_block_w_sideband_v18 (store, store.open_blocks_handle, transaction, *nano::genesis ().open);
 	}
 
 	// Upgrade should work
@@ -1291,12 +1291,12 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		ASSERT_EQ (confirmation_height_info.height, 1);
 		ASSERT_EQ (confirmation_height_info.frontier, genesis.hash ());
 		// These databases get removed after an upgrade, so readd them
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_v1", MDB_CREATE, &store.state_blocks_v1));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "accounts_v1", MDB_CREATE, &store.accounts_v1));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "pending_v1", MDB_CREATE, &store.pending_v1));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "send", MDB_CREATE, &store.send_blocks));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.state_blocks));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_v1", MDB_CREATE, &store.state_blocks_v1_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "accounts_v1", MDB_CREATE, &store.accounts_v1_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "pending_v1", MDB_CREATE, &store.pending_v1_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "send", MDB_CREATE, &store.send_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.state_blocks_handle));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send).code);
@@ -1307,22 +1307,22 @@ TEST (mdb_block_store, upgrade_v14_v15)
 
 		store.pending.del (transaction, nano::pending_key (nano::genesis_account, state_send.hash ()));
 
-		write_sideband_v14 (store, transaction, state_send, store.state_blocks_v1);
-		write_sideband_v14 (store, transaction, epoch, store.state_blocks_v1);
-		write_block_w_sideband_v18 (store, store.open_blocks, transaction, *genesis.open);
-		write_block_w_sideband_v18 (store, store.send_blocks, transaction, send);
+		write_sideband_v14 (store, transaction, state_send, store.state_blocks_v1_handle);
+		write_sideband_v14 (store, transaction, epoch, store.state_blocks_v1_handle);
+		write_block_w_sideband_v18 (store, store.open_blocks_handle, transaction, *genesis.open);
+		write_block_w_sideband_v18 (store, store.send_blocks_handle, transaction, send);
 
 		// Remove from blocks table
 		store.block_del (transaction, state_send.hash ());
 		store.block_del (transaction, epoch.hash ());
 
 		// Turn pending into v14
-		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v0, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_0)), 0));
-		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v1, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_1)), 0));
+		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v0_handle, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_0)), 0));
+		ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v1_handle, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ())), nano::mdb_val (nano::pending_info_v14 (nano::genesis_account, nano::Gxrb_ratio, nano::epoch::epoch_1)), 0));
 
 		// This should fail as sizes are no longer correct for account_info
 		nano::mdb_val value;
-		ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.accounts_v1, nano::mdb_val (nano::genesis_account), value));
+		ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.accounts_v1_handle, nano::mdb_val (nano::genesis_account), value));
 		nano::account_info info;
 		ASSERT_NE (value.size (), info.db_size ());
 		store.account.del (transaction, nano::genesis_account);
@@ -1339,7 +1339,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 
 	// Size of account_info should now equal that set in db
 	nano::mdb_val value;
-	ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.accounts, nano::mdb_val (nano::genesis_account), value));
+	ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.accounts_handle, nano::mdb_val (nano::genesis_account), value));
 	nano::account_info info (value);
 	ASSERT_EQ (value.size (), info.db_size ());
 
@@ -1350,11 +1350,11 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	ASSERT_EQ (confirmation_height_info.frontier, genesis.hash ());
 
 	// accounts_v1, state_blocks_v1 & pending_v1 tables should be deleted
-	auto error_get_accounts_v1 (mdb_get (store.env.tx (transaction), store.accounts_v1, nano::mdb_val (nano::genesis_account), value));
+	auto error_get_accounts_v1 (mdb_get (store.env.tx (transaction), store.accounts_v1_handle, nano::mdb_val (nano::genesis_account), value));
 	ASSERT_NE (error_get_accounts_v1, MDB_SUCCESS);
-	auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_v1, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ())), value));
+	auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_v1_handle, nano::mdb_val (nano::pending_key (nano::dev_genesis_key.pub, state_send.hash ())), value));
 	ASSERT_NE (error_get_pending_v1, MDB_SUCCESS);
-	auto error_get_state_v1 (mdb_get (store.env.tx (transaction), store.state_blocks_v1, nano::mdb_val (state_send.hash ()), value));
+	auto error_get_state_v1 (mdb_get (store.env.tx (transaction), store.state_blocks_v1_handle, nano::mdb_val (state_send.hash ()), value));
 	ASSERT_NE (error_get_state_v1, MDB_SUCCESS);
 
 	// Check that the epochs are set correctly for the sideband, accounts and pending entries
@@ -1394,15 +1394,15 @@ TEST (mdb_block_store, upgrade_v15_v16)
 		store.initialize (transaction, genesis, ledger.cache);
 		// The representation table should get removed after, so readd it so that we can later confirm this actually happens
 		auto txn = store.env.tx (transaction);
-		ASSERT_FALSE (mdb_dbi_open (txn, "representation", MDB_CREATE, &store.representation));
+		ASSERT_FALSE (mdb_dbi_open (txn, "representation", MDB_CREATE, &store.representation_handle));
 		auto weight = ledger.cache.rep_weights.representation_get (nano::genesis_account);
-		ASSERT_EQ (MDB_SUCCESS, mdb_put (txn, store.representation, nano::mdb_val (nano::genesis_account), nano::mdb_val (nano::uint128_union (weight)), 0));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks));
-		write_block_w_sideband_v18 (store, store.open_blocks, transaction, *genesis.open);
+		ASSERT_EQ (MDB_SUCCESS, mdb_put (txn, store.representation_handle, nano::mdb_val (nano::genesis_account), nano::mdb_val (nano::uint128_union (weight)), 0));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks_handle));
+		write_block_w_sideband_v18 (store, store.open_blocks_handle, transaction, *genesis.open);
 		// Lower the database to the previous version
 		store.version_put (transaction, 15);
 		// Confirm the rep weight exists in the database
-		ASSERT_EQ (MDB_SUCCESS, mdb_get (store.env.tx (transaction), store.representation, nano::mdb_val (nano::genesis_account), value));
+		ASSERT_EQ (MDB_SUCCESS, mdb_get (store.env.tx (transaction), store.representation_handle, nano::mdb_val (nano::genesis_account), value));
 		store.confirmation_height.del (transaction, nano::genesis_account);
 	}
 
@@ -1413,9 +1413,9 @@ TEST (mdb_block_store, upgrade_v15_v16)
 	auto transaction (store.tx_begin_read ());
 
 	// The representation table should now be deleted
-	auto error_get_representation (mdb_get (store.env.tx (transaction), store.representation, nano::mdb_val (nano::genesis_account), value));
+	auto error_get_representation (mdb_get (store.env.tx (transaction), store.representation_handle, nano::mdb_val (nano::genesis_account), value));
 	ASSERT_NE (MDB_SUCCESS, error_get_representation);
-	ASSERT_EQ (store.representation, 0);
+	ASSERT_EQ (store.representation_handle, 0);
 
 	// Version should be correct
 	ASSERT_LT (15, store.version_get (transaction));
@@ -1450,12 +1450,12 @@ TEST (mdb_block_store, upgrade_v16_v17)
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
 			modify_confirmation_height_to_v15 (store, transaction, nano::genesis_account, confirmation_height);
 
-			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks));
-			write_block_w_sideband_v18 (store, store.open_blocks, transaction, *genesis.open);
-			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.state_blocks));
-			write_block_w_sideband_v18 (store, store.state_blocks, transaction, block1);
-			write_block_w_sideband_v18 (store, store.state_blocks, transaction, block2);
-			write_block_w_sideband_v18 (store, store.state_blocks, transaction, block3);
+			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks_handle));
+			write_block_w_sideband_v18 (store, store.open_blocks_handle, transaction, *genesis.open);
+			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.state_blocks_handle));
+			write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, block1);
+			write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, block2);
+			write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, block3);
 
 			// Lower the database to the previous version
 			store.version_put (transaction, 16);
@@ -1531,19 +1531,19 @@ TEST (mdb_block_store, upgrade_v17_v18)
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_open).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send_epoch_link).code);
 
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "send", MDB_CREATE, &store.send_blocks));
-		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.state_blocks));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "send", MDB_CREATE, &store.send_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.state_blocks_handle));
 
 		// Downgrade the store
 		store.version_put (transaction, 17);
 
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, state_receive);
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, epoch_first);
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, state_send2);
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, state_send_epoch_link);
-		write_block_w_sideband_v18 (store, store.open_blocks, transaction, *genesis.open);
-		write_block_w_sideband_v18 (store, store.send_blocks, transaction, send_zero);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, state_receive);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, epoch_first);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, state_send2);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, state_send_epoch_link);
+		write_block_w_sideband_v18 (store, store.open_blocks_handle, transaction, *genesis.open);
+		write_block_w_sideband_v18 (store, store.send_blocks_handle, transaction, send_zero);
 
 		// Replace with the previous sideband version for state blocks
 		// The upgrade can resume after upgrading some blocks, test this by only downgrading some of them
@@ -1572,7 +1572,7 @@ TEST (mdb_block_store, upgrade_v17_v18)
 
 	// Size of state block should equal that set in db (no change)
 	nano::mdb_val value;
-	ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.blocks, nano::mdb_val (state_send.hash ()), value));
+	ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.blocks_handle, nano::mdb_val (state_send.hash ()), value));
 	ASSERT_EQ (value.size (), sizeof (nano::block_type) + nano::state_block::size + nano::block_sideband::size (nano::block_type::state));
 
 	// Check that sidebands are correctly populated
@@ -1725,20 +1725,20 @@ TEST (mdb_block_store, upgrade_v18_v19)
 
 		// These tables need to be re-opened and populated so that an upgrade can be done
 		auto txn = store.env.tx (transaction);
-		ASSERT_FALSE (mdb_dbi_open (txn, "open", MDB_CREATE, &store.open_blocks));
-		ASSERT_FALSE (mdb_dbi_open (txn, "receive", MDB_CREATE, &store.receive_blocks));
-		ASSERT_FALSE (mdb_dbi_open (txn, "send", MDB_CREATE, &store.send_blocks));
-		ASSERT_FALSE (mdb_dbi_open (txn, "change", MDB_CREATE, &store.change_blocks));
-		ASSERT_FALSE (mdb_dbi_open (txn, "state_blocks", MDB_CREATE, &store.state_blocks));
+		ASSERT_FALSE (mdb_dbi_open (txn, "open", MDB_CREATE, &store.open_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (txn, "receive", MDB_CREATE, &store.receive_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (txn, "send", MDB_CREATE, &store.send_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (txn, "change", MDB_CREATE, &store.change_blocks_handle));
+		ASSERT_FALSE (mdb_dbi_open (txn, "state_blocks", MDB_CREATE, &store.state_blocks_handle));
 
 		// Modify blocks back to the old tables
-		write_block_w_sideband_v18 (store, store.open_blocks, transaction, *genesis.open);
-		write_block_w_sideband_v18 (store, store.send_blocks, transaction, send);
-		write_block_w_sideband_v18 (store, store.receive_blocks, transaction, receive);
-		write_block_w_sideband_v18 (store, store.change_blocks, transaction, change);
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, state_epoch);
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, state_send);
-		write_block_w_sideband_v18 (store, store.state_blocks, transaction, state_open);
+		write_block_w_sideband_v18 (store, store.open_blocks_handle, transaction, *genesis.open);
+		write_block_w_sideband_v18 (store, store.send_blocks_handle, transaction, send);
+		write_block_w_sideband_v18 (store, store.receive_blocks_handle, transaction, receive);
+		write_block_w_sideband_v18 (store, store.change_blocks_handle, transaction, change);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, state_epoch);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, state_send);
+		write_block_w_sideband_v18 (store, store.state_blocks_handle, transaction, state_open);
 
 		store.version_put (transaction, 18);
 	}
@@ -1750,11 +1750,11 @@ TEST (mdb_block_store, upgrade_v18_v19)
 	auto transaction (store.tx_begin_read ());
 
 	// These tables should be deleted
-	ASSERT_EQ (store.send_blocks, 0);
-	ASSERT_EQ (store.receive_blocks, 0);
-	ASSERT_EQ (store.change_blocks, 0);
-	ASSERT_EQ (store.open_blocks, 0);
-	ASSERT_EQ (store.state_blocks, 0);
+	ASSERT_EQ (store.send_blocks_handle, 0);
+	ASSERT_EQ (store.receive_blocks_handle, 0);
+	ASSERT_EQ (store.change_blocks_handle, 0);
+	ASSERT_EQ (store.open_blocks_handle, 0);
+	ASSERT_EQ (store.state_blocks_handle, 0);
 
 	// Confirm these blocks all exist after the upgrade
 	ASSERT_TRUE (store.block_get (transaction, send.hash ()));
@@ -1776,7 +1776,7 @@ TEST (mdb_block_store, upgrade_v18_v19)
 	ASSERT_EQ (nano::epoch::epoch_1, state_open_disk->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, state_open_disk->sideband ().source_epoch);
 
-	ASSERT_EQ (7, store.count (transaction, store.blocks));
+	ASSERT_EQ (7, store.count (transaction, store.blocks_handle));
 
 	// Version should be correct
 	ASSERT_LT (18, store.version_get (transaction));
@@ -1829,13 +1829,13 @@ TEST (mdb_block_store, upgrade_v20_v21)
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, genesis, ledger.cache);
 		// Delete pruned table
-		ASSERT_FALSE (mdb_drop (store.env.tx (transaction), store.final_vote_handle, 1));
+		ASSERT_FALSE (mdb_drop (store.env.tx (transaction), store.final_votes_handle, 1));
 		store.version_put (transaction, 20);
 	}
 	// Upgrading should create the table
 	nano::mdb_store store (logger, path);
 	ASSERT_FALSE (store.init_error ());
-	ASSERT_NE (store.final_vote_handle, 0);
+	ASSERT_NE (store.final_votes_handle, 0);
 
 	// Version should be correct
 	auto transaction (store.tx_begin_read ());
@@ -2072,7 +2072,7 @@ void write_sideband_v14 (nano::mdb_store & store_a, nano::transaction & transact
 	}
 
 	MDB_val val{ data.size (), data.data () };
-	ASSERT_FALSE (mdb_put (store_a.env.tx (transaction_a), block->sideband ().details.epoch == nano::epoch::epoch_0 ? store_a.state_blocks_v0 : store_a.state_blocks_v1, nano::mdb_val (block_a.hash ()), &val, 0));
+	ASSERT_FALSE (mdb_put (store_a.env.tx (transaction_a), block->sideband ().details.epoch == nano::epoch::epoch_0 ? store_a.state_blocks_v0_handle : store_a.state_blocks_v1_handle, nano::mdb_val (block_a.hash ()), &val, 0));
 }
 
 void write_sideband_v15 (nano::mdb_store & store_a, nano::transaction & transaction_a, nano::block const & block_a)
@@ -2091,7 +2091,7 @@ void write_sideband_v15 (nano::mdb_store & store_a, nano::transaction & transact
 	}
 
 	MDB_val val{ data.size (), data.data () };
-	ASSERT_FALSE (mdb_put (store_a.env.tx (transaction_a), store_a.state_blocks, nano::mdb_val (block_a.hash ()), &val, 0));
+	ASSERT_FALSE (mdb_put (store_a.env.tx (transaction_a), store_a.state_blocks_handle, nano::mdb_val (block_a.hash ()), &val, 0));
 }
 
 void write_block_w_sideband_v18 (nano::mdb_store & store_a, MDB_dbi database, nano::write_transaction & transaction_a, nano::block const & block_a)
@@ -2118,7 +2118,7 @@ void modify_account_info_to_v14 (nano::mdb_store & store, nano::transaction cons
 	nano::account_info info;
 	ASSERT_FALSE (store.account.get (transaction, account, info));
 	nano::account_info_v14 account_info_v14 (info.head, rep_block, info.open_block, info.balance, info.modified, info.block_count, confirmation_height, info.epoch ());
-	auto status (mdb_put (store.env.tx (transaction), info.epoch () == nano::epoch::epoch_0 ? store.accounts_v0 : store.accounts_v1, nano::mdb_val (account), nano::mdb_val (account_info_v14), 0));
+	auto status (mdb_put (store.env.tx (transaction), info.epoch () == nano::epoch::epoch_0 ? store.accounts_v0_handle : store.accounts_v1_handle, nano::mdb_val (account), nano::mdb_val (account_info_v14), 0));
 	ASSERT_EQ (status, 0);
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1128,7 +1128,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	ASSERT_FALSE (node2->ledger.block_or_pruned_exists (state_open->hash ()));
 	{
 		auto transaction (node2->store.tx_begin_read ());
-		ASSERT_TRUE (node2->store.unchecked_exists (transaction, nano::unchecked_key (send2->root ().as_block_hash (), send2->hash ())));
+		ASSERT_TRUE (node2->store.unchecked.exists (transaction, nano::unchecked_key (send2->root ().as_block_hash (), send2->hash ())));
 	}
 	// Insert missing block
 	node2->process_active (send1);
@@ -1845,7 +1845,7 @@ TEST (bulk, genesis_pruning)
 	ASSERT_EQ (1, node2->ledger.cache.block_count);
 	{
 		auto transaction (node2->store.tx_begin_write ());
-		node2->store.unchecked_clear (transaction);
+		node2->store.unchecked.clear (transaction);
 	}
 	// Insert pruned blocks
 	node2->process_active (send1);

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -255,7 +255,7 @@ TEST (confirmation_height, gap_bootstrap)
 		// Confirmation heights should not be updated
 		{
 			auto transaction (node1.store.tx_begin_read ());
-			auto unchecked_count (node1.store.unchecked_count (transaction));
+			auto unchecked_count (node1.store.unchecked.count (transaction));
 			ASSERT_EQ (unchecked_count, 2);
 
 			nano::confirmation_height_info confirmation_height_info;
@@ -271,7 +271,7 @@ TEST (confirmation_height, gap_bootstrap)
 		// Confirmation height should be unchanged and unchecked should now be 0
 		{
 			auto transaction (node1.store.tx_begin_read ());
-			auto unchecked_count (node1.store.unchecked_count (transaction));
+			auto unchecked_count (node1.store.unchecked.count (transaction));
 			ASSERT_EQ (unchecked_count, 0);
 
 			nano::confirmation_height_info confirmation_height_info;
@@ -358,7 +358,7 @@ TEST (confirmation_height, gap_live)
 
 		// This should confirm the open block and the source of the receive blocks
 		auto transaction (node->store.tx_begin_read ());
-		auto unchecked_count (node->store.unchecked_count (transaction));
+		auto unchecked_count (node->store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
 
 		nano::confirmation_height_info confirmation_height_info;

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2664,7 +2664,7 @@ TEST (ledger, epoch_open_pending)
 	node1.block_processor.flush ();
 	ASSERT_FALSE (node1.ledger.block_or_pruned_exists (epoch_open->hash ()));
 	// Open block should be inserted into unchecked
-	auto blocks (node1.store.unchecked_get (node1.store.tx_begin_read (), nano::hash_or_account (epoch_open->account ()).hash));
+	auto blocks (node1.store.unchecked.get (node1.store.tx_begin_read (), nano::hash_or_account (epoch_open->account ()).hash));
 	ASSERT_EQ (blocks.size (), 1);
 	ASSERT_EQ (blocks[0].block->full_hash (), epoch_open->full_hash ());
 	ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid_epoch);
@@ -2852,10 +2852,10 @@ TEST (ledger, unchecked_epoch)
 	node1.block_processor.flush ();
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
-		auto blocks (node1.store.unchecked_get (transaction, epoch1->previous ()));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
+		auto blocks (node1.store.unchecked.get (transaction, epoch1->previous ()));
 		ASSERT_EQ (blocks.size (), 1);
 		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid_epoch);
 	}
@@ -2865,9 +2865,9 @@ TEST (ledger, unchecked_epoch)
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, epoch1->hash ()));
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
 		nano::account_info info;
 		ASSERT_FALSE (node1.store.account_get (transaction, destination.pub, info));
 		ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);
@@ -2897,10 +2897,10 @@ TEST (ledger, unchecked_epoch_invalid)
 	node1.block_processor.flush ();
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 2);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
-		auto blocks (node1.store.unchecked_get (transaction, epoch1->previous ()));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
+		auto blocks (node1.store.unchecked.get (transaction, epoch1->previous ()));
 		ASSERT_EQ (blocks.size (), 2);
 		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid);
 		ASSERT_EQ (blocks[1].verified, nano::signature_verification::valid);
@@ -2913,9 +2913,9 @@ TEST (ledger, unchecked_epoch_invalid)
 		ASSERT_FALSE (node1.store.block_exists (transaction, epoch1->hash ()));
 		ASSERT_TRUE (node1.store.block_exists (transaction, epoch2->hash ()));
 		ASSERT_TRUE (node1.active.empty ());
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
 		nano::account_info info;
 		ASSERT_FALSE (node1.store.account_get (transaction, destination.pub, info));
 		ASSERT_NE (info.epoch (), nano::epoch::epoch_1);
@@ -2947,10 +2947,10 @@ TEST (ledger, unchecked_open)
 	node1.block_processor.flush ();
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
-		auto blocks (node1.store.unchecked_get (transaction, open1->source ()));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
+		auto blocks (node1.store.unchecked.get (transaction, open1->source ()));
 		ASSERT_EQ (blocks.size (), 1);
 		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid);
 	}
@@ -2959,9 +2959,9 @@ TEST (ledger, unchecked_open)
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, open1->hash ()));
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
 	}
 }
 
@@ -2985,10 +2985,10 @@ TEST (ledger, unchecked_receive)
 	// Previous block for receive1 is unknown, signature cannot be validated
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
-		auto blocks (node1.store.unchecked_get (transaction, receive1->previous ()));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
+		auto blocks (node1.store.unchecked.get (transaction, receive1->previous ()));
 		ASSERT_EQ (blocks.size (), 1);
 		ASSERT_EQ (blocks[0].verified, nano::signature_verification::unknown);
 	}
@@ -2997,10 +2997,10 @@ TEST (ledger, unchecked_receive)
 	// Previous block for receive1 is known, signature was validated
 	{
 		auto transaction (node1.store.tx_begin_read ());
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
-		auto blocks (node1.store.unchecked_get (transaction, receive1->source ()));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
+		auto blocks (node1.store.unchecked.get (transaction, receive1->source ()));
 		ASSERT_EQ (blocks.size (), 1);
 		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid);
 	}
@@ -3009,9 +3009,9 @@ TEST (ledger, unchecked_receive)
 	{
 		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block_exists (transaction, receive1->hash ()));
-		auto unchecked_count (node1.store.unchecked_count (transaction));
+		auto unchecked_count (node1.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
-		ASSERT_EQ (unchecked_count, node1.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node1.store.unchecked.count (transaction));
 	}
 }
 
@@ -3868,7 +3868,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 
 		store.pending_put (transaction, nano::pending_key (nano::genesis_account, send->hash ()), nano::pending_info (nano::genesis_account, 100, nano::epoch::epoch_0));
 		store.pruned_put (transaction, send->hash ());
-		store.unchecked_put (transaction, nano::genesis_hash, send);
+		store.unchecked.put (transaction, nano::genesis_hash, send);
 		store.version_put (transaction, version);
 		send->sideband_set ({});
 		store.block_put (transaction, send->hash (), *send);
@@ -3905,7 +3905,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_TRUE (rocksdb_store.final_vote_get (rocksdb_transaction, nano::root (send->previous ())).size () == 1);
 	ASSERT_EQ (rocksdb_store.final_vote_get (rocksdb_transaction, nano::root (send->previous ()))[0], nano::block_hash (2));
 
-	auto unchecked_infos = rocksdb_store.unchecked_get (rocksdb_transaction, nano::genesis_hash);
+	auto unchecked_infos = rocksdb_store.unchecked.get (rocksdb_transaction, nano::genesis_hash);
 	ASSERT_EQ (unchecked_infos.size (), 1);
 	ASSERT_EQ (unchecked_infos.front ().account, nano::genesis_account);
 	ASSERT_EQ (*unchecked_infos.front ().block, *send);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3331,7 +3331,7 @@ TEST (node, block_processor_signatures)
 	// Invalid signature to unchecked
 	{
 		auto transaction (node1.store.tx_begin_write ());
-		node1.store.unchecked_put (transaction, send5->previous (), send5);
+		node1.store.unchecked.put (transaction, send5->previous (), send5);
 	}
 	auto receive1 = builder.make_block ()
 					.account (key1.pub)
@@ -3690,27 +3690,27 @@ TEST (node, unchecked_cleanup)
 	node.config.unchecked_cutoff_time = std::chrono::seconds (2);
 	{
 		auto transaction (node.store.tx_begin_read ());
-		auto unchecked_count (node.store.unchecked_count (transaction));
+		auto unchecked_count (node.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
-		ASSERT_EQ (unchecked_count, node.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node.store.unchecked.count (transaction));
 	}
 	std::this_thread::sleep_for (std::chrono::seconds (1));
 	node.unchecked_cleanup ();
 	ASSERT_TRUE (node.network.publish_filter.apply (bytes.data (), bytes.size ()));
 	{
 		auto transaction (node.store.tx_begin_read ());
-		auto unchecked_count (node.store.unchecked_count (transaction));
+		auto unchecked_count (node.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 1);
-		ASSERT_EQ (unchecked_count, node.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node.store.unchecked.count (transaction));
 	}
 	std::this_thread::sleep_for (std::chrono::seconds (2));
 	node.unchecked_cleanup ();
 	ASSERT_FALSE (node.network.publish_filter.apply (bytes.data (), bytes.size ()));
 	{
 		auto transaction (node.store.tx_begin_read ());
-		auto unchecked_count (node.store.unchecked_count (transaction));
+		auto unchecked_count (node.store.unchecked.count (transaction));
 		ASSERT_EQ (unchecked_count, 0);
-		ASSERT_EQ (unchecked_count, node.store.unchecked_count (transaction));
+		ASSERT_EQ (unchecked_count, node.store.unchecked.count (transaction));
 	}
 }
 

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -421,7 +421,7 @@ int main (int argc, char * const * argv)
 			}
 
 			// Check all unchecked keys for matching frontier hashes. Indicates an issue with process_batch algorithm
-			for (auto i (node->store.unchecked_begin (transaction)), n (node->store.unchecked_end ()); i != n; ++i)
+			for (auto i (node->store.unchecked.begin (transaction)), n (node->store.unchecked.end ()); i != n; ++i)
 			{
 				auto it = frontier_hashes.find (i->first.key ());
 				if (it != frontier_hashes.cend ())
@@ -991,7 +991,7 @@ int main (int argc, char * const * argv)
 				if (timer_l.after_deadline (std::chrono::seconds (15)))
 				{
 					timer_l.restart ();
-					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked), %3% remaining") % node->ledger.cache.block_count % node->store.unchecked_count (node->store.tx_begin_read ()) % node->block_processor.size ()) << std::endl;
+					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked), %3% remaining") % node->ledger.cache.block_count % node->store.unchecked.count (node->store.tx_begin_read ()) % node->block_processor.size ()) << std::endl;
 				}
 			}
 
@@ -1845,7 +1845,7 @@ int main (int argc, char * const * argv)
 				if (timer_l.after_deadline (std::chrono::seconds (60)))
 				{
 					timer_l.restart ();
-					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.cache.block_count % node.node->store.unchecked_count (node.node->store.tx_begin_read ())) << std::endl;
+					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.cache.block_count % node.node->store.unchecked.count (node.node->store.tx_begin_read ())) << std::endl;
 				}
 			}
 

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -403,7 +403,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (block->previous (), hash);
-			node.store.unchecked_put (transaction_a, unchecked_key, info_a);
+			node.store.unchecked.unchecked_put (transaction_a, unchecked_key, info_a);
 
 			events_a.events.emplace_back ([this, hash] (nano::transaction const & /* unused */) { this->node.gap_cache.add (hash); });
 
@@ -423,7 +423,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (node.ledger.block_source (transaction_a, *(block)), hash);
-			node.store.unchecked_put (transaction_a, unchecked_key, info_a);
+			node.store.unchecked.unchecked_put (transaction_a, unchecked_key, info_a);
 
 			events_a.events.emplace_back ([this, hash] (nano::transaction const & /* unused */) { this->node.gap_cache.add (hash); });
 
@@ -443,7 +443,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (block->account (), hash); // Specific unchecked key starting with epoch open block account public key
-			node.store.unchecked_put (transaction_a, unchecked_key, info_a);
+			node.store.unchecked.unchecked_put (transaction_a, unchecked_key, info_a);
 
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
 			break;
@@ -548,12 +548,12 @@ void nano::block_processor::process_old (nano::transaction const & transaction_a
 
 void nano::block_processor::queue_unchecked (nano::write_transaction const & transaction_a, nano::hash_or_account const & hash_or_account_a)
 {
-	auto unchecked_blocks (node.store.unchecked_get (transaction_a, hash_or_account_a.hash));
+	auto unchecked_blocks (node.store.unchecked.unchecked_get (transaction_a, hash_or_account_a.hash));
 	for (auto & info : unchecked_blocks)
 	{
 		if (!node.flags.disable_block_processor_unchecked_deletion)
 		{
-			node.store.unchecked_del (transaction_a, nano::unchecked_key (hash_or_account_a, info.block->hash ()));
+			node.store.unchecked.unchecked_del (transaction_a, nano::unchecked_key (hash_or_account_a, info.block->hash ()));
 		}
 		add (info);
 	}

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -403,7 +403,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (block->previous (), hash);
-			node.store.unchecked.unchecked_put (transaction_a, unchecked_key, info_a);
+			node.store.unchecked.put (transaction_a, unchecked_key, info_a);
 
 			events_a.events.emplace_back ([this, hash] (nano::transaction const & /* unused */) { this->node.gap_cache.add (hash); });
 
@@ -423,7 +423,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (node.ledger.block_source (transaction_a, *(block)), hash);
-			node.store.unchecked.unchecked_put (transaction_a, unchecked_key, info_a);
+			node.store.unchecked.put (transaction_a, unchecked_key, info_a);
 
 			events_a.events.emplace_back ([this, hash] (nano::transaction const & /* unused */) { this->node.gap_cache.add (hash); });
 
@@ -443,7 +443,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			}
 
 			nano::unchecked_key unchecked_key (block->account (), hash); // Specific unchecked key starting with epoch open block account public key
-			node.store.unchecked.unchecked_put (transaction_a, unchecked_key, info_a);
+			node.store.unchecked.put (transaction_a, unchecked_key, info_a);
 
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
 			break;
@@ -548,12 +548,12 @@ void nano::block_processor::process_old (nano::transaction const & transaction_a
 
 void nano::block_processor::queue_unchecked (nano::write_transaction const & transaction_a, nano::hash_or_account const & hash_or_account_a)
 {
-	auto unchecked_blocks (node.store.unchecked.unchecked_get (transaction_a, hash_or_account_a.hash));
+	auto unchecked_blocks (node.store.unchecked.get (transaction_a, hash_or_account_a.hash));
 	for (auto & info : unchecked_blocks)
 	{
 		if (!node.flags.disable_block_processor_unchecked_deletion)
 		{
-			node.store.unchecked.unchecked_del (transaction_a, nano::unchecked_key (hash_or_account_a, info.block->hash ()));
+			node.store.unchecked.del (transaction_a, nano::unchecked_key (hash_or_account_a, info.block->hash ()));
 		}
 		add (info);
 	}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -220,7 +220,7 @@ bool copy_database (boost::filesystem::path const & data_path, boost::program_op
 		auto & store (node.node->store);
 		if (vm.count ("unchecked_clear"))
 		{
-			node.node->store.unchecked.unchecked_clear (store.tx_begin_write ());
+			node.node->store.unchecked.clear (store.tx_begin_write ());
 		}
 		if (vm.count ("clear_send_ids"))
 		{
@@ -491,7 +491,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		if (!node.node->init_error ())
 		{
 			auto transaction (node.node->store.tx_begin_write ());
-			node.node->store.unchecked.unchecked_clear (transaction);
+			node.node->store.unchecked.clear (transaction);
 			std::cout << "Unchecked blocks deleted" << std::endl;
 		}
 		else

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -220,7 +220,7 @@ bool copy_database (boost::filesystem::path const & data_path, boost::program_op
 		auto & store (node.node->store);
 		if (vm.count ("unchecked_clear"))
 		{
-			node.node->store.unchecked_clear (store.tx_begin_write ());
+			node.node->store.unchecked.unchecked_clear (store.tx_begin_write ());
 		}
 		if (vm.count ("clear_send_ids"))
 		{
@@ -491,7 +491,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		if (!node.node->init_error ())
 		{
 			auto transaction (node.node->store.tx_begin_write ());
-			node.node->store.unchecked_clear (transaction);
+			node.node->store.unchecked.unchecked_clear (transaction);
 			std::cout << "Unchecked blocks deleted" << std::endl;
 		}
 		else

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1313,7 +1313,7 @@ void nano::json_handler::block_account ()
 void nano::json_handler::block_count ()
 {
 	response_l.put ("count", std::to_string (node.ledger.cache.block_count));
-	response_l.put ("unchecked", std::to_string (node.store.unchecked_count (node.store.tx_begin_read ())));
+	response_l.put ("unchecked", std::to_string (node.store.unchecked.unchecked_count (node.store.tx_begin_read ())));
 	response_l.put ("cemented", std::to_string (node.ledger.cache.cemented_count));
 	if (node.flags.enable_pruning)
 	{
@@ -3936,7 +3936,7 @@ void nano::json_handler::unchecked ()
 	{
 		boost::property_tree::ptree unchecked;
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.unchecked_begin (transaction)), n (node.store.unchecked_end ()); i != n && unchecked.size () < count; ++i)
+		for (auto i (node.store.unchecked.unchecked_begin (transaction)), n (node.store.unchecked.unchecked_end ()); i != n && unchecked.size () < count; ++i)
 		{
 			nano::unchecked_info const & info (i->second);
 			if (json_block_l)
@@ -3961,7 +3961,7 @@ void nano::json_handler::unchecked_clear ()
 {
 	node.workers.push_task (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
 		auto transaction (rpc_l->node.store.tx_begin_write ({ tables::unchecked }));
-		rpc_l->node.store.unchecked_clear (transaction);
+		rpc_l->node.store.unchecked.unchecked_clear (transaction);
 		rpc_l->response_l.put ("success", "");
 		rpc_l->response_errors ();
 	}));
@@ -3974,7 +3974,7 @@ void nano::json_handler::unchecked_get ()
 	if (!ec)
 	{
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.unchecked_begin (transaction)), n (node.store.unchecked_end ()); i != n; ++i)
+		for (auto i (node.store.unchecked.unchecked_begin (transaction)), n (node.store.unchecked.unchecked_end ()); i != n; ++i)
 		{
 			nano::unchecked_key const & key (i->first);
 			if (key.hash == hash)
@@ -4022,7 +4022,7 @@ void nano::json_handler::unchecked_keys ()
 	{
 		boost::property_tree::ptree unchecked;
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.unchecked_begin (transaction, nano::unchecked_key (key, 0))), n (node.store.unchecked_end ()); i != n && unchecked.size () < count; ++i)
+		for (auto i (node.store.unchecked.unchecked_begin (transaction, nano::unchecked_key (key, 0))), n (node.store.unchecked.unchecked_end ()); i != n && unchecked.size () < count; ++i)
 		{
 			boost::property_tree::ptree entry;
 			nano::unchecked_info const & info (i->second);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1313,7 +1313,7 @@ void nano::json_handler::block_account ()
 void nano::json_handler::block_count ()
 {
 	response_l.put ("count", std::to_string (node.ledger.cache.block_count));
-	response_l.put ("unchecked", std::to_string (node.store.unchecked.unchecked_count (node.store.tx_begin_read ())));
+	response_l.put ("unchecked", std::to_string (node.store.unchecked.count (node.store.tx_begin_read ())));
 	response_l.put ("cemented", std::to_string (node.ledger.cache.cemented_count));
 	if (node.flags.enable_pruning)
 	{
@@ -3936,7 +3936,7 @@ void nano::json_handler::unchecked ()
 	{
 		boost::property_tree::ptree unchecked;
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.unchecked.unchecked_begin (transaction)), n (node.store.unchecked.unchecked_end ()); i != n && unchecked.size () < count; ++i)
+		for (auto i (node.store.unchecked.begin (transaction)), n (node.store.unchecked.end ()); i != n && unchecked.size () < count; ++i)
 		{
 			nano::unchecked_info const & info (i->second);
 			if (json_block_l)
@@ -3961,7 +3961,7 @@ void nano::json_handler::unchecked_clear ()
 {
 	node.workers.push_task (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
 		auto transaction (rpc_l->node.store.tx_begin_write ({ tables::unchecked }));
-		rpc_l->node.store.unchecked.unchecked_clear (transaction);
+		rpc_l->node.store.unchecked.clear (transaction);
 		rpc_l->response_l.put ("success", "");
 		rpc_l->response_errors ();
 	}));
@@ -3974,7 +3974,7 @@ void nano::json_handler::unchecked_get ()
 	if (!ec)
 	{
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.unchecked.unchecked_begin (transaction)), n (node.store.unchecked.unchecked_end ()); i != n; ++i)
+		for (auto i (node.store.unchecked.begin (transaction)), n (node.store.unchecked.end ()); i != n; ++i)
 		{
 			nano::unchecked_key const & key (i->first);
 			if (key.hash == hash)
@@ -4022,7 +4022,7 @@ void nano::json_handler::unchecked_keys ()
 	{
 		boost::property_tree::ptree unchecked;
 		auto transaction (node.store.tx_begin_read ());
-		for (auto i (node.store.unchecked.unchecked_begin (transaction, nano::unchecked_key (key, 0))), n (node.store.unchecked.unchecked_end ()); i != n && unchecked.size () < count; ++i)
+		for (auto i (node.store.unchecked.begin (transaction, nano::unchecked_key (key, 0))), n (node.store.unchecked.end ()); i != n && unchecked.size () < count; ++i)
 		{
 			boost::property_tree::ptree entry;
 			nano::unchecked_info const & info (i->second);

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -42,11 +42,11 @@ void mdb_val::convert_buffer_to_value ()
 
 nano::mdb_store::mdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade_a) :
 	block_store_partial{ unchecked_mdb_store },
+	unchecked_mdb_store{ *this },
 	logger (logger_a),
 	env (error, path_a, nano::mdb_env::options::make ().set_config (lmdb_config_a).set_use_no_mem_init (true)),
 	mdb_txn_tracker (logger_a, txn_tracking_config_a, block_processor_batch_max_time_a),
-	txn_tracking_enabled (txn_tracking_config_a.enable),
-	unchecked_mdb_store{ *this }
+	txn_tracking_enabled (txn_tracking_config_a.enable)
 {
 	if (!error)
 	{
@@ -790,10 +790,10 @@ void nano::mdb_store::create_backup_file (nano::mdb_env & env_a, boost::filesyst
 	}
 }
 
-std::vector<nano::unchecked_info> nano::unchecked_mdb_store::unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
+std::vector<nano::unchecked_info> nano::unchecked_mdb_store::get (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	std::vector<nano::unchecked_info> result;
-	for (auto i (unchecked_begin (transaction_a, nano::unchecked_key (hash_a, 0))), n (unchecked_end ()); i != n && i->first.key () == hash_a; ++i)
+	for (auto i (begin (transaction_a, nano::unchecked_key (hash_a, 0))), n (end ()); i != n && i->first.key () == hash_a; ++i)
 	{
 		nano::unchecked_info const & unchecked_info (i->second);
 		result.push_back (unchecked_info);

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -801,6 +801,9 @@ std::vector<nano::unchecked_info> nano::unchecked_mdb_store::unchecked_get (nano
 	return result;
 }
 
+nano::unchecked_mdb_store::unchecked_mdb_store (nano::mdb_store & mdb_store_a) :
+	unchecked_store_partial<MDB_val, mdb_store> (mdb_store_a){};
+
 void nano::mdb_store::version_put (nano::write_transaction const & transaction_a, int version_a)
 {
 	nano::uint256_union version_key (1);

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -36,8 +36,7 @@ class unchecked_mdb_store : public unchecked_store_partial<MDB_val, mdb_store>
 	//	nano::mdb_store & mdb_store;
 
 public:
-	explicit unchecked_mdb_store (nano::mdb_store & mdb_store_a) :
-		unchecked_store_partial<MDB_val, mdb_store> (mdb_store_a){};
+	explicit unchecked_mdb_store (nano::mdb_store & mdb_store_a);
 
 	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 };

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -8,8 +8,8 @@
 #include <nano/node/lmdb/lmdb_iterator.hpp>
 #include <nano/node/lmdb/lmdb_txn.hpp>
 #include <nano/secure/blockstore_partial.hpp>
-#include <nano/secure/store/unchecked_store_partial.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/secure/store/unchecked_store_partial.hpp>
 #include <nano/secure/versioning.hpp>
 
 #include <boost/optional.hpp>
@@ -33,10 +33,11 @@ class mdb_store;
 
 class unchecked_mdb_store : public unchecked_store_partial<MDB_val, mdb_store>
 {
-	nano::mdb_store & mdb_store;
+	//	nano::mdb_store & mdb_store;
 
 public:
-	explicit unchecked_mdb_store (nano::mdb_store & mdb_store_a) : unchecked_store_partial (mdb_store_a){};
+	explicit unchecked_mdb_store (nano::mdb_store & mdb_store_a) :
+		unchecked_store_partial<MDB_val, mdb_store> (mdb_store_a){};
 
 	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 };
@@ -49,8 +50,8 @@ class mdb_store : public block_store_partial<MDB_val, mdb_store>
 	nano::unchecked_mdb_store unchecked_mdb_store;
 
 public:
-//	using block_store_partial::block_exists;
-//	using unchecked_store_partial::unchecked_put;
+	//	using block_store_partial::block_exists;
+	//	using unchecked_store_partial::unchecked_put;
 
 	mdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -75,91 +75,91 @@ public:
 	 * Maps head block to owning account
 	 * nano::block_hash -> nano::account
 	 */
-	MDB_dbi frontiers{ 0 };
+	MDB_dbi frontiers_handle{ 0 };
 
 	/**
 	 * Maps account v1 to account information, head, rep, open, balance, timestamp and block count. (Removed)
 	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
 	 */
-	MDB_dbi accounts_v0{ 0 };
+	MDB_dbi accounts_v0_handle{ 0 };
 
 	/**
 	 * Maps account v0 to account information, head, rep, open, balance, timestamp and block count. (Removed)
 	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
 	 */
-	MDB_dbi accounts_v1{ 0 };
+	MDB_dbi accounts_v1_handle{ 0 };
 
 	/**
 	 * Maps account v0 to account information, head, rep, open, balance, timestamp, block count and epoch
 	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t, nano::epoch
 	 */
-	MDB_dbi accounts{ 0 };
+	MDB_dbi accounts_handle{ 0 };
 
 	/**
 	 * Maps block hash to send block. (Removed)
 	 * nano::block_hash -> nano::send_block
 	 */
-	MDB_dbi send_blocks{ 0 };
+	MDB_dbi send_blocks_handle{ 0 };
 
 	/**
 	 * Maps block hash to receive block. (Removed)
 	 * nano::block_hash -> nano::receive_block
 	 */
-	MDB_dbi receive_blocks{ 0 };
+	MDB_dbi receive_blocks_handle{ 0 };
 
 	/**
 	 * Maps block hash to open block. (Removed)
 	 * nano::block_hash -> nano::open_block
 	 */
-	MDB_dbi open_blocks{ 0 };
+	MDB_dbi open_blocks_handle{ 0 };
 
 	/**
 	 * Maps block hash to change block. (Removed)
 	 * nano::block_hash -> nano::change_block
 	 */
-	MDB_dbi change_blocks{ 0 };
+	MDB_dbi change_blocks_handle{ 0 };
 
 	/**
 	 * Maps block hash to v0 state block. (Removed)
 	 * nano::block_hash -> nano::state_block
 	 */
-	MDB_dbi state_blocks_v0{ 0 };
+	MDB_dbi state_blocks_v0_handle{ 0 };
 
 	/**
 	 * Maps block hash to v1 state block. (Removed)
 	 * nano::block_hash -> nano::state_block
 	 */
-	MDB_dbi state_blocks_v1{ 0 };
+	MDB_dbi state_blocks_v1_handle{ 0 };
 
 	/**
 	 * Maps block hash to state block. (Removed)
 	 * nano::block_hash -> nano::state_block
 	 */
-	MDB_dbi state_blocks{ 0 };
+	MDB_dbi state_blocks_handle{ 0 };
 
 	/**
 	 * Maps min_version 0 (destination account, pending block) to (source account, amount). (Removed)
 	 * nano::account, nano::block_hash -> nano::account, nano::amount
 	 */
-	MDB_dbi pending_v0{ 0 };
+	MDB_dbi pending_v0_handle{ 0 };
 
 	/**
 	 * Maps min_version 1 (destination account, pending block) to (source account, amount). (Removed)
 	 * nano::account, nano::block_hash -> nano::account, nano::amount
 	 */
-	MDB_dbi pending_v1{ 0 };
+	MDB_dbi pending_v1_handle{ 0 };
 
 	/**
 	 * Maps (destination account, pending block) to (source account, amount, version). (Removed)
 	 * nano::account, nano::block_hash -> nano::account, nano::amount, nano::epoch
 	 */
-	MDB_dbi lmdb_pending{ 0 };
+	MDB_dbi pending_handle{ 0 };
 
 	/**
 	 * Representative weights. (Removed)
 	 * nano::account -> nano::uint128_t
 	 */
-	MDB_dbi representation{ 0 };
+	MDB_dbi representation_handle{ 0 };
 
 	/**
 	 * Unchecked bootstrap blocks info.
@@ -177,7 +177,7 @@ public:
 	 * Meta information about block store, such as versions.
 	 * nano::uint256_union (arbitrary key) -> blob
 	 */
-	MDB_dbi meta{ 0 };
+	MDB_dbi meta_handle{ 0 };
 
 	/**
 	 * Pruned blocks hashes
@@ -189,7 +189,7 @@ public:
 	 * Endpoints for peers
 	 * nano::endpoint_key -> no_value
 	*/
-	MDB_dbi peer_handle{ 0 };
+	MDB_dbi peers_handle{ 0 };
 
 	/*
 	 * Confirmation height of an account, and the hash for the block at that height
@@ -201,13 +201,13 @@ public:
 	 * Contains block_sideband and block for all block types (legacy send/change/open/receive & state blocks)
 	 * nano::block_hash -> nano::block_sideband, nano::block
 	 */
-	MDB_dbi blocks{ 0 };
+	MDB_dbi blocks_handle{ 0 };
 
 	/**
 	 * Maps root to block hash for generated final votes.
 	 * nano::qualified_root -> nano::block_hash
 	 */
-	MDB_dbi final_vote_handle{ 0 };
+	MDB_dbi final_votes_handle{ 0 };
 
 	bool exists (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -8,6 +8,7 @@
 #include <nano/node/lmdb/lmdb_iterator.hpp>
 #include <nano/node/lmdb/lmdb_txn.hpp>
 #include <nano/secure/blockstore_partial.hpp>
+#include <nano/secure/store/unchecked_store_partial.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/versioning.hpp>
 
@@ -35,7 +36,7 @@ class mdb_store : public block_store_partial<MDB_val, mdb_store>
 {
 public:
 	using block_store_partial::block_exists;
-	using block_store_partial::unchecked_put;
+	using unchecked_store_partial::unchecked_put;
 
 	mdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -33,12 +33,9 @@ class mdb_store;
 
 class unchecked_mdb_store : public unchecked_store_partial<MDB_val, mdb_store>
 {
-	//	nano::mdb_store & mdb_store;
-
 public:
-	explicit unchecked_mdb_store (nano::mdb_store & mdb_store_a);
-
-	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+	explicit unchecked_mdb_store (nano::mdb_store &);
+	std::vector<nano::unchecked_info> get (nano::transaction const &, nano::block_hash const &);
 };
 
 /**
@@ -46,11 +43,8 @@ public:
  */
 class mdb_store : public block_store_partial<MDB_val, mdb_store>
 {
-	nano::unchecked_mdb_store unchecked_mdb_store;
-
 public:
-	//	using block_store_partial::block_exists;
-	//	using unchecked_store_partial::unchecked_put;
+	friend class nano::unchecked_mdb_store;
 
 	mdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
@@ -69,6 +63,8 @@ public:
 	unsigned max_block_write_batch_num () const override;
 
 private:
+	nano::unchecked_mdb_store unchecked_mdb_store;
+
 	nano::logger_mt & logger;
 	bool error{ false };
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -406,7 +406,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 			if (!flags.disable_unchecked_drop && !use_bootstrap_weight && !flags.read_only)
 			{
 				auto transaction (store.tx_begin_write ({ tables::unchecked }));
-				store.unchecked_clear (transaction);
+				store.unchecked.unchecked_clear (transaction);
 				logger.always_log ("Dropping unchecked blocks");
 			}
 		}
@@ -921,7 +921,7 @@ void nano::node::unchecked_cleanup ()
 		auto now (nano::seconds_since_epoch ());
 		auto transaction (store.tx_begin_read ());
 		// Max 1M records to clean, max 2 minutes reading to prevent slow i/o systems issues
-		for (auto i (store.unchecked_begin (transaction)), n (store.unchecked_end ()); i != n && cleaning_list.size () < 1024 * 1024 && nano::seconds_since_epoch () - now < 120; ++i)
+		for (auto i (store.unchecked.unchecked_begin (transaction)), n (store.unchecked.unchecked_end ()); i != n && cleaning_list.size () < 1024 * 1024 && nano::seconds_since_epoch () - now < 120; ++i)
 		{
 			nano::unchecked_key const & key (i->first);
 			nano::unchecked_info const & info (i->second);
@@ -945,9 +945,9 @@ void nano::node::unchecked_cleanup ()
 		{
 			auto key (cleaning_list.front ());
 			cleaning_list.pop_front ();
-			if (store.unchecked_exists (transaction, key))
+			if (store.unchecked.unchecked_exists (transaction, key))
 			{
-				store.unchecked_del (transaction, key);
+				store.unchecked.unchecked_del (transaction, key);
 			}
 		}
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -406,7 +406,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 			if (!flags.disable_unchecked_drop && !use_bootstrap_weight && !flags.read_only)
 			{
 				auto transaction (store.tx_begin_write ({ tables::unchecked }));
-				store.unchecked.unchecked_clear (transaction);
+				store.unchecked.clear (transaction);
 				logger.always_log ("Dropping unchecked blocks");
 			}
 		}
@@ -921,7 +921,7 @@ void nano::node::unchecked_cleanup ()
 		auto now (nano::seconds_since_epoch ());
 		auto transaction (store.tx_begin_read ());
 		// Max 1M records to clean, max 2 minutes reading to prevent slow i/o systems issues
-		for (auto i (store.unchecked.unchecked_begin (transaction)), n (store.unchecked.unchecked_end ()); i != n && cleaning_list.size () < 1024 * 1024 && nano::seconds_since_epoch () - now < 120; ++i)
+		for (auto i (store.unchecked.begin (transaction)), n (store.unchecked.end ()); i != n && cleaning_list.size () < 1024 * 1024 && nano::seconds_since_epoch () - now < 120; ++i)
 		{
 			nano::unchecked_key const & key (i->first);
 			nano::unchecked_info const & info (i->second);
@@ -945,9 +945,9 @@ void nano::node::unchecked_cleanup ()
 		{
 			auto key (cleaning_list.front ());
 			cleaning_list.pop_front ();
-			if (store.unchecked.unchecked_exists (transaction, key))
+			if (store.unchecked.exists (transaction, key))
 			{
-				store.unchecked.unchecked_del (transaction, key);
+				store.unchecked.del (transaction, key);
 			}
 		}
 	}

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -590,7 +590,7 @@ int nano::rocksdb_store::clear (rocksdb::ColumnFamilyHandle * column_family)
 	return status.code ();
 }
 
-std::vector<nano::unchecked_info> nano::rocksdb_store::unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
+std::vector<nano::unchecked_info> nano::unchecked_rocksdb_store::unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto cf = table_to_column_family (tables::unchecked);
 
@@ -914,3 +914,4 @@ nano::rocksdb_store::tombstone_info::tombstone_info (uint64_t num_since_last_flu
 
 // Explicitly instantiate
 template class nano::block_store_partial<rocksdb::Slice, nano::rocksdb_store>;
+template class nano::unchecked_store_partial<rocksdb::Slice, rocksdb_store>;

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -6,6 +6,7 @@
 #include <nano/node/rocksdb/rocksdb_iterator.hpp>
 #include <nano/secure/blockstore_partial.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/secure/store/unchecked_store_partial.hpp>
 
 #include <rocksdb/db.h>
 #include <rocksdb/filter_policy.h>
@@ -19,6 +20,17 @@ namespace nano
 {
 class logging_mt;
 class rocksdb_config;
+class rocksdb_store;
+
+class unchecked_rocksdb_store : public unchecked_store_partial<rocksdb::Slice, rocksdb_store>
+{
+public:
+	unchecked_rocksdb_store () :
+		unchecked_store_partial (rocksdb_store)
+	{};
+
+	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+};
 
 /**
  * rocksdb implementation of the block store
@@ -34,7 +46,6 @@ public:
 
 	uint64_t count (nano::transaction const & transaction_a, tables table_a) const override;
 	void version_put (nano::write_transaction const &, int) override;
-	std::vector<nano::unchecked_info> unchecked_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 
 	bool exists (nano::transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a) const;
 	int get (nano::transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a, nano::rocksdb_val & value_a) const;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -633,7 +633,7 @@ nano::telemetry_data nano::local_telemetry_data (nano::ledger const & ledger_a, 
 	telemetry_data.bandwidth_cap = bandwidth_limit_a;
 	telemetry_data.protocol_version = network_params_a.protocol.protocol_version;
 	telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - statup_time_a).count ();
-	telemetry_data.unchecked_count = ledger_a.store.unchecked_count (ledger_a.store.tx_begin_read ());
+	telemetry_data.unchecked_count = ledger_a.store.unchecked.count (ledger_a.store.tx_begin_read ());
 	telemetry_data.genesis_block = network_params_a.ledger.genesis_hash;
 	telemetry_data.peer_count = nano::narrow_cast<decltype (telemetry_data.peer_count)> (network_a.size ());
 	telemetry_data.account_count = ledger_a.cache.account_count;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -923,7 +923,7 @@ std::string nano_qt::status::text ()
 	std::string count_string;
 	{
 		auto size (wallet.wallet_m->wallets.node.ledger.cache.block_count.load ());
-		unchecked = wallet.wallet_m->wallets.node.store.unchecked_count (wallet.wallet_m->wallets.node.store.tx_begin_read ());
+		unchecked = wallet.wallet_m->wallets.node.store.unchecked.count (wallet.wallet_m->wallets.node.store.tx_begin_read ());
 		count_string = std::to_string (size);
 	}
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6433,14 +6433,14 @@ TEST (rpc, unchecked_clear)
 	node.block_processor.flush ();
 	boost::property_tree::ptree request;
 	{
-		ASSERT_EQ (node.store.unchecked_count (node.store.tx_begin_read ()), 1);
+		ASSERT_EQ (node.store.unchecked.count (node.store.tx_begin_read ()), 1);
 	}
 	request.put ("action", "unchecked_clear");
 	test_response response (request, rpc.config.port, system.io_ctx);
 	ASSERT_TIMELY (5s, response.status != 0);
 	ASSERT_EQ (200, response.status);
 
-	ASSERT_TIMELY (10s, node.store.unchecked_count (node.store.tx_begin_read ()) == 0);
+	ASSERT_TIMELY (10s, node.store.unchecked.count (node.store.tx_begin_read ()) == 0);
 }
 
 TEST (rpc, unopened)

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -54,7 +54,8 @@ add_library(
   versioning.hpp
   versioning.cpp
   working.hpp
-  store/frontier_store_partial.hpp)
+  store/frontier_store_partial.hpp
+  store/unchecked_store_partial.hpp)
 
 target_link_libraries(
   secure

--- a/nano/secure/blockstore.cpp
+++ b/nano/secure/blockstore.cpp
@@ -105,7 +105,8 @@ bool nano::write_transaction::contains (nano::tables table_a) const
 	return impl->contains (table_a);
 }
 
-nano::block_store::block_store (nano::frontier_store & frontier_store_a) :
-	frontier (frontier_store_a)
+nano::block_store::block_store (nano::frontier_store & frontier_store_a, nano::unchecked_store & unchecked_store_a) :
+	frontier (frontier_store_a),
+	unchecked (unchecked_store_a)
 {
 }

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -632,13 +632,29 @@ public:
 	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const = 0;
 };
 
+class unchecked_store
+{
+public:
+	virtual void unchecked_clear (nano::write_transaction const &) = 0;
+	virtual void unchecked_put (nano::write_transaction const &, nano::unchecked_key const &, nano::unchecked_info const &) = 0;
+	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
+	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
+	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
+	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
+	virtual size_t unchecked_count (nano::transaction const &) = 0;
+	virtual void unchecked_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const = 0;
+};
+
 /**
  * Manages block storage and iteration
  */
 class block_store
 {
 public:
-	explicit block_store (nano::frontier_store &);
+	explicit block_store (nano::frontier_store &, nano::unchecked_store &);
 	virtual ~block_store () = default;
 	virtual void initialize (nano::write_transaction const &, nano::genesis const &, nano::ledger_cache &) = 0;
 	virtual void block_put (nano::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;
@@ -683,16 +699,7 @@ public:
 	virtual nano::uint128_t block_balance_calculated (std::shared_ptr<nano::block> const &) const = 0;
 	virtual nano::epoch block_version (nano::transaction const &, nano::block_hash const &) = 0;
 
-	virtual void unchecked_clear (nano::write_transaction const &) = 0;
-	virtual void unchecked_put (nano::write_transaction const &, nano::unchecked_key const &, nano::unchecked_info const &) = 0;
-	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
-	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
-	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
-	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
-	virtual size_t unchecked_count (nano::transaction const &) = 0;
+	unchecked_store & unchecked;
 
 	virtual void online_weight_put (nano::write_transaction const &, uint64_t, nano::amount const &) = 0;
 	virtual void online_weight_del (nano::write_transaction const &, uint64_t) = 0;
@@ -737,7 +744,6 @@ public:
 	virtual void accounts_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const &) const = 0;
 	virtual void confirmation_height_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const &) const = 0;
 	virtual void pending_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const = 0;
-	virtual void unchecked_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const = 0;
 	virtual void pruned_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const = 0;
 	virtual void blocks_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;
 	virtual void final_vote_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const = 0;

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -638,17 +638,17 @@ public:
 class unchecked_store
 {
 public:
-	virtual void unchecked_clear (nano::write_transaction const &) = 0;
-	virtual void unchecked_put (nano::write_transaction const &, nano::unchecked_key const &, nano::unchecked_info const &) = 0;
-	virtual void unchecked_put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
-	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) = 0;
-	virtual bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
-	virtual void unchecked_del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &) const = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
-	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const = 0;
-	virtual size_t unchecked_count (nano::transaction const &) = 0;
-	virtual void unchecked_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const = 0;
+	virtual void clear (nano::write_transaction const &) = 0;
+	virtual void put (nano::write_transaction const &, nano::unchecked_key const &, nano::unchecked_info const &) = 0;
+	virtual void put (nano::write_transaction const &, nano::block_hash const &, std::shared_ptr<nano::block> const &) = 0;
+	virtual std::vector<nano::unchecked_info> get (nano::transaction const &, nano::block_hash const &) = 0;
+	virtual bool exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) = 0;
+	virtual void del (nano::write_transaction const &, nano::unchecked_key const &) = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> begin (nano::transaction const &, nano::unchecked_key const &) const = 0;
+	virtual nano::store_iterator<nano::unchecked_key, nano::unchecked_info> end () const = 0;
+	virtual size_t count (nano::transaction const &) = 0;
+	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const = 0;
 };
 
 /**

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -632,6 +632,9 @@ public:
 	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const = 0;
 };
 
+/**
+ * Manages unchecked storage and iteration
+ */
 class unchecked_store
 {
 public:

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -41,9 +41,7 @@ template <typename Val, typename Derived_Store>
 class block_store_partial : public block_store
 {
 	nano::frontier_store_partial<Val, Derived_Store> frontier_store;
-
-
-	nano::unchecked_store_partial<Val, Derived_Store> unchecked_store_partial;
+	nano::unchecked_store_partial<Val, Derived_Store> & unchecked_store_partial;
 
 	friend void release_assert_success<Val, Derived_Store> (block_store_partial<Val, Derived_Store> const & block_store, const int status);
 
@@ -57,10 +55,10 @@ public:
 
 	friend class nano::unchecked_store_partial<Val, Derived_Store>;
 
-	block_store_partial () :
-		block_store{ frontier_store, unchecked_store_partial },
+	block_store_partial (nano::unchecked_store_partial<Val, Derived_Store> & unchecked_store_partial_a) :
+		block_store{ frontier_store, unchecked_store_partial_a },
 		frontier_store{ *this },
-		unchecked_store_partial{ *this }
+		unchecked_store_partial (unchecked_store_partial_a)
 	{
 	}
 

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -54,7 +54,7 @@ public:
 
 	friend class nano::unchecked_store_partial<Val, Derived_Store>;
 
-	block_store_partial (nano::unchecked_store_partial<Val, Derived_Store> & unchecked_store_partial_a) :
+	explicit block_store_partial (nano::unchecked_store_partial<Val, Derived_Store> & unchecked_store_partial_a) :
 		block_store{ frontier_store, unchecked_store_partial_a },
 		frontier_store{ *this },
 		unchecked_store_partial (unchecked_store_partial_a)

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -47,11 +47,10 @@ class block_store_partial : public block_store
 
 public:
 	using block_store::block_exists;
-//	using unchecked_store::unchecked_put;
+	//	using unchecked_store::unchecked_put;
 
 	friend class nano::block_predecessor_set<Val, Derived_Store>;
 	friend class nano::frontier_store_partial<Val, Derived_Store>;
-
 
 	friend class nano::unchecked_store_partial<Val, Derived_Store>;
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1436,12 +1436,12 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 			}
 		});
 
-		store.unchecked_for_each_par (
+		store.unchecked.unchecked_for_each_par (
 		[&rocksdb_store] (nano::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::unchecked }));
-				rocksdb_store->unchecked_put (rocksdb_transaction, i->first, i->second);
+				rocksdb_store->unchecked.unchecked_put (rocksdb_transaction, i->first, i->second);
 			}
 		});
 
@@ -1515,7 +1515,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 		}
 
 		// Compare counts
-		error |= store.unchecked_count (lmdb_transaction) != rocksdb_store->unchecked_count (rocksdb_transaction);
+		error |= store.unchecked.unchecked_count (lmdb_transaction) != rocksdb_store->unchecked.unchecked_count (rocksdb_transaction);
 		error |= store.peer_count (lmdb_transaction) != rocksdb_store->peer_count (rocksdb_transaction);
 		error |= store.pruned_count (lmdb_transaction) != rocksdb_store->pruned_count (rocksdb_transaction);
 		error |= store.final_vote_count (lmdb_transaction) != rocksdb_store->final_vote_count (rocksdb_transaction);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1436,12 +1436,12 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 			}
 		});
 
-		store.unchecked.unchecked_for_each_par (
+		store.unchecked.for_each_par (
 		[&rocksdb_store] (nano::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::unchecked }));
-				rocksdb_store->unchecked.unchecked_put (rocksdb_transaction, i->first, i->second);
+				rocksdb_store->unchecked.put (rocksdb_transaction, i->first, i->second);
 			}
 		});
 
@@ -1515,7 +1515,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 		}
 
 		// Compare counts
-		error |= store.unchecked.unchecked_count (lmdb_transaction) != rocksdb_store->unchecked.unchecked_count (rocksdb_transaction);
+		error |= store.unchecked.count (lmdb_transaction) != rocksdb_store->unchecked.count (rocksdb_transaction);
 		error |= store.peer_count (lmdb_transaction) != rocksdb_store->peer_count (rocksdb_transaction);
 		error |= store.pruned_count (lmdb_transaction) != rocksdb_store->pruned_count (rocksdb_transaction);
 		error |= store.final_vote_count (lmdb_transaction) != rocksdb_store->final_vote_count (rocksdb_transaction);

--- a/nano/secure/store/unchecked_store_partial.hpp
+++ b/nano/secure/store/unchecked_store_partial.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <nano/secure/blockstore_partial.hpp>
+
+namespace
+{
+template <typename T>
+void parallel_traversal (std::function<void (T const &, T const &, bool const)> const & action);
+}
+
+namespace nano
+{
+template <typename Val, typename Derived_Store>
+class block_store_partial;
+
+template <typename Val, typename Derived_Store>
+void release_assert_success (block_store_partial<Val, Derived_Store> const & block_store, const int status);
+
+template <typename Val, typename Derived_Store>
+class unchecked_store_partial : public unchecked_store
+{
+private:
+	nano::block_store_partial<Val, Derived_Store> & block_store;
+
+	friend void release_assert_success<Val, Derived_Store> (block_store_partial<Val, Derived_Store> const & block_store, const int status);
+
+public:
+	explicit unchecked_store_partial (nano::block_store_partial<Val, Derived_Store> & block_store_a) :
+		block_store (block_store_a){};
+
+	void unchecked_clear (nano::write_transaction const & transaction_a) override
+	{
+		auto status = block_store.drop (transaction_a, tables::unchecked);
+		release_assert_success (*this, status);
+	}
+
+	void unchecked_put (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a) override
+	{
+		nano::db_val<Val> info (info_a);
+		auto status (put (transaction_a, tables::unchecked, key_a, info));
+		release_assert_success (*this, status);
+	}
+
+	void unchecked_put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, std::shared_ptr<nano::block> const & block_a) override
+	{
+		nano::unchecked_key key (hash_a, block_a->hash ());
+		nano::unchecked_info info (block_a, block_a->account (), nano::seconds_since_epoch (), nano::signature_verification::unknown);
+		unchecked_put (transaction_a, key, info);
+	}
+
+	bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override
+	{
+		nano::db_val<Val> value;
+		auto status (get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
+		release_assert (success (status) || not_found (status));
+		return (success (status));
+	}
+
+	void unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
+	{
+		auto status (block_store.del (transaction_a, tables::unchecked, key_a));
+		release_assert_success (*this, status);
+	}
+
+	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const override
+	{
+		return nano::store_iterator<nano::unchecked_key, nano::unchecked_info> (nullptr);
+	}
+
+	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const & transaction_a) const override
+	{
+		return block_store.template make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction_a, tables::unchecked);
+	}
+
+	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override
+	{
+		return make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction_a, tables::unchecked, nano::db_val<Val> (key_a));
+	}
+
+	size_t unchecked_count (nano::transaction const & transaction_a) override
+	{
+		return block_store.count (transaction_a, tables::unchecked);
+	}
+
+	void unchecked_for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override
+	{
+		parallel_traversal<nano::uint512_t> (
+		[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {
+			nano::unchecked_key key_start (start);
+			nano::unchecked_key key_end (end);
+			auto transaction (this->tx_begin_read ());
+			action_a (transaction, this->unchecked_begin (transaction, key_start), !is_last ? this->unchecked_begin (transaction, key_end) : this->unchecked_end ());
+		});
+	}
+};
+
+}

--- a/nano/secure/store/unchecked_store_partial.hpp
+++ b/nano/secure/store/unchecked_store_partial.hpp
@@ -25,20 +25,20 @@ private:
 	friend void release_assert_success<Val, Derived_Store> (block_store_partial<Val, Derived_Store> const & block_store, const int status);
 
 public:
-	explicit unchecked_store_partial (nano::block_store_partial<Val, Derived_Store> & block_store_a) :
+	unchecked_store_partial (nano::block_store_partial<Val, Derived_Store> & block_store_a) :
 		block_store (block_store_a){};
 
 	void unchecked_clear (nano::write_transaction const & transaction_a) override
 	{
 		auto status = block_store.drop (transaction_a, tables::unchecked);
-		release_assert_success (*this, status);
+		release_assert_success (block_store, status);
 	}
 
 	void unchecked_put (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a, nano::unchecked_info const & info_a) override
 	{
 		nano::db_val<Val> info (info_a);
-		auto status (put (transaction_a, tables::unchecked, key_a, info));
-		release_assert_success (*this, status);
+		auto status (block_store.put (transaction_a, tables::unchecked, key_a, info));
+		release_assert_success (block_store, status);
 	}
 
 	void unchecked_put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, std::shared_ptr<nano::block> const & block_a) override
@@ -48,18 +48,23 @@ public:
 		unchecked_put (transaction_a, key, info);
 	}
 
+	virtual std::vector<nano::unchecked_info> unchecked_get (nano::transaction const &, nano::block_hash const &) override
+	{
+		release_assert (false);
+	};
+
 	bool unchecked_exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override
 	{
 		nano::db_val<Val> value;
-		auto status (get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
-		release_assert (success (status) || not_found (status));
-		return (success (status));
+		auto status (block_store.get (transaction_a, tables::unchecked, nano::db_val<Val> (unchecked_key_a), value));
+		release_assert (block_store.success (status) || block_store.not_found (status));
+		return (block_store.success (status));
 	}
 
 	void unchecked_del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override
 	{
 		auto status (block_store.del (transaction_a, tables::unchecked, key_a));
-		release_assert_success (*this, status);
+		release_assert_success (block_store, status);
 	}
 
 	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_end () const override
@@ -74,7 +79,7 @@ public:
 
 	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> unchecked_begin (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override
 	{
-		return make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction_a, tables::unchecked, nano::db_val<Val> (key_a));
+		return block_store.template make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction_a, tables::unchecked, nano::db_val<Val> (key_a));
 	}
 
 	size_t unchecked_count (nano::transaction const & transaction_a) override
@@ -88,7 +93,7 @@ public:
 		[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {
 			nano::unchecked_key key_start (start);
 			nano::unchecked_key key_end (end);
-			auto transaction (this->tx_begin_read ());
+			auto transaction (this->block_store.tx_begin_read ());
 			action_a (transaction, this->unchecked_begin (transaction, key_start), !is_last ? this->unchecked_begin (transaction, key_end) : this->unchecked_end ());
 		});
 	}

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -398,10 +398,10 @@ TEST (store, unchecked_load)
 	for (auto i (0); i < 1000000; ++i)
 	{
 		auto transaction (node.store.tx_begin_write ());
-		node.store.unchecked_put (transaction, i, block);
+		node.store.unchecked.put (transaction, i, block);
 	}
 	auto transaction (node.store.tx_begin_read ());
-	ASSERT_EQ (num_unchecked, node.store.unchecked_count (transaction));
+	ASSERT_EQ (num_unchecked, node.store.unchecked.count (transaction));
 }
 
 TEST (store, vote_load)


### PR DESCRIPTION
- Moves unchecked store methods out of the block store class as part of issue #3255
- Adds _handle suffix to the LMDB table handlers so they don't conflict with the new store objects