### PR TITLE
Cleanup of genesis constants within ledger_constants

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -328,7 +328,7 @@ TEST (block_store, genesis)
 	auto hash (genesis.hash ());
 	nano::ledger_cache ledger_cache;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger_cache);
+	store->initialize (transaction, ledger_cache);
 	nano::account_info info;
 	ASSERT_FALSE (store->account.get (transaction, nano::genesis_account, info));
 	ASSERT_EQ (hash, info.head);
@@ -668,7 +668,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		// Lower the database to the max version unsupported for upgrades
 		store.version.put (transaction, store.minimum_version - 1);
 	}
@@ -686,7 +686,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		// Lower the database version to the minimum version supported for upgrade.
 		store.version.put (transaction, store.minimum_version);
 		store.confirmation_height.del (transaction, nano::genesis_account);
@@ -882,7 +882,7 @@ TEST (block_store, cemented_count_cache)
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
 	nano::ledger_cache ledger_cache;
-	store->initialize (transaction, genesis, ledger_cache);
+	store->initialize (transaction, ledger_cache);
 	ASSERT_EQ (1, ledger_cache.cemented_count);
 }
 
@@ -895,7 +895,7 @@ TEST (block_store, block_random)
 	{
 		nano::ledger_cache ledger_cache;
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger_cache);
+		store->initialize (transaction, ledger_cache);
 	}
 	auto transaction (store->tx_begin_read ());
 	auto block (store->block.random (transaction));
@@ -915,7 +915,7 @@ TEST (block_store, pruned_random)
 	{
 		nano::ledger_cache ledger_cache;
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger_cache);
+		store->initialize (transaction, ledger_cache);
 		store->pruned.put (transaction, hash1);
 	}
 	auto transaction (store->tx_begin_read ());
@@ -977,7 +977,7 @@ TEST (block_store, state_block)
 	{
 		nano::ledger_cache ledger_cache;
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger_cache);
+		store->initialize (transaction, ledger_cache);
 		ASSERT_EQ (nano::block_type::state, block1.type ());
 		store->block.put (transaction, block1.hash (), block1);
 		ASSERT_TRUE (store->block.exists (transaction, block1.hash ()));
@@ -1014,7 +1014,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::stat stat;
 	nano::ledger ledger (store, stat);
 	auto transaction (store.tx_begin_write ());
-	store.initialize (transaction, genesis, ledger.cache);
+	store.initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send (genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
@@ -1283,7 +1283,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		nano::account_info account_info;
 		ASSERT_FALSE (store.account.get (transaction, nano::genesis_account, account_info));
 		nano::confirmation_height_info confirmation_height_info;
@@ -1391,7 +1391,7 @@ TEST (mdb_block_store, upgrade_v15_v16)
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		// The representation table should get removed after, so readd it so that we can later confirm this actually happens
 		auto txn = store.env.tx (transaction);
 		ASSERT_FALSE (mdb_dbi_open (txn, "representation", MDB_CREATE, &store.representation_handle));
@@ -1444,7 +1444,7 @@ TEST (mdb_block_store, upgrade_v16_v17)
 			nano::stat stats;
 			nano::ledger ledger (store, stats);
 			auto transaction (store.tx_begin_write ());
-			store.initialize (transaction, genesis, ledger.cache);
+			store.initialize (transaction, ledger.cache);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
@@ -1517,7 +1517,7 @@ TEST (mdb_block_store, upgrade_v17_v18)
 		auto transaction (store.tx_begin_write ());
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send_zero).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive_zero).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch).code);
@@ -1714,7 +1714,7 @@ TEST (mdb_block_store, upgrade_v18_v19)
 		nano::stat stats;
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
@@ -1797,7 +1797,7 @@ TEST (mdb_block_store, upgrade_v19_v20)
 		nano::mdb_store store (logger, path);
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		// Delete pruned table
 		ASSERT_FALSE (mdb_drop (store.env.tx (transaction), store.pruned_handle, 1));
 		store.version.put (transaction, 19);
@@ -1827,7 +1827,7 @@ TEST (mdb_block_store, upgrade_v20_v21)
 		nano::mdb_store store (logger, path);
 		nano::ledger ledger (store, stats);
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		// Delete pruned table
 		ASSERT_FALSE (mdb_drop (store.env.tx (transaction), store.final_votes_handle, 1));
 		store.version.put (transaction, 20);

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -732,7 +732,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		auto send = std::make_shared<nano::send_block> (genesis.hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 		{
 			auto transaction (store->tx_begin_write ());
-			store->initialize (transaction, genesis, ledger.cache);
+			store->initialize (transaction, ledger.cache);
 		}
 
 		uint64_t batch_write_size = 2048;
@@ -809,7 +809,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		auto send = std::make_shared<nano::send_block> (nano::genesis_hash, key1.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::genesis_hash));
 		{
 			auto transaction (store->tx_begin_write ());
-			store->initialize (transaction, genesis, ledger.cache);
+			store->initialize (transaction, ledger.cache);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 		}
 
@@ -881,7 +881,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		auto open = std::make_shared<nano::state_block> (key1.pub, 0, 0, nano::Gxrb_ratio, send->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 		{
 			auto transaction (store->tx_begin_write ());
-			store->initialize (transaction, genesis, ledger.cache);
+			store->initialize (transaction, ledger.cache);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 		}
@@ -1376,7 +1376,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::genesis_amount - nano::Gxrb_ratio * 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (send->hash ()));
 	{
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger.cache);
+		store->initialize (transaction, ledger.cache);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	}
@@ -1429,7 +1429,7 @@ TEST (confirmation_height, pruned_source)
 	auto open2 = std::make_shared<nano::state_block> (key2.pub, 0, key1.pub, 50, send2->hash (), key2.prv, key2.pub, *pool.generate (key2.pub));
 	{
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger.cache);
+		store->initialize (transaction, ledger.cache);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -48,7 +48,7 @@ TEST (ledger, genesis_balance)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	auto balance (ledger.account_balance (transaction, nano::genesis_account));
 	ASSERT_EQ (nano::genesis_amount, balance);
 	auto amount (ledger.amount (transaction, nano::genesis_account));
