### PR TITLE
Fix for network.peer_max_tcp_attempt

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -899,11 +899,11 @@ TEST (network, replace_port)
 
 TEST (network, peer_max_tcp_attempts)
 {
-	nano::system system (1);
-	auto node (system.nodes[0]);
 	// Add nodes that can accept TCP connection, but not node ID handshake
 	nano::node_flags node_flags;
-	node_flags.disable_tcp_realtime = true;
+	node_flags.disable_connection_cleanup = true;
+	nano::system system;
+	auto node = system.add_node (node_flags);
 	for (auto i (0); i < node->network_params.node.max_peers_per_ip; ++i)
 	{
 		auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -105,7 +105,10 @@ nano::network::~network ()
 
 void nano::network::start ()
 {
-	ongoing_cleanup ();
+	if (!node.flags.disable_connection_cleanup)
+	{
+		ongoing_cleanup ();
+	}
 	ongoing_syn_cookie_cleanup ();
 	if (!node.flags.disable_udp)
 	{

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -148,6 +148,7 @@ public:
 	bool enable_pruning{ false };
 	bool fast_bootstrap{ false };
 	bool read_only{ false };
+	bool disable_connection_cleanup{ false };
 	nano::confirmation_height_mode confirmation_height_processor_mode{ nano::confirmation_height_mode::automatic };
 	nano::generate_cache generate_cache;
 	bool inactive_node{ false };


### PR DESCRIPTION
This test starts several node instances which can be slow to start, especially with TEST_USE_ROCKSDB=1. This would cause connections to be cleaned up before the substantial ASSERTs were checked. This splits the node construction and connection loops so connections are done immediately before the network checks.