### PR TITLE
Use ledger_walker from within the confirmation_height_processor

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1374,7 +1374,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	}
 
-	nano::confirmation_height_processor confirmation_height_processor (ledger, write_database_queue, 10ms, logging, logger, initialized_latch, nano::confirmation_height_mode::unbounded);
+	nano::confirmation_height_processor confirmation_height_processor (ledger, write_database_queue, 10ms, logging, logger, initialized_latch, true, nano::confirmation_height_mode::unbounded);
 	nano::timer<> timer;
 	timer.start ();
 	{

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -6,9 +6,6 @@
 
 #include <numeric>
 
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-
 using namespace std::chrono_literals;
 
 TEST (ledger_walker, genesis_block)
@@ -221,5 +218,3 @@ TEST (ledger_walker, ladder_geometry)
 
 	EXPECT_EQ (amounts_expected_itr, amounts_expected_backwards.crend ());
 }
-
-#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -551,10 +551,10 @@ TEST (telemetry, remove_peer_different_genesis)
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
 	// Change genesis block to something else in this test (this is the reference telemetry processing uses).
-	nano::network_params network_params{ nano::networks::nano_dev_network };
-	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
-	nano::node_config config{ network_params };
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work));
+    nano::network_params network_params{ nano::networks::nano_dev_network };
+    network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
+    nano::node_config config{ network_params };
+    auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	node0->network.merge_peer (node1->network.endpoint ());
@@ -581,10 +581,10 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 	nano::system system (1, nano::transport::transport_type::udp, node_flags);
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
-	nano::network_params network_params{ nano::networks::nano_dev_network };
-	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
-	nano::node_config config{ network_params };
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags));
+    nano::network_params network_params{ nano::networks::nano_dev_network };
+    network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
+    nano::node_config config{ network_params };
+    auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.network.protocol_version));

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -551,10 +551,10 @@ TEST (telemetry, remove_peer_different_genesis)
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
 	// Change genesis block to something else in this test (this is the reference telemetry processing uses).
-    nano::network_params network_params{ nano::networks::nano_dev_network };
-    network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
-    nano::node_config config{ network_params };
-    auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work));
+	nano::network_params network_params{ nano::networks::nano_dev_network };
+	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
+	nano::node_config config{ network_params };
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	node0->network.merge_peer (node1->network.endpoint ());
@@ -581,10 +581,10 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 	nano::system system (1, nano::transport::transport_type::udp, node_flags);
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
-    nano::network_params network_params{ nano::networks::nano_dev_network };
-    network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
-    nano::node_config config{ network_params };
-    auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags));
+	nano::network_params network_params{ nano::networks::nano_dev_network };
+	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
+	nano::node_config config{ network_params };
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.network.protocol_version));

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/confirmation_height_processor.hpp>
@@ -9,14 +10,16 @@
 
 #include <boost/thread/latch.hpp>
 
-#include <numeric>
-
 nano::confirmation_height_processor::confirmation_height_processor (nano::ledger & ledger_a, nano::write_database_queue & write_database_queue_a, std::chrono::milliseconds batch_separate_pending_min_time_a, nano::logging const & logging_a, nano::logger_mt & logger_a, boost::latch & latch, confirmation_height_mode mode_a) :
 	ledger (ledger_a),
 	write_database_queue (write_database_queue_a),
 	// clang-format off
-unbounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
-bounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
+    unbounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
+    bounded_processor (ledger_a, write_database_queue_a, batch_separate_pending_min_time_a, logging_a, logger_a, stopped, batch_write_size, [this](auto & cemented_blocks) { this->notify_observers (cemented_blocks); }, [this](auto const & block_hash_a) { this->notify_observers (block_hash_a); }, [this]() { return this->awaiting_processing_size (); }),
+    // TODO: keep this until diskhash builds fine on Windows
+    #ifndef _WIN32
+    walker (ledger_a),
+    #endif
 	// clang-format on
 	thread ([this, &latch, mode_a] () {
 		nano::thread_role::set (nano::thread_role::name::confirmation_height_processing);
@@ -133,6 +136,74 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 			}
 		}
 	}
+}
+
+void nano::confirmation_height_processor::run_walker ()
+{
+// TODO: keep this until diskhash builds fine on Windows
+#ifndef _WIN32
+
+	nano::unique_lock<nano::mutex> lk (mutex);
+	while (!stopped)
+	{
+		if (awaiting_processing.empty ())
+		{
+			lk.unlock ();
+			condition.wait (lk, [this] () {
+				return !awaiting_processing.empty ();
+			});
+		}
+
+		if (paused)
+		{
+			// Pausing is only utilised in some tests to help prevent it processing added blocks until required.
+			debug_assert (network_params.network.is_dev_network ());
+
+			lk.unlock ();
+			condition.wait (lk, [this] () {
+				return !paused;
+			});
+		}
+
+		const auto block = awaiting_processing.get<tag_sequence> ().front ().block;
+		awaiting_processing.get<tag_sequence> ().pop_front ();
+
+		const auto read_confirmation_height = [this] (const auto & transaction, const auto & account) {
+			nano::confirmation_height_info confirmation_height_info{};
+			if (ledger.store.confirmation_height.get (transaction, account, confirmation_height_info))
+			{
+				debug_assert (false);
+			}
+
+			return confirmation_height_info.height;
+		};
+
+		lk.unlock ();
+
+		walker.walk (
+		block->hash (),
+		[&] (const auto & block) {
+			return block->sideband ().height > read_confirmation_height (ledger.store.tx_begin_read (), block->account ());
+		},
+		[&] (const auto & block) {
+			const auto & block_height = block->sideband ().height;
+			const auto write_transaction = ledger.store.tx_begin_write ({}, { nano::tables::confirmation_height });
+
+			auto existing_confirmation_height = read_confirmation_height (write_transaction, block->account ());
+			if (existing_confirmation_height < block_height)
+			{
+				++ledger.cache.cemented_count;
+				ledger.stats.add (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in, block_height - existing_confirmation_height);
+				ledger.store.confirmation_height.put (write_transaction, block->account (), nano::confirmation_height_info{ block_height, block->hash () });
+
+				notify_observers ({ block });
+			}
+		});
+
+		lk.lock ();
+	}
+
+#endif
 }
 
 // Pausing only affects processing new blocks, not the current one being processed. Currently only used in tests

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/timer.hpp>
 #include <nano/node/confirmation_height_bounded.hpp>
 #include <nano/node/confirmation_height_unbounded.hpp>
