### PR TITLE
Remove qt_system target we dont need it or use it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,12 +685,8 @@ if(NANO_GUI OR RAIBLOCKS_GUI)
                  SUFFIX ".com")
   endif()
 
-  add_executable(qt_system nano/qt_system/entry.cpp)
-
-  target_link_libraries(qt_system qt node Qt5::Gui Qt5::Widgets)
-
   set_target_properties(
-    qt nano_wallet qt_system
+    qt nano_wallet
     PROPERTIES COMPILE_FLAGS "-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")
 
   if(NANO_TEST OR RAIBLOCKS_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -686,8 +686,8 @@ if(NANO_GUI OR RAIBLOCKS_GUI)
   endif()
 
   set_target_properties(
-    qt nano_wallet
-    PROPERTIES COMPILE_FLAGS "-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")
+    qt nano_wallet PROPERTIES COMPILE_FLAGS
+                              "-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")
 
   if(NANO_TEST OR RAIBLOCKS_TEST)
     add_executable(qt_test nano/qt_test/entry.cpp nano/qt_test/qt.cpp)


### PR DESCRIPTION
since test_common only builds on NANO_TEST=1 qt_system depends on test_common
qt_system is a utility script, we can remove it, and its not required for nano_node target