### PR TITLE
Fix CI clang-format script: tell if clang-format cannot be found

### DIFF
--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -2,7 +2,12 @@
 
 set -e
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "${REPO_ROOT}"
-./ci/update-clang-format
-find nano -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format -i
+CLANG_FORMAT="clang-format"
+if [ $(builtin type -p "$CLANG_FORMAT") ]; then
+	REPO_ROOT=$(git rev-parse --show-toplevel)
+	cd "$REPO_ROOT"
+	./ci/update-clang-format
+	find nano -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs "$CLANG_FORMAT" -i
+else
+	echo "'$CLANG_FORMAT' could not be detected in your PATH. Do you have it installed?"
+fi


### PR DESCRIPTION
This is a prerequisite for an upcoming PR in which we want to validate and hardcode the version of `clang-format` that is used so that it stays consistent across users + CI environments.