### PR TITLE
Network selector

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -702,7 +702,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		nano::raw_key junk1;
 		junk1.clear ();
 		nano::uint256_union junk2 (0);
-		nano::kdf kdf{ inactive_node->node->config.network_params.kdf_work};
+		nano::kdf kdf{ inactive_node->node->config.network_params.kdf_work };
 		kdf.phs (junk1, "", junk2);
 		std::cout << "Testing time retrieval latency... " << std::flush;
 		nano::timer<std::chrono::nanoseconds> timer (nano::timer_state::started);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -21,7 +21,7 @@ const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TE
 }
 
 nano::node_config::node_config () :
-	node_config (0, nano::logging (), nano::network_params{ nano::network_constants::active_network})
+	node_config (0, nano::logging (), nano::network_params{ nano::network_constants::active_network })
 {
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -21,7 +21,7 @@ const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TE
 }
 
 nano::node_config::node_config () :
-	node_config (0, nano::logging (), nano::dev::network_params)
+	node_config (0, nano::logging (), nano::network_params{ nano::network_constants::active_network})
 {
 }
 


### PR DESCRIPTION
This PR addresses a bug that fixed the runtime network to nano_dev_network regardless of CLI network flags or CMake ACTIVE_NETWORK option chosen