### PR TITLE
Fix for active_transactions.pessimistic_elections unit test

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1318,7 +1318,7 @@ TEST (active_transactions, pessimistic_elections)
 	}
 
 	// Activation of cemented frontier successor should get started after the first pessimistic block is confirmed
-	ASSERT_TIMELY (10s, node.active.active (send->qualified_root ()));
+	ASSERT_TIMELY (10s, node.active.active (send2->qualified_root ()));
 
 	node.active.confirm_expired_frontiers_pessimistically (node.store.tx_begin_read (), 100, election_count);
 	ASSERT_EQ (1, election_count);


### PR DESCRIPTION
This assert was sometimes failing:
ASSERT_TIMELY (10s, node.active.active (send->qualified_root ()));

We think the original intention was to check "send2" and not "send".
send2 should become active for an election after its parent gets confirmed.