### PR TITLE
fix failing build with boost >= 1.76

### DIFF
--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -112,6 +112,7 @@ struct hash<::nano::tcp_endpoint>
 		return ehash (endpoint_a);
 	}
 };
+#ifndef BOOST_ASIO_HAS_STD_HASH
 template <>
 struct hash<boost::asio::ip::address>
 {
@@ -121,6 +122,7 @@ struct hash<boost::asio::ip::address>
 		return ihash (ip_a);
 	}
 };
+#endif
 }
 namespace boost
 {


### PR DESCRIPTION
Boost 1.76 include the following changes:

>  Added `std::hash` specialisations for IP addresses.
> Added `std::hash` specialisations for `ip::basic_endpoint<>`. 

(see https://www.boost.org/doc/libs/1_76_0/doc/html/boost_asio/history.html#boost_asio.history.asio_1_18_2___boost_1_76 )

As such, when building with boost 1.76, the compiler threw a redefinition error. This `#ifdef` fixes that, while remaining backwards-compatible with non-bleeding-edge boost versions.