### PR TITLE
Fix for unit test bulk.offline_send

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1761,7 +1761,7 @@ TEST (bulk, offline_send)
 	node1->scheduler.flush ();
 	// Wait to finish election background tasks
 	ASSERT_TIMELY (10s, node1->active.empty ());
-	ASSERT_TRUE (node1->block_confirmed (send1->hash ()));
+	ASSERT_TIMELY (10s, node1->block_confirmed (send1->hash ()));
 	// Initiate bootstrap
 	node2->bootstrap_initiator.bootstrap (node1->network.endpoint ());
 	// Nodes should find each other


### PR DESCRIPTION
The test expected the ledger to be able to report a block as confirmed
because the active transaction container was empty. But it has to allow
for some time for the data/event to flow to the ledger.

Converted an assert to an assert timely to allow for that propagation.

This is the failure:
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from bulk
[ RUN      ] bulk.offline_send
/home/ds/nano/branches/develop/nano-node/nano/core_test/bootstrap.cpp:1764: Failure
Value of: node1->block_confirmed (send1->hash ())
  Actual: false
Expected: true
terminate called after throwing an instance of 'testing::internal::GoogleTestFailureException'
  what():  /home/ds/nano/branches/develop/nano-node/nano/core_test/bootstrap.cpp:1764: Failure
Value of: node1->block_confirmed (send1->hash ())
  Actual: false
Expected: true
Aborted