@@ -74,7 +74,7 @@ TEST (ledger, process_modifies_sideband)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
-	store->initialize (store->tx_begin_write (), genesis, ledger.cache);
+	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), send1).code);
@@ -91,7 +91,7 @@ TEST (ledger, process_send)
 	nano::ledger ledger (*store, stats);
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -191,7 +191,7 @@ TEST (ledger, process_receive)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -255,7 +255,7 @@ TEST (ledger, rollback_receiver)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -295,7 +295,7 @@ TEST (ledger, rollback_representation)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key5;
 	nano::change_block change1 (genesis.hash (), key5.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -349,7 +349,7 @@ TEST (ledger, receive_rollback)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send (genesis.hash (), nano::dev_genesis_key.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
@@ -367,7 +367,7 @@ TEST (ledger, process_duplicate)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -390,7 +390,7 @@ TEST (ledger, representative_genesis)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	auto latest (ledger.latest (transaction, nano::dev_genesis_key.pub));
 	ASSERT_FALSE (latest.is_zero ());
 	ASSERT_EQ (genesis.open->hash (), ledger.representative (transaction, latest));
@@ -405,7 +405,7 @@ TEST (ledger, weight)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::genesis_account));
 }
 
@@ -419,7 +419,7 @@ TEST (ledger, representative_change)
 	nano::keypair key2;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
@@ -459,7 +459,7 @@ TEST (ledger, send_fork)
 	nano::keypair key3;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -480,7 +480,7 @@ TEST (ledger, receive_fork)
 	nano::keypair key3;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -507,7 +507,7 @@ TEST (ledger, open_fork)
 	nano::keypair key3;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -540,7 +540,7 @@ TEST (ledger, representation)
 	auto & rep_weights = ledger.cache.rep_weights;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	ASSERT_EQ (nano::genesis_amount, rep_weights.representation_get (nano::dev_genesis_key.pub));
 	nano::keypair key2;
