### PR TITLE
Removing deprecated lmdb_max_dbs config option

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -597,7 +597,6 @@ TEST (node_config, serialization)
 	config1.callback_address = "dev";
 	config1.callback_port = 10;
 	config1.callback_target = "dev";
-	config1.deprecated_lmdb_max_dbs = 256;
 	nano::jsonconfig tree;
 	config1.serialize_json (tree);
 	nano::logging logging2;
@@ -613,7 +612,6 @@ TEST (node_config, serialization)
 	ASSERT_NE (config2.callback_address, config1.callback_address);
 	ASSERT_NE (config2.callback_port, config1.callback_port);
 	ASSERT_NE (config2.callback_target, config1.callback_target);
-	ASSERT_NE (config2.deprecated_lmdb_max_dbs, config1.deprecated_lmdb_max_dbs);
 
 	ASSERT_FALSE (tree.get_optional<std::string> ("epoch_block_link"));
 	ASSERT_FALSE (tree.get_optional<std::string> ("epoch_block_signer"));
@@ -630,7 +628,6 @@ TEST (node_config, serialization)
 	ASSERT_EQ (config2.callback_address, config1.callback_address);
 	ASSERT_EQ (config2.callback_port, config1.callback_port);
 	ASSERT_EQ (config2.callback_target, config1.callback_target);
-	ASSERT_EQ (config2.deprecated_lmdb_max_dbs, config1.deprecated_lmdb_max_dbs);
 }
 
 TEST (node_config, v17_values)

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -163,7 +163,6 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.external_address, defaults.node.external_address);
 	ASSERT_EQ (conf.node.external_port, defaults.node.external_port);
 	ASSERT_EQ (conf.node.io_threads, defaults.node.io_threads);
-	ASSERT_EQ (conf.node.deprecated_lmdb_max_dbs, defaults.node.deprecated_lmdb_max_dbs);
 	ASSERT_EQ (conf.node.max_work_generate_multiplier, defaults.node.max_work_generate_multiplier);
 	ASSERT_EQ (conf.node.network_threads, defaults.node.network_threads);
 	ASSERT_EQ (conf.node.secondary_work_peers, defaults.node.secondary_work_peers);
@@ -564,7 +563,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.external_address, defaults.node.external_address);
 	ASSERT_NE (conf.node.external_port, defaults.node.external_port);
 	ASSERT_NE (conf.node.io_threads, defaults.node.io_threads);
-	ASSERT_NE (conf.node.deprecated_lmdb_max_dbs, defaults.node.deprecated_lmdb_max_dbs);
 	ASSERT_NE (conf.node.max_work_generate_multiplier, defaults.node.max_work_generate_multiplier);
 	ASSERT_NE (conf.node.frontiers_confirmation, defaults.node.frontiers_confirmation);
 	ASSERT_NE (conf.node.network_threads, defaults.node.network_threads);

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -73,30 +73,6 @@ TEST (wallets, remove)
 	}
 }
 
-// Keeps breaking whenever we add new DBs
-TEST (wallets, DISABLED_wallet_create_max)
-{
-	nano::system system (1);
-	bool error (false);
-	nano::wallets wallets (error, *system.nodes[0]);
-	const int nonWalletDbs = 19;
-	for (int i = 0; i < system.nodes[0]->config.deprecated_lmdb_max_dbs - nonWalletDbs; i++)
-	{
-		auto wallet_id = nano::random_wallet_id ();
-		auto wallet = wallets.create (wallet_id);
-		auto existing = wallets.items.find (wallet_id);
-		ASSERT_TRUE (existing != wallets.items.end ());
-		nano::raw_key seed;
-		seed = 0;
-		auto transaction (system.nodes[0]->store.tx_begin_write ());
-		existing->second->store.seed_set (transaction, seed);
-	}
-	auto wallet_id = nano::random_wallet_id ();
-	wallets.create (wallet_id);
-	auto existing = wallets.items.find (wallet_id);
-	ASSERT_TRUE (existing == wallets.items.end ());
-}
-
 TEST (wallets, reload)
 {
 	nano::system system (1);

--- a/nano/lib/lmdbconfig.cpp
+++ b/nano/lib/lmdbconfig.cpp
@@ -29,18 +29,12 @@ nano::error nano::lmdb_config::serialize_toml (nano::tomlconfig & toml) const
 	return toml.get_error ();
 }
 
