### PR TITLE
Disable compilation/usage of diskhash on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,8 +379,10 @@ find_package(Boost 1.70.0 REQUIRED COMPONENTS filesystem log log_setup thread
                                               program_options system)
 
 # diskhash
-add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
-include_directories(diskhash/src)
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
+  include_directories(diskhash/src)
+endif()
 
 # RocksDB
 include_directories(rocksdb/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,7 @@ find_package(Boost 1.70.0 REQUIRED COMPONENTS filesystem log log_setup thread
                                               program_options system)
 
 # diskhash
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
   include_directories(diskhash/src)
 endif()

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -6,6 +6,9 @@
 
 #include <numeric>
 
+// TODO: keep this until diskhash builds fine on Windows
+#ifndef _WIN32
+
 using namespace std::chrono_literals;
 
 TEST (ledger_walker, genesis_block)
@@ -218,3 +221,5 @@ TEST (ledger_walker, ladder_geometry)
 
 	EXPECT_EQ (amounts_expected_itr, amounts_expected_backwards.crend ());
 }
+
+#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -150,6 +150,10 @@ add_library(
   write_database_queue.cpp
   xorshift.hpp)
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(DISKHASH diskhash)
+endif()
+
 target_link_libraries(
   node
   rpc
@@ -166,7 +170,7 @@ target_link_libraries(
   Boost::thread
   Boost::boost
   rocksdb
-  diskhash
+  ${DISKHASH}
   ${CMAKE_DL_LIBS}
   ${psapi_lib})
 

--- a/nano/node/ledger_walker.cpp
+++ b/nano/node/ledger_walker.cpp
@@ -1,3 +1,6 @@
+// TODO: keep this until diskhash builds fine on Windows
+#ifndef _WIN32
+
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/node/ledger_walker.hpp>
@@ -173,3 +176,5 @@ std::shared_ptr<nano::block> nano::ledger_walker::dequeue_block (nano::transacti
 
 	return block;
 }
+
+#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/node/ledger_walker.hpp
+++ b/nano/node/ledger_walker.hpp
@@ -1,3 +1,6 @@
+// TODO: keep this until diskhash builds fine on Windows
+#ifndef _WIN32
+
 #pragma once
 
 #include <nano/lib/numbers.hpp>
@@ -58,3 +61,5 @@ private:
 };
 
 }
+
+#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -32,9 +32,9 @@ std::shared_ptr<nano::node> nano::system::add_node (nano::node_flags node_flags_
 std::shared_ptr<nano::node> nano::system::add_node (nano::node_config const & node_config_a, nano::node_flags node_flags_a, nano::transport::transport_type type_a)
 {
 	auto node (std::make_shared<nano::node> (io_ctx, nano::unique_path (), node_config_a, work, node_flags_a, node_sequence++));
-	for (auto i: initialization_blocks)
+	for (auto i : initialization_blocks)
 	{
-		auto result = node->ledger.process (node->store.tx_begin_write(), *i);
+		auto result = node->ledger.process (node->store.tx_begin_write (), *i);
 		debug_assert (result.code == nano::process_result::progress);
 	}
 	debug_assert (!node->init_error ());
@@ -154,27 +154,27 @@ void nano::system::ledger_initialization_set (std::vector<nano::keypair> const &
 	nano::block_hash previous = nano::genesis_hash;
 	auto amount = (nano::genesis_amount - reserve.number ()) / reps.size ();
 	auto balance = nano::genesis_amount;
-	for (auto const & i: reps)
+	for (auto const & i : reps)
 	{
 		balance -= amount;
 		nano::state_block_builder builder;
 		builder.account (nano::dev_genesis_key.pub)
-		       .previous (previous)
-		       .representative(nano::dev_genesis_key.pub)
-		       .link (i.pub)
-		       .balance (balance)
-		       .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
-		       .work (*work.generate (previous));
+		.previous (previous)
+		.representative (nano::dev_genesis_key.pub)
+		.link (i.pub)
+		.balance (balance)
+		.sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+		.work (*work.generate (previous));
 		initialization_blocks.emplace_back (builder.build_shared ());
 		previous = initialization_blocks.back ()->hash ();
 		builder.make_block ();
 		builder.account (i.pub)
-		       .previous (0)
-		       .representative(i.pub)
-		       .link (previous)
-		       .balance (amount)
-		       .sign (i.prv, i.pub)
-		       .work (*work.generate (i.pub));
+		.previous (0)
+		.representative (i.pub)
+		.link (previous)
+		.balance (amount)
+		.sign (i.prv, i.pub)
+		.work (*work.generate (i.pub));
 		initialization_blocks.emplace_back (builder.build_shared ());
 	}
 }

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -54,6 +54,7 @@ public:
 	std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
 	double deadline_scaling_factor{ 1.0 };
 	unsigned node_sequence{ 0 };
+
 private:
 	std::vector<std::shared_ptr<nano::block>> initialization_blocks;
 };


### PR DESCRIPTION
As per discussed yesterday, I am temporarily disabling the compilation/usage of `diskhash` on Windows so that we can get the Windows build green again. This should be until further development is ready in PR #3366 .