@@ -614,7 +614,7 @@ TEST (ledger, double_open)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key2;
 	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -634,7 +634,7 @@ TEST (ledger, double_receive)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key2;
 	nano::send_block send1 (genesis.hash (), key2.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -920,7 +920,7 @@ TEST (ledger, fail_change_old)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::change_block block (genesis.hash (), key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -939,7 +939,7 @@ TEST (ledger, fail_change_gap_previous)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::change_block block (1, key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::root (1)));
@@ -956,7 +956,7 @@ TEST (ledger, fail_change_bad_signature)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::change_block block (genesis.hash (), key1.pub, nano::keypair ().prv, 0, *pool.generate (genesis.hash ()));
@@ -973,7 +973,7 @@ TEST (ledger, fail_change_fork)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::change_block block1 (genesis.hash (), key1.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -994,7 +994,7 @@ TEST (ledger, fail_send_old)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1013,7 +1013,7 @@ TEST (ledger, fail_send_gap_previous)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block (1, key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (nano::root (1)));
@@ -1030,7 +1030,7 @@ TEST (ledger, fail_send_bad_signature)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block (genesis.hash (), key1.pub, 1, nano::keypair ().prv, 0, *pool.generate (genesis.hash ()));
@@ -1047,7 +1047,7 @@ TEST (ledger, fail_send_negative_spend)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1066,7 +1066,7 @@ TEST (ledger, fail_send_fork)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1085,7 +1085,7 @@ TEST (ledger, fail_open_old)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1104,7 +1104,7 @@ TEST (ledger, fail_open_gap_source)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::open_block block2 (1, 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1121,7 +1121,7 @@ TEST (ledger, fail_open_bad_signature)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1140,7 +1140,7 @@ TEST (ledger, fail_open_fork_previous)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1163,7 +1163,7 @@ TEST (ledger, fail_open_account_mismatch)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1183,7 +1183,7 @@ TEST (ledger, fail_receive_old)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1206,7 +1206,7 @@ TEST (ledger, fail_receive_gap_source)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1232,7 +1232,7 @@ TEST (ledger, fail_receive_overreceive)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1255,7 +1255,7 @@ TEST (ledger, fail_receive_bad_signature)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1281,7 +1281,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1307,7 +1307,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1330,7 +1330,7 @@ TEST (ledger, fail_receive_fork_previous)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 1, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1360,7 +1360,7 @@ TEST (ledger, fail_receive_received_source)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	nano::send_block block1 (genesis.hash (), key1.pub, 2, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1409,7 +1409,7 @@ TEST (ledger, latest_root)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub));
@@ -1429,7 +1429,7 @@ TEST (ledger, change_representative_move_representation)
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	auto hash1 (genesis.hash ());
 	ASSERT_EQ (nano::genesis_amount, ledger.weight (nano::dev_genesis_key.pub));
@@ -1454,7 +1454,7 @@ TEST (ledger, send_open_receive_rollback)
 	nano::ledger ledger (*store, stats);
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -1517,7 +1517,7 @@ TEST (ledger, bootstrap_rep_weight)
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	{
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger.cache);
+		store->initialize (transaction, ledger.cache);
 		ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
 		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 50, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (info1.head));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
@@ -1550,7 +1550,7 @@ TEST (ledger, block_destination_source)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair dest;
 	nano::uint128_t balance (nano::genesis_amount);
@@ -1596,7 +1596,7 @@ TEST (ledger, state_account)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1612,7 +1612,7 @@ TEST (ledger, state_send_receive)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1654,7 +1654,7 @@ TEST (ledger, state_receive)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1689,7 +1689,7 @@ TEST (ledger, state_rep_change)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
 	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1717,7 +1717,7 @@ TEST (ledger, state_open)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1757,7 +1757,7 @@ TEST (ledger, send_after_state_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1775,7 +1775,7 @@ TEST (ledger, receive_after_state_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1793,7 +1793,7 @@ TEST (ledger, change_after_state_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1811,7 +1811,7 @@ TEST (ledger, state_unreceivable_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1835,7 +1835,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1859,7 +1859,7 @@ TEST (ledger, state_no_link_amount_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1877,7 +1877,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1902,7 +1902,7 @@ TEST (ledger, state_open_state_fork)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1923,7 +1923,7 @@ TEST (ledger, state_state_open_fork)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1945,7 +1945,7 @@ TEST (ledger, state_open_previous_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1963,7 +1963,7 @@ TEST (ledger, state_open_source_fail)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -1981,7 +1981,7 @@ TEST (ledger, state_send_change)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2009,7 +2009,7 @@ TEST (ledger, state_receive_change)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2046,7 +2046,7 @@ TEST (ledger, state_open_old)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2067,7 +2067,7 @@ TEST (ledger, state_receive_old)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2092,7 +2092,7 @@ TEST (ledger, state_rollback_send)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2124,7 +2124,7 @@ TEST (ledger, state_rollback_receive)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2151,7 +2151,7 @@ TEST (ledger, state_rollback_received_send)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2179,7 +2179,7 @@ TEST (ledger, state_rep_change_rollback)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
 	nano::state_block change1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2200,7 +2200,7 @@ TEST (ledger, state_open_rollback)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2227,7 +2227,7 @@ TEST (ledger, state_send_change_rollback)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair rep;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), rep.pub, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2249,7 +2249,7 @@ TEST (ledger, state_receive_change_rollback)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2273,7 +2273,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2344,7 +2344,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2410,7 +2410,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2491,7 +2491,7 @@ TEST (ledger, epoch_blocks_fork)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	nano::send_block send1 (genesis.hash (), nano::account (0), nano::genesis_amount, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
@@ -2675,7 +2675,7 @@ TEST (ledger, could_fit)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair destination;
 	// Test legacy and state change blocks could_fit
@@ -2916,7 +2916,7 @@ TEST (ledger, confirmation_height_not_updated)
 	nano::ledger ledger (*store, stats);
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info account_info;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, account_info));
@@ -2978,7 +2978,7 @@ TEST (ledger, work_validation)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
-	store->initialize (store->tx_begin_write (), genesis, ledger.cache);
+	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::block_builder builder;
 	auto gen = nano::dev_genesis_key;
@@ -3073,7 +3073,7 @@ TEST (ledger, dependents_confirmed)
 	nano::ledger ledger (*store, stats);
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *genesis.open));
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
@@ -3147,7 +3147,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
 	auto send1 = builder.state ()
@@ -3198,7 +3198,7 @@ TEST (ledger, block_confirmed)
 	nano::ledger ledger (*store, stats);
 	auto transaction (store->tx_begin_write ());
 	nano::genesis genesis;
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	ASSERT_TRUE (ledger.block_confirmed (transaction, genesis.open->hash ()));
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key1;
@@ -3230,7 +3230,7 @@ TEST (ledger, cache)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
-	store->initialize (store->tx_begin_write (), genesis, ledger.cache);
+	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::block_builder builder;
 
@@ -3344,7 +3344,7 @@ TEST (ledger, pruning_action)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -3401,7 +3401,7 @@ TEST (ledger, pruning_large_chain)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	size_t send_receive_pairs (20);
 	auto last_hash (genesis.hash ());
@@ -3438,7 +3438,7 @@ TEST (ledger, pruning_source_rollback)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block epoch1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
@@ -3490,7 +3490,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -3569,7 +3569,7 @@ TEST (ledger, pruning_process_error)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -3599,7 +3599,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::genesis genesis;
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send1 (genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -3644,7 +3644,7 @@ TEST (ledger, pruning_safe_functions)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -3687,7 +3687,7 @@ TEST (ledger, hash_root_random)
 	ledger.pruning = true;
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::genesis_account, genesis.hash (), nano::genesis_account, nano::genesis_amount - nano::Gxrb_ratio, nano::genesis_account, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *pool.generate (genesis.hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -3748,7 +3748,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 
 	{
 		auto transaction (store.tx_begin_write ());
-		store.initialize (transaction, genesis, ledger.cache);
+		store.initialize (transaction, ledger.cache);
 		ASSERT_FALSE (store.init_error ());
 
 		// Lower the database to the max version unsupported for upgrades
@@ -3811,7 +3811,7 @@ TEST (ledger, unconfirmed_frontiers)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
-	store->initialize (store->tx_begin_write (), genesis, ledger.cache);
+	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 
 	auto unconfirmed_frontiers = ledger.unconfirmed_frontiers ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3726,7 +3726,7 @@ TEST (node, dont_write_lock_node)
 			nano::genesis genesis;
 			nano::ledger_cache ledger_cache;
 			auto transaction (store->tx_begin_write ());
-			store->initialize (transaction, genesis, ledger_cache);
+			store->initialize (transaction, ledger_cache);
 		}
 
 		// Hold write lock open until main thread is done needing it

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -16,7 +16,7 @@ TEST (processor_service, bad_send_signature)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));
@@ -35,7 +35,7 @@ TEST (processor_service, bad_receive_signature)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev_genesis_key.pub, info1));

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -563,7 +563,7 @@ TEST (telemetry, remove_peer_different_genesis)
 				 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 				 .work (0)
 				 .build_shared ();
-	node1->network_params.ledger.genesis_block = junk;
+	node1->network_params.ledger.genesis = junk;
 	node1->start ();
 	system.nodes.push_back (node1);
 	node0->network.merge_peer (node1->network.endpoint ());
@@ -601,7 +601,7 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 				 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
 				 .work (0)
 				 .build_shared ();
-	node1->network_params.ledger.genesis_block = junk;
+	node1->network_params.ledger.genesis = junk;
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.protocol.protocol_version));

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -553,7 +553,17 @@ TEST (telemetry, remove_peer_different_genesis)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
 	// Change genesis block to something else in this test (this is the reference telemetry processing uses).
 	// Possible TSAN issue in the future if something else uses this, but will only appear in tests.
