### PR TITLE
Changing nano::block_store_partial to hold nano::ledger_constants by reference

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -34,7 +34,7 @@ void write_block_w_sideband_v18 (nano::mdb_store & store_a, MDB_dbi database, na
 TEST (block_store, construction)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 }
 
@@ -109,7 +109,7 @@ TEST (block_store, sideband_serialization)
 TEST (block_store, add_item)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block.sideband_set ({});
@@ -132,7 +132,7 @@ TEST (block_store, add_item)
 TEST (block_store, clear_successor)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block1.sideband_set ({});
@@ -164,7 +164,7 @@ TEST (block_store, clear_successor)
 TEST (block_store, add_nonempty_block)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
 	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
@@ -183,7 +183,7 @@ TEST (block_store, add_nonempty_block)
 TEST (block_store, add_two_items)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
 	nano::open_block block (0, 1, 1, nano::keypair ().prv, 0, 0);
@@ -214,7 +214,7 @@ TEST (block_store, add_two_items)
 TEST (block_store, add_receive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
 	nano::keypair key2;
@@ -236,7 +236,7 @@ TEST (block_store, add_receive)
 TEST (block_store, add_pending)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
 	nano::pending_key key2 (0, 0);
@@ -254,7 +254,7 @@ TEST (block_store, add_pending)
 TEST (block_store, pending_iterator)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_write ());
 	ASSERT_EQ (store->pending.end (), store->pending.begin (transaction));
@@ -279,7 +279,7 @@ TEST (block_store, pending_iterator)
 TEST (block_store, pending_iterator_comparison)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	auto transaction (store->tx_begin_write ());
@@ -322,7 +322,7 @@ TEST (block_store, pending_iterator_comparison)
 TEST (block_store, genesis)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::ledger_cache ledger_cache;
 	auto transaction (store->tx_begin_write ());
@@ -350,7 +350,7 @@ TEST (block_store, genesis)
 TEST (bootstrap, simple)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
@@ -373,7 +373,7 @@ TEST (unchecked, multiple)
 		return;
 	}
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
@@ -390,7 +390,7 @@ TEST (unchecked, multiple)
 TEST (unchecked, double_put)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
@@ -405,7 +405,7 @@ TEST (unchecked, double_put)
 TEST (unchecked, multiple_get)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5));
 	auto block2 (std::make_shared<nano::send_block> (3, 1, 2, nano::keypair ().prv, 4, 5));
@@ -456,7 +456,7 @@ TEST (unchecked, multiple_get)
 TEST (block_store, empty_accounts)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_read ());
 	auto begin (store->account.begin (transaction));
@@ -467,7 +467,7 @@ TEST (block_store, empty_accounts)
 TEST (block_store, one_block)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block1.sideband_set ({});
@@ -479,7 +479,7 @@ TEST (block_store, one_block)
 TEST (block_store, empty_bootstrap)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_read ());
 	auto begin (store->unchecked.begin (transaction));
@@ -490,7 +490,7 @@ TEST (block_store, empty_bootstrap)
 TEST (block_store, one_bootstrap)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	auto transaction (store->tx_begin_write ());
@@ -511,7 +511,7 @@ TEST (block_store, one_bootstrap)
 TEST (block_store, unchecked_begin_search)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key0;
 	nano::send_block block1 (0, 1, 2, key0.prv, key0.pub, 3);
@@ -521,7 +521,7 @@ TEST (block_store, unchecked_begin_search)
 TEST (block_store, frontier_retrieval)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::account account1 (0);
 	nano::account_info info1 (0, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
@@ -536,7 +536,7 @@ TEST (block_store, frontier_retrieval)
 TEST (block_store, one_account)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::account account (0);
 	nano::block_hash hash (0);
@@ -563,7 +563,7 @@ TEST (block_store, one_account)
 TEST (block_store, two_block)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::open_block block1 (0, 1, 1, nano::keypair ().prv, 0, 0);
 	block1.sideband_set ({});
@@ -586,7 +586,7 @@ TEST (block_store, two_block)
 TEST (block_store, two_account)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::account account1 (1);
 	nano::block_hash hash1 (2);
@@ -628,7 +628,7 @@ TEST (block_store, two_account)
 TEST (block_store, latest_find)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::account account1 (1);
 	nano::block_hash hash1 (2);
@@ -661,7 +661,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 	auto path (nano::unique_path ());
 	nano::logger_mt logger;
 	{
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		nano::stat stats;
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -672,14 +672,14 @@ TEST (mdb_block_store, supported_version_upgrades)
 
 	// Upgrade should fail
 	{
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (store.init_error ());
 	}
 
 	auto path1 (nano::unique_path ());
 	// Now try with the minimum version
 	{
-		nano::mdb_store store (logger, path1);
+		nano::mdb_store store (logger, path1, nano::dev::constants);
 		nano::stat stats;
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -695,7 +695,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 
 	// Upgrade should work
 	{
-		nano::mdb_store store (logger, path1);
+		nano::mdb_store store (logger, path1, nano::dev::constants);
 		ASSERT_FALSE (store.init_error ());
 	}
 }
@@ -708,7 +708,7 @@ TEST (mdb_block_store, bad_path)
 		return;
 	}
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, boost::filesystem::path ("///"));
+	nano::mdb_store store (logger, boost::filesystem::path ("///"), nano::dev::constants);
 	ASSERT_TRUE (store.init_error ());
 }
 
