### PR TITLE
This fixes an issue where nano_node couldn't be built with sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,8 +240,12 @@ else()
   if(${USING_ASAN} OR ${USING_ASAN_INT})
     if(${USING_ASAN_INT})
       add_compile_options(-fsanitize=address,undefined,integer)
+      add_compile_options(
+        -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/asan_blacklist)
     else()
       add_compile_options(-fsanitize=address,undefined)
+      add_compile_options(
+        -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/asan_blacklist)
     endif()
     add_definitions(-DED25519_NO_INLINE_ASM)
   elseif(${USING_TSAN})
@@ -317,9 +321,13 @@ else()
   if(${USING_ASAN_INT})
     set(PLATFORM_LINK_FLAGS
         "${PLATFORM_LINK_FLAGS} -fsanitize=address,undefined,integer")
+    set(PLATFORM_LINK_FLAGS
+        "${PLATFORM_LINK_FLAGS} -fsanitize=address,undefined -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/asan_blacklist"
+    )
   elseif(${USING_ASAN})
     set(PLATFORM_LINK_FLAGS
-        "${PLATFORM_LINK_FLAGS} -fsanitize=address,undefined")
+        "${PLATFORM_LINK_FLAGS} -fsanitize=address,undefined -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/asan_blacklist"
+    )
   elseif(${USING_TSAN})
     set(PLATFORM_LINK_FLAGS "${PLATFORM_LINK_FLAGS} -fsanitize=thread")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/asan_blacklist
+++ b/asan_blacklist
@@ -1,1 +1,2 @@
-src:*ed25519*
+#/boost/boost/any.hpp:249:17: runtime error: downcast of address
+src:*boost/any.hpp


### PR DESCRIPTION
This fixes an issue where nano_node couldn't be built with sanitizers enabled with clang because a post-build step would execute a nano_node command, get a sanitizer error, and fail. The failure originated inside the boost/any.hpp file. This seems to have been an issue in versions earlier than 1.69 though it appears to be an issue at least in 1.74. http://boost.2283326.n4.nabble.com/undefined-behavior-in-Boost-Program-Options-td4708585.html

This hooks the asan_blacklist file up as an exclusion list in the CMakeLists.txt file and excludes boost/any.hpp from sanitizer instrumentation.