### PR TITLE
Removing static initialization of nano::network_params

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -253,11 +253,11 @@ TEST (active_transactions, inactive_votes_cache_fork)
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_loopback> (node));
 	auto channel1 (node.network.udp_channels.create (node.network.endpoint ()));
 	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 1);
-	node.network.inbound (nano::publish (send2), channel1);
+	node.network.inbound (nano::publish{ nano::dev::network_params.network, send2 }, channel1);
 	node.block_processor.flush ();
 	ASSERT_NE (nullptr, node.block (send2->hash ()));
 	node.scheduler.flush (); // Start election, otherwise conflicting block won't be inserted into election
-	node.network.inbound (nano::publish (send1), channel1);
+	node.network.inbound (nano::publish{ nano::dev::network_params.network, send1 }, channel1);
 	node.block_processor.flush ();
 	bool confirmed (false);
 	system.deadline_set (5s);

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -270,7 +270,7 @@ TEST (change_block, deserialize)
 
 TEST (frontier_req, serialization)
 {
-	nano::frontier_req request1;
+	nano::frontier_req request1{ nano::dev::network_params.network };
 	request1.start = 1;
 	request1.age = 2;
 	request1.count = 3;
@@ -293,7 +293,7 @@ TEST (block, publish_req_serialization)
 	nano::keypair key1;
 	nano::keypair key2;
 	auto block (std::make_shared<nano::send_block> (0, key2.pub, 200, nano::keypair ().prv, 2, 3));
-	nano::publish req (block);
+	nano::publish req{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1262,10 +1262,9 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	}
 	// Extract confirmation height to a separate database
 	auto path (nano::unique_path ());
-	nano::network_params network_params;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	nano::state_block epoch (nano::dev::genesis_key.pub, send.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
+	nano::state_block epoch (nano::dev::genesis_key.pub, send.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
 	nano::state_block state_send (nano::dev::genesis_key.pub, epoch.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch.hash ()));
 	{
 		nano::logger_mt logger;
@@ -1483,20 +1482,19 @@ TEST (mdb_block_store, upgrade_v17_v18)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::keypair key3;
-	nano::network_params network_params;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
 	nano::send_block send_zero (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::state_block state_receive_zero (nano::dev::genesis_key.pub, send_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, send_zero.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send_zero.hash ()));
-	nano::state_block epoch (nano::dev::genesis_key.pub, state_receive_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_receive_zero.hash ()));
+	nano::state_block epoch (nano::dev::genesis_key.pub, state_receive_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_receive_zero.hash ()));
 	nano::state_block state_send (nano::dev::genesis_key.pub, epoch.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch.hash ()));
 	nano::state_block state_receive (nano::dev::genesis_key.pub, state_send.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, state_send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_send.hash ()));
 	nano::state_block state_change (nano::dev::genesis_key.pub, state_receive.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_receive.hash ()));
 	nano::state_block state_send_change (nano::dev::genesis_key.pub, state_change.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_change.hash ()));
-	nano::state_block epoch_first (key1.pub, 0, 0, 0, network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (key1.pub));
+	nano::state_block epoch_first (key1.pub, 0, 0, 0, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (key1.pub));
 	nano::state_block state_receive2 (key1.pub, epoch_first.hash (), key1.pub, nano::Gxrb_ratio, state_send_change.hash (), key1.prv, key1.pub, *pool.generate (epoch_first.hash ()));
 	nano::state_block state_send2 (nano::dev::genesis_key.pub, state_send_change.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_send_change.hash ()));
 	nano::state_block state_open (key2.pub, 0, key2.pub, nano::Gxrb_ratio, state_send2.hash (), key2.prv, key2.pub, *pool.generate (key2.pub));
-	nano::state_block state_send_epoch_link (key2.pub, state_open.hash (), key2.pub, 0, network_params.ledger.epochs.link (nano::epoch::epoch_2), key2.prv, key2.pub, *pool.generate (state_open.hash ()));
+	nano::state_block state_send_epoch_link (key2.pub, state_open.hash (), key2.pub, 0, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_2), key2.prv, key2.pub, *pool.generate (state_open.hash ()));
 	{
 		nano::logger_mt logger;
 		nano::mdb_store store (logger, path, nano::dev::constants);
@@ -1685,11 +1683,10 @@ TEST (mdb_block_store, upgrade_v18_v19)
 	auto path (nano::unique_path ());
 	nano::keypair key1;
 	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
-	nano::network_params network_params;
 	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
 	nano::change_block change (receive.hash (), 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (receive.hash ()));
-	nano::state_block state_epoch (nano::dev::genesis_key.pub, change.hash (), 0, nano::dev::constants.genesis_amount, network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change.hash ()));
+	nano::state_block state_epoch (nano::dev::genesis_key.pub, change.hash (), 0, nano::dev::constants.genesis_amount, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change.hash ()));
 	nano::state_block state_send (nano::dev::genesis_key.pub, state_epoch.hash (), 0, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_epoch.hash ()));
 	nano::state_block state_open (key1.pub, 0, 0, nano::Gxrb_ratio, state_send.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -12,7 +12,7 @@ TEST (bulk_pull, no_address)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = 1;
 	req->end = 2;
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -25,10 +25,10 @@ TEST (bulk_pull, genesis_to_end)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end.clear ();
-	connection->requests.push (std::unique_ptr<nano::message>{});
+	connection->requests.push (nullptr);
 	auto request (std::make_shared<nano::bulk_pull_server> (connection, std::move (req)));
 	ASSERT_EQ (system.nodes[0]->latest (nano::dev::genesis_key.pub), request->current);
 	ASSERT_EQ (request->request->end, request->request->end);
@@ -39,7 +39,7 @@ TEST (bulk_pull, no_end)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end = 1;
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -64,7 +64,7 @@ TEST (bulk_pull, end_not_owned)
 	system.nodes[0]->work_generate_blocking (open);
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = key2.pub;
 	req->end = nano::dev::genesis->hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -76,7 +76,7 @@ TEST (bulk_pull, none)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end = nano::dev::genesis->hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -89,7 +89,7 @@ TEST (bulk_pull, get_next_on_open)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -105,7 +105,7 @@ TEST (bulk_pull, by_block)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis->hash ();
 	req->end.clear ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -122,7 +122,7 @@ TEST (bulk_pull, by_block_single)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis->hash ();
 	req->end = nano::dev::genesis->hash ();
 	connection->requests.push (std::unique_ptr<nano::message>{});
@@ -146,7 +146,7 @@ TEST (bulk_pull, count_limit)
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive1).code);
 
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node0), node0));
-	auto req = std::make_unique<nano::bulk_pull> ();
+	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = receive1->hash ();
 	req->set_count_present (true);
 	req->count = 2;
@@ -1393,7 +1393,7 @@ TEST (frontier_req_response, DISABLED_destruction)
 		{
 			nano::system system (1);
 			auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
-			auto req = std::make_unique<nano::frontier_req> ();
+			auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 			req->start.clear ();
 			req->age = std::numeric_limits<decltype (req->age)>::max ();
 			req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -1408,7 +1408,7 @@ TEST (frontier_req, begin)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::frontier_req> ();
+	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -1422,7 +1422,7 @@ TEST (frontier_req, end)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::frontier_req> ();
+	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub.number () + 1;
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -1464,7 +1464,7 @@ TEST (frontier_req, count)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive1).code);
 
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req = std::make_unique<nano::frontier_req> ();
+	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = 1;
@@ -1478,7 +1478,7 @@ TEST (frontier_req, time_bound)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::frontier_req> ();
+	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = 1;
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -1487,7 +1487,7 @@ TEST (frontier_req, time_bound)
 	ASSERT_EQ (nano::dev::genesis_key.pub, request->current);
 	// Wait 2 seconds until age of account will be > 1 seconds
 	std::this_thread::sleep_for (std::chrono::milliseconds (2100));
-	auto req2 (std::make_unique<nano::frontier_req> ());
+	auto req2 (std::make_unique<nano::frontier_req> (nano::dev::network_params.network));
 	req2->start.clear ();
 	req2->age = 1;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
