### PR TITLE
Convert nano::bootstrap_connection::connections to a reference

### DIFF
--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -187,7 +187,7 @@ void nano::bulk_pull_client::received_type ()
 			// Avoid re-using slow peers, or peers that sent the wrong blocks.
 			if (!connection->pending_stop && (expected == pull.end || (pull.count != 0 && pull.count == pull_blocks)))
 			{
-				connection->connections->pool_connection (connection);
+				connection->connections.pool_connection (connection);
 			}
 			break;
 		}
@@ -253,7 +253,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 			}
 			else if (stop_pull && block_expected)
 			{
-				connection->connections->pool_connection (connection);
+				connection->connections.pool_connection (connection);
 			}
 		}
 		else if (block == nullptr)
@@ -376,7 +376,7 @@ void nano::bulk_pull_account_client::receive_pending ()
 				}
 				else
 				{
-					this_l->connection->connections->pool_connection (this_l->connection);
+					this_l->connection->connections.pool_connection (this_l->connection);
 				}
 			}
 			else

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -13,7 +13,7 @@ constexpr double nano::bootstrap_limits::bootstrap_minimum_termination_time_sec;
 constexpr unsigned nano::bootstrap_limits::bootstrap_max_new_connections;
 constexpr unsigned nano::bootstrap_limits::requeued_pulls_processed_blocks_factor;
 
-nano::bootstrap_client::bootstrap_client (std::shared_ptr<nano::node> const & node_a, std::shared_ptr<nano::bootstrap_connections> const & connections_a, std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a) :
+nano::bootstrap_client::bootstrap_client (std::shared_ptr<nano::node> const & node_a, nano::bootstrap_connections & connections_a, std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a) :
 	node (node_a),
 	connections (connections_a),
 	channel (channel_a),
@@ -21,14 +21,14 @@ nano::bootstrap_client::bootstrap_client (std::shared_ptr<nano::node> const & no
 	receive_buffer (std::make_shared<std::vector<uint8_t>> ()),
 	start_time_m (std::chrono::steady_clock::now ())
 {
-	++connections->connections_count;
+	++connections.connections_count;
 	receive_buffer->resize (256);
 	channel->set_endpoint ();
 }
 
 nano::bootstrap_client::~bootstrap_client ()
 {
-	--connections->connections_count;
+	--connections.connections_count;
 }
 
 double nano::bootstrap_client::sample_block_rate ()
@@ -154,7 +154,7 @@ void nano::bootstrap_connections::connect_client (nano::tcp_endpoint const & end
 			{
 				this_l->node.logger.try_log (boost::str (boost::format ("Connection established to %1%") % endpoint_a));
 			}
-			auto client (std::make_shared<nano::bootstrap_client> (this_l->node.shared (), this_l, std::make_shared<nano::transport::channel_tcp> (*this_l->node.shared (), socket), socket));
+			auto client (std::make_shared<nano::bootstrap_client> (this_l->node.shared (), *this_l, std::make_shared<nano::transport::channel_tcp> (*this_l->node.shared (), socket), socket));
 			this_l->pool_connection (client, true, push_front);
 		}
 		else

--- a/nano/node/bootstrap/bootstrap_connections.hpp
+++ b/nano/node/bootstrap/bootstrap_connections.hpp
@@ -21,7 +21,7 @@ class pull_info;
 class bootstrap_client final : public std::enable_shared_from_this<bootstrap_client>
 {
 public:
-	bootstrap_client (std::shared_ptr<nano::node> const & node_a, std::shared_ptr<nano::bootstrap_connections> const & connections_a, std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a);
+	bootstrap_client (std::shared_ptr<nano::node> const & node_a, nano::bootstrap_connections & connections_a, std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a);
 	~bootstrap_client ();
 	std::shared_ptr<nano::bootstrap_client> shared ();
 	void stop (bool force);
@@ -29,7 +29,7 @@ public:
 	double elapsed_seconds () const;
 	void set_start_time (std::chrono::steady_clock::time_point start_time_a);
 	std::shared_ptr<nano::node> node;
-	std::shared_ptr<nano::bootstrap_connections> connections;
+	nano::bootstrap_connections & connections;
 	std::shared_ptr<nano::transport::channel_tcp> channel;
 	std::shared_ptr<nano::socket> socket;
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -199,7 +199,7 @@ void nano::frontier_req_client::received_frontier (boost::system::error_code con
 			catch (std::future_error &)
 			{
 			}
-			connection->connections->pool_connection (connection);
+			connection->connections.pool_connection (connection);
 		}
 	}
 	else


### PR DESCRIPTION
nano::bootstrap_connections is composed of nano::bootstrap_connection. Convert nano::bootstrap_connection::connections to a reference since it doesn't manage lifetime.