### PR TITLE
Removing static mutex for the random pool

### DIFF
--- a/nano/crypto_lib/random_pool.cpp
+++ b/nano/crypto_lib/random_pool.cpp
@@ -2,31 +2,26 @@
 
 #include <crypto/cryptopp/osrng.h>
 
-std::mutex nano::random_pool::mutex;
-
 void nano::random_pool::generate_block (unsigned char * output, size_t size)
 {
 	auto & pool = get_pool ();
-	std::lock_guard guard (mutex);
 	pool.GenerateBlock (output, size);
 }
 
 unsigned nano::random_pool::generate_word32 (unsigned min, unsigned max)
 {
 	auto & pool = get_pool ();
-	std::lock_guard guard (mutex);
 	return pool.GenerateWord32 (min, max);
 }
 
 unsigned char nano::random_pool::generate_byte ()
 {
 	auto & pool = get_pool ();
-	std::lock_guard guard (mutex);
 	return pool.GenerateByte ();
 }
 
 CryptoPP::AutoSeededRandomPool & nano::random_pool::get_pool ()
 {
-	static CryptoPP::AutoSeededRandomPool pool;
+	static thread_local CryptoPP::AutoSeededRandomPool pool;
 	return pool;
 }

--- a/nano/crypto_lib/random_pool.hpp
+++ b/nano/crypto_lib/random_pool.hpp
@@ -22,7 +22,6 @@ public:
 	random_pool & operator= (random_pool const &) = delete;
 
 private:
-	static std::mutex mutex;
 	static CryptoPP::AutoSeededRandomPool & get_pool ();
 
 	template <class Iter>

--- a/nano/crypto_lib/random_pool_shuffle.hpp
+++ b/nano/crypto_lib/random_pool_shuffle.hpp
@@ -9,7 +9,6 @@ namespace nano
 template <class Iter>
 void random_pool_shuffle (Iter begin, Iter end)
 {
-	std::lock_guard guard (random_pool::mutex);
 	random_pool::get_pool ().Shuffle (begin, end);
 }
 }


### PR DESCRIPTION
Removing static mutex for the random pool and replacing the random pool with a thread_local version so it is thread safe.