### PR TITLE
Remove static instantiation of network_constants

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -312,7 +312,7 @@ TEST (block, publish_req_serialization)
 TEST (block, difficulty)
 {
 	nano::send_block block (0, 1, 2, nano::keypair ().prv, 4, 5);
-	ASSERT_EQ (block.difficulty (), nano::work_difficulty (block.work_version (), block.root (), block.block_work ()));
+	ASSERT_EQ (block.difficulty (), nano::dev::network_params.network.publish_thresholds.difficulty (block.work_version (), block.root (), block.block_work ()));
 }
 
 TEST (state_block, serialization)

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -312,7 +312,7 @@ TEST (block, publish_req_serialization)
 TEST (block, difficulty)
 {
 	nano::send_block block (0, 1, 2, nano::keypair ().prv, 4, 5);
-	ASSERT_EQ (block.difficulty (), nano::dev::network_params.network.publish_thresholds.difficulty (block.work_version (), block.root (), block.block_work ()));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.difficulty (block), nano::dev::network_params.network.publish_thresholds.difficulty (block.work_version (), block.root (), block.block_work ()));
 }
 
 TEST (state_block, serialization)

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -312,7 +312,7 @@ TEST (block, publish_req_serialization)
 TEST (block, difficulty)
 {
 	nano::send_block block (0, 1, 2, nano::keypair ().prv, 4, 5);
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.difficulty (block), nano::dev::network_params.network.publish_thresholds.difficulty (block.work_version (), block.root (), block.block_work ()));
+	ASSERT_EQ (nano::dev::network_params.work.difficulty (block), nano::dev::network_params.work.difficulty (block.work_version (), block.root (), block.block_work ()));
 }
 
 TEST (state_block, serialization)

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1006,7 +1006,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::ledger ledger (store, stat, nano::dev::constants);
 	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
@@ -1262,7 +1262,7 @@ TEST (mdb_block_store, upgrade_v14_v15)
 	}
 	// Extract confirmation height to a separate database
 	auto path (nano::unique_path ());
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::state_block epoch (nano::dev::genesis_key.pub, send.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
 	nano::state_block state_send (nano::dev::genesis_key.pub, epoch.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch.hash ()));
@@ -1416,7 +1416,7 @@ TEST (mdb_block_store, upgrade_v16_v17)
 		// Don't test this in rocksdb mode
 		return;
 	}
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block block1 (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::state_block block2 (nano::dev::genesis_key.pub, block1.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio - 1, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
 	nano::state_block block3 (nano::dev::genesis_key.pub, block2.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio - 2, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block2.hash ()));
@@ -1482,7 +1482,7 @@ TEST (mdb_block_store, upgrade_v17_v18)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::keypair key3;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send_zero (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::state_block state_receive_zero (nano::dev::genesis_key.pub, send_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, send_zero.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send_zero.hash ()));
 	nano::state_block epoch (nano::dev::genesis_key.pub, state_receive_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_receive_zero.hash ()));
@@ -1682,7 +1682,7 @@ TEST (mdb_block_store, upgrade_v18_v19)
 	}
 	auto path (nano::unique_path ());
 	nano::keypair key1;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
 	nano::change_block change (receive.hash (), 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (receive.hash ()));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -723,7 +723,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		nano::stat stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
 		auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 		{
@@ -799,7 +799,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::stat stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
 		auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 		{
@@ -869,7 +869,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::stat stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
 		auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 		auto open = std::make_shared<nano::state_block> (key1.pub, 0, 0, nano::Gxrb_ratio, send->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
@@ -1362,7 +1362,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	boost::latch initialized_latch{ 0 };
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::logging logging;
 	nano::keypair key1;
 	auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
@@ -1412,7 +1412,7 @@ TEST (confirmation_height, pruned_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::write_database_queue write_database_queue (false);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1, key2;
 	auto send1 = std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 100, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto open1 = std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 100, send1->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));

--- a/nano/core_test/core_test_main.cc
+++ b/nano/core_test/core_test_main.cc
@@ -2,6 +2,7 @@
 
 #include <nano/node/common.hpp>
 #include <nano/node/logging.hpp>
+#include <nano/secure/utility.hpp>
 
 #include <boost/filesystem/path.hpp>
 
@@ -9,7 +10,6 @@ namespace nano
 {
 void cleanup_dev_directories_on_exit ();
 void force_nano_dev_network ();
-boost::filesystem::path unique_path ();
 }
 
 GTEST_API_ int main (int argc, char ** argv)

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -3,6 +3,7 @@
 #include <nano/lib/epoch.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/work.hpp>
+#include <nano/secure/common.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
@@ -106,10 +107,9 @@ TEST (difficulty, zero)
 
 TEST (difficulty, network_constants)
 {
-	nano::network_constants constants;
-	auto & full_thresholds = constants.publish_full;
-	auto & beta_thresholds = constants.publish_beta;
-	auto & dev_thresholds = constants.publish_dev;
+	auto & full_thresholds = nano::work_thresholds::publish_full;
+	auto & beta_thresholds = nano::work_thresholds::publish_beta;
+	auto & dev_thresholds = nano::work_thresholds::publish_dev;
 
 	ASSERT_NEAR (8., nano::difficulty::to_multiplier (full_thresholds.epoch_2, full_thresholds.epoch_1), 1e-10);
 	ASSERT_NEAR (1 / 8., nano::difficulty::to_multiplier (full_thresholds.epoch_2_receive, full_thresholds.epoch_1), 1e-10);
@@ -128,23 +128,23 @@ TEST (difficulty, network_constants)
 	ASSERT_NEAR (1., nano::difficulty::to_multiplier (dev_thresholds.epoch_2, dev_thresholds.base), 1e-10);
 
 	nano::work_version version{ nano::work_version::work_1 };
-	ASSERT_EQ (constants.publish_thresholds.base, constants.publish_thresholds.epoch_2);
-	ASSERT_EQ (constants.publish_thresholds.base, nano::work_threshold_base (version));
-	ASSERT_EQ (constants.publish_thresholds.entry, nano::work_threshold_entry (version, nano::block_type::state));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::send));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::receive));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::open));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::change));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
-	ASSERT_EQ (constants.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::dev::network_params.network.publish_thresholds.epoch_2);
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::work_threshold_base (version));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.entry, nano::work_threshold_entry (version, nano::block_type::state));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::send));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::receive));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::open));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::change));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
 
 	// Send [+ change]
-	ASSERT_EQ (constants.publish_thresholds.epoch_2, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	// Change
-	ASSERT_EQ (constants.publish_thresholds.epoch_2, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, false)));
 	// Receive [+ change] / Open
-	ASSERT_EQ (constants.publish_thresholds.epoch_2_receive, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	// Epoch
-	ASSERT_EQ (constants.publish_thresholds.epoch_2_receive, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, true)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, true)));
 }

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -135,16 +135,16 @@ TEST (difficulty, network_constants)
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::receive));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::open));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::change));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
 
 	// Send [+ change]
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	// Change
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, false)));
 	// Receive [+ change] / Open
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	// Epoch
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, true)));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, true)));
 }

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -129,7 +129,7 @@ TEST (difficulty, network_constants)
 
 	nano::work_version version{ nano::work_version::work_1 };
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::dev::network_params.network.publish_thresholds.epoch_2);
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::work_threshold_base (version));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::dev::network_params.network.publish_thresholds.threshold_base (version));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.entry, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::state));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::send));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::receive));

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -130,11 +130,11 @@ TEST (difficulty, network_constants)
 	nano::work_version version{ nano::work_version::work_1 };
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::dev::network_params.network.publish_thresholds.epoch_2);
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::work_threshold_base (version));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.entry, nano::work_threshold_entry (version, nano::block_type::state));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::send));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::receive));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::open));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold_entry (version, nano::block_type::change));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.entry, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::state));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::send));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::receive));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::open));
+	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::change));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
 	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::work_threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));

--- a/nano/core_test/difficulty.cpp
+++ b/nano/core_test/difficulty.cpp
@@ -128,23 +128,23 @@ TEST (difficulty, network_constants)
 	ASSERT_NEAR (1., nano::difficulty::to_multiplier (dev_thresholds.epoch_2, dev_thresholds.base), 1e-10);
 
 	nano::work_version version{ nano::work_version::work_1 };
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::dev::network_params.network.publish_thresholds.epoch_2);
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.base, nano::dev::network_params.network.publish_thresholds.threshold_base (version));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.entry, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::state));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::send));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::receive));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::open));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold_entry (version, nano::block_type::change));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_1, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.work.base, nano::dev::network_params.work.epoch_2);
+	ASSERT_EQ (nano::dev::network_params.work.base, nano::dev::network_params.work.threshold_base (version));
+	ASSERT_EQ (nano::dev::network_params.work.entry, nano::dev::network_params.work.threshold_entry (version, nano::block_type::state));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold_entry (version, nano::block_type::send));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold_entry (version, nano::block_type::receive));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold_entry (version, nano::block_type::open));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold_entry (version, nano::block_type::change));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_0, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_1, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_1, false, false, false)));
 
 	// Send [+ change]
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_2, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	// Change
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, false)));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_2, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, false)));
 	// Receive [+ change] / Open
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_2_receive, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	// Epoch
-	ASSERT_EQ (nano::dev::network_params.network.publish_thresholds.epoch_2_receive, nano::dev::network_params.network.publish_thresholds.threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, true)));
+	ASSERT_EQ (nano::dev::network_params.work.epoch_2_receive, nano::dev::network_params.work.threshold (version, nano::block_details (nano::epoch::epoch_2, false, false, true)));
 }

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -10,7 +10,7 @@ TEST (distributed_work, stopped)
 {
 	nano::system system (1);
 	system.nodes[0]->distributed_work.stop ();
-	ASSERT_TRUE (system.nodes[0]->distributed_work.make (nano::work_version::work_1, nano::block_hash (), {}, nano::dev::network_params.network.publish_thresholds.base, {}));
+	ASSERT_TRUE (system.nodes[0]->distributed_work.make (nano::work_version::work_1, nano::block_hash (), {}, nano::dev::network_params.work.base, {}));
 }
 
 TEST (distributed_work, no_peers)
@@ -25,9 +25,9 @@ TEST (distributed_work, no_peers)
 		work = work_a;
 		done = true;
 	};
-	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, node->config.work_peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
+	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, node->config.work_peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
 	// should only be removed after cleanup
 	ASSERT_EQ (1, node->distributed_work.size ());
 	while (node->distributed_work.size () > 0)
@@ -43,7 +43,7 @@ TEST (distributed_work, no_peers_disabled)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto & node = *system.add_node (node_config);
-	ASSERT_TRUE (node.distributed_work.make (nano::work_version::work_1, nano::block_hash (), node.config.work_peers, nano::dev::network_params.network.publish_thresholds.base, {}));
+	ASSERT_TRUE (node.distributed_work.make (nano::work_version::work_1, nano::block_hash (), node.config.work_peers, nano::dev::network_params.work.base, {}));
 }
 
 TEST (distributed_work, no_peers_cancel)
@@ -58,7 +58,7 @@ TEST (distributed_work, no_peers_cancel)
 		ASSERT_FALSE (work_a.is_initialized ());
 		done = true;
 	};
-	ASSERT_FALSE (node.distributed_work.make (nano::work_version::work_1, hash, node.config.work_peers, nano::difficulty::from_multiplier (1e6, node.network_params.network.publish_thresholds.base), callback_to_cancel));
+	ASSERT_FALSE (node.distributed_work.make (nano::work_version::work_1, hash, node.config.work_peers, nano::difficulty::from_multiplier (1e6, node.network_params.work.base), callback_to_cancel));
 	ASSERT_EQ (1, node.distributed_work.size ());
 	// cleanup should not cancel or remove an ongoing work
 	node.distributed_work.cleanup_finished ();
@@ -70,7 +70,7 @@ TEST (distributed_work, no_peers_cancel)
 
 	// now using observer
 	done = false;
-	ASSERT_FALSE (node.distributed_work.make (nano::work_version::work_1, hash, node.config.work_peers, nano::difficulty::from_multiplier (1e6, node.network_params.network.publish_thresholds.base), callback_to_cancel));
+	ASSERT_FALSE (node.distributed_work.make (nano::work_version::work_1, hash, node.config.work_peers, nano::difficulty::from_multiplier (1e6, node.network_params.work.base), callback_to_cancel));
 	ASSERT_EQ (1, node.distributed_work.size ());
 	node.observers.work_cancel.notify (hash);
 	ASSERT_TIMELY (20s, done && node.distributed_work.size () == 0);
@@ -90,7 +90,7 @@ TEST (distributed_work, no_peers_multi)
 	// Test many works for the same root
 	for (unsigned i{ 0 }; i < total; ++i)
 	{
-		ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, node->config.work_peers, nano::difficulty::from_multiplier (10, node->network_params.network.publish_thresholds.base), callback));
+		ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, node->config.work_peers, nano::difficulty::from_multiplier (10, node->network_params.work.base), callback));
 	}
 	ASSERT_TIMELY (5s, count == total);
 	system.deadline_set (5s);
@@ -104,7 +104,7 @@ TEST (distributed_work, no_peers_multi)
 	for (unsigned i{ 0 }; i < total; ++i)
 	{
 		nano::block_hash hash_i (i + 1);
-		ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash_i, node->config.work_peers, node->network_params.network.publish_thresholds.base, callback));
+		ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash_i, node->config.work_peers, node->network_params.work.base, callback));
 	}
 	ASSERT_TIMELY (5s, count == total);
 	system.deadline_set (5s);
@@ -136,9 +136,9 @@ TEST (distributed_work, peer)
 	work_peer->start ();
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("::ffff:127.0.0.1", work_peer->port ());
-	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
+	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
 	ASSERT_EQ (1, work_peer->generations_good);
 	ASSERT_EQ (0, work_peer->generations_bad);
 	ASSERT_NO_ERROR (system.poll ());
@@ -162,9 +162,9 @@ TEST (distributed_work, peer_malicious)
 	malicious_peer->start ();
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("::ffff:127.0.0.1", malicious_peer->port ());
-	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
+	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
 	ASSERT_TIMELY (5s, malicious_peer->generations_bad >= 1);
 	// make sure it was *not* the malicious peer that replied
 	ASSERT_EQ (0, malicious_peer->generations_good);
@@ -179,7 +179,7 @@ TEST (distributed_work, peer_malicious)
 	auto malicious_peer2 (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::malicious));
 	malicious_peer2->start ();
 	peers[0].second = malicious_peer2->port ();
-	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, {}, nano::account ()));
+	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, {}, nano::account ()));
 	ASSERT_TIMELY (5s, malicious_peer2->generations_bad >= 2);
 	node->distributed_work.cancel (hash);
 	ASSERT_EQ (0, malicious_peer2->cancels);
@@ -208,9 +208,9 @@ TEST (distributed_work, peer_multi)
 	peers.emplace_back ("localhost", malicious_peer->port ());
 	peers.emplace_back ("localhost", slow_peer->port ());
 	peers.emplace_back ("localhost", good_peer->port ());
-	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
+	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
 	ASSERT_TIMELY (5s, slow_peer->cancels == 1);
 	ASSERT_EQ (0, malicious_peer->generations_good);
 	ASSERT_EQ (1, malicious_peer->generations_bad);
@@ -239,7 +239,7 @@ TEST (distributed_work, fail_resolve)
 	};
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("beeb.boop.123z", 0);
-	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
+	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
 }

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -27,7 +27,7 @@ TEST (distributed_work, no_peers)
 	};
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, node->config.work_peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
 	// should only be removed after cleanup
 	ASSERT_EQ (1, node->distributed_work.size ());
 	while (node->distributed_work.size () > 0)
@@ -138,7 +138,7 @@ TEST (distributed_work, peer)
 	peers.emplace_back ("::ffff:127.0.0.1", work_peer->port ());
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
 	ASSERT_EQ (1, work_peer->generations_good);
 	ASSERT_EQ (0, work_peer->generations_bad);
 	ASSERT_NO_ERROR (system.poll ());
@@ -164,7 +164,7 @@ TEST (distributed_work, peer_malicious)
 	peers.emplace_back ("::ffff:127.0.0.1", malicious_peer->port ());
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
 	ASSERT_TIMELY (5s, malicious_peer->generations_bad >= 1);
 	// make sure it was *not* the malicious peer that replied
 	ASSERT_EQ (0, malicious_peer->generations_good);
@@ -210,7 +210,7 @@ TEST (distributed_work, peer_multi)
 	peers.emplace_back ("localhost", good_peer->port ());
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
 	ASSERT_TIMELY (5s, slow_peer->cancels == 1);
 	ASSERT_EQ (0, malicious_peer->generations_good);
 	ASSERT_EQ (1, malicious_peer->generations_bad);
@@ -241,5 +241,5 @@ TEST (distributed_work, fail_resolve)
 	peers.emplace_back ("beeb.boop.123z", 0);
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.network.publish_thresholds.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, *work), node->network_params.network.publish_thresholds.base);
 }

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -10,7 +10,7 @@ TEST (distributed_work, stopped)
 {
 	nano::system system (1);
 	system.nodes[0]->distributed_work.stop ();
-	ASSERT_TRUE (system.nodes[0]->distributed_work.make (nano::work_version::work_1, nano::block_hash (), {}, nano::network_constants ().publish_thresholds.base, {}));
+	ASSERT_TRUE (system.nodes[0]->distributed_work.make (nano::work_version::work_1, nano::block_hash (), {}, nano::dev::network_params.network.publish_thresholds.base, {}));
 }
 
 TEST (distributed_work, no_peers)