@@ -721,14 +721,14 @@ TEST (block_store, DISABLED_already_open) // File can be shared
 	file.open (path.string ().c_str ());
 	ASSERT_TRUE (file.is_open ());
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, path);
+	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (store->init_error ());
 }
 
 TEST (block_store, roots)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::send_block send_block (0, 1, 2, nano::keypair ().prv, 4, 5);
 	ASSERT_EQ (send_block.hashables.previous, send_block.root ());
@@ -743,7 +743,7 @@ TEST (block_store, roots)
 TEST (block_store, pending_exists)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::pending_key two (2, 0);
 	nano::pending_info pending;
@@ -756,7 +756,7 @@ TEST (block_store, pending_exists)
 TEST (block_store, latest_exists)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::account two (2);
 	nano::account_info info;
@@ -770,7 +770,7 @@ TEST (block_store, latest_exists)
 TEST (block_store, large_iteration)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	std::unordered_set<nano::account> accounts1;
 	for (auto i (0); i < 1000; ++i)
@@ -809,7 +809,7 @@ TEST (block_store, large_iteration)
 TEST (block_store, frontier)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_write ());
 	nano::block_hash hash (100);
@@ -824,7 +824,7 @@ TEST (block_store, frontier)
 TEST (block_store, block_replace)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::send_block send1 (0, 0, 0, nano::keypair ().prv, 0, 1);
 	send1.sideband_set ({});
@@ -841,7 +841,7 @@ TEST (block_store, block_replace)
 TEST (block_store, block_count)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	{
 		auto transaction (store->tx_begin_write ());
@@ -858,7 +858,7 @@ TEST (block_store, block_count)
 TEST (block_store, account_count)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	{
 		auto transaction (store->tx_begin_write ());
@@ -874,7 +874,7 @@ TEST (block_store, account_count)
 TEST (block_store, cemented_count_cache)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_write ());
 	nano::ledger_cache ledger_cache;
@@ -885,7 +885,7 @@ TEST (block_store, cemented_count_cache)
 TEST (block_store, block_random)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	{
 		nano::ledger_cache ledger_cache;
 		auto transaction (store->tx_begin_write ());
@@ -900,7 +900,7 @@ TEST (block_store, block_random)
 TEST (block_store, pruned_random)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
 	block.sideband_set ({});
@@ -921,7 +921,7 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 {
 	auto path (nano::unique_path ());
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	auto transaction (store.tx_begin_write ());
 	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 1));
 	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked_handle));
@@ -961,7 +961,7 @@ TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort ta
 TEST (block_store, state_block)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::keypair key1;
 	nano::state_block block1 (1, nano::dev::genesis->hash (), 3, 4, 6, key1.prv, key1.pub, 7);
@@ -1000,7 +1000,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::keypair key3;
-	nano::mdb_store store (logger, nano::unique_path ());
+	nano::mdb_store store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	nano::stat stat;
 	nano::ledger ledger (store, stat, nano::dev::constants);
@@ -1060,7 +1060,7 @@ TEST (mdb_block_store, sideband_height)
 TEST (block_store, peers)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 
 	nano::endpoint_key endpoint (boost::asio::ip::address_v6::any ().to_bytes (), 100);
