### PR TITLE
Removing null checks for nano::bootstrap::socket

### DIFF
--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -136,10 +136,7 @@ void nano::bootstrap_server::stop ()
 {
 	if (!stopped.exchange (true))
 	{
-		if (socket != nullptr)
-		{
-			socket->close ();
-		}
+		socket->close ();
 	}
 }
 
@@ -583,25 +580,17 @@ void nano::bootstrap_server::finish_request_async ()
 
 void nano::bootstrap_server::timeout ()
 {
-	if (socket != nullptr)
+	if (socket->has_timed_out ())
 	{
-		if (socket->has_timed_out ())
+		if (node->config.logging.bulk_pull_logging ())
 		{
-			if (node->config.logging.bulk_pull_logging ())
-			{
-				node->logger.try_log ("Closing incoming tcp / bootstrap server by timeout");
-			}
-			{
-				nano::lock_guard<nano::mutex> lock (node->bootstrap.mutex);
-				node->bootstrap.connections.erase (this);
-			}
-			socket->close ();
+			node->logger.try_log ("Closing incoming tcp / bootstrap server by timeout");
 		}
-	}
-	else
-	{
-		nano::lock_guard<nano::mutex> lock (node->bootstrap.mutex);
-		node->bootstrap.connections.erase (this);
+		{
+			nano::lock_guard<nano::mutex> lock (node->bootstrap.mutex);
+			node->bootstrap.connections.erase (this);
+		}
+		socket->close ();
 	}
 }
 

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -59,7 +59,7 @@ public:
 	bool is_bootstrap_connection ();
 	bool is_realtime_connection ();
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;
-	std::shared_ptr<nano::socket> socket;
+	std::shared_ptr<nano::socket> const socket;
 	std::shared_ptr<nano::node> node;
 	nano::mutex mutex;
 	std::queue<std::unique_ptr<nano::message>> requests;


### PR DESCRIPTION
 Removing null checks for nano::bootstrap::socket since it's required to be non-null on construction and is never nulled out during execution.