@@ -43,7 +43,7 @@ TEST (distributed_work, no_peers_disabled)
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto & node = *system.add_node (node_config);
-	ASSERT_TRUE (node.distributed_work.make (nano::work_version::work_1, nano::block_hash (), node.config.work_peers, nano::network_constants ().publish_thresholds.base, {}));
+	ASSERT_TRUE (node.distributed_work.make (nano::work_version::work_1, nano::block_hash (), node.config.work_peers, nano::dev::network_params.network.publish_thresholds.base, {}));
 }
 
 TEST (distributed_work, no_peers_cancel)

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -141,14 +141,14 @@ private:
 		if (type == work_peer_type::good)
 		{
 			auto hash = hash_a;
-			auto request_difficulty = work_pool.network_constants.publish_thresholds.threshold_base (version);
+			auto request_difficulty = work_pool.network_constants.work.threshold_base (version);
 			work_pool.generate (version, hash, request_difficulty, [this_l = shared_from_this (), hash] (boost::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
-				auto result_difficulty (this_l->work_pool.network_constants.publish_thresholds.difficulty (this_l->version, hash, result));
+				auto result_difficulty (this_l->work_pool.network_constants.work.difficulty (this_l->version, hash, result));
 				ptree::ptree message_l;
 				message_l.put ("work", nano::to_string_hex (result));
 				message_l.put ("difficulty", nano::to_string_hex (result_difficulty));
-				message_l.put ("multiplier", nano::to_string (nano::difficulty::to_multiplier (result_difficulty, this_l->work_pool.network_constants.publish_thresholds.threshold_base (this_l->version))));
+				message_l.put ("multiplier", nano::to_string (nano::difficulty::to_multiplier (result_difficulty, this_l->work_pool.network_constants.work.threshold_base (this_l->version))));
 				message_l.put ("hash", hash.to_string ());
 				std::stringstream ostream;
 				ptree::write_json (ostream, message_l);

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -138,20 +138,17 @@ private:
 
 	void handle_generate (nano::block_hash const & hash_a)
 	{
-		static nano::network_constants constants;
 		if (type == work_peer_type::good)
 		{
 			auto hash = hash_a;
-			auto request_difficulty = constants.publish_thresholds.threshold_base (version);
-			auto this_l (shared_from_this ());
-			work_pool.generate (version, hash, request_difficulty, [this_l, hash] (boost::optional<uint64_t> work_a) {
+			auto request_difficulty = work_pool.network_constants.publish_thresholds.threshold_base (version);
+			work_pool.generate (version, hash, request_difficulty, [this_l = shared_from_this (), hash] (boost::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
-				static nano::network_constants constants;
-				auto result_difficulty (constants.publish_thresholds.difficulty (this_l->version, hash, result));
+				auto result_difficulty (this_l->work_pool.network_constants.publish_thresholds.difficulty (this_l->version, hash, result));
 				ptree::ptree message_l;
 				message_l.put ("work", nano::to_string_hex (result));
 				message_l.put ("difficulty", nano::to_string_hex (result_difficulty));
-				message_l.put ("multiplier", nano::to_string (nano::difficulty::to_multiplier (result_difficulty, constants.publish_thresholds.threshold_base (this_l->version))));
+				message_l.put ("multiplier", nano::to_string (nano::difficulty::to_multiplier (result_difficulty, this_l->work_pool.network_constants.publish_thresholds.threshold_base (this_l->version))));
 				message_l.put ("hash", hash.to_string ());
 				std::stringstream ostream;
 				ptree::write_json (ostream, message_l);

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -138,10 +138,11 @@ private:
 
 	void handle_generate (nano::block_hash const & hash_a)
 	{
+		static nano::network_constants constants;
 		if (type == work_peer_type::good)
 		{
 			auto hash = hash_a;
-			auto request_difficulty = nano::work_threshold_base (version);
+			auto request_difficulty = constants.publish_thresholds.threshold_base (version);
 			auto this_l (shared_from_this ());
 			work_pool.generate (version, hash, request_difficulty, [this_l, hash] (boost::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
@@ -149,7 +150,7 @@ private:
 				ptree::ptree message_l;
 				message_l.put ("work", nano::to_string_hex (result));
 				message_l.put ("difficulty", nano::to_string_hex (result_difficulty));
-				message_l.put ("multiplier", nano::to_string (nano::difficulty::to_multiplier (result_difficulty, nano::work_threshold_base (this_l->version))));
+				message_l.put ("multiplier", nano::to_string (nano::difficulty::to_multiplier (result_difficulty, constants.publish_thresholds.threshold_base (this_l->version))));
 				message_l.put ("hash", hash.to_string ());
 				std::stringstream ostream;
 				ptree::write_json (ostream, message_l);

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -146,7 +146,8 @@ private:
 			auto this_l (shared_from_this ());
 			work_pool.generate (version, hash, request_difficulty, [this_l, hash] (boost::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
-				auto result_difficulty (nano::work_difficulty (this_l->version, hash, result));
+				static nano::network_constants constants;
+				auto result_difficulty (constants.publish_thresholds.difficulty (this_l->version, hash, result));
 				ptree::ptree message_l;
 				message_l.put ("work", nano::to_string_hex (result));
 				message_l.put ("difficulty", nano::to_string_hex (result_difficulty));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2893,9 +2893,9 @@ TEST (ledger, work_validation)
 
 	// With random work the block doesn't pass, then modifies the block with sufficient work and ensures a correct result
 	auto process_block = [&store, &ledger, &pool] (nano::block & block_a, nano::block_details const details_a) {
-		auto threshold = nano::dev::network_params.network.publish_thresholds.threshold (block_a.work_version (), details_a);
+		auto threshold = nano::dev::network_params.work.threshold (block_a.work_version (), details_a);
 		// Rarely failed with random work, so modify until it doesn't have enough difficulty
-		while (nano::dev::network_params.network.publish_thresholds.difficulty (block_a) >= threshold)
+		while (nano::dev::network_params.work.difficulty (block_a) >= threshold)
 		{
 			block_a.block_work_set (block_a.block_work () + 1);
 		}

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2895,7 +2895,7 @@ TEST (ledger, work_validation)
 	auto process_block = [&store, &ledger, &pool] (nano::block & block_a, nano::block_details const details_a) {
 		auto threshold = nano::dev::network_params.network.publish_thresholds.threshold (block_a.work_version (), details_a);
 		// Rarely failed with random work, so modify until it doesn't have enough difficulty
-		while (block_a.difficulty () >= threshold)
+		while (nano::dev::network_params.network.publish_thresholds.difficulty (block_a) >= threshold)
 		{
 			block_a.block_work_set (block_a.block_work () + 1);
 		}

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2893,7 +2893,7 @@ TEST (ledger, work_validation)
 
 	// With random work the block doesn't pass, then modifies the block with sufficient work and ensures a correct result
 	auto process_block = [&store, &ledger, &pool] (nano::block & block_a, nano::block_details const details_a) {
-		auto threshold = nano::work_threshold (block_a.work_version (), details_a);
+		auto threshold = nano::dev::network_params.network.publish_thresholds.threshold (block_a.work_version (), details_a);
 		// Rarely failed with random work, so modify until it doesn't have enough difficulty
 		while (block_a.difficulty () >= threshold)
 		{

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -73,7 +73,7 @@ TEST (ledger, process_modifies_sideband)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), send1).code);
 	ASSERT_EQ (send1.sideband ().timestamp, store->block.get (store->tx_begin_read (), send1.hash ())->sideband ().timestamp);
@@ -89,7 +89,7 @@ TEST (ledger, process_send)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
@@ -188,7 +188,7 @@ TEST (ledger, process_receive)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
@@ -251,7 +251,7 @@ TEST (ledger, rollback_receiver)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
@@ -290,7 +290,7 @@ TEST (ledger, rollback_representation)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key5;
 	nano::change_block change1 (nano::dev::genesis->hash (), key5.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
@@ -343,7 +343,7 @@ TEST (ledger, receive_rollback)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
 	nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
@@ -360,7 +360,7 @@ TEST (ledger, process_duplicate)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
@@ -409,7 +409,7 @@ TEST (ledger, representative_change)
 	nano::keypair key2;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	nano::account_info info1;
@@ -448,7 +448,7 @@ TEST (ledger, send_fork)
 	nano::keypair key3;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::send_block block (info1.head, key2.pub, 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
@@ -468,7 +468,7 @@ TEST (ledger, receive_fork)
 	nano::keypair key3;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::send_block block (info1.head, key2.pub, 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
@@ -494,7 +494,7 @@ TEST (ledger, open_fork)
 	nano::keypair key3;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::send_block block (info1.head, key2.pub, 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
@@ -526,7 +526,7 @@ TEST (ledger, representation)
 	auto & rep_weights = ledger.cache.rep_weights;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	nano::keypair key2;
 	nano::send_block block1 (nano::dev::genesis->hash (), key2.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
@@ -599,7 +599,7 @@ TEST (ledger, double_open)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
 	nano::send_block send1 (nano::dev::genesis->hash (), key2.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -618,7 +618,7 @@ TEST (ledger, double_receive)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
 	nano::send_block send1 (nano::dev::genesis->hash (), key2.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -896,7 +896,7 @@ TEST (ledger, fail_change_old)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::change_block block (nano::dev::genesis->hash (), key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block));
@@ -914,7 +914,7 @@ TEST (ledger, fail_change_gap_previous)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::change_block block (1, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::root (1)));
 	auto result1 (ledger.process (transaction, block));
@@ -930,7 +930,7 @@ TEST (ledger, fail_change_bad_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::change_block block (nano::dev::genesis->hash (), key1.pub, nano::keypair ().prv, 0, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block));
@@ -946,7 +946,7 @@ TEST (ledger, fail_change_fork)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::change_block block1 (nano::dev::genesis->hash (), key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -966,7 +966,7 @@ TEST (ledger, fail_send_old)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block));
@@ -984,7 +984,7 @@ TEST (ledger, fail_send_gap_previous)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block (1, key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::root (1)));
 	auto result1 (ledger.process (transaction, block));
@@ -1000,7 +1000,7 @@ TEST (ledger, fail_send_bad_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block (nano::dev::genesis->hash (), key1.pub, 1, nano::keypair ().prv, 0, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block));
@@ -1016,7 +1016,7 @@ TEST (ledger, fail_send_negative_spend)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1034,7 +1034,7 @@ TEST (ledger, fail_send_fork)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1052,7 +1052,7 @@ TEST (ledger, fail_open_old)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1070,7 +1070,7 @@ TEST (ledger, fail_open_gap_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::open_block block2 (1, 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
 	auto result2 (ledger.process (transaction, block2));
@@ -1086,7 +1086,7 @@ TEST (ledger, fail_open_bad_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1104,7 +1104,7 @@ TEST (ledger, fail_open_fork_previous)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1126,7 +1126,7 @@ TEST (ledger, fail_open_account_mismatch)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1145,7 +1145,7 @@ TEST (ledger, fail_receive_old)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
@@ -1167,7 +1167,7 @@ TEST (ledger, fail_receive_gap_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1192,7 +1192,7 @@ TEST (ledger, fail_receive_overreceive)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1214,7 +1214,7 @@ TEST (ledger, fail_receive_bad_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1239,7 +1239,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1264,7 +1264,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1286,7 +1286,7 @@ TEST (ledger, fail_receive_fork_previous)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1315,7 +1315,7 @@ TEST (ledger, fail_receive_received_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	auto result1 (ledger.process (transaction, block1));
@@ -1363,7 +1363,7 @@ TEST (ledger, latest_root)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub));
 	auto hash1 (ledger.latest (transaction, nano::dev::genesis_key.pub));
@@ -1382,7 +1382,7 @@ TEST (ledger, change_representative_move_representation)
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	nano::send_block send (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
@@ -1405,7 +1405,7 @@ TEST (ledger, send_open_receive_rollback)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key1;
@@ -1463,7 +1463,7 @@ TEST (ledger, bootstrap_rep_weight)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::account_info info1;
 	nano::keypair key2;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache);
@@ -1499,7 +1499,7 @@ TEST (ledger, block_destination_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair dest;
 	nano::uint128_t balance (nano::dev::constants.genesis_amount);
 	balance -= nano::Gxrb_ratio;
@@ -1544,7 +1544,7 @@ TEST (ledger, state_account)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send1.hash ()));
@@ -1559,7 +1559,7 @@ TEST (ledger, state_send_receive)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -1600,7 +1600,7 @@ TEST (ledger, state_receive)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -1634,7 +1634,7 @@ TEST (ledger, state_rep_change)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::state_block change1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
@@ -1661,7 +1661,7 @@ TEST (ledger, state_open)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1700,7 +1700,7 @@ TEST (ledger, send_after_state_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::send_block send2 (send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
@@ -1717,7 +1717,7 @@ TEST (ledger, receive_after_state_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::receive_block receive1 (send1.hash (), send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
@@ -1734,7 +1734,7 @@ TEST (ledger, change_after_state_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair rep;
@@ -1751,7 +1751,7 @@ TEST (ledger, state_unreceivable_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -1774,7 +1774,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -1797,7 +1797,7 @@ TEST (ledger, state_no_link_amount_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair rep;
@@ -1814,7 +1814,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -1838,7 +1838,7 @@ TEST (ledger, state_open_state_fork)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1858,7 +1858,7 @@ TEST (ledger, state_state_open_fork)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1879,7 +1879,7 @@ TEST (ledger, state_open_previous_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1896,7 +1896,7 @@ TEST (ledger, state_open_source_fail)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1913,7 +1913,7 @@ TEST (ledger, state_send_change)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1940,7 +1940,7 @@ TEST (ledger, state_receive_change)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -1976,7 +1976,7 @@ TEST (ledger, state_open_old)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -1996,7 +1996,7 @@ TEST (ledger, state_receive_old)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2020,7 +2020,7 @@ TEST (ledger, state_rollback_send)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -2051,7 +2051,7 @@ TEST (ledger, state_rollback_receive)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
@@ -2077,7 +2077,7 @@ TEST (ledger, state_rollback_received_send)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2104,7 +2104,7 @@ TEST (ledger, state_rep_change_rollback)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::state_block change1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
@@ -2124,7 +2124,7 @@ TEST (ledger, state_open_rollback)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2150,7 +2150,7 @@ TEST (ledger, state_send_change_rollback)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2171,7 +2171,7 @@ TEST (ledger, state_receive_change_rollback)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	nano::keypair rep;
@@ -2194,7 +2194,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
@@ -2264,7 +2264,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	// Trying to upgrade from epoch 0 to epoch 2. It is a requirement epoch upgrades are sequential unless the account is unopened
@@ -2329,7 +2329,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2409,7 +2409,7 @@ TEST (ledger, epoch_blocks_fork)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::send_block send1 (nano::dev::genesis->hash (), nano::account (0), nano::dev::constants.genesis_amount, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
@@ -2430,7 +2430,7 @@ TEST (ledger, successor_epoch)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send1 (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	nano::state_block open (key1.pub, 0, key1.pub, 1, send1.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
 	nano::state_block change (key1.pub, open.hash (), key1.pub, 1, 0, key1.prv, key1.pub, *pool.generate (open.hash ()));
@@ -2454,7 +2454,7 @@ TEST (ledger, epoch_open_pending)
 	nano::block_builder builder;
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto epoch_open = builder.state ()
 					  .account (key1.pub)
@@ -2498,7 +2498,7 @@ TEST (ledger, block_hash_account_conflict)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::keypair key2;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 
 	/*
 	 * Generate a send block whose destination is a block hash already
@@ -2590,7 +2590,7 @@ TEST (ledger, could_fit)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	// Test legacy and state change blocks could_fit
 	nano::change_block change1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
@@ -2826,7 +2826,7 @@ TEST (ledger, confirmation_height_not_updated)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info account_info;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, account_info));
 	nano::keypair key;
@@ -2886,7 +2886,7 @@ TEST (ledger, work_validation)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto gen = nano::dev::genesis_key;
 	nano::keypair key;
@@ -2981,7 +2981,7 @@ TEST (ledger, dependents_confirmed)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *nano::dev::genesis));
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -3053,7 +3053,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -3104,7 +3104,7 @@ TEST (ledger, block_confirmed)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
 	ASSERT_TRUE (ledger.block_confirmed (transaction, nano::dev::genesis->hash ()));
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -3134,7 +3134,7 @@ TEST (ledger, cache)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 
 	size_t const total = 100;
@@ -3247,7 +3247,7 @@ TEST (ledger, pruning_action)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -3303,7 +3303,7 @@ TEST (ledger, pruning_large_chain)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	size_t send_receive_pairs (20);
 	auto last_hash (nano::dev::genesis->hash ());
 	for (auto i (0); i < send_receive_pairs; i++)
@@ -3339,7 +3339,7 @@ TEST (ledger, pruning_source_rollback)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
 	nano::state_block send1 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
@@ -3390,7 +3390,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
@@ -3468,7 +3468,7 @@ TEST (ledger, pruning_process_error)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_EQ (0, ledger.cache.pruned_count);
@@ -3497,7 +3497,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
@@ -3541,7 +3541,7 @@ TEST (ledger, pruning_safe_functions)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -3583,7 +3583,7 @@ TEST (ledger, hash_root_random)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
@@ -3625,7 +3625,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	nano::mdb_store store (logger, path / "data.ldb", nano::dev::constants);
 	nano::stat stats;
 	nano::ledger ledger (store, stats, nano::dev::constants);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 
 	auto send = nano::state_block_builder ()
 				.account (nano::dev::genesis_key.pub)
@@ -3705,7 +3705,7 @@ TEST (ledger, unconfirmed_frontiers)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 
 	auto unconfirmed_frontiers = ledger.unconfirmed_frontiers ();
 	ASSERT_TRUE (unconfirmed_frontiers.empty ());

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -67,8 +67,7 @@ TEST (message_parser, exact_confirm_ack_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::network_constants network;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, std::move (block)));
 	nano::confirm_ack message{ nano::dev::network_params.network, vote };
@@ -102,8 +101,7 @@ TEST (message_parser, exact_confirm_req_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::network_constants network;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::confirm_req message{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
@@ -136,8 +134,7 @@ TEST (message_parser, exact_confirm_req_hash_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::network_constants network;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
 	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
 	nano::confirm_req message{ nano::dev::network_params.network, block.hash (), block.root () };
 	std::vector<uint8_t> bytes;
@@ -170,8 +167,7 @@ TEST (message_parser, exact_publish_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::network_constants network;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::publish message{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
@@ -204,8 +200,7 @@ TEST (message_parser, exact_keepalive_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::network_constants network;
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, network);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
 	nano::keepalive message{ nano::dev::network_params.network };
 	std::vector<uint8_t> bytes;
 	{

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -326,20 +326,20 @@ TEST (network, send_insufficient_work)
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work) != 0);
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
 	// Legacy block work between epoch_2_recieve & epoch_1
-	auto block2 (std::make_shared<nano::send_block> (block1->hash (), 1, 20, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, system.work_generate_limited (block1->hash (), node1.network_params.network.publish_thresholds.epoch_2_receive, node1.network_params.network.publish_thresholds.epoch_1 - 1)));
+	auto block2 (std::make_shared<nano::send_block> (block1->hash (), 1, 20, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, system.work_generate_limited (block1->hash (), node1.network_params.work.epoch_2_receive, node1.network_params.work.epoch_1 - 1)));
 	nano::publish publish2{ nano::dev::network_params.network, block2 };
 	tcp_channel->send (publish2, [] (boost::system::error_code const & ec, size_t size) {});
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work) != 1);
 	ASSERT_EQ (2, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
 	// Legacy block work epoch_1
-	auto block3 (std::make_shared<nano::send_block> (block2->hash (), 1, 20, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (block2->hash (), node1.network_params.network.publish_thresholds.epoch_2)));
+	auto block3 (std::make_shared<nano::send_block> (block2->hash (), 1, 20, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (block2->hash (), node1.network_params.work.epoch_2)));
 	nano::publish publish3{ nano::dev::network_params.network, block3 };
 	tcp_channel->send (publish3, [] (boost::system::error_code const & ec, size_t size) {});
 	ASSERT_EQ (0, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in));
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in));
 	// State block work epoch_2_recieve
-	auto block4 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, block1->hash (), nano::dev::genesis_key.pub, 20, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, system.work_generate_limited (block1->hash (), node1.network_params.network.publish_thresholds.epoch_2_receive, node1.network_params.network.publish_thresholds.epoch_1 - 1)));
+	auto block4 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, block1->hash (), nano::dev::genesis_key.pub, 20, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, system.work_generate_limited (block1->hash (), node1.network_params.work.epoch_2_receive, node1.network_params.work.epoch_1 - 1)));
 	nano::publish publish4{ nano::dev::network_params.network, block4 };
 	tcp_channel->send (publish4, [] (boost::system::error_code const & ec, size_t size) {});
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);

--- a/nano/core_test/network_filter.cpp
+++ b/nano/core_test/network_filter.cpp
@@ -8,7 +8,6 @@
 
 TEST (network_filter, unit)
 {
-	nano::ledger_constants constants{ nano::networks::nano_dev_network };
 	nano::network_filter filter (1);
 	auto one_block = [&filter] (std::shared_ptr<nano::block> const & block_a, bool expect_duplicate_a) {
 		nano::publish message{ nano::dev::network_params.network, block_a };
@@ -32,15 +31,15 @@ TEST (network_filter, unit)
 		ASSERT_NE (nullptr, block);
 		ASSERT_EQ (*block, *block_a);
 	};
-	one_block (constants.genesis, false);
+	one_block (nano::dev::genesis, false);
 	for (int i = 0; i < 10; ++i)
 	{
-		one_block (constants.genesis, true);
+		one_block (nano::dev::genesis, true);
 	}
 	nano::state_block_builder builder;
 	auto new_block = builder
 					 .account (nano::dev::genesis_key.pub)
-					 .previous (constants.genesis->hash ())
+					 .previous (nano::dev::genesis->hash ())
 					 .representative (nano::dev::genesis_key.pub)
 					 .balance (nano::dev::constants.genesis_amount - 10 * nano::xrb_ratio)
 					 .link (nano::public_key ())
@@ -55,14 +54,13 @@ TEST (network_filter, unit)
 	}
 	for (int i = 0; i < 100; ++i)
 	{
-		one_block (constants.genesis, false);
+		one_block (nano::dev::genesis, false);
 		one_block (new_block, false);
 	}
 }
 
 TEST (network_filter, many)
 {
-	nano::ledger_constants constants{ nano::networks::nano_dev_network };
 	nano::network_filter filter (4);
 	nano::keypair key1;
 	for (int i = 0; i < 100; ++i)
@@ -70,7 +68,7 @@ TEST (network_filter, many)
 		nano::state_block_builder builder;
 		auto block = builder
 					 .account (nano::dev::genesis_key.pub)
-					 .previous (constants.genesis->hash ())
+					 .previous (nano::dev::genesis->hash ())
 					 .representative (nano::dev::genesis_key.pub)
 					 .balance (nano::dev::constants.genesis_amount - i * 10 * nano::xrb_ratio)
 					 .link (key1.pub)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -36,21 +36,21 @@ TEST (node, work_generate)
 	nano::block_hash root{ 1 };
 	nano::work_version version{ nano::work_version::work_1 };
 	{
-		auto difficulty = nano::difficulty::from_multiplier (1.5, node.network_params.network.publish_thresholds.base);
+		auto difficulty = nano::difficulty::from_multiplier (1.5, node.network_params.work.base);
 		auto work = node.work_generate_blocking (version, root, difficulty);
 		ASSERT_TRUE (work.is_initialized ());
-		ASSERT_TRUE (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= difficulty);
+		ASSERT_TRUE (nano::dev::network_params.work.difficulty (version, root, *work) >= difficulty);
 	}
 	{
-		auto difficulty = nano::difficulty::from_multiplier (0.5, node.network_params.network.publish_thresholds.base);
+		auto difficulty = nano::difficulty::from_multiplier (0.5, node.network_params.work.base);
 		boost::optional<uint64_t> work;
 		do
 		{
 			work = node.work_generate_blocking (version, root, difficulty);
-		} while (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= node.network_params.network.publish_thresholds.base);
+		} while (nano::dev::network_params.work.difficulty (version, root, *work) >= node.network_params.work.base);
 		ASSERT_TRUE (work.is_initialized ());
-		ASSERT_TRUE (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= difficulty);
-		ASSERT_FALSE (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= node.network_params.network.publish_thresholds.base);
+		ASSERT_TRUE (nano::dev::network_params.work.difficulty (version, root, *work) >= difficulty);
+		ASSERT_FALSE (nano::dev::network_params.work.difficulty (version, root, *work) >= node.network_params.work.base);
 	}
 }
 
@@ -4550,7 +4550,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_TIMELY (2s, node2.block (send2->hash ()));
 
 	// Re-processing older blocks with updated work also does not start an election
-	node.work_generate_blocking (*open, nano::dev::network_params.network.publish_thresholds.difficulty (*open) + 1);
+	node.work_generate_blocking (*open, nano::dev::network_params.work.difficulty (*open) + 1);
 	node.process_local (open);
 	node.block_processor.flush ();
 	node.scheduler.flush ();
@@ -4563,7 +4563,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 
 	/// The election was dropped but it's still not possible to restart it
-	node.work_generate_blocking (*open, nano::dev::network_params.network.publish_thresholds.difficulty (*open) + 1);
+	node.work_generate_blocking (*open, nano::dev::network_params.work.difficulty (*open) + 1);
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 	node.process_local (open);
 	node.block_processor.flush ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -60,8 +60,8 @@ TEST (node, block_store_path_failure)
 	auto path (nano::unique_path ());
 	nano::logging logging;
 	logging.init (path);
-	nano::work_pool work (std::numeric_limits<unsigned>::max ());
-	auto node (std::make_shared<nano::node> (*service, nano::get_available_port (), path, logging, work));
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	auto node (std::make_shared<nano::node> (*service, nano::get_available_port (), path, logging, pool));
 	ASSERT_TRUE (node->wallets.items.empty ());
 	node->stop ();
 }
@@ -91,9 +91,9 @@ TEST (node, password_fanout)
 	nano::node_config config;
 	config.peering_port = nano::get_available_port ();
 	config.logging.init (path);
-	nano::work_pool work (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	config.password_fanout = 10;
-	nano::node node (io_ctx, path, config, work);
+	nano::node node (io_ctx, path, config, pool);
 	auto wallet (node.wallets.create (100));
 	ASSERT_EQ (10, wallet->store.password.values.size ());
 	node.stop ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4550,7 +4550,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_TIMELY (2s, node2.block (send2->hash ()));
 
 	// Re-processing older blocks with updated work also does not start an election
-	node.work_generate_blocking (*open, open->difficulty () + 1);
+	node.work_generate_blocking (*open, nano::dev::network_params.network.publish_thresholds.difficulty (*open) + 1);
 	node.process_local (open);
 	node.block_processor.flush ();
 	node.scheduler.flush ();
@@ -4563,7 +4563,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 
 	/// The election was dropped but it's still not possible to restart it
-	node.work_generate_blocking (*open, open->difficulty () + 1);
+	node.work_generate_blocking (*open, nano::dev::network_params.network.publish_thresholds.difficulty (*open) + 1);
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 	node.process_local (open);
 	node.block_processor.flush ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -39,7 +39,7 @@ TEST (node, work_generate)
 		auto difficulty = nano::difficulty::from_multiplier (1.5, node.network_params.network.publish_thresholds.base);
 		auto work = node.work_generate_blocking (version, root, difficulty);
 		ASSERT_TRUE (work.is_initialized ());
-		ASSERT_TRUE (nano::work_difficulty (version, root, *work) >= difficulty);
+		ASSERT_TRUE (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= difficulty);
 	}
 	{
 		auto difficulty = nano::difficulty::from_multiplier (0.5, node.network_params.network.publish_thresholds.base);
@@ -47,10 +47,10 @@ TEST (node, work_generate)
 		do
 		{
 			work = node.work_generate_blocking (version, root, difficulty);
-		} while (nano::work_difficulty (version, root, *work) >= node.network_params.network.publish_thresholds.base);
+		} while (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= node.network_params.network.publish_thresholds.base);
 		ASSERT_TRUE (work.is_initialized ());
-		ASSERT_TRUE (nano::work_difficulty (version, root, *work) >= difficulty);
-		ASSERT_FALSE (nano::work_difficulty (version, root, *work) >= node.network_params.network.publish_thresholds.base);
+		ASSERT_TRUE (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= difficulty);
+		ASSERT_FALSE (nano::dev::network_params.network.publish_thresholds.difficulty (version, root, *work) >= node.network_params.network.publish_thresholds.base);
 	}
 }
 

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -16,7 +16,7 @@ TEST (processor_service, bad_send_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
@@ -34,7 +34,7 @@ TEST (processor_service, bad_receive_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::send_block send (info1.head, nano::dev::genesis_key.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -10,9 +10,8 @@ TEST (system, work_generate_limited)
 {
 	nano::system system;
 	nano::block_hash key (1);
-	nano::network_constants constants;
-	auto min = constants.publish_thresholds.entry;
-	auto max = constants.publish_thresholds.base;
+	auto min = nano::dev::network_params.network.publish_thresholds.entry;
+	auto max = nano::dev::network_params.network.publish_thresholds.base;
 	for (int i = 0; i < 5; ++i)
 	{
 		auto work = system.work_generate_limited (key, min, max);

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -15,7 +15,7 @@ TEST (system, work_generate_limited)
 	for (int i = 0; i < 5; ++i)
 	{
 		auto work = system.work_generate_limited (key, min, max);
-		auto difficulty = nano::work_difficulty (nano::work_version::work_1, key, work);
+		auto difficulty = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, key, work);
 		ASSERT_GE (difficulty, min);
 		ASSERT_LT (difficulty, max);
 	}

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -10,12 +10,12 @@ TEST (system, work_generate_limited)
 {
 	nano::system system;
 	nano::block_hash key (1);
-	auto min = nano::dev::network_params.network.publish_thresholds.entry;
-	auto max = nano::dev::network_params.network.publish_thresholds.base;
+	auto min = nano::dev::network_params.work.entry;
+	auto max = nano::dev::network_params.work.base;
 	for (int i = 0; i < 5; ++i)
 	{
 		auto work = system.work_generate_limited (key, min, max);
-		auto difficulty = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, key, work);
+		auto difficulty = nano::dev::network_params.work.difficulty (nano::work_version::work_1, key, work);
 		ASSERT_GE (difficulty, min);
 		ASSERT_LT (difficulty, max);
 	}

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -550,20 +550,11 @@ TEST (telemetry, remove_peer_different_genesis)
 	nano::system system (1);
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
 	// Change genesis block to something else in this test (this is the reference telemetry processing uses).
-	// Possible TSAN issue in the future if something else uses this, but will only appear in tests.
-	nano::state_block_builder builder;
-	auto junk = builder
-				.account (nano::dev::genesis_key.pub)
-				.previous (0)
-				.representative (nano::dev::genesis_key.pub)
-				.balance (0)
-				.link (0)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (0)
-				.build_shared ();
-	node1->network_params.ledger.genesis = junk;
+	nano::network_params network_params{ nano::networks::nano_dev_network };
+	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
+	nano::node_config config{ network_params };
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	node0->network.merge_peer (node1->network.endpoint ());
@@ -590,18 +581,10 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 	nano::system system (1, nano::transport::transport_type::udp, node_flags);
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
-	nano::state_block_builder builder;
-	auto junk = builder
-				.account (nano::dev::genesis_key.pub)
-				.previous (0)
-				.representative (nano::dev::genesis_key.pub)
-				.balance (0)
-				.link (0)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (0)
-				.build_shared ();
-	node1->network_params.ledger.genesis = junk;
+	nano::network_params network_params{ nano::networks::nano_dev_network };
+	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
+	nano::node_config config{ network_params };
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.network.protocol_version));

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -88,8 +88,8 @@ TEST (toml, rpc_config_deserialize_defaults)
 
 	nano::tomlconfig t;
 	t.read (ss);
-	nano::rpc_config conf;
-	nano::rpc_config defaults;
+	nano::rpc_config conf{ nano::dev::network_params.network };
+	nano::rpc_config defaults{ nano::dev::network_params.network };
 	conf.deserialize_toml (t);
 
 	ASSERT_FALSE (t.get_error ()) << t.get_error ().get_message ();
@@ -717,8 +717,8 @@ TEST (toml, rpc_config_deserialize_no_defaults)
 
 	nano::tomlconfig toml;
 	toml.read (ss);
-	nano::rpc_config conf;
-	nano::rpc_config defaults;
+	nano::rpc_config conf{ nano::dev::network_params.network };
+	nano::rpc_config defaults{ nano::dev::network_params.network };
 	conf.deserialize_toml (toml);
 
 	ASSERT_FALSE (toml.get_error ()) << toml.get_error ().get_message ();
@@ -752,8 +752,8 @@ TEST (toml, rpc_config_no_required)
 
 	nano::tomlconfig toml;
 	toml.read (ss);
-	nano::rpc_config conf;
-	nano::rpc_config defaults;
+	nano::rpc_config conf{ nano::dev::network_params.network };
+	nano::rpc_config defaults{ nano::dev::network_params.network };
 	conf.deserialize_toml (toml);
 
 	ASSERT_FALSE (toml.get_error ()) << toml.get_error ().get_message ();

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -822,7 +822,7 @@ TEST (wallet, no_work)
 	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), false));
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
-	ASSERT_GE (block->difficulty (), nano::work_threshold (block->work_version (), block->sideband ().details));
+	ASSERT_GE (block->difficulty (), nano::dev::network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details));
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	uint64_t cached_work (0);
 	system.wallet (0)->store.work_get (transaction, nano::dev::genesis_key.pub, cached_work);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -822,7 +822,7 @@ TEST (wallet, no_work)
 	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), false));
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
-	ASSERT_GE (block->difficulty (), nano::dev::network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details));
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (*block), nano::dev::network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details));
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	uint64_t cached_work (0);
 	system.wallet (0)->store.work_get (transaction, nano::dev::genesis_key.pub, cached_work);
@@ -1022,9 +1022,9 @@ TEST (wallet, epoch_2_validation)
 
 		auto receive = wallet.receive_action (send->hash (), nano::dev::genesis_key.pub, amount, send->link ().as_account (), 1);
 		ASSERT_NE (nullptr, receive);
-		if (receive->difficulty () < node.network_params.network.publish_thresholds.base)
+		if (nano::dev::network_params.network.publish_thresholds.difficulty (*receive) < node.network_params.network.publish_thresholds.base)
 		{
-			ASSERT_GE (receive->difficulty (), node.network_params.network.publish_thresholds.epoch_2_receive);
+			ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (*receive), node.network_params.network.publish_thresholds.epoch_2_receive);
 			ASSERT_EQ (nano::epoch::epoch_2, receive->sideband ().details.epoch);
 			ASSERT_EQ (nano::epoch::epoch_2, receive->sideband ().source_epoch);
 			break;
@@ -1074,9 +1074,9 @@ TEST (wallet, epoch_2_receive_propagation)
 
 		auto receive2 = wallet.receive_action (send2->hash (), key.pub, amount, send2->link ().as_account (), 1);
 		ASSERT_NE (nullptr, receive2);
-		if (receive2->difficulty () < node.network_params.network.publish_thresholds.base)
+		if (nano::dev::network_params.network.publish_thresholds.difficulty (*receive2) < node.network_params.network.publish_thresholds.base)
 		{
-			ASSERT_GE (receive2->difficulty (), node.network_params.network.publish_thresholds.epoch_2_receive);
+			ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (*receive2), node.network_params.network.publish_thresholds.epoch_2_receive);
 			ASSERT_EQ (nano::epoch::epoch_2, node.store.block.version (node.store.tx_begin_read (), receive2->hash ()));
 			ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().source_epoch);
 			break;
@@ -1119,9 +1119,9 @@ TEST (wallet, epoch_2_receive_unopened)
 
 		auto receive1 = wallet.receive_action (send1->hash (), key.pub, amount, send1->link ().as_account (), 1);
 		ASSERT_NE (nullptr, receive1);
-		if (receive1->difficulty () < node.network_params.network.publish_thresholds.base)
+		if (nano::dev::network_params.network.publish_thresholds.difficulty (*receive1) < node.network_params.network.publish_thresholds.base)
 		{
-			ASSERT_GE (receive1->difficulty (), node.network_params.network.publish_thresholds.epoch_2_receive);
+			ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (*receive1), node.network_params.network.publish_thresholds.epoch_2_receive);
 			ASSERT_EQ (nano::epoch::epoch_2, node.store.block.version (node.store.tx_begin_read (), receive1->hash ()));
 			ASSERT_EQ (nano::epoch::epoch_1, receive1->sideband ().source_epoch);
 			break;

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -645,7 +645,7 @@ TEST (wallet, work)
 		uint64_t work (0);
 		if (!wallet->store.work_get (transaction, nano::dev::genesis_key.pub, work))
 		{
-			done = nano::work_difficulty (nano::dev::genesis->work_version (), nano::dev::genesis->hash (), work) >= system.nodes[0]->default_difficulty (nano::dev::genesis->work_version ());
+			done = nano::dev::network_params.network.publish_thresholds.difficulty (nano::dev::genesis->work_version (), nano::dev::genesis->hash (), work) >= system.nodes[0]->default_difficulty (nano::dev::genesis->work_version ());
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -675,7 +675,7 @@ TEST (wallet, work_generate)
 		ASSERT_NO_ERROR (system.poll ());
 		auto block_transaction (node1.store.tx_begin_read ());
 		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		again = wallet->store.work_get (transaction, account1, work1) || nano::work_difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1) < node1.default_difficulty (block->work_version ());
+		again = wallet->store.work_get (transaction, account1, work1) || nano::dev::network_params.network.publish_thresholds.difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1) < node1.default_difficulty (block->work_version ());
 	}
 }
 
@@ -705,10 +705,10 @@ TEST (wallet, work_cache_delayed)
 		ASSERT_NO_ERROR (system.poll ());
 		if (!wallet->store.work_get (node1.wallets.tx_begin_read (), account1, work1))
 		{
-			again = nano::work_difficulty (nano::work_version::work_1, block2->hash (), work1) < threshold;
+			again = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, block2->hash (), work1) < threshold;
 		}
 	}
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, block2->hash (), work1), threshold);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, block2->hash (), work1), threshold);
 }
 
 TEST (wallet, insert_locked)

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -19,7 +19,7 @@ TEST (work, one)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::change_block block (1, 1, nano::keypair ().prv, 3, 4);
 	block.block_work_set (*pool.generate (block.root ()));
-	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (block.work_version ()), block.difficulty ());
+	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (block.work_version ()), nano::dev::network_params.network.publish_thresholds.difficulty (block));
 }
 
 TEST (work, disabled)
@@ -33,9 +33,9 @@ TEST (work, validate)
 {
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send_block (1, 1, 2, nano::keypair ().prv, 4, 6);
-	ASSERT_LT (send_block.difficulty (), nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()));
+	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.difficulty (send_block), nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()));
 	send_block.block_work_set (*pool.generate (send_block.root ()));
-	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()), send_block.difficulty ());
+	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()), nano::dev::network_params.network.publish_thresholds.difficulty (send_block));
 }
 
 TEST (work, cancel)

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -17,7 +17,7 @@
 TEST (work, one)
 {
 	nano::network_constants network_constants;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::change_block block (1, 1, nano::keypair ().prv, 3, 4);
 	block.block_work_set (*pool.generate (block.root ()));
 	ASSERT_LT (nano::work_threshold_base (block.work_version ()), block.difficulty ());
@@ -26,7 +26,7 @@ TEST (work, one)
 TEST (work, disabled)
 {
 	nano::network_constants network_constants;
-	nano::work_pool pool (0);
+	nano::work_pool pool{ nano::dev::network_params.network, 0 };
 	auto result (pool.generate (nano::block_hash ()));
 	ASSERT_FALSE (result.is_initialized ());
 }
@@ -34,7 +34,7 @@ TEST (work, disabled)
 TEST (work, validate)
 {
 	nano::network_constants network_constants;
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send_block (1, 1, 2, nano::keypair ().prv, 4, 6);
 	ASSERT_LT (send_block.difficulty (), nano::work_threshold_base (send_block.work_version ()));
 	send_block.block_work_set (*pool.generate (send_block.root ()));
@@ -43,7 +43,7 @@ TEST (work, validate)
 
 TEST (work, cancel)
 {
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto iterations (0);
 	auto done (false);
 	while (!done)
@@ -61,7 +61,7 @@ TEST (work, cancel)
 
 TEST (work, cancel_many)
 {
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::root key1 (1);
 	nano::root key2 (2);
 	nano::root key3 (1);
@@ -93,9 +93,9 @@ TEST (work, opencl)
 		if (opencl != nullptr)
 		{
 			// 0 threads, should add 1 for managing OpenCL
-			nano::work_pool pool (0, std::chrono::nanoseconds (0), [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
+			nano::work_pool pool{ nano::dev::network_params.network, 0, std::chrono::nanoseconds (0), [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
 				return opencl->generate_work (version_a, root_a, difficulty_a);
-			});
+			} };
 			ASSERT_NE (nullptr, pool.opencl);
 			nano::root root;
 			uint64_t difficulty (0xff00000000000000);
@@ -136,7 +136,7 @@ TEST (work, opencl_config)
 
 TEST (work, difficulty)
 {
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::root root (1);
 	uint64_t difficulty1 (0xff00000000000000);
 	uint64_t difficulty2 (0xfff0000000000000);
@@ -160,7 +160,7 @@ TEST (work, difficulty)
 TEST (work, eco_pow)
 {
 	auto work_func = [] (std::promise<std::chrono::nanoseconds> & promise, std::chrono::nanoseconds interval) {
-		nano::work_pool pool (1, interval);
+		nano::work_pool pool{ nano::dev::network_params.network, 1, interval };
 		constexpr auto num_iterations = 5;
 
 		nano::timer<std::chrono::nanoseconds> timer;

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -19,7 +19,7 @@ TEST (work, one)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::change_block block (1, 1, nano::keypair ().prv, 3, 4);
 	block.block_work_set (*pool.generate (block.root ()));
-	ASSERT_LT (nano::work_threshold_base (block.work_version ()), block.difficulty ());
+	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (block.work_version ()), block.difficulty ());
 }
 
 TEST (work, disabled)
@@ -33,9 +33,9 @@ TEST (work, validate)
 {
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send_block (1, 1, 2, nano::keypair ().prv, 4, 6);
-	ASSERT_LT (send_block.difficulty (), nano::work_threshold_base (send_block.work_version ()));
+	ASSERT_LT (send_block.difficulty (), nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()));
 	send_block.block_work_set (*pool.generate (send_block.root ()));
-	ASSERT_LT (nano::work_threshold_base (send_block.work_version ()), send_block.difficulty ());
+	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()), send_block.difficulty ());
 }
 
 TEST (work, cancel)

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -100,7 +100,7 @@ TEST (work, opencl)
 			{
 				nano::random_pool::generate_block (root.bytes.data (), root.bytes.size ());
 				auto result (*pool.generate (nano::work_version::work_1, root, difficulty));
-				ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, root, result), difficulty);
+				ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, result), difficulty);
 				difficulty += difficulty_add;
 			}
 		}
@@ -141,14 +141,14 @@ TEST (work, difficulty)
 	do
 	{
 		auto work1 = *pool.generate (nano::work_version::work_1, root, difficulty1);
-		result_difficulty1 = nano::work_difficulty (nano::work_version::work_1, root, work1);
+		result_difficulty1 = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, work1);
 	} while (result_difficulty1 > difficulty2);
 	ASSERT_GT (result_difficulty1, difficulty1);
 	uint64_t result_difficulty2 (0);
 	do
 	{
 		auto work2 = *pool.generate (nano::work_version::work_1, root, difficulty2);
-		result_difficulty2 = nano::work_difficulty (nano::work_version::work_1, root, work2);
+		result_difficulty2 = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, work2);
 	} while (result_difficulty2 > difficulty3);
 	ASSERT_GT (result_difficulty2, difficulty2);
 }
@@ -170,7 +170,7 @@ TEST (work, eco_pow)
 			do
 			{
 				auto work = *pool.generate (nano::work_version::work_1, root, difficulty1);
-				result_difficulty = nano::work_difficulty (nano::work_version::work_1, root, work);
+				result_difficulty = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, work);
 			} while (result_difficulty > difficulty2);
 			ASSERT_GT (result_difficulty, difficulty1);
 		}

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -16,7 +16,6 @@
 
 TEST (work, one)
 {
-	nano::network_constants network_constants;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::change_block block (1, 1, nano::keypair ().prv, 3, 4);
 	block.block_work_set (*pool.generate (block.root ()));
@@ -25,7 +24,6 @@ TEST (work, one)
 
 TEST (work, disabled)
 {
-	nano::network_constants network_constants;
 	nano::work_pool pool{ nano::dev::network_params.network, 0 };
 	auto result (pool.generate (nano::block_hash ()));
 	ASSERT_FALSE (result.is_initialized ());
@@ -33,7 +31,6 @@ TEST (work, disabled)
 
 TEST (work, validate)
 {
-	nano::network_constants network_constants;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send_block (1, 1, 2, nano::keypair ().prv, 4, 6);
 	ASSERT_LT (send_block.difficulty (), nano::work_threshold_base (send_block.work_version ()));
@@ -50,7 +47,7 @@ TEST (work, cancel)
 	{
 		nano::root key (1);
 		pool.generate (
-		nano::work_version::work_1, key, nano::network_constants ().publish_thresholds.base, [&done] (boost::optional<uint64_t> work_a) {
+		nano::work_version::work_1, key, nano::dev::network_params.network.publish_thresholds.base, [&done] (boost::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
 		pool.cancel (key);
@@ -68,13 +65,12 @@ TEST (work, cancel_many)
 	nano::root key4 (1);
 	nano::root key5 (3);
 	nano::root key6 (1);
-	nano::network_constants constants;
-	pool.generate (nano::work_version::work_1, key1, constants.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key2, constants.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key3, constants.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key4, constants.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key5, constants.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key6, constants.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key1, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key2, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key3, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key4, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key5, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key6, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
 	pool.cancel (key1);
 }
 

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -19,7 +19,7 @@ TEST (work, one)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::change_block block (1, 1, nano::keypair ().prv, 3, 4);
 	block.block_work_set (*pool.generate (block.root ()));
-	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (block.work_version ()), nano::dev::network_params.network.publish_thresholds.difficulty (block));
+	ASSERT_LT (nano::dev::network_params.work.threshold_base (block.work_version ()), nano::dev::network_params.work.difficulty (block));
 }
 
 TEST (work, disabled)
@@ -33,9 +33,9 @@ TEST (work, validate)
 {
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::send_block send_block (1, 1, 2, nano::keypair ().prv, 4, 6);
-	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.difficulty (send_block), nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()));
+	ASSERT_LT (nano::dev::network_params.work.difficulty (send_block), nano::dev::network_params.work.threshold_base (send_block.work_version ()));
 	send_block.block_work_set (*pool.generate (send_block.root ()));
-	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.threshold_base (send_block.work_version ()), nano::dev::network_params.network.publish_thresholds.difficulty (send_block));
+	ASSERT_LT (nano::dev::network_params.work.threshold_base (send_block.work_version ()), nano::dev::network_params.work.difficulty (send_block));
 }
 
 TEST (work, cancel)
@@ -47,7 +47,7 @@ TEST (work, cancel)
 	{
 		nano::root key (1);
 		pool.generate (
-		nano::work_version::work_1, key, nano::dev::network_params.network.publish_thresholds.base, [&done] (boost::optional<uint64_t> work_a) {
+		nano::work_version::work_1, key, nano::dev::network_params.work.base, [&done] (boost::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
 		pool.cancel (key);
@@ -65,12 +65,12 @@ TEST (work, cancel_many)
 	nano::root key4 (1);
 	nano::root key5 (3);
 	nano::root key6 (1);
-	pool.generate (nano::work_version::work_1, key1, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key2, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key3, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key4, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key5, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key6, nano::dev::network_params.network.publish_thresholds.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key1, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key2, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key3, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key4, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key5, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key6, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
 	pool.cancel (key1);
 }
 
@@ -85,7 +85,7 @@ TEST (work, opencl)
 	if (!environment.platforms.empty () && !environment.platforms.begin ()->devices.empty ())
 	{
 		nano::opencl_config config (0, 0, 16 * 1024);
-		auto opencl (nano::opencl_work::create (true, config, logger, nano::dev::network_params.network.publish_thresholds));
+		auto opencl (nano::opencl_work::create (true, config, logger, nano::dev::network_params.work));
 		if (opencl != nullptr)
 		{
 			// 0 threads, should add 1 for managing OpenCL
@@ -100,7 +100,7 @@ TEST (work, opencl)
 			{
 				nano::random_pool::generate_block (root.bytes.data (), root.bytes.size ());
 				auto result (*pool.generate (nano::work_version::work_1, root, difficulty));
-				ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, result), difficulty);
+				ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, root, result), difficulty);
 				difficulty += difficulty_add;
 			}
 		}
@@ -141,14 +141,14 @@ TEST (work, difficulty)
 	do
 	{
 		auto work1 = *pool.generate (nano::work_version::work_1, root, difficulty1);
-		result_difficulty1 = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, work1);
+		result_difficulty1 = nano::dev::network_params.work.difficulty (nano::work_version::work_1, root, work1);
 	} while (result_difficulty1 > difficulty2);
 	ASSERT_GT (result_difficulty1, difficulty1);
 	uint64_t result_difficulty2 (0);
 	do
 	{
 		auto work2 = *pool.generate (nano::work_version::work_1, root, difficulty2);
-		result_difficulty2 = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, work2);
+		result_difficulty2 = nano::dev::network_params.work.difficulty (nano::work_version::work_1, root, work2);
 	} while (result_difficulty2 > difficulty3);
 	ASSERT_GT (result_difficulty2, difficulty2);
 }
@@ -170,7 +170,7 @@ TEST (work, eco_pow)
 			do
 			{
 				auto work = *pool.generate (nano::work_version::work_1, root, difficulty1);
-				result_difficulty = nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, root, work);
+				result_difficulty = nano::dev::network_params.work.difficulty (nano::work_version::work_1, root, work);
 			} while (result_difficulty > difficulty2);
 			ASSERT_GT (result_difficulty, difficulty1);
 		}

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -85,7 +85,7 @@ TEST (work, opencl)
 	if (!environment.platforms.empty () && !environment.platforms.begin ()->devices.empty ())
 	{
 		nano::opencl_config config (0, 0, 16 * 1024);
-		auto opencl (nano::opencl_work::create (true, config, logger));
+		auto opencl (nano::opencl_work::create (true, config, logger, nano::dev::network_params.network.publish_thresholds));
 		if (opencl != nullptr)
 		{
 			// 0 threads, should add 1 for managing OpenCL

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -83,12 +83,6 @@ nano::work_version nano::block::work_version () const
 	return nano::work_version::work_1;
 }
 
-uint64_t nano::block::difficulty () const
-{
-	static nano::network_constants constants;
-	return constants.publish_thresholds.difficulty (this->work_version (), this->root (), this->block_work ());
-}
-
 nano::block_hash nano::block::generate_hash () const
 {
 	nano::block_hash result;

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -85,7 +85,8 @@ nano::work_version nano::block::work_version () const
 
 uint64_t nano::block::difficulty () const
 {
-	return nano::work_difficulty (this->work_version (), this->root (), this->block_work ());
+	static nano::network_constants constants;
+	return constants.publish_thresholds.difficulty (this->work_version (), this->root (), this->block_work ());
 }
 
 nano::block_hash nano::block::generate_hash () const

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -113,7 +113,6 @@ public:
 	virtual bool valid_predecessor (nano::block const &) const = 0;
 	static size_t size (nano::block_type);
 	virtual nano::work_version work_version () const;
-	uint64_t difficulty () const;
 	// If there are any changes to the hashables, call this to update the cached hash
 	void refresh ();
 

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -180,6 +180,20 @@ uint64_t nano::work_thresholds::threshold_base (nano::work_version const version
 	return result;
 }
 
+uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
+{
+	uint64_t result{ 0 };
+	switch (version_a)
+	{
+		case nano::work_version::work_1:
+			result = value (root_a, work_a);
+			break;
+		default:
+			debug_assert (false && "Invalid version specified to work_difficulty");
+	}
+	return result;
+}
+
 namespace nano
 {
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -108,6 +108,21 @@ uint64_t nano::work_thresholds::threshold (nano::block_details const & details_a
 	return result;
 }
 
+uint64_t nano::work_thresholds::threshold (nano::work_version const version_a, nano::block_details const details_a)
+{
+	static nano::network_constants network_constants;
+	uint64_t result{ std::numeric_limits<uint64_t>::max () };
+	switch (version_a)
+	{
+		case nano::work_version::work_1:
+			result = network_constants.publish_thresholds.threshold (details_a);
+			break;
+		default:
+			debug_assert (false && "Invalid version specified to ledger work_threshold");
+	}
+	return result;
+}
+
 namespace nano
 {
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -24,32 +24,32 @@ struct HexTo
 };
 } // namespace
 
-namespace nano
-{
-work_thresholds const network_constants::publish_full (
+nano::work_thresholds const nano::work_thresholds::publish_full (
 0xffffffc000000000,
 0xfffffff800000000, // 8x higher than epoch_1
 0xfffffe0000000000 // 8x lower than epoch_1
 );
 
-work_thresholds const network_constants::publish_beta (
+nano::work_thresholds const nano::work_thresholds::publish_beta (
 0xfffff00000000000, // 64x lower than publish_full.epoch_1
 0xfffff00000000000, // same as epoch_1
 0xffffe00000000000 // 2x lower than epoch_1
 );
 
-work_thresholds const network_constants::publish_dev (
+nano::work_thresholds const nano::work_thresholds::publish_dev (
 0xfe00000000000000, // Very low for tests
 0xffc0000000000000, // 8x higher than epoch_1
 0xf000000000000000 // 8x lower than epoch_1
 );
 
-work_thresholds const network_constants::publish_test ( //defaults to live network levels
+nano::work_thresholds const nano::work_thresholds::publish_test ( //defaults to live network levels
 get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
 );
 
+namespace nano
+{
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
 uint8_t get_major_node_version ()

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -166,6 +166,20 @@ double nano::work_thresholds::denormalized_multiplier (double const multiplier_a
 	return multiplier;
 }
 
+uint64_t nano::work_thresholds::threshold_base (nano::work_version const version_a)
+{
+	uint64_t result{ std::numeric_limits<uint64_t>::max () };
+	switch (version_a)
+	{
+		case nano::work_version::work_1:
+			result = base;
+			break;
+		default:
+			debug_assert (false && "Invalid version specified to work_threshold_base");
+	}
+	return result;
+}
+
 namespace nano
 {
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -70,6 +70,24 @@ uint64_t nano::work_thresholds::threshold_entry (nano::work_version const versio
 	return result;
 }
 
+#ifndef NANO_FUZZER_TEST
+uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_a)
+{
+	uint64_t result;
+	blake2b_state hash;
+	blake2b_init (&hash, sizeof (result));
+	blake2b_update (&hash, reinterpret_cast<uint8_t *> (&work_a), sizeof (work_a));
+	blake2b_update (&hash, root_a.bytes.data (), root_a.bytes.size ());
+	blake2b_final (&hash, reinterpret_cast<uint8_t *> (&result), sizeof (result));
+	return result;
+}
+#else
+uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_a)
+{
+	return base + 1;
+}
+#endif
+
 namespace nano
 {
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -71,7 +71,7 @@ uint64_t nano::work_thresholds::threshold_entry (nano::work_version const versio
 }
 
 #ifndef NANO_FUZZER_TEST
-uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_a)
+uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_a) const
 {
 	uint64_t result;
 	blake2b_state hash;
@@ -82,13 +82,13 @@ uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_
 	return result;
 }
 #else
-uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_a)
+uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_a) const
 {
 	return base + 1;
 }
 #endif
 
-uint64_t nano::work_thresholds::threshold (nano::block_details const & details_a)
+uint64_t nano::work_thresholds::threshold (nano::block_details const & details_a) const
 {
 	static_assert (nano::epoch::max == nano::epoch::epoch_2, "work_v1::threshold is ill-defined");
 
@@ -108,7 +108,7 @@ uint64_t nano::work_thresholds::threshold (nano::block_details const & details_a
 	return result;
 }
 
-uint64_t nano::work_thresholds::threshold (nano::work_version const version_a, nano::block_details const details_a)
+uint64_t nano::work_thresholds::threshold (nano::work_version const version_a, nano::block_details const details_a) const
 {
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (version_a)
@@ -122,7 +122,7 @@ uint64_t nano::work_thresholds::threshold (nano::work_version const version_a, n
 	return result;
 }
 
-double nano::work_thresholds::normalized_multiplier (double const multiplier_a, uint64_t const threshold_a)
+double nano::work_thresholds::normalized_multiplier (double const multiplier_a, uint64_t const threshold_a) const
 {
 	debug_assert (multiplier_a >= 1);
 	auto multiplier (multiplier_a);
@@ -151,7 +151,7 @@ double nano::work_thresholds::normalized_multiplier (double const multiplier_a, 
 	return multiplier;
 }
 
-double nano::work_thresholds::denormalized_multiplier (double const multiplier_a, uint64_t const threshold_a)
+double nano::work_thresholds::denormalized_multiplier (double const multiplier_a, uint64_t const threshold_a) const
 {
 	debug_assert (multiplier_a >= 1);
 	auto multiplier (multiplier_a);
@@ -165,7 +165,7 @@ double nano::work_thresholds::denormalized_multiplier (double const multiplier_a
 	return multiplier;
 }
 
-uint64_t nano::work_thresholds::threshold_base (nano::work_version const version_a)
+uint64_t nano::work_thresholds::threshold_base (nano::work_version const version_a) const
 {
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (version_a)
@@ -179,7 +179,7 @@ uint64_t nano::work_thresholds::threshold_base (nano::work_version const version
 	return result;
 }
 
-uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
+uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a) const
 {
 	uint64_t result{ 0 };
 	switch (version_a)
@@ -193,7 +193,7 @@ uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, 
 	return result;
 }
 
-bool nano::work_thresholds::validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
+bool nano::work_thresholds::validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a) const
 {
 	return difficulty (version_a, root_a, work_a) < threshold_entry (version_a, nano::block_type::state);
 }

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 
 #include <boost/filesystem/path.hpp>
@@ -47,6 +48,27 @@ get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
 );
+
+uint64_t nano::work_thresholds::threshold_entry (nano::work_version const version_a, nano::block_type const type_a)
+{
+	uint64_t result{ std::numeric_limits<uint64_t>::max () };
+	if (type_a == nano::block_type::state)
+	{
+		switch (version_a)
+		{
+			case nano::work_version::work_1:
+				result = entry;
+				break;
+			default:
+				debug_assert (false && "Invalid version specified to work_threshold_entry");
+		}
+	}
+	else
+	{
+		result = epoch_1;
+	}
+	return result;
+}
 
 namespace nano
 {

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -193,6 +193,11 @@ uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, 
 	return result;
 }
 
+uint64_t nano::work_thresholds::difficulty (nano::block const & block_a) const
+{
+	return difficulty (block_a.work_version (), block_a.root (), block_a.block_work ());
+}
+
 bool nano::work_thresholds::validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a) const
 {
 	return difficulty (version_a, root_a, work_a) < threshold_entry (version_a, nano::block_type::state);
@@ -200,7 +205,7 @@ bool nano::work_thresholds::validate_entry (nano::work_version const version_a, 
 
 bool nano::work_thresholds::validate_entry (nano::block const & block_a) const
 {
-	return block_a.difficulty () < threshold_entry (block_a.work_version (), block_a.type ());
+	return difficulty (block_a) < threshold_entry (block_a.work_version (), block_a.type ());
 }
 
 namespace nano

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -49,7 +49,7 @@ get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x hi
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
 );
 
-uint64_t nano::work_thresholds::threshold_entry (nano::work_version const version_a, nano::block_type const type_a)
+uint64_t nano::work_thresholds::threshold_entry (nano::work_version const version_a, nano::block_type const type_a) const
 {
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	if (type_a == nano::block_type::state)
@@ -110,12 +110,11 @@ uint64_t nano::work_thresholds::threshold (nano::block_details const & details_a
 
 uint64_t nano::work_thresholds::threshold (nano::work_version const version_a, nano::block_details const details_a)
 {
-	static nano::network_constants network_constants;
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = network_constants.publish_thresholds.threshold (details_a);
+			result = threshold (details_a);
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to ledger work_threshold");
@@ -197,6 +196,11 @@ uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, 
 bool nano::work_thresholds::validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
 {
 	return difficulty (version_a, root_a, work_a) < threshold_entry (version_a, nano::block_type::state);
+}
+
+bool nano::work_thresholds::validate_entry (nano::block const & block_a) const
+{
+	return block_a.difficulty () < threshold_entry (block_a.work_version (), block_a.type ());
 }
 
 namespace nano

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -88,6 +88,26 @@ uint64_t nano::work_thresholds::value (nano::root const & root_a, uint64_t work_
 }
 #endif
 
+uint64_t nano::work_thresholds::threshold (nano::block_details const & details_a)
+{
+	static_assert (nano::epoch::max == nano::epoch::epoch_2, "work_v1::threshold is ill-defined");
+
+	uint64_t result{ std::numeric_limits<uint64_t>::max () };
+	switch (details_a.epoch)
+	{
+		case nano::epoch::epoch_2:
+			result = (details_a.is_receive || details_a.is_epoch) ? epoch_2_receive : epoch_2;
+			break;
+		case nano::epoch::epoch_1:
+		case nano::epoch::epoch_0:
+			result = epoch_1;
+			break;
+		default:
+			debug_assert (false && "Invalid epoch specified to work_v1 ledger work_threshold");
+	}
+	return result;
+}
+
 namespace nano
 {
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -194,6 +194,11 @@ uint64_t nano::work_thresholds::difficulty (nano::work_version const version_a, 
 	return result;
 }
 
+bool nano::work_thresholds::validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
+{
+	return difficulty (version_a, root_a, work_a) < threshold_entry (version_a, nano::block_type::state);
+}
+
 namespace nano
 {
 const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -134,9 +134,9 @@ public:
 class network_constants
 {
 public:
-	network_constants (nano::networks network_a) :
+	network_constants (nano::work_thresholds & work, nano::networks network_a) :
 		current_network (network_a),
-		publish_thresholds (is_live_network () ? nano::work_thresholds::publish_full : is_beta_network () ? nano::work_thresholds::publish_beta : is_test_network () ? nano::work_thresholds::publish_test : nano::work_thresholds::publish_dev)
+		work{ work }
 	{
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
@@ -160,7 +160,7 @@ public:
 
 	/** The network this param object represents. This may differ from the global active network; this is needed for certain --debug... commands */
 	nano::networks current_network{ nano::network_constants::active_network };
-	nano::work_thresholds publish_thresholds;
+	nano::work_thresholds & work;
 
 	unsigned principal_weight_factor;
 	uint16_t default_node_port;
@@ -235,7 +235,7 @@ public:
 		return error;
 	}
 
-	const char * get_current_network_as_string () const
+	const char * get_current_network_as_string ()
 	{
 		return is_live_network () ? "live" : is_beta_network () ? "beta" : is_test_network () ? "test" : "dev";
 	}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -134,11 +134,6 @@ public:
 class network_constants
 {
 public:
-	network_constants () :
-		network_constants (network_constants::active_network)
-	{
-	}
-
 	network_constants (nano::networks network_a) :
 		current_network (network_a),
 		publish_thresholds (is_live_network () ? nano::work_thresholds::publish_full : is_beta_network () ? nano::work_thresholds::publish_beta : is_test_network () ? nano::work_thresholds::publish_test : nano::work_thresholds::publish_dev)

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -112,15 +112,15 @@ public:
 	}
 
 	uint64_t threshold_entry (nano::work_version const, nano::block_type const) const;
-	uint64_t threshold (nano::block_details const &);
+	uint64_t threshold (nano::block_details const &) const;
 	// Ledger threshold
-	uint64_t threshold (nano::work_version const, nano::block_details const);
-	uint64_t threshold_base (nano::work_version const);
-	uint64_t value (nano::root const & root_a, uint64_t work_a);
-	double normalized_multiplier (double const, uint64_t const);
-	double denormalized_multiplier (double const, uint64_t const);
-	uint64_t difficulty (nano::work_version const, nano::root const &, uint64_t const);
-	bool validate_entry (nano::work_version const, nano::root const &, uint64_t const);
+	uint64_t threshold (nano::work_version const, nano::block_details const) const;
+	uint64_t threshold_base (nano::work_version const) const;
+	uint64_t value (nano::root const & root_a, uint64_t work_a) const;
+	double normalized_multiplier (double const, uint64_t const) const;
+	double denormalized_multiplier (double const, uint64_t const) const;
+	uint64_t difficulty (nano::work_version const, nano::root const &, uint64_t const) const;
+	bool validate_entry (nano::work_version const, nano::root const &, uint64_t const) const;
 	bool validate_entry (nano::block const &) const;
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -83,6 +83,7 @@ enum class work_version
 };
 enum class block_type : uint8_t;
 class root;
+class block_details;
 
 class work_thresholds
 {
@@ -111,6 +112,7 @@ public:
 
 	uint64_t threshold_entry (nano::work_version const, nano::block_type const);
 	uint64_t value (nano::root const & root_a, uint64_t work_a);
+	uint64_t threshold (nano::block_details const &);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -113,6 +113,8 @@ public:
 	uint64_t threshold_entry (nano::work_version const, nano::block_type const);
 	uint64_t value (nano::root const & root_a, uint64_t work_a);
 	uint64_t threshold (nano::block_details const &);
+	// Ledger threshold
+	uint64_t threshold (nano::work_version const, nano::block_details const);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -115,6 +115,8 @@ public:
 	uint64_t threshold (nano::block_details const &);
 	// Ledger threshold
 	uint64_t threshold (nano::work_version const, nano::block_details const);
+	double normalized_multiplier (double const, uint64_t const);
+	double denormalized_multiplier (double const, uint64_t const);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -111,10 +111,11 @@ public:
 	}
 
 	uint64_t threshold_entry (nano::work_version const, nano::block_type const);
-	uint64_t value (nano::root const & root_a, uint64_t work_a);
 	uint64_t threshold (nano::block_details const &);
 	// Ledger threshold
 	uint64_t threshold (nano::work_version const, nano::block_details const);
+	uint64_t threshold_base (nano::work_version const);
+	uint64_t value (nano::root const & root_a, uint64_t work_a);
 	double normalized_multiplier (double const, uint64_t const);
 	double denormalized_multiplier (double const, uint64_t const);
 

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -83,6 +83,7 @@ enum class work_version
 };
 enum class block_type : uint8_t;
 class root;
+class block;
 class block_details;
 
 class work_thresholds
@@ -110,7 +111,7 @@ public:
 		return other_a;
 	}
 
-	uint64_t threshold_entry (nano::work_version const, nano::block_type const);
+	uint64_t threshold_entry (nano::work_version const, nano::block_type const) const;
 	uint64_t threshold (nano::block_details const &);
 	// Ledger threshold
 	uint64_t threshold (nano::work_version const, nano::block_details const);
@@ -120,6 +121,7 @@ public:
 	double denormalized_multiplier (double const, uint64_t const);
 	uint64_t difficulty (nano::work_version const, nano::root const &, uint64_t const);
 	bool validate_entry (nano::work_version const, nano::root const &, uint64_t const);
+	bool validate_entry (nano::block const &) const;
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -76,8 +76,16 @@ enum class networks : uint16_t
 	nano_test_network = 0x5258, // 'R', 'X'
 };
 
-struct work_thresholds
+enum class work_version
 {
+	unspecified,
+	work_1
+};
+enum class block_type : uint8_t;
+
+class work_thresholds
+{
+public:
 	uint64_t const epoch_1;
 	uint64_t const epoch_2;
 	uint64_t const epoch_2_receive;
@@ -99,6 +107,8 @@ struct work_thresholds
 	{
 		return other_a;
 	}
+
+	uint64_t threshold_entry (nano::work_version const, nano::block_type const);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -118,6 +118,7 @@ public:
 	uint64_t value (nano::root const & root_a, uint64_t work_a);
 	double normalized_multiplier (double const, uint64_t const);
 	double denormalized_multiplier (double const, uint64_t const);
+	uint64_t difficulty (nano::work_version const, nano::root const &, uint64_t const);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -119,6 +119,7 @@ public:
 	double normalized_multiplier (double const, uint64_t const);
 	double denormalized_multiplier (double const, uint64_t const);
 	uint64_t difficulty (nano::work_version const, nano::root const &, uint64_t const);
+	bool validate_entry (nano::work_version const, nano::root const &, uint64_t const);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -82,6 +82,7 @@ enum class work_version
 	work_1
 };
 enum class block_type : uint8_t;
+class root;
 
 class work_thresholds
 {
@@ -109,6 +110,7 @@ public:
 	}
 
 	uint64_t threshold_entry (nano::work_version const, nano::block_type const);
+	uint64_t value (nano::root const & root_a, uint64_t work_a);
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
 	static const nano::work_thresholds publish_full;

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -120,6 +120,7 @@ public:
 	double normalized_multiplier (double const, uint64_t const) const;
 	double denormalized_multiplier (double const, uint64_t const) const;
 	uint64_t difficulty (nano::work_version const, nano::root const &, uint64_t const) const;
+	uint64_t difficulty (nano::block const & block_a) const;
 	bool validate_entry (nano::work_version const, nano::root const &, uint64_t const) const;
 	bool validate_entry (nano::block const &) const;
 

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -99,6 +99,12 @@ struct work_thresholds
 	{
 		return other_a;
 	}
+
+	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
+	static const nano::work_thresholds publish_full;
+	static const nano::work_thresholds publish_beta;
+	static const nano::work_thresholds publish_dev;
+	static const nano::work_thresholds publish_test;
 };
 
 class network_constants
@@ -111,7 +117,7 @@ public:
 
 	network_constants (nano::networks network_a) :
 		current_network (network_a),
-		publish_thresholds (is_live_network () ? publish_full : is_beta_network () ? publish_beta : is_test_network () ? publish_test : publish_dev)
+		publish_thresholds (is_live_network () ? nano::work_thresholds::publish_full : is_beta_network () ? nano::work_thresholds::publish_beta : is_test_network () ? nano::work_thresholds::publish_test : nano::work_thresholds::publish_dev)
 	{
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
@@ -129,12 +135,6 @@ public:
 		max_peers_per_subnetwork = max_peers_per_ip * 4;
 		peer_dump_interval = is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
 	}
-
-	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
-	static const nano::work_thresholds publish_full;
-	static const nano::work_thresholds publish_beta;
-	static const nano::work_thresholds publish_dev;
-	static const nano::work_thresholds publish_test;
 
 	/** Error message when an invalid network is specified */
 	static const char * active_network_err_msg;

--- a/nano/lib/rocksdbconfig.cpp
+++ b/nano/lib/rocksdbconfig.cpp
@@ -31,7 +31,6 @@ nano::error nano::rocksdb_config::deserialize_toml (nano::tomlconfig & toml)
 
 bool nano::rocksdb_config::using_rocksdb_in_tests ()
 {
-	static nano::network_constants network_constants;
 	auto use_rocksdb_str = std::getenv ("TEST_USE_ROCKSDB");
-	return network_constants.is_dev_network () && use_rocksdb_str && (boost::lexical_cast<int> (use_rocksdb_str) == 1);
+	return use_rocksdb_str && (boost::lexical_cast<int> (use_rocksdb_str) == 1);
 }

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -54,15 +54,17 @@ nano::error nano::rpc_secure_config::deserialize_toml (nano::tomlconfig & toml)
 	return toml.get_error ();
 }
 
-nano::rpc_config::rpc_config () :
-	address (boost::asio::ip::address_v6::loopback ().to_string ())
+nano::rpc_config::rpc_config (nano::network_constants & network_constants) :
+	rpc_process{ network_constants },
+	address{ boost::asio::ip::address_v6::loopback ().to_string () }
 {
 }
 
-nano::rpc_config::rpc_config (uint16_t port_a, bool enable_control_a) :
-	address (boost::asio::ip::address_v6::loopback ().to_string ()),
-	port (port_a),
-	enable_control (enable_control_a)
+nano::rpc_config::rpc_config (nano::network_constants & network_constants, uint16_t port_a, bool enable_control_a) :
+	rpc_process{ network_constants },
+	address{ boost::asio::ip::address_v6::loopback ().to_string () },
+	port{ port_a },
+	enable_control{ enable_control_a }
 {
 }
 
@@ -183,8 +185,9 @@ nano::error nano::rpc_config::deserialize_toml (nano::tomlconfig & toml)
 	return toml.get_error ();
 }
 
-nano::rpc_process_config::rpc_process_config () :
-	ipc_address (boost::asio::ip::address_v6::loopback ().to_string ())
+nano::rpc_process_config::rpc_process_config (nano::network_constants & network_constants) :
+	network_constants{ network_constants },
+	ipc_address{ boost::asio::ip::address_v6::loopback ().to_string () }
 {
 }
 
@@ -206,7 +209,7 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 		else
 		{
 			// Migrate
-			nano::rpc_config config_json_l;
+			nano::rpc_config config_json_l{ config_a.rpc_process.network_constants };
 			error = read_and_update_rpc_config (data_path_a, config_json_l);
 
 			if (!error)
@@ -215,7 +218,7 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 				config_json_l.serialize_toml (toml_l);
 
 				// Only write out non-default values
-				nano::rpc_config config_defaults_l;
+				nano::rpc_config config_defaults_l{ config_a.rpc_process.network_constants };
 				nano::tomlconfig toml_defaults_l;
 				config_defaults_l.serialize_toml (toml_defaults_l);
 

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -48,8 +48,8 @@ public:
 class rpc_process_config final
 {
 public:
-	rpc_process_config ();
-	nano::network_constants network_constants;
+	rpc_process_config (nano::network_constants & network_constants);
+	nano::network_constants & network_constants;
 	unsigned io_threads{ (4 < std::thread::hardware_concurrency ()) ? std::thread::hardware_concurrency () : 4 };
 	std::string ipc_address;
 	uint16_t ipc_port{ network_constants.default_ipc_port };
@@ -69,8 +69,8 @@ public:
 class rpc_config final
 {
 public:
-	rpc_config ();
-	explicit rpc_config (uint16_t, bool);
+	explicit rpc_config (nano::network_constants & network_constants);
+	explicit rpc_config (nano::network_constants & network_constants, uint16_t, bool);
 	nano::error serialize_json (nano::jsonconfig &) const;
 	nano::error deserialize_json (bool & upgraded_a, nano::jsonconfig &);
 	nano::error serialize_toml (nano::tomlconfig &) const;

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -123,8 +123,7 @@ nano::thread_runner::thread_runner (boost::asio::io_context & io_ctx_a, unsigned
 {
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
-	auto count = (is_sanitizer_build && nano::network_constants{}.is_dev_network ()) ? 1 : service_threads_a; // This is a workaround to a bad interaction between TSAN, multiple coroutines, and multiple threads servicing io_context. Only use 1 thread if sanitizers are attached
-	for (auto i (0u); i < count; ++i)
+	for (auto i (0u); i < service_threads_a; ++i)
 	{
 		threads.emplace_back (attrs, [&io_ctx_a] () {
 			nano::thread_role::set (nano::thread_role::name::io);

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -376,14 +376,12 @@ void nano::work_pool::generate (nano::work_version const version_a, nano::root c
 
 boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a)
 {
-	static nano::network_constants network_constants;
 	debug_assert (network_constants.is_dev_network ());
 	return generate (nano::work_version::work_1, root_a, network_constants.publish_thresholds.base);
 }
 
 boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a, uint64_t difficulty_a)
 {
-	static nano::network_constants network_constants;
 	debug_assert (network_constants.is_dev_network ());
 	return generate (nano::work_version::work_1, root_a, difficulty_a);
 }

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -64,21 +64,6 @@ uint64_t nano::work_threshold_base (nano::work_version const version_a)
 	return result;
 }
 
-uint64_t nano::work_threshold (nano::work_version const version_a, nano::block_details const details_a)
-{
-	static nano::network_constants network_constants;
-	uint64_t result{ std::numeric_limits<uint64_t>::max () };
-	switch (version_a)
-	{
-		case nano::work_version::work_1:
-			result = network_constants.publish_thresholds.threshold (details_a);
-			break;
-		default:
-			debug_assert (false && "Invalid version specified to ledger work_threshold");
-	}
-	return result;
-}
-
 double nano::normalized_multiplier (double const multiplier_a, uint64_t const threshold_a)
 {
 	static nano::network_constants network_constants;

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -90,7 +90,7 @@ void nano::work_pool::loop (uint64_t thread)
 			if (opt_work.is_initialized ())
 			{
 				work = *opt_work;
-				output = network_constants.publish_thresholds.value (current_l.item, work);
+				output = network_constants.work.value (current_l.item, work);
 			}
 			else
 			{
@@ -123,7 +123,7 @@ void nano::work_pool::loop (uint64_t thread)
 			{
 				// If the ticket matches what we started with, we're the ones that found the solution
 				debug_assert (output >= current_l.difficulty);
-				debug_assert (current_l.difficulty == 0 || network_constants.publish_thresholds.value (current_l.item, work) == output);
+				debug_assert (current_l.difficulty == 0 || network_constants.work.value (current_l.item, work) == output);
 				// Signal other threads to stop their work next time they check ticket
 				++ticket;
 				pending.pop_front ();
@@ -201,7 +201,7 @@ void nano::work_pool::generate (nano::work_version const version_a, nano::root c
 boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a)
 {
 	debug_assert (network_constants.is_dev_network ());
-	return generate (nano::work_version::work_1, root_a, network_constants.publish_thresholds.base);
+	return generate (nano::work_version::work_1, root_a, network_constants.work.base);
 }
 
 boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a, uint64_t difficulty_a)

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -49,21 +49,6 @@ uint64_t nano::work_difficulty (nano::work_version const version_a, nano::root c
 	return result;
 }
 
-uint64_t nano::work_threshold_base (nano::work_version const version_a)
-{
-	uint64_t result{ std::numeric_limits<uint64_t>::max () };
-	switch (version_a)
-	{
-		case nano::work_version::work_1:
-			static nano::network_constants network_constants;
-			result = network_constants.publish_thresholds.base;
-			break;
-		default:
-			debug_assert (false && "Invalid version specified to work_threshold_base");
-	}
-	return result;
-}
-
 nano::work_pool::work_pool (nano::network_constants & network_constants, unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
 	network_constants{ network_constants },
 	ticket (0),

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -24,12 +24,14 @@ std::string nano::to_string (nano::work_version const version_a)
 
 bool nano::work_validate_entry (nano::block const & block_a)
 {
-	return block_a.difficulty () < nano::work_threshold_entry (block_a.work_version (), block_a.type ());
+	static nano::network_constants network_constants;
+	return block_a.difficulty () < network_constants.publish_thresholds.threshold_entry (block_a.work_version (), block_a.type ());
 }
 
 bool nano::work_validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
 {
-	return nano::work_difficulty (version_a, root_a, work_a) < nano::work_threshold_entry (version_a, nano::block_type::state);
+	static nano::network_constants network_constants;
+	return nano::work_difficulty (version_a, root_a, work_a) < network_constants.publish_thresholds.threshold_entry (version_a, nano::block_type::state);
 }
 
 uint64_t nano::work_difficulty (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
@@ -52,32 +54,11 @@ uint64_t nano::work_threshold_base (nano::work_version const version_a)
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = nano::work_v1::threshold_base ();
+			static nano::network_constants network_constants;
+			result = network_constants.publish_thresholds.base;
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to work_threshold_base");
-	}
-	return result;
-}
-
-uint64_t nano::work_threshold_entry (nano::work_version const version_a, nano::block_type const type_a)
-{
-	uint64_t result{ std::numeric_limits<uint64_t>::max () };
-	if (type_a == nano::block_type::state)
-	{
-		switch (version_a)
-		{
-			case nano::work_version::work_1:
-				result = nano::work_v1::threshold_entry ();
-				break;
-			default:
-				debug_assert (false && "Invalid version specified to work_threshold_entry");
-		}
-	}
-	else
-	{
-		static nano::network_constants network_constants;
-		result = network_constants.publish_thresholds.epoch_1;
 	}
 	return result;
 }
@@ -94,18 +75,6 @@ uint64_t nano::work_threshold (nano::work_version const version_a, nano::block_d
 			debug_assert (false && "Invalid version specified to ledger work_threshold");
 	}
 	return result;
-}
-
-uint64_t nano::work_v1::threshold_base ()
-{
-	static nano::network_constants network_constants;
-	return network_constants.publish_thresholds.base;
-}
-
-uint64_t nano::work_v1::threshold_entry ()
-{
-	static nano::network_constants network_constants;
-	return network_constants.publish_thresholds.entry;
 }
 
 uint64_t nano::work_v1::threshold (nano::block_details const details_a)

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -64,51 +64,6 @@ uint64_t nano::work_threshold_base (nano::work_version const version_a)
 	return result;
 }
 
-double nano::normalized_multiplier (double const multiplier_a, uint64_t const threshold_a)
-{
-	static nano::network_constants network_constants;
-	debug_assert (multiplier_a >= 1);
-	auto multiplier (multiplier_a);
-	/* Normalization rules
-	ratio = multiplier of max work threshold (send epoch 2) from given threshold
-	i.e. max = 0xfe00000000000000, given = 0xf000000000000000, ratio = 8.0
-	normalized = (multiplier + (ratio - 1)) / ratio;
-	Epoch 1
-	multiplier	 | normalized
-	1.0 		 | 1.0
-	9.0 		 | 2.0
-	25.0 		 | 4.0
-	Epoch 2 (receive / epoch subtypes)
-	multiplier	 | normalized
-	1.0 		 | 1.0
-	65.0 		 | 2.0
-	241.0 		 | 4.0
-	*/
-	if (threshold_a == network_constants.publish_thresholds.epoch_1 || threshold_a == network_constants.publish_thresholds.epoch_2_receive)
-	{
-		auto ratio (nano::difficulty::to_multiplier (network_constants.publish_thresholds.epoch_2, threshold_a));
-		debug_assert (ratio >= 1);
-		multiplier = (multiplier + (ratio - 1.0)) / ratio;
-		debug_assert (multiplier >= 1);
-	}
-	return multiplier;
-}
-
-double nano::denormalized_multiplier (double const multiplier_a, uint64_t const threshold_a)
-{
-	static nano::network_constants network_constants;
-	debug_assert (multiplier_a >= 1);
-	auto multiplier (multiplier_a);
-	if (threshold_a == network_constants.publish_thresholds.epoch_1 || threshold_a == network_constants.publish_thresholds.epoch_2_receive)
-	{
-		auto ratio (nano::difficulty::to_multiplier (network_constants.publish_thresholds.epoch_2, threshold_a));
-		debug_assert (ratio >= 1);
-		multiplier = multiplier * ratio + 1.0 - ratio;
-		debug_assert (multiplier >= 1);
-	}
-	return multiplier;
-}
-
 nano::work_pool::work_pool (nano::network_constants & network_constants, unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
 	network_constants{ network_constants },
 	ticket (0),

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -28,12 +28,6 @@ bool nano::work_validate_entry (nano::block const & block_a)
 	return block_a.difficulty () < network_constants.publish_thresholds.threshold_entry (block_a.work_version (), block_a.type ());
 }
 
-bool nano::work_validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
-{
-	static nano::network_constants network_constants;
-	return network_constants.publish_thresholds.difficulty (version_a, root_a, work_a) < network_constants.publish_thresholds.threshold_entry (version_a, nano::block_type::state);
-}
-
 nano::work_pool::work_pool (nano::network_constants & network_constants, unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
 	network_constants{ network_constants },
 	ticket (0),

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -198,7 +198,8 @@ double nano::denormalized_multiplier (double const multiplier_a, uint64_t const 
 	return multiplier;
 }
 
-nano::work_pool::work_pool (unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
+nano::work_pool::work_pool (nano::network_constants & network_constants, unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
+	network_constants{ network_constants },
 	ticket (0),
 	done (false),
 	pow_rate_limiter (pow_rate_limiter_a),

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -31,22 +31,7 @@ bool nano::work_validate_entry (nano::block const & block_a)
 bool nano::work_validate_entry (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
 {
 	static nano::network_constants network_constants;
-	return nano::work_difficulty (version_a, root_a, work_a) < network_constants.publish_thresholds.threshold_entry (version_a, nano::block_type::state);
-}
-
-uint64_t nano::work_difficulty (nano::work_version const version_a, nano::root const & root_a, uint64_t const work_a)
-{
-	static nano::network_constants network_constants;
-	uint64_t result{ 0 };
-	switch (version_a)
-	{
-		case nano::work_version::work_1:
-			result = network_constants.publish_thresholds.value (root_a, work_a);
-			break;
-		default:
-			debug_assert (false && "Invalid version specified to work_difficulty");
-	}
-	return result;
+	return network_constants.publish_thresholds.difficulty (version_a, root_a, work_a) < network_constants.publish_thresholds.threshold_entry (version_a, nano::block_type::state);
 }
 
 nano::work_pool::work_pool (nano::network_constants & network_constants, unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -22,12 +22,6 @@ std::string nano::to_string (nano::work_version const version_a)
 	return result;
 }
 
-bool nano::work_validate_entry (nano::block const & block_a)
-{
-	static nano::network_constants network_constants;
-	return block_a.difficulty () < network_constants.publish_thresholds.threshold_entry (block_a.work_version (), block_a.type ());
-}
-
 nano::work_pool::work_pool (nano::network_constants & network_constants, unsigned max_threads_a, std::chrono::nanoseconds pow_rate_limiter_a, std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl_a) :
 	network_constants{ network_constants },
 	ticket (0),

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -66,35 +66,15 @@ uint64_t nano::work_threshold_base (nano::work_version const version_a)
 
 uint64_t nano::work_threshold (nano::work_version const version_a, nano::block_details const details_a)
 {
+	static nano::network_constants network_constants;
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = nano::work_v1::threshold (details_a);
+			result = network_constants.publish_thresholds.threshold (details_a);
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to ledger work_threshold");
-	}
-	return result;
-}
-
-uint64_t nano::work_v1::threshold (nano::block_details const details_a)
-{
-	static_assert (nano::epoch::max == nano::epoch::epoch_2, "work_v1::threshold is ill-defined");
-	static nano::network_constants network_constants;
-
-	uint64_t result{ std::numeric_limits<uint64_t>::max () };
-	switch (details_a.epoch)
-	{
-		case nano::epoch::epoch_2:
-			result = (details_a.is_receive || details_a.is_epoch) ? network_constants.publish_thresholds.epoch_2_receive : network_constants.publish_thresholds.epoch_2;
-			break;
-		case nano::epoch::epoch_1:
-		case nano::epoch::epoch_0:
-			result = network_constants.publish_thresholds.epoch_1;
-			break;
-		default:
-			debug_assert (false && "Invalid epoch specified to work_v1 ledger work_threshold");
 	}
 	return result;
 }

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -13,11 +13,6 @@
 
 namespace nano
 {
-enum class work_version
-{
-	unspecified,
-	work_1
-};
 std::string to_string (nano::work_version const version_a);
 
 class block;
@@ -29,15 +24,12 @@ bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t
 uint64_t work_difficulty (nano::work_version const, nano::root const &, uint64_t const);
 
 uint64_t work_threshold_base (nano::work_version const);
-uint64_t work_threshold_entry (nano::work_version const, nano::block_type const);
 // Ledger threshold
 uint64_t work_threshold (nano::work_version const, nano::block_details const);
 
 namespace work_v1
 {
 	uint64_t value (nano::root const & root_a, uint64_t work_a);
-	uint64_t threshold_base ();
-	uint64_t threshold_entry ();
 	uint64_t threshold (nano::block_details const);
 }
 

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -21,8 +21,6 @@ enum class block_type : uint8_t;
 bool work_validate_entry (nano::block const &);
 bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t const);
 
-uint64_t work_difficulty (nano::work_version const, nano::root const &, uint64_t const);
-
 class opencl_work;
 class work_item final
 {

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -29,7 +29,6 @@ uint64_t work_threshold (nano::work_version const, nano::block_details const);
 
 namespace work_v1
 {
-	uint64_t value (nano::root const & root_a, uint64_t work_a);
 	uint64_t threshold (nano::block_details const);
 }
 

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -19,7 +19,6 @@ class block;
 class block_details;
 enum class block_type : uint8_t;
 bool work_validate_entry (nano::block const &);
-bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t const);
 
 class opencl_work;
 class work_item final

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -24,8 +24,6 @@ bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t
 uint64_t work_difficulty (nano::work_version const, nano::root const &, uint64_t const);
 
 uint64_t work_threshold_base (nano::work_version const);
-// Ledger threshold
-uint64_t work_threshold (nano::work_version const, nano::block_details const);
 
 double normalized_multiplier (double const, uint64_t const);
 double denormalized_multiplier (double const, uint64_t const);

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -59,7 +59,7 @@ public:
 class work_pool final
 {
 public:
-	work_pool (unsigned, std::chrono::nanoseconds = std::chrono::nanoseconds (0), std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> = nullptr);
+	work_pool (nano::network_constants & network_constants, unsigned, std::chrono::nanoseconds = std::chrono::nanoseconds (0), std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> = nullptr);
 	~work_pool ();
 	void loop (uint64_t);
 	void stop ();
@@ -70,7 +70,7 @@ public:
 	boost::optional<uint64_t> generate (nano::root const &);
 	boost::optional<uint64_t> generate (nano::root const &, uint64_t);
 	size_t size ();
-	nano::network_constants network_constants;
+	nano::network_constants & network_constants;
 	std::atomic<int> ticket;
 	bool done;
 	std::vector<boost::thread> threads;

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -23,7 +23,6 @@ bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t
 
 uint64_t work_difficulty (nano::work_version const, nano::root const &, uint64_t const);
 
-uint64_t work_threshold_base (nano::work_version const);
 class opencl_work;
 class work_item final
 {

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -24,9 +24,6 @@ bool work_validate_entry (nano::work_version const, nano::root const &, uint64_t
 uint64_t work_difficulty (nano::work_version const, nano::root const &, uint64_t const);
 
 uint64_t work_threshold_base (nano::work_version const);
-
-double normalized_multiplier (double const, uint64_t const);
-double denormalized_multiplier (double const, uint64_t const);
 class opencl_work;
 class work_item final
 {

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -18,7 +18,6 @@ std::string to_string (nano::work_version const version_a);
 class block;
 class block_details;
 enum class block_type : uint8_t;
-bool work_validate_entry (nano::block const &);
 
 class opencl_work;
 class work_item final

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -27,11 +27,6 @@ uint64_t work_threshold_base (nano::work_version const);
 // Ledger threshold
 uint64_t work_threshold (nano::work_version const, nano::block_details const);
 
-namespace work_v1
-{
-	uint64_t threshold (nano::block_details const);
-}
-
 double normalized_multiplier (double const, uint64_t const);
 double denormalized_multiplier (double const, uint64_t const);
 class opencl_work;

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -56,7 +56,7 @@ void write_config_files (boost::filesystem::path const & data_path, int index)
 	daemon_config.serialize_toml (toml);
 	toml.write (nano::get_node_toml_config_path (data_path));
 
-	nano::rpc_config rpc_config;
+	nano::rpc_config rpc_config{ daemon_config.node.network_params.network };
 	rpc_config.port = rpc_port_start + index;
 	rpc_config.enable_control = true;
 	rpc_config.rpc_process.ipc_port = ipc_port_start + index;

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -360,8 +360,7 @@ int main (int argc, char * const * argv)
 		data_paths.push_back (std::move (data_path));
 	}
 
-	nano::network_constants network_constants;
-	auto current_network = network_constants.get_current_network_as_string ();
+	auto current_network = nano::dev::network_params.network.get_current_network_as_string ();
 	std::vector<std::unique_ptr<boost::process::child>> nodes;
 	std::vector<std::unique_ptr<boost::process::child>> rpc_servers;
 	for (auto const & data_path : data_paths)

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -119,7 +119,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 					if (!config.rpc.child_process.enable)
 					{
 						// Launch rpc in-process
-						nano::rpc_config rpc_config;
+						nano::rpc_config rpc_config{ config.node.network_params.network };
 						auto error = nano::read_rpc_config_toml (data_path, rpc_config, flags.rpc_config_overrides);
 						if (error)
 						{

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -60,7 +60,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 		config.node.logging.init (data_path);
 		nano::logger_mt logger{ config.node.logging.min_time_between_log_output };
 		boost::asio::io_context io_ctx;
-		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
+		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.network.publish_thresholds));
 		nano::work_pool opencl_work (config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
 			return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
 		}

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -60,7 +60,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 		config.node.logging.init (data_path);
 		nano::logger_mt logger{ config.node.logging.min_time_between_log_output };
 		boost::asio::io_context io_ctx;
-		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.network.publish_thresholds));
+		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.work));
 		nano::work_pool opencl_work (config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
 			return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
 		}

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -61,7 +61,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 		nano::logger_mt logger{ config.node.logging.min_time_between_log_output };
 		boost::asio::io_context io_ctx;
 		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
-		nano::work_pool opencl_work (config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
+		nano::work_pool opencl_work (config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
 			return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
 		}
 																									  : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1567,7 +1567,7 @@ int main (int argc, char * const * argv)
 						}
 					}
 					// Check if block work value is correct
-					if (block->difficulty () < node->network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details))
+					if (node->network_params.network.publish_thresholds.difficulty (*block) < node->network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details))
 					{
 						print_error_message (boost::str (boost::format ("Invalid work for block %1% value: %2%\n") % hash.to_string () % nano::to_string_hex (block->block_work ())));
 					}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -325,7 +325,7 @@ int main (int argc, char * const * argv)
 				if (!key.decode_hex (key_it->second.as<std::string> ()))
 				{
 					nano::keypair genesis (key.to_string ());
-					nano::work_pool work{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+					nano::work_pool work{ network_params.network, std::numeric_limits<unsigned>::max () };
 					std::cout << "Genesis: " << genesis.prv.to_string () << "\n"
 							  << "Public: " << genesis.pub.to_string () << "\n"
 							  << "Account: " << genesis.pub.to_account () << "\n";
@@ -341,7 +341,7 @@ int main (int argc, char * const * argv)
 								  << "Account: " << rep.pub.to_account () << "\n";
 					}
 					nano::uint128_t balance (std::numeric_limits<nano::uint128_t>::max ());
-					nano::open_block genesis_block (reinterpret_cast<const nano::block_hash &> (genesis.pub), genesis.pub, genesis.pub, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, genesis.pub, network_params.network.publish_thresholds.epoch_1));
+					nano::open_block genesis_block (reinterpret_cast<const nano::block_hash &> (genesis.pub), genesis.pub, genesis.pub, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, genesis.pub, network_params.work.epoch_1));
 					std::cout << genesis_block.to_json ();
 					std::cout.flush ();
 					nano::block_hash previous (genesis_block.hash ());
@@ -353,7 +353,7 @@ int main (int argc, char * const * argv)
 						{
 							debug_assert (balance > weekly_distribution);
 							balance = balance < (weekly_distribution * 2) ? 0 : balance - weekly_distribution;
-							nano::send_block send (previous, landing.pub, balance, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, previous, network_params.network.publish_thresholds.epoch_1));
+							nano::send_block send (previous, landing.pub, balance, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, previous, network_params.work.epoch_1));
 							previous = send.hash ();
 							std::cout << send.to_json ();
 							std::cout.flush ();
@@ -515,7 +515,7 @@ int main (int argc, char * const * argv)
 			uint64_t count{ 10000000U }; // 10M
 			for (uint64_t i (0); i < count; ++i)
 			{
-				valid = network_params.network.publish_thresholds.value (hash, i) > difficulty;
+				valid = network_params.work.value (hash, i) > difficulty;
 			}
 			std::ostringstream oss (valid ? "true" : "false"); // IO forces compiler to not dismiss the variable
 			auto total_time (std::chrono::duration_cast<std::chrono::nanoseconds> (std::chrono::steady_clock::now () - start).count ());
@@ -607,7 +607,7 @@ int main (int argc, char * const * argv)
 						{
 							nano::logger_mt logger;
 							nano::opencl_config config (platform, device, threads);
-							auto opencl (nano::opencl_work::create (true, config, logger, network_params.network.publish_thresholds));
+							auto opencl (nano::opencl_work::create (true, config, logger, network_params.work));
 							nano::work_pool work_pool{ network_params.network, 0, std::chrono::nanoseconds (0), opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 								return opencl->generate_work (version_a, root_a, difficulty_a);
 							}
@@ -914,7 +914,7 @@ int main (int argc, char * const * argv)
 							.balance (genesis_balance)
 							.link (keys[i].pub)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							.work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
+							.work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.work.epoch_1))
 							.build ();
 
 				genesis_latest = send->hash ();
@@ -927,7 +927,7 @@ int main (int argc, char * const * argv)
 							.balance (balances[i])
 							.link (genesis_latest)
 							.sign (keys[i].prv, keys[i].pub)
-							.work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.network.publish_thresholds.epoch_1))
+							.work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.work.epoch_1))
 							.build ();
 
 				frontiers[i] = open->hash ();
@@ -948,7 +948,7 @@ int main (int argc, char * const * argv)
 								.balance (balances[j])
 								.link (keys[other].pub)
 								.sign (keys[j].prv, keys[j].pub)
-								.work (*node->work.generate (nano::work_version::work_1, frontiers[j], node->network_params.network.publish_thresholds.epoch_1))
+								.work (*node->work.generate (nano::work_version::work_1, frontiers[j], node->network_params.work.epoch_1))
 								.build ();
 
 					frontiers[j] = send->hash ();
@@ -963,7 +963,7 @@ int main (int argc, char * const * argv)
 								   .balance (balances[other])
 								   .link (frontiers[j].as_block_hash ())
 								   .sign (keys[other].prv, keys[other].pub)
-								   .work (*node->work.generate (nano::work_version::work_1, frontiers[other], node->network_params.network.publish_thresholds.epoch_1))
+								   .work (*node->work.generate (nano::work_version::work_1, frontiers[other], node->network_params.work.epoch_1))
 								   .build ();
 
 					frontiers[other] = receive->hash ();
@@ -1027,7 +1027,7 @@ int main (int argc, char * const * argv)
 							.balance (genesis_balance)
 							.link (keys[i].pub)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							.work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
+							.work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.work.epoch_1))
 							.build ();
 
 				genesis_latest = send->hash ();
@@ -1040,7 +1040,7 @@ int main (int argc, char * const * argv)
 							.balance (balance)
 							.link (genesis_latest)
 							.sign (keys[i].prv, keys[i].pub)
-							.work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.network.publish_thresholds.epoch_1))
+							.work (*node->work.generate (nano::work_version::work_1, keys[i].pub, node->network_params.work.epoch_1))
 							.build ();
 
 				node->ledger.process (transaction, *open);
@@ -1059,7 +1059,7 @@ int main (int argc, char * const * argv)
 							.balance (genesis_balance)
 							.link (destination.pub)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							.work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.network.publish_thresholds.epoch_1))
+							.work (*node->work.generate (nano::work_version::work_1, genesis_latest, node->network_params.work.epoch_1))
 							.build ();
 
 				genesis_latest = send->hash ();
@@ -1124,7 +1124,7 @@ int main (int argc, char * const * argv)
 			std::cout << boost::str (boost::format ("Starting generating %1% blocks...\n") % (count * 2));
 			boost::asio::io_context io_ctx1;
 			boost::asio::io_context io_ctx2;
-			nano::work_pool work{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+			nano::work_pool work{ network_params.network, std::numeric_limits<unsigned>::max () };
 			nano::logging logging;
 			auto path1 (nano::unique_path ());
 			auto path2 (nano::unique_path ());
@@ -1164,7 +1164,7 @@ int main (int argc, char * const * argv)
 							.balance (genesis_balance)
 							.link (key.pub)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							.work (*work.generate (nano::work_version::work_1, genesis_latest, nano::dev::network_params.network.publish_thresholds.epoch_1))
+							.work (*work.generate (nano::work_version::work_1, genesis_latest, nano::dev::network_params.work.epoch_1))
 							.build ();
 
 				genesis_latest = send->hash ();
@@ -1176,7 +1176,7 @@ int main (int argc, char * const * argv)
 							.balance (1)
 							.link (genesis_latest)
 							.sign (key.prv, key.pub)
-							.work (*work.generate (nano::work_version::work_1, key.pub, nano::dev::network_params.network.publish_thresholds.epoch_1))
+							.work (*work.generate (nano::work_version::work_1, key.pub, nano::dev::network_params.work.epoch_1))
 							.build ();
 
 				blocks.push_back (std::move (send));
@@ -1564,7 +1564,7 @@ int main (int argc, char * const * argv)
 						}
 					}
 					// Check if block work value is correct
-					if (node->network_params.network.publish_thresholds.difficulty (*block) < node->network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details))
+					if (node->network_params.work.difficulty (*block) < node->network_params.work.threshold (block->work_version (), block->sideband ().details))
 					{
 						print_error_message (boost::str (boost::format ("Invalid work for block %1% value: %2%\n") % hash.to_string () % nano::to_string_hex (block->block_work ())));
 					}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -508,6 +508,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_validate"))
 		{
+			nano::network_constants network_constants;
 			uint64_t difficulty{ nano::work_thresholds::publish_full.base };
 			std::cerr << "Starting validation profile" << std::endl;
 			auto start (std::chrono::steady_clock::now ());
@@ -516,7 +517,7 @@ int main (int argc, char * const * argv)
 			uint64_t count{ 10000000U }; // 10M
 			for (uint64_t i (0); i < count; ++i)
 			{
-				valid = nano::work_v1::value (hash, i) > difficulty;
+				valid = network_constants.publish_thresholds.value (hash, i) > difficulty;
 			}
 			std::ostringstream oss (valid ? "true" : "false"); // IO forces compiler to not dismiss the variable
 			auto total_time (std::chrono::duration_cast<std::chrono::nanoseconds> (std::chrono::steady_clock::now () - start).count ());

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1567,7 +1567,7 @@ int main (int argc, char * const * argv)
 						}
 					}
 					// Check if block work value is correct
-					if (block->difficulty () < nano::work_threshold (block->work_version (), block->sideband ().details))
+					if (block->difficulty () < node->network_params.network.publish_thresholds.threshold (block->work_version (), block->sideband ().details))
 					{
 						print_error_message (boost::str (boost::format ("Invalid work for block %1% value: %2%\n") % hash.to_string () % nano::to_string_hex (block->block_work ())));
 					}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -456,7 +456,7 @@ int main (int argc, char * const * argv)
 		else if (vm.count ("debug_profile_generate"))
 		{
 			nano::network_constants network_constants;
-			uint64_t difficulty{ network_constants.publish_full.base };
+			uint64_t difficulty{ nano::work_thresholds::publish_full.base };
 			auto multiplier_it = vm.find ("multiplier");
 			if (multiplier_it != vm.end ())
 			{
@@ -495,7 +495,7 @@ int main (int argc, char * const * argv)
 			nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
 			if (!result)
 			{
-				std::cerr << boost::str (boost::format ("Starting generation profiling. Difficulty: %1$#x (%2%x from base difficulty %3$#x)\n") % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
+				std::cerr << boost::str (boost::format ("Starting generation profiling. Difficulty: %1$#x (%2%x from base difficulty %3$#x)\n") % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, nano::work_thresholds::publish_full.base), 4) % nano::work_thresholds::publish_full.base);
 				while (!result)
 				{
 					block.hashables.previous.qwords[0] += 1;
@@ -508,7 +508,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_profile_validate"))
 		{
-			uint64_t difficulty{ nano::network_constants ().publish_full.base };
+			uint64_t difficulty{ nano::work_thresholds::publish_full.base };
 			std::cerr << "Starting validation profile" << std::endl;
 			auto start (std::chrono::steady_clock::now ());
 			bool valid{ false };
@@ -572,7 +572,7 @@ int main (int argc, char * const * argv)
 						return -1;
 					}
 				}
-				uint64_t difficulty (network_constants.publish_full.base);
+				uint64_t difficulty (nano::work_thresholds::publish_full.base);
 				auto multiplier_it = vm.find ("multiplier");
 				if (multiplier_it != vm.end ())
 				{
@@ -615,7 +615,7 @@ int main (int argc, char * const * argv)
 							}
 																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
 							nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
-							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x (%5%x from base difficulty %6$#x)\n") % platform % device % threads % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
+							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x (%5%x from base difficulty %6$#x)\n") % platform % device % threads % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, nano::work_thresholds::publish_full.base), 4) % nano::work_thresholds::publish_full.base);
 							for (uint64_t i (0); true; ++i)
 							{
 								block.hashables.previous.qwords[0] += 1;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -324,7 +324,7 @@ int main (int argc, char * const * argv)
 				if (!key.decode_hex (key_it->second.as<std::string> ()))
 				{
 					nano::keypair genesis (key.to_string ());
-					nano::work_pool work (std::numeric_limits<unsigned>::max ());
+					nano::work_pool work{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 					std::cout << "Genesis: " << genesis.prv.to_string () << "\n"
 							  << "Public: " << genesis.pub.to_string () << "\n"
 							  << "Account: " << genesis.pub.to_account () << "\n";
@@ -491,7 +491,7 @@ int main (int argc, char * const * argv)
 				pow_rate_limiter = std::chrono::nanoseconds (boost::lexical_cast<uint64_t> (pow_sleep_interval_it->second.as<std::string> ()));
 			}
 
-			nano::work_pool work (std::numeric_limits<unsigned>::max (), pow_rate_limiter);
+			nano::work_pool work{ network_constants, std::numeric_limits<unsigned>::max (), pow_rate_limiter };
 			nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
 			if (!result)
 			{
@@ -610,10 +610,10 @@ int main (int argc, char * const * argv)
 							nano::logger_mt logger;
 							nano::opencl_config config (platform, device, threads);
 							auto opencl (nano::opencl_work::create (true, config, logger));
-							nano::work_pool work_pool (0, std::chrono::nanoseconds (0), opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
+							nano::work_pool work_pool{ network_constants, 0, std::chrono::nanoseconds (0), opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 								return opencl->generate_work (version_a, root_a, difficulty_a);
 							}
-																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
 							nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
 							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x (%5%x from base difficulty %6$#x)\n") % platform % device % threads % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, network_constants.publish_full.base), 4) % network_constants.publish_full.base);
 							for (uint64_t i (0); true; ++i)
@@ -1126,7 +1126,7 @@ int main (int argc, char * const * argv)
 			std::cout << boost::str (boost::format ("Starting generating %1% blocks...\n") % (count * 2));
 			boost::asio::io_context io_ctx1;
 			boost::asio::io_context io_ctx2;
-			nano::work_pool work (std::numeric_limits<unsigned>::max ());
+			nano::work_pool work{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 			nano::logging logging;
 			auto path1 (nano::unique_path ());
 			auto path2 (nano::unique_path ());

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -610,7 +610,7 @@ int main (int argc, char * const * argv)
 						{
 							nano::logger_mt logger;
 							nano::opencl_config config (platform, device, threads);
-							auto opencl (nano::opencl_work::create (true, config, logger));
+							auto opencl (nano::opencl_work::create (true, config, logger, network_constants.publish_thresholds));
 							nano::work_pool work_pool{ network_constants, 0, std::chrono::nanoseconds (0), opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 								return opencl->generate_work (version_a, root_a, difficulty_a);
 							}

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -39,9 +39,9 @@ void run (boost::filesystem::path const & data_path, std::vector<std::string> co
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 	std::unique_ptr<nano::thread_runner> runner;
-	nano::network_constants network;
 
-	nano::rpc_config rpc_config{ network };
+	nano::network_params network_params{ nano::network_constants::active_network };
+	nano::rpc_config rpc_config{ network_params.network };
 	auto error = nano::read_rpc_config_toml (data_path, rpc_config, config_overrides);
 	if (!error)
 	{

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -39,8 +39,9 @@ void run (boost::filesystem::path const & data_path, std::vector<std::string> co
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 	std::unique_ptr<nano::thread_runner> runner;
+	nano::network_constants network;
 
-	nano::rpc_config rpc_config;
+	nano::rpc_config rpc_config{ network };
 	auto error = nano::read_rpc_config_toml (data_path, rpc_config, config_overrides);
 	if (!error)
 	{

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -107,10 +107,10 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 		std::shared_ptr<nano_qt::wallet> gui;
 		nano::set_application_icon (application);
 		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
-		nano::work_pool work (config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
+		nano::work_pool work{ config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 			return opencl->generate_work (version_a, root_a, difficulty_a);
 		}
-																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
 		node = std::make_shared<nano::node> (io_ctx, data_path, config.node, work, flags);
 		if (!node->init_error ())
 		{

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -167,7 +167,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 				if (!config.rpc.child_process.enable)
 				{
 					// Launch rpc in-process
-					nano::rpc_config rpc_config;
+					nano::rpc_config rpc_config{ config.node.network_params.network };
 					auto error = nano::read_rpc_config_toml (data_path, rpc_config, flags.rpc_config_overrides);
 					if (error)
 					{

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -106,7 +106,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 		std::shared_ptr<nano::node> node;
 		std::shared_ptr<nano_qt::wallet> gui;
 		nano::set_application_icon (application);
-		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.network.publish_thresholds));
+		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.work));
 		nano::work_pool work{ config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 			return opencl->generate_work (version_a, root_a, difficulty_a);
 		}

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -106,7 +106,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 		std::shared_ptr<nano::node> node;
 		std::shared_ptr<nano_qt::wallet> gui;
 		nano::set_application_icon (application);
-		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger));
+		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.network.publish_thresholds));
 		nano::work_pool work{ config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
 			return opencl->generate_work (version_a, root_a, difficulty_a);
 		}

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -501,7 +501,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 		{
 			if (node.config.logging.ledger_logging ())
 			{
-				node.logger.try_log (boost::str (boost::format ("Insufficient work for %1% : %2% (difficulty %3%)") % hash.to_string () % nano::to_string_hex (block->block_work ()) % nano::to_string_hex (block->difficulty ())));
+				node.logger.try_log (boost::str (boost::format ("Insufficient work for %1% : %2% (difficulty %3%)") % hash.to_string () % nano::to_string_hex (block->block_work ()) % nano::to_string_hex (node.network_params.network.publish_thresholds.difficulty (*block))));
 			}
 			break;
 		}

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -105,7 +105,7 @@ void nano::block_processor::add (std::shared_ptr<nano::block> const & block_a, u
 
 void nano::block_processor::add (nano::unchecked_info const & info_a)
 {
-	debug_assert (!node.network_params.network.publish_thresholds.validate_entry (*info_a.block));
+	debug_assert (!node.network_params.work.validate_entry (*info_a.block));
 	bool quarter_full (size () > node.flags.block_processor_full_size / 4);
 	if (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || info_a.block->type () == nano::block_type::open || !info_a.account.is_zero ()))
 	{
@@ -124,7 +124,7 @@ void nano::block_processor::add (nano::unchecked_info const & info_a)
 void nano::block_processor::add_local (nano::unchecked_info const & info_a)
 {
 	release_assert (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || !info_a.account.is_zero ()));
-	debug_assert (!node.network_params.network.publish_thresholds.validate_entry (*info_a.block));
+	debug_assert (!node.network_params.work.validate_entry (*info_a.block));
 	state_block_signature_verification.add (info_a);
 }
 
@@ -501,7 +501,7 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 		{
 			if (node.config.logging.ledger_logging ())
 			{
-				node.logger.try_log (boost::str (boost::format ("Insufficient work for %1% : %2% (difficulty %3%)") % hash.to_string () % nano::to_string_hex (block->block_work ()) % nano::to_string_hex (node.network_params.network.publish_thresholds.difficulty (*block))));
+				node.logger.try_log (boost::str (boost::format ("Insufficient work for %1% : %2% (difficulty %3%)") % hash.to_string () % nano::to_string_hex (block->block_work ()) % nano::to_string_hex (node.network_params.work.difficulty (*block))));
 			}
 			break;
 		}

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -105,7 +105,7 @@ void nano::block_processor::add (std::shared_ptr<nano::block> const & block_a, u
 
 void nano::block_processor::add (nano::unchecked_info const & info_a)
 {
-	debug_assert (!nano::work_validate_entry (*info_a.block));
+	debug_assert (!node.network_params.network.publish_thresholds.validate_entry (*info_a.block));
 	bool quarter_full (size () > node.flags.block_processor_full_size / 4);
 	if (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || info_a.block->type () == nano::block_type::open || !info_a.account.is_zero ()))
 	{
@@ -124,7 +124,7 @@ void nano::block_processor::add (nano::unchecked_info const & info_a)
 void nano::block_processor::add_local (nano::unchecked_info const & info_a)
 {
 	release_assert (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || !info_a.account.is_zero ()));
-	debug_assert (!nano::work_validate_entry (*info_a.block));
+	debug_assert (!node.network_params.network.publish_thresholds.validate_entry (*info_a.block));
 	state_block_signature_verification.add (info_a);
 }
 

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -208,7 +208,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (connection->receive_buffer->data (), size_a);
 		auto block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !nano::work_validate_entry (*block))
+		if (block != nullptr && !connection->node->network_params.network.publish_thresholds.validate_entry (*block))
 		{
 			auto hash (block->hash ());
 			if (connection->node->config.logging.bulk_pull_logging ())

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -208,7 +208,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (connection->receive_buffer->data (), size_a);
 		auto block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !connection->node->network_params.network.publish_thresholds.validate_entry (*block))
+		if (block != nullptr && !connection->node->network_params.work.validate_entry (*block))
 		{
 			auto hash (block->hash ());
 			if (connection->node->config.logging.bulk_pull_logging ())

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -232,7 +232,7 @@ void nano::bulk_push_server::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (receive_buffer->data (), size_a);
 		auto block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !connection->node->network_params.network.publish_thresholds.validate_entry (*block))
+		if (block != nullptr && !connection->node->network_params.work.validate_entry (*block))
 		{
 			connection->node->process_active (std::move (block));
 			throttled_receive ();

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -232,7 +232,7 @@ void nano::bulk_push_server::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (receive_buffer->data (), size_a);
 		auto block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !nano::work_validate_entry (*block))
+		if (block != nullptr && !connection->node->network_params.network.publish_thresholds.validate_entry (*block))
 		{
 			connection->node->process_active (std::move (block));
 			throttled_receive ();

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -426,7 +426,7 @@ void nano::bootstrap_server::receive_publish_action (boost::system::error_code c
 			{
 				if (is_realtime_connection ())
 				{
-					if (!node->network_params.network.publish_thresholds.validate_entry (*request->block))
+					if (!node->network_params.work.validate_entry (*request->block))
 					{
 						add_request (std::unique_ptr<nano::message> (request.release ()));
 					}
@@ -494,7 +494,7 @@ void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_co
 						if (!vote_block.which ())
 						{
 							auto const & block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-							if (node->network_params.network.publish_thresholds.validate_entry (*block))
+							if (node->network_params.work.validate_entry (*block))
 							{
 								process_vote = false;
 								node->stats.inc_detail_only (nano::stat::type::error, nano::stat::detail::insufficient_work);

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -426,7 +426,7 @@ void nano::bootstrap_server::receive_publish_action (boost::system::error_code c
 			{
 				if (is_realtime_connection ())
 				{
-					if (!nano::work_validate_entry (*request->block))
+					if (!node->network_params.network.publish_thresholds.validate_entry (*request->block))
 					{
 						add_request (std::unique_ptr<nano::message> (request.release ()));
 					}
@@ -494,7 +494,7 @@ void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_co
 						if (!vote_block.which ())
 						{
 							auto const & block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-							if (nano::work_validate_entry (*block))
+							if (node->network_params.network.publish_thresholds.validate_entry (*block))
 							{
 								process_vote = false;
 								node->stats.inc_detail_only (nano::stat::type::error, nano::stat::detail::insufficient_work);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -664,7 +664,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		else if (type == "rpc")
 		{
 			valid_type = true;
-			nano::rpc_config config;
+			nano::rpc_config config{ nano::dev::network_params.network };
 			config.serialize_toml (toml);
 		}
 		else

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -424,7 +424,7 @@ void nano::message_parser::deserialize_publish (nano::stream & stream_a, nano::m
 	nano::publish incoming (error, stream_a, header_a, digest_a, &block_uniquer);
 	if (!error && at_end (stream_a))
 	{
-		if (!network.publish_thresholds.validate_entry (*incoming.block))
+		if (!network.work.validate_entry (*incoming.block))
 		{
 			visitor.publish (incoming);
 		}
@@ -445,7 +445,7 @@ void nano::message_parser::deserialize_confirm_req (nano::stream & stream_a, nan
 	nano::confirm_req incoming (error, stream_a, header_a, &block_uniquer);
 	if (!error && at_end (stream_a))
 	{
-		if (incoming.block == nullptr || !network.publish_thresholds.validate_entry (*incoming.block))
+		if (incoming.block == nullptr || !network.work.validate_entry (*incoming.block))
 		{
 			visitor.confirm_req (incoming);
 		}
@@ -471,7 +471,7 @@ void nano::message_parser::deserialize_confirm_ack (nano::stream & stream_a, nan
 			if (!vote_block.which ())
 			{
 				auto const & block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-				if (network.publish_thresholds.validate_entry (*block))
+				if (network.work.validate_entry (*block))
 				{
 					status = parse_status::insufficient_work;
 					break;

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -424,7 +424,7 @@ void nano::message_parser::deserialize_publish (nano::stream & stream_a, nano::m
 	nano::publish incoming (error, stream_a, header_a, digest_a, &block_uniquer);
 	if (!error && at_end (stream_a))
 	{
-		if (!nano::work_validate_entry (*incoming.block))
+		if (!network.publish_thresholds.validate_entry (*incoming.block))
 		{
 			visitor.publish (incoming);
 		}
@@ -445,7 +445,7 @@ void nano::message_parser::deserialize_confirm_req (nano::stream & stream_a, nan
 	nano::confirm_req incoming (error, stream_a, header_a, &block_uniquer);
 	if (!error && at_end (stream_a))
 	{
-		if (incoming.block == nullptr || !nano::work_validate_entry (*incoming.block))
+		if (incoming.block == nullptr || !network.publish_thresholds.validate_entry (*incoming.block))
 		{
 			visitor.confirm_req (incoming);
 		}
@@ -471,7 +471,7 @@ void nano::message_parser::deserialize_confirm_ack (nano::stream & stream_a, nan
 			if (!vote_block.which ())
 			{
 				auto const & block (boost::get<std::shared_ptr<nano::block>> (vote_block));
-				if (nano::work_validate_entry (*block))
+				if (network.publish_thresholds.validate_entry (*block))
 				{
 					status = parse_status::insufficient_work;
 					break;

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -239,7 +239,7 @@ void nano::distributed_work::success (std::string const & body_a, nano::tcp_endp
 		uint64_t work;
 		if (!nano::from_string_hex (work_text, work))
 		{
-			if (nano::dev::network_params.network.publish_thresholds.difficulty (request.version, request.root, work) >= request.difficulty)
+			if (nano::dev::network_params.work.difficulty (request.version, request.root, work) >= request.difficulty)
 			{
 				error = false;
 				node.unresponsive_work_peers = false;

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -239,7 +239,7 @@ void nano::distributed_work::success (std::string const & body_a, nano::tcp_endp
 		uint64_t work;
 		if (!nano::from_string_hex (work_text, work))
 		{
-			if (nano::work_difficulty (request.version, request.root, work) >= request.difficulty)
+			if (nano::dev::network_params.network.publish_thresholds.difficulty (request.version, request.root, work) >= request.difficulty)
 			{
 				error = false;
 				node.unresponsive_work_peers = false;

--- a/nano/node/ipc/ipc_config.hpp
+++ b/nano/node/ipc/ipc_config.hpp
@@ -52,11 +52,12 @@ namespace ipc
 	class ipc_config_tcp_socket : public ipc_config_transport
 	{
 	public:
-		ipc_config_tcp_socket () :
-			port (network_constants.default_ipc_port)
+		ipc_config_tcp_socket (nano::network_constants & network_constants) :
+			network_constants{ network_constants },
+			port{ network_constants.default_ipc_port }
 		{
 		}
-		nano::network_constants network_constants;
+		nano::network_constants & network_constants;
 		/** Listening port */
 		uint16_t port;
 	};
@@ -65,6 +66,10 @@ namespace ipc
 	class ipc_config
 	{
 	public:
+		ipc_config (nano::network_constants & network_constants) :
+			transport_tcp{ network_constants }
+		{
+		}
 		nano::error deserialize_json (bool & upgraded_a, nano::jsonconfig & json_a);
 		nano::error serialize_json (nano::jsonconfig & json) const;
 		nano::error deserialize_toml (nano::tomlconfig & toml_a);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3123,7 +3123,7 @@ void nano::json_handler::process ()
 		}
 		if (!rpc_l->ec)
 		{
-			if (!nano::work_validate_entry (*block))
+			if (!rpc_l->node.network_params.network.publish_thresholds.validate_entry (*block))
 			{
 				if (!is_async)
 				{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1481,7 +1481,7 @@ void nano::json_handler::block_create ()
 		auto block_response_put_l = [rpc_l, this] (nano::block const & block_a) {
 			boost::property_tree::ptree response_l;
 			response_l.put ("hash", block_a.hash ().to_string ());
-			response_l.put ("difficulty", nano::to_string_hex (block_a.difficulty ()));
+			response_l.put ("difficulty", nano::to_string_hex (rpc_l->node.network_params.network.publish_thresholds.difficulty (block_a)));
 			bool json_block_l = request.get<bool> ("json_block", false);
 			if (json_block_l)
 			{
@@ -4901,7 +4901,7 @@ void nano::json_handler::work_generate ()
 					difficulty = difficulty_ledger (*block);
 				}
 				// If optional block difficulty is higher than requested difficulty, send error
-				if (!ec && block->difficulty () >= difficulty)
+				if (!ec && node.network_params.network.publish_thresholds.difficulty (*block) >= difficulty)
 				{
 					ec = nano::error_rpc::block_work_enough;
 				}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -829,7 +829,7 @@ void nano::json_handler::account_representative_set ()
 					if (!rpc_l->ec)
 					{
 						nano::block_details details (info.epoch (), false, false, false);
-						if (nano::work_difficulty (nano::work_version::work_1, info.head, work) < rpc_l->node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
+						if (rpc_l->node.network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, info.head, work) < rpc_l->node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
 						{
 							rpc_l->ec = nano::error_common::invalid_work;
 						}
@@ -3284,7 +3284,7 @@ void nano::json_handler::receive ()
 							head = account;
 						}
 						nano::block_details details (epoch, false, true, false);
-						if (nano::work_difficulty (nano::work_version::work_1, head, work) < node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
+						if (node.network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, head, work) < node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
 						{
 							ec = nano::error_common::invalid_work;
 						}
@@ -3628,7 +3628,7 @@ void nano::json_handler::send ()
 			if (!ec && work)
 			{
 				nano::block_details details (info.epoch (), true, false, false);
-				if (nano::work_difficulty (nano::work_version::work_1, info.head, work) < node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
+				if (node.network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, info.head, work) < node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
 				{
 					ec = nano::error_common::invalid_work;
 				}
@@ -4919,7 +4919,7 @@ void nano::json_handler::work_generate ()
 					uint64_t work (work_a.value ());
 					response_l.put ("work", nano::to_string_hex (work));
 					std::stringstream ostream;
-					auto result_difficulty (nano::work_difficulty (work_version, hash, work));
+					auto result_difficulty (rpc_l->node.network_params.network.publish_thresholds.difficulty (work_version, hash, work));
 					response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 					auto result_multiplier = nano::difficulty::to_multiplier (result_difficulty, node.default_difficulty (work_version));
 					response_l.put ("multiplier", nano::to_string (result_multiplier));
@@ -5045,7 +5045,7 @@ void nano::json_handler::work_validate ()
 		 * * valid_receive: the work is valid for a receive block in an epoch_2 upgraded account
 		 */
 
-		auto result_difficulty (nano::work_difficulty (work_version, hash, work));
+		auto result_difficulty (node.network_params.network.publish_thresholds.difficulty (work_version, hash, work));
 		if (request.count ("difficulty"))
 		{
 			response_l.put ("valid", (result_difficulty >= difficulty) ? "1" : "0");

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -414,7 +414,7 @@ uint64_t nano::json_handler::difficulty_ledger (nano::block const & block_a)
 			details_found = true;
 		}
 	}
-	return details_found ? nano::work_threshold (block_a.work_version (), details) : node.default_difficulty (block_a.work_version ());
+	return details_found ? node.network_params.network.publish_thresholds.threshold (block_a.work_version (), details) : node.default_difficulty (block_a.work_version ());
 }
 
 double nano::json_handler::multiplier_optional_impl (nano::work_version const version_a, uint64_t & difficulty)
@@ -829,7 +829,7 @@ void nano::json_handler::account_representative_set ()
 					if (!rpc_l->ec)
 					{
 						nano::block_details details (info.epoch (), false, false, false);
-						if (nano::work_difficulty (nano::work_version::work_1, info.head, work) < nano::work_threshold (nano::work_version::work_1, details))
+						if (nano::work_difficulty (nano::work_version::work_1, info.head, work) < rpc_l->node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
 						{
 							rpc_l->ec = nano::error_common::invalid_work;
 						}
@@ -3284,7 +3284,7 @@ void nano::json_handler::receive ()
 							head = account;
 						}
 						nano::block_details details (epoch, false, true, false);
-						if (nano::work_difficulty (nano::work_version::work_1, head, work) < nano::work_threshold (nano::work_version::work_1, details))
+						if (nano::work_difficulty (nano::work_version::work_1, head, work) < node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
 						{
 							ec = nano::error_common::invalid_work;
 						}
@@ -3628,7 +3628,7 @@ void nano::json_handler::send ()
 			if (!ec && work)
 			{
 				nano::block_details details (info.epoch (), true, false, false);
-				if (nano::work_difficulty (nano::work_version::work_1, info.head, work) < nano::work_threshold (nano::work_version::work_1, details))
+				if (nano::work_difficulty (nano::work_version::work_1, info.head, work) < node.network_params.network.publish_thresholds.threshold (nano::work_version::work_1, details))
 				{
 					ec = nano::error_common::invalid_work;
 				}
@@ -5051,7 +5051,7 @@ void nano::json_handler::work_validate ()
 			response_l.put ("valid", (result_difficulty >= difficulty) ? "1" : "0");
 		}
 		response_l.put ("valid_all", (result_difficulty >= node.default_difficulty (work_version)) ? "1" : "0");
-		response_l.put ("valid_receive", (result_difficulty >= nano::work_threshold (work_version, nano::block_details (nano::epoch::epoch_2, false, true, false))) ? "1" : "0");
+		response_l.put ("valid_receive", (result_difficulty >= node.network_params.network.publish_thresholds.threshold (work_version, nano::block_details (nano::epoch::epoch_2, false, true, false))) ? "1" : "0");
 		response_l.put ("difficulty", nano::to_string_hex (result_difficulty));
 		auto result_multiplier = nano::difficulty::to_multiplier (result_difficulty, node.default_difficulty (work_version));
 		response_l.put ("multiplier", nano::to_string (result_multiplier));

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -60,7 +60,7 @@ void nano::json_handler::process_request (bool unsafe_a)
 		boost::property_tree::read_json (istream, request);
 		if (node_rpc_config.request_callback)
 		{
-			debug_assert (nano::network_constants ().is_dev_network ());
+			debug_assert (node.network_params.network.is_dev_network ());
 			node_rpc_config.request_callback (request);
 		}
 		action = request.get<std::string> ("action");

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1027,7 +1027,7 @@ void nano::json_handler::active_difficulty ()
 	auto const multiplier_active = 1.0;
 	auto const default_difficulty (node.default_difficulty (nano::work_version::work_1));
 	auto const default_receive_difficulty (node.default_receive_difficulty (nano::work_version::work_1));
-	auto const receive_current_denormalized (nano::denormalized_multiplier (multiplier_active, node.network_params.network.publish_thresholds.epoch_2_receive));
+	auto const receive_current_denormalized (node.network_params.network.publish_thresholds.denormalized_multiplier (multiplier_active, node.network_params.network.publish_thresholds.epoch_2_receive));
 	response_l.put ("deprecated", "1");
 	response_l.put ("network_minimum", nano::to_string_hex (default_difficulty));
 	response_l.put ("network_receive_minimum", nano::to_string_hex (default_receive_difficulty));

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4872,7 +4872,7 @@ void nano::json_handler::work_generate ()
 		auto hash (hash_impl ());
 		auto difficulty (difficulty_optional_impl (work_version));
 		multiplier_optional_impl (work_version, difficulty);
-		if (!ec && (difficulty > node.max_work_generate_difficulty (work_version) || difficulty < nano::work_threshold_entry (work_version, nano::block_type::state)))
+		if (!ec && (difficulty > node.max_work_generate_difficulty (work_version) || difficulty < node.network_params.network.publish_thresholds.threshold_entry (work_version, nano::block_type::state)))
 		{
 			ec = nano::error_rpc::difficulty_limit;
 		}

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -93,13 +93,9 @@ nano::mdb_store::mdb_store (nano::logger_mt & logger_a, boost::filesystem::path 
 		// (can be a few minutes with the --fast_bootstrap flag for instance)
 		if (!is_fully_upgraded)
 		{
-			nano::network_constants network_constants;
 			if (!is_fresh_db)
 			{
-				if (!network_constants.is_dev_network ())
-				{
-					std::cout << "Upgrade in progress..." << std::endl;
-				}
+				logger.always_log ("Upgrade in progress...");
 				if (backup_before_upgrade_a)
 				{
 					create_backup_file (env, path_a, logger_a);
@@ -115,7 +111,7 @@ nano::mdb_store::mdb_store (nano::logger_mt & logger_a, boost::filesystem::path 
 				}
 			}
 
-			if (needs_vacuuming && !network_constants.is_dev_network ())
+			if (needs_vacuuming)
 			{
 				logger.always_log ("Preparing vacuum...");
 				auto vacuum_success = vacuum_after_upgrade (path_a, lmdb_config_a);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1114,7 +1114,7 @@ uint64_t nano::node::default_difficulty (nano::work_version const version_a) con
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = network_params.network.publish_thresholds.threshold_base (version_a);
+			result = network_params.work.threshold_base (version_a);
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to default_difficulty");
@@ -1128,7 +1128,7 @@ uint64_t nano::node::default_receive_difficulty (nano::work_version const versio
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = network_params.network.publish_thresholds.epoch_2_receive;
+			result = network_params.work.epoch_2_receive;
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to default_receive_difficulty");
@@ -1459,7 +1459,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 	auto upgrader_process = [] (nano::node & node_a, std::atomic<uint64_t> & counter, std::shared_ptr<nano::block> const & epoch, uint64_t difficulty, nano::public_key const & signer_a, nano::root const & root_a, nano::account const & account_a) {
 		epoch->block_work_set (node_a.work_generate_blocking (nano::work_version::work_1, root_a, difficulty).value_or (0));
 		bool valid_signature (!nano::validate_message (signer_a, epoch->hash (), epoch->block_signature ()));
-		bool valid_work (node_a.network_params.network.publish_thresholds.difficulty (*epoch) >= difficulty);
+		bool valid_work (node_a.network_params.work.difficulty (*epoch) >= difficulty);
 		nano::process_result result (nano::process_result::old);
 		if (valid_signature && valid_work)
 		{
@@ -1546,7 +1546,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 				if (!store.account.get (transaction, account, info) && info.epoch () < epoch_a)
 				{
 					++attempts;
-					auto difficulty (network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
+					auto difficulty (network_params.work.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
 					nano::root const & root (info.head);
 					std::shared_ptr<nano::block> epoch = builder.state ()
 														 .account (account)
@@ -1624,7 +1624,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 					{
 						++attempts;
 						release_assert (nano::epochs::is_sequential (info.epoch, epoch_a));
-						auto difficulty (network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
+						auto difficulty (network_params.work.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
 						nano::root const & root (key.account);
 						nano::account const & account (key.account);
 						std::shared_ptr<nano::block> epoch = builder.state ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1110,12 +1110,11 @@ int nano::node::price (nano::uint128_t const & balance_a, int amount_a)
 
 uint64_t nano::node::default_difficulty (nano::work_version const version_a) const
 {
-	nano::network_constants constants;
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = constants.publish_thresholds.threshold_base (version_a);
+			result = network_params.network.publish_thresholds.threshold_base (version_a);
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to default_difficulty");

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1546,7 +1546,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 				if (!store.account.get (transaction, account, info) && info.epoch () < epoch_a)
 				{
 					++attempts;
-					auto difficulty (nano::work_threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
+					auto difficulty (network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
 					nano::root const & root (info.head);
 					std::shared_ptr<nano::block> epoch = builder.state ()
 														 .account (account)
@@ -1624,7 +1624,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 					{
 						++attempts;
 						release_assert (nano::epochs::is_sequential (info.epoch, epoch_a));
-						auto difficulty (nano::work_threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
+						auto difficulty (network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
 						nano::root const & root (key.account);
 						nano::account const & account (key.account);
 						std::shared_ptr<nano::block> epoch = builder.state ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1763,7 +1763,7 @@ void nano::node::populate_backlog ()
 
 nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
 	io_context (std::make_shared<boost::asio::io_context> ()),
-	work (1)
+	work{ nano::dev::network_params.network, 1 }
 {
 	boost::system::error_code error_chmod;
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1460,7 +1460,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 	auto upgrader_process = [] (nano::node & node_a, std::atomic<uint64_t> & counter, std::shared_ptr<nano::block> const & epoch, uint64_t difficulty, nano::public_key const & signer_a, nano::root const & root_a, nano::account const & account_a) {
 		epoch->block_work_set (node_a.work_generate_blocking (nano::work_version::work_1, root_a, difficulty).value_or (0));
 		bool valid_signature (!nano::validate_message (signer_a, epoch->hash (), epoch->block_signature ()));
-		bool valid_work (epoch->difficulty () >= difficulty);
+		bool valid_work (node_a.network_params.network.publish_thresholds.difficulty (*epoch) >= difficulty);
 		nano::process_result result (nano::process_result::old);
 		if (valid_signature && valid_work)
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1110,11 +1110,12 @@ int nano::node::price (nano::uint128_t const & balance_a, int amount_a)
 
 uint64_t nano::node::default_difficulty (nano::work_version const version_a) const
 {
+	nano::network_constants constants;
 	uint64_t result{ std::numeric_limits<uint64_t>::max () };
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = nano::work_threshold_base (version_a);
+			result = constants.publish_thresholds.threshold_base (version_a);
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to default_difficulty");

--- a/nano/node/node_rpc_config.cpp
+++ b/nano/node/node_rpc_config.cpp
@@ -59,6 +59,5 @@ nano::error nano::node_rpc_config::deserialize_json (bool & upgraded_a, nano::js
 
 void nano::node_rpc_config::set_request_callback (std::function<void (boost::property_tree::ptree const &)> callback_a)
 {
-	debug_assert (nano::network_constants ().is_dev_network ());
 	request_callback = std::move (callback_a);
 }

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -29,6 +29,7 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 	network_params{ network_params },
 	peering_port{ peering_port_a },
 	logging{ logging_a },
+	websocket_config{ network_params.network },
 	external_address{ boost::asio::ip::address_v6{}.to_string () }
 {
 	// The default constructor passes 0 to indicate we should use the default port,

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -30,6 +30,7 @@ nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & l
 	peering_port{ peering_port_a },
 	logging{ logging_a },
 	websocket_config{ network_params.network },
+	ipc_config{ network_params.network },
 	external_address{ boost::asio::ip::address_v6{}.to_string () }
 {
 	// The default constructor passes 0 to indicate we should use the default port,

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -351,7 +351,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time_l);
 		conf_height_processor_batch_min_time = std::chrono::milliseconds (conf_height_processor_batch_min_time_l);
 
-		nano::network_constants network;
 		toml.get<double> ("max_work_generate_multiplier", max_work_generate_multiplier);
 
 		toml.get<uint32_t> ("max_queued_requests", max_queued_requests);
@@ -392,7 +391,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_elections_size <= 250 && !network.is_dev_network ())
+		if (active_elections_size <= 250 && !network_params.network.is_dev_network ())
 		{
 			toml.get_error ().set ("active_elections_size must be greater than 250");
 		}
@@ -416,7 +415,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ((boost::format ("block_processor_batch_max_time value must be equal or larger than %1%ms") % network_params.node.process_confirmed_interval.count ()).str ());
 		}
-		if (max_pruning_age < std::chrono::seconds (5 * 60) && !network.is_dev_network ())
+		if (max_pruning_age < std::chrono::seconds (5 * 60) && !network_params.network.is_dev_network ())
 		{
 			toml.get_error ().set ("max_pruning_age must be greater than or equal to 5 minutes");
 		}
@@ -684,7 +683,6 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get ("conf_height_processor_batch_min_time", conf_height_processor_batch_min_time_l);
 		conf_height_processor_batch_min_time = std::chrono::milliseconds (conf_height_processor_batch_min_time_l);
 
-		nano::network_constants network;
 		// Validate ranges
 		if (password_fanout < 16 || password_fanout > 1024 * 1024)
 		{
@@ -694,7 +692,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_elections_size <= 250 && !network.is_dev_network ())
+		if (active_elections_size <= 250 && !network_params.network.is_dev_network ())
 		{
 			json.get_error ().set ("active_elections_size must be greater than 250");
 		}

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -20,12 +20,12 @@ const char * default_live_peer_network = "peering.nano.org";
 const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 
-nano::node_config::node_config () :
-	node_config (0, nano::logging (), nano::network_params{ nano::network_constants::active_network })
+nano::node_config::node_config (nano::network_params & network_params) :
+	node_config (0, nano::logging (), network_params)
 {
 }
 
-nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & logging_a, nano::network_params network_params) :
+nano::node_config::node_config (uint16_t peering_port_a, nano::logging const & logging_a, nano::network_params & network_params) :
 	network_params{ network_params },
 	peering_port{ peering_port_a },
 	logging{ logging_a },

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -34,15 +34,15 @@ enum class frontiers_confirmation_mode : uint8_t
 class node_config
 {
 public:
-	node_config ();
-	node_config (uint16_t, nano::logging const &, nano::network_params network_params = nano::dev::network_params);
+	node_config (nano::network_params & network_params = nano::dev::network_params);
+	node_config (uint16_t, nano::logging const &, nano::network_params & network_params = nano::dev::network_params);
 	nano::error serialize_json (nano::jsonconfig &) const;
 	nano::error deserialize_json (bool &, nano::jsonconfig &);
 	nano::error serialize_toml (nano::tomlconfig &) const;
 	nano::error deserialize_toml (nano::tomlconfig &);
 	bool upgrade_json (unsigned, nano::jsonconfig &);
 	nano::account random_representative () const;
-	nano::network_params network_params;
+	nano::network_params & network_params;
 	uint16_t peering_port{ 0 };
 	nano::logging logging;
 	std::vector<std::pair<std::string, uint16_t>> work_peers;

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -455,7 +455,8 @@ boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version c
 	uint64_t result (0);
 	unsigned thread_count (config.threads);
 	size_t work_size[] = { thread_count, 0, 0 };
-	while (nano::work_difficulty (version_a, root_a, result) < difficulty_a && !error && ticket_a == ticket_l)
+	static nano::network_constants constants;
+	while (constants.publish_thresholds.difficulty (version_a, root_a, result) < difficulty_a && !error && ticket_a == ticket_l)
 	{
 		result = rand.next ();
 		cl_int write_error1 = clEnqueueWriteBuffer (queue, attempt_buffer, false, 0, sizeof (uint64_t), &result, 0, nullptr, nullptr);

--- a/nano/node/openclwork.hpp
+++ b/nano/node/openclwork.hpp
@@ -40,11 +40,11 @@ class work_pool;
 class opencl_work
 {
 public:
-	opencl_work (bool &, nano::opencl_config const &, nano::opencl_environment &, nano::logger_mt &);
+	opencl_work (bool &, nano::opencl_config const &, nano::opencl_environment &, nano::logger_mt &, nano::work_thresholds & work);
 	~opencl_work ();
 	boost::optional<uint64_t> generate_work (nano::work_version const, nano::root const &, uint64_t const);
 	boost::optional<uint64_t> generate_work (nano::work_version const, nano::root const &, uint64_t const, std::atomic<int> &);
-	static std::unique_ptr<opencl_work> create (bool, nano::opencl_config const &, nano::logger_mt &);
+	static std::unique_ptr<opencl_work> create (bool, nano::opencl_config const &, nano::logger_mt &, nano::work_thresholds & work);
 	nano::opencl_config const & config;
 	nano::mutex mutex;
 	cl_context context;
@@ -57,5 +57,6 @@ public:
 	cl_command_queue queue;
 	nano::xorshift1024star rand;
 	nano::logger_mt & logger;
+	nano::work_thresholds & work;
 };
 }

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -542,7 +542,6 @@ uint64_t nano::rocksdb_store::count (nano::transaction const & transaction_a, ta
 	// otherwise there can be performance issues.
 	else if (table_a == tables::accounts)
 	{
-		debug_assert (network_constants ().is_dev_network ());
 		for (auto i (account.begin (transaction_a)), n (account.end ()); i != n; ++i)
 		{
 			++sum;
@@ -558,7 +557,6 @@ uint64_t nano::rocksdb_store::count (nano::transaction const & transaction_a, ta
 	}
 	else if (table_a == tables::confirmation_height)
 	{
-		debug_assert (network_constants ().is_dev_network ());
 		for (auto i (confirmation_height.begin (transaction_a)), n (confirmation_height.end ()); i != n; ++i)
 		{
 			++sum;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1043,7 +1043,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 	wallets.delayed_work->erase (account_a);
 	if (block_a != nullptr)
 	{
-		auto required_difficulty{ nano::work_threshold (block_a->work_version (), details_a) };
+		auto required_difficulty{ wallets.node.network_params.network.publish_thresholds.threshold (block_a->work_version (), details_a) };
 		if (block_a->difficulty () < required_difficulty)
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1043,8 +1043,8 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 	wallets.delayed_work->erase (account_a);
 	if (block_a != nullptr)
 	{
-		auto required_difficulty{ wallets.node.network_params.network.publish_thresholds.threshold (block_a->work_version (), details_a) };
-		if (wallets.node.network_params.network.publish_thresholds.difficulty (*block_a) < required_difficulty)
+		auto required_difficulty{ wallets.node.network_params.work.threshold (block_a->work_version (), details_a) };
+		if (wallets.node.network_params.work.difficulty (*block_a) < required_difficulty)
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));
 			debug_assert (required_difficulty <= wallets.node.max_work_generate_difficulty (block_a->work_version ()));
@@ -1130,7 +1130,7 @@ void nano::wallet::send_async (nano::account const & source_a, nano::account con
 // Update work for account if latest root is root_a
 void nano::wallet::work_update (nano::transaction const & transaction_a, nano::account const & account_a, nano::root const & root_a, uint64_t work_a)
 {
-	debug_assert (!wallets.node.network_params.network.publish_thresholds.validate_entry (nano::work_version::work_1, root_a, work_a));
+	debug_assert (!wallets.node.network_params.work.validate_entry (nano::work_version::work_1, root_a, work_a));
 	debug_assert (store.exists (transaction_a, account_a));
 	auto block_transaction (wallets.node.store.tx_begin_read ());
 	auto latest (wallets.node.ledger.latest_root (block_transaction, account_a));

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1130,7 +1130,7 @@ void nano::wallet::send_async (nano::account const & source_a, nano::account con
 // Update work for account if latest root is root_a
 void nano::wallet::work_update (nano::transaction const & transaction_a, nano::account const & account_a, nano::root const & root_a, uint64_t work_a)
 {
-	debug_assert (!nano::work_validate_entry (nano::work_version::work_1, root_a, work_a));
+	debug_assert (!wallets.node.network_params.network.publish_thresholds.validate_entry (nano::work_version::work_1, root_a, work_a));
 	debug_assert (store.exists (transaction_a, account_a));
 	auto block_transaction (wallets.node.store.tx_begin_read ());
 	auto latest (wallets.node.ledger.latest_root (block_transaction, account_a));

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1044,7 +1044,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 	if (block_a != nullptr)
 	{
 		auto required_difficulty{ wallets.node.network_params.network.publish_thresholds.threshold (block_a->work_version (), details_a) };
-		if (block_a->difficulty () < required_difficulty)
+		if (wallets.node.network_params.network.publish_thresholds.difficulty (*block_a) < required_difficulty)
 		{
 			wallets.node.logger.try_log (boost::str (boost::format ("Cached or provided work for block %1% account %2% is invalid, regenerating") % block_a->hash ().to_string () % account_a.to_account ()));
 			debug_assert (required_difficulty <= wallets.node.max_work_generate_difficulty (block_a->work_version ()));

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -809,7 +809,7 @@ nano::websocket::message nano::websocket::message_builder::work_generation (nano
 		boost::property_tree::ptree result_l;
 		result_l.put ("source", peer_a);
 		result_l.put ("work", nano::to_string_hex (work_a));
-		auto result_difficulty_l (nano::dev::network_params.network.publish_thresholds.difficulty (version_a, root_a, work_a));
+		auto result_difficulty_l (nano::dev::network_params.work.difficulty (version_a, root_a, work_a));
 		result_l.put ("difficulty", nano::to_string_hex (result_difficulty_l));
 		auto result_multiplier_l (nano::difficulty::to_multiplier (result_difficulty_l, publish_threshold_a));
 		result_l.put ("multiplier", nano::to_string (result_multiplier_l));

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -809,7 +809,7 @@ nano::websocket::message nano::websocket::message_builder::work_generation (nano
 		boost::property_tree::ptree result_l;
 		result_l.put ("source", peer_a);
 		result_l.put ("work", nano::to_string_hex (work_a));
-		auto result_difficulty_l (nano::work_difficulty (version_a, root_a, work_a));
+		auto result_difficulty_l (nano::dev::network_params.network.publish_thresholds.difficulty (version_a, root_a, work_a));
 		result_l.put ("difficulty", nano::to_string_hex (result_difficulty_l));
 		auto result_multiplier_l (nano::difficulty::to_multiplier (result_difficulty_l, publish_threshold_a));
 		result_l.put ("multiplier", nano::to_string (result_multiplier_l));

--- a/nano/node/websocketconfig.cpp
+++ b/nano/node/websocketconfig.cpp
@@ -3,9 +3,10 @@
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/websocketconfig.hpp>
 
-nano::websocket::config::config () :
-	port (network_constants.default_websocket_port),
-	address (boost::asio::ip::address_v6::loopback ().to_string ())
+nano::websocket::config::config (nano::network_constants & network_constants) :
+	network_constants{ network_constants },
+	port{ network_constants.default_websocket_port },
+	address{ boost::asio::ip::address_v6::loopback ().to_string () }
 {
 }
 

--- a/nano/node/websocketconfig.hpp
+++ b/nano/node/websocketconfig.hpp
@@ -13,12 +13,12 @@ namespace websocket
 	class config final
 	{
 	public:
-		config ();
+		config (nano::network_constants & network_constants);
 		nano::error deserialize_json (nano::jsonconfig & json_a);
 		nano::error serialize_json (nano::jsonconfig & json) const;
 		nano::error deserialize_toml (nano::tomlconfig & toml_a);
 		nano::error serialize_toml (nano::tomlconfig & toml) const;
-		nano::network_constants network_constants;
+		nano::network_constants & network_constants;
 		bool enabled{ false };
 		uint16_t port;
 		std::string address;

--- a/nano/node/write_database_queue.cpp
+++ b/nano/node/write_database_queue.cpp
@@ -90,7 +90,7 @@ nano::write_guard nano::write_database_queue::wait (nano::writer writer)
 
 bool nano::write_database_queue::contains (nano::writer writer)
 {
-	debug_assert (!use_noops && nano::network_constants ().is_dev_network ());
+	debug_assert (!use_noops);
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return std::find (queue.cbegin (), queue.cend (), writer) != queue.cend ();
 }

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2003,7 +2003,7 @@ nano_qt::block_entry::block_entry (nano_qt::wallet & wallet_a) :
 			{
 				show_label_ok (*status);
 				this->status->setText ("");
-				if (!nano::work_validate_entry (*block_l))
+				if (!this->wallet.node.network_params.network.publish_thresholds.validate_entry (*block_l))
 				{
 					this->wallet.node.process_active (std::move (block_l));
 				}

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2003,7 +2003,7 @@ nano_qt::block_entry::block_entry (nano_qt::wallet & wallet_a) :
 			{
 				show_label_ok (*status);
 				this->status->setText ("");
-				if (!this->wallet.node.network_params.network.publish_thresholds.validate_entry (*block_l))
+				if (!this->wallet.node.network_params.work.validate_entry (*block_l))
 				{
 					this->wallet.node.process_active (std::move (block_l));
 				}
@@ -2241,7 +2241,7 @@ void nano_qt::block_creation::create_send ()
 						nano::block_details details;
 						details.is_send = true;
 						details.epoch = info.epoch ();
-						auto const required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (send.work_version (), details) };
+						auto const required_difficulty{ wallet.node.network_params.work.threshold (send.work_version (), details) };
 						if (wallet.node.work_generate_blocking (send, required_difficulty).is_initialized ())
 						{
 							std::string block_l;
@@ -2325,7 +2325,7 @@ void nano_qt::block_creation::create_receive ()
 							nano::block_details details;
 							details.is_receive = true;
 							details.epoch = std::max (info.epoch (), pending.epoch);
-							auto required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (receive.work_version (), details) };
+							auto required_difficulty{ wallet.node.network_params.work.threshold (receive.work_version (), details) };
 							if (wallet.node.work_generate_blocking (receive, required_difficulty).is_initialized ())
 							{
 								std::string block_l;
@@ -2408,7 +2408,7 @@ void nano_qt::block_creation::create_change ()
 					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key, account_l, 0);
 					nano::block_details details;
 					details.epoch = info.epoch ();
-					auto const required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (change.work_version (), details) };
+					auto const required_difficulty{ wallet.node.network_params.work.threshold (change.work_version (), details) };
 					if (wallet.node.work_generate_blocking (change, required_difficulty).is_initialized ())
 					{
 						std::string block_l;
@@ -2490,7 +2490,7 @@ void nano_qt::block_creation::create_open ()
 								nano::block_details details;
 								details.is_receive = true;
 								details.epoch = pending.epoch;
-								auto const required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (open.work_version (), details) };
+								auto const required_difficulty{ wallet.node.network_params.work.threshold (open.work_version (), details) };
 								if (wallet.node.work_generate_blocking (open, required_difficulty).is_initialized ())
 								{
 									std::string block_l;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2241,7 +2241,7 @@ void nano_qt::block_creation::create_send ()
 						nano::block_details details;
 						details.is_send = true;
 						details.epoch = info.epoch ();
-						auto const required_difficulty{ nano::work_threshold (send.work_version (), details) };
+						auto const required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (send.work_version (), details) };
 						if (wallet.node.work_generate_blocking (send, required_difficulty).is_initialized ())
 						{
 							std::string block_l;
@@ -2325,7 +2325,7 @@ void nano_qt::block_creation::create_receive ()
 							nano::block_details details;
 							details.is_receive = true;
 							details.epoch = std::max (info.epoch (), pending.epoch);
-							auto required_difficulty{ nano::work_threshold (receive.work_version (), details) };
+							auto required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (receive.work_version (), details) };
 							if (wallet.node.work_generate_blocking (receive, required_difficulty).is_initialized ())
 							{
 								std::string block_l;
@@ -2408,7 +2408,7 @@ void nano_qt::block_creation::create_change ()
 					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key, account_l, 0);
 					nano::block_details details;
 					details.epoch = info.epoch ();
-					auto const required_difficulty{ nano::work_threshold (change.work_version (), details) };
+					auto const required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (change.work_version (), details) };
 					if (wallet.node.work_generate_blocking (change, required_difficulty).is_initialized ())
 					{
 						std::string block_l;
@@ -2490,7 +2490,7 @@ void nano_qt::block_creation::create_open ()
 								nano::block_details details;
 								details.is_receive = true;
 								details.epoch = pending.epoch;
-								auto const required_difficulty{ nano::work_threshold (open.work_version (), details) };
+								auto const required_difficulty{ wallet.node.network_params.network.publish_thresholds.threshold (open.work_version (), details) };
 								if (wallet.node.work_generate_blocking (open, required_difficulty).is_initialized ())
 								{
 									std::string block_l;

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -835,7 +835,7 @@ TEST (wallet, seed_work_generation)
 		ASSERT_NO_ERROR (ec);
 	}
 	auto transaction (system.nodes[0]->store.tx_begin_read ());
-	ASSERT_GE (nano::work_difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), system.nodes[0]->default_difficulty (nano::work_version::work_1));
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), system.nodes[0]->default_difficulty (nano::work_version::work_1));
 }
 
 TEST (wallet, backup_seed)

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -835,7 +835,7 @@ TEST (wallet, seed_work_generation)
 		ASSERT_NO_ERROR (ec);
 	}
 	auto transaction (system.nodes[0]->store.tx_begin_read ());
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), system.nodes[0]->default_difficulty (nano::work_version::work_1));
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), system.nodes[0]->default_difficulty (nano::work_version::work_1));
 }
 
 TEST (wallet, backup_seed)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -524,7 +524,7 @@ TEST (rpc, send_epoch_2)
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv, false);
 
-	auto target_difficulty = nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false));
+	auto target_difficulty = nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false));
 	ASSERT_LT (node->network_params.network.publish_thresholds.entry, target_difficulty);
 	auto min_difficulty = node->network_params.network.publish_thresholds.entry;
 
@@ -2147,7 +2147,7 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
 	nano::state_block block (key.pub, 0, nano::dev::genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, 0);
-	auto threshold (nano::work_threshold (block.work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	auto threshold (nano::dev::network_params.network.publish_thresholds.threshold (block.work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	block.block_work_set (system.work_generate_limited (block.root ().as_block_hash (), 1, threshold - 1));
 	nano::block_hash hash (block.root ().as_block_hash ());
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
@@ -2542,7 +2542,7 @@ TEST (rpc, account_representative_set_epoch_2)
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv, false);
 
-	auto target_difficulty = nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, false, false));
+	auto target_difficulty = nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, false, false));
 	ASSERT_LT (node->network_params.network.publish_thresholds.entry, target_difficulty);
 	auto min_difficulty = node->network_params.network.publish_thresholds.entry;
 
@@ -4361,7 +4361,7 @@ TEST (rpc, block_create_state_open)
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
 	auto difficulty (state_block->difficulty ());
-	ASSERT_GT (difficulty, nano::work_threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false)));
+	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
@@ -4441,7 +4441,7 @@ TEST (rpc, block_create_open_epoch_v2)
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
 	auto difficulty (state_block->difficulty ());
-	ASSERT_GT (difficulty, nano::work_threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
@@ -4485,7 +4485,7 @@ TEST (rpc, block_create_receive_epoch_v2)
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
 	auto difficulty (state_block->difficulty ());
-	ASSERT_GT (difficulty, nano::work_threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
 	ASSERT_EQ (nano::process_result::progress, process_result.code);
@@ -4527,7 +4527,7 @@ TEST (rpc, block_create_send_epoch_v2)
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
 	auto difficulty (state_block->difficulty ());
-	ASSERT_GT (difficulty, nano::work_threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
 	ASSERT_EQ (nano::process_result::progress, process_result.code);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -199,7 +199,7 @@ std::tuple<std::shared_ptr<nano::rpc>, std::unique_ptr<rpc_context>> add_rpc (na
 	auto scoped_thread_name_io (std::make_unique<scoped_io_thread_name_change> ());
 	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
 	auto ipc_server (std::make_unique<nano::ipc::ipc_server> (*node_a, *node_rpc_config));
-	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	nano::rpc_config rpc_config (node_a->network_params.network, nano::get_available_port (), true);
 	rpc_config.rpc_process.ipc_port = node_a->config.ipc_config.transport_tcp.port;
 	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config));
 	auto rpc (std::make_shared<nano::rpc> (system.io_ctx, rpc_config, *ipc_rpc_processor));
@@ -5499,7 +5499,7 @@ TEST (rpc, simultaneous_calls)
 	nano::thread_runner runner (system.io_ctx, node->config.io_threads);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
-	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	nano::rpc_config rpc_config{ nano::dev::network_params.network, nano::get_available_port (), true };
 	rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
 	rpc_config.rpc_process.num_ipc_connections = 8;
 	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
@@ -5553,7 +5553,7 @@ TEST (rpc, in_process)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
-	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	nano::rpc_config rpc_config (nano::dev::network_params.network, nano::get_available_port (), true);
 	rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
@@ -5572,7 +5572,7 @@ TEST (rpc, in_process)
 
 TEST (rpc_config, serialization)
 {
-	nano::rpc_config config1;
+	nano::rpc_config config1{ nano::dev::network_params.network };
 	config1.address = boost::asio::ip::address_v6::any ().to_string ();
 	config1.port = 10;
 	config1.enable_control = true;
@@ -5583,7 +5583,7 @@ TEST (rpc_config, serialization)
 	config1.rpc_process.num_ipc_connections = 99;
 	nano::jsonconfig tree;
 	config1.serialize_json (tree);
-	nano::rpc_config config2;
+	nano::rpc_config config2{ nano::dev::network_params.network };
 	ASSERT_NE (config2.address, config1.address);
 	ASSERT_NE (config2.port, config1.port);
 	ASSERT_NE (config2.enable_control, config1.enable_control);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2215,7 +2215,7 @@ TEST (rpc, work_peer_bad)
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = *work_a;
 	});
-	ASSERT_TIMELY (5s, nano::work_difficulty (nano::work_version::work_1, hash1, work) >= nano::work_threshold_base (nano::work_version::work_1));
+	ASSERT_TIMELY (5s, nano::work_difficulty (nano::work_version::work_1, hash1, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
 }
 
 TEST (rpc, work_peer_one)
@@ -2231,7 +2231,7 @@ TEST (rpc, work_peer_one)
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = *work_a;
 	});
-	ASSERT_TIMELY (5s, nano::work_difficulty (nano::work_version::work_1, key1.pub, work) >= nano::work_threshold_base (nano::work_version::work_1));
+	ASSERT_TIMELY (5s, nano::work_difficulty (nano::work_version::work_1, key1.pub, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
 }
 
 TEST (rpc, work_peer_many)
@@ -2258,7 +2258,7 @@ TEST (rpc, work_peer_many)
 		node1.work_generate (nano::work_version::work_1, key1.pub, node1.network_params.network.publish_thresholds.base, [&work = works[i]] (boost::optional<uint64_t> work_a) {
 			work = *work_a;
 		});
-		while (nano::work_difficulty (nano::work_version::work_1, key1.pub, works[i]) < nano::work_threshold_base (nano::work_version::work_1))
+		while (nano::work_difficulty (nano::work_version::work_1, key1.pub, works[i]) < nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1))
 		{
 			system1.poll ();
 			system2.poll ();

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5474,7 +5474,7 @@ TEST (rpc, active_difficulty)
 		uint64_t network_receive_current;
 		ASSERT_FALSE (nano::from_string_hex (network_receive_current_text, network_receive_current));
 		auto network_receive_current_multiplier (nano::difficulty::to_multiplier (network_receive_current, network_receive_minimum));
-		auto network_receive_current_normalized_multiplier (nano::normalized_multiplier (network_receive_current_multiplier, network_receive_minimum));
+		auto network_receive_current_normalized_multiplier (nano::dev::network_params.network.publish_thresholds.normalized_multiplier (network_receive_current_multiplier, network_receive_minimum));
 		ASSERT_NEAR (network_receive_current_normalized_multiplier, multiplier, 1e-6);
 		ASSERT_EQ (response.not_found (), response.find ("difficulty_trend"));
 	}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1641,8 +1641,8 @@ TEST (rpc, process_ledger_insufficient_work)
 	auto min_difficulty = node->network_params.network.publish_thresholds.entry;
 	auto max_difficulty = node->network_params.network.publish_thresholds.epoch_1;
 	nano::state_block send (nano::dev::genesis->account (), latest, nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, system.work_generate_limited (latest, min_difficulty, max_difficulty));
-	ASSERT_LT (send.difficulty (), max_difficulty);
-	ASSERT_GE (send.difficulty (), min_difficulty);
+	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.difficulty (send), max_difficulty);
+	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (send), min_difficulty);
 	boost::property_tree::ptree request;
 	request.put ("action", "process");
 	std::string json;
@@ -2087,7 +2087,7 @@ TEST (rpc, work_generate_block_low)
 	auto threshold (node->default_difficulty (block.work_version ()));
 	block.block_work_set (system.work_generate_limited (block.root ().as_block_hash (), threshold, nano::difficulty::from_multiplier (node->config.max_work_generate_multiplier / 10, threshold)));
 	nano::block_hash hash (block.root ().as_block_hash ());
-	auto block_difficulty (block.difficulty ());
+	auto block_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (block));
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
 	request.put ("hash", hash.to_string ());
@@ -4228,7 +4228,7 @@ TEST (rpc, block_create)
 	std::string send_hash (response.get<std::string> ("hash"));
 	ASSERT_EQ (send.hash ().to_string (), send_hash);
 	std::string send_difficulty (response.get<std::string> ("difficulty"));
-	ASSERT_EQ (nano::to_string_hex (send.difficulty ()), send_difficulty);
+	ASSERT_EQ (nano::to_string_hex (nano::dev::network_params.network.publish_thresholds.difficulty (send)), send_difficulty);
 	auto send_text (response.get<std::string> ("block"));
 	boost::property_tree::ptree block_l;
 	std::stringstream block_stream (send_text);
@@ -4360,7 +4360,7 @@ TEST (rpc, block_create_state_open)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (state_block->difficulty ());
+	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
 	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	rpc_ctx->io_scope->reset ();
@@ -4406,7 +4406,7 @@ TEST (rpc, block_create_state_request_work)
 		boost::property_tree::read_json (block_stream, block_l);
 		auto block (nano::deserialize_block_json (block_l));
 		ASSERT_NE (nullptr, block);
-		ASSERT_GE (block->difficulty (), node->default_difficulty (nano::work_version::work_1));
+		ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (*block), node->default_difficulty (nano::work_version::work_1));
 	}
 }
 
@@ -4440,7 +4440,7 @@ TEST (rpc, block_create_open_epoch_v2)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (state_block->difficulty ());
+	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
 	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	rpc_ctx->io_scope->reset ();
@@ -4484,7 +4484,7 @@ TEST (rpc, block_create_receive_epoch_v2)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (state_block->difficulty ());
+	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
 	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
@@ -4526,7 +4526,7 @@ TEST (rpc, block_create_send_epoch_v2)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (state_block->difficulty ());
+	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
 	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1949,7 +1949,7 @@ TEST (rpc, work_generate)
 		auto work_text (response.json.get<std::string> ("work"));
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -1980,7 +1980,7 @@ TEST (rpc, work_generate_difficulty)
 		auto work_text (response.get<std::string> ("work"));
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -1997,7 +1997,7 @@ TEST (rpc, work_generate_difficulty)
 		auto work_text (response.get<std::string> ("work"));
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
 		ASSERT_GE (result_difficulty, difficulty);
 	}
 	{
@@ -2031,7 +2031,7 @@ TEST (rpc, work_generate_multiplier)
 		ASSERT_TRUE (work_text.is_initialized ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
-		auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2062,7 +2062,7 @@ TEST (rpc, work_generate_block_high)
 	nano::keypair key;
 	nano::state_block block (key.pub, 0, nano::dev::genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, *node->work_generate_blocking (key.pub));
 	nano::block_hash hash (block.root ().as_block_hash ());
-	auto block_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, block.block_work ()));
+	auto block_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, block.block_work ()));
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
 	request.put ("hash", hash.to_string ());
@@ -2103,7 +2103,7 @@ TEST (rpc, work_generate_block_low)
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
 		ASSERT_NE (block.block_work (), work);
-		auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2167,7 +2167,7 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 		ASSERT_TRUE (work_text.is_initialized ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
-		auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2215,7 +2215,7 @@ TEST (rpc, work_peer_bad)
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = *work_a;
 	});
-	ASSERT_TIMELY (5s, nano::work_difficulty (nano::work_version::work_1, hash1, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
+	ASSERT_TIMELY (5s, nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash1, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
 }
 
 TEST (rpc, work_peer_one)
@@ -2231,7 +2231,7 @@ TEST (rpc, work_peer_one)
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = *work_a;
 	});
-	ASSERT_TIMELY (5s, nano::work_difficulty (nano::work_version::work_1, key1.pub, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
+	ASSERT_TIMELY (5s, nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, key1.pub, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
 }
 
 TEST (rpc, work_peer_many)
@@ -2258,7 +2258,7 @@ TEST (rpc, work_peer_many)
 		node1.work_generate (nano::work_version::work_1, key1.pub, node1.network_params.network.publish_thresholds.base, [&work = works[i]] (boost::optional<uint64_t> work_a) {
 			work = *work_a;
 		});
-		while (nano::work_difficulty (nano::work_version::work_1, key1.pub, works[i]) < nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1))
+		while (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, key1.pub, works[i]) < nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1))
 		{
 			system1.poll ();
 			system2.poll ();
@@ -2744,7 +2744,7 @@ TEST (rpc, work_validate)
 		double multiplier (response.get<double> ("multiplier"));
 		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, node1->default_difficulty (nano::work_version::work_1)), 1e-6);
 	}
-	auto result_difficulty (nano::work_difficulty (nano::work_version::work_1, hash, work1));
+	auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work1));
 	ASSERT_GE (result_difficulty, node1->default_difficulty (nano::work_version::work_1));
 	request.put ("work", nano::to_string_hex (work1));
 	request.put ("difficulty", nano::to_string_hex (result_difficulty));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -524,9 +524,9 @@ TEST (rpc, send_epoch_2)
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv, false);
 
-	auto target_difficulty = nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false));
-	ASSERT_LT (node->network_params.network.publish_thresholds.entry, target_difficulty);
-	auto min_difficulty = node->network_params.network.publish_thresholds.entry;
+	auto target_difficulty = nano::dev::network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false));
+	ASSERT_LT (node->network_params.work.entry, target_difficulty);
+	auto min_difficulty = node->network_params.work.entry;
 
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -1636,13 +1636,13 @@ TEST (rpc, process_ledger_insufficient_work)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
-	ASSERT_LT (node->network_params.network.publish_thresholds.entry, node->network_params.network.publish_thresholds.epoch_1);
+	ASSERT_LT (node->network_params.work.entry, node->network_params.work.epoch_1);
 	auto latest (node->latest (nano::dev::genesis_key.pub));
-	auto min_difficulty = node->network_params.network.publish_thresholds.entry;
-	auto max_difficulty = node->network_params.network.publish_thresholds.epoch_1;
+	auto min_difficulty = node->network_params.work.entry;
+	auto max_difficulty = node->network_params.work.epoch_1;
 	nano::state_block send (nano::dev::genesis->account (), latest, nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, system.work_generate_limited (latest, min_difficulty, max_difficulty));
-	ASSERT_LT (nano::dev::network_params.network.publish_thresholds.difficulty (send), max_difficulty);
-	ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (send), min_difficulty);
+	ASSERT_LT (nano::dev::network_params.work.difficulty (send), max_difficulty);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (send), min_difficulty);
 	boost::property_tree::ptree request;
 	request.put ("action", "process");
 	std::string json;
@@ -1949,7 +1949,7 @@ TEST (rpc, work_generate)
 		auto work_text (response.json.get<std::string> ("work"));
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.json.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -1980,7 +1980,7 @@ TEST (rpc, work_generate_difficulty)
 		auto work_text (response.get<std::string> ("work"));
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -1997,7 +1997,7 @@ TEST (rpc, work_generate_difficulty)
 		auto work_text (response.get<std::string> ("work"));
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (work_text, work));
-		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
 		ASSERT_GE (result_difficulty, difficulty);
 	}
 	{
@@ -2031,7 +2031,7 @@ TEST (rpc, work_generate_multiplier)
 		ASSERT_TRUE (work_text.is_initialized ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
-		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2062,7 +2062,7 @@ TEST (rpc, work_generate_block_high)
 	nano::keypair key;
 	nano::state_block block (key.pub, 0, nano::dev::genesis_key.pub, nano::Gxrb_ratio, 123, key.prv, key.pub, *node->work_generate_blocking (key.pub));
 	nano::block_hash hash (block.root ().as_block_hash ());
-	auto block_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, block.block_work ()));
+	auto block_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, block.block_work ()));
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
 	request.put ("hash", hash.to_string ());
@@ -2087,7 +2087,7 @@ TEST (rpc, work_generate_block_low)
 	auto threshold (node->default_difficulty (block.work_version ()));
 	block.block_work_set (system.work_generate_limited (block.root ().as_block_hash (), threshold, nano::difficulty::from_multiplier (node->config.max_work_generate_multiplier / 10, threshold)));
 	nano::block_hash hash (block.root ().as_block_hash ());
-	auto block_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (block));
+	auto block_difficulty (nano::dev::network_params.work.difficulty (block));
 	boost::property_tree::ptree request;
 	request.put ("action", "work_generate");
 	request.put ("hash", hash.to_string ());
@@ -2103,7 +2103,7 @@ TEST (rpc, work_generate_block_low)
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
 		ASSERT_NE (block.block_work (), work);
-		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
@@ -2147,7 +2147,7 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	ASSERT_NE (nullptr, send_block);
 	nano::state_block block (key.pub, 0, nano::dev::genesis_key.pub, nano::Gxrb_ratio, send_block->hash (), key.prv, key.pub, 0);
-	auto threshold (nano::dev::network_params.network.publish_thresholds.threshold (block.work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	auto threshold (nano::dev::network_params.work.threshold (block.work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	block.block_work_set (system.work_generate_limited (block.root ().as_block_hash (), 1, threshold - 1));
 	nano::block_hash hash (block.root ().as_block_hash ());
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
@@ -2167,13 +2167,13 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 		ASSERT_TRUE (work_text.is_initialized ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
-		auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work));
+		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
 		auto response_difficulty_text (response.get<std::string> ("difficulty"));
 		uint64_t response_difficulty;
 		ASSERT_FALSE (nano::from_string_hex (response_difficulty_text, response_difficulty));
 		ASSERT_EQ (result_difficulty, response_difficulty);
-		ASSERT_GE (result_difficulty, node->network_params.network.publish_thresholds.epoch_2_receive);
-		finished = result_difficulty < node->network_params.network.publish_thresholds.epoch_1;
+		ASSERT_GE (result_difficulty, node->network_params.work.epoch_2_receive);
+		finished = result_difficulty < node->network_params.work.epoch_1;
 		ASSERT_LT (++iteration, 200);
 	}
 }
@@ -2191,7 +2191,7 @@ TEST (rpc, work_cancel)
 	system.deadline_set (10s);
 	while (!done)
 	{
-		system.work.generate (nano::work_version::work_1, hash1, node1->network_params.network.publish_thresholds.base, [&done] (boost::optional<uint64_t> work_a) {
+		system.work.generate (nano::work_version::work_1, hash1, node1->network_params.work.base, [&done] (boost::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
 		auto response1 (wait_response (system, rpc, request1));
@@ -2211,11 +2211,11 @@ TEST (rpc, work_peer_bad)
 	auto [rpc, rpc_ctx] = add_rpc (system, node1);
 	nano::block_hash hash1 (1);
 	std::atomic<uint64_t> work (0);
-	node2.work_generate (nano::work_version::work_1, hash1, node2.network_params.network.publish_thresholds.base, [&work] (boost::optional<uint64_t> work_a) {
+	node2.work_generate (nano::work_version::work_1, hash1, node2.network_params.work.base, [&work] (boost::optional<uint64_t> work_a) {
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = *work_a;
 	});
-	ASSERT_TIMELY (5s, nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash1, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
+	ASSERT_TIMELY (5s, nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash1, work) >= nano::dev::network_params.work.threshold_base (nano::work_version::work_1));
 }
 
 TEST (rpc, work_peer_one)
@@ -2227,11 +2227,11 @@ TEST (rpc, work_peer_one)
 	node2.config.work_peers.push_back (std::make_pair (node1->network.endpoint ().address ().to_string (), rpc->config.port));
 	nano::keypair key1;
 	std::atomic<uint64_t> work (0);
-	node2.work_generate (nano::work_version::work_1, key1.pub, node1->network_params.network.publish_thresholds.base, [&work] (boost::optional<uint64_t> work_a) {
+	node2.work_generate (nano::work_version::work_1, key1.pub, node1->network_params.work.base, [&work] (boost::optional<uint64_t> work_a) {
 		ASSERT_TRUE (work_a.is_initialized ());
 		work = *work_a;
 	});
-	ASSERT_TIMELY (5s, nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, key1.pub, work) >= nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1));
+	ASSERT_TIMELY (5s, nano::dev::network_params.work.difficulty (nano::work_version::work_1, key1.pub, work) >= nano::dev::network_params.work.threshold_base (nano::work_version::work_1));
 }
 
 TEST (rpc, work_peer_many)
@@ -2255,10 +2255,10 @@ TEST (rpc, work_peer_many)
 	for (auto i (0); i < works.size (); ++i)
 	{
 		nano::keypair key1;
-		node1.work_generate (nano::work_version::work_1, key1.pub, node1.network_params.network.publish_thresholds.base, [&work = works[i]] (boost::optional<uint64_t> work_a) {
+		node1.work_generate (nano::work_version::work_1, key1.pub, node1.network_params.work.base, [&work = works[i]] (boost::optional<uint64_t> work_a) {
 			work = *work_a;
 		});
-		while (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, key1.pub, works[i]) < nano::dev::network_params.network.publish_thresholds.threshold_base (nano::work_version::work_1))
+		while (nano::dev::network_params.work.difficulty (nano::work_version::work_1, key1.pub, works[i]) < nano::dev::network_params.work.threshold_base (nano::work_version::work_1))
 		{
 			system1.poll ();
 			system2.poll ();
@@ -2542,9 +2542,9 @@ TEST (rpc, account_representative_set_epoch_2)
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv, false);
 
-	auto target_difficulty = nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, false, false));
-	ASSERT_LT (node->network_params.network.publish_thresholds.entry, target_difficulty);
-	auto min_difficulty = node->network_params.network.publish_thresholds.entry;
+	auto target_difficulty = nano::dev::network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, false, false));
+	ASSERT_LT (node->network_params.work.entry, target_difficulty);
+	auto min_difficulty = node->network_params.work.entry;
 
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -2744,7 +2744,7 @@ TEST (rpc, work_validate)
 		double multiplier (response.get<double> ("multiplier"));
 		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, node1->default_difficulty (nano::work_version::work_1)), 1e-6);
 	}
-	auto result_difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (nano::work_version::work_1, hash, work1));
+	auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work1));
 	ASSERT_GE (result_difficulty, node1->default_difficulty (nano::work_version::work_1));
 	request.put ("work", nano::to_string_hex (work1));
 	request.put ("difficulty", nano::to_string_hex (result_difficulty));
@@ -2761,7 +2761,7 @@ TEST (rpc, work_validate)
 		auto response (wait_response (system, rpc, request));
 		ASSERT_EQ (result_difficulty >= difficulty4, response.get<bool> ("valid"));
 		ASSERT_EQ (result_difficulty >= node1->default_difficulty (nano::work_version::work_1), response.get<bool> ("valid_all"));
-		ASSERT_EQ (result_difficulty >= node1->network_params.network.publish_thresholds.epoch_2_receive, response.get<bool> ("valid_all"));
+		ASSERT_EQ (result_difficulty >= node1->network_params.work.epoch_2_receive, response.get<bool> ("valid_all"));
 	}
 	uint64_t work3 (*node1->work_generate_blocking (hash, difficulty4));
 	request.put ("work", nano::to_string_hex (work3));
@@ -2779,8 +2779,8 @@ TEST (rpc, work_validate_epoch_2)
 	auto node = add_ipc_enabled_node (system);
 	auto epoch1 = system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1);
 	ASSERT_NE (nullptr, epoch1);
-	ASSERT_EQ (node->network_params.network.publish_thresholds.epoch_2, node->network_params.network.publish_thresholds.base);
-	auto work = system.work_generate_limited (epoch1->hash (), node->network_params.network.publish_thresholds.epoch_1, node->network_params.network.publish_thresholds.base);
+	ASSERT_EQ (node->network_params.work.epoch_2, node->network_params.work.base);
+	auto work = system.work_generate_limited (epoch1->hash (), node->network_params.work.epoch_1, node->network_params.work.base);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "work_validate");
@@ -2795,7 +2795,7 @@ TEST (rpc, work_validate_epoch_2)
 		uint64_t difficulty{ 0 };
 		ASSERT_FALSE (nano::from_string_hex (difficulty_text, difficulty));
 		double multiplier (response.get<double> ("multiplier"));
-		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, node->network_params.network.publish_thresholds.epoch_2), 1e-6);
+		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, node->network_params.work.epoch_2), 1e-6);
 	};
 	// After upgrading, the higher difficulty is used to validate and calculate the multiplier
 	rpc_ctx->io_scope->reset ();
@@ -4228,7 +4228,7 @@ TEST (rpc, block_create)
 	std::string send_hash (response.get<std::string> ("hash"));
 	ASSERT_EQ (send.hash ().to_string (), send_hash);
 	std::string send_difficulty (response.get<std::string> ("difficulty"));
-	ASSERT_EQ (nano::to_string_hex (nano::dev::network_params.network.publish_thresholds.difficulty (send)), send_difficulty);
+	ASSERT_EQ (nano::to_string_hex (nano::dev::network_params.work.difficulty (send)), send_difficulty);
 	auto send_text (response.get<std::string> ("block"));
 	boost::property_tree::ptree block_l;
 	std::stringstream block_stream (send_text);
@@ -4360,8 +4360,8 @@ TEST (rpc, block_create_state_open)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
-	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false)));
+	auto difficulty (nano::dev::network_params.work.difficulty (*state_block));
+	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
@@ -4406,7 +4406,7 @@ TEST (rpc, block_create_state_request_work)
 		boost::property_tree::read_json (block_stream, block_l);
 		auto block (nano::deserialize_block_json (block_l));
 		ASSERT_NE (nullptr, block);
-		ASSERT_GE (nano::dev::network_params.network.publish_thresholds.difficulty (*block), node->default_difficulty (nano::work_version::work_1));
+		ASSERT_GE (nano::dev::network_params.work.difficulty (*block), node->default_difficulty (nano::work_version::work_1));
 	}
 }
 
@@ -4440,8 +4440,8 @@ TEST (rpc, block_create_open_epoch_v2)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
-	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	auto difficulty (nano::dev::network_params.work.difficulty (*state_block));
+	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
@@ -4484,8 +4484,8 @@ TEST (rpc, block_create_receive_epoch_v2)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
-	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	auto difficulty (nano::dev::network_params.work.difficulty (*state_block));
+	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
 	ASSERT_EQ (nano::process_result::progress, process_result.code);
@@ -4526,8 +4526,8 @@ TEST (rpc, block_create_send_epoch_v2)
 	ASSERT_NE (nullptr, state_block);
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
-	auto difficulty (nano::dev::network_params.network.publish_thresholds.difficulty (*state_block));
-	ASSERT_GT (difficulty, nano::dev::network_params.network.publish_thresholds.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	auto difficulty (nano::dev::network_params.work.difficulty (*state_block));
+	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	rpc_ctx->io_scope->reset ();
 	auto process_result (node->process (*state_block));
 	ASSERT_EQ (nano::process_result::progress, process_result.code);
@@ -5450,7 +5450,7 @@ TEST (rpc, active_difficulty)
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
-	ASSERT_EQ (node->default_difficulty (nano::work_version::work_1), node->network_params.network.publish_thresholds.epoch_2);
+	ASSERT_EQ (node->default_difficulty (nano::work_version::work_1), node->network_params.work.epoch_2);
 	boost::property_tree::ptree request;
 	request.put ("action", "active_difficulty");
 	auto expected_multiplier{ 1.0 };
@@ -5474,7 +5474,7 @@ TEST (rpc, active_difficulty)
 		uint64_t network_receive_current;
 		ASSERT_FALSE (nano::from_string_hex (network_receive_current_text, network_receive_current));
 		auto network_receive_current_multiplier (nano::difficulty::to_multiplier (network_receive_current, network_receive_minimum));
-		auto network_receive_current_normalized_multiplier (nano::dev::network_params.network.publish_thresholds.normalized_multiplier (network_receive_current_multiplier, network_receive_minimum));
+		auto network_receive_current_normalized_multiplier (nano::dev::network_params.work.normalized_multiplier (network_receive_current_multiplier, network_receive_minimum));
 		ASSERT_NEAR (network_receive_current_normalized_multiplier, multiplier, 1e-6);
 		ASSERT_EQ (response.not_found (), response.find ("difficulty_trend"));
 	}

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -86,19 +86,15 @@ nano::ledger_constants & nano::dev::constants{ nano::dev::network_params.ledger 
 std::shared_ptr<nano::block> & nano::dev::genesis = nano::dev::constants.genesis;
 
 nano::network_params::network_params (nano::networks network_a) :
-	network (network_a), ledger (network), voting (network), node (network), portmapping (network), bootstrap (network)
+	network (network_a), ledger (network.publish_thresholds, network.network ()), voting (network), node (network), portmapping (network), bootstrap (network)
 {
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_dev_work = 8;
 	kdf_work = network.is_dev_network () ? kdf_dev_work : kdf_full_work;
 }
 
-nano::ledger_constants::ledger_constants (nano::network_constants & network_constants) :
-	ledger_constants (network_constants.network ())
-{
-}
-
-nano::ledger_constants::ledger_constants (nano::networks network_a) :
+nano::ledger_constants::ledger_constants (nano::work_thresholds & work, nano::networks network_a) :
+	work{ work },
 	zero_key ("0"),
 	nano_beta_account (beta_public_key_data),
 	nano_live_account (live_public_key_data),

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -86,7 +86,13 @@ nano::ledger_constants & nano::dev::constants{ nano::dev::network_params.ledger 
 std::shared_ptr<nano::block> & nano::dev::genesis = nano::dev::constants.genesis;
 
 nano::network_params::network_params (nano::networks network_a) :
-	network (network_a), ledger (network.publish_thresholds, network.network ()), voting (network), node (network), portmapping (network), bootstrap (network)
+	work{ network_a == nano::networks::nano_live_network ? nano::work_thresholds::publish_full : network_a == nano::networks::nano_beta_network ? nano::work_thresholds::publish_beta : network_a == nano::networks::nano_test_network ? nano::work_thresholds::publish_test : nano::work_thresholds::publish_dev },
+	network{ work, network_a },
+	ledger{ work, network_a },
+	voting{ network },
+	node{ network },
+	portmapping{ network },
+	bootstrap{ network }
 {
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_dev_work = 8;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -439,13 +439,14 @@ public:
 	network_params (nano::networks network_a);
 
 	unsigned kdf_work;
-	network_constants network;
-	ledger_constants ledger;
-	random_constants random;
-	voting_constants voting;
-	node_constants node;
-	portmapping_constants portmapping;
-	bootstrap_constants bootstrap;
+	nano::work_thresholds work;
+	nano::network_constants network;
+	nano::ledger_constants ledger;
+	nano::random_constants random;
+	nano::voting_constants voting;
+	nano::node_constants node;
+	nano::portmapping_constants portmapping;
+	nano::bootstrap_constants bootstrap;
 };
 
 enum class confirmation_height_mode

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -340,8 +340,8 @@ class network_params;
 class ledger_constants
 {
 public:
-	ledger_constants (nano::network_constants & network_constants);
-	ledger_constants (nano::networks network_a);
+	ledger_constants (nano::work_thresholds & work, nano::networks network_a);
+	nano::work_thresholds & work;
 	nano::keypair zero_key;
 	nano::account nano_beta_account;
 	nano::account nano_live_account;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -346,8 +346,7 @@ void ledger_processor::state_block_impl (nano::state_block & block_a)
 				if (result.code == nano::process_result::progress)
 				{
 					nano::block_details block_details (epoch, is_send, is_receive, false);
-					nano::network_constants constants;
-					result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+					result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
 						ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
@@ -447,8 +446,7 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							nano::block_details block_details (epoch, false, false, true);
-							nano::network_constants constants;
-							result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+							result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 							if (result.code == nano::process_result::progress)
 							{
 								ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::epoch_block);
@@ -500,8 +498,7 @@ void ledger_processor::change_block (nano::change_block & block_a)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-						nano::network_constants constants;
-						result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+						result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
@@ -550,8 +547,7 @@ void ledger_processor::send_block (nano::send_block & block_a)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-						nano::network_constants constants;
-						result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+						result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
@@ -628,8 +624,7 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 									if (result.code == nano::process_result::progress)
 									{
 										nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-										nano::network_constants constants;
-										result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+										result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 										if (result.code == nano::process_result::progress)
 										{
 											auto new_balance (info.balance.number () + pending.amount.number ());
@@ -702,8 +697,7 @@ void ledger_processor::open_block (nano::open_block & block_a)
 							if (result.code == nano::process_result::progress)
 							{
 								nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-								nano::network_constants constants;
-								result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+								result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 								if (result.code == nano::process_result::progress)
 								{
 #ifdef NDEBUG
@@ -870,7 +864,7 @@ nano::uint128_t nano::ledger::account_pending (nano::transaction const & transac
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a, nano::signature_verification verification)
 {
 	static nano::network_constants network_constants;
-	debug_assert (!network_constants.publish_thresholds.validate_entry (block_a) || constants.genesis == nano::dev::genesis);
+	debug_assert (!constants.work.validate_entry (block_a) || constants.genesis == nano::dev::genesis);
 	ledger_processor processor (*this, transaction_a, verification);
 	block_a.visit (processor);
 	if (processor.result.code == nano::process_result::progress)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -346,7 +346,7 @@ void ledger_processor::state_block_impl (nano::state_block & block_a)
 				if (result.code == nano::process_result::progress)
 				{
 					nano::block_details block_details (epoch, is_send, is_receive, false);
-					result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+					result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
 						ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
@@ -446,7 +446,7 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							nano::block_details block_details (epoch, false, false, true);
-							result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+							result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 							if (result.code == nano::process_result::progress)
 							{
 								ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::epoch_block);
@@ -498,7 +498,7 @@ void ledger_processor::change_block (nano::change_block & block_a)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-						result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+						result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
@@ -547,7 +547,7 @@ void ledger_processor::send_block (nano::send_block & block_a)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-						result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+						result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
@@ -624,7 +624,7 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 									if (result.code == nano::process_result::progress)
 									{
 										nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-										result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+										result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 										if (result.code == nano::process_result::progress)
 										{
 											auto new_balance (info.balance.number () + pending.amount.number ());
@@ -697,7 +697,7 @@ void ledger_processor::open_block (nano::open_block & block_a)
 							if (result.code == nano::process_result::progress)
 							{
 								nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-								result.code = block_a.difficulty () >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+								result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 								if (result.code == nano::process_result::progress)
 								{
 #ifdef NDEBUG

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -346,7 +346,8 @@ void ledger_processor::state_block_impl (nano::state_block & block_a)
 				if (result.code == nano::process_result::progress)
 				{
 					nano::block_details block_details (epoch, is_send, is_receive, false);
-					result.code = block_a.difficulty () >= nano::work_threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+					nano::network_constants constants;
+					result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
 						ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
@@ -446,7 +447,8 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							nano::block_details block_details (epoch, false, false, true);
-							result.code = block_a.difficulty () >= nano::work_threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+							nano::network_constants constants;
+							result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 							if (result.code == nano::process_result::progress)
 							{
 								ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::epoch_block);
@@ -498,7 +500,8 @@ void ledger_processor::change_block (nano::change_block & block_a)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-						result.code = block_a.difficulty () >= nano::work_threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+						nano::network_constants constants;
+						result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
@@ -547,7 +550,8 @@ void ledger_processor::send_block (nano::send_block & block_a)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-						result.code = block_a.difficulty () >= nano::work_threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+						nano::network_constants constants;
+						result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
@@ -624,7 +628,8 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 									if (result.code == nano::process_result::progress)
 									{
 										nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-										result.code = block_a.difficulty () >= nano::work_threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+										nano::network_constants constants;
+										result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 										if (result.code == nano::process_result::progress)
 										{
 											auto new_balance (info.balance.number () + pending.amount.number ());
@@ -697,7 +702,8 @@ void ledger_processor::open_block (nano::open_block & block_a)
 							if (result.code == nano::process_result::progress)
 							{
 								nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
-								result.code = block_a.difficulty () >= nano::work_threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
+								nano::network_constants constants;
+								result.code = block_a.difficulty () >= constants.publish_thresholds.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 								if (result.code == nano::process_result::progress)
 								{
 #ifdef NDEBUG

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -863,7 +863,6 @@ nano::uint128_t nano::ledger::account_pending (nano::transaction const & transac
 
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a, nano::signature_verification verification)
 {
-	static nano::network_constants network_constants;
 	debug_assert (!constants.work.validate_entry (block_a) || constants.genesis == nano::dev::genesis);
 	ledger_processor processor (*this, transaction_a, verification);
 	block_a.visit (processor);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -869,7 +869,8 @@ nano::uint128_t nano::ledger::account_pending (nano::transaction const & transac
 
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a, nano::signature_verification verification)
 {
-	debug_assert (!nano::work_validate_entry (block_a) || constants.genesis == nano::dev::genesis);
+	static nano::network_constants network_constants;
+	debug_assert (!network_constants.publish_thresholds.validate_entry (block_a) || constants.genesis == nano::dev::genesis);
 	ledger_processor processor (*this, transaction_a, verification);
 	block_a.visit (processor);
 	if (processor.result.code == nano::process_result::progress)

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -6,11 +6,10 @@
 
 static std::vector<boost::filesystem::path> all_unique_paths;
 
-boost::filesystem::path nano::working_path ()
+boost::filesystem::path nano::working_path (nano::networks network)
 {
-	static nano::network_constants network_constants;
 	auto result (nano::app_path ());
-	switch (network_constants.network ())
+	switch (network)
 	{
 		case nano::networks::invalid:
 			release_assert (false);
@@ -31,9 +30,9 @@ boost::filesystem::path nano::working_path ()
 	return result;
 }
 
-boost::filesystem::path nano::unique_path ()
+boost::filesystem::path nano::unique_path (nano::networks network)
 {
-	auto result (working_path () / boost::filesystem::unique_path ());
+	auto result (working_path (network) / boost::filesystem::unique_path ());
 	all_unique_paths.push_back (result);
 	return result;
 }

--- a/nano/secure/utility.hpp
+++ b/nano/secure/utility.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <crypto/cryptopp/osrng.h>
+#include <nano/lib/config.hpp>
 
 #include <boost/filesystem/path.hpp>
 
 namespace nano
 {
 // OS-specific way of finding a path to a home directory.
-boost::filesystem::path working_path ();
+boost::filesystem::path working_path (nano::networks network = nano::network_constants::active_network);
 // Get a unique path within the home directory, used for testing.
 // Any directories created at this location will be removed when a test finishes.
-boost::filesystem::path unique_path ();
+boost::filesystem::path unique_path (nano::networks network = nano::network_constants::active_network);
 // Remove all unique tmp directories created by the process
 void remove_temporary_directories ();
 // Generic signal handler declarations

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1609,7 +1609,7 @@ TEST (node, mass_epoch_upgrader)
 							 .link (info.key.pub)
 							 .representative (nano::dev::genesis_key.pub)
 							 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							 .work (*node.work_generate_blocking (latest, nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
+							 .work (*node.work_generate_blocking (latest, nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
 							 .build (ec);
 				ASSERT_FALSE (ec);
 				ASSERT_NE (nullptr, block);
@@ -1633,7 +1633,7 @@ TEST (node, mass_epoch_upgrader)
 						 .link (info.pending_hash)
 						 .representative (info.key.pub)
 						 .sign (info.key.prv, info.key.pub)
-						 .work (*node.work_generate_blocking (info.key.pub, nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
+						 .work (*node.work_generate_blocking (info.key.pub, nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
 						 .build (ec);
 			ASSERT_FALSE (ec);
 			ASSERT_NE (nullptr, block);
@@ -1723,7 +1723,7 @@ TEST (node, mass_block_new)
 	std::vector<nano::keypair> keys (num_blocks);
 	nano::state_block_builder builder;
 	std::vector<std::shared_ptr<nano::state_block>> send_blocks;
-	auto send_threshold (nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	auto send_threshold (nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	auto latest_genesis = node.latest (nano::dev::genesis_key.pub);
 	for (auto i = 0; i < num_blocks; ++i)
 	{
@@ -1746,7 +1746,7 @@ TEST (node, mass_block_new)
 	std::cout << "Send blocks time: " << timer.stop ().count () << " " << timer.unit () << "\n\n";
 
 	std::vector<std::shared_ptr<nano::state_block>> open_blocks;
-	auto receive_threshold (nano::work_threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	auto receive_threshold (nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	for (auto i = 0; i < num_blocks; ++i)
 	{
 		auto const & key = keys[i];

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1609,7 +1609,7 @@ TEST (node, mass_epoch_upgrader)
 							 .link (info.key.pub)
 							 .representative (nano::dev::genesis_key.pub)
 							 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							 .work (*node.work_generate_blocking (latest, nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
+							 .work (*node.work_generate_blocking (latest, node_config.network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
 							 .build (ec);
 				ASSERT_FALSE (ec);
 				ASSERT_NE (nullptr, block);
@@ -1633,7 +1633,7 @@ TEST (node, mass_epoch_upgrader)
 						 .link (info.pending_hash)
 						 .representative (info.key.pub)
 						 .sign (info.key.prv, info.key.pub)
-						 .work (*node.work_generate_blocking (info.key.pub, nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
+						 .work (*node.work_generate_blocking (info.key.pub, node_config.network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_0, false, false, false))))
 						 .build (ec);
 			ASSERT_FALSE (ec);
 			ASSERT_NE (nullptr, block);
@@ -1723,7 +1723,7 @@ TEST (node, mass_block_new)
 	std::vector<nano::keypair> keys (num_blocks);
 	nano::state_block_builder builder;
 	std::vector<std::shared_ptr<nano::state_block>> send_blocks;
-	auto send_threshold (nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false)));
+	auto send_threshold (nano::dev::network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	auto latest_genesis = node.latest (nano::dev::genesis_key.pub);
 	for (auto i = 0; i < num_blocks; ++i)
 	{
@@ -1746,7 +1746,7 @@ TEST (node, mass_block_new)
 	std::cout << "Send blocks time: " << timer.stop ().count () << " " << timer.unit () << "\n\n";
 
 	std::vector<std::shared_ptr<nano::state_block>> open_blocks;
-	auto receive_threshold (nano::dev::network_params.network.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, true, false)));
+	auto receive_threshold (nano::dev::network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	for (auto i = 0; i < num_blocks; ++i)
 	{
 		auto const & key = keys[i];

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -97,7 +97,7 @@ TEST (ledger, deep_account_compute)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
 	auto balance (nano::dev::constants.genesis_amount - 1);
 	nano::send_block send (nano::dev::genesis->hash (), key.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
@@ -968,7 +968,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	nano::stat stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
-	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	std::atomic<bool> stopped{ false };
 	boost::latch initialized_latch{ 0 };
 

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -205,7 +205,7 @@ uint64_t nano::system::work_generate_limited (nano::block_hash const & root_a, u
 	do
 	{
 		result = *work.generate (root_a, min_a);
-	} while (work.network_constants.publish_thresholds.difficulty (nano::work_version::work_1, root_a, result) >= max_a);
+	} while (work.network_constants.work.difficulty (nano::work_version::work_1, root_a, result) >= max_a);
 	return result;
 }
 
@@ -226,7 +226,7 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 				 .link (ledger_a.epoch_link (epoch_a))
 				 .representative (dev_genesis_key.pub)
 				 .sign (dev_genesis_key.prv, dev_genesis_key.pub)
-				 .work (*pool_a.generate (latest, pool_a.network_constants.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
+				 .work (*pool_a.generate (latest, pool_a.network_constants.work.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
 				 .build (ec);
 
 	bool error{ true };

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -219,6 +219,7 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 
 	nano::state_block_builder builder;
 	std::error_code ec;
+	nano::network_constants constants;
 	auto epoch = builder
 				 .account (dev_genesis_key.pub)
 				 .previous (latest)
@@ -226,7 +227,7 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 				 .link (ledger_a.epoch_link (epoch_a))
 				 .representative (dev_genesis_key.pub)
 				 .sign (dev_genesis_key.prv, dev_genesis_key.pub)
-				 .work (*pool_a.generate (latest, nano::work_threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
+				 .work (*pool_a.generate (latest, constants.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
 				 .build (ec);
 
 	bool error{ true };

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -202,11 +202,10 @@ uint64_t nano::system::work_generate_limited (nano::block_hash const & root_a, u
 {
 	debug_assert (min_a > 0);
 	uint64_t result = 0;
-	static nano::network_constants constants;
 	do
 	{
 		result = *work.generate (root_a, min_a);
-	} while (constants.publish_thresholds.difficulty (nano::work_version::work_1, root_a, result) >= max_a);
+	} while (work.network_constants.publish_thresholds.difficulty (nano::work_version::work_1, root_a, result) >= max_a);
 	return result;
 }
 
@@ -220,7 +219,6 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 
 	nano::state_block_builder builder;
 	std::error_code ec;
-	static nano::network_constants constants;
 	auto epoch = builder
 				 .account (dev_genesis_key.pub)
 				 .previous (latest)
@@ -228,7 +226,7 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 				 .link (ledger_a.epoch_link (epoch_a))
 				 .representative (dev_genesis_key.pub)
 				 .sign (dev_genesis_key.prv, dev_genesis_key.pub)
-				 .work (*pool_a.generate (latest, constants.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
+				 .work (*pool_a.generate (latest, pool_a.network_constants.publish_thresholds.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true))))
 				 .build (ec);
 
 	bool error{ true };

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -202,10 +202,11 @@ uint64_t nano::system::work_generate_limited (nano::block_hash const & root_a, u
 {
 	debug_assert (min_a > 0);
 	uint64_t result = 0;
+	static nano::network_constants constants;
 	do
 	{
 		result = *work.generate (root_a, min_a);
-	} while (nano::work_difficulty (nano::work_version::work_1, root_a, result) >= max_a);
+	} while (constants.publish_thresholds.difficulty (nano::work_version::work_1, root_a, result) >= max_a);
 	return result;
 }
 
@@ -219,7 +220,7 @@ std::unique_ptr<nano::state_block> nano::upgrade_epoch (nano::work_pool & pool_a
 
 	nano::state_block_builder builder;
 	std::error_code ec;
-	nano::network_constants constants;
+	static nano::network_constants constants;
 	auto epoch = builder
 				 .account (dev_genesis_key.pub)
 				 .previous (latest)

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -50,7 +50,7 @@ public:
 	boost::asio::io_context io_ctx;
 	std::vector<std::shared_ptr<nano::node>> nodes;
 	nano::logging logging;
-	nano::work_pool work{ std::max (std::thread::hardware_concurrency (), 1u) };
+	nano::work_pool work{ nano::dev::network_params.network, std::max (std::thread::hardware_concurrency (), 1u) };
 	std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
 	double deadline_scaling_factor{ 1.0 };
 	unsigned node_sequence{ 0 };


### PR DESCRIPTION
This change removes static references to network_constants that were littered around the code. Additionally, free-functions related to work difficulty and value calculations were moved on to the work_thrsholds class.

This PR is best reviewed on a per-commit basis, each commit is self-contained with clean test runs.