### PR TITLE
Converting sever static initializations of nano::network_params to references

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -17,7 +17,7 @@ TEST (wallet, no_special_keys_accounts)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::keypair key1;
@@ -38,7 +38,7 @@ TEST (wallet, no_key)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::keypair key1;
@@ -53,7 +53,7 @@ TEST (wallet, fetch_locked)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_TRUE (wallet.valid_password (transaction));
 	nano::keypair key1;
@@ -75,7 +75,7 @@ TEST (wallet, retrieval)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::keypair key1;
@@ -97,7 +97,7 @@ TEST (wallet, empty_iteration)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	auto i (wallet.begin (transaction));
@@ -111,7 +111,7 @@ TEST (wallet, one_item_iteration)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::keypair key1;
@@ -137,7 +137,7 @@ TEST (wallet, two_item_iteration)
 	ASSERT_NE (key1.pub, key2.pub);
 	std::unordered_set<nano::public_key> pubs;
 	std::unordered_set<nano::raw_key> prvs;
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	{
 		auto transaction (env.tx_begin_write ());
 		nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
@@ -277,7 +277,7 @@ TEST (wallet, find_none)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::account account (1000);
@@ -290,7 +290,7 @@ TEST (wallet, find_existing)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::keypair key1;
@@ -309,7 +309,7 @@ TEST (wallet, rekey)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::raw_key password;
@@ -381,7 +381,7 @@ TEST (wallet, hash_password)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (init);
 	nano::raw_key hash1;
@@ -430,7 +430,7 @@ TEST (wallet, reopen_default_password)
 	nano::mdb_env env (init, nano::unique_path ());
 	auto transaction (env.tx_begin_write ());
 	ASSERT_FALSE (init);
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	{
 		nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 		ASSERT_FALSE (init);
@@ -466,7 +466,7 @@ TEST (wallet, representative)
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (error, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (error);
 	ASSERT_FALSE (wallet.is_representative (transaction));
@@ -487,7 +487,7 @@ TEST (wallet, serialize_json_empty)
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (error);
 	std::string serialized;
@@ -512,7 +512,7 @@ TEST (wallet, serialize_json_one)
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (error);
 	nano::keypair key;
@@ -541,7 +541,7 @@ TEST (wallet, serialize_json_password)
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (error);
 	nano::keypair key;
@@ -574,7 +574,7 @@ TEST (wallet_store, move)
 	nano::mdb_env env (error, nano::unique_path ());
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet1 (error, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	ASSERT_FALSE (error);
 	nano::keypair key1;
@@ -732,7 +732,7 @@ TEST (wallet, deterministic_keys)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	auto key1 = wallet.deterministic_key (transaction, 0);
 	auto key2 = wallet.deterministic_key (transaction, 0);
@@ -775,7 +775,7 @@ TEST (wallet, reseed)
 	nano::mdb_env env (init, nano::unique_path ());
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (init, kdf, transaction, nano::dev::genesis->account (), 1, "0");
 	nano::raw_key seed1;
 	seed1 = 1;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1786,7 +1786,6 @@ int main (int argc, char * const * argv)
 			node_flags.read_only = false;
 			nano::update_flags (node_flags, vm);
 			nano::inactive_node node (nano::unique_path (), node_flags);
-			nano::genesis genesis;
 			auto begin (std::chrono::high_resolution_clock::now ());
 			uint64_t block_count (0);
 			size_t count (0);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -702,7 +702,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		nano::raw_key junk1;
 		junk1.clear ();
 		nano::uint256_union junk2 (0);
-		nano::kdf kdf;
+		nano::kdf kdf{ inactive_node->node->config.network_params.kdf_work};
 		kdf.phs (junk1, "", junk2);
 		std::cout << "Testing time retrieval latency... " << std::flush;
 		nano::timer<std::chrono::nanoseconds> timer (nano::timer_state::started);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -345,7 +345,6 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 			is_initialized = (store.account.begin (transaction) != store.account.end ());
 		}
 
-		nano::genesis genesis;
 		if (!is_initialized && !flags.read_only)
 		{
 			auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers }));
@@ -353,7 +352,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 			store.initialize (transaction, ledger.cache);
 		}
 