-	node1->network_params.ledger.genesis_hash = nano::block_hash ("0");
+	nano::state_block_builder builder;
+	auto junk = builder
+				 .account (nano::dev_genesis_key.pub)
+				 .previous (0)
+				 .representative (nano::dev_genesis_key.pub)
+				 .balance (0)
+				 .link (0)
+				 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
+	node1->network_params.ledger.genesis_block = junk;
 	node1->start ();
 	system.nodes.push_back (node1);
 	node0->network.merge_peer (node1->network.endpoint ());
@@ -581,7 +591,17 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
-	node1->network_params.ledger.genesis_hash = nano::block_hash ("0");
+	nano::state_block_builder builder;
+	auto junk = builder
+				 .account (nano::dev_genesis_key.pub)
+				 .previous (0)
+				 .representative (nano::dev_genesis_key.pub)
+				 .balance (0)
+				 .link (0)
+				 .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
+	node1->network_params.ledger.genesis_block = junk;
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.protocol.protocol_version));

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -247,7 +247,7 @@ bool nano::bootstrap_attempt_lazy::process_block_lazy (std::shared_ptr<nano::blo
 	if (!lazy_blocks_processed (hash))
 	{
 		// Search for new dependencies
-		if (!block_a->source ().is_zero () && !node->ledger.block_or_pruned_exists (block_a->source ()) && block_a->source () != node->network_params.ledger.genesis_account)
+		if (!block_a->source ().is_zero () && !node->ledger.block_or_pruned_exists (block_a->source ()) && block_a->source () != node->network_params.ledger.genesis_account ())
 		{
 			lazy_add (block_a->source (), retry_limit);
 		}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -574,7 +574,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					{
 						auto transaction (node.node->store.tx_begin_write ());
 						auto conf_height_reset_num = 0;
-						if (account == node.node->network_params.ledger.genesis_account)
+						if (account == node.node->network_params.ledger.genesis_account ())
 						{
 							conf_height_reset_num = 1;
 							node.node->store.confirmation_height.put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_hash });
@@ -1307,7 +1307,7 @@ void reset_confirmation_heights (nano::write_transaction const & transaction, na
 
 	// Then make sure the confirmation height of the genesis account open block is 1
 	nano::network_params network_params;
-	store.confirmation_height.put (transaction, network_params.ledger.genesis_account, { 1, network_params.ledger.genesis_hash });
+	store.confirmation_height.put (transaction, network_params.ledger.genesis_account (), { 1, network_params.ledger.genesis_hash });
 }
 
 bool is_using_rocksdb (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec)

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -577,7 +577,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						if (account == node.node->network_params.ledger.genesis_account ())
 						{
 							conf_height_reset_num = 1;
-							node.node->store.confirmation_height.put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_hash });
+							node.node->store.confirmation_height.put (transaction, account, { confirmation_height_info.height, node.node->network_params.ledger.genesis_hash () });
 						}
 						else
 						{
@@ -1307,7 +1307,7 @@ void reset_confirmation_heights (nano::write_transaction const & transaction, na
 
 	// Then make sure the confirmation height of the genesis account open block is 1
 	nano::network_params network_params;
-	store.confirmation_height.put (transaction, network_params.ledger.genesis_account (), { 1, network_params.ledger.genesis_hash });
+	store.confirmation_height.put (transaction, network_params.ledger.genesis_account (), { 1, network_params.ledger.genesis_hash () });
 }
 
 bool is_using_rocksdb (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec)

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1038,7 +1038,7 @@ void nano::json_handler::active_difficulty ()
 
 void nano::json_handler::available_supply ()
 {
-	auto genesis_balance (node.balance (node.network_params.ledger.genesis_account)); // Cold storage genesis
+	auto genesis_balance (node.balance (node.network_params.ledger.genesis_account ())); // Cold storage genesis
 	auto landing_balance (node.balance (nano::account ("059F68AAB29DE0D3A27443625C7EA9CDDB6517A8B76FE37727EF6A4D76832AD5"))); // Active unavailable account
 	auto faucet_balance (node.balance (nano::account ("8E319CE6F3025E5B2DF66DA7AB1467FE48F1679C13DD43BFDB29FA2E9FC40D3B"))); // Faucet account
 	auto burned_balance ((node.balance_pending (nano::account (0), false)).second); // Burning 0 account
@@ -2315,7 +2315,7 @@ public:
 			// Report opens as a receive
 			tree.put ("type", "receive");
 		}
-		if (block_a.hashables.source != network_params.ledger.genesis_account)
+		if (block_a.hashables.source != network_params.ledger.genesis_account ())
 		{
 			bool error_or_pruned (false);
 			auto amount (handler.node.ledger.amount_safe (transaction, hash, error_or_pruned).convert_to<std::string> ());
@@ -2331,7 +2331,7 @@ public:
 		}
 		else
 		{
-			tree.put ("account", network_params.ledger.genesis_account.to_account ());
+			tree.put ("account", network_params.ledger.genesis_account ().to_account ());
 			tree.put ("amount", network_params.ledger.genesis_amount.convert_to<std::string> ());
 		}
 	}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4143,7 +4143,7 @@ void nano::json_handler::version ()
 	response_l.put ("node_vendor", boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING));
 	response_l.put ("store_vendor", node.store.vendor_get ());
 	response_l.put ("network", node.network_params.network.get_current_network_as_string ());
-	response_l.put ("network_identifier", node.network_params.ledger.genesis_hash.to_string ());
+	response_l.put ("network_identifier", node.network_params.ledger.genesis_hash ().to_string ());
 	response_l.put ("build_info", BUILD_INFO);
 	response_errors ();
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -349,7 +349,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 		{
 			auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers }));
 			// Store was empty meaning we just created it, add the genesis block
