### PR TITLE
Removing redundant check in telemetry limiter.

### DIFF
--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -246,9 +246,8 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 					if (is_realtime_connection ())
 					{
 						// Only handle telemetry requests if they are outside of the cutoff time
-						auto is_very_first_message = last_telemetry_req == std::chrono::steady_clock::time_point{};
 						auto cache_exceeded = std::chrono::steady_clock::now () >= last_telemetry_req + nano::telemetry_cache_cutoffs::network_to_time (node->network_params.network);
-						if (is_very_first_message || cache_exceeded)
+						if (cache_exceeded)
 						{
 							last_telemetry_req = std::chrono::steady_clock::now ();
 							add_request (std::make_unique<nano::telemetry_req> (header));


### PR DESCRIPTION
 Time points are default constructed at the lowest time point which will already pass the duration check making it redundant.