@@ -1501,7 +1501,7 @@ TEST (frontier_req, time_cutoff)
 {
 	nano::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
-	auto req = std::make_unique<nano::frontier_req> ();
+	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = 3;
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -1511,7 +1511,7 @@ TEST (frontier_req, time_cutoff)
 	ASSERT_EQ (nano::dev::genesis->hash (), request->frontier);
 	// Wait 4 seconds until age of account will be > 3 seconds
 	std::this_thread::sleep_for (std::chrono::milliseconds (4100));
-	auto req2 (std::make_unique<nano::frontier_req> ());
+	auto req2 (std::make_unique<nano::frontier_req> (nano::dev::network_params.network));
 	req2->start.clear ();
 	req2->age = 3;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
@@ -1590,7 +1590,7 @@ TEST (frontier_req, confirmed_frontier)
 
 	// Request for all accounts (confirmed only)
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req = std::make_unique<nano::frontier_req> ();
+	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
 	req->count = std::numeric_limits<decltype (req->count)>::max ();
@@ -1604,7 +1604,7 @@ TEST (frontier_req, confirmed_frontier)
 
 	// Request starting with account before genesis (confirmed only)
 	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req2 = std::make_unique<nano::frontier_req> ();
+	auto req2 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req2->start = key_before_genesis.pub;
 	req2->age = std::numeric_limits<decltype (req2->age)>::max ();
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
@@ -1618,7 +1618,7 @@ TEST (frontier_req, confirmed_frontier)
 
 	// Request starting with account after genesis (confirmed only)
 	auto connection3 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req3 = std::make_unique<nano::frontier_req> ();
+	auto req3 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req3->start = key_after_genesis.pub;
 	req3->age = std::numeric_limits<decltype (req3->age)>::max ();
 	req3->count = std::numeric_limits<decltype (req3->count)>::max ();
@@ -1632,7 +1632,7 @@ TEST (frontier_req, confirmed_frontier)
 
 	// Request for all accounts (unconfirmed blocks)
 	auto connection4 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req4 = std::make_unique<nano::frontier_req> ();
+	auto req4 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req4->start.clear ();
 	req4->age = std::numeric_limits<decltype (req4->age)>::max ();
 	req4->count = std::numeric_limits<decltype (req4->count)>::max ();
@@ -1644,7 +1644,7 @@ TEST (frontier_req, confirmed_frontier)
 
 	// Request starting with account after genesis (unconfirmed blocks)
 	auto connection5 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req5 = std::make_unique<nano::frontier_req> ();
+	auto req5 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req5->start = key_after_genesis.pub;
 	req5->age = std::numeric_limits<decltype (req5->age)>::max ();
 	req5->count = std::numeric_limits<decltype (req5->count)>::max ();
@@ -1658,7 +1658,7 @@ TEST (frontier_req, confirmed_frontier)
 	nano::blocks_confirm (*node1, { send1, receive1 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()));
 	auto connection6 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req6 = std::make_unique<nano::frontier_req> ();
+	auto req6 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req6->start = key_before_genesis.pub;
 	req6->age = std::numeric_limits<decltype (req6->age)>::max ();
 	req6->count = std::numeric_limits<decltype (req6->count)>::max ();
@@ -1674,7 +1674,7 @@ TEST (frontier_req, confirmed_frontier)
 	nano::blocks_confirm (*node1, { send2, receive2 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send2->hash ()) && node1->block_confirmed (receive2->hash ()));
 	auto connection7 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
-	auto req7 = std::make_unique<nano::frontier_req> ();
+	auto req7 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req7->start = key_after_genesis.pub;
 	req7->age = std::numeric_limits<decltype (req7->age)>::max ();
 	req7->count = std::numeric_limits<decltype (req7->count)>::max ();
@@ -1851,7 +1851,7 @@ TEST (bulk_pull_account, basics)
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
 
 	{
-		auto req = std::make_unique<nano::bulk_pull_account> ();
+		auto req = std::make_unique<nano::bulk_pull_account> (nano::dev::network_params.network);
 		req->account = key1.pub;
 		req->minimum_amount = 5;
 		req->flags = nano::bulk_pull_account_flags ();
@@ -1870,7 +1870,7 @@ TEST (bulk_pull_account, basics)
 	}
 
 	{
-		auto req = std::make_unique<nano::bulk_pull_account> ();
+		auto req = std::make_unique<nano::bulk_pull_account> (nano::dev::network_params.network);
 		req->account = key1.pub;
 		req->minimum_amount = 0;
 		req->flags = nano::bulk_pull_account_flags::pending_address_only;

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -533,7 +533,7 @@ TEST (bootstrap_processor, lazy_hash)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -607,7 +607,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, true, "123456");
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -745,7 +745,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (3, node1->ledger.cache.pruned_count);
 	// Start lazy bootstrap with last block in chain known
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->ledger.cache.block_count == 9);
@@ -848,7 +848,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->block (change3->hash ()));
@@ -906,7 +906,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (receive->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
@@ -958,7 +958,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (15s, !node2->bootstrap_initiator.in_progress ());
@@ -1020,7 +1020,7 @@ TEST (bootstrap_processor, DISABLED_lazy_destinations)
 
 	// Start lazy bootstrap with last block in sender chain
 	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
@@ -1098,7 +1098,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	// Start lazy bootstrap with last block in sender chain
 	config.peering_port = nano::get_available_port ();
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	auto lazy_attempt (node2->bootstrap_initiator.current_lazy_attempt ());
@@ -1153,7 +1153,7 @@ TEST (bootstrap_processor, lazy_cancel)
 
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (send1->hash (), true); // Start "confirmed" block bootstrap
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -1228,7 +1228,7 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -1295,7 +1295,7 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -1369,7 +1369,7 @@ TEST (bootstrap_processor, multiple_attempts)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.bootstrap_initiator_threads = 3;
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work));
-	node2->network.udp_channels.insert (node1->network.endpoint (), node2->network_params.protocol.protocol_version);
+	node2->network.udp_channels.insert (node1->network.endpoint (), node2->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	node2->bootstrap_initiator.bootstrap ();
 	auto lazy_attempt (node2->bootstrap_initiator.current_lazy_attempt ());

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -654,10 +654,10 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		ASSERT_EQ (1, node1->network.size ());
 		nano::keypair key1;
 		auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
-		nano::publish publish1 (send1);
+		nano::publish publish1{ nano::dev::network_params.network, send1 };
 		nano::keypair key2;
 		auto send2 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key2.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
-		nano::publish publish2 (send2);
+		nano::publish publish2{ nano::dev::network_params.network, send2 };
 		auto channel1 (node1->network.udp_channels.create (node1->network.endpoint ()));
 		node1->network.inbound (publish1, channel1);
 		node1->block_processor.flush ();

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -12,7 +12,7 @@ namespace
 {
 void add_callback_stats (nano::node & node, std::vector<nano::block_hash> * observer_order = nullptr, nano::mutex * mutex = nullptr)
 {
-	node.observers.blocks.add ([&stats = node.stats, observer_order, mutex] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::amount const &, bool) {
+	node.observers.blocks.add ([&stats = node.stats, observer_order, mutex] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::amount const &, bool, bool) {
 		stats.inc (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out);
 		if (mutex)
 		{

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -146,7 +146,6 @@ private:
 			work_pool.generate (version, hash, request_difficulty, [this_l, hash] (boost::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
 				auto result_difficulty (nano::work_difficulty (this_l->version, hash, result));
-				static nano::network_params params;
 				ptree::ptree message_l;
 				message_l.put ("work", nano::to_string_hex (result));
 				message_l.put ("difficulty", nano::to_string_hex (result_difficulty));

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -65,7 +65,7 @@ TEST (message, publish_serialization)
 	auto error (false);
 	nano::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version_min (), header.version_min ());
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version_min (), header.version_min);
 	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, header.version_using);
 	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, header.version_max);
 	ASSERT_EQ (nano::message_type::publish, header.type);

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -44,7 +44,6 @@ TEST (message, keepalive_deserialize)
 
 TEST (message, publish_serialization)
 {
-	nano::network_params params;
 	nano::publish publish (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	publish.header.network = nano::networks::nano_dev_network;
 	ASSERT_EQ (nano::block_type::send, publish.header.block_type ());
@@ -56,9 +55,9 @@ TEST (message, publish_serialization)
 	ASSERT_EQ (8, bytes.size ());
 	ASSERT_EQ (0x52, bytes[0]);
 	ASSERT_EQ (0x41, bytes[1]);
-	ASSERT_EQ (params.protocol.protocol_version, bytes[2]);
-	ASSERT_EQ (params.protocol.protocol_version, bytes[3]);
-	ASSERT_EQ (params.protocol.protocol_version_min (), bytes[4]);
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, bytes[2]);
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, bytes[3]);
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version_min (), bytes[4]);
 	ASSERT_EQ (static_cast<uint8_t> (nano::message_type::publish), bytes[5]);
 	ASSERT_EQ (0x00, bytes[6]); // extensions
 	ASSERT_EQ (static_cast<uint8_t> (nano::block_type::send), bytes[7]);
@@ -66,9 +65,9 @@ TEST (message, publish_serialization)
 	auto error (false);
 	nano::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (params.protocol.protocol_version_min (), header.version_min ());
-	ASSERT_EQ (params.protocol.protocol_version, header.version_using);
-	ASSERT_EQ (params.protocol.protocol_version, header.version_max);
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version_min (), header.version_min ());
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, header.version_using);
+	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, header.version_max);
 	ASSERT_EQ (nano::message_type::publish, header.type);
 }
 

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -8,7 +8,7 @@
 
 TEST (message, keepalive_serialization)
 {
-	nano::keepalive request1;
+	nano::keepalive request1{ nano::dev::network_params.network };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -25,7 +25,7 @@ TEST (message, keepalive_serialization)
 
 TEST (message, keepalive_deserialize)
 {
-	nano::keepalive message1;
+	nano::keepalive message1{ nano::dev::network_params.network };
 	message1.peers[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000);
 	std::vector<uint8_t> bytes;
 	{
@@ -44,11 +44,7 @@ TEST (message, keepalive_deserialize)
 
 TEST (message, publish_serialization)
 {
-	nano::publish publish (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
-	publish.header.network = nano::networks::nano_dev_network;
-	publish.header.version_max = 6;
-	publish.header.version_using = 5;
-	publish.header.version_min = 4;
+	nano::publish publish{ nano::dev::network_params.network, std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5) };
 	ASSERT_EQ (nano::block_type::send, publish.header.block_type ());
 	std::vector<uint8_t> bytes;
 	{
@@ -58,9 +54,9 @@ TEST (message, publish_serialization)
 	ASSERT_EQ (8, bytes.size ());
 	ASSERT_EQ (0x52, bytes[0]);
 	ASSERT_EQ (0x41, bytes[1]);
-	ASSERT_EQ (6, bytes[2]);
-	ASSERT_EQ (5, bytes[3]);
-	ASSERT_EQ (4, bytes[4]);
+	ASSERT_EQ (nano::dev::network_params.network.protocol_version, bytes[2]);
+	ASSERT_EQ (nano::dev::network_params.network.protocol_version, bytes[3]);
+	ASSERT_EQ (nano::dev::network_params.network.protocol_version_min, bytes[4]);
 	ASSERT_EQ (static_cast<uint8_t> (nano::message_type::publish), bytes[5]);
 	ASSERT_EQ (0x00, bytes[6]); // extensions
 	ASSERT_EQ (static_cast<uint8_t> (nano::block_type::send), bytes[7]);
@@ -68,9 +64,9 @@ TEST (message, publish_serialization)
 	auto error (false);
 	nano::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (4, header.version_min);
-	ASSERT_EQ (5, header.version_using);
-	ASSERT_EQ (6, header.version_max);
+	ASSERT_EQ (nano::dev::network_params.network.protocol_version_min, header.version_min);
+	ASSERT_EQ (nano::dev::network_params.network.protocol_version, header.version_using);
+	ASSERT_EQ (nano::dev::network_params.network.protocol_version, header.version_max);
 	ASSERT_EQ (nano::message_type::publish, header.type);
 }
 
@@ -78,7 +74,7 @@ TEST (message, confirm_ack_serialization)
 {
 	nano::keypair key1;
 	auto vote (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, std::make_shared<nano::send_block> (0, 1, 2, key1.prv, 4, 5)));
-	nano::confirm_ack con1 (vote);
+	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream1 (bytes);
@@ -106,7 +102,7 @@ TEST (message, confirm_ack_hash_serialization)
 	}
 	nano::keypair representative1;
 	auto vote (std::make_shared<nano::vote> (representative1.pub, representative1.prv, 0, hashes));
-	nano::confirm_ack con1 (vote);
+	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream1 (bytes);
@@ -134,7 +130,7 @@ TEST (message, confirm_req_serialization)
 	nano::keypair key1;
 	nano::keypair key2;
 	auto block (std::make_shared<nano::send_block> (0, key2.pub, 200, nano::keypair ().prv, 2, 3));
-	nano::confirm_req req (block);
+	nano::confirm_req req{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -154,7 +150,7 @@ TEST (message, confirm_req_hash_serialization)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::send_block block (1, key2.pub, 200, nano::keypair ().prv, 2, 3);
-	nano::confirm_req req (block.hash (), block.root ());
+	nano::confirm_req req{ nano::dev::network_params.network, block.hash (), block.root () };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -187,7 +183,7 @@ TEST (message, confirm_req_hash_batch_serialization)
 		roots_hashes.push_back (std::make_pair (block.hash (), block.root ()));
 	}
 	roots_hashes.push_back (std::make_pair (open.hash (), open.root ()));
-	nano::confirm_req req (roots_hashes);
+	nano::confirm_req req{ nano::dev::network_params.network, roots_hashes };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -46,6 +46,9 @@ TEST (message, publish_serialization)
 {
 	nano::publish publish (std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5));
 	publish.header.network = nano::networks::nano_dev_network;
+	publish.header.version_max = 6;
+	publish.header.version_using = 5;
+	publish.header.version_min = 4;
 	ASSERT_EQ (nano::block_type::send, publish.header.block_type ());
 	std::vector<uint8_t> bytes;
 	{
@@ -55,9 +58,9 @@ TEST (message, publish_serialization)
 	ASSERT_EQ (8, bytes.size ());
 	ASSERT_EQ (0x52, bytes[0]);
 	ASSERT_EQ (0x41, bytes[1]);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, bytes[2]);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, bytes[3]);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version_min (), bytes[4]);
+	ASSERT_EQ (6, bytes[2]);
+	ASSERT_EQ (5, bytes[3]);
+	ASSERT_EQ (4, bytes[4]);
 	ASSERT_EQ (static_cast<uint8_t> (nano::message_type::publish), bytes[5]);
 	ASSERT_EQ (0x00, bytes[6]); // extensions
 	ASSERT_EQ (static_cast<uint8_t> (nano::block_type::send), bytes[7]);
@@ -65,9 +68,9 @@ TEST (message, publish_serialization)
 	auto error (false);
 	nano::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version_min (), header.version_min);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, header.version_using);
-	ASSERT_EQ (nano::dev::network_params.protocol.protocol_version, header.version_max);
+	ASSERT_EQ (4, header.version_min);
+	ASSERT_EQ (5, header.version_using);
+	ASSERT_EQ (6, header.version_max);
 	ASSERT_EQ (nano::message_type::publish, header.type);
 }
 

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -67,8 +67,8 @@ TEST (message_parser, exact_confirm_ack_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::protocol_constants protocol;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
+	nano::network_constants network;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, std::move (block)));
 	nano::confirm_ack message (vote);
@@ -102,8 +102,8 @@ TEST (message_parser, exact_confirm_req_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::protocol_constants protocol;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
+	nano::network_constants network;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::confirm_req message (std::move (block));
 	std::vector<uint8_t> bytes;
@@ -136,8 +136,8 @@ TEST (message_parser, exact_confirm_req_hash_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::protocol_constants protocol;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
+	nano::network_constants network;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
 	nano::confirm_req message (block.hash (), block.root ());
 	std::vector<uint8_t> bytes;
@@ -170,8 +170,8 @@ TEST (message_parser, exact_publish_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::protocol_constants protocol;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
+	nano::network_constants network;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::publish message (std::move (block));
 	std::vector<uint8_t> bytes;
@@ -204,8 +204,8 @@ TEST (message_parser, exact_keepalive_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::protocol_constants protocol;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
+	nano::network_constants network;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	nano::keepalive message;
 	std::vector<uint8_t> bytes;
 	{

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -67,7 +67,8 @@ TEST (message_parser, exact_confirm_ack_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::protocol_constants protocol;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, std::move (block)));
 	nano::confirm_ack message (vote);
@@ -101,7 +102,8 @@ TEST (message_parser, exact_confirm_req_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::protocol_constants protocol;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::confirm_req message (std::move (block));
 	std::vector<uint8_t> bytes;
@@ -134,7 +136,8 @@ TEST (message_parser, exact_confirm_req_hash_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::protocol_constants protocol;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
 	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
 	nano::confirm_req message (block.hash (), block.root ());
 	std::vector<uint8_t> bytes;
@@ -167,7 +170,8 @@ TEST (message_parser, exact_publish_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::protocol_constants protocol;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::publish message (std::move (block));
 	std::vector<uint8_t> bytes;
@@ -200,7 +204,8 @@ TEST (message_parser, exact_keepalive_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::protocol_constants protocol;
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, protocol);
 	nano::keepalive message;
 	std::vector<uint8_t> bytes;
 	{

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -71,7 +71,7 @@ TEST (message_parser, exact_confirm_ack_size)
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, std::move (block)));
-	nano::confirm_ack message (vote);
+	nano::confirm_ack message{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -105,7 +105,7 @@ TEST (message_parser, exact_confirm_req_size)
 	nano::network_constants network;
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
-	nano::confirm_req message (std::move (block));
+	nano::confirm_req message{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -139,7 +139,7 @@ TEST (message_parser, exact_confirm_req_hash_size)
 	nano::network_constants network;
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
-	nano::confirm_req message (block.hash (), block.root ());
+	nano::confirm_req message{ nano::dev::network_params.network, block.hash (), block.root () };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -173,7 +173,7 @@ TEST (message_parser, exact_publish_size)
 	nano::network_constants network;
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
-	nano::publish message (std::move (block));
+	nano::publish message{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -206,7 +206,7 @@ TEST (message_parser, exact_keepalive_size)
 	nano::vote_uniquer vote_uniquer (block_uniquer);
 	nano::network_constants network;
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
-	nano::keepalive message;
+	nano::keepalive message{ nano::dev::network_params.network };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);

--- a/nano/core_test/network_filter.cpp
+++ b/nano/core_test/network_filter.cpp
@@ -11,7 +11,7 @@ TEST (network_filter, unit)
 	nano::ledger_constants constants{ nano::networks::nano_dev_network };
 	nano::network_filter filter (1);
 	auto one_block = [&filter] (std::shared_ptr<nano::block> const & block_a, bool expect_duplicate_a) {
-		nano::publish message (block_a);
+		nano::publish message{ nano::dev::network_params.network, block_a };
 		auto bytes (message.to_bytes ());
 		nano::bufferstream stream (bytes->data (), bytes->size ());
 
@@ -78,7 +78,7 @@ TEST (network_filter, many)
 					 .work (0)
 					 .build_shared ();
 
-		nano::publish message (block);
+		nano::publish message{ nano::dev::network_params.network, block };
 		auto bytes (message.to_bytes ());
 		nano::bufferstream stream (bytes->data (), bytes->size ());
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -536,12 +536,12 @@ TEST (node, connect_after_junk)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	std::vector<uint8_t> junk_buffer;
 	junk_buffer.push_back (0);
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.protocol.protocol_version));
+	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.network.protocol_version));
 	channel1->send_buffer (nano::shared_const_buffer (std::move (junk_buffer)), [] (boost::system::error_code const &, size_t) {});
 	ASSERT_TIMELY (10s, node0->stats.count (nano::stat::type::error) != 0);
 	node1->start ();
 	system.nodes.push_back (node1);
-	auto channel2 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.protocol.protocol_version));
+	auto channel2 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.network.protocol_version));
 	node1->network.send_keepalive (channel2);
 	ASSERT_TIMELY (10s, !node1->network.empty ());
 	node1->stop ();
@@ -1020,7 +1020,7 @@ TEST (node_flags, disable_udp)
 	ASSERT_EQ (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.udp_channels.get_local_endpoint ());
 	ASSERT_NE (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.endpoint ());
 	// Send UDP message
-	auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node2->network.endpoint (), node2->network_params.protocol.protocol_version));
+	auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node2->network.endpoint (), node2->network_params.network.protocol_version));
 	node1->network.send_keepalive (channel);
 	std::this_thread::sleep_for (std::chrono::milliseconds (500));
 	// Check empty network