-nano::error nano::lmdb_config::deserialize_toml (nano::tomlconfig & toml, bool is_deprecated_lmdb_dbs_used)
+nano::error nano::lmdb_config::deserialize_toml (nano::tomlconfig & toml)
 {
 	static nano::network_params params;
 	auto default_max_databases = max_databases;
 	toml.get_optional<uint32_t> ("max_databases", max_databases);
 	toml.get_optional<size_t> ("map_size", map_size);
-
-	// For now we accept either setting, but not both
-	if (!params.network.is_dev_network () && is_deprecated_lmdb_dbs_used && default_max_databases != max_databases)
-	{
-		toml.get_error ().set ("Both the deprecated node.lmdb_max_dbs and the new node.lmdb.max_databases setting are used. Please use max_databases only.");
-	}
 
 	if (!toml.get_error ())
 	{

--- a/nano/lib/lmdbconfig.hpp
+++ b/nano/lib/lmdbconfig.hpp
@@ -40,7 +40,7 @@ public:
 	};
 
 	nano::error serialize_toml (nano::tomlconfig & toml_a) const;
-	nano::error deserialize_toml (nano::tomlconfig & toml_a, bool is_deprecated_lmdb_dbs_used);
+	nano::error deserialize_toml (nano::tomlconfig & toml_a);
 
 	/** Sync strategy for the ledger database */
 	sync_strategy sync{ always };

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -88,7 +88,6 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("bootstrap_connections_max", bootstrap_connections_max, "Maximum number of inbound bootstrap connections. Defaults to 64.\nWarning: a larger amount of connections may use additional system memory.\ntype:uint64");
 	toml.put ("bootstrap_initiator_threads", bootstrap_initiator_threads, "Number of threads dedicated to concurrent bootstrap attempts. Defaults to 1.\nWarning: a larger amount of attempts may use additional system memory and disk IO.\ntype:uint64");
 	toml.put ("bootstrap_frontier_request_count", bootstrap_frontier_request_count, "Number frontiers per bootstrap frontier request. Defaults to 1048576.\ntype:uint32,[1024..4294967295]");
-	toml.put ("lmdb_max_dbs", deprecated_lmdb_max_dbs, "DEPRECATED: use node.lmdb.max_databases instead.\nMaximum open lmdb databases. Increase default if more than 100 wallets is required.\nNote: external management is recommended when a large number of wallets is required (see https://docs.nano.org/integration-guides/key-management/).\ntype:uint64");
 	toml.put ("block_processor_batch_max_time", block_processor_batch_max_time.count (), "The maximum time the block processor can continuously process blocks for.\ntype:milliseconds");
 	toml.put ("allow_local_peers", allow_local_peers, "Enable or disable local host peering.\ntype:bool");
 	toml.put ("vote_minimum", vote_minimum.to_string_dec (), "Local representatives do not vote if the delegated weight is under this threshold. Saves on system resources.\ntype:string,amount,raw");
@@ -323,27 +322,10 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get<bool> ("allow_local_peers", allow_local_peers);
 		toml.get<unsigned> (signature_checker_threads_key, signature_checker_threads);
 
-		auto lmdb_max_dbs_default = deprecated_lmdb_max_dbs;
-		toml.get<int> ("lmdb_max_dbs", deprecated_lmdb_max_dbs);
-		bool is_deprecated_lmdb_dbs_used = lmdb_max_dbs_default != deprecated_lmdb_max_dbs;
-
-		// Note: using the deprecated setting will result in a fail-fast config error in the future
-		if (!network_params.network.is_dev_network () && is_deprecated_lmdb_dbs_used)
-		{
-			std::cerr << "WARNING: The node.lmdb_max_dbs setting is deprecated and will be removed in a future version." << std::endl;
-			std::cerr << "Please use the node.lmdb.max_databases setting instead." << std::endl;
-		}
-
 		if (toml.has_key ("lmdb"))
 		{
 			auto lmdb_config_l (toml.get_required_child ("lmdb"));
-			lmdb_config.deserialize_toml (lmdb_config_l, is_deprecated_lmdb_dbs_used);
-
-			// Note that the lmdb config fails if both the deprecated and new setting are changed.
-			if (is_deprecated_lmdb_dbs_used)
-			{
-				lmdb_config.max_databases = deprecated_lmdb_max_dbs;
-			}
+			lmdb_config.deserialize_toml (lmdb_config_l);
 		}
 
 		boost::asio::ip::address_v6 external_address_l;
@@ -496,7 +478,6 @@ nano::error nano::node_config::serialize_json (nano::jsonconfig & json) const
 	json.put ("callback_address", callback_address);
 	json.put ("callback_port", callback_port);
 	json.put ("callback_target", callback_target);
-	json.put ("lmdb_max_dbs", deprecated_lmdb_max_dbs);
 	json.put ("block_processor_batch_max_time", block_processor_batch_max_time.count ());
 	json.put ("allow_local_peers", allow_local_peers);
 	json.put ("vote_minimum", vote_minimum.to_string_dec ());
@@ -679,7 +660,6 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get<std::string> ("callback_address", callback_address);
 		json.get<uint16_t> ("callback_port", callback_port);
 		json.get<std::string> ("callback_target", callback_target);
-		json.get<int> ("lmdb_max_dbs", deprecated_lmdb_max_dbs);
 		json.get<bool> ("enable_voting", enable_voting);
 		json.get<bool> ("allow_local_peers", allow_local_peers);
 		json.get<unsigned> (signature_checker_threads_key, signature_checker_threads);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -73,7 +73,6 @@ public:
 	std::string callback_address;
 	uint16_t callback_port{ 0 };
 	std::string callback_target;
-	[[deprecated]] int deprecated_lmdb_max_dbs{ 128 };
 	bool allow_local_peers{ !(network_params.network.is_live_network () || network_params.network.is_test_network ()) }; // disable by default for live network
 	nano::stat_config stat_config;
 	nano::ipc::ipc_config ipc_config;


### PR DESCRIPTION
 This option has been replaced with lmdb.max_databases.