### PR TITLE
test_common not required for qt only for qt_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,7 +639,6 @@ if(NANO_GUI OR RAIBLOCKS_GUI)
     node
     secure
     nano_lib
-    test_common
     libminiupnpc-static
     Qt5::Gui
     Qt5::Widgets)


### PR DESCRIPTION
Allows qt targets to build without requiring NANO_TEST enabled as test_common is not used outside of tests
closes #3404 