### PR TITLE
Convert static network id code to instance code

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -46,6 +46,7 @@ TEST (message, publish_serialization)
 {
 	nano::network_params params;
 	nano::publish publish (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
+	publish.header.network = nano::networks::nano_dev_network;
 	ASSERT_EQ (nano::block_type::send, publish.header.block_type ());
 	std::vector<uint8_t> bytes;
 	{

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1256,3 +1256,17 @@ TEST (network, loopback_channel)
 	++node1.network.port;
 	ASSERT_NE (channel1.get_endpoint (), node1.network.endpoint ());
 }
+
+// Ensure the network filters messages with the incorrect magic number
+TEST (network, filter)
+{
+	nano::system system{ 1 };
+	auto & node1 = *system.nodes[0];
+	nano::keepalive keepalive;
+	keepalive.header.network = nano::networks::nano_dev_network;
+	node1.network.inbound (keepalive, std::make_shared<nano::transport::channel_loopback> (node1));
+	ASSERT_EQ (0, node1.stats.count (nano::stat::type::message, nano::stat::detail::invalid_network));
+	keepalive.header.network = nano::networks::invalid;
+	node1.network.inbound (keepalive, std::make_shared<nano::transport::channel_loopback> (node1));
+	ASSERT_EQ (1, node1.stats.count (nano::stat::type::message, nano::stat::detail::invalid_network));
+}

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -112,7 +112,7 @@ std::array<uint8_t, 2> test_magic_number ()
 
 void force_nano_dev_network ()
 {
-	nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+	nano::network_constants::set_active_network (nano::networks::nano_dev_network);
 }
 
 bool running_within_valgrind ()

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -64,6 +64,7 @@ std::array<uint8_t, 2> test_magic_number ();
  */
 enum class networks : uint16_t
 {
+	invalid = 0x0,
 	// Low work parameters, publicly known genesis key, dev IP ports
 	nano_dev_network = 0x5241, // 'R', 'A'
 	// Normal work parameters, secret beta genesis key, beta IP ports

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -61,18 +61,17 @@ std::array<uint8_t, 2> test_magic_number ();
 
 /**
  * Network variants with different genesis blocks and network parameters
- * @warning Enum values are used in integral comparisons; do not change.
  */
-enum class nano_networks
+enum class networks : uint16_t
 {
 	// Low work parameters, publicly known genesis key, dev IP ports
-	nano_dev_network = 0,
+	nano_dev_network = 0x5241, // 'R', 'A'
 	// Normal work parameters, secret beta genesis key, beta IP ports
-	nano_beta_network = 1,
+	nano_beta_network = 0x5242, // 'R', 'B'
 	// Normal work parameters, secret live key, live IP ports
-	nano_live_network = 2,
+	nano_live_network = 0x5243, // 'R', 'C'
 	// Normal work parameters, secret test genesis key, test IP ports
-	nano_test_network = 3,
+	nano_test_network = 0x5258, // 'R', 'X'
 };
 
 struct work_thresholds
@@ -108,7 +107,7 @@ public:
 	{
 	}
 
-	network_constants (nano_networks network_a) :
+	network_constants (nano::networks network_a) :
 		current_network (network_a),
 		publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : is_test_network () ? publish_test : publish_dev)
 	{
@@ -132,7 +131,7 @@ public:
 	static const char * active_network_err_msg;
 
 	/** The network this param object represents. This may differ from the global active network; this is needed for certain --debug... commands */
-	nano_networks current_network{ nano::network_constants::active_network };
+	nano::networks current_network{ nano::network_constants::active_network };
 	nano::work_thresholds publish_thresholds;
 
 	unsigned principal_weight_factor;
@@ -143,7 +142,7 @@ public:
 	unsigned request_interval_ms;
 
 	/** Returns the network this object contains values for */
-	nano_networks network () const
+	nano::networks network () const
 	{
 		return current_network;
 	}
@@ -153,7 +152,7 @@ public:
 	 * If not called, the compile-time option will be used.
 	 * @param network_a The new active network
 	 */
-	static void set_active_network (nano_networks network_a)
+	static void set_active_network (nano::networks network_a)
 	{
 		active_network = network_a;
 	}
@@ -168,19 +167,19 @@ public:
 		auto error{ false };
 		if (network_a == "live")
 		{
-			active_network = nano::nano_networks::nano_live_network;
+			active_network = nano::networks::nano_live_network;
 		}
 		else if (network_a == "beta")
 		{
-			active_network = nano::nano_networks::nano_beta_network;
+			active_network = nano::networks::nano_beta_network;
 		}
 		else if (network_a == "dev")
 		{
-			active_network = nano::nano_networks::nano_dev_network;
+			active_network = nano::networks::nano_dev_network;
 		}
 		else if (network_a == "test")
 		{
-			active_network = nano::nano_networks::nano_test_network;
+			active_network = nano::networks::nano_test_network;
 		}
 		else
 		{
@@ -196,23 +195,23 @@ public:
 
 	bool is_live_network () const
 	{
-		return current_network == nano_networks::nano_live_network;
+		return current_network == nano::networks::nano_live_network;
 	}
 	bool is_beta_network () const
 	{
-		return current_network == nano_networks::nano_beta_network;
+		return current_network == nano::networks::nano_beta_network;
 	}
 	bool is_dev_network () const
 	{
-		return current_network == nano_networks::nano_dev_network;
+		return current_network == nano::networks::nano_dev_network;
 	}
 	bool is_test_network () const
 	{
-		return current_network == nano_networks::nano_test_network;
+		return current_network == nano::networks::nano_test_network;
 	}
 
 	/** Initial value is ACTIVE_NETWORK compile flag, but can be overridden by a CLI flag */
-	static nano::nano_networks active_network;
+	static nano::networks active_network;
 };
 
 std::string get_config_path (boost::filesystem::path const & data_path);

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -883,6 +883,9 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::generator_spacing:
 			res = "generator_spacing";
 			break;
+		case nano::stat::detail::invalid_network:
+			res = "invalid_network";
+			break;
 	}
 	return res;
 }

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -255,6 +255,7 @@ public:
 		insufficient_work,
 		http_callback,
 		unreachable_host,
+		invalid_network,
 
 		// confirmation_observer specific
 		active_quorum,

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -887,7 +887,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_process"))
 		{
-			nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+			nano::network_constants::set_active_network (nano::networks::nano_dev_network);
 			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t num_accounts (100000);
@@ -1004,7 +1004,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_votes"))
 		{
-			nano::network_constants::set_active_network (nano::nano_networks::nano_dev_network);
+			nano::network_constants::set_active_network (nano::networks::nano_dev_network);
 			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t num_elections (40000);

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -82,13 +82,14 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 	try
 	{
 		static nano::network_params network_params;
-		uint16_t extensions_l;
-		nano::read (stream_a, network);
-		boost::endian::big_to_native_inplace (network);
+		uint16_t network_bytes;
+		nano::read (stream_a, network_bytes);
+		network = static_cast<nano::networks> (boost::endian::big_to_native (network_bytes));
 		nano::read (stream_a, version_max);
 		nano::read (stream_a, version_using);
 		nano::read (stream_a, version_min_m);
 		nano::read (stream_a, type);
+		uint16_t extensions_l;
 		nano::read (stream_a, extensions_l);
 		extensions = extensions_l;
 	}

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -68,7 +68,7 @@ nano::message_header::message_header (bool & error_a, nano::stream & stream_a)
 void nano::message_header::serialize (nano::stream & stream_a) const
 {
 	static nano::network_params network_params;
-	nano::write (stream_a, boost::endian::native_to_big (network));
+	nano::write (stream_a, boost::endian::native_to_big (static_cast<uint16_t> (network)));
 	nano::write (stream_a, version_max);
 	nano::write (stream_a, version_using);
 	nano::write (stream_a, get_protocol_constants ().protocol_version_min ());

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -50,6 +50,7 @@ uint64_t nano::ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint1
 }
 
 nano::message_header::message_header (nano::message_type type_a) :
+	network (nano::network_constants::active_network),
 	version_max (get_protocol_constants ().protocol_version),
 	version_using (get_protocol_constants ().protocol_version),
 	type (type_a)
@@ -67,7 +68,7 @@ nano::message_header::message_header (bool & error_a, nano::stream & stream_a)
 void nano::message_header::serialize (nano::stream & stream_a) const
 {
 	static nano::network_params network_params;
-	nano::write (stream_a, network_params.header_magic_number);
+	nano::write (stream_a, boost::endian::native_to_big (network));
 	nano::write (stream_a, version_max);
 	nano::write (stream_a, version_using);
 	nano::write (stream_a, get_protocol_constants ().protocol_version_min ());
@@ -82,13 +83,8 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 	{
 		static nano::network_params network_params;
 		uint16_t extensions_l;
-		std::array<uint8_t, 2> magic_number_l;
-		read (stream_a, magic_number_l);
-		if (magic_number_l != network_params.header_magic_number)
-		{
-			throw std::runtime_error ("Magic numbers do not match");
-		}
-
+		nano::read (stream_a, network);
+		boost::endian::big_to_native_inplace (network);
 		nano::read (stream_a, version_max);
 		nano::read (stream_a, version_using);
 		nano::read (stream_a, version_min_m);

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -204,7 +204,7 @@ private:
 public:
 	nano::message_type type;
 	std::bitset<16> extensions;
-	static size_t constexpr size = sizeof (network_params::header_magic_number) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min_m) + sizeof (type) + sizeof (/* extensions */ uint16_t);
+	static size_t constexpr size = sizeof (nano::networks) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min_m) + sizeof (type) + sizeof (/* extensions */ uint16_t);
 
 	void flag_set (uint8_t);
 	static uint8_t constexpr bulk_pull_count_present_flag = 0;

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -195,6 +195,7 @@ public:
 	void block_type_set (nano::block_type);
 	uint8_t count_get () const;
 	void count_set (uint8_t);
+	nano::networks network;
 	uint8_t version_max;
 	uint8_t version_using;
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -21,7 +21,7 @@ nano::network::network (nano::node & node_a, uint16_t port_a) :
 		}
 		else
 		{
-			node.stats.inc (nano::stat::type::message, nano::stat::detail::invalid_network);
+			this->node.stats.inc (nano::stat::type::message, nano::stat::detail::invalid_network);
 		}
 	} },
 	buffer_container (node_a.stats, nano::network::buffer_size, 4096), // 2Mb receive buffer

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -12,8 +12,18 @@
 #include <numeric>
 
 nano::network::network (nano::node & node_a, uint16_t port_a) :