-			store.initialize (transaction, genesis, ledger.cache);
+			store.initialize (transaction, ledger.cache);
 		}
 
 		if (!ledger.block_or_pruned_exists (genesis.hash ()))

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1318,7 +1318,7 @@ void nano::node::process_confirmed_data (nano::transaction const & transaction_a
 	bool error (false);
 	auto previous_balance (ledger.balance_safe (transaction_a, previous, error));
 	auto block_balance (store.block.balance_calculated (block_a));
-	if (hash_a != ledger.network_params.ledger.genesis_account)
+	if (hash_a != ledger.network_params.ledger.genesis_account ())
 	{
 		if (!error)
 		{

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -40,7 +40,7 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 	{
 		case nano::networks::nano_dev_network:
 			enable_voting = true;
-			preconfigured_representatives.push_back (network_params.ledger.genesis_account);
+			preconfigured_representatives.push_back (network_params.ledger.genesis_account ());
 			break;
 		case nano::networks::nano_beta_network:
 		{
@@ -63,7 +63,7 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 			break;
 		case nano::networks::nano_test_network:
 			preconfigured_peers.push_back (default_test_peer_network);
-			preconfigured_representatives.push_back (network_params.ledger.genesis_account);
+			preconfigured_representatives.push_back (network_params.ledger.genesis_account ());
 			break;
 		default:
 			debug_assert (false);

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -92,7 +92,7 @@ bool nano::telemetry::verify_message (nano::telemetry_ack const & message_a, nan
 		if (!remove_channel)
 		{
 			// Check for different genesis blocks
-			remove_channel = (message_a.data.genesis_block != network_params.ledger.genesis_hash);
+			remove_channel = (message_a.data.genesis_block != network_params.ledger.genesis_hash ());
 			if (remove_channel)
 			{
 				stats.inc (nano::stat::type::telemetry, nano::stat::detail::different_genesis_hash);
@@ -634,7 +634,7 @@ nano::telemetry_data nano::local_telemetry_data (nano::ledger const & ledger_a, 
 	telemetry_data.protocol_version = network_params_a.protocol.protocol_version;
 	telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - statup_time_a).count ();
 	telemetry_data.unchecked_count = ledger_a.store.unchecked.count (ledger_a.store.tx_begin_read ());
-	telemetry_data.genesis_block = network_params_a.ledger.genesis_hash;
+	telemetry_data.genesis_block = network_params_a.ledger.genesis_hash ();
 	telemetry_data.peer_count = nano::narrow_cast<decltype (telemetry_data.peer_count)> (network_a.size ());
 	telemetry_data.account_count = ledger_a.cache.account_count;
 	telemetry_data.major_version = nano::get_major_node_version ();

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -544,7 +544,7 @@ public:
 	{
 		static nano::network_params params;
 		type = "Receive";
-		if (block_a.hashables.source != params.ledger.genesis_account)
+		if (block_a.hashables.source != params.ledger.genesis_account ())
 		{
 			bool error_or_pruned (false);
 			account = ledger.account_safe (transaction, block_a.hashables.source, error_or_pruned);
@@ -556,7 +556,7 @@ public:
 		}
 		else
 		{
-			account = params.ledger.genesis_account;
+			account = params.ledger.genesis_account ();
 			amount = params.ledger.genesis_amount;
 		}
 	}

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -519,7 +519,7 @@ TEST (history, short_text)
 	nano::ledger ledger (*store, system.nodes[0]->stats);
 	{
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger.cache);
+		store->initialize (transaction, ledger.cache);
 		nano::keypair key;
 		auto latest (ledger.latest (transaction, nano::dev_genesis_key.pub));
 		nano::send_block send (latest, nano::dev_genesis_key.pub, 0, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
@@ -560,7 +560,7 @@ TEST (history, pruned_source)
 	// Basic pruning for legacy blocks. Previous block is pruned, source is pruned
 	{
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger.cache);
+		store->initialize (transaction, ledger.cache);
 		auto latest (ledger.latest (transaction, nano::dev_genesis_key.pub));
 		nano::send_block send1 (latest, nano::dev_genesis_key.pub, nano::genesis_amount - 100, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (latest));
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -113,7 +113,7 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	nano_beta_genesis (parse_block_from_genesis_data (beta_genesis_data)),
 	nano_live_genesis (parse_block_from_genesis_data (live_genesis_data)),
 	nano_test_genesis (parse_block_from_genesis_data (test_genesis_data)),
-	genesis_block (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
+	genesis (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 	burn_account (0),
 	nano_dev_final_votes_canary_account (dev_public_key_data),
@@ -144,14 +144,14 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 
 nano::account nano::ledger_constants::genesis_account () const
 {
-	auto result = genesis_block->account ();
+	auto result = genesis->account ();
 	debug_assert (!result.is_zero ());
 	return result;
 }
 
 nano::block_hash nano::ledger_constants::genesis_hash () const
 {
-	auto result = genesis_block->hash ();
+	auto result = genesis->hash ();
 	debug_assert (!result.is_zero ());
 	return result;
 }
@@ -830,7 +830,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (vo
 nano::genesis::genesis ()
 {
 	static nano::network_params network_params;
-	open = network_params.ledger.genesis_block;
+	open = network_params.ledger.genesis;
 	debug_assert (open != nullptr);
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -113,7 +113,6 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	nano_beta_genesis (parse_block_from_genesis_data (beta_genesis_data)),
 	nano_live_genesis (parse_block_from_genesis_data (live_genesis_data)),
 	nano_test_genesis (parse_block_from_genesis_data (test_genesis_data)),
-	genesis_account (network_a == nano::networks::nano_dev_network ? nano_dev_account : network_a == nano::networks::nano_beta_network ? nano_beta_account : network_a == nano::networks::nano_test_network ? nano_test_account : nano_live_account),
 	genesis_block (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
 	genesis_hash (genesis_block->hash ()),
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
@@ -132,7 +131,7 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	nano::link epoch_link_v1;
 	const char * epoch_message_v1 ("epoch v1 block");
 	strncpy ((char *)epoch_link_v1.bytes.data (), epoch_message_v1, epoch_link_v1.bytes.size ());
-	epochs.add (nano::epoch::epoch_1, genesis_account, epoch_link_v1);
+	epochs.add (nano::epoch::epoch_1, genesis_account (), epoch_link_v1);
 
 	nano::link epoch_link_v2;
 	nano::account nano_live_epoch_v2_signer;
@@ -142,6 +141,13 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	const char * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);
+}
+
+nano::account nano::ledger_constants::genesis_account () const
+{
+	auto result = genesis_block->account ();
+	debug_assert (!result.is_zero ());
+	return result;
 }
 
 nano::random_constants::random_constants ()

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -109,13 +109,13 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	nano_beta_account (beta_public_key_data),
 	nano_live_account (live_public_key_data),
 	nano_test_account (test_public_key_data),
-	nano_dev_genesis (dev_genesis_data),
-	nano_beta_genesis (beta_genesis_data),
-	nano_live_genesis (live_genesis_data),
-	nano_test_genesis (test_genesis_data),
+	nano_dev_genesis (parse_block_from_genesis_data (dev_genesis_data)),
+	nano_beta_genesis (parse_block_from_genesis_data (beta_genesis_data)),
+	nano_live_genesis (parse_block_from_genesis_data (live_genesis_data)),
+	nano_test_genesis (parse_block_from_genesis_data (test_genesis_data)),
 	genesis_account (network_a == nano::networks::nano_dev_network ? nano_dev_account : network_a == nano::networks::nano_beta_network ? nano_beta_account : network_a == nano::networks::nano_test_network ? nano_test_account : nano_live_account),
 	genesis_block (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
-	genesis_hash (parse_block_from_genesis_data (genesis_block)->hash ()),
+	genesis_hash (genesis_block->hash ()),
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 	burn_account (0),
 	nano_dev_final_votes_canary_account (dev_public_key_data),
@@ -818,7 +818,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (vo
 nano::genesis::genesis ()
 {
 	static nano::network_params network_params;
-	open = parse_block_from_genesis_data (network_params.ledger.genesis_block);
+	open = network_params.ledger.genesis_block;
 	debug_assert (open != nullptr);
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -114,7 +114,6 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	nano_live_genesis (parse_block_from_genesis_data (live_genesis_data)),
 	nano_test_genesis (parse_block_from_genesis_data (test_genesis_data)),
 	genesis_block (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
-	genesis_hash (genesis_block->hash ()),
 	genesis_amount (std::numeric_limits<nano::uint128_t>::max ()),
 	burn_account (0),
 	nano_dev_final_votes_canary_account (dev_public_key_data),
@@ -146,6 +145,13 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 nano::account nano::ledger_constants::genesis_account () const
 {
 	auto result = genesis_block->account ();
+	debug_assert (!result.is_zero ());
+	return result;
+}
+
+nano::block_hash nano::ledger_constants::genesis_hash () const
+{
+	auto result = genesis_block->hash ();
 	debug_assert (!result.is_zero ());
 	return result;
 }

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -374,12 +374,12 @@ public:
 	nano::account nano_beta_account;
 	nano::account nano_live_account;
 	nano::account nano_test_account;
-	std::string nano_dev_genesis;
-	std::string nano_beta_genesis;
-	std::string nano_live_genesis;
-	std::string nano_test_genesis;
+	std::shared_ptr<nano::block> nano_dev_genesis;
+	std::shared_ptr<nano::block> nano_beta_genesis;
+	std::shared_ptr<nano::block> nano_live_genesis;
+	std::shared_ptr<nano::block> nano_test_genesis;
 	nano::account genesis_account;
-	std::string genesis_block;
+	std::shared_ptr<nano::block> genesis_block;
 	nano::block_hash genesis_hash;
 	nano::uint128_t genesis_amount;
 	nano::account burn_account;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -368,6 +368,7 @@ class ledger_constants
 public:
 	ledger_constants (nano::network_constants & network_constants);
 	ledger_constants (nano::networks network_a);
+	nano::account genesis_account () const;
 	nano::keypair zero_key;
 	nano::keypair dev_genesis_key;
 	nano::account nano_dev_account;
@@ -378,7 +379,6 @@ public:
 	std::shared_ptr<nano::block> nano_beta_genesis;
 	std::shared_ptr<nano::block> nano_live_genesis;
 	std::shared_ptr<nano::block> nano_test_genesis;
-	nano::account genesis_account;
 	std::shared_ptr<nano::block> genesis_block;
 	nano::block_hash genesis_hash;
 	nano::uint128_t genesis_amount;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -380,7 +380,7 @@ public:
 	std::shared_ptr<nano::block> nano_beta_genesis;
 	std::shared_ptr<nano::block> nano_live_genesis;
 	std::shared_ptr<nano::block> nano_test_genesis;
-	std::shared_ptr<nano::block> genesis_block;
+	std::shared_ptr<nano::block> genesis;
 	nano::uint128_t genesis_amount;
 	nano::account burn_account;
 	nano::account nano_dev_final_votes_canary_account;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -369,6 +369,7 @@ public:
 	ledger_constants (nano::network_constants & network_constants);
 	ledger_constants (nano::networks network_a);
 	nano::account genesis_account () const;
+	nano::block_hash genesis_hash () const;
 	nano::keypair zero_key;
 	nano::keypair dev_genesis_key;
 	nano::account nano_dev_account;
@@ -380,7 +381,6 @@ public:
 	std::shared_ptr<nano::block> nano_live_genesis;
 	std::shared_ptr<nano::block> nano_test_genesis;
 	std::shared_ptr<nano::block> genesis_block;
-	nano::block_hash genesis_hash;
 	nano::uint128_t genesis_amount;
 	nano::account burn_account;
 	nano::account nano_dev_final_votes_canary_account;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1102,7 +1102,7 @@ nano::account nano::ledger::account_safe (nano::transaction const & transaction_
 // Return amount decrease or increase for block
 nano::uint128_t nano::ledger::amount (nano::transaction const & transaction_a, nano::account const & account_a)
 {
-	release_assert (account_a == network_params.ledger.genesis_account);
+	release_assert (account_a == network_params.ledger.genesis_account ());
 	return network_params.ledger.genesis_amount;
 }
 
@@ -1204,7 +1204,7 @@ public:
 	}
 	void open_block (nano::open_block const & block_a) override
 	{
-		if (block_a.source () != ledger.network_params.ledger.genesis_account)
+		if (block_a.source () != ledger.network_params.ledger.genesis_account ())
 		{
 			result[0] = block_a.source ();
 		}

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1342,7 +1342,7 @@ uint64_t nano::ledger::pruning_action (nano::write_transaction & transaction_a, 
 {
 	uint64_t pruned_count (0);
 	nano::block_hash hash (hash_a);
-	while (!hash.is_zero () && hash != network_params.ledger.genesis_hash)
+	while (!hash.is_zero () && hash != network_params.ledger.genesis_hash ())
 	{
 		auto block (store.block.get (transaction_a, hash));
 		if (block != nullptr)

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -834,7 +834,7 @@ public:
 	);
 	// clang-format on
 	virtual ~store () = default;
-	virtual void initialize (nano::write_transaction const &, nano::genesis const &, nano::ledger_cache &) = 0;
+	virtual void initialize (nano::write_transaction const &, nano::ledger_cache &) = 0;
 	virtual bool root_exists (nano::transaction const &, nano::root const &) = 0;
 
 	block_store & block;

--- a/nano/secure/store_partial.hpp
+++ b/nano/secure/store_partial.hpp
@@ -105,7 +105,7 @@ public:
 	 */
 	void initialize (nano::write_transaction const & transaction_a, nano::ledger_cache & ledger_cache_a) override
 	{
-		auto & genesis = *network_params.ledger.genesis_block;
+		auto & genesis = *network_params.ledger.genesis;
 		auto hash_l (genesis.hash ());
 		debug_assert (account.begin (transaction_a) == account.end ());
 		genesis.sideband_set (nano::block_sideband (network_params.ledger.genesis_account (), 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));

--- a/nano/secure/store_partial.hpp
+++ b/nano/secure/store_partial.hpp
@@ -107,16 +107,16 @@ public:
 	{
 		auto hash_l (genesis_a.hash ());
 		debug_assert (account.begin (transaction_a) == account.end ());
-		genesis_a.open->sideband_set (nano::block_sideband (network_params.ledger.genesis_account, 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
+		genesis_a.open->sideband_set (nano::block_sideband (network_params.ledger.genesis_account (), 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 		block.put (transaction_a, hash_l, *genesis_a.open);
 		++ledger_cache_a.block_count;
-		confirmation_height.put (transaction_a, network_params.ledger.genesis_account, nano::confirmation_height_info{ 1, genesis_a.hash () });
+		confirmation_height.put (transaction_a, network_params.ledger.genesis_account (), nano::confirmation_height_info{ 1, genesis_a.hash () });
 		++ledger_cache_a.cemented_count;
-		ledger_cache_a.final_votes_confirmation_canary = (network_params.ledger.final_votes_canary_account == network_params.ledger.genesis_account && 1 >= network_params.ledger.final_votes_canary_height);
-		account.put (transaction_a, network_params.ledger.genesis_account, { hash_l, network_params.ledger.genesis_account, genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
+		ledger_cache_a.final_votes_confirmation_canary = (network_params.ledger.final_votes_canary_account == network_params.ledger.genesis_account () && 1 >= network_params.ledger.final_votes_canary_height);
+		account.put (transaction_a, network_params.ledger.genesis_account (), { hash_l, network_params.ledger.genesis_account (), genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
 		++ledger_cache_a.account_count;
-		ledger_cache_a.rep_weights.representation_put (network_params.ledger.genesis_account, std::numeric_limits<nano::uint128_t>::max ());
-		frontier.put (transaction_a, hash_l, network_params.ledger.genesis_account);
+		ledger_cache_a.rep_weights.representation_put (network_params.ledger.genesis_account (), std::numeric_limits<nano::uint128_t>::max ());
+		frontier.put (transaction_a, hash_l, network_params.ledger.genesis_account ());
 	}
 
 	bool root_exists (nano::transaction const & transaction_a, nano::root const & root_a) override

--- a/nano/secure/store_partial.hpp
+++ b/nano/secure/store_partial.hpp
@@ -103,17 +103,18 @@ public:
 	 * If using a different store version than the latest then you may need
 	 * to modify some of the objects in the store to be appropriate for the version before an upgrade.
 	 */
-	void initialize (nano::write_transaction const & transaction_a, nano::genesis const & genesis_a, nano::ledger_cache & ledger_cache_a) override
+	void initialize (nano::write_transaction const & transaction_a, nano::ledger_cache & ledger_cache_a) override
 	{
-		auto hash_l (genesis_a.hash ());
+		auto & genesis = *network_params.ledger.genesis_block;
+		auto hash_l (genesis.hash ());
 		debug_assert (account.begin (transaction_a) == account.end ());
-		genesis_a.open->sideband_set (nano::block_sideband (network_params.ledger.genesis_account (), 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
-		block.put (transaction_a, hash_l, *genesis_a.open);
+		genesis.sideband_set (nano::block_sideband (network_params.ledger.genesis_account (), 0, network_params.ledger.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
+		block.put (transaction_a, hash_l, genesis);
 		++ledger_cache_a.block_count;
-		confirmation_height.put (transaction_a, network_params.ledger.genesis_account (), nano::confirmation_height_info{ 1, genesis_a.hash () });
+		confirmation_height.put (transaction_a, network_params.ledger.genesis_account (), nano::confirmation_height_info{ 1, genesis.hash () });
 		++ledger_cache_a.cemented_count;
 		ledger_cache_a.final_votes_confirmation_canary = (network_params.ledger.final_votes_canary_account == network_params.ledger.genesis_account () && 1 >= network_params.ledger.final_votes_canary_height);
-		account.put (transaction_a, network_params.ledger.genesis_account (), { hash_l, network_params.ledger.genesis_account (), genesis_a.open->hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
+		account.put (transaction_a, network_params.ledger.genesis_account (), { hash_l, network_params.ledger.genesis_account (), genesis.hash (), std::numeric_limits<nano::uint128_t>::max (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0 });
 		++ledger_cache_a.account_count;
 		ledger_cache_a.rep_weights.representation_put (network_params.ledger.genesis_account (), std::numeric_limits<nano::uint128_t>::max ());
 		frontier.put (transaction_a, hash_l, network_params.ledger.genesis_account ());

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -97,7 +97,7 @@ TEST (ledger, deep_account_compute)
 	nano::ledger ledger (*store, stats);
 	nano::genesis genesis;
 	auto transaction (store->tx_begin_write ());
-	store->initialize (transaction, genesis, ledger.cache);
+	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::keypair key;
 	auto balance (nano::genesis_amount - 1);
@@ -987,7 +987,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 
 	{
 		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, genesis, ledger.cache);
+		store->initialize (transaction, ledger.cache);
 
 		// Send from genesis account to all other accounts and create open block for them
 		for (auto i = 0; i < num_accounts; ++i)

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -398,7 +398,7 @@ void nano::system::generate_receive (nano::node & node_a)
 	}
 	if (send_block != nullptr)
 	{
-		auto receive_error (wallet (0)->receive_sync (send_block, nano::ledger_constants (nano::networks::nano_dev_network).genesis_account, std::numeric_limits<nano::uint128_t>::max ()));
+		auto receive_error (wallet (0)->receive_sync (send_block, nano::ledger_constants (nano::networks::nano_dev_network).genesis_account (), std::numeric_limits<nano::uint128_t>::max ()));
 		(void)receive_error;
 	}
 }

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -13,7 +13,7 @@ void nano::compare_default_telemetry_response_data_excluding_signature (nano::te
 	ASSERT_EQ (telemetry_data_a.unchecked_count, 0);
 	ASSERT_EQ (telemetry_data_a.account_count, 1);
 	ASSERT_LT (telemetry_data_a.uptime, 100);
-	ASSERT_EQ (telemetry_data_a.genesis_block, network_params_a.ledger.genesis_hash);
+	ASSERT_EQ (telemetry_data_a.genesis_block, network_params_a.ledger.genesis_hash ());
 	ASSERT_EQ (telemetry_data_a.major_version, nano::get_major_node_version ());
 	ASSERT_EQ (telemetry_data_a.minor_version, nano::get_minor_node_version ());
 	ASSERT_EQ (telemetry_data_a.patch_version, nano::get_patch_node_version ());

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -19,7 +19,7 @@ nano::keypair const & nano::zero_key (dev_constants.zero_key);
 nano::keypair const & nano::dev_genesis_key (dev_constants.dev_genesis_key);
 nano::account const & nano::nano_dev_account (dev_constants.nano_dev_account);
 nano::account const & nano::genesis_account (dev_constants.genesis_account ());
-nano::block_hash const & nano::genesis_hash (dev_constants.genesis_hash);
+nano::block_hash const & nano::genesis_hash (dev_constants.genesis_hash ());
 nano::uint128_t const & nano::genesis_amount (dev_constants.genesis_amount);
 nano::account const & nano::burn_account (dev_constants.burn_account);
 

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -18,7 +18,7 @@ nano::ledger_constants dev_constants (nano::networks::nano_dev_network);
 nano::keypair const & nano::zero_key (dev_constants.zero_key);
 nano::keypair const & nano::dev_genesis_key (dev_constants.dev_genesis_key);
 nano::account const & nano::nano_dev_account (dev_constants.nano_dev_account);
-nano::account const & nano::genesis_account (dev_constants.genesis_account);
+nano::account const & nano::genesis_account (dev_constants.genesis_account ());
 nano::block_hash const & nano::genesis_hash (dev_constants.genesis_hash);
 nano::uint128_t const & nano::genesis_amount (dev_constants.genesis_amount);
 nano::account const & nano::burn_account (dev_constants.burn_account);

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -18,7 +18,6 @@ nano::ledger_constants dev_constants (nano::networks::nano_dev_network);
 nano::keypair const & nano::zero_key (dev_constants.zero_key);
 nano::keypair const & nano::dev_genesis_key (dev_constants.dev_genesis_key);
 nano::account const & nano::nano_dev_account (dev_constants.nano_dev_account);
-std::string const & nano::nano_dev_genesis (dev_constants.nano_dev_genesis);
 nano::account const & nano::genesis_account (dev_constants.genesis_account);
 nano::block_hash const & nano::genesis_hash (dev_constants.genesis_hash);
 nano::uint128_t const & nano::genesis_amount (dev_constants.genesis_amount);

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -55,8 +55,6 @@ class system;
 
 extern nano::keypair const & zero_key;
 extern nano::keypair const & dev_genesis_key;
-extern std::string const & nano_dev_genesis;
-extern std::string const & genesis_block;
 extern nano::block_hash const & genesis_hash;
 extern nano::public_key const & nano_dev_account;
 extern nano::public_key const & genesis_account;


### PR DESCRIPTION
genesis_block is converted to a block shared_ptr rather than the textual data which callers don't need and could regenerate from the block format.
Replace member variables genesis_hash and genesis_account with same-named functions that derive their values from the genesis block eliminating some memorization.
Remove the nano::genesis parameter from block_store::initialize as most of the body of the function uses the network_params.ledger_constants member to obtain genesis constants anyway. 