### PR TITLE
This disallows passing in a nullptr socket in to bootstrap_server.

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -11,7 +11,7 @@ using namespace std::chrono_literals;
 TEST (bulk_pull, no_address)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = 1;
 	req->end = 2;
@@ -24,7 +24,7 @@ TEST (bulk_pull, no_address)
 TEST (bulk_pull, genesis_to_end)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::dev_genesis_key.pub;
 	req->end.clear ();
@@ -38,7 +38,7 @@ TEST (bulk_pull, genesis_to_end)
 TEST (bulk_pull, no_end)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::dev_genesis_key.pub;
 	req->end = 1;
@@ -63,7 +63,7 @@ TEST (bulk_pull, end_not_owned)
 	open.signature = nano::sign_message (key2.prv, key2.pub, open.hash ());
 	system.nodes[0]->work_generate_blocking (open);
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	nano::genesis genesis;
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = key2.pub;
@@ -76,7 +76,7 @@ TEST (bulk_pull, end_not_owned)
 TEST (bulk_pull, none)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	nano::genesis genesis;
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::dev_genesis_key.pub;
@@ -90,7 +90,7 @@ TEST (bulk_pull, none)
 TEST (bulk_pull, get_next_on_open)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = nano::dev_genesis_key.pub;
 	req->end.clear ();
@@ -106,7 +106,7 @@ TEST (bulk_pull, get_next_on_open)
 TEST (bulk_pull, by_block)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	nano::genesis genesis;
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = genesis.hash ();
@@ -124,7 +124,7 @@ TEST (bulk_pull, by_block)
 TEST (bulk_pull, by_block_single)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	nano::genesis genesis;
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = genesis.hash ();
@@ -150,7 +150,7 @@ TEST (bulk_pull, count_limit)
 	auto receive1 (std::make_shared<nano::receive_block> (send1->hash (), send1->hash (), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive1).code);
 
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, node0));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node0), node0));
 	auto req = std::make_unique<nano::bulk_pull> ();
 	req->start = receive1->hash ();
 	req->set_count_present (true);
@@ -1426,7 +1426,7 @@ TEST (frontier_req_response, DISABLED_destruction)
 TEST (frontier_req, begin)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1441,7 +1441,7 @@ TEST (frontier_req, begin)
 TEST (frontier_req, end)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> ();
 	req->start = nano::dev_genesis_key.pub.number () + 1;
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1484,7 +1484,7 @@ TEST (frontier_req, count)
 	node1->work_generate_blocking (*receive1);
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive1).code);
 
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1498,7 +1498,7 @@ TEST (frontier_req, count)
 TEST (frontier_req, time_bound)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = 1;
@@ -1512,7 +1512,7 @@ TEST (frontier_req, time_bound)
 	req2->start.clear ();
 	req2->age = 1;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
-	auto connection2 (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	connection2->requests.push (std::unique_ptr<nano::message>{});
 	auto request2 (std::make_shared<nano::frontier_req_server> (connection, std::move (req2)));
 	ASSERT_TRUE (request2->current.is_zero ());
@@ -1521,7 +1521,7 @@ TEST (frontier_req, time_bound)
 TEST (frontier_req, time_cutoff)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = 3;
@@ -1537,7 +1537,7 @@ TEST (frontier_req, time_cutoff)
 	req2->start.clear ();
 	req2->age = 3;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
-	auto connection2 (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 	connection2->requests.push (std::unique_ptr<nano::message>{});
 	auto request2 (std::make_shared<nano::frontier_req_server> (connection, std::move (req2)));
 	ASSERT_TRUE (request2->frontier.is_zero ());
@@ -1612,7 +1612,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive2).code);
 
 	// Request for all accounts (confirmed only)
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req = std::make_unique<nano::frontier_req> ();
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1626,7 +1626,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (genesis.hash (), request->frontier);
 
 	// Request starting with account before genesis (confirmed only)
-	auto connection2 (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req2 = std::make_unique<nano::frontier_req> ();
 	req2->start = key_before_genesis.pub;
 	req2->age = std::numeric_limits<decltype (req2->age)>::max ();
@@ -1640,7 +1640,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (genesis.hash (), request2->frontier);
 
 	// Request starting with account after genesis (confirmed only)
-	auto connection3 (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection3 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req3 = std::make_unique<nano::frontier_req> ();
 	req3->start = key_after_genesis.pub;
 	req3->age = std::numeric_limits<decltype (req3->age)>::max ();
@@ -1654,7 +1654,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_TRUE (request3->frontier.is_zero ());
 
 	// Request for all accounts (unconfirmed blocks)
-	auto connection4 (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection4 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req4 = std::make_unique<nano::frontier_req> ();
 	req4->start.clear ();
 	req4->age = std::numeric_limits<decltype (req4->age)>::max ();
@@ -1666,7 +1666,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (receive1->hash (), request4->frontier);
 
 	// Request starting with account after genesis (unconfirmed blocks)
-	auto connection5 (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection5 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req5 = std::make_unique<nano::frontier_req> ();
 	req5->start = key_after_genesis.pub;
 	req5->age = std::numeric_limits<decltype (req5->age)>::max ();
@@ -1680,7 +1680,7 @@ TEST (frontier_req, confirmed_frontier)
 	// Confirm account before genesis (confirmed only)
 	nano::blocks_confirm (*node1, { send1, receive1 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()));
-	auto connection6 (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection6 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req6 = std::make_unique<nano::frontier_req> ();
 	req6->start = key_before_genesis.pub;
 	req6->age = std::numeric_limits<decltype (req6->age)>::max ();
@@ -1696,7 +1696,7 @@ TEST (frontier_req, confirmed_frontier)
 	// Confirm account after genesis (confirmed only)
 	nano::blocks_confirm (*node1, { send2, receive2 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send2->hash ()) && node1->block_confirmed (receive2->hash ()));
-	auto connection7 (std::make_shared<nano::bootstrap_server> (nullptr, node1));
+	auto connection7 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
 	auto req7 = std::make_unique<nano::frontier_req> ();
 	req7->start = key_after_genesis.pub;
 	req7->age = std::numeric_limits<decltype (req7->age)>::max ();
@@ -1871,7 +1871,7 @@ TEST (bulk_pull_account, basics)
 	auto send2 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 10));
 	auto send3 (system.wallet (0)->send_action (nano::genesis_account, key1.pub, 2));
 	ASSERT_TIMELY (5s, system.nodes[0]->balance (key1.pub) == 25);
-	auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 
 	{
 		auto req = std::make_unique<nano::bulk_pull_account> ();

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -102,6 +102,7 @@ nano::bootstrap_server::bootstrap_server (std::shared_ptr<nano::socket> const & 
 	socket (socket_a),
 	node (node_a)
 {
+	debug_assert (socket_a != nullptr);
 	receive_buffer->resize (1024);
 }
 


### PR DESCRIPTION
This was only done in tests so it didn't reflect actual usage.