### PR TITLE
Fix fill_keepalive_self so the low index entries aren't clobbered.

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1262,3 +1262,11 @@ TEST (network, filter)
 	node1.network.inbound (keepalive, std::make_shared<nano::transport::channel_loopback> (node1));
 	ASSERT_EQ (1, node1.stats.count (nano::stat::type::message, nano::stat::detail::invalid_network));
 }
+
+TEST (network, fill_keepalive_self)
+{
+	nano::system system{ 2 };
+	std::array<nano::endpoint, 8> target;
+	system.nodes[0]->network.fill_keepalive_self (target);
+	ASSERT_TRUE (target[2].port () == system.nodes[1]->network.port);
+}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -684,6 +684,10 @@ void nano::network::random_fill (std::array<nano::endpoint, 8> & target_a) const
 void nano::network::fill_keepalive_self (std::array<nano::endpoint, 8> & target_a) const
 {
 	random_fill (target_a);
+	// We will clobber values in index 0 and 1 and if there are only 2 nodes in the system, these are the only positions occupied
+	// Move these items to index 2 and 3 so they propagate
+	target_a[2] = target_a[0];
+	target_a[3] = target_a[1];
 	// Replace part of message with node external address or listening port
 	target_a[1] = nano::endpoint (boost::asio::ip::address_v6{}, 0); // For node v19 (response channels)
 	if (node.config.external_address != boost::asio::ip::address_v6{}.to_string () && node.config.external_port != 0)


### PR DESCRIPTION
Fill_keepalive_self sets special values in index 0 and 1 to refer to the peering port of the node. Values are also filled from the lowest index so the lowest entries would get clobbered. Preserve these values in index 2 and 3.