+	id (nano::network_constants::active_network),
 	syn_cookies (node_a.network_params.node.max_peers_per_ip),
-	inbound{ [this] (nano::message const & message, std::shared_ptr<nano::transport::channel> const & channel) { process_message (message, channel); } },
+	inbound{ [this] (nano::message const & message, std::shared_ptr<nano::transport::channel> const & channel) {
+		if (message.header.network == id)
+		{
+			process_message (message, channel);
+		}
+		else
+		{
+			node.stats.inc (nano::stat::type::message, nano::stat::detail::invalid_network);
+		}
+	} },
 	buffer_container (node_a.stats, nano::network::buffer_size, 4096), // 2Mb receive buffer
 	resolver (node_a.io_ctx),
 	limiter (node_a.config.bandwidth_limit_burst_ratio, node_a.config.bandwidth_limit),

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -120,6 +120,7 @@ class network final
 public:
 	network (nano::node &, uint16_t);
 	~network ();
+	nano::networks id;
 	void start ();
 	void stop ();
 	void flood_message (nano::message const &, nano::buffer_drop_policy const = nano::buffer_drop_policy::limiter, float const = 1.0f);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -38,11 +38,11 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 	}
 	switch (network_params.network.network ())
 	{
-		case nano::nano_networks::nano_dev_network:
+		case nano::networks::nano_dev_network:
 			enable_voting = true;
 			preconfigured_representatives.push_back (network_params.ledger.genesis_account);
 			break;
-		case nano::nano_networks::nano_beta_network:
+		case nano::networks::nano_beta_network:
 		{
 			preconfigured_peers.push_back (default_beta_peer_network);
 			nano::account offline_representative;
@@ -50,7 +50,7 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 			preconfigured_representatives.emplace_back (offline_representative);
 			break;
 		}
-		case nano::nano_networks::nano_live_network:
+		case nano::networks::nano_live_network:
 			preconfigured_peers.push_back (default_live_peer_network);
 			preconfigured_representatives.emplace_back ("A30E0A32ED41C8607AA9212843392E853FCBCB4E7CB194E35C94F07F91DE59EF");
 			preconfigured_representatives.emplace_back ("67556D31DDFC2A440BF6147501449B4CB9572278D034EE686A6BEE29851681DF");
@@ -61,7 +61,7 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 			preconfigured_representatives.emplace_back ("2298FAB7C61058E77EA554CB93EDEEDA0692CBFCC540AB213B2836B29029E23A");
 			preconfigured_representatives.emplace_back ("3FE80B4BC842E82C1C18ABFEEC47EA989E63953BC82AC411F304D13833D52A56");
 			break;
-		case nano::nano_networks::nano_test_network:
+		case nano::networks::nano_test_network:
 			preconfigured_peers.push_back (default_test_peer_network);
 			preconfigured_representatives.push_back (network_params.ledger.genesis_account);
 			break;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -90,7 +90,6 @@ nano::network_params::network_params (nano::networks network_a) :
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_dev_work = 8;
 	kdf_work = network.is_dev_network () ? kdf_dev_work : kdf_full_work;
-	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'R', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'R', 'B' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'R', 'C' } } : nano::test_magic_number ();
 }
 
 uint8_t nano::protocol_constants::protocol_version_min () const

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -21,7 +21,7 @@ size_t constexpr nano::open_block::size;
 size_t constexpr nano::change_block::size;
 size_t constexpr nano::state_block::size;
 
