### PR TITLE
Fix ledger_walker.genesis_account_longer unit test on macOS

### DIFF
--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -50,7 +50,7 @@ TEST (ledger_walker, genesis_account_longer)
 
 	nano::ledger_walker ledger_walker{ node->ledger };
 	EXPECT_TRUE (ledger_walker.walked_blocks.empty ());
-	EXPECT_EQ (1, ledger_walker.walked_blocks.bucket_count ());
+	EXPECT_LE (ledger_walker.walked_blocks.bucket_count (), 1);
 	EXPECT_TRUE (ledger_walker.blocks_to_walk.empty ());
 
 	const auto get_number_of_walked_blocks = [&ledger_walker] (const auto & start_block_hash) {
@@ -82,7 +82,7 @@ TEST (ledger_walker, genesis_account_longer)
 	}
 
 	EXPECT_TRUE (ledger_walker.walked_blocks.empty ());
-	EXPECT_EQ (1, ledger_walker.walked_blocks.bucket_count ());
+	EXPECT_LE (ledger_walker.walked_blocks.bucket_count (), 1);
 	EXPECT_TRUE (ledger_walker.blocks_to_walk.empty ());
 }
 


### PR DESCRIPTION
Honestly the test expectation (that was oddly failing on [osx_test CI step](https://github.com/nanocurrency/nano-node/pull/3372/checks?check_run_id=3010562315#step:4:2399)) isn't something truly needed nor relevant.

But apparently `libc++` and `libstdc++` have different strategies for hashing policies when the hashmap is empty.

This should fix it. 