### PR TITLE
Fix for unit test active_transactions.vote_replays #3360

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -530,7 +530,6 @@ TEST (active_transactions, vote_replays)
 	// Open new account
 	auto vote_open1 (std::make_shared<nano::vote> (nano::dev_genesis_key.pub, nano::dev_genesis_key.prv, std::numeric_limits<uint64_t>::max (), open1));
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote_open1));
-	ASSERT_EQ (1, node.active.size ());
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_open1));
 	ASSERT_TIMELY (3s, node.active.empty ());
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_open1));


### PR DESCRIPTION
We cannot expect the vote to survive long enough for the test to see it

Fixes issue:
https://github.com/nanocurrency/nano-node/issues/3360