+#include <nano/node/ledger_walker.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/store.hpp>
 
@@ -39,6 +40,7 @@ public:
 	void stop ();
 	void add (std::shared_ptr<nano::block> const &);
 	void run (confirmation_height_mode);
+	void run_walker ();
 	size_t awaiting_processing_size () const;
 	bool is_processing_added_block (nano::block_hash const & hash_a) const;
 	bool is_processing_block (nano::block_hash const &) const;
@@ -94,6 +96,12 @@ private:
 
 	confirmation_height_unbounded unbounded_processor;
 	confirmation_height_bounded bounded_processor;
+
+// TODO: keep this until diskhash builds fine on Windows
+#ifndef _WIN32
+	ledger_walker walker;
+#endif
+
 	std::thread thread;
 
 	void set_next_hash ();

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -97,9 +97,9 @@ private:
 	confirmation_height_unbounded unbounded_processor;
 	confirmation_height_bounded bounded_processor;
 
-    ledger_walker walker;
+	ledger_walker walker;
 
-    bool is_dev_network;
+	bool is_dev_network;
 
 	std::thread thread;
 

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -33,7 +33,7 @@ class write_database_queue;
 class confirmation_height_processor final
 {
 public:
-	confirmation_height_processor (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, boost::latch & initialized_latch, confirmation_height_mode = confirmation_height_mode::automatic);
+	confirmation_height_processor (nano::ledger &, nano::write_database_queue &, std::chrono::milliseconds, nano::logging const &, nano::logger_mt &, boost::latch & initialized_latch, bool is_dev_network, confirmation_height_mode = confirmation_height_mode::automatic);
 	~confirmation_height_processor ();
 	void pause ();
 	void unpause ();
@@ -97,10 +97,9 @@ private:
 	confirmation_height_unbounded unbounded_processor;
 	confirmation_height_bounded bounded_processor;
 
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-	ledger_walker walker;
-#endif
+    ledger_walker walker;
+
+    bool is_dev_network;
 
 	std::thread thread;
 

--- a/nano/node/ledger_walker.cpp
+++ b/nano/node/ledger_walker.cpp
@@ -1,6 +1,3 @@
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/node/ledger_walker.hpp>
@@ -176,5 +173,3 @@ std::shared_ptr<nano::block> nano::ledger_walker::dequeue_block (nano::transacti
 
 	return block;
 }
-
-#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/node/ledger_walker.hpp
+++ b/nano/node/ledger_walker.hpp
@@ -37,8 +37,7 @@ public:
 	void walk (nano::block_hash const & end_block_hash_a, visitor_callback const & visitor_callback_a);
 
 	/** How many blocks will be held in the in-memory hash before using the disk hash for walking. */
-	// TODO TSB: make this 65536
-	static constexpr std::size_t in_memory_block_count = 0;
+	static constexpr std::size_t in_memory_block_count = 65536;
 
 private:
 	nano::ledger const & ledger;

--- a/nano/node/ledger_walker.hpp
+++ b/nano/node/ledger_walker.hpp
@@ -1,6 +1,3 @@
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-
 #pragma once
 
 #include <nano/lib/numbers.hpp>
@@ -61,5 +58,3 @@ private:
 };
 
 }
-
-#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -116,7 +116,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	online_reps (ledger, config),
 	history{ config.network_params.voting },
 	vote_uniquer (block_uniquer),
-	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
+	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, network_params.network.is_dev_network (), flags.confirmation_height_processor_mode),
 	active (*this, confirmation_height_processor),
 	scheduler{ *this },
 	aggregator (config, stats, active.generator, active.final_generator, history, ledger, wallets, active),

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -973,7 +973,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	boost::latch initialized_latch{ 0 };
 
 	nano::block_hash block_hash_being_processed{ 0 };
-	nano::confirmation_height_processor confirmation_height_processor{ ledger, write_database_queue, 10ms, logging, logger, initialized_latch, confirmation_height_mode::automatic };
+	nano::confirmation_height_processor confirmation_height_processor{ ledger, write_database_queue, 10ms, logging, logger, initialized_latch, true, confirmation_height_mode::automatic };
 
 	auto const num_accounts = 100000;
 


### PR DESCRIPTION
The ugly ifdefs can be taken out (together with the ones from `ledger_walker.cpp`) pretty soon once everything is stable with diskhash on Windows.

Besides that, this PR adds the `run_walker` method to the `confirmation_height_processor`, but does not attempt to remove already used code -- @clemahieu that's the bit of refactoring we were discussing that you could help with. Please let me know if something is not clear or not complete before that final refactoring and the removal of the bounded/unbounded processors can be done. Additionally, I would like to make `awaiting_processing` a simple std::deque or something like that instead of the complex `boost::multi_index_container` that we have right now, because we will likely no longer need that (currently it's used just to be able to prevent double callback for cemented blocks).