@@ -1618,7 +1618,7 @@ TEST (node, DISABLED_fork_stale)
 	auto & node1 (*system1.nodes[0]);
 	auto & node2 (*system2.nodes[0]);
 	node2.bootstrap_initiator.bootstrap (node1.network.endpoint (), false);
-	std::shared_ptr<nano::transport::channel> channel (std::make_shared<nano::transport::channel_udp> (node2.network.udp_channels, node1.network.endpoint (), node2.network_params.protocol.protocol_version));
+	std::shared_ptr<nano::transport::channel> channel (std::make_shared<nano::transport::channel_udp> (node2.network.udp_channels, node1.network.endpoint (), node2.network_params.network.protocol_version));
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, std::vector<nano::block_hash> ());
 	node2.rep_crawler.response (channel, vote);
 	nano::keypair key1;
@@ -2252,8 +2252,8 @@ TEST (node, rep_remove)
 	}
 	// Add inactive UDP representative channel
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
-	std::shared_ptr<nano::transport::channel> channel0 (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint0, node.network_params.protocol.protocol_version));
-	auto channel_udp = node.network.udp_channels.insert (endpoint0, node.network_params.protocol.protocol_version);
+	std::shared_ptr<nano::transport::channel> channel0 (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint0, node.network_params.network.protocol_version));
+	auto channel_udp = node.network.udp_channels.insert (endpoint0, node.network_params.network.protocol_version);
 	auto vote1 = std::make_shared<nano::vote> (keypair1.pub, keypair1.prv, 0, nano::dev::genesis);
 	ASSERT_FALSE (node.rep_crawler.response (channel0, vote1));
 	ASSERT_TIMELY (5s, node.rep_crawler.representative_count () == 1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1486,7 +1486,7 @@ TEST (node, coherent_observer)
 {
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
-	node1.observers.blocks.add ([&node1] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::uint128_t const &, bool) {
+	node1.observers.blocks.add ([&node1] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::uint128_t const &, bool, bool) {
 		auto transaction (node1.store.tx_begin_read ());
 		ASSERT_TRUE (node1.store.block.exists (transaction, status_a.winner->hash ()));
 	});

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -361,7 +361,7 @@ TEST (node, receive_gap)
 				 .work (0)
 				 .build_shared ();
 	node1.work_generate_blocking (*block);
-	nano::publish message (block);
+	nano::publish message{ nano::dev::network_params.network, block };
 	node1.network.inbound (message, node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.block_processor.flush ();
 	ASSERT_EQ (1, node1.gap_cache.size ());
@@ -1191,7 +1191,7 @@ TEST (node, fork_flip)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	nano::publish publish1 (send1);
+	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	nano::keypair key2;
 	auto send2 = builder.make_block ()
 				 .previous (nano::dev::genesis->hash ())
@@ -1200,7 +1200,7 @@ TEST (node, fork_flip)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	nano::publish publish2 (send2);
+	nano::publish publish2{ nano::dev::network_params.network, send2 };
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.network.inbound (publish1, channel1);
 	node1.block_processor.flush ();
@@ -1258,7 +1258,7 @@ TEST (node, fork_multi_flip)
 					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					 .work (*system.work.generate (nano::dev::genesis->hash ()))
 					 .build_shared ();
-		nano::publish publish1 (send1);
+		nano::publish publish1{ nano::dev::network_params.network, send1 };
 		nano::keypair key2;
 		auto send2 = builder.make_block ()
 					 .previous (nano::dev::genesis->hash ())
@@ -1267,7 +1267,7 @@ TEST (node, fork_multi_flip)
 					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					 .work (*system.work.generate (nano::dev::genesis->hash ()))
 					 .build_shared ();
-		nano::publish publish2 (send2);
+		nano::publish publish2{ nano::dev::network_params.network, send2 };
 		auto send3 = builder.make_block ()
 					 .previous (publish2.block->hash ())
 					 .destination (key2.pub)
@@ -1275,7 +1275,7 @@ TEST (node, fork_multi_flip)
 					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					 .work (*system.work.generate (publish2.block->hash ()))
 					 .build_shared ();
-		nano::publish publish3 (send3);
+		nano::publish publish3{ nano::dev::network_params.network, send3 };
 		node1.network.inbound (publish1, node1.network.udp_channels.create (node1.network.endpoint ()));
 		node2.network.inbound (publish2, node2.network.udp_channels.create (node2.network.endpoint ()));
 		node2.network.inbound (publish3, node2.network.udp_channels.create (node2.network.endpoint ()));
@@ -1368,7 +1368,7 @@ TEST (node, fork_open)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	nano::publish publish1 (send1);
+	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
 	node1.network.inbound (publish1, channel1);
 	node1.block_processor.flush ();
@@ -1385,7 +1385,7 @@ TEST (node, fork_open)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1.pub))
 				 .build_shared ();
-	nano::publish publish2 (open1);
+	nano::publish publish2{ nano::dev::network_params.network, open1 };
 	node1.network.inbound (publish2, channel1);
 	node1.block_processor.flush ();
 	node1.scheduler.flush ();
@@ -1397,7 +1397,7 @@ TEST (node, fork_open)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1.pub))
 				 .build_shared ();
-	nano::publish publish3 (open2);
+	nano::publish publish3{ nano::dev::network_params.network, open2 };
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	node1.network.inbound (publish3, channel1);
 	node1.block_processor.flush ();
@@ -1531,7 +1531,7 @@ TEST (node, fork_no_vote_quorum)
 	auto transaction (system.wallet (1)->wallets.tx_begin_read ());
 	ASSERT_FALSE (system.wallet (1)->store.fetch (transaction, key1, key3));
 	auto vote (std::make_shared<nano::vote> (key1, key3, 0, send2));
-	nano::confirm_ack confirm (vote);
+	nano::confirm_ack confirm{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> buffer;
 	{
 		nano::vectorstream stream (buffer);
@@ -2692,8 +2692,8 @@ TEST (node, local_votes_cache)
 	election->force_confirm ();
 	ASSERT_TIMELY (3s, node.ledger.cache.cemented_count == 3);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::confirm_req message1 (send1);
-	nano::confirm_req message2 (send2);
+	nano::confirm_req message1{ nano::dev::network_params.network, send1 };
+	nano::confirm_req message2{ nano::dev::network_params.network, send2 };
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
 	node.network.inbound (message1, channel);
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 1);
@@ -2715,7 +2715,7 @@ TEST (node, local_votes_cache)
 		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send3).code);
 	}
-	nano::confirm_req message3 (send3);
+	nano::confirm_req message3{ nano::dev::network_params.network, send3 };
 	for (auto i (0); i < 100; ++i)
 	{
 		node.network.inbound (message3, channel);
@@ -2772,7 +2772,7 @@ TEST (node, local_votes_cache_batch)
 					.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *receive1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> batch{ { send2->hash (), send2->root () }, { receive1->hash (), receive1->root () } };
-	nano::confirm_req message (batch);
+	nano::confirm_req message{ nano::dev::network_params.network, batch };
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
 	// Generates and sends one vote for both hashes which is then cached
 	node.network.inbound (message, channel);
@@ -2787,10 +2787,10 @@ TEST (node, local_votes_cache_batch)
 	// Test when votes are different
 	node.history.erase (send2->root ());
 	node.history.erase (receive1->root ());
-	node.network.inbound (nano::confirm_req (send2->hash (), send2->root ()), channel);
+	node.network.inbound (nano::confirm_req{ nano::dev::network_params.network, send2->hash (), send2->root () }, channel);
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 3);
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
-	node.network.inbound (nano::confirm_req (receive1->hash (), receive1->root ()), channel);
+	node.network.inbound (nano::confirm_req{ nano::dev::network_params.network, receive1->hash (), receive1->root () }, channel);
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 4);
 	ASSERT_EQ (4, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	// There are two different votes, so both should be sent in response
@@ -2807,7 +2807,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Repsond with cached vote
-	nano::confirm_req message1 (nano::dev::genesis);
+	nano::confirm_req message1{ nano::dev::network_params.network, nano::dev::genesis };
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
 	node.network.inbound (message1, channel);
 	ASSERT_TIMELY (3s, !node.history.votes (nano::dev::genesis->root (), nano::dev::genesis->hash ()).empty ());
@@ -2828,7 +2828,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
 	// One of the hashes is cached
 	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes{ std::make_pair (nano::dev::genesis->hash (), nano::dev::genesis->root ()), std::make_pair (send1->hash (), send1->root ()) };
-	nano::confirm_req message2 (roots_hashes);
+	nano::confirm_req message2{ nano::dev::network_params.network, roots_hashes };
 	node.network.inbound (message2, channel);
 	ASSERT_TIMELY (3s, !node.history.votes (send1->root (), send1->hash ()).empty ());
 	auto votes2 (node.history.votes (send1->root (), send1->hash ()));
@@ -3231,13 +3231,13 @@ TEST (node, fork_election_invalid_block_signature)
 				 .sign (nano::dev::genesis_key.prv, 0) // Invalid signature
 				 .build_shared ();
 	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
-	node1.network.inbound (nano::publish (send1), channel1);
+	node1.network.inbound (nano::publish{ nano::dev::network_params.network, send1 }, channel1);
 	ASSERT_TIMELY (5s, node1.active.active (send1->qualified_root ()));
 	auto election (node1.active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
-	node1.network.inbound (nano::publish (send3), channel1);
-	node1.network.inbound (nano::publish (send2), channel1);
+	node1.network.inbound (nano::publish{ nano::dev::network_params.network, send3 }, channel1);
+	node1.network.inbound (nano::publish{ nano::dev::network_params.network, send2 }, channel1);
 	ASSERT_TIMELY (3s, election->blocks ().size () > 1);
 	ASSERT_EQ (election->blocks ()[send2->hash ()]->block_signature (), send2->block_signature ());
 }

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -22,9 +22,9 @@ TEST (peer_container, no_recontact)
 	ASSERT_EQ (0, network.size ());
 	network.channel_observer = [&observed_peer] (std::shared_ptr<nano::transport::channel> const &) { ++observed_peer; };
 	node1.network.disconnect_observer = [&observed_disconnect] () { observed_disconnect = true; };
-	auto channel (network.udp_channels.insert (endpoint1, node1.network_params.protocol.protocol_version));
+	auto channel (network.udp_channels.insert (endpoint1, node1.network_params.network.protocol_version));
 	ASSERT_EQ (1, network.size ());
-	ASSERT_EQ (channel, network.udp_channels.insert (endpoint1, node1.network_params.protocol.protocol_version));
+	ASSERT_EQ (channel, network.udp_channels.insert (endpoint1, node1.network_params.network.protocol_version));
 	node1.network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (5));
 	ASSERT_TRUE (network.empty ());
 	ASSERT_EQ (1, observed_peer);
@@ -126,7 +126,7 @@ TEST (peer_container, list_fanout)
 	auto list1 (node.network.list (node.network.fanout ()));
 	ASSERT_TRUE (list1.empty ());
 	auto add_peer = [&node] (const uint16_t port_a) {
-		ASSERT_NE (nullptr, node.network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), port_a), node.network_params.protocol.protocol_version));
+		ASSERT_NE (nullptr, node.network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), port_a), node.network_params.network.protocol_version));
 	};
 	add_peer (9998);
 	ASSERT_EQ (1, node.network.size ());
@@ -161,7 +161,7 @@ TEST (peer_container, reachout)
 	auto & node1 = *system.add_node (node_flags);
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
 	// Make sure having been contacted by them already indicates we shouldn't reach out
-	node1.network.udp_channels.insert (endpoint0, node1.network_params.protocol.protocol_version);
+	node1.network.udp_channels.insert (endpoint0, node1.network_params.network.protocol_version);
 	ASSERT_TRUE (node1.network.reachout (endpoint0));
 	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
 	ASSERT_FALSE (node1.network.reachout (endpoint1));

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -179,8 +179,8 @@ TEST (peer_container, depeer)
 {
 	nano::system system (1);
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
-	nano::keepalive message;
-	message.header.version_using = 1;
+	nano::keepalive message{ nano::dev::network_params.network };
+	const_cast<uint8_t &> (message.header.version_using) = 1;
 	auto bytes (message.to_bytes ());
 	nano::message_buffer buffer = { bytes->data (), bytes->size (), endpoint0 };
 	system.nodes[0]->network.udp_channels.receive_action (&buffer);

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -284,7 +284,7 @@ TEST (telemetry, receive_from_non_listening_channel)
 {
 	nano::system system;
 	auto node = system.add_node ();
-	nano::telemetry_ack message (nano::telemetry_data{});
+	nano::telemetry_ack message{ nano::dev::network_params.network, nano::telemetry_data{} };
 	node->network.inbound (message, node->network.udp_channels.create (node->network.endpoint ()));
 	// We have not sent a telemetry_req message to this endpoint, so shouldn't count telemetry_ack received from it.
 	ASSERT_EQ (node->telemetry->telemetry_data_size (), 0);
@@ -412,7 +412,7 @@ TEST (telemetry, dos_tcp)
 
 	wait_peer_connections (system);
 
-	nano::telemetry_req message;
+	nano::telemetry_req message{ nano::dev::network_params.network };
 	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
 	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
 		ASSERT_FALSE (ec);
@@ -455,7 +455,7 @@ TEST (telemetry, dos_udp)
 
 	wait_peer_connections (system);
 
-	nano::telemetry_req message;
+	nano::telemetry_req message{ nano::dev::network_params.network };
 	auto channel (node_client->network.udp_channels.create (node_server->network.endpoint ()));
 	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
 		ASSERT_FALSE (ec);
@@ -532,7 +532,7 @@ TEST (telemetry, max_possible_size)
 	nano::telemetry_data data;
 	data.unknown_data.resize (nano::message_header::telemetry_size_mask.to_ulong () - nano::telemetry_data::latest_size);
 
-	nano::telemetry_ack message (data);
+	nano::telemetry_ack message{ nano::dev::network_params.network, data };
 	wait_peer_connections (system);
 
 	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
@@ -651,7 +651,7 @@ TEST (telemetry, remove_peer_invalid_signature)
 	auto telemetry_data = nano::local_telemetry_data (node->ledger, node->network, node->config.bandwidth_limit, node->network_params, node->startup_time, node->default_difficulty (nano::work_version::work_1), node->node_id);
 	// Change anything so that the signed message is incorrect
 	telemetry_data.block_count = 0;
-	auto telemetry_ack = nano::telemetry_ack (telemetry_data);
+	auto telemetry_ack = nano::telemetry_ack{ nano::dev::network_params.network, telemetry_data };
 	node->network.inbound (telemetry_ack, channel);
 
 	ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::telemetry, nano::stat::detail::invalid_signature) > 0);

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -604,8 +604,8 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 	node1->network_params.ledger.genesis = junk;
 	node1->start ();
 	system.nodes.push_back (node1);
