### PR TITLE
wallet_pending and accounts_pending handle empty results differently

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1002,7 +1002,10 @@ void nano::json_handler::accounts_pending ()
 					});
 				}
 			}
-			pending.add_child (account.to_account (), peers_l);
+			if (!peers_l.empty ())
+			{
+				pending.add_child (account.to_account (), peers_l);
+			}
 		}
 	}
 	response_l.add_child ("blocks", pending);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -142,7 +142,15 @@ boost::property_tree::ptree wait_response (nano::system & system, std::shared_pt
 void check_block_response_count (nano::system & system, std::shared_ptr<nano::rpc> const & rpc, boost::property_tree::ptree & request, uint64_t size_count)
 {
 	auto response (wait_response (system, rpc, request));
-	ASSERT_EQ (size_count, response.get_child ("blocks").front ().second.size ());
+	auto & blocks = response.get_child ("blocks");
+	if (size_count > 0)
+	{
+		ASSERT_EQ (size_count, blocks.front ().second.size ());
+	}
+	else
+	{
+		ASSERT_TRUE (blocks.empty ());
+	}
 }
 
 class scoped_io_thread_name_change


### PR DESCRIPTION
Accounts_pending inserted an entry with an empty array and wallet_pending didn't insert a result at all. This caused wallet_pending to fail check_block_response_count.