### PR TITLE
Removing incorrect TCP assert

### DIFF
--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -329,7 +329,6 @@ void nano::transport::tcp_channels::process_message (nano::message const & messa
 				{
 					// Initial node_id_handshake request without node ID
 					debug_assert (message_a.header.type == nano::message_type::node_id_handshake);
-					debug_assert (type_a == nano::socket::type_t::undefined);
 					node.stats.inc (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in);
 				}
 			}


### PR DESCRIPTION
The node id handshake messages can come in under any socket type and this is the incorrect place to do such a check.