-	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.protocol.protocol_version));
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node1->network_params.protocol.protocol_version));
+	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.network.protocol_version));
+	auto channel1 (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node1->network_params.network.protocol_version));
 	node0->network.send_keepalive (channel1);
 	node1->network.send_keepalive (channel0);
 

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -572,8 +572,8 @@ TEST (telemetry, remove_peer_different_genesis)
 
 	ASSERT_TIMELY (1s, 0 == node0->network.size ());
 	ASSERT_TIMELY (1s, 0 == node1->network.size ());
-	ASSERT_EQ (node0->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::out), 1);
-	ASSERT_EQ (node1->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::out), 1);
+	ASSERT_GE (node0->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::out), 1);
+	ASSERT_GE (node1->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::out), 1);
 
 	nano::lock_guard<nano::mutex> guard (node0->network.excluded_peers.mutex);
 	ASSERT_EQ (1, node0->network.excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ().count (node1->network.endpoint ().address ()));

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -11,8 +11,7 @@ namespace nano
 {
 TEST (local_vote_history, basic)
 {
-	nano::network_params params;
-	nano::local_vote_history history{ params.voting };
+	nano::local_vote_history history{ nano::dev::network_params.voting };
 	ASSERT_FALSE (history.exists (1));
 	ASSERT_FALSE (history.exists (2));
 	ASSERT_TRUE (history.votes (1).empty ());

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -141,7 +141,7 @@ TEST (websocket, stopped_election)
 	// Create election, then erase it, causing a websocket message to be emitted
 	nano::keypair key1;
 	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
-	nano::publish publish1 (send1);
+	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 (node1->network.udp_channels.create (node1->network.endpoint ()));
 	node1->network.inbound (publish1, channel1);
 	node1->block_processor.flush ();

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -240,6 +240,10 @@ public:
 
 	/** Initial value is ACTIVE_NETWORK compile flag, but can be overridden by a CLI flag */
 	static nano::networks active_network;
+	/** Current protocol version */
+	uint8_t const protocol_version = 0x12;
+	/** Minimum accepted protocol version */
+	uint8_t const protocol_version_min = 0x12;
 };
 
 std::string get_config_path (boost::filesystem::path const & data_path);

--- a/nano/lib/lmdbconfig.cpp
+++ b/nano/lib/lmdbconfig.cpp
@@ -31,7 +31,6 @@ nano::error nano::lmdb_config::serialize_toml (nano::tomlconfig & toml) const
 
 nano::error nano::lmdb_config::deserialize_toml (nano::tomlconfig & toml)
 {
-	static nano::network_params params;
 	auto default_max_databases = max_databases;
 	toml.get_optional<uint32_t> ("max_databases", max_databases);
 	toml.get_optional<size_t> ("map_size", map_size);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -887,8 +887,6 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_process"))
 		{
-			nano::network_constants::set_active_network (nano::networks::nano_dev_network);
-			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t num_accounts (100000);
 			size_t num_iterations (5); // 100,000 * 5 * 2 = 1,000,000 blocks
@@ -1004,8 +1002,6 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_votes"))
 		{
-			nano::network_constants::set_active_network (nano::networks::nano_dev_network);
-			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t num_elections (40000);
 			size_t num_representatives (25);
@@ -1112,8 +1108,6 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_frontiers_confirmation"))
 		{
-			nano::force_nano_dev_network ();
-			nano::network_params dev_params;
 			nano::block_builder builder;
 			size_t count (32 * 1024);
 			auto count_it = vm.find ("count");
@@ -1172,7 +1166,7 @@ int main (int argc, char * const * argv)
 							.balance (genesis_balance)
 							.link (key.pub)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							.work (*work.generate (nano::work_version::work_1, genesis_latest, dev_params.network.publish_thresholds.epoch_1))
+							.work (*work.generate (nano::work_version::work_1, genesis_latest, nano::dev::network_params.network.publish_thresholds.epoch_1))
 							.build ();
 
 				genesis_latest = send->hash ();
@@ -1184,7 +1178,7 @@ int main (int argc, char * const * argv)
 							.balance (1)
 							.link (genesis_latest)
 							.sign (key.prv, key.pub)
-							.work (*work.generate (nano::work_version::work_1, key.pub, dev_params.network.publish_thresholds.epoch_1))
+							.work (*work.generate (nano::work_version::work_1, key.pub, nano::dev::network_params.network.publish_thresholds.epoch_1))
 							.build ();
 
 				blocks.push_back (std::move (send));

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -440,14 +440,14 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_kdf"))
 		{
-			nano::network_params network_params;
+			auto inactive_node = nano::default_inactive_node (data_path, vm);
 			nano::uint256_union result;
 			nano::uint256_union salt (0);
 			std::string password ("");
 			while (true)
 			{
 				auto begin1 (std::chrono::high_resolution_clock::now ());
-				auto success (argon2_hash (1, network_params.kdf_work, 1, password.data (), password.size (), salt.bytes.data (), salt.bytes.size (), result.bytes.data (), result.bytes.size (), NULL, 0, Argon2_d, 0x10));
+				auto success (argon2_hash (1, inactive_node->node->network_params.kdf_work, 1, password.data (), password.size (), salt.bytes.data (), salt.bytes.size (), result.bytes.data (), result.bytes.size (), NULL, 0, Argon2_d, 0x10));
 				(void)success;
 				auto end1 (std::chrono::high_resolution_clock::now ());
 				std::cerr << boost::str (boost::format ("Derivation time: %1%us\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -183,9 +183,10 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 			nano::account account (0);
 			nano::uint128_t amount (0);
 			bool is_state_send (false);
+			bool is_state_epoch (false);
 			nano::account pending_account (0);
-			node.process_confirmed_data (transaction, block_a, block_a->hash (), account, amount, is_state_send, pending_account);
-			node.observers.blocks.notify (nano::election_status{ block_a, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::inactive_confirmation_height }, {}, account, amount, is_state_send);
+			node.process_confirmed_data (transaction, block_a, block_a->hash (), account, amount, is_state_send, is_state_epoch, pending_account);
+			node.observers.blocks.notify (nano::election_status{ block_a, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::inactive_confirmation_height }, {}, account, amount, is_state_send, is_state_epoch);
 		}
 		else
 		{
@@ -208,15 +209,16 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 					nano::account account (0);
 					nano::uint128_t amount (0);
 					bool is_state_send (false);
+					bool is_state_epoch (false);
 					nano::account pending_account (0);
-					node.process_confirmed_data (transaction, block_a, hash, account, amount, is_state_send, pending_account);
+					node.process_confirmed_data (transaction, block_a, hash, account, amount, is_state_send, is_state_epoch, pending_account);
 					election_lk.lock ();
 					election->status.type = *election_status_type;
 					election->status.confirmation_request_count = election->confirmation_request_count;
 					status_l = election->status;
 					election_lk.unlock ();
 					auto votes (election->votes_with_weight ());
-					node.observers.blocks.notify (status_l, votes, account, amount, is_state_send);
+					node.observers.blocks.notify (status_l, votes, account, amount, is_state_send, is_state_epoch);
 					if (amount > 0)
 					{
 						node.observers.account_balance.notify (account, false);

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -55,7 +55,7 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 	{
 		if (!node.flags.disable_udp)
 		{
-			node.network.udp_channels.insert (nano::transport::map_endpoint_to_v6 (endpoint_a), node.network_params.protocol.protocol_version);
+			node.network.udp_channels.insert (nano::transport::map_endpoint_to_v6 (endpoint_a), node.network_params.network.protocol_version);
 		}
 		else if (!node.flags.disable_tcp_realtime)
 		{

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -58,7 +58,7 @@ void nano::bulk_pull_client::request ()
 {
 	debug_assert (!pull.head.is_zero () || pull.retry_limit <= connection->node->network_params.bootstrap.lazy_retry_limit);
 	expected = pull.head;
-	nano::bulk_pull req;
+	nano::bulk_pull req{ connection->node->network_params.network };
 	if (pull.head == pull.head_original && pull.attempts % 4 < 3)
 	{
 		// Account for new pulls
@@ -300,7 +300,7 @@ nano::bulk_pull_account_client::~bulk_pull_account_client ()
 
 void nano::bulk_pull_account_client::request ()
 {
-	nano::bulk_pull_account req;
+	nano::bulk_pull_account req{ connection->node->network_params.network };
 	req.account = account;
 	req.minimum_amount = connection->node->config.receive_minimum;
 	req.flags = nano::bulk_pull_account_flags::pending_hash_and_amount;

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -17,7 +17,7 @@ nano::bulk_push_client::~bulk_push_client ()
 
 void nano::bulk_push_client::start ()
 {
-	nano::bulk_push message;
+	nano::bulk_push message{ connection->node->network_params.network };
 	auto this_l (shared_from_this ());
 	connection->channel->send (
 	message, [this_l] (boost::system::error_code const & ec, size_t size_a) {

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -14,7 +14,7 @@ constexpr size_t nano::frontier_req_client::size_frontier;
 
 void nano::frontier_req_client::run (nano::account const & start_account_a, uint32_t const frontiers_age_a, uint32_t const count_a)
 {
-	nano::frontier_req request;
+	nano::frontier_req request{ connection->node->network_params.network };
 	request.start = (start_account_a.is_zero () || start_account_a.number () == std::numeric_limits<nano::uint256_t>::max ()) ? start_account_a : start_account_a.number () + 1;
 	request.age = frontiers_age_a;
 	request.count = count_a;

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -670,6 +670,9 @@ public:
 			debug_assert (!nano::validate_message (response->first, *message_a.query, response->second));
 			auto cookie (connection->node->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (connection->remote_endpoint)));
 			nano::node_id_handshake response_message (cookie, response);
+			response_message.header.version_max = connection->node->network_params.protocol.protocol_version;
+			response_message.header.version_using = connection->node->network_params.protocol.protocol_version;
+			response_message.header.version_min = connection->node->network_params.protocol.protocol_version_min ();
 			auto shared_const_buffer = response_message.to_shared_const_buffer ();
 			connection->socket->async_write (shared_const_buffer, [connection = std::weak_ptr<nano::bootstrap_server> (connection)] (boost::system::error_code const & ec, size_t size_a) {
 				if (auto connection_l = connection.lock ())

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -670,9 +670,9 @@ public:
 			debug_assert (!nano::validate_message (response->first, *message_a.query, response->second));
 			auto cookie (connection->node->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (connection->remote_endpoint)));
 			nano::node_id_handshake response_message (cookie, response);
-			response_message.header.version_max = connection->node->network_params.protocol.protocol_version;
-			response_message.header.version_using = connection->node->network_params.protocol.protocol_version;
-			response_message.header.version_min = connection->node->network_params.protocol.protocol_version_min ();
+			response_message.header.version_max = connection->node->network_params.network.protocol_version;
+			response_message.header.version_using = connection->node->network_params.network.protocol_version;
+			response_message.header.version_min = connection->node->network_params.network.protocol_version_min;
 			auto shared_const_buffer = response_message.to_shared_const_buffer ();
 			connection->socket->async_write (shared_const_buffer, [connection = std::weak_ptr<nano::bootstrap_server> (connection)] (boost::system::error_code const & ec, size_t size_a) {
 				if (auto connection_l = connection.lock ())

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -669,10 +669,7 @@ public:
 			boost::optional<std::pair<nano::account, nano::signature>> response (std::make_pair (connection->node->node_id.pub, nano::sign_message (connection->node->node_id.prv, connection->node->node_id.pub, *message_a.query)));
 			debug_assert (!nano::validate_message (response->first, *message_a.query, response->second));
 			auto cookie (connection->node->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (connection->remote_endpoint)));
-			nano::node_id_handshake response_message (cookie, response);
-			response_message.header.version_max = connection->node->network_params.network.protocol_version;
-			response_message.header.version_using = connection->node->network_params.network.protocol_version;
-			response_message.header.version_min = connection->node->network_params.network.protocol_version_min;
+			nano::node_id_handshake response_message (connection->node->network_params.network, cookie, response);
 			auto shared_const_buffer = response_message.to_shared_const_buffer ();
 			connection->socket->async_write (shared_const_buffer, [connection = std::weak_ptr<nano::bootstrap_server> (connection)] (boost::system::error_code const & ec, size_t size_a) {
 				if (auto connection_l = connection.lock ())

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -56,7 +56,6 @@ nano::message_header::message_header (bool & error_a, nano::stream & stream_a)
 
 void nano::message_header::serialize (nano::stream & stream_a) const
 {
-	static nano::network_params network_params;
 	nano::write (stream_a, boost::endian::native_to_big (static_cast<uint16_t> (network)));
 	nano::write (stream_a, version_max);
 	nano::write (stream_a, version_using);
@@ -70,7 +69,6 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 	auto error (false);
 	try
 	{
-		static nano::network_params network_params;
 		uint16_t network_bytes;
 		nano::read (stream_a, network_bytes);
 		network = static_cast<nano::networks> (boost::endian::big_to_native (network_bytes));

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -21,15 +21,6 @@ std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::dev;
 std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::beta;
 std::chrono::seconds constexpr nano::telemetry_cache_cutoffs::live;
 
-namespace
-{
-nano::protocol_constants const & get_protocol_constants ()
-{
-	static nano::network_params params;
-	return params.protocol;
-}
-}
-
 uint64_t nano::ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint16_t port)
 {
 	static nano::random_constants constants;
@@ -51,9 +42,6 @@ uint64_t nano::ip_address_hash_raw (boost::asio::ip::address const & ip_a, uint1
 
 nano::message_header::message_header (nano::message_type type_a) :
 	network (nano::network_constants::active_network),
-	version_max (get_protocol_constants ().protocol_version),
-	version_using (get_protocol_constants ().protocol_version),
-	version_min (get_protocol_constants ().protocol_version_min ()),
 	type (type_a)
 {
 }

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -313,14 +313,14 @@ std::string nano::message_parser::status_string ()
 	return "[unknown parse_status]";
 }
 
-nano::message_parser::message_parser (nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a, nano::protocol_constants const & protocol) :
+nano::message_parser::message_parser (nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a, nano::network_constants const & network) :
 	publish_filter (publish_filter_a),
 	block_uniquer (block_uniquer_a),
 	vote_uniquer (vote_uniquer_a),
 	visitor (visitor_a),
 	pool (pool_a),
 	status (parse_status::success),
-	protocol{ protocol }
+	network{ network }
 {
 }
 
@@ -335,7 +335,7 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 		nano::message_header header (error, stream);
 		if (!error)
 		{
-			if (header.version_using < protocol.protocol_version_min ())
+			if (header.version_using < network.protocol_version_min)
 			{
 				status = parse_status::outdated_version;
 			}

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -53,6 +53,7 @@ nano::message_header::message_header (nano::message_type type_a) :
 	network (nano::network_constants::active_network),
 	version_max (get_protocol_constants ().protocol_version),
 	version_using (get_protocol_constants ().protocol_version),
+	version_min (get_protocol_constants ().protocol_version_min ()),
 	type (type_a)
 {
 }
@@ -71,7 +72,7 @@ void nano::message_header::serialize (nano::stream & stream_a) const
 	nano::write (stream_a, boost::endian::native_to_big (static_cast<uint16_t> (network)));
 	nano::write (stream_a, version_max);
 	nano::write (stream_a, version_using);
-	nano::write (stream_a, get_protocol_constants ().protocol_version_min ());
+	nano::write (stream_a, version_min);
 	nano::write (stream_a, type);
 	nano::write (stream_a, static_cast<uint16_t> (extensions.to_ullong ()));
 }
@@ -87,7 +88,7 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 		network = static_cast<nano::networks> (boost::endian::big_to_native (network_bytes));
 		nano::read (stream_a, version_max);
 		nano::read (stream_a, version_using);
-		nano::read (stream_a, version_min_m);
+		nano::read (stream_a, version_min);
 		nano::read (stream_a, type);
 		uint16_t extensions_l;
 		nano::read (stream_a, extensions_l);
@@ -99,12 +100,6 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 	}
 
 	return error;
-}
-
-uint8_t nano::message_header::version_min () const
-{
-	debug_assert (version_min_m != std::numeric_limits<uint8_t>::max ());
-	return version_min_m;
 }
 
 nano::message::message (nano::message_type type_a) :

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -327,19 +327,19 @@ std::string nano::message_parser::status_string ()
 	return "[unknown parse_status]";
 }
 
-nano::message_parser::message_parser (nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a) :
+nano::message_parser::message_parser (nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a, nano::protocol_constants const & protocol) :
 	publish_filter (publish_filter_a),
 	block_uniquer (block_uniquer_a),
 	vote_uniquer (vote_uniquer_a),
 	visitor (visitor_a),
 	pool (pool_a),
-	status (parse_status::success)
+	status (parse_status::success),
+	protocol{ protocol }
 {
 }
 
 void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t size_a)
 {
-	static nano::network_constants network_constants;
 	status = parse_status::success;
 	auto error (false);
 	if (size_a <= max_safe_udp_message_size)
@@ -349,7 +349,7 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 		nano::message_header header (error, stream);
 		if (!error)
 		{
-			if (header.version_using < get_protocol_constants ().protocol_version_min ())
+			if (header.version_using < protocol.protocol_version_min ())
 			{
 				status = parse_status::outdated_version;
 			}

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -236,6 +236,7 @@ public:
 	nano::message_header header;
 };
 class work_pool;
+class network_constants;
 class message_parser final
 {
 public:
@@ -255,7 +256,7 @@ public:
 		outdated_version,
 		duplicate_publish_message
 	};
-	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &, nano::protocol_constants const & protocol);
+	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &, nano::network_constants const & protocol);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (nano::stream &, nano::message_header const &);
 	void deserialize_publish (nano::stream &, nano::message_header const &, nano::uint128_t const & = 0);
@@ -271,7 +272,7 @@ public:
 	nano::message_visitor & visitor;
 	nano::work_pool & pool;
 	parse_status status;
-	nano::protocol_constants const & protocol;
+	nano::network_constants const & network;
 	std::string status_string ();
 	static const size_t max_safe_udp_message_size;
 };

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -187,7 +187,7 @@ class message_visitor;
 class message_header final
 {
 public:
-	explicit message_header (nano::message_type);
+	message_header (nano::network_constants const &, nano::message_type);
 	message_header (bool &, nano::stream &);
 	void serialize (nano::stream &) const;
 	bool deserialize (nano::stream &);
@@ -225,7 +225,7 @@ public:
 class message
 {
 public:
-	explicit message (nano::message_type);
+	explicit message (nano::network_constants const &, nano::message_type);
 	explicit message (nano::message_header const &);
 	virtual ~message () = default;
 	virtual void serialize (nano::stream &) const = 0;
@@ -279,7 +279,7 @@ public:
 class keepalive final : public message
 {
 public:
-	keepalive ();
+	explicit keepalive (nano::network_constants const & constants);
 	keepalive (bool &, nano::stream &, nano::message_header const &);
 	void visit (nano::message_visitor &) const override;
 	void serialize (nano::stream &) const override;
@@ -292,7 +292,7 @@ class publish final : public message
 {
 public:
 	publish (bool &, nano::stream &, nano::message_header const &, nano::uint128_t const & = 0, nano::block_uniquer * = nullptr);
-	explicit publish (std::shared_ptr<nano::block> const &);
+	publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const &);
 	void visit (nano::message_visitor &) const override;
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
@@ -304,9 +304,9 @@ class confirm_req final : public message
 {
 public:
 	confirm_req (bool &, nano::stream &, nano::message_header const &, nano::block_uniquer * = nullptr);
-	explicit confirm_req (std::shared_ptr<nano::block> const &);
-	confirm_req (std::vector<std::pair<nano::block_hash, nano::root>> const &);
-	confirm_req (nano::block_hash const &, nano::root const &);
+	confirm_req (nano::network_constants const & constants, std::shared_ptr<nano::block> const &);
+	confirm_req (nano::network_constants const & constants, std::vector<std::pair<nano::block_hash, nano::root>> const &);
+	confirm_req (nano::network_constants const & constants, nano::block_hash const &, nano::root const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	void visit (nano::message_visitor &) const override;
@@ -320,7 +320,7 @@ class confirm_ack final : public message
 {
 public:
 	confirm_ack (bool &, nano::stream &, nano::message_header const &, nano::vote_uniquer * = nullptr);
-	explicit confirm_ack (std::shared_ptr<nano::vote> const &);
+	confirm_ack (nano::network_constants const & constants, std::shared_ptr<nano::vote> const &);
 	void serialize (nano::stream &) const override;
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_ack const &) const;
@@ -330,7 +330,7 @@ public:
 class frontier_req final : public message
 {
 public:
-	frontier_req ();
+	explicit frontier_req (nano::network_constants const & constants);
 	frontier_req (bool &, nano::stream &, nano::message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
@@ -389,7 +389,7 @@ private:
 class telemetry_req final : public message
 {
 public:
-	telemetry_req ();
+	explicit telemetry_req (nano::network_constants const & constants);
 	explicit telemetry_req (nano::message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
@@ -398,9 +398,9 @@ public:
 class telemetry_ack final : public message
 {
 public:
-	telemetry_ack ();
+	explicit telemetry_ack (nano::network_constants const & constants);
 	telemetry_ack (bool &, nano::stream &, nano::message_header const &);
-	explicit telemetry_ack (telemetry_data const &);
+	telemetry_ack (nano::network_constants const & constants, telemetry_data const &);
 	void serialize (nano::stream &) const override;
 	void visit (nano::message_visitor &) const override;
 	bool deserialize (nano::stream &);
@@ -414,7 +414,7 @@ class bulk_pull final : public message
 {
 public:
 	using count_t = uint32_t;
-	bulk_pull ();
+	explicit bulk_pull (nano::network_constants const & constants);
 	bulk_pull (bool &, nano::stream &, nano::message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
@@ -431,7 +431,7 @@ public:
 class bulk_pull_account final : public message
 {
 public:
-	bulk_pull_account ();
+	explicit bulk_pull_account (nano::network_constants const & constants);
 	bulk_pull_account (bool &, nano::stream &, nano::message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
@@ -444,7 +444,7 @@ public:
 class bulk_push final : public message
 {
 public:
-	bulk_push ();
+	explicit bulk_push (nano::network_constants const & constants);
 	explicit bulk_push (nano::message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
@@ -454,7 +454,7 @@ class node_id_handshake final : public message
 {
 public:
 	node_id_handshake (bool &, nano::stream &, nano::message_header const &);
-	node_id_handshake (boost::optional<nano::uint256_union>, boost::optional<std::pair<nano::account, nano::signature>>);
+	node_id_handshake (nano::network_constants const & constants, boost::optional<nano::uint256_union>, boost::optional<std::pair<nano::account, nano::signature>>);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -198,14 +198,12 @@ public:
 	nano::networks network;
 	uint8_t version_max;
 	uint8_t version_using;
-
-private:
-	uint8_t version_min_m{ std::numeric_limits<uint8_t>::max () };
+	uint8_t version_min;
 
 public:
 	nano::message_type type;
 	std::bitset<16> extensions;
-	static size_t constexpr size = sizeof (nano::networks) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min_m) + sizeof (type) + sizeof (/* extensions */ uint16_t);
+	static size_t constexpr size = sizeof (nano::networks) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min) + sizeof (type) + sizeof (/* extensions */ uint16_t);
 
 	void flag_set (uint8_t);
 	static uint8_t constexpr bulk_pull_count_present_flag = 0;
@@ -216,7 +214,6 @@ public:
 	static uint8_t constexpr node_id_handshake_response_flag = 1;
 	bool node_id_handshake_is_query () const;
 	bool node_id_handshake_is_response () const;
-	uint8_t version_min () const;
 
 	/** Size of the payload in bytes. For some messages, the payload size is based on header flags. */
 	size_t payload_length_bytes () const;

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -255,7 +255,7 @@ public:
 		outdated_version,
 		duplicate_publish_message
 	};
-	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &);
+	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &, nano::protocol_constants const & protocol);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (nano::stream &, nano::message_header const &);
 	void deserialize_publish (nano::stream &, nano::message_header const &, nano::uint128_t const & = 0);
@@ -271,6 +271,7 @@ public:
 	nano::message_visitor & visitor;
 	nano::work_pool & pool;
 	parse_status status;
+	nano::protocol_constants const & protocol;
 	std::string status_string ();
 	static const size_t max_safe_udp_message_size;
 };

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -459,18 +459,15 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 						}
 
 						// Update the maximum amount of blocks to write next time based on the time it took to cement this batch.
-						if (!network_params.network.is_dev_network ())
+						if (time_spent_cementing > maximum_batch_write_time)
 						{
-							if (time_spent_cementing > maximum_batch_write_time)
-							{
-								// Reduce (unless we have hit a floor)
-								batch_write_size = std::max<uint64_t> (minimum_batch_write_size, batch_write_size - amount_to_change);
-							}
-							else if (time_spent_cementing < maximum_batch_write_time_increase_cutoff)
-							{
-								// Increase amount of blocks written for next batch if the time for writing this one is sufficiently lower than the max time to warrant changing
-								batch_write_size += amount_to_change;
-							}
+							// Reduce (unless we have hit a floor)
+							batch_write_size = std::max<uint64_t> (minimum_batch_write_size, batch_write_size - amount_to_change);
+						}
+						else if (time_spent_cementing < maximum_batch_write_time_increase_cutoff)
+						{
+							// Increase amount of blocks written for next batch if the time for writing this one is sufficiently lower than the max time to warrant changing
+							batch_write_size += amount_to_change;
 						}
 
 						scoped_write_guard_a.release ();
@@ -538,7 +535,7 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 	// Bail if there was an error. This indicates that there was a fatal issue with the ledger
 	// (the blocks probably got rolled back when they shouldn't have).
 	release_assert (!error);
-	if (!network_params.network.is_dev_network () && time_spent_cementing > maximum_batch_write_time)
+	if (time_spent_cementing > maximum_batch_write_time)
 	{
 		// Reduce (unless we have hit a floor)
 		batch_write_size = std::max<uint64_t> (minimum_batch_write_size, batch_write_size - amount_to_change);

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -128,7 +128,6 @@ private:
 	std::function<void (std::vector<std::shared_ptr<nano::block>> const &)> notify_observers_callback;
 	std::function<void (nano::block_hash const &)> notify_block_already_cemented_observers_callback;
 	std::function<uint64_t ()> awaiting_processing_size_callback;
-	nano::network_params network_params;
 
 	friend std::unique_ptr<nano::container_info_component> collect_container_info (confirmation_height_bounded &, std::string const & name_a);
 };

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -128,7 +128,6 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 			else
 			{
 				// Pausing is only utilised in some tests to help prevent it processing added blocks until required.
-				debug_assert (network_params.network.is_dev_network ());
 				original_block = nullptr;
 				condition.wait (lk);
 			}

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -91,7 +91,6 @@ private:
 	nano::write_database_queue & write_database_queue;
 	/** The maximum amount of blocks to write at once. This is dynamically modified by the bounded processor based on previous write performance **/
 	uint64_t batch_write_size{ 16384 };
-	nano::network_params network_params;
 
 	confirmation_height_unbounded unbounded_processor;
 	confirmation_height_bounded bounded_processor;

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -381,8 +381,8 @@ void nano::confirmation_height_unbounded::cement_blocks (nano::write_guard & sco
 			if (pending.height > confirmation_height)
 			{
 				auto block = ledger.store.block.get (transaction, pending.hash);
-				debug_assert (network_params.network.is_dev_network () || ledger.pruning || block != nullptr);
-				debug_assert (network_params.network.is_dev_network () || ledger.pruning || block->sideband ().height == pending.height);
+				debug_assert (ledger.pruning || block != nullptr);
+				debug_assert (ledger.pruning || block->sideband ().height == pending.height);
 
 				if (!block)
 				{

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -95,7 +95,6 @@ private:
 	void collect_unconfirmed_receive_and_sources_for_account (uint64_t, uint64_t, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account const &, nano::read_transaction const &, std::vector<receive_source_pair> &, std::vector<nano::block_hash> &, std::vector<nano::block_hash> &, std::shared_ptr<nano::block> original_block);
 	void prepare_iterated_blocks_for_cementing (preparation_data &);
 
-	nano::network_params network_params;
 	nano::ledger & ledger;
 	nano::write_database_queue & write_database_queue;
 	std::chrono::milliseconds batch_separate_pending_min_time;

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -31,7 +31,7 @@ bool nano::confirmation_solicitor::broadcast (nano::election const & election_a)
 	if (rebroadcasted++ < max_block_broadcasts)
 	{
 		auto const & hash (election_a.status.winner->hash ());
-		nano::publish winner (election_a.status.winner);
+		nano::publish winner{ config.network_params.network, election_a.status.winner };
 		unsigned count = 0;
 		// Directed broadcasting to principal representatives
 		for (auto i (representatives_broadcasts.begin ()), n (representatives_broadcasts.end ()); i != n && count < max_election_broadcasts; ++i)
@@ -98,14 +98,14 @@ void nano::confirmation_solicitor::flush ()
 			roots_hashes_l.push_back (root_hash);
 			if (roots_hashes_l.size () == nano::network::confirm_req_hashes_max)
 			{
-				nano::confirm_req req (roots_hashes_l);
+				nano::confirm_req req{ config.network_params.network, roots_hashes_l };
 				channel->send (req);
 				roots_hashes_l.clear ();
 			}
 		}
 		if (!roots_hashes_l.empty ())
 		{
-			nano::confirm_req req (roots_hashes_l);
+			nano::confirm_req req{ config.network_params.network, roots_hashes_l };
 			channel->send (req);
 		}
 	}

--- a/nano/node/ipc/flatbuffers_util.cpp
+++ b/nano/node/ipc/flatbuffers_util.cpp
@@ -3,9 +3,8 @@
 #include <nano/node/ipc/flatbuffers_util.hpp>
 #include <nano/secure/common.hpp>
 
-std::unique_ptr<nanoapi::BlockStateT> nano::ipc::flatbuffers_builder::from (nano::state_block const & block_a, nano::amount const & amount_a, bool is_state_send_a)
+std::unique_ptr<nanoapi::BlockStateT> nano::ipc::flatbuffers_builder::from (nano::state_block const & block_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a)
 {
-	static nano::network_params params;
 	auto block (std::make_unique<nanoapi::BlockStateT> ());
 	block->account = block_a.account ().to_account ();
 	block->hash = block_a.hash ().to_string ();
@@ -25,7 +24,7 @@ std::unique_ptr<nanoapi::BlockStateT> nano::ipc::flatbuffers_builder::from (nano
 	{
 		block->subtype = nanoapi::BlockSubType::BlockSubType_change;
 	}
-	else if (amount_a == 0 && params.ledger.epochs.is_epoch_link (block_a.link ()))
+	else if (amount_a == 0 && is_state_epoch_a)
 	{
 		block->subtype = nanoapi::BlockSubType::BlockSubType_epoch;
 	}
@@ -82,14 +81,14 @@ std::unique_ptr<nanoapi::BlockChangeT> nano::ipc::flatbuffers_builder::from (nan
 	return block;
 }
 
-nanoapi::BlockUnion nano::ipc::flatbuffers_builder::block_to_union (nano::block const & block_a, nano::amount const & amount_a, bool is_state_send_a)
+nanoapi::BlockUnion nano::ipc::flatbuffers_builder::block_to_union (nano::block const & block_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a)
 {
 	nanoapi::BlockUnion u;
 	switch (block_a.type ())
 	{
 		case nano::block_type::state:
 		{
-			u.Set (*from (dynamic_cast<nano::state_block const &> (block_a), amount_a, is_state_send_a));
+			u.Set (*from (dynamic_cast<nano::state_block const &> (block_a), amount_a, is_state_send_a, is_state_epoch_a));
 			break;
 		}
 		case nano::block_type::send:

--- a/nano/node/ipc/flatbuffers_util.hpp
+++ b/nano/node/ipc/flatbuffers_util.hpp
@@ -21,8 +21,8 @@ namespace ipc
 	class flatbuffers_builder
 	{
 	public:
-		static nanoapi::BlockUnion block_to_union (nano::block const & block_a, nano::amount const & amount_a, bool is_state_send_a = false);
-		static std::unique_ptr<nanoapi::BlockStateT> from (nano::state_block const & block_a, nano::amount const & amount_a, bool is_state_send_a);
+		static nanoapi::BlockUnion block_to_union (nano::block const & block_a, nano::amount const & amount_a, bool is_state_send_a = false, bool is_state_epoch_a = false);
+		static std::unique_ptr<nanoapi::BlockStateT> from (nano::state_block const & block_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a);
 		static std::unique_ptr<nanoapi::BlockSendT> from (nano::send_block const & block_a);
 		static std::unique_ptr<nanoapi::BlockReceiveT> from (nano::receive_block const & block_a);
 		static std::unique_ptr<nanoapi::BlockOpenT> from (nano::open_block const & block_a);

--- a/nano/node/ipc/ipc_broker.cpp
+++ b/nano/node/ipc/ipc_broker.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<flatbuffers::Parser> nano::ipc::subscriber::get_parser (nano::ip
 
 void nano::ipc::broker::start ()
 {
-	node.observers.blocks.add ([this_l = shared_from_this ()] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a) {
+	node.observers.blocks.add ([this_l = shared_from_this ()] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a) {
 		debug_assert (status_a.type != nano::election_status_type::ongoing);
 
 		try
@@ -51,7 +51,7 @@ void nano::ipc::broker::start ()
 						break;
 				};
 				confirmation->confirmation_type = nanoapi::TopicConfirmationType::TopicConfirmationType_active_quorum;
-				confirmation->block = nano::ipc::flatbuffers_builder::block_to_union (*status_a.winner, amount_a, is_state_send_a);
+				confirmation->block = nano::ipc::flatbuffers_builder::block_to_union (*status_a.winner, amount_a, is_state_send_a, is_state_epoch_a);
 				confirmation->election_info = std::make_unique<nanoapi::ElectionInfoT> ();
 				confirmation->election_info->duration = status_a.election_duration.count ();
 				confirmation->election_info->time = status_a.election_end.count ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4182,7 +4182,7 @@ void nano::json_handler::version ()
 {
 	response_l.put ("rpc_version", "1");
 	response_l.put ("store_version", std::to_string (node.store_version ()));
-	response_l.put ("protocol_version", std::to_string (node.network_params.protocol.protocol_version));
+	response_l.put ("protocol_version", std::to_string (node.network_params.network.protocol_version));
 	response_l.put ("node_vendor", boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING));
 	response_l.put ("store_vendor", node.store.vendor_get ());
 	response_l.put ("network", node.network_params.network.get_current_network_as_string ());

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1138,14 +1138,16 @@ void nano::json_handler::block_confirm ()
 				bool error_or_pruned (false);
 				auto amount (node.ledger.amount_safe (transaction, hash, error_or_pruned));
 				bool is_state_send (false);
+				bool is_state_epoch (false);
 				if (!error_or_pruned)
 				{
 					if (auto state = dynamic_cast<nano::state_block *> (block_l.get ()))
 					{
 						is_state_send = node.ledger.is_send (transaction, *state);
+						is_state_epoch = amount == 0 && node.ledger.is_epoch_link (state->link ());
 					}
 				}
-				node.observers.blocks.notify (status, {}, account, amount, is_state_send);
+				node.observers.blocks.notify (status, {}, account, amount, is_state_send, is_state_epoch);
 			}
 			response_l.put ("started", "1");
 		}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2326,7 +2326,7 @@ public:
 			// Report opens as a receive
 			tree.put ("type", "receive");
 		}
-		if (block_a.hashables.source != network_params.ledger.genesis->account ())
+		if (block_a.hashables.source != handler.node.ledger.constants.genesis->account ())
 		{
 			bool error_or_pruned (false);
 			auto amount (handler.node.ledger.amount_safe (transaction, hash, error_or_pruned).convert_to<std::string> ());
@@ -2342,7 +2342,7 @@ public:
 		}
 		else
 		{
-			tree.put ("account", network_params.ledger.genesis->account ().to_account ());
+			tree.put ("account", handler.node.ledger.constants.genesis->account ().to_account ());
 			tree.put ("amount", nano::dev::constants.genesis_amount.convert_to<std::string> ());
 		}
 	}
@@ -2455,7 +2455,6 @@ public:
 	nano::transaction & transaction;
 	boost::property_tree::ptree & tree;
 	nano::block_hash const & hash;
-	nano::network_params network_params;
 	std::vector<nano::public_key> const & accounts_filter;
 };
 }

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -180,7 +180,7 @@ void nano::network::send_node_id_handshake (std::shared_ptr<nano::transport::cha
 	channel_a->send (message);
 }
 
-void nano::network::flood_message (nano::message const & message_a, nano::buffer_drop_policy const drop_policy_a, float const scale_a)
+void nano::network::flood_message (nano::message & message_a, nano::buffer_drop_policy const drop_policy_a, float const scale_a)
 {
 	for (auto & i : list (fanout (scale_a)))
 	{

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -699,11 +699,11 @@ nano::tcp_endpoint nano::network::bootstrap_peer (bool lazy_bootstrap)
 	bool use_udp_peer (nano::random_pool::generate_word32 (0, 1));
 	if (use_udp_peer || tcp_channels.size () == 0)
 	{
-		result = udp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min ());
+		result = udp_channels.bootstrap_peer (node.network_params.network.protocol_version_min);
 	}
 	if (result == nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0))
 	{
-		result = tcp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min ());
+		result = tcp_channels.bootstrap_peer (node.network_params.network.protocol_version_min);
 	}
 	return result;
 }

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -124,18 +124,8 @@ public:
 	void start ();
 	void stop ();
 	void flood_message (nano::message &, nano::buffer_drop_policy const = nano::buffer_drop_policy::limiter, float const = 1.0f);
-	void flood_keepalive (float const scale_a = 1.0f)
-	{
-		nano::keepalive message;
-		random_fill (message.peers);
-		flood_message (message, nano::buffer_drop_policy::limiter, scale_a);
-	}
-	void flood_keepalive_self (float const scale_a = 0.5f)
-	{
-		nano::keepalive message;
-		fill_keepalive_self (message.peers);
-		flood_message (message, nano::buffer_drop_policy::limiter, scale_a);
-	}
+	void flood_keepalive (float const scale_a = 1.0f);
+	void flood_keepalive_self (float const scale_a = 0.5f);
 	void flood_vote (std::shared_ptr<nano::vote> const &, float scale);
 	void flood_vote_pr (std::shared_ptr<nano::vote> const &);
 	// Flood block to all PRs and a random selection of non-PRs

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -123,7 +123,7 @@ public:
 	nano::networks id;
 	void start ();
 	void stop ();
-	void flood_message (nano::message const &, nano::buffer_drop_policy const = nano::buffer_drop_policy::limiter, float const = 1.0f);
+	void flood_message (nano::message &, nano::buffer_drop_policy const = nano::buffer_drop_policy::limiter, float const = 1.0f);
 	void flood_keepalive (float const scale_a = 1.0f)
 	{
 		nano::keepalive message;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -119,7 +119,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
 	active (*this, confirmation_height_processor),
 	scheduler{ *this },
-	aggregator (network_params.network, config, stats, active.generator, active.final_generator, history, ledger, wallets, active),
+	aggregator (config, stats, active.generator, active.final_generator, history, ledger, wallets, active),
 	wallets (wallets_store.init_error (), *this),
 	startup_time (std::chrono::steady_clock::now ()),
 	node_seq (seq)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -100,7 +100,7 @@ public:
 	std::shared_ptr<nano::node> shared ();
 	int store_version ();
 	void receive_confirmed (nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a);
-	void process_confirmed_data (nano::transaction const &, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account &, nano::uint128_t &, bool &, nano::account &);
+	void process_confirmed_data (nano::transaction const &, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account &, nano::uint128_t &, bool &, bool &, nano::account &);
 	void process_confirmed (nano::election_status const &, uint64_t = 0);
 	void process_active (std::shared_ptr<nano::block> const &);
 	nano::process_return process (nano::block &);

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -11,7 +11,7 @@ class telemetry;
 class node_observers final
 {
 public:
-	using blocks_t = nano::observer_set<nano::election_status const &, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::uint128_t const &, bool>;
+	using blocks_t = nano::observer_set<nano::election_status const &, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::uint128_t const &, bool, bool>;
 	blocks_t blocks;
 	nano::observer_set<bool> wallet;
 	nano::observer_set<std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>, nano::vote_code> vote;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -378,7 +378,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		}
 
 		// Validate ranges
-		nano::network_params network_params;
 		if (election_hint_weight_percent < 5 || election_hint_weight_percent > 50)
 		{
 			toml.get_error ().set ("election_hint_weight_percent must be a number between 5 and 50");

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -50,7 +50,7 @@ std::string nano::port_mapping::to_string ()
 
 void nano::port_mapping::refresh_devices ()
 {
-	if (!network_params.network.is_dev_network ())
+	if (!node.network_params.network.is_dev_network ())
 	{
 		upnp_state upnp_l;
 		int discover_error_l = 0;
@@ -96,7 +96,7 @@ nano::endpoint nano::port_mapping::external_address ()
 
 void nano::port_mapping::refresh_mapping ()
 {
-	debug_assert (!network_params.network.is_dev_network ());
+	debug_assert (!node.network_params.network.is_dev_network ());
 	if (on)
 	{
 		nano::lock_guard<nano::mutex> guard_l (mutex);
@@ -106,8 +106,8 @@ void nano::port_mapping::refresh_mapping ()
 		// We don't map the RPC port because, unless RPC authentication was added, this would almost always be a security risk
 		for (auto & protocol : protocols | boost::adaptors::filtered ([] (auto const & p) { return p.enabled; }))
 		{
-			auto upnp_description = std::string ("Nano Node (") + network_params.network.get_current_network_as_string () + ")";
-			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (network_params.portmapping.lease_duration.count ()).c_str ()));
+			auto upnp_description = std::string ("Nano Node (") + node.network_params.network.get_current_network_as_string () + ")";
+			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (node.network_params.portmapping.lease_duration.count ()).c_str ()));
 
 			if (add_port_mapping_error_l == UPNPCOMMAND_SUCCESS)
 			{
@@ -128,7 +128,7 @@ void nano::port_mapping::refresh_mapping ()
 bool nano::port_mapping::check_lost_or_old_mapping ()
 {
 	// Long discovery time and fast setup/teardown make this impractical for testing
-	debug_assert (!network_params.network.is_dev_network ());
+	debug_assert (!node.network_params.network.is_dev_network ());
 	bool result_l (false);
 	nano::lock_guard<nano::mutex> guard_l (mutex);
 	auto node_port_l (std::to_string (node.network.endpoint ().port ()));
@@ -141,7 +141,7 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 		remaining_mapping_duration_l.fill (0);
 		auto verify_port_mapping_error_l (UPNP_GetSpecificPortMappingEntry (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), protocol.name, nullptr, int_client_l.data (), int_port_l.data (), nullptr, nullptr, remaining_mapping_duration_l.data ()));
 		auto remaining_from_port_mapping = std::atoi (remaining_mapping_duration_l.data ());
-		auto lease_duration = network_params.portmapping.lease_duration.count ();
+		auto lease_duration = node.network_params.portmapping.lease_duration.count ();
 		auto lease_duration_divided_by_two = (lease_duration / 2);
 		auto recent_lease = (remaining_from_port_mapping >= lease_duration_divided_by_two);
 		if (verify_port_mapping_error_l != UPNPCOMMAND_SUCCESS)
@@ -178,7 +178,7 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 
 void nano::port_mapping::check_mapping_loop ()
 {
-	auto health_check_period = network_params.portmapping.health_check_period;
+	auto health_check_period = node.network_params.portmapping.health_check_period;
 
 	refresh_devices ();
 

--- a/nano/node/portmapping.hpp
+++ b/nano/node/portmapping.hpp
@@ -58,7 +58,6 @@ private:
 	std::string get_config_port (std::string const &);
 	upnp_state upnp;
 	nano::node & node;
-	nano::network_params network_params;
 	boost::asio::ip::address_v4 address;
 	std::array<mapping_protocol, 2> protocols;
 	uint64_t check_count{ 0 };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -324,9 +324,9 @@ void nano::rep_crawler::update_weights ()
 	}
 }
 
-std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, nano::uint128_t const weight_a, boost::optional<decltype (nano::protocol_constants::protocol_version)> const & opt_version_min_a)
+std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, nano::uint128_t const weight_a, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a)
 {
-	auto version_min (opt_version_min_a.value_or (node.network_params.protocol.protocol_version_min ()));
+	auto version_min (opt_version_min_a.value_or (node.network_params.network.protocol_version_min));
 	std::vector<representative> result;
 	nano::lock_guard<nano::mutex> lock (probable_reps_mutex);
 	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)
@@ -339,7 +339,7 @@ std::vector<nano::representative> nano::rep_crawler::representatives (size_t cou
 	return result;
 }
 
-std::vector<nano::representative> nano::rep_crawler::principal_representatives (size_t count_a, boost::optional<decltype (nano::protocol_constants::protocol_version)> const & opt_version_min_a)
+std::vector<nano::representative> nano::rep_crawler::principal_representatives (size_t count_a, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a)
 {
 	return representatives (count_a, node.minimum_principal_weight (), opt_version_min_a);
 }

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -106,10 +106,10 @@ public:
 	nano::uint128_t total_weight () const;
 
 	/** Request a list of the top \p count_a known representatives in descending order of weight, with at least \p weight_a voting weight, and optionally with a minimum version \p opt_version_min_a */
-	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max (), nano::uint128_t const weight_a = 0, boost::optional<decltype (nano::protocol_constants::protocol_version)> const & opt_version_min_a = boost::none);
+	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max (), nano::uint128_t const weight_a = 0, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a = boost::none);
 
 	/** Request a list of the top \p count_a known principal representatives in descending order of weight, optionally with a minimum version \p opt_version_min_a */
-	std::vector<representative> principal_representatives (size_t count_a = std::numeric_limits<size_t>::max (), boost::optional<decltype (nano::protocol_constants::protocol_version)> const & opt_version_min_a = boost::none);
+	std::vector<representative> principal_representatives (size_t count_a = std::numeric_limits<size_t>::max (), boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a = boost::none);
 
 	/** Request a list of the top \p count_a known representative endpoints. */
 	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (size_t count_a);

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -11,9 +11,10 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/store.hpp>
 
-nano::request_aggregator::request_aggregator (nano::network_constants const & network_constants_a, nano::node_config const & config_a, nano::stat & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
-	max_delay (network_constants_a.is_dev_network () ? 50 : 300),
-	small_delay (network_constants_a.is_dev_network () ? 10 : 50),
+nano::request_aggregator::request_aggregator (nano::node_config const & config_a, nano::stat & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
+	config{ config_a },
+	max_delay (config_a.network_params.network.is_dev_network () ? 50 : 300),
+	small_delay (config_a.network_params.network.is_dev_network () ? 10 : 50),
 	max_channel_requests (config_a.max_queued_requests),
 	stats (stats_a),
 	local_votes (history_a),
@@ -150,7 +151,7 @@ bool nano::request_aggregator::empty ()
 
 void nano::request_aggregator::reply_action (std::shared_ptr<nano::vote> const & vote_a, std::shared_ptr<nano::transport::channel> const & channel_a) const
 {
-	nano::confirm_ack confirm (vote_a);
+	nano::confirm_ack confirm{ config.network_params.network, vote_a };
 	channel_a->send (confirm);
 }
 
@@ -277,7 +278,7 @@ std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr
 				// Let the node know about the alternative block
 				if (block->hash () != hash)
 				{
-					nano::publish publish (block);
+					nano::publish publish (config.network_params.network, block);
 					channel_a->send (publish);
 				}
 			}

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -59,7 +59,7 @@ class request_aggregator final
 	// clang-format on
 
 public:
-	request_aggregator (nano::network_constants const &, nano::node_config const & config, nano::stat & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_transactions &);
+	request_aggregator (nano::node_config const & config, nano::stat & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_transactions &);
 
 	/** Add a new request by \p channel_a for hashes \p hashes_roots_a */
 	void add (std::shared_ptr<nano::transport::channel> const & channel_a, std::vector<std::pair<nano::block_hash, nano::root>> const & hashes_roots_a);
@@ -68,6 +68,7 @@ public:
 	size_t size ();
 	bool empty ();
 
+	nano::node_config const & config;
 	const std::chrono::milliseconds max_delay;
 	const std::chrono::milliseconds small_delay;
 	const size_t max_channel_requests;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -631,7 +631,7 @@ nano::telemetry_data nano::local_telemetry_data (nano::ledger const & ledger_a, 
 	telemetry_data.block_count = ledger_a.cache.block_count;
 	telemetry_data.cemented_count = ledger_a.cache.cemented_count;
 	telemetry_data.bandwidth_cap = bandwidth_limit_a;
-	telemetry_data.protocol_version = network_params_a.protocol.protocol_version;
+	telemetry_data.protocol_version = network_params_a.network.protocol_version;
 	telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - statup_time_a).count ();
 	telemetry_data.unchecked_count = ledger_a.store.unchecked.count (ledger_a.store.tx_begin_read ());
 	telemetry_data.genesis_block = network_params_a.ledger.genesis->hash ();

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -352,7 +352,7 @@ void nano::telemetry::fire_request_message (std::shared_ptr<nano::transport::cha
 	}
 
 	std::weak_ptr<nano::telemetry> this_w (shared_from_this ());
-	nano::telemetry_req message;
+	nano::telemetry_req message{ network_params.network };
 	// clang-format off
 	channel_a->send (message, [this_w, endpoint = channel_a->get_endpoint (), round_l](boost::system::error_code const & ec, size_t size_a) {
 		if (auto this_l = this_w.lock ())

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -670,12 +670,11 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 									channel_a->set_last_packet_received (std::chrono::steady_clock::now ());
 									boost::optional<std::pair<nano::account, nano::signature>> response (std::make_pair (node_l->node_id.pub, nano::sign_message (node_l->node_id.prv, node_l->node_id.pub, *message.query)));
 									nano::node_id_handshake response_message (boost::none, response);
-									auto bytes = response_message.to_shared_const_buffer ();
 									if (node_l->config.logging.network_node_id_handshake_logging ())
 									{
 										node_l->logger.try_log (boost::str (boost::format ("Node ID handshake response sent with node ID %1% to %2%: query %3%") % node_l->node_id.pub.to_node_id () % endpoint_a % (*message.query).to_string ()));
 									}
-									channel_a->send_buffer (bytes, [node_w, channel_a, endpoint_a, callback_a, cleanup_and_udp_fallback] (boost::system::error_code const & ec, size_t size_a) {
+									channel_a->send (response_message, [node_w, channel_a, endpoint_a, callback_a, cleanup_and_udp_fallback] (boost::system::error_code const & ec, size_t size_a) {
 										if (auto node_l = node_w.lock ())
 										{
 											if (!ec && channel_a)

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -572,7 +572,6 @@ void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint_a
 				// TCP node ID handshake
 				auto cookie (node_l->network.syn_cookies.assign (endpoint_a));
 				nano::node_id_handshake message (cookie, boost::none);
-				auto bytes = message.to_shared_const_buffer ();
 				if (node_l->config.logging.network_node_id_handshake_logging ())
 				{
 					node_l->logger.try_log (boost::str (boost::format ("Node ID handshake request sent with node ID %1% to %2%: query %3%") % node_l->node_id.pub.to_node_id () % endpoint_a % (*cookie).to_string ()));
@@ -581,7 +580,7 @@ void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint_a
 				std::shared_ptr<std::vector<uint8_t>> receive_buffer (std::make_shared<std::vector<uint8_t>> ());
 				receive_buffer->resize (256);
 				node_l->network.tcp_channels.push_node_id_handshake_socket (socket);
-				channel->send_buffer (bytes, [node_w, channel, endpoint_a, receive_buffer, callback_a] (boost::system::error_code const & ec, size_t size_a) {
+				channel->send (message, [node_w, channel, endpoint_a, receive_buffer, callback_a] (boost::system::error_code const & ec, size_t size_a) {
 					if (auto node_l = node_w.lock ())
 					{
 						if (!ec)

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -445,7 +445,7 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 
 void nano::transport::tcp_channels::ongoing_keepalive ()
 {
-	nano::keepalive message;
+	nano::keepalive message{ node.network_params.network };
 	node.network.random_fill (message.peers);
 	nano::unique_lock<nano::mutex> lock (mutex);
 	// Wake up channels
@@ -571,7 +571,7 @@ void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint_a
 			{
 				// TCP node ID handshake
 				auto cookie (node_l->network.syn_cookies.assign (endpoint_a));
-				nano::node_id_handshake message (cookie, boost::none);
+				nano::node_id_handshake message (node_l->network_params.network, cookie, boost::none);
 				if (node_l->config.logging.network_node_id_handshake_logging ())
 				{
 					node_l->logger.try_log (boost::str (boost::format ("Node ID handshake request sent with node ID %1% to %2%: query %3%") % node_l->node_id.pub.to_node_id () % endpoint_a % (*cookie).to_string ()));
@@ -669,7 +669,7 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 									channel_a->set_node_id (node_id);
 									channel_a->set_last_packet_received (std::chrono::steady_clock::now ());
 									boost::optional<std::pair<nano::account, nano::signature>> response (std::make_pair (node_l->node_id.pub, nano::sign_message (node_l->node_id.prv, node_l->node_id.pub, *message.query)));
-									nano::node_id_handshake response_message (boost::none, response);
+									nano::node_id_handshake response_message (node_l->network_params.network, boost::none, response);
 									if (node_l->config.logging.network_node_id_handshake_logging ())
 									{
 										node_l->logger.try_log (boost::str (boost::format ("Node ID handshake response sent with node ID %1% to %2%: query %3%") % node_l->node_id.pub.to_node_id () % endpoint_a % (*message.query).to_string ()));

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -100,8 +100,11 @@ nano::transport::channel::channel (nano::node & node_a) :
 	set_network_version (node_a.network_params.protocol.protocol_version);
 }
 
-void nano::transport::channel::send (nano::message const & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
+void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
+	message_a.header.version_max = node.network_params.protocol.protocol_version;
+	message_a.header.version_using = node.network_params.protocol.protocol_version;
+	message_a.header.version_min = node.network_params.protocol.protocol_version_min ();
 	callback_visitor visitor;
 	message_a.visit (visitor);
 	auto buffer (message_a.to_shared_const_buffer ());

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -97,14 +97,14 @@ boost::asio::ip::address nano::transport::ipv4_address_or_ipv6_subnet (boost::as
 nano::transport::channel::channel (nano::node & node_a) :
 	node (node_a)
 {
-	set_network_version (node_a.network_params.protocol.protocol_version);
+	set_network_version (node_a.network_params.network.protocol_version);
 }
 
 void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
-	message_a.header.version_max = node.network_params.protocol.protocol_version;
-	message_a.header.version_using = node.network_params.protocol.protocol_version;
-	message_a.header.version_min = node.network_params.protocol.protocol_version_min ();
+	message_a.header.version_max = node.network_params.network.protocol_version;
+	message_a.header.version_using = node.network_params.network.protocol_version;
+	message_a.header.version_min = node.network_params.network.protocol_version_min;
 	callback_visitor visitor;
 	message_a.visit (visitor);
 	auto buffer (message_a.to_shared_const_buffer ());
@@ -138,7 +138,7 @@ nano::transport::channel_loopback::channel_loopback (nano::node & node_a) :
 	channel (node_a), endpoint (node_a.network.endpoint ())
 {
 	set_node_id (node_a.node_id.pub);
-	set_network_version (node_a.network_params.protocol.protocol_version);
+	set_network_version (node_a.network_params.network.protocol_version);
 }
 
 size_t nano::transport::channel_loopback::hash_code () const

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -102,9 +102,6 @@ nano::transport::channel::channel (nano::node & node_a) :
 
 void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
-	message_a.header.version_max = node.network_params.network.protocol_version;
-	message_a.header.version_using = node.network_params.network.protocol_version;
-	message_a.header.version_min = node.network_params.network.protocol_version_min;
 	callback_visitor visitor;
 	message_a.visit (visitor);
 	auto buffer (message_a.to_shared_const_buffer ());

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -47,7 +47,7 @@ namespace transport
 		virtual ~channel () = default;
 		virtual size_t hash_code () const = 0;
 		virtual bool operator== (nano::transport::channel const &) const = 0;
-		void send (nano::message const & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a = nullptr, nano::buffer_drop_policy policy_a = nano::buffer_drop_policy::limiter);
+		void send (nano::message & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a = nullptr, nano::buffer_drop_policy policy_a = nano::buffer_drop_policy::limiter);
 		virtual void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) = 0;
 		virtual std::string to_string () const = 0;
 		virtual nano::endpoint get_endpoint () const = 0;

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -388,7 +388,7 @@ public:
 				else if (!node.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (endpoint)))
 				{
 					// Don't start connection if TCP channel to same IP:port exists
-					find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint, node.network_params.protocol.protocol_version);
+					find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint, node.network_params.network.protocol_version);
 					node.network.send_node_id_handshake (find_channel, *cookie, boost::none);
 				}
 			}
@@ -500,7 +500,7 @@ public:
 			auto find_channel (node.network.udp_channels.channel (endpoint));
 			if (!find_channel)
 			{
-				find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint, node.network_params.protocol.protocol_version);
+				find_channel = std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint, node.network_params.network.protocol_version);
 			}
 			node.network.send_node_id_handshake (find_channel, out_query, out_respond_to);
 		}
@@ -541,7 +541,7 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 	if (allowed_sender)
 	{
 		udp_message_visitor visitor (node, data_a->endpoint, sink);
-		nano::message_parser parser (node.network.publish_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work, node.network_params.protocol);
+		nano::message_parser parser (node.network.publish_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work, node.network_params.network);
 		parser.deserialize_buffer (data_a->buffer, data_a->size);
 		if (parser.status == nano::message_parser::parse_status::success)
 		{
@@ -625,7 +625,7 @@ void nano::transport::udp_channels::process_packets ()
 
 std::shared_ptr<nano::transport::channel> nano::transport::udp_channels::create (nano::endpoint const & endpoint_a)
 {
-	return std::make_shared<nano::transport::channel_udp> (*this, endpoint_a, node.network_params.protocol.protocol_version);
+	return std::make_shared<nano::transport::channel_udp> (*this, endpoint_a, node.network_params.network.protocol_version);
 }
 
 bool nano::transport::udp_channels::max_ip_connections (nano::endpoint const & endpoint_a)

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -686,7 +686,7 @@ void nano::transport::udp_channels::purge (std::chrono::steady_clock::time_point
 
 void nano::transport::udp_channels::ongoing_keepalive ()
 {
-	nano::keepalive message;
+	nano::keepalive message{ node.network_params.network };
 	node.network.random_fill (message.peers);
 	std::vector<std::shared_ptr<nano::transport::channel_udp>> send_list;
 	nano::unique_lock<nano::mutex> lock (mutex);

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -541,7 +541,7 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 	if (allowed_sender)
 	{
 		udp_message_visitor visitor (node, data_a->endpoint, sink);
-		nano::message_parser parser (node.network.publish_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work);
+		nano::message_parser parser (node.network.publish_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work, node.network_params.protocol);
 		parser.deserialize_buffer (data_a->buffer, data_a->size);
 		if (parser.status == nano::message_parser::parse_status::success)
 		{

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -148,7 +148,6 @@ private:
 	static size_t constexpr max_requests{ 2048 };
 	std::deque<request_t> requests;
 	std::deque<candidate_t> candidates;
-	nano::network_params network_params;
 	std::atomic<bool> stopped{ false };
 	bool started{ false };
 	std::thread thread;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -157,7 +157,6 @@ public:
 	nano::public_key change_seed (nano::transaction const & transaction_a, nano::raw_key const & prv_a, uint32_t count = 0);
 	void deterministic_restore (nano::transaction const & transaction_a);
 	bool live ();
-	nano::network_params network_params;
 	std::unordered_set<nano::account> free_accounts;
 	std::function<void (bool, bool)> lock_observer;
 	nano::wallet_store store;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1289,7 +1289,7 @@ void nano_qt::wallet::start ()
 			this_l->push_main_stack (this_l->send_blocks_window);
 		}
 	});
-	node.observers.blocks.add ([this_w] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::uint128_t const & amount_a, bool) {
+	node.observers.blocks.add ([this_w] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::uint128_t const & amount_a, bool, bool) {
 		if (auto this_l = this_w.lock ())
 		{
 			this_l->application.postEvent (&this_l->processor, new eventloop_event ([this_w, status_a, account_a] () {

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -542,9 +542,8 @@ public:
 	}
 	void open_block (nano::open_block const & block_a)
 	{
-		static nano::network_params params;
 		type = "Receive";
-		if (block_a.hashables.source != params.ledger.genesis->account ())
+		if (block_a.hashables.source != ledger.constants.genesis->account ())
 		{
 			bool error_or_pruned (false);
 			account = ledger.account_safe (transaction, block_a.hashables.source, error_or_pruned);
@@ -556,7 +555,7 @@ public:
 		}
 		else
 		{
-			account = params.ledger.genesis->account ();
+			account = ledger.constants.genesis->account ();
 			amount = nano::dev::constants.genesis_amount;
 		}
 	}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1688,18 +1688,18 @@ TEST (rpc, peers)
 	auto port = nano::get_available_port ();
 	system.add_node (nano::node_config (port, system.logging));
 	nano::endpoint endpoint (boost::asio::ip::make_address_v6 ("fc00::1"), 4000);
-	node->network.udp_channels.insert (endpoint, node->network_params.protocol.protocol_version);
+	node->network.udp_channels.insert (endpoint, node->network_params.network.protocol_version);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
 	auto response (wait_response (system, rpc, request));
 	auto & peers_node (response.get_child ("peers"));
 	ASSERT_EQ (2, peers_node.size ());
-	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), peers_node.get<std::string> ((boost::format ("[::1]:%1%") % port).str ()));
+	ASSERT_EQ (std::to_string (node->network_params.network.protocol_version), peers_node.get<std::string> ((boost::format ("[::1]:%1%") % port).str ()));
 	// Previously "[::ffff:80.80.80.80]:4000", but IPv4 address cause "No such node thrown in the test body" issue with peers_node.get
 	std::stringstream endpoint_text;
 	endpoint_text << endpoint;
-	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), peers_node.get<std::string> (endpoint_text.str ()));
+	ASSERT_EQ (std::to_string (node->network_params.network.protocol_version), peers_node.get<std::string> (endpoint_text.str ()));
 }
 
 TEST (rpc, peers_node_id)
@@ -1709,7 +1709,7 @@ TEST (rpc, peers_node_id)
 	auto port = nano::get_available_port ();
 	system.add_node (nano::node_config (port, system.logging));
 	nano::endpoint endpoint (boost::asio::ip::make_address_v6 ("fc00::1"), 4000);
-	node->network.udp_channels.insert (endpoint, node->network_params.protocol.protocol_version);
+	node->network.udp_channels.insert (endpoint, node->network_params.network.protocol_version);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
@@ -1718,12 +1718,12 @@ TEST (rpc, peers_node_id)
 	auto & peers_node (response.get_child ("peers"));
 	ASSERT_EQ (2, peers_node.size ());
 	auto tree1 (peers_node.get_child ((boost::format ("[::1]:%1%") % port).str ()));
-	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), tree1.get<std::string> ("protocol_version"));
+	ASSERT_EQ (std::to_string (node->network_params.network.protocol_version), tree1.get<std::string> ("protocol_version"));
 	ASSERT_EQ (system.nodes[1]->node_id.pub.to_node_id (), tree1.get<std::string> ("node_id"));
 	std::stringstream endpoint_text;
 	endpoint_text << endpoint;
 	auto tree2 (peers_node.get_child (endpoint_text.str ()));
-	ASSERT_EQ (std::to_string (node->network_params.protocol.protocol_version), tree2.get<std::string> ("protocol_version"));
+	ASSERT_EQ (std::to_string (node->network_params.network.protocol_version), tree2.get<std::string> ("protocol_version"));
 	ASSERT_EQ ("", tree2.get<std::string> ("node_id"));
 }
 
@@ -1909,7 +1909,7 @@ TEST (rpc, version)
 		auto transaction (node1->store.tx_begin_read ());
 		ASSERT_EQ (std::to_string (node1->store.version.get (transaction)), response1.json.get<std::string> ("store_version"));
 	}
-	ASSERT_EQ (std::to_string (node1->network_params.protocol.protocol_version), response1.json.get<std::string> ("protocol_version"));
+	ASSERT_EQ (std::to_string (node1->network_params.network.protocol_version), response1.json.get<std::string> ("protocol_version"));
 	ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING), response1.json.get<std::string> ("node_vendor"));
 	ASSERT_EQ (node1->store.vendor_get (), response1.json.get<std::string> ("store_vendor"));
 	auto network_label (node1->network_params.network.get_current_network_as_string ());
@@ -5828,7 +5828,7 @@ TEST (rpc, account_lazy_start)
 	node_config.ipc_config.transport_tcp.enabled = true;
 	node_config.ipc_config.transport_tcp.port = nano::get_available_port ();
 	auto node2 = system.add_node (node_config, node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.protocol.protocol_version);
+	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	auto [rpc, rpc_ctx] = add_rpc (system, node2);
 	boost::property_tree::ptree request;
 	request.put ("action", "account_info");

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -93,11 +93,6 @@ nano::network_params::network_params (nano::networks network_a) :
 	kdf_work = network.is_dev_network () ? kdf_dev_work : kdf_full_work;
 }
 
-uint8_t nano::protocol_constants::protocol_version_min () const
-{
-	return protocol_version_min_m;
-}
-
 nano::ledger_constants::ledger_constants (nano::network_constants & network_constants) :
 	ledger_constants (network_constants.network ())
 {

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -85,11 +85,6 @@ nano::network_params nano::dev::network_params{ nano::networks::nano_dev_network
 nano::ledger_constants & nano::dev::constants{ nano::dev::network_params.ledger };
 std::shared_ptr<nano::block> & nano::dev::genesis = nano::dev::constants.genesis;
 
-nano::network_params::network_params () :
-	network_params (network_constants::active_network)
-{
-}
-
 nano::network_params::network_params (nano::networks network_a) :
 	network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
 {

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -453,9 +453,6 @@ public:
 class network_params
 {
 public:
-	/** Populate values based on the current active network */
-	network_params ();
-
 	/** Populate values based on \p network_a */
 	network_params (nano::networks network_a);
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -336,24 +336,6 @@ enum class tally_result
 
 class network_params;
 
-/** Protocol versions whose value may depend on the active network */
-class protocol_constants
-{
-public:
-	/** Current protocol version */
-	uint8_t const protocol_version = 0x12;
-
-	/** Minimum accepted protocol version */
-	uint8_t protocol_version_min () const;
-
-private:
-	/* Minimum protocol version we will establish connections to */
-	uint8_t const protocol_version_min_m = 0x12;
-};
-
-// Some places use the decltype of protocol_version instead of protocol_version_min. To keep those checks simpler we check that the decltypes match ignoring differences in const
-static_assert (std::is_same<std::remove_const_t<decltype (protocol_constants ().protocol_version)>, decltype (protocol_constants ().protocol_version_min ())>::value, "protocol_min should match");
-
 /** Genesis keys and ledger constants for network variants */
 class ledger_constants
 {
@@ -458,7 +440,6 @@ public:
 
 	unsigned kdf_work;
 	network_constants network;
-	protocol_constants protocol;
 	ledger_constants ledger;
 	random_constants random;
 	voting_constants voting;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1476,7 +1476,6 @@ TEST (telemetry, many_nodes)
 	}
 
 	// Check the metrics
-	nano::network_params params;
 	for (auto & data : telemetry_datas)
 	{
 		ASSERT_EQ (data.unchecked_count, 0);
@@ -1484,7 +1483,7 @@ TEST (telemetry, many_nodes)
 		ASSERT_LE (data.peer_count, 9U);
 		ASSERT_EQ (data.account_count, 1);
 		ASSERT_TRUE (data.block_count == 2);
-		ASSERT_EQ (data.protocol_version, params.protocol.protocol_version);
+		ASSERT_EQ (data.protocol_version, nano::dev::network_params.protocol.protocol_version);
 		ASSERT_GE (data.bandwidth_cap, 100000);
 		ASSERT_LT (data.bandwidth_cap, 100000 + system.nodes.size ());
 		ASSERT_EQ (data.major_version, nano::get_major_node_version ());

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1483,7 +1483,7 @@ TEST (telemetry, many_nodes)
 		ASSERT_LE (data.peer_count, 9U);
 		ASSERT_EQ (data.account_count, 1);
 		ASSERT_TRUE (data.block_count == 2);
-		ASSERT_EQ (data.protocol_version, nano::dev::network_params.protocol.protocol_version);
+		ASSERT_EQ (data.protocol_version, nano::dev::network_params.network.protocol_version);
 		ASSERT_GE (data.bandwidth_cap, 100000);
 		ASSERT_LT (data.bandwidth_cap, 100000 + system.nodes.size ());
 		ASSERT_EQ (data.major_version, nano::get_major_node_version ());

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<nano::node> nano::system::add_node (nano::node_config const & no
 			else
 			{
 				// UDP connection
-				auto channel (std::make_shared<nano::transport::channel_udp> ((*j)->network.udp_channels, (*i)->network.endpoint (), node1->network_params.protocol.protocol_version));
+				auto channel (std::make_shared<nano::transport::channel_udp> ((*j)->network.udp_channels, (*i)->network.endpoint (), node1->network_params.network.protocol_version));
 				(*j)->network.send_keepalive (channel);
 			}
 			do

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -9,7 +9,7 @@ void nano::compare_default_telemetry_response_data_excluding_signature (nano::te
 	ASSERT_EQ (telemetry_data_a.cemented_count, 1);
 	ASSERT_EQ (telemetry_data_a.bandwidth_cap, bandwidth_limit_a);
 	ASSERT_EQ (telemetry_data_a.peer_count, 1);
-	ASSERT_EQ (telemetry_data_a.protocol_version, network_params_a.protocol.protocol_version);
+	ASSERT_EQ (telemetry_data_a.protocol_version, network_params_a.network.protocol_version);
 	ASSERT_EQ (telemetry_data_a.unchecked_count, 0);
 	ASSERT_EQ (telemetry_data_a.account_count, 1);
 	ASSERT_LT (telemetry_data_a.uptime, 100);


### PR DESCRIPTION
This is a series of commits to remove static instantiation of nano::network_params. Static initialization is a bad practice in general and prevents more complex configurations, hindered config reloading, and is generally counterintuitive. 