### PR TITLE
Rename socket::type_t

### DIFF
--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -34,13 +34,6 @@ private:
 std::unique_ptr<container_info_component> collect_container_info (bootstrap_listener & bootstrap_listener, std::string const & name);
 
 class message;
-enum class bootstrap_server_type
-{
-	undefined,
-	bootstrap,
-	realtime,
-	realtime_response_server // special type for tcp channel response server
-};
 class bootstrap_server final : public std::enable_shared_from_this<nano::bootstrap_server>
 {
 public:
@@ -71,7 +64,7 @@ public:
 	nano::mutex mutex;
 	std::queue<std::unique_ptr<nano::message>> requests;
 	std::atomic<bool> stopped{ false };
-	std::atomic<nano::bootstrap_server_type> type{ nano::bootstrap_server_type::undefined };
+	std::atomic<nano::socket::type_t> type{ nano::socket::type_t::undefined };
 	// Remote enpoint used to remove response channel even after socket closing
 	nano::tcp_endpoint remote_endpoint{ boost::asio::ip::address_v6::any (), 0 };
 	nano::account remote_node_id{ 0 };

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -925,7 +925,7 @@ nano::tcp_message_item nano::tcp_message_manager::get_message ()
 	}
 	else
 	{
-		result = nano::tcp_message_item{ std::make_shared<nano::keepalive> (), nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0), 0, nullptr, nano::bootstrap_server_type::undefined };
+		result = nano::tcp_message_item{ std::make_shared<nano::keepalive> (), nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0), 0, nullptr, nano::socket::type_t::undefined };
 	}
 	lock.unlock ();
 	producer_condition.notify_one ();

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -33,6 +33,13 @@ class socket : public std::enable_shared_from_this<nano::socket>
 	friend class server_socket;
 
 public:
+	enum class type_t
+	{
+		undefined,
+		bootstrap,
+		realtime,
+		realtime_response_server // special type for tcp channel response server
+	};
 	/**
 	 * Constructor
 	 * @param node Owning node

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -288,7 +288,7 @@ void nano::transport::tcp_channels::process_messages ()
 	}
 }
 
-void nano::transport::tcp_channels::process_message (nano::message const & message_a, nano::tcp_endpoint const & endpoint_a, nano::account const & node_id_a, std::shared_ptr<nano::socket> const & socket_a, nano::bootstrap_server_type type_a)
+void nano::transport::tcp_channels::process_message (nano::message const & message_a, nano::tcp_endpoint const & endpoint_a, nano::account const & node_id_a, std::shared_ptr<nano::socket> const & socket_a, nano::socket::type_t type_a)
 {
 	if (!stopped && message_a.header.version_using >= protocol_constants ().protocol_version_min ())
 	{
@@ -315,9 +315,9 @@ void nano::transport::tcp_channels::process_message (nano::message const & messa
 					temporary_channel->set_node_id (node_id_a);
 					temporary_channel->set_network_version (message_a.header.version_using);
 					temporary_channel->temporary = true;
-					debug_assert (type_a == nano::bootstrap_server_type::realtime || type_a == nano::bootstrap_server_type::realtime_response_server);
+					debug_assert (type_a == nano::socket::type_t::realtime || type_a == nano::socket::type_t::realtime_response_server);
 					// Don't insert temporary channels for response_server
-					if (type_a == nano::bootstrap_server_type::realtime)
+					if (type_a == nano::socket::type_t::realtime)
 					{
 						insert (temporary_channel, socket_a, nullptr);
 					}
@@ -327,7 +327,7 @@ void nano::transport::tcp_channels::process_message (nano::message const & messa
 				{
 					// Initial node_id_handshake request without node ID
 					debug_assert (message_a.header.type == nano::message_type::node_id_handshake);
-					debug_assert (type_a == nano::bootstrap_server_type::undefined);
+					debug_assert (type_a == nano::socket::type_t::undefined);
 					node.stats.inc (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in);
 				}
 			}
@@ -691,7 +691,7 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 														callback_a (channel_a);
 													}
 													// Listen for possible responses
-													response_server->type = nano::bootstrap_server_type::realtime_response_server;
+													response_server->type = nano::socket::type_t::realtime_response_server;
 													response_server->remote_node_id = channel_a->get_node_id ();
 													response_server->receive ();
 													node_l->network.tcp_channels.remove_node_id_handshake_socket (socket_l);

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -17,7 +17,6 @@ namespace mi = boost::multi_index;
 namespace nano
 {
 class bootstrap_server;
-enum class bootstrap_server_type;
 class tcp_message_item final
 {
 public:
@@ -25,7 +24,7 @@ public:
 	nano::tcp_endpoint endpoint;
 	nano::account node_id;
 	std::shared_ptr<nano::socket> socket;
-	nano::bootstrap_server_type type;
+	nano::socket::type_t type;
 };
 namespace transport
 {
@@ -93,7 +92,7 @@ namespace transport
 		void start ();
 		void stop ();
 		void process_messages ();
-		void process_message (nano::message const &, nano::tcp_endpoint const &, nano::account const &, std::shared_ptr<nano::socket> const &, nano::bootstrap_server_type);
+		void process_message (nano::message const &, nano::tcp_endpoint const &, nano::account const &, std::shared_ptr<nano::socket> const &, nano::socket::type_t);
 		bool max_ip_connections (nano::tcp_endpoint const &);
 		// Should we reach out to this endpoint with a keepalive message
 		bool reachout (nano::endpoint const &);


### PR DESCRIPTION
This renames bootstrap_server_type to socket::type_t and moves the type declaration on to the socket class since this is a socket-related property, not necessarily related to bootstrapping.