-		if (!ledger.block_or_pruned_exists (genesis.hash ()))
+		if (!ledger.block_or_pruned_exists (config.network_params.ledger.genesis->hash ()))
 		{
 			std::stringstream ss;
 			ss << "Genesis block not found. This commonly indicates a configuration issue, check that the --network or --data_path command line arguments are correct, "

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -89,6 +89,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	io_ctx (io_ctx_a),
 	node_initialized_latch (1),
 	config (config_a),
+	network_params{ config.network_params },
 	stats (config.stat_config),
 	workers (std::max (3u, config.io_threads / 4), nano::thread_role::name::worker),
 	flags (flags_a),

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -154,8 +154,8 @@ public:
 	nano::write_database_queue write_database_queue;
 	boost::asio::io_context & io_ctx;
 	boost::latch node_initialized_latch;
-	nano::network_params network_params;
 	nano::node_config config;
+	nano::network_params & network_params;
 	nano::stat stats;
 	nano::thread_pool workers;
 	std::shared_ptr<nano::websocket::listener> websocket_server;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -21,14 +21,15 @@ const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TE
 }
 
 nano::node_config::node_config () :
-	node_config (0, nano::logging ())
+	node_config (0, nano::logging (), nano::dev::network_params)
 {
 }
 
-nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & logging_a) :
-	peering_port (peering_port_a),
-	logging (logging_a),
-	external_address (boost::asio::ip::address_v6{}.to_string ())
+nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & logging_a, nano::network_params network_params) :
+	network_params{ network_params },
+	peering_port{ peering_port_a },
+	logging{ logging_a },
+	external_address{ boost::asio::ip::address_v6{}.to_string () }
 {
 	// The default constructor passes 0 to indicate we should use the default port,
 	// which is determined at node startup based on active network.

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -35,7 +35,7 @@ class node_config
 {
 public:
 	node_config ();
-	node_config (uint16_t, nano::logging const &);
+	node_config (uint16_t, nano::logging const &, nano::network_params network_params = nano::dev::network_params);
 	nano::error serialize_json (nano::jsonconfig &) const;
 	nano::error deserialize_json (bool &, nano::jsonconfig &);
 	nano::error serialize_toml (nano::tomlconfig &) const;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -651,9 +651,8 @@ void nano::wallet_store::version_put (nano::transaction const & transaction_a, u
 
 void nano::kdf::phs (nano::raw_key & result_a, std::string const & password_a, nano::uint256_union const & salt_a)
 {
-	static nano::network_params network_params;
 	nano::lock_guard<nano::mutex> lock (mutex);
-	auto success (argon2_hash (1, network_params.kdf_work, 1, password_a.data (), password_a.size (), salt_a.bytes.data (), salt_a.bytes.size (), result_a.bytes.data (), result_a.bytes.size (), NULL, 0, Argon2_d, 0x10));
+	auto success (argon2_hash (1, kdf_work, 1, password_a.data (), password_a.size (), salt_a.bytes.data (), salt_a.bytes.size (), result_a.bytes.data (), result_a.bytes.size (), NULL, 0, Argon2_d, 0x10));
 	debug_assert (success == 0);
 	(void)success;
 }
@@ -1336,6 +1335,7 @@ void nano::wallets::do_wallet_actions ()
 
 nano::wallets::wallets (bool error_a, nano::node & node_a) :
 	observer ([] (bool) {}),
+	kdf{ node_a.config.network_params.kdf_work },
 	node (node_a),
 	env (boost::polymorphic_downcast<nano::mdb_wallets_store *> (node_a.wallets_store_impl.get ())->environment),
 	stopped (false),

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1334,6 +1334,7 @@ void nano::wallets::do_wallet_actions ()
 }
 
 nano::wallets::wallets (bool error_a, nano::node & node_a) :
+	network_params{ node_a.config.network_params },
 	observer ([] (bool) {}),
 	kdf{ node_a.config.network_params.kdf_work },
 	node (node_a),

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -216,7 +216,7 @@ public:
 	void split_if_needed (nano::transaction &, nano::store &);
 	void move_table (std::string const &, MDB_txn *, MDB_txn *);
 	std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> get_wallets ();
-	nano::network_params network_params;
+	nano::network_params & network_params;
 	std::function<void (bool)> observer;
 	std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> items;
 	std::multimap<nano::uint128_t, std::pair<std::shared_ptr<nano::wallet>, std::function<void (nano::wallet &)>>, std::greater<nano::uint128_t>> actions;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -34,8 +34,13 @@ private:
 class kdf final
 {
 public:
+	kdf (unsigned & kdf_work) :
+		kdf_work{ kdf_work }
+	{
+	}
 	void phs (nano::raw_key &, std::string const &, nano::uint256_union const &);
 	nano::mutex mutex;
+	unsigned & kdf_work;
 };
 enum class key_type
 {

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -515,7 +515,6 @@ TEST (history, short_text)
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::genesis genesis;
 	nano::ledger ledger (*store, system.nodes[0]->stats, nano::dev::constants);
 	{
 		auto transaction (store->tx_begin_write ());
@@ -553,7 +552,6 @@ TEST (history, pruned_source)
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	auto store = nano::make_store (system.nodes[0]->logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::genesis genesis;
 	nano::ledger ledger (*store, system.nodes[0]->stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::block_hash next_pruning;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -897,10 +897,9 @@ TEST (rpc, block_account)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
-	nano::genesis genesis;
 	boost::property_tree::ptree request;
 	request.put ("action", "block_account");
-	request.put ("hash", genesis.hash ().to_string ());
+	request.put ("hash", nano::dev::genesis->hash ().to_string ());
 	auto response (wait_response (system, rpc, request));
 	std::string account_text (response.get<std::string> ("account"));
 	nano::account account;
@@ -1093,7 +1092,6 @@ TEST (rpc, history)
 	ASSERT_NE (nullptr, send);
 	auto receive (system.wallet (0)->receive_action (send->hash (), nano::dev::genesis_key.pub, node0->config.receive_minimum.number (), send->link ().as_account ()));
 	ASSERT_NE (nullptr, receive);
-	nano::genesis genesis;
 	nano::state_block usend (nano::dev::genesis->account (), node0->latest (nano::dev::genesis->account ()), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work_generate_blocking (node0->latest (nano::dev::genesis->account ())));
 	nano::state_block ureceive (nano::dev::genesis->account (), usend.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, usend.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work_generate_blocking (usend.hash ()));
 	nano::state_block uchange (nano::dev::genesis->account (), ureceive.hash (), nano::keypair ().pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work_generate_blocking (ureceive.hash ()));
@@ -1136,7 +1134,7 @@ TEST (rpc, history)
 	ASSERT_EQ ("receive", std::get<0> (history_l[4]));
 	ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), std::get<1> (history_l[4]));
 	ASSERT_EQ (nano::dev::constants.genesis_amount.convert_to<std::string> (), std::get<2> (history_l[4]));
-	ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[4]));
+	ASSERT_EQ (nano::dev::genesis->hash ().to_string (), std::get<3> (history_l[4]));
 }
 
 TEST (rpc, account_history)
@@ -1150,7 +1148,6 @@ TEST (rpc, account_history)
 	ASSERT_NE (nullptr, send);
 	auto receive (system.wallet (0)->receive_action (send->hash (), nano::dev::genesis_key.pub, node0->config.receive_minimum.number (), send->link ().as_account ()));
 	ASSERT_NE (nullptr, receive);
-	nano::genesis genesis;
 	nano::state_block usend (nano::dev::genesis->account (), node0->latest (nano::dev::genesis->account ()), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work_generate_blocking (node0->latest (nano::dev::genesis->account ())));
 	nano::state_block ureceive (nano::dev::genesis->account (), usend.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, usend.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work_generate_blocking (usend.hash ()));
 	nano::state_block uchange (nano::dev::genesis->account (), ureceive.hash (), nano::keypair ().pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work_generate_blocking (ureceive.hash ()));
@@ -1198,7 +1195,7 @@ TEST (rpc, account_history)
 		ASSERT_EQ ("receive", std::get<0> (history_l[4]));
 		ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), std::get<1> (history_l[4]));
 		ASSERT_EQ (nano::dev::constants.genesis_amount.convert_to<std::string> (), std::get<2> (history_l[4]));
