### PR TITLE
Fix half principal rep check

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -82,7 +82,7 @@ nano::frontiers_confirmation_info nano::active_transactions::get_frontiers_confi
 	// Limit maximum count of elections to start
 	auto rep_counts (node.wallets.reps ());
 	bool representative (node.config.enable_voting && rep_counts.voting > 0);
-	bool half_princpal_representative (representative && rep_counts.half_principal > 0);
+	bool half_princpal_representative (representative && rep_counts.have_half_rep ());
 	/* Check less frequently for regular nodes in auto mode */
 	bool agressive_mode (half_princpal_representative || node.config.frontiers_confirmation == nano::frontiers_confirmation_mode::always);
 	auto is_dev_network = node.network_params.network.is_dev_network ();

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1643,6 +1643,11 @@ bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t 
 		lock = nano::unique_lock<nano::mutex> (reps_cache_mutex);
 	}
 
+	if (weight >= half_principal_weight_a)
+	{
+		++representatives.half_principal;
+	}
+
 	auto insert_result = representatives.accounts.insert (account_a);
 	if (!insert_result.second)
 	{
@@ -1650,11 +1655,6 @@ bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t 
 	}
 
 	++representatives.voting;
-
-	if (weight >= half_principal_weight_a)
-	{
-		++representatives.half_principal;
-	}
 
 	return true;
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1645,7 +1645,7 @@ bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t 
 
 	if (weight >= half_principal_weight_a)
 	{
-		++representatives.half_principal;
+		representatives.half_principal = true;
 	}
 
 	auto insert_result = representatives.accounts.insert (account_a);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -165,11 +165,11 @@ class wallet_representatives
 {
 public:
 	uint64_t voting{ 0 }; // Number of representatives with at least the configured minimum voting weight
-	uint64_t half_principal{ 0 }; // Number of representatives with at least 50% of principal representative requirements
+	bool half_principal{ false }; // has representatives with at least 50% of principal representative requirements
 	std::unordered_set<nano::account> accounts; // Representatives with at least the configured minimum voting weight
 	bool have_half_rep () const
 	{
-		return half_principal > 0;
+		return half_principal;
 	}
 	bool exists (nano::account const & rep_a) const
 	{
@@ -178,7 +178,7 @@ public:
 	void clear ()
 	{
 		voting = 0;
-		half_principal = 0;
+		half_principal = false;
 		accounts.clear ();
 	}
 };


### PR DESCRIPTION
Check for half principal even if the account is a duplicate
    
An account might be added that is not a half principal but might become a half principal later. So we should check for half principal every time.

 Convert half_principal counter to boolean
 
The counting of half principals without tracking what is counted is
unreliable. Fortunately, we only care about whether a half principal
exists or not. So therefore convert the counter to a boolean so that
the counter does not get used when it is wrong.

