### PR TITLE
Passing nano::ledger_constants in to nano::ledger

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -663,7 +663,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 	{
 		nano::mdb_store store (logger, path);
 		nano::stat stats;
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 		// Lower the database to the max version unsupported for upgrades
@@ -681,7 +681,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 	{
 		nano::mdb_store store (logger, path1);
 		nano::stat stats;
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 		// Lower the database version to the minimum version supported for upgrade.
@@ -1003,7 +1003,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::mdb_store store (logger, nano::unique_path ());
 	ASSERT_FALSE (store.init_error ());
 	nano::stat stat;
-	nano::ledger ledger (store, stat);
+	nano::ledger ledger (store, stat, nano::dev::constants);
 	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1271,7 +1271,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 		nano::logger_mt logger;
 		nano::mdb_store store (logger, path);
 		nano::stat stats;
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 		nano::account_info account_info;
@@ -1378,7 +1378,7 @@ TEST (mdb_block_store, upgrade_v15_v16)
 		nano::logger_mt logger;
 		nano::mdb_store store (logger, path);
 		nano::stat stats;
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 		// The representation table should get removed after, so readd it so that we can later confirm this actually happens
@@ -1429,7 +1429,7 @@ TEST (mdb_block_store, upgrade_v16_v17)
 			nano::logger_mt logger;
 			nano::mdb_store store (logger, path);
 			nano::stat stats;
-			nano::ledger ledger (store, stats);
+			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1502,7 +1502,7 @@ TEST (mdb_block_store, upgrade_v17_v18)
 		nano::mdb_store store (logger, path);
 		auto transaction (store.tx_begin_write ());
 		nano::stat stats;
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		store.initialize (transaction, ledger.cache);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send_zero).code);
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive_zero).code);
@@ -1697,7 +1697,7 @@ TEST (mdb_block_store, upgrade_v18_v19)
 		nano::logger_mt logger;
 		nano::mdb_store store (logger, path);
 		nano::stat stats;
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 
@@ -1779,7 +1779,7 @@ TEST (mdb_block_store, upgrade_v19_v20)
 	nano::stat stats;
 	{
 		nano::mdb_store store (logger, path);
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 		// Delete pruned table
@@ -1808,7 +1808,7 @@ TEST (mdb_block_store, upgrade_v20_v21)
 	nano::stat stats;
 	{
 		nano::mdb_store store (logger, path);
-		nano::ledger ledger (store, stats);
+		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
 		// Delete pruned table

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -721,7 +721,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		auto store = nano::make_store (logger, path);
 		ASSERT_TRUE (!store->init_error ());
 		nano::stat stats;
-		nano::ledger ledger (*store, stats);
+		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
@@ -797,7 +797,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		auto store = nano::make_store (logger, path);
 		ASSERT_TRUE (!store->init_error ());
 		nano::stat stats;
-		nano::ledger ledger (*store, stats);
+		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
@@ -867,7 +867,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		auto store = nano::make_store (logger, path);
 		ASSERT_TRUE (!store->init_error ());
 		nano::stat stats;
-		nano::ledger ledger (*store, stats);
+		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 		nano::keypair key1;
@@ -1359,7 +1359,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	auto store = nano::make_store (logger, path);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	boost::latch initialized_latch{ 0 };
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1409,7 +1409,7 @@ TEST (confirmation_height, pruned_source)
 	auto store = nano::make_store (logger, path);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::write_database_queue write_database_queue (false);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -21,7 +21,7 @@ TEST (ledger, store_error)
 	nano::mdb_store store (logger, boost::filesystem::path ("///"));
 	ASSERT_TRUE (store.init_error ());
 	nano::stat stats;
-	nano::ledger ledger (store, stats);
+	nano::ledger ledger (store, stats, nano::dev::constants);
 }
 
 // Ledger can be initialized and returns a basic query for an empty account
@@ -31,7 +31,7 @@ TEST (ledger, empty)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::account account;
 	auto transaction (store->tx_begin_read ());
 	auto balance (ledger.account_balance (transaction, account));
@@ -45,7 +45,7 @@ TEST (ledger, genesis_balance)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	auto balance (ledger.account_balance (transaction, nano::dev::genesis->account ()));
@@ -71,7 +71,7 @@ TEST (ledger, process_modifies_sideband)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
@@ -86,7 +86,7 @@ TEST (ledger, process_send)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -185,7 +185,7 @@ TEST (ledger, process_receive)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -248,7 +248,7 @@ TEST (ledger, rollback_receiver)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -287,7 +287,7 @@ TEST (ledger, rollback_representation)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -340,7 +340,7 @@ TEST (ledger, receive_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -357,7 +357,7 @@ TEST (ledger, process_duplicate)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -379,7 +379,7 @@ TEST (ledger, representative_genesis)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	auto latest (ledger.latest (transaction, nano::dev::genesis_key.pub));
@@ -393,7 +393,7 @@ TEST (ledger, weight)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
@@ -405,7 +405,7 @@ TEST (ledger, representative_change)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::keypair key2;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -443,7 +443,7 @@ TEST (ledger, send_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::keypair key2;
 	nano::keypair key3;
 	auto transaction (store->tx_begin_write ());
@@ -463,7 +463,7 @@ TEST (ledger, receive_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::keypair key2;
 	nano::keypair key3;
 	auto transaction (store->tx_begin_write ());
@@ -489,7 +489,7 @@ TEST (ledger, open_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::keypair key2;
 	nano::keypair key3;
 	auto transaction (store->tx_begin_write ());
@@ -522,7 +522,7 @@ TEST (ledger, representation)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto & rep_weights = ledger.cache.rep_weights;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -596,7 +596,7 @@ TEST (ledger, double_open)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -615,7 +615,7 @@ TEST (ledger, double_receive)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -893,7 +893,7 @@ TEST (ledger, fail_change_old)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -911,7 +911,7 @@ TEST (ledger, fail_change_gap_previous)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -927,7 +927,7 @@ TEST (ledger, fail_change_bad_signature)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -943,7 +943,7 @@ TEST (ledger, fail_change_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -963,7 +963,7 @@ TEST (ledger, fail_send_old)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -981,7 +981,7 @@ TEST (ledger, fail_send_gap_previous)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -997,7 +997,7 @@ TEST (ledger, fail_send_bad_signature)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1013,7 +1013,7 @@ TEST (ledger, fail_send_negative_spend)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1031,7 +1031,7 @@ TEST (ledger, fail_send_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1049,7 +1049,7 @@ TEST (ledger, fail_open_old)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1067,7 +1067,7 @@ TEST (ledger, fail_open_gap_source)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1083,7 +1083,7 @@ TEST (ledger, fail_open_bad_signature)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1101,7 +1101,7 @@ TEST (ledger, fail_open_fork_previous)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1123,7 +1123,7 @@ TEST (ledger, fail_open_account_mismatch)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1142,7 +1142,7 @@ TEST (ledger, fail_receive_old)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1164,7 +1164,7 @@ TEST (ledger, fail_receive_gap_source)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1189,7 +1189,7 @@ TEST (ledger, fail_receive_overreceive)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1211,7 +1211,7 @@ TEST (ledger, fail_receive_bad_signature)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1236,7 +1236,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1261,7 +1261,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1283,7 +1283,7 @@ TEST (ledger, fail_receive_fork_previous)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1312,7 +1312,7 @@ TEST (ledger, fail_receive_received_source)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1347,7 +1347,7 @@ TEST (ledger, latest_empty)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::keypair key;
 	auto transaction (store->tx_begin_read ());
 	auto latest (ledger.latest (transaction, key.pub));
@@ -1360,7 +1360,7 @@ TEST (ledger, latest_root)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1378,7 +1378,7 @@ TEST (ledger, change_representative_move_representation)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -1402,7 +1402,7 @@ TEST (ledger, send_open_receive_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1460,7 +1460,7 @@ TEST (ledger, bootstrap_rep_weight)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::account_info info1;
 	nano::keypair key2;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1496,7 +1496,7 @@ TEST (ledger, block_destination_source)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1541,7 +1541,7 @@ TEST (ledger, state_account)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1556,7 +1556,7 @@ TEST (ledger, state_send_receive)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1597,7 +1597,7 @@ TEST (ledger, state_receive)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1631,7 +1631,7 @@ TEST (ledger, state_rep_change)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1658,7 +1658,7 @@ TEST (ledger, state_open)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1697,7 +1697,7 @@ TEST (ledger, send_after_state_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1714,7 +1714,7 @@ TEST (ledger, receive_after_state_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1731,7 +1731,7 @@ TEST (ledger, change_after_state_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1748,7 +1748,7 @@ TEST (ledger, state_unreceivable_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1771,7 +1771,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1794,7 +1794,7 @@ TEST (ledger, state_no_link_amount_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1811,7 +1811,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1835,7 +1835,7 @@ TEST (ledger, state_open_state_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1855,7 +1855,7 @@ TEST (ledger, state_state_open_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1876,7 +1876,7 @@ TEST (ledger, state_open_previous_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1893,7 +1893,7 @@ TEST (ledger, state_open_source_fail)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1910,7 +1910,7 @@ TEST (ledger, state_send_change)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1937,7 +1937,7 @@ TEST (ledger, state_receive_change)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1973,7 +1973,7 @@ TEST (ledger, state_open_old)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -1993,7 +1993,7 @@ TEST (ledger, state_receive_old)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2017,7 +2017,7 @@ TEST (ledger, state_rollback_send)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2048,7 +2048,7 @@ TEST (ledger, state_rollback_receive)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2074,7 +2074,7 @@ TEST (ledger, state_rollback_received_send)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2101,7 +2101,7 @@ TEST (ledger, state_rep_change_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2121,7 +2121,7 @@ TEST (ledger, state_open_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2147,7 +2147,7 @@ TEST (ledger, state_send_change_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2168,7 +2168,7 @@ TEST (ledger, state_receive_change_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2191,7 +2191,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2261,7 +2261,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2326,7 +2326,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2406,7 +2406,7 @@ TEST (ledger, epoch_blocks_fork)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2587,7 +2587,7 @@ TEST (ledger, could_fit)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2823,7 +2823,7 @@ TEST (ledger, confirmation_height_not_updated)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -2884,7 +2884,7 @@ TEST (ledger, work_validation)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::block_builder builder;
@@ -2977,7 +2977,7 @@ TEST (ledger, dependents_confirmed)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *nano::dev::genesis));
@@ -3049,7 +3049,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3100,7 +3100,7 @@ TEST (ledger, block_confirmed)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	ASSERT_TRUE (ledger.block_confirmed (transaction, nano::dev::genesis->hash ()));
@@ -3132,7 +3132,7 @@ TEST (ledger, cache)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::block_builder builder;
@@ -3184,7 +3184,7 @@ TEST (ledger, cache)
 		++block_count;
 		--genesis_weight;
 		cache_check (ledger.cache);
-		cache_check (nano::ledger (*store, stats).cache);
+		cache_check (nano::ledger (*store, stats, nano::dev::constants).cache);
 
 		{
 			auto transaction (store->tx_begin_write ());
@@ -3194,7 +3194,7 @@ TEST (ledger, cache)
 		++block_count;
 		++account_count;
 		cache_check (ledger.cache);
-		cache_check (nano::ledger (*store, stats).cache);
+		cache_check (nano::ledger (*store, stats, nano::dev::constants).cache);
 
 		{
 			auto transaction (store->tx_begin_write ());
@@ -3209,7 +3209,7 @@ TEST (ledger, cache)
 
 		++cemented_count;
 		cache_check (ledger.cache);
-		cache_check (nano::ledger (*store, stats).cache);
+		cache_check (nano::ledger (*store, stats, nano::dev::constants).cache);
 
 		{
 			auto transaction (store->tx_begin_write ());
@@ -3224,7 +3224,7 @@ TEST (ledger, cache)
 
 		++cemented_count;
 		cache_check (ledger.cache);
-		cache_check (nano::ledger (*store, stats).cache);
+		cache_check (nano::ledger (*store, stats, nano::dev::constants).cache);
 
 		{
 			auto transaction (store->tx_begin_write ());
@@ -3233,7 +3233,7 @@ TEST (ledger, cache)
 		}
 		++pruned_count;
 		cache_check (ledger.cache);
-		cache_check (nano::ledger (*store, stats).cache);
+		cache_check (nano::ledger (*store, stats, nano::dev::constants).cache);
 	}
 }
 
@@ -3243,7 +3243,7 @@ TEST (ledger, pruning_action)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3299,7 +3299,7 @@ TEST (ledger, pruning_large_chain)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3335,7 +3335,7 @@ TEST (ledger, pruning_source_rollback)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3386,7 +3386,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3464,7 +3464,7 @@ TEST (ledger, pruning_process_error)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3492,7 +3492,7 @@ TEST (ledger, pruning_legacy_blocks)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
@@ -3537,7 +3537,7 @@ TEST (ledger, pruning_safe_functions)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3579,7 +3579,7 @@ TEST (ledger, hash_root_random)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
@@ -3624,7 +3624,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	uint16_t port = 100;
 	nano::mdb_store store (logger, path / "data.ldb");
 	nano::stat stats;
-	nano::ledger ledger (store, stats);
+	nano::ledger ledger (store, stats, nano::dev::constants);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 
 	auto send = nano::state_block_builder ()
@@ -3703,7 +3703,7 @@ TEST (ledger, unconfirmed_frontiers)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -13,7 +13,7 @@ TEST (processor_service, bad_send_signature)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -31,7 +31,7 @@ TEST (processor_service, bad_receive_signature)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -29,7 +29,7 @@ nano::block_processor::block_processor (nano::node & node_a, nano::write_databas
 	next_log (std::chrono::steady_clock::now ()),
 	node (node_a),
 	write_database_queue (write_database_queue_a),
-	state_block_signature_verification (node.checker, node.ledger.network_params.ledger.epochs, node.config, node.logger, node.flags.block_processor_verification_size)
+	state_block_signature_verification (node.checker, node.ledger.constants.epochs, node.config, node.logger, node.flags.block_processor_verification_size)
 {
 	state_block_signature_verification.blocks_verified_callback = [this] (std::deque<nano::unchecked_info> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures) {
 		this->process_verified_state_blocks (items, verifications, hashes, blocks_signatures);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -100,7 +100,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),
 	wallets_store (*wallets_store_impl),
 	gap_cache (*this),
-	ledger (store, stats, flags_a.generate_cache),
+	ledger (store, stats, network_params.ledger, flags_a.generate_cache),
 	checker (config.signature_checker_threads),
 	network (*this, config.peering_port),
 	telemetry (std::make_shared<nano::telemetry> (network, workers, observers.telemetry, stats, network_params, flags.disable_ongoing_telemetry_requests)),
@@ -1318,7 +1318,7 @@ void nano::node::process_confirmed_data (nano::transaction const & transaction_a
 	bool error (false);
 	auto previous_balance (ledger.balance_safe (transaction_a, previous, error));
 	auto block_balance (store.block.balance_calculated (block_a));
-	if (hash_a != ledger.network_params.ledger.genesis->account ())
+	if (hash_a != ledger.constants.genesis->account ())
 	{
 		if (!error)
 		{

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -516,7 +516,7 @@ TEST (history, short_text)
 	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::genesis genesis;
-	nano::ledger ledger (*store, system.nodes[0]->stats);
+	nano::ledger ledger (*store, system.nodes[0]->stats, nano::dev::constants);
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache);
@@ -554,7 +554,7 @@ TEST (history, pruned_source)
 	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path ());
 	ASSERT_TRUE (!store->init_error ());
 	nano::genesis genesis;
-	nano::ledger ledger (*store, system.nodes[0]->stats);
+	nano::ledger ledger (*store, system.nodes[0]->stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::block_hash next_pruning;
 	// Basic pruning for legacy blocks. Previous block is pruned, source is pruned

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -436,7 +436,7 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 				}
 				if (result.code == nano::process_result::progress)
 				{
-					auto epoch = ledger.network_params.ledger.epochs.epoch (block_a.hashables.link);
+					auto epoch = ledger.constants.epochs.epoch (block_a.hashables.link);
 					// Must be an epoch for an unopened account or the epoch upgrade must be sequential
 					auto is_valid_epoch_upgrade = account_error ? static_cast<std::underlying_type_t<nano::epoch>> (epoch) > 0 : nano::epochs::is_sequential (info.epoch (), epoch);
 					result.code = is_valid_epoch_upgrade ? nano::process_result::progress : nano::process_result::block_position;
@@ -690,7 +690,7 @@ void ledger_processor::open_block (nano::open_block & block_a)
 					result.code = ledger.store.pending.get (transaction, key, pending) ? nano::process_result::unreceivable : nano::process_result::progress; // Has this source already been received (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
-						result.code = block_a.hashables.account == ledger.network_params.ledger.burn_account ? nano::process_result::opened_burn_account : nano::process_result::progress; // Is it burning 0 account? (Malicious)
+						result.code = block_a.hashables.account == ledger.constants.burn_account ? nano::process_result::opened_burn_account : nano::process_result::progress; // Is it burning 0 account? (Malicious)
 						if (result.code == nano::process_result::progress)
 						{
 							result.code = pending.epoch == nano::epoch::epoch_0 ? nano::process_result::progress : nano::process_result::unreceivable; // Are we receiving a state-only send? (Malformed)
@@ -736,10 +736,11 @@ ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::write_transac
 }
 } // namespace
 
-nano::ledger::ledger (nano::store & store_a, nano::stat & stat_a, nano::generate_cache const & generate_cache_a) :
-	store (store_a),
-	stats (stat_a),
-	check_bootstrap_weights (true)
+nano::ledger::ledger (nano::store & store_a, nano::stat & stat_a, nano::ledger_constants & constants, nano::generate_cache const & generate_cache_a) :
+	constants{ constants },
+	store{ store_a },
+	stats{ stat_a },
+	check_bootstrap_weights{ true }
 {
 	if (!store.init_error ())
 	{
@@ -787,9 +788,9 @@ void nano::ledger::initialize (nano::generate_cache const & generate_cache_a)
 
 	// Final votes requirement for confirmation canary block
 	nano::confirmation_height_info confirmation_height_info;
-	if (!store.confirmation_height.get (transaction, network_params.ledger.final_votes_canary_account, confirmation_height_info))
+	if (!store.confirmation_height.get (transaction, constants.final_votes_canary_account, confirmation_height_info))
 	{
-		cache.final_votes_confirmation_canary = (confirmation_height_info.height >= network_params.ledger.final_votes_canary_height);
+		cache.final_votes_confirmation_canary = (confirmation_height_info.height >= constants.final_votes_canary_height);
 	}
 }
 
@@ -862,7 +863,7 @@ nano::uint128_t nano::ledger::account_pending (nano::transaction const & transac
 
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a, nano::signature_verification verification)
 {
-	debug_assert (!nano::work_validate_entry (block_a) || network_params.network.is_dev_network ());
+	debug_assert (!nano::work_validate_entry (block_a) || constants.genesis == nano::dev::genesis);
 	ledger_processor processor (*this, transaction_a, verification);
 	block_a.visit (processor);
 	if (processor.result.code == nano::process_result::progress)
@@ -1102,7 +1103,7 @@ nano::account nano::ledger::account_safe (nano::transaction const & transaction_
 // Return amount decrease or increase for block
 nano::uint128_t nano::ledger::amount (nano::transaction const & transaction_a, nano::account const & account_a)
 {
-	release_assert (account_a == network_params.ledger.genesis->account ());
+	release_assert (account_a == constants.genesis->account ());
 	return nano::dev::constants.genesis_amount;
 }
 
@@ -1181,7 +1182,7 @@ bool nano::ledger::dependents_confirmed (nano::transaction const & transaction_a
 
 bool nano::ledger::is_epoch_link (nano::link const & link_a) const
 {
-	return network_params.ledger.epochs.is_epoch_link (link_a);
+	return constants.epochs.is_epoch_link (link_a);
 }
 
 class dependent_block_visitor : public nano::block_visitor
@@ -1204,7 +1205,7 @@ public:
 	}
 	void open_block (nano::open_block const & block_a) override
 	{
-		if (block_a.source () != ledger.network_params.ledger.genesis->account ())
+		if (block_a.source () != ledger.constants.genesis->account ())
 		{
 			result[0] = block_a.source ();
 		}
@@ -1237,12 +1238,12 @@ std::array<nano::block_hash, 2> nano::ledger::dependent_blocks (nano::transactio
 
 nano::account const & nano::ledger::epoch_signer (nano::link const & link_a) const
 {
-	return network_params.ledger.epochs.signer (network_params.ledger.epochs.epoch (link_a));
+	return constants.epochs.signer (constants.epochs.epoch (link_a));
 }
 
 nano::link const & nano::ledger::epoch_link (nano::epoch epoch_a) const
 {
-	return network_params.ledger.epochs.link (epoch_a);
+	return constants.epochs.link (epoch_a);
 }
 
 void nano::ledger::update_account (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::account_info const & old_a, nano::account_info const & new_a)
@@ -1342,7 +1343,7 @@ uint64_t nano::ledger::pruning_action (nano::write_transaction & transaction_a, 
 {
 	uint64_t pruned_count (0);
 	nano::block_hash hash (hash_a);
-	while (!hash.is_zero () && hash != network_params.ledger.genesis->hash ())
+	while (!hash.is_zero () && hash != constants.genesis->hash ())
 	{
 		auto block (store.block.get (transaction_a, hash));
 		if (block != nullptr)

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -26,7 +26,7 @@ public:
 class ledger final
 {
 public:
-	ledger (nano::store &, nano::stat &, nano::generate_cache const & = nano::generate_cache ());
+	ledger (nano::store &, nano::stat &, nano::ledger_constants & constants, nano::generate_cache const & = nano::generate_cache ());
 	nano::account account (nano::transaction const &, nano::block_hash const &) const;
 	nano::account account_safe (nano::transaction const &, nano::block_hash const &, bool &) const;
 	nano::uint128_t amount (nano::transaction const &, nano::account const &);
@@ -68,7 +68,7 @@ public:
 	std::multimap<uint64_t, uncemented_info, std::greater<>> unconfirmed_frontiers () const;
 	bool migrate_lmdb_to_rocksdb (boost::filesystem::path const &) const;
 	static nano::uint128_t const unit;
-	nano::network_params network_params;
+	nano::ledger_constants & constants;
 	nano::store & store;
 	nano::ledger_cache cache;
 	nano::stat & stats;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -94,7 +94,7 @@ TEST (ledger, deep_account_compute)
 	auto store = nano::make_store (logger, nano::unique_path ());
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -966,7 +966,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	auto store = nano::make_store (logger, path);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
-	nano::ledger ledger (*store, stats);
+	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	std::atomic<bool> stopped{ false };


### PR DESCRIPTION
Passing nano::ledger_constants in to nano::ledger rather than it being statically initialized. Further work in the effort to reduce static initialization.