### PR TITLE
Remove 1 sec socket timeout in dev mode (becomes 2 sec as in normal m…

### DIFF
--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -124,7 +124,7 @@ void nano::socket::stop_timer ()
 void nano::socket::checkup ()
 {
 	std::weak_ptr<nano::socket> this_w (shared_from_this ());
-	node.workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::seconds (node.network_params.network.is_dev_network () ? 1 : 2), [this_w] () {
+	node.workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::seconds (2), [this_w] () {
 		if (auto this_l = this_w.lock ())
 		{
 			uint64_t now (nano::seconds_since_epoch ());


### PR DESCRIPTION
…ode)

A 1 second timeout seems a little too aggressive even in dev mode.
It can lead to false failures in tests.

Also, it is a complication too far. It is an extra logical branch,
a complication that, as far as I can see, it does not give us anything
useful, except from the possibility of slightly faster unit test runs but
reliability should be more important than a possible slight speed increase
in unit test execution.