-		ASSERT_EQ (genesis.hash ().to_string (), std::get<3> (history_l[4]));
+		ASSERT_EQ (nano::dev::genesis->hash ().to_string (), std::get<3> (history_l[4]));
 		ASSERT_EQ ("1", std::get<4> (history_l[4])); // change block (height 2) is skipped
 	}
 	// Test count and reverse
@@ -1284,8 +1281,7 @@ TEST (rpc, history_pruning)
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
 	auto node0 = add_ipc_enabled_node (system, node_config, node_flags);
-	nano::genesis genesis;
-	auto change (std::make_shared<nano::change_block> (genesis.hash (), nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work.generate (genesis.hash ())));
+	auto change (std::make_shared<nano::change_block> (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work.generate (nano::dev::genesis->hash ())));
 	node0->process_active (change);
 	auto send (std::make_shared<nano::send_block> (change->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - node0->config.receive_minimum.number (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node0->work.generate (change->hash ())));
 	node0->process_active (send);
@@ -2873,7 +2869,6 @@ TEST (rpc, republish)
 {
 	nano::system system;
 	nano::keypair key;
-	nano::genesis genesis;
 	auto node1 = add_ipc_enabled_node (system);
 	system.add_node ();
 	auto latest (node1->latest (nano::dev::genesis_key.pub));
@@ -2896,7 +2891,7 @@ TEST (rpc, republish)
 	ASSERT_EQ (1, blocks.size ());
 	ASSERT_EQ (send.hash (), blocks[0]);
 
-	request.put ("hash", genesis.hash ().to_string ());
+	request.put ("hash", nano::dev::genesis->hash ().to_string ());
 	request.put ("count", 1);
 	auto response1 (wait_response (system, rpc, request));
 	blocks_node = response1.get_child ("blocks");
@@ -2906,7 +2901,7 @@ TEST (rpc, republish)
 		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
 	}
 	ASSERT_EQ (1, blocks.size ());
-	ASSERT_EQ (genesis.hash (), blocks[0]);
+	ASSERT_EQ (nano::dev::genesis->hash (), blocks[0]);
 
 	request.put ("hash", open.hash ().to_string ());
 	request.put ("sources", 2);
@@ -2918,7 +2913,7 @@ TEST (rpc, republish)
 		blocks.push_back (nano::block_hash (i->second.get<std::string> ("")));
 	}
 	ASSERT_EQ (3, blocks.size ());
