### PR TITLE
Remove load_test from github CI

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -70,13 +70,9 @@ run_tests() {
     xvfb_run_ ./qt_test
     qt_test_res=${?}
 
-    ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_SEC-${TIMEOUT_DEFAULT}} ./load_test -s 150 -n 5
-    load_test_res=${?}
-
     echo "Core Test return code: ${core_test_res}"
     echo "RPC  Test return code: ${rpc_test_res}"
     echo "QT Test return code: ${qt_test_res}"
-    echo "Load Test return code: ${load_test_res}"
     return ${core_test_res}
 }
 


### PR DESCRIPTION
The load_test is currently broken. It usually loops forever and the CI
is waiting for it to timeout. Even if it did work, we ignore its result.
So overall, the load_test in CI is a liability at the moment and it
is offering us nothing in CI.