### PR TITLE
Don't reference get_available_port from within the node lib.

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1781,7 +1781,7 @@ nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost:
 	}
 
 	auto & node_config = daemon_config.node;
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = 24000;
 	node_config.logging.max_size = std::numeric_limits<std::uintmax_t>::max ();
 	node_config.logging.init (path_a);
 


### PR DESCRIPTION
Currently, the node lib doesn't reference the test_common library and likely shouldn't just for the purpose of getting a dummy port for command-line options. This change uses test port 24000 for nano::inactive_node which is used for CLI options and won't collide with live or debug ports.