### PR TITLE
Remove node_id_handshake_sockets as unneeded.

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -177,7 +177,6 @@ TEST (node, send_single_many_peers)
 	for (auto node : system.nodes)
 	{
 		ASSERT_TRUE (node->stopped);
-		ASSERT_TRUE (node->network.tcp_channels.node_id_handhake_sockets_empty ());
 	}
 }
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -105,9 +105,6 @@ namespace transport
 		void start_tcp (nano::endpoint const &, std::function<void (std::shared_ptr<nano::transport::channel> const &)> const & = nullptr);
 		void start_tcp_receive_node_id (std::shared_ptr<nano::transport::channel_tcp> const &, nano::endpoint const &, std::shared_ptr<std::vector<uint8_t>> const &, std::function<void (std::shared_ptr<nano::transport::channel> const &)> const &);
 		void udp_fallback (nano::endpoint const &, std::function<void (std::shared_ptr<nano::transport::channel> const &)> const &);
-		void push_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a);
-		void remove_node_id_handshake_socket (std::shared_ptr<nano::socket> const & socket_a);
-		bool node_id_handhake_sockets_empty () const;
 		nano::node & node;
 
 	private:
@@ -228,8 +225,6 @@ namespace transport
 				mi::member<tcp_endpoint_attempt, std::chrono::steady_clock::time_point, &tcp_endpoint_attempt::last_attempt>>>>
 		attempts;
 		// clang-format on
-		// This owns the sockets until the node_id_handshake has been completed. Needed to prevent self referencing callbacks, they are periodically removed if any are dangling.
-		std::vector<std::shared_ptr<nano::socket>> node_id_handshake_sockets;
 		std::atomic<bool> stopped{ false };
 
 		friend class network_peer_max_tcp_attempts_subnetwork_Test;


### PR DESCRIPTION
Original commit references a leak, however, none of the clearing operations actually close the socket, they simply decrement the shared_ptr counter.
Additionally, removal operations are incorrectly implemented as they delete the shared_ptr in question and every shared_ptr following until the end of the container.