@@ -1158,7 +1158,7 @@ TEST (block_store, endpoint_key_byte_order)
 TEST (block_store, online_weight)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	{
 		auto transaction (store->tx_begin_write ());
@@ -1193,7 +1193,7 @@ TEST (block_store, online_weight)
 TEST (block_store, pruned_blocks)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 
 	nano::keypair key1;
@@ -1269,7 +1269,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	nano::state_block state_send (nano::dev::genesis_key.pub, epoch.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch.hash ()));
 	{
 		nano::logger_mt logger;
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		nano::stat stats;
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -1323,7 +1323,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 
 	// Now do the upgrade
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	auto transaction (store.tx_begin_read ());
 
@@ -1376,7 +1376,7 @@ TEST (mdb_block_store, upgrade_v15_v16)
 	nano::mdb_val value;
 	{
 		nano::logger_mt logger;
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		nano::stat stats;
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -1397,7 +1397,7 @@ TEST (mdb_block_store, upgrade_v15_v16)
 
 	// Now do the upgrade
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	auto transaction (store.tx_begin_read ());
 
@@ -1427,7 +1427,7 @@ TEST (mdb_block_store, upgrade_v16_v17)
 		nano::mdb_val value;
 		{
 			nano::logger_mt logger;
-			nano::mdb_store store (logger, path);
+			nano::mdb_store store (logger, path, nano::dev::constants);
 			nano::stat stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
@@ -1450,7 +1450,7 @@ TEST (mdb_block_store, upgrade_v16_v17)
 
 		// Now do the upgrade
 		nano::logger_mt logger;
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		ASSERT_FALSE (store.init_error ());
 		auto transaction (store.tx_begin_read ());
 
@@ -1499,7 +1499,7 @@ TEST (mdb_block_store, upgrade_v17_v18)
 	nano::state_block state_send_epoch_link (key2.pub, state_open.hash (), key2.pub, 0, network_params.ledger.epochs.link (nano::epoch::epoch_2), key2.prv, key2.pub, *pool.generate (state_open.hash ()));
 	{
 		nano::logger_mt logger;
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		nano::stat stats;
 		nano::ledger ledger (store, stats, nano::dev::constants);
@@ -1552,7 +1552,7 @@ TEST (mdb_block_store, upgrade_v17_v18)
 
 	// Now do the upgrade
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	auto transaction (store.tx_begin_read ());
 
@@ -1695,7 +1695,7 @@ TEST (mdb_block_store, upgrade_v18_v19)
 
 	{
 		nano::logger_mt logger;
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		nano::stat stats;
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -1730,7 +1730,7 @@ TEST (mdb_block_store, upgrade_v18_v19)
 
 	// Now do the upgrade
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	auto transaction (store.tx_begin_read ());
 
@@ -1778,7 +1778,7 @@ TEST (mdb_block_store, upgrade_v19_v20)
 	nano::logger_mt logger;
 	nano::stat stats;
 	{
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
@@ -1787,7 +1787,7 @@ TEST (mdb_block_store, upgrade_v19_v20)
 		store.version.put (transaction, 19);
 	}
 	// Upgrading should create the table
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	ASSERT_NE (store.pruned_handle, 0);
 
@@ -1807,7 +1807,7 @@ TEST (mdb_block_store, upgrade_v20_v21)
 	nano::logger_mt logger;
 	nano::stat stats;
 	{
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache);
@@ -1816,7 +1816,7 @@ TEST (mdb_block_store, upgrade_v20_v21)
 		store.version.put (transaction, 20);
 	}
 	// Upgrading should create the table
-	nano::mdb_store store (logger, path);
+	nano::mdb_store store (logger, path, nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	ASSERT_NE (store.final_votes_handle, 0);
 
@@ -1850,7 +1850,7 @@ TEST (mdb_block_store, upgrade_backup)
 
 	{
 		nano::logger_mt logger;
-		nano::mdb_store store (logger, path);
+		nano::mdb_store store (logger, path, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.version.put (transaction, 14);
 	}
@@ -1858,7 +1858,7 @@ TEST (mdb_block_store, upgrade_backup)
 
 	// Now do the upgrade and confirm that backup is saved
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, path, nano::txn_tracking_config{}, std::chrono::seconds (5), nano::lmdb_config{}, true);
+	nano::mdb_store store (logger, path, nano::dev::constants, nano::txn_tracking_config{}, std::chrono::seconds (5), nano::lmdb_config{}, true);
 	ASSERT_FALSE (store.init_error ());
 	auto transaction (store.tx_begin_read ());
 	ASSERT_LT (14, store.version.get (transaction));
@@ -1875,7 +1875,7 @@ TEST (block_store, confirmation_height)
 	}
 	auto path (nano::unique_path ());
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, path);
+	auto store = nano::make_store (logger, path, nano::dev::constants);
 
 	nano::account account1 (0);
 	nano::account account2 (1);
@@ -1921,7 +1921,7 @@ TEST (block_store, final_vote)
 	}
 	auto path (nano::unique_path ());
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, path);
+	auto store = nano::make_store (logger, path, nano::dev::constants);
 
 	{
 		auto qualified_root = nano::dev::genesis->qualified_root ();
@@ -1947,7 +1947,7 @@ TEST (block_store, incompatible_version)
 	auto path (nano::unique_path ());
 	nano::logger_mt logger;
 	{
-		auto store = nano::make_store (logger, path);
+		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_FALSE (store->init_error ());
 
 		// Put version to an unreachable number so that it should always be incompatible
@@ -1957,7 +1957,7 @@ TEST (block_store, incompatible_version)
 
 	// Now try and read it, should give an error
 	{
-		auto store = nano::make_store (logger, path, true);
+		auto store = nano::make_store (logger, path, nano::dev::constants, true);
 		ASSERT_TRUE (store->init_error ());
 
 		auto transaction = store->tx_begin_read ();
@@ -1969,7 +1969,7 @@ TEST (block_store, incompatible_version)
 TEST (block_store, reset_renew_existing_transaction)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 
 	nano::keypair key1;
@@ -2006,7 +2006,7 @@ TEST (block_store, rocksdb_force_test_env_variable)
 	constexpr auto env_var = "TEST_USE_ROCKSDB";
 	auto value = std::getenv (env_var);
 
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 
 	auto mdb_cast = dynamic_cast<nano::mdb_store *> (store.get ());
 	if (value && boost::lexical_cast<int> (value) == 1)
@@ -2026,7 +2026,7 @@ TEST (rocksdb_block_store, tombstone_count)
 	if (nano::rocksdb_config::using_rocksdb_in_tests ())
 	{
 		nano::logger_mt logger;
-		auto store = std::make_unique<nano::rocksdb_store> (logger, nano::unique_path ());
+		auto store = std::make_unique<nano::rocksdb_store> (logger, nano::unique_path (), nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
 		auto transaction = store->tx_begin_write ();
 		auto block1 (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -718,7 +718,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		nano::logger_mt logger;
 		nano::logging logging;
 		auto path (nano::unique_path ());
-		auto store = nano::make_store (logger, path);
+		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
 		nano::stat stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -794,7 +794,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::logging logging;
 		nano::logger_mt logger;
 		auto path (nano::unique_path ());
-		auto store = nano::make_store (logger, path);
+		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
 		nano::stat stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -864,7 +864,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::logging logging;
 		nano::logger_mt logger;
 		auto path (nano::unique_path ());
-		auto store = nano::make_store (logger, path);
+		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
 		nano::stat stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1356,7 +1356,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	}
 	nano::logger_mt logger;
 	auto path (nano::unique_path ());
-	auto store = nano::make_store (logger, path);
+	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1406,7 +1406,7 @@ TEST (confirmation_height, pruned_source)
 	nano::logger_mt logger;
 	nano::logging logging;
 	auto path (nano::unique_path ());
-	auto store = nano::make_store (logger, path);
+	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -18,7 +18,7 @@ TEST (ledger, store_error)
 		return;
 	}
 	nano::logger_mt logger;
-	nano::mdb_store store (logger, boost::filesystem::path ("///"));
+	nano::mdb_store store (logger, boost::filesystem::path ("///"), nano::dev::constants);
 	ASSERT_TRUE (store.init_error ());
 	nano::stat stats;
 	nano::ledger ledger (store, stats, nano::dev::constants);
@@ -28,7 +28,7 @@ TEST (ledger, store_error)
 TEST (ledger, empty)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -42,7 +42,7 @@ TEST (ledger, empty)
 TEST (ledger, genesis_balance)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -68,7 +68,7 @@ TEST (ledger, genesis_balance)
 TEST (ledger, process_modifies_sideband)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -83,7 +83,7 @@ TEST (ledger, process_modifies_sideband)
 TEST (ledger, process_send)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -182,7 +182,7 @@ TEST (ledger, process_send)
 TEST (ledger, process_receive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -245,7 +245,7 @@ TEST (ledger, process_receive)
 TEST (ledger, rollback_receiver)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -284,7 +284,7 @@ TEST (ledger, rollback_receiver)
 TEST (ledger, rollback_representation)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -337,7 +337,7 @@ TEST (ledger, rollback_representation)
 TEST (ledger, receive_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -354,7 +354,7 @@ TEST (ledger, receive_rollback)
 TEST (ledger, process_duplicate)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -376,7 +376,7 @@ TEST (ledger, process_duplicate)
 TEST (ledger, representative_genesis)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -390,7 +390,7 @@ TEST (ledger, representative_genesis)
 TEST (ledger, weight)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -402,7 +402,7 @@ TEST (ledger, weight)
 TEST (ledger, representative_change)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -440,7 +440,7 @@ TEST (ledger, representative_change)
 TEST (ledger, send_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -460,7 +460,7 @@ TEST (ledger, send_fork)
 TEST (ledger, receive_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -486,7 +486,7 @@ TEST (ledger, receive_fork)
 TEST (ledger, open_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -519,7 +519,7 @@ TEST (ledger, representation_changes)
 TEST (ledger, representation)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -593,7 +593,7 @@ TEST (ledger, representation)
 TEST (ledger, double_open)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -612,7 +612,7 @@ TEST (ledger, double_open)
 TEST (ledger, double_receive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -890,7 +890,7 @@ TEST (ledger, successor)
 TEST (ledger, fail_change_old)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -908,7 +908,7 @@ TEST (ledger, fail_change_old)
 TEST (ledger, fail_change_gap_previous)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -924,7 +924,7 @@ TEST (ledger, fail_change_gap_previous)
 TEST (ledger, fail_change_bad_signature)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -940,7 +940,7 @@ TEST (ledger, fail_change_bad_signature)
 TEST (ledger, fail_change_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -960,7 +960,7 @@ TEST (ledger, fail_change_fork)
 TEST (ledger, fail_send_old)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -978,7 +978,7 @@ TEST (ledger, fail_send_old)
 TEST (ledger, fail_send_gap_previous)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -994,7 +994,7 @@ TEST (ledger, fail_send_gap_previous)
 TEST (ledger, fail_send_bad_signature)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1010,7 +1010,7 @@ TEST (ledger, fail_send_bad_signature)
 TEST (ledger, fail_send_negative_spend)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1028,7 +1028,7 @@ TEST (ledger, fail_send_negative_spend)
 TEST (ledger, fail_send_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1046,7 +1046,7 @@ TEST (ledger, fail_send_fork)
 TEST (ledger, fail_open_old)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1064,7 +1064,7 @@ TEST (ledger, fail_open_old)
 TEST (ledger, fail_open_gap_source)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1080,7 +1080,7 @@ TEST (ledger, fail_open_gap_source)
 TEST (ledger, fail_open_bad_signature)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1098,7 +1098,7 @@ TEST (ledger, fail_open_bad_signature)
 TEST (ledger, fail_open_fork_previous)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1120,7 +1120,7 @@ TEST (ledger, fail_open_fork_previous)
 TEST (ledger, fail_open_account_mismatch)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1139,7 +1139,7 @@ TEST (ledger, fail_open_account_mismatch)
 TEST (ledger, fail_receive_old)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1161,7 +1161,7 @@ TEST (ledger, fail_receive_old)
 TEST (ledger, fail_receive_gap_source)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1186,7 +1186,7 @@ TEST (ledger, fail_receive_gap_source)
 TEST (ledger, fail_receive_overreceive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1208,7 +1208,7 @@ TEST (ledger, fail_receive_overreceive)
 TEST (ledger, fail_receive_bad_signature)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1233,7 +1233,7 @@ TEST (ledger, fail_receive_bad_signature)
 TEST (ledger, fail_receive_gap_previous_opened)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1258,7 +1258,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 TEST (ledger, fail_receive_gap_previous_unopened)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1280,7 +1280,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 TEST (ledger, fail_receive_fork_previous)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1309,7 +1309,7 @@ TEST (ledger, fail_receive_fork_previous)
 TEST (ledger, fail_receive_received_source)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1344,7 +1344,7 @@ TEST (ledger, fail_receive_received_source)
 TEST (ledger, latest_empty)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1357,7 +1357,7 @@ TEST (ledger, latest_empty)
 TEST (ledger, latest_root)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1375,7 +1375,7 @@ TEST (ledger, latest_root)
 TEST (ledger, change_representative_move_representation)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1399,7 +1399,7 @@ TEST (ledger, change_representative_move_representation)
 TEST (ledger, send_open_receive_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1457,7 +1457,7 @@ TEST (ledger, send_open_receive_rollback)
 TEST (ledger, bootstrap_rep_weight)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1493,7 +1493,7 @@ TEST (ledger, bootstrap_rep_weight)
 TEST (ledger, block_destination_source)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1538,7 +1538,7 @@ TEST (ledger, block_destination_source)
 TEST (ledger, state_account)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1553,7 +1553,7 @@ TEST (ledger, state_account)
 TEST (ledger, state_send_receive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1594,7 +1594,7 @@ TEST (ledger, state_send_receive)
 TEST (ledger, state_receive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1628,7 +1628,7 @@ TEST (ledger, state_receive)
 TEST (ledger, state_rep_change)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1655,7 +1655,7 @@ TEST (ledger, state_rep_change)
 TEST (ledger, state_open)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1694,7 +1694,7 @@ TEST (ledger, state_open)
 TEST (ledger, send_after_state_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1711,7 +1711,7 @@ TEST (ledger, send_after_state_fail)
 TEST (ledger, receive_after_state_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1728,7 +1728,7 @@ TEST (ledger, receive_after_state_fail)
 TEST (ledger, change_after_state_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1745,7 +1745,7 @@ TEST (ledger, change_after_state_fail)
 TEST (ledger, state_unreceivable_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1768,7 +1768,7 @@ TEST (ledger, state_unreceivable_fail)
 TEST (ledger, state_receive_bad_amount_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1791,7 +1791,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 TEST (ledger, state_no_link_amount_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1808,7 +1808,7 @@ TEST (ledger, state_no_link_amount_fail)
 TEST (ledger, state_receive_wrong_account_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1832,7 +1832,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 TEST (ledger, state_open_state_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1852,7 +1852,7 @@ TEST (ledger, state_open_state_fork)
 TEST (ledger, state_state_open_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1873,7 +1873,7 @@ TEST (ledger, state_state_open_fork)
 TEST (ledger, state_open_previous_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1890,7 +1890,7 @@ TEST (ledger, state_open_previous_fail)
 TEST (ledger, state_open_source_fail)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1907,7 +1907,7 @@ TEST (ledger, state_open_source_fail)
 TEST (ledger, state_send_change)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1934,7 +1934,7 @@ TEST (ledger, state_send_change)
 TEST (ledger, state_receive_change)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1970,7 +1970,7 @@ TEST (ledger, state_receive_change)
 TEST (ledger, state_open_old)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -1990,7 +1990,7 @@ TEST (ledger, state_open_old)
 TEST (ledger, state_receive_old)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2014,7 +2014,7 @@ TEST (ledger, state_receive_old)
 TEST (ledger, state_rollback_send)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2045,7 +2045,7 @@ TEST (ledger, state_rollback_send)
 TEST (ledger, state_rollback_receive)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2071,7 +2071,7 @@ TEST (ledger, state_rollback_receive)
 TEST (ledger, state_rollback_received_send)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2098,7 +2098,7 @@ TEST (ledger, state_rollback_received_send)
 TEST (ledger, state_rep_change_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2118,7 +2118,7 @@ TEST (ledger, state_rep_change_rollback)
 TEST (ledger, state_open_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2144,7 +2144,7 @@ TEST (ledger, state_open_rollback)
 TEST (ledger, state_send_change_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2165,7 +2165,7 @@ TEST (ledger, state_send_change_rollback)
 TEST (ledger, state_receive_change_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2188,7 +2188,7 @@ TEST (ledger, state_receive_change_rollback)
 TEST (ledger, epoch_blocks_v1_general)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2258,7 +2258,7 @@ TEST (ledger, epoch_blocks_v1_general)
 TEST (ledger, epoch_blocks_v2_general)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2323,7 +2323,7 @@ TEST (ledger, epoch_blocks_v2_general)
 TEST (ledger, epoch_blocks_receive_upgrade)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2403,7 +2403,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 TEST (ledger, epoch_blocks_fork)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2584,7 +2584,7 @@ TEST (ledger, block_hash_account_conflict)
 TEST (ledger, could_fit)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2820,7 +2820,7 @@ TEST (ledger, unchecked_receive)
 TEST (ledger, confirmation_height_not_updated)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2881,7 +2881,7 @@ TEST (ledger, zero_rep)
 TEST (ledger, work_validation)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -2974,7 +2974,7 @@ TEST (ledger, dependents_confirmed)
 {
 	nano::block_builder builder;
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3046,7 +3046,7 @@ TEST (ledger, dependents_confirmed_pruning)
 {
 	nano::block_builder builder;
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3097,7 +3097,7 @@ TEST (ledger, block_confirmed)
 {
 	nano::block_builder builder;
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3129,7 +3129,7 @@ TEST (ledger, block_confirmed)
 TEST (ledger, cache)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3240,7 +3240,7 @@ TEST (ledger, cache)
 TEST (ledger, pruning_action)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3296,7 +3296,7 @@ TEST (ledger, pruning_action)
 TEST (ledger, pruning_large_chain)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3332,7 +3332,7 @@ TEST (ledger, pruning_large_chain)
 TEST (ledger, pruning_source_rollback)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3383,7 +3383,7 @@ TEST (ledger, pruning_source_rollback)
 TEST (ledger, pruning_source_rollback_legacy)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3461,7 +3461,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 TEST (ledger, pruning_process_error)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3489,7 +3489,7 @@ TEST (ledger, pruning_process_error)
 TEST (ledger, pruning_legacy_blocks)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3534,7 +3534,7 @@ TEST (ledger, pruning_legacy_blocks)
 TEST (ledger, pruning_safe_functions)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3576,7 +3576,7 @@ TEST (ledger, pruning_safe_functions)
 TEST (ledger, hash_root_random)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -3622,7 +3622,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	nano::logger_mt logger;
 	boost::asio::ip::address_v6 address (boost::asio::ip::make_address_v6 ("::ffff:127.0.0.1"));
 	uint16_t port = 100;
-	nano::mdb_store store (logger, path / "data.ldb");
+	nano::mdb_store store (logger, path / "data.ldb", nano::dev::constants);
 	nano::stat stats;
 	nano::ledger ledger (store, stats, nano::dev::constants);
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
@@ -3664,7 +3664,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	auto error = ledger.migrate_lmdb_to_rocksdb (path);
 	ASSERT_FALSE (error);
 
-	nano::rocksdb_store rocksdb_store (logger, path / "rocksdb");
+	nano::rocksdb_store rocksdb_store (logger, path / "rocksdb", nano::dev::constants);
 	auto rocksdb_transaction (rocksdb_store.tx_begin_read ());
 
 	nano::pending_info pending_info;
@@ -3700,7 +3700,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 TEST (ledger, unconfirmed_frontiers)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3692,7 +3692,7 @@ TEST (node, dont_write_lock_node)
 	std::promise<void> finished_promise;
 	std::thread ([&path, &write_lock_held_promise, &finished_promise] () {
 		nano::logger_mt logger;
-		auto store = nano::make_store (logger, path, false, true);
+		auto store = nano::make_store (logger, path, nano::dev::constants, false, true);
 		{
 			nano::ledger_cache ledger_cache;
 			auto transaction (store->tx_begin_write ());

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -10,7 +10,7 @@
 TEST (processor_service, bad_send_signature)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -28,7 +28,7 @@ TEST (processor_service, bad_send_signature)
 TEST (processor_service, bad_receive_signature)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -40,9 +40,10 @@ void mdb_val::convert_buffer_to_value ()
 }
 }
 
-nano::mdb_store::mdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade_a) :
+nano::mdb_store::mdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade_a) :
 	// clang-format off
 	store_partial{
+		constants,
 		block_store_partial,
 		frontier_store_partial,
 		account_store_partial,
@@ -551,7 +552,7 @@ void nano::mdb_store::upgrade_v17_to_v18 (nano::write_transaction const & transa
 		{
 			prev_balance = block_balance_v18 (transaction_a, block->hashables.previous);
 		}
-		if (block->hashables.balance == prev_balance && network_params.ledger.epochs.is_epoch_link (block->hashables.link))
+		if (block->hashables.balance == prev_balance && constants.epochs.is_epoch_link (block->hashables.link))
 		{
 			is_epoch = true;
 		}

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -69,7 +69,7 @@ private:
 	friend class nano::unchecked_mdb_store;
 
 public:
-	mdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+	mdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
 	nano::read_transaction tx_begin_read () const override;
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -95,7 +95,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	work (work_a),
 	distributed_work (*this),
 	logger (config_a.logging.min_time_between_log_output),
-	store_impl (nano::make_store (logger, application_path_a, flags.read_only, true, config_a.rocksdb_config, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
+	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a.rocksdb_config, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
 	store (*store_impl),
 	wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),
 	wallets_store (*wallets_store_impl),
@@ -1819,12 +1819,12 @@ nano::node_flags const & nano::inactive_node_flag_defaults ()
 	return node_flags;
 }
 
-std::unique_ptr<nano::store> nano::make_store (nano::logger_mt & logger, boost::filesystem::path const & path, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
+std::unique_ptr<nano::store> nano::make_store (nano::logger_mt & logger, boost::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
 {
 	if (rocksdb_config.enable)
 	{
-		return std::make_unique<nano::rocksdb_store> (logger, add_db_postfix ? path / "rocksdb" : path, rocksdb_config, read_only);
+		return std::make_unique<nano::rocksdb_store> (logger, add_db_postfix ? path / "rocksdb" : path, constants, rocksdb_config, read_only);
 	}
 
-	return std::make_unique<nano::mdb_store> (logger, add_db_postfix ? path / "data.ldb" : path, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
+	return std::make_unique<nano::mdb_store> (logger, add_db_postfix ? path / "data.ldb" : path, constants, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
 }

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -63,9 +63,10 @@ void rocksdb_val::convert_buffer_to_value ()
 }
 }
 
-nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::rocksdb_config const & rocksdb_config_a, bool open_read_only_a) :
+nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::ledger_constants & constants, nano::rocksdb_config const & rocksdb_config_a, bool open_read_only_a) :
 	// clang-format off
 	store_partial{
+		constants,
 		block_store_partial,
 		frontier_store_partial,
 		account_store_partial,
@@ -91,6 +92,7 @@ nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesyste
 	final_vote_store_partial{ *this },
 	version_rocksdb_store{ *this },
 	logger{ logger_a },
+	constants{ constants },
 	rocksdb_config{ rocksdb_config_a },
 	max_block_write_batch_num_m{ nano::narrow_cast<unsigned> (blocks_memtable_size_bytes () / (2 * (sizeof (nano::block_type) + nano::state_block::size + nano::block_sideband::size (nano::block_type::state)))) },
 	cf_name_table_map{ create_cf_name_table_map () }
@@ -856,7 +858,7 @@ bool nano::rocksdb_store::copy_db (boost::filesystem::path const & destination_p
 	// Open it so that it flushes all WAL files
 	if (status.ok ())
 	{
-		nano::rocksdb_store rocksdb_store (logger, destination_path.string (), rocksdb_config, false);
+		nano::rocksdb_store rocksdb_store (logger, destination_path.string (), constants, rocksdb_config, false);
 		return !rocksdb_store.init_error ();
 	}
 	return false;

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -73,7 +73,7 @@ public:
 	friend class nano::unchecked_rocksdb_store;
 	friend class nano::version_rocksdb_store;
 
-	explicit rocksdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::rocksdb_config const & = nano::rocksdb_config{}, bool open_read_only = false);
+	explicit rocksdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::ledger_constants & constants, nano::rocksdb_config const & = nano::rocksdb_config{}, bool open_read_only = false);
 
 	nano::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
 	nano::read_transaction tx_begin_read () const override;
@@ -113,6 +113,7 @@ public:
 private:
 	bool error{ false };
 	nano::logger_mt & logger;
+	nano::ledger_constants & constants;
 	// Optimistic transactions are used in write mode
 	rocksdb::OptimisticTransactionDB * optimistic_db = nullptr;
 	std::unique_ptr<rocksdb::DB> db;

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -513,7 +513,7 @@ TEST (history, short_text)
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
-	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path ());
+	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::genesis genesis;
 	nano::ledger ledger (*store, system.nodes[0]->stats, nano::dev::constants);
@@ -551,7 +551,7 @@ TEST (history, pruned_source)
 		account = system.account (transaction, 0);
 	}
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
-	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path ());
+	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::genesis genesis;
 	nano::ledger ledger (*store, system.nodes[0]->stats, nano::dev::constants);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1417,7 +1417,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data
 	// Open rocksdb database
 	nano::rocksdb_config rocksdb_config;
 	rocksdb_config.enable = true;
-	auto rocksdb_store = nano::make_store (logger, data_path_a, false, true, rocksdb_config);
+	auto rocksdb_store = nano::make_store (logger, data_path_a, nano::dev::constants, false, true, rocksdb_config);
 
 	if (!rocksdb_store->init_error ())
 	{

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -869,7 +869,7 @@ public:
 	virtual std::string vendor_get () const = 0;
 };
 
-std::unique_ptr<nano::store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, bool open_read_only = false, bool add_db_postfix = false, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+std::unique_ptr<nano::store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = false, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 }
 
 namespace std

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -91,7 +91,7 @@ TEST (system, receive_while_synchronizing)
 TEST (ledger, deep_account_compute)
 {
 	nano::logger_mt logger;
-	auto store = nano::make_store (logger, nano::unique_path ());
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
@@ -424,7 +424,7 @@ TEST (store, pruned_load)
 	constexpr auto batch_size = 20;
 	boost::unordered_set<nano::block_hash> hashes;
 	{
-		auto store = nano::make_store (logger, path);
+		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_FALSE (store->init_error ());
 		for (auto i (0); i < num_pruned / batch_size; ++i)
 		{
@@ -453,7 +453,7 @@ TEST (store, pruned_load)
 	}
 	// Reinitialize store
 	{
-		auto store = nano::make_store (logger, path);
+		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_FALSE (store->init_error ());
 		auto transaction (store->tx_begin_read ());
 		ASSERT_EQ (expected_result, store->pruned.count (transaction));
@@ -963,7 +963,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	nano::logger_mt logger;
 	nano::logging logging;
 	auto path (nano::unique_path ());
-	auto store = nano::make_store (logger, path);
+	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);


### PR DESCRIPTION
Changing nano::block_store_partial to hold nano::ledger_constants by reference rather than statically instantiating it. More work on reducing dependency on static initialization.