### PR TITLE
Adding 'explicit' specifier to uint256_constructor for strings.

### DIFF
--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -66,7 +66,7 @@ public:
 	 * Decode from hex string
 	 * @warning Aborts at runtime if the input is invalid
 	 */
-	uint256_union (std::string const &);
+	explicit uint256_union (std::string const &);
 	uint256_union (uint64_t);
 	uint256_union (nano::uint256_t const &);
 	void encrypt (nano::raw_key const &, nano::raw_key const &, uint128_union const &);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -577,7 +577,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						if (account == node.node->network_params.ledger.genesis_account)
 						{
 							conf_height_reset_num = 1;
-							node.node->store.confirmation_height.put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_block });
+							node.node->store.confirmation_height.put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_hash });
 						}
 						else
 						{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -654,7 +654,7 @@ void nano::json_handler::account_info ()
 			std::shared_ptr<nano::block> confirmed_frontier_block;
 			if (include_confirmed && confirmation_height_info.height > 0)
 			{
-				confirmed_frontier_block = node.store.block.get (transaction, confirmed_frontier);
+				confirmed_frontier_block = node.store.block.get (transaction, confirmation_height_info.frontier);
 			}
 
 			if (representative)
@@ -668,7 +668,7 @@ void nano::json_handler::account_info ()
 						confirmed_representative = confirmed_frontier_block->representative ();
 						if (confirmed_representative.is_zero ())
 						{
-							confirmed_representative = node.store.block.get (transaction, node.ledger.representative (transaction, confirmed_frontier))->representative ();
+							confirmed_representative = node.store.block.get (transaction, node.ledger.representative (transaction, confirmation_height_info.frontier))->representative ();
 						}
 					}
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2985,7 +2985,7 @@ TEST (rpc, accounts_frontiers)
 		std::string account_text (frontiers.first);
 		ASSERT_EQ (nano::dev_genesis_key.pub.to_account (), account_text);
 		std::string frontier_text (frontiers.second.get<std::string> (""));
-		ASSERT_EQ (node->latest (nano::genesis_account), frontier_text);
+		ASSERT_EQ (node->latest (nano::genesis_account), nano::block_hash{ frontier_text });
 	}
 }
 
@@ -5873,7 +5873,7 @@ TEST (rpc, receive)
 		auto receive_text (response.get<std::string> ("block"));
 		nano::account_info info;
 		ASSERT_FALSE (node->store.account.get (node->store.tx_begin_read (), key1.pub, info));
-		ASSERT_EQ (info.head, receive_text);
+		ASSERT_EQ (info.head, nano::block_hash{ receive_text });
 	}
 	// Trying to receive the same block should fail with unreceivable
 	{
@@ -6024,7 +6024,7 @@ TEST (rpc, receive_pruned)
 		auto receive_text (response.get<std::string> ("block"));
 		nano::account_info info;
 		ASSERT_FALSE (node2->store.account.get (node2->store.tx_begin_read (), key1.pub, info));
-		ASSERT_EQ (info.head, receive_text);
+		ASSERT_EQ (info.head, nano::block_hash{ receive_text });
 	}
 	// Trying to receive the same block should fail with unreceivable
 	{


### PR DESCRIPTION
 This removes unnecessary parsing in RPC commands and catches a bug in the confirmation_height_clear CLI command where it interpreting the genesis block json contents as a block hash, which would cause a release assert.