-	ASSERT_EQ (genesis.hash (), blocks[0]);
+	ASSERT_EQ (nano::dev::genesis->hash (), blocks[0]);
 	ASSERT_EQ (send.hash (), blocks[1]);
 	ASSERT_EQ (open.hash (), blocks[2]);
 }
@@ -3446,7 +3441,6 @@ TEST (rpc, wallet_republish)
 {
 	nano::system system;
 	auto node1 = add_ipc_enabled_node (system);
-	nano::genesis genesis;
 	nano::keypair key;
 	while (key.pub < nano::dev::genesis_key.pub)
 	{
@@ -3624,7 +3618,6 @@ TEST (rpc, account_info)
 {
 	nano::system system;
 	nano::keypair key;
-	nano::genesis genesis;
 
 	auto node1 = add_ipc_enabled_node (system);
 	auto [rpc, rpc_ctx] = add_rpc (system, node1);
@@ -3651,7 +3644,7 @@ TEST (rpc, account_info)
 	auto time (nano::seconds_since_epoch ());
 	{
 		auto transaction = node1->store.tx_begin_write ();
-		node1->store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, { 1, genesis.hash () });
+		node1->store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, { 1, nano::dev::genesis->hash () });
 	}
 	rpc_ctx->io_scope->renew ();
 
@@ -3661,9 +3654,9 @@ TEST (rpc, account_info)
 		std::string frontier (response.get<std::string> ("frontier"));
 		ASSERT_EQ (send.hash ().to_string (), frontier);
 		std::string open_block (response.get<std::string> ("open_block"));
-		ASSERT_EQ (genesis.hash ().to_string (), open_block);
+		ASSERT_EQ (nano::dev::genesis->hash ().to_string (), open_block);
 		std::string representative_block (response.get<std::string> ("representative_block"));
-		ASSERT_EQ (genesis.hash ().to_string (), representative_block);
+		ASSERT_EQ (nano::dev::genesis->hash ().to_string (), representative_block);
 		std::string balance (response.get<std::string> ("balance"));
 		ASSERT_EQ ("100", balance);
 		std::string modified_timestamp (response.get<std::string> ("modified_timestamp"));
@@ -3673,7 +3666,7 @@ TEST (rpc, account_info)
 		std::string confirmation_height (response.get<std::string> ("confirmation_height"));
 		ASSERT_EQ ("1", confirmation_height);
 		std::string confirmation_height_frontier (response.get<std::string> ("confirmation_height_frontier"));
-		ASSERT_EQ (genesis.hash ().to_string (), confirmation_height_frontier);
+		ASSERT_EQ (nano::dev::genesis->hash ().to_string (), confirmation_height_frontier);
 		ASSERT_EQ (0, response.get<uint8_t> ("account_version"));
 		boost::optional<std::string> weight (response.get_optional<std::string> ("weight"));
 		ASSERT_FALSE (weight.is_initialized ());
@@ -4311,7 +4304,6 @@ TEST (rpc, block_create_state)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
-	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -4319,11 +4311,11 @@ TEST (rpc, block_create_state)
 	request.put ("type", "state");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
-	request.put ("previous", genesis.hash ().to_string ());
+	request.put ("previous", nano::dev::genesis->hash ().to_string ());
 	request.put ("representative", nano::dev::genesis_key.pub.to_account ());
 	request.put ("balance", (nano::dev::constants.genesis_amount - nano::Gxrb_ratio).convert_to<std::string> ());
 	request.put ("link", key.pub.to_account ());
-	request.put ("work", nano::to_string_hex (*node->work_generate_blocking (genesis.hash ())));
+	request.put ("work", nano::to_string_hex (*node->work_generate_blocking (nano::dev::genesis->hash ())));
 	auto response (wait_response (system, rpc, request));
 	std::string state_hash (response.get<std::string> ("hash"));
 	auto state_text (response.get<std::string> ("block"));
@@ -4344,7 +4336,6 @@ TEST (rpc, block_create_state_open)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
-	nano::genesis genesis;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
@@ -4896,8 +4887,7 @@ TEST (rpc, block_confirm)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, genesis.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node->work_generate_blocking (genesis.hash ())));
+	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node->work_generate_blocking (nano::dev::genesis->hash ())));
 	{
 		auto transaction (node->store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
@@ -4934,16 +4924,15 @@ TEST (rpc, block_confirm_confirmed)
 	config.callback_target = "/";
 	config.logging.init (path);
 	auto node = add_ipc_enabled_node (system, config);
-	nano::genesis genesis;
 	{
 		auto transaction (node->store.tx_begin_read ());
-		ASSERT_TRUE (node->ledger.block_confirmed (transaction, genesis.hash ()));
+		ASSERT_TRUE (node->ledger.block_confirmed (transaction, nano::dev::genesis->hash ()));
 	}
 	ASSERT_EQ (0, node->stats.count (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out));
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_confirm");
-	request.put ("hash", genesis.hash ().to_string ());
+	request.put ("hash", nano::dev::genesis->hash ().to_string ());
 	auto response (wait_response (system, rpc, request));
 	ASSERT_EQ ("1", response.get<std::string> ("started"));
 	// Check confirmation history
@@ -5965,9 +5954,8 @@ TEST (rpc, receive_work_disabled)
 	node->wallets.items.begin ()->first.encode_hex (wallet_text);
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
-	nano::genesis genesis;
 	ASSERT_TRUE (worker_node.work_generation_enabled ());
-	auto send1 (wallet->send_action (nano::dev::genesis_key.pub, key1.pub, node->config.receive_minimum.number () - 1, *worker_node.work_generate_blocking (genesis.hash ()), false));
+	auto send1 (wallet->send_action (nano::dev::genesis_key.pub, key1.pub, node->config.receive_minimum.number () - 1, *worker_node.work_generate_blocking (nano::dev::genesis->hash ()), false));
 	ASSERT_TRUE (send1 != nullptr);
 	ASSERT_TIMELY (5s, node->balance (nano::dev::genesis_key.pub) != nano::dev::constants.genesis_amount);
 	ASSERT_FALSE (node->store.account.exists (node->store.tx_begin_read (), key1.pub));
@@ -6218,8 +6206,7 @@ TEST (rpc, confirmation_active)
 	auto node1 (system.add_node (node_config, node_flags));
 	auto [rpc, rpc_ctx] = add_rpc (system, node1);
 
-	nano::genesis genesis;
-	auto send1 (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::public_key (), nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
 	auto send2 (std::make_shared<nano::send_block> (send1->hash (), nano::public_key (), nano::dev::constants.genesis_amount - 200, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1->hash ())));
 	node1->process_active (send1);
 	node1->process_active (send2);
@@ -6247,8 +6234,7 @@ TEST (rpc, confirmation_info)
 	auto node1 = add_ipc_enabled_node (system);
 	auto [rpc, rpc_ctx] = add_rpc (system, node1);
 
-	nano::genesis genesis;
-	auto send (std::make_shared<nano::send_block> (genesis.hash (), nano::public_key (), nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (genesis.hash ())));
+	auto send (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::public_key (), nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
 	node1->process_active (send);
 	node1->block_processor.flush ();
 	node1->scheduler.flush ();

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -829,7 +829,7 @@ TEST (rpc, wallet_export)
 	bool error (false);
 	rpc_ctx->io_scope->reset ();
 	auto transaction (node->wallets.tx_begin_write ());
-	nano::kdf kdf;
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store store (error, kdf, transaction, nano::dev::genesis->account (), 1, "0", wallet_json);
 	ASSERT_FALSE (error);
 	ASSERT_TRUE (store.exists (transaction, nano::dev::genesis_key.pub));

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -81,7 +81,8 @@ std::string const test_canary_public_key_data = nano::get_env_or_default ("NANO_
 }
 
 nano::keypair nano::dev::genesis_key{ dev_private_key_data };
-nano::ledger_constants nano::dev::constants{ nano::networks::nano_dev_network };
+nano::network_params nano::dev::network_params{ nano::networks::nano_dev_network };
+nano::ledger_constants & nano::dev::constants{ network_params.ledger };
 std::shared_ptr<nano::block> & nano::dev::genesis = nano::dev::constants.genesis;
 
 nano::network_params::network_params () :

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -813,18 +813,6 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (vo
 	return composite;
 }
 
-nano::genesis::genesis ()
-{
-	static nano::network_params network_params;
-	open = network_params.ledger.genesis;
-	debug_assert (open != nullptr);
-}
-
-nano::block_hash nano::genesis::hash () const
-{
-	return open->hash ();
-}
-
 nano::wallet_id nano::random_wallet_id ()
 {
 	nano::wallet_id wallet_id;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -131,10 +131,10 @@ nano::ledger_constants::ledger_constants (nano::networks network_a) :
 	nano_test_final_votes_canary_height (1),
 	final_votes_canary_height (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_height : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_height : network_a == nano::networks::nano_test_network ? nano_test_final_votes_canary_height : nano_live_final_votes_canary_height)
 {
-	nano_beta_genesis->sideband_set (nano::block_sideband (nano_beta_genesis->account (), 0, nano::dev::constants.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
-	nano_dev_genesis->sideband_set (nano::block_sideband (nano_dev_genesis->account (), 0, nano::dev::constants.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
-	nano_live_genesis->sideband_set (nano::block_sideband (nano_live_genesis->account (), 0, nano::dev::constants.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
-	nano_test_genesis->sideband_set (nano::block_sideband (nano_test_genesis->account (), 0, nano::dev::constants.genesis_amount, 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
+	nano_beta_genesis->sideband_set (nano::block_sideband (nano_beta_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
+	nano_dev_genesis->sideband_set (nano::block_sideband (nano_dev_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
+	nano_live_genesis->sideband_set (nano::block_sideband (nano_live_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
+	nano_test_genesis->sideband_set (nano::block_sideband (nano_test_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 
 	nano::link epoch_link_v1;
 	const char * epoch_message_v1 ("epoch v1 block");

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -82,7 +82,7 @@ std::string const test_canary_public_key_data = nano::get_env_or_default ("NANO_
 
 nano::keypair nano::dev::genesis_key{ dev_private_key_data };
 nano::network_params nano::dev::network_params{ nano::networks::nano_dev_network };
-nano::ledger_constants & nano::dev::constants{ network_params.ledger };
+nano::ledger_constants & nano::dev::constants{ nano::dev::network_params.ledger };
 std::shared_ptr<nano::block> & nano::dev::genesis = nano::dev::constants.genesis;
 
 nano::network_params::network_params () :

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -334,14 +334,6 @@ enum class tally_result
 	confirm
 };
 
-class genesis final
-{
-public:
-	genesis ();
-	nano::block_hash hash () const;
-	std::shared_ptr<nano::block> open;
-};
-
 class network_params;
 
 /** Protocol versions whose value may depend on the active network */

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -395,7 +395,8 @@ public:
 namespace dev
 {
 	extern nano::keypair genesis_key;
-	extern nano::ledger_constants constants;
+	extern nano::network_params network_params;
+	extern nano::ledger_constants & constants;
 	extern std::shared_ptr<nano::block> & genesis;
 }
 


### PR DESCRIPTION
These are a series of commits that remove static initialization of network_params