-nano::nano_networks nano::network_constants::active_network = nano::nano_networks::ACTIVE_NETWORK;
+nano::networks nano::network_constants::active_network = nano::networks::ACTIVE_NETWORK;
 
 namespace
 {
@@ -84,7 +84,7 @@ nano::network_params::network_params () :
 {
 }
 
-nano::network_params::network_params (nano::nano_networks network_a) :
+nano::network_params::network_params (nano::networks network_a) :
 	network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
 {
 	unsigned constexpr kdf_full_work = 64 * 1024;
@@ -103,7 +103,7 @@ nano::ledger_constants::ledger_constants (nano::network_constants & network_cons
 {
 }
 
-nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
+nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	zero_key ("0"),
 	dev_genesis_key (dev_private_key_data),
 	nano_dev_account (dev_public_key_data),
@@ -114,8 +114,8 @@ nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
 	nano_beta_genesis (beta_genesis_data),
 	nano_live_genesis (live_genesis_data),
 	nano_test_genesis (test_genesis_data),
-	genesis_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_account),
-	genesis_block (network_a == nano::nano_networks::nano_dev_network ? nano_dev_genesis : network_a == nano::nano_networks::nano_beta_network ? nano_beta_genesis : network_a == nano::nano_networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
+	genesis_account (network_a == nano::networks::nano_dev_network ? nano_dev_account : network_a == nano::networks::nano_beta_network ? nano_beta_account : network_a == nano::networks::nano_test_network ? nano_test_account : nano_live_account),
+	genesis_block (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
 	genesis_hash (parse_block_from_genesis_data (genesis_block)->hash ()),
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 	burn_account (0),
@@ -123,12 +123,12 @@ nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
 	nano_beta_final_votes_canary_account (beta_canary_public_key_data),
 	nano_live_final_votes_canary_account (live_canary_public_key_data),
 	nano_test_final_votes_canary_account (test_canary_public_key_data),
-	final_votes_canary_account (network_a == nano::nano_networks::nano_dev_network ? nano_dev_final_votes_canary_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_final_votes_canary_account : network_a == nano::nano_networks::nano_test_network ? nano_test_final_votes_canary_account : nano_live_final_votes_canary_account),
+	final_votes_canary_account (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_account : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_account : network_a == nano::networks::nano_test_network ? nano_test_final_votes_canary_account : nano_live_final_votes_canary_account),
 	nano_dev_final_votes_canary_height (1),
 	nano_beta_final_votes_canary_height (1),
 	nano_live_final_votes_canary_height (1),
 	nano_test_final_votes_canary_height (1),
-	final_votes_canary_height (network_a == nano::nano_networks::nano_dev_network ? nano_dev_final_votes_canary_height : network_a == nano::nano_networks::nano_beta_network ? nano_beta_final_votes_canary_height : network_a == nano::nano_networks::nano_test_network ? nano_test_final_votes_canary_height : nano_live_final_votes_canary_height)
+	final_votes_canary_height (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_height : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_height : network_a == nano::networks::nano_test_network ? nano_test_final_votes_canary_height : nano_live_final_votes_canary_height)
 {
 	nano::link epoch_link_v1;
 	const char * epoch_message_v1 ("epoch v1 block");
@@ -139,7 +139,7 @@ nano::ledger_constants::ledger_constants (nano::nano_networks network_a) :
 	nano::account nano_live_epoch_v2_signer;
 	auto error (nano_live_epoch_v2_signer.decode_account ("nano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
 	debug_assert (!error);
-	auto epoch_v2_signer (network_a == nano::nano_networks::nano_dev_network ? nano_dev_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : network_a == nano::nano_networks::nano_test_network ? nano_test_account : nano_live_epoch_v2_signer);
+	auto epoch_v2_signer (network_a == nano::networks::nano_dev_network ? nano_dev_account : network_a == nano::networks::nano_beta_network ? nano_beta_account : network_a == nano::networks::nano_test_network ? nano_test_account : nano_live_epoch_v2_signer);
 	const char * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -475,7 +475,6 @@ public:
 	/** Populate values based on \p network_a */
 	network_params (nano::networks network_a);
 
-	std::array<uint8_t, 2> header_magic_number;
 	unsigned kdf_work;
 	network_constants network;
 	protocol_constants protocol;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -367,7 +367,7 @@ class ledger_constants
 {
 public:
 	ledger_constants (nano::network_constants & network_constants);
-	ledger_constants (nano::nano_networks network_a);
+	ledger_constants (nano::networks network_a);
 	nano::keypair zero_key;
 	nano::keypair dev_genesis_key;
 	nano::account nano_dev_account;
@@ -473,7 +473,7 @@ public:
 	network_params ();
 
 	/** Populate values based on \p network_a */
-	network_params (nano::nano_networks network_a);
+	network_params (nano::networks network_a);
 
 	std::array<uint8_t, 2> header_magic_number;
 	unsigned kdf_work;

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -12,6 +12,9 @@ boost::filesystem::path nano::working_path (bool legacy)
 	auto result (nano::app_path ());
 	switch (network_constants.network ())
 	{
+		case nano::networks::invalid:
+			release_assert (false);
+			break;
 		case nano::networks::nano_dev_network:
 			if (!legacy)
 			{

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -12,7 +12,7 @@ boost::filesystem::path nano::working_path (bool legacy)
 	auto result (nano::app_path ());
 	switch (network_constants.network ())
 	{
-		case nano::nano_networks::nano_dev_network:
+		case nano::networks::nano_dev_network:
 			if (!legacy)
 			{
 				result /= "NanoDev";
@@ -22,7 +22,7 @@ boost::filesystem::path nano::working_path (bool legacy)
 				result /= "RaiBlocksDev";
 			}
 			break;
-		case nano::nano_networks::nano_beta_network:
+		case nano::networks::nano_beta_network:
 			if (!legacy)
 			{
 				result /= "NanoBeta";
@@ -32,7 +32,7 @@ boost::filesystem::path nano::working_path (bool legacy)
 				result /= "RaiBlocksBeta";
 			}
 			break;
-		case nano::nano_networks::nano_live_network:
+		case nano::networks::nano_live_network:
 			if (!legacy)
 			{
 				result /= "Nano";
@@ -42,7 +42,7 @@ boost::filesystem::path nano::working_path (bool legacy)
 				result /= "RaiBlocks";
 			}
 			break;
-		case nano::nano_networks::nano_test_network:
+		case nano::networks::nano_test_network:
 			if (!legacy)
 			{
 				result /= "NanoTest";

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -212,7 +212,7 @@ uint64_t nano::system::work_generate_limited (nano::block_hash const & root_a, u
 std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a, nano::ledger & ledger_a, nano::epoch epoch_a)
 {
 	auto transaction (ledger_a.store.tx_begin_write ());
-	auto dev_genesis_key = nano::ledger_constants (nano::nano_networks::nano_dev_network).dev_genesis_key;
+	auto dev_genesis_key = nano::ledger_constants (nano::networks::nano_dev_network).dev_genesis_key;
 	auto account = dev_genesis_key.pub;
 	auto latest = ledger_a.latest (transaction, account);
 	auto balance = ledger_a.account_balance (transaction, account);
@@ -398,7 +398,7 @@ void nano::system::generate_receive (nano::node & node_a)
 	}
 	if (send_block != nullptr)
 	{
-		auto receive_error (wallet (0)->receive_sync (send_block, nano::ledger_constants (nano::nano_networks::nano_dev_network).genesis_account, std::numeric_limits<nano::uint128_t>::max ()));
+		auto receive_error (wallet (0)->receive_sync (send_block, nano::ledger_constants (nano::networks::nano_dev_network).genesis_account, std::numeric_limits<nano::uint128_t>::max ()));
 		(void)receive_error;
 	}
 }
@@ -523,7 +523,7 @@ void nano::system::generate_send_new (nano::node & node_a, std::vector<nano::acc
 void nano::system::generate_mass_activity (uint32_t count_a, nano::node & node_a)
 {
 	std::vector<nano::account> accounts;
-	auto dev_genesis_key = nano::ledger_constants (nano::nano_networks::nano_dev_network).dev_genesis_key;
+	auto dev_genesis_key = nano::ledger_constants (nano::networks::nano_dev_network).dev_genesis_key;
 	wallet (0)->insert_adhoc (dev_genesis_key.prv);
 	accounts.push_back (dev_genesis_key.pub);
 	auto previous (std::chrono::steady_clock::now ());

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -12,7 +12,7 @@ using namespace std::chrono_literals;
 /* Convenience constants for tests which are always on the test network */
 namespace
 {
-nano::ledger_constants dev_constants (nano::nano_networks::nano_dev_network);
+nano::ledger_constants dev_constants (nano::networks::nano_dev_network);
 }
 
 nano::keypair const & nano::zero_key (dev_constants.zero_key);


### PR DESCRIPTION
This change cleans up some of the static data related to the network id/magic number parsed in message headers. Originally the network the node would run on, test/dev/beta/live, was determined statically by a CMake variable. This was changed to be able to be overridden at runtime with the --network flag however many of the static variables remained which needed awkward workarounds to deal with.