### PR TITLE
Require fixed version of clang-format

### DIFF
--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   clang_format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -16,7 +16,7 @@ jobs:
         run: ci/check-commit-format.sh
   
   cmake_format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e

--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -8,10 +8,10 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - name: Installing clang-format 10
+      - name: Installing clang-format 12
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: sudo apt-get install clang-format-10
+        run: sudo apt-get install clang-format-12
       - name: Clang Format
         run: ci/check-commit-format.sh
   

--- a/.github/workflows/beta_artifacts.yml
+++ b/.github/workflows/beta_artifacts.yml
@@ -41,7 +41,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
 
   linux_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: tag
@@ -66,7 +66,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
 
   linux_docker_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: tag

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       LCOV: 1
       COMPILER: gcc
       BOOST_ROOT: /tmp/boost
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         TEST_USE_ROCKSDB: [0, 1]
@@ -48,7 +48,7 @@ jobs:
           parallel: true
   finish:
     needs: coverage_test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: coverallsapp/github-action@8cbef1dea373ebce56de0a14c68d6267baa10b44
         with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -6,7 +6,7 @@ on:
       - develop
 jobs:
   linux_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:

--- a/.github/workflows/live_artifacts.yml
+++ b/.github/workflows/live_artifacts.yml
@@ -40,7 +40,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
 
   linux_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: tag
@@ -65,7 +65,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
 
   linux_docker_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: tag

--- a/.github/workflows/test_network_artifacts.yml
+++ b/.github/workflows/test_network_artifacts.yml
@@ -41,7 +41,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
 
   linux_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: tag
@@ -66,7 +66,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
 
   linux_docker_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: tag

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         COMPILER: [gcc, clang-6]
         RELEASE: 
           - ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COMPILER: ${{ matrix.COMPILER }}
       TEST_USE_ROCKSDB: ${{ matrix.TEST_USE_ROCKSDB }}

--- a/ci/check-commit-format.sh
+++ b/ci/check-commit-format.sh
@@ -1,38 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-FOUND=0
+set -e
 
-# hard requirement of clang-format 10.0.0
-CF_EXECUTABLE='
-  clang-format-10.0.0
-  clang-format-10.0
-  clang-format-10
-  clang-format
-'
-
-# check different executable strings
-for executable in $CF_EXECUTABLE; do
-    if type -p "$executable" >/dev/null; then
-        clang_format="$executable"
-        FOUND=1
-        break
-    fi
-done
-
-# alert if not installed
-if [ $FOUND == 0 ]; then
-    echo "clang-format not found, please install 10.0.0 first"
-    exit 1
-fi
-
-# check if old version is found
-if ! "$clang_format" --version | grep '10.0.0' &>/dev/null; then
-    echo "clang-format version 10.0.0 is required, please update it"
-    exit 1
-fi
-
-
-REPO_ROOT=$(git rev-parse --show-toplevel)
+source detect-clang-format.sh
+source common.sh
 
 "${REPO_ROOT}/ci/update-clang-format"
 

--- a/ci/check-commit-format.sh
+++ b/ci/check-commit-format.sh
@@ -2,14 +2,15 @@
 
 set -e
 
-source $(dirname $BASH_SOURCE)/detect-clang-format.sh
-source $(dirname $BASH_SOURCE)/common.sh
+source "$(dirname "$BASH_SOURCE")/detect-clang-format.sh"
+source "$(dirname "$BASH_SOURCE")/common.sh"
 
 "$REPO_ROOT/ci/update-clang-format"
 
-RESULT=$(python $REPO_ROOT/ci/git-clang-format.py --diff --extensions "hpp,cpp")
-if [ "$RESULT" != "no modified files to format" ] && [ "$RESULT" != "clang-format did not modify any files" ]; then
-    python $REPO_ROOT/ci/git-clang-format.py --diff --extensions "hpp,cpp"
+clang_format_result=$(python "$REPO_ROOT/ci/git-clang-format.py" --diff --extensions "hpp,cpp")
+if [[ $clang_format_result != "no modified files to format" ]] &&
+   [[ $clang_format_result != "clang-format did not modify any files" ]]; then
+    python "$REPO_ROOT/ci/git-clang-format.py" --diff --extensions "hpp,cpp"
     echo
     echo "Code formatting differs from expected - please run ci/clang-format-all.sh"
     exit 1

--- a/ci/check-commit-format.sh
+++ b/ci/check-commit-format.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-source detect-clang-format.sh
-source common.sh
+source $(dirname $BASH_SOURCE)/detect-clang-format.sh
+source $(dirname $BASH_SOURCE)/common.sh
 
-"${REPO_ROOT}/ci/update-clang-format"
+"$REPO_ROOT/ci/update-clang-format"
 
 RESULT=$(python $REPO_ROOT/ci/git-clang-format.py --diff --extensions "hpp,cpp")
 if [ "$RESULT" != "no modified files to format" ] && [ "$RESULT" != "clang-format did not modify any files" ]; then

--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-source detect-clang-format.sh
-source common.sh
+source $(dirname $BASH_SOURCE)/detect-clang-format.sh
+source $(dirname $BASH_SOURCE)/common.sh
 
 cd "$REPO_ROOT"
 ./ci/update-clang-format

--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -2,12 +2,9 @@
 
 set -e
 
-CLANG_FORMAT="clang-format"
-if [ $(builtin type -p "$CLANG_FORMAT") ]; then
-	REPO_ROOT=$(git rev-parse --show-toplevel)
-	cd "$REPO_ROOT"
-	./ci/update-clang-format
-	find nano -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs "$CLANG_FORMAT" -i
-else
-	echo "'$CLANG_FORMAT' could not be detected in your PATH. Do you have it installed?"
-fi
+source detect-clang-format.sh
+source common.sh
+
+cd "$REPO_ROOT"
+./ci/update-clang-format
+find nano -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs "$CLANG_FORMAT" -i

--- a/ci/cmake-format-all.sh
+++ b/ci/cmake-format-all.sh
@@ -1,11 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-if ! command -v cmake-format &>/dev/null; then
+source "$(dirname "$BASH_SOURCE")/common.sh"
+
+if ! [[ $(builtin type -p cmake-format) ]]; then
     echo "pip install cmake-format to continue"
     exit 1
 fi
-REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "${REPO_ROOT}"
-find "${REPO_ROOT}" -iwholename "${REPO_ROOT}/nano/*/CMakeLists.txt" -o -iwholename "${REPO_ROOT}/CMakeLists.txt" -o -iwholename "${REPO_ROOT}/coverage/CMakeLists.txt" | xargs cmake-format -i
+
+cd "$REPO_ROOT"
+
+find "$REPO_ROOT" -iwholename "$REPO_ROOT/nano/*/CMakeLists.txt"   \
+                  -o                                               \
+                  -iwholename "$REPO_ROOT/CMakeLists.txt"          \
+                  -o                                               \
+                  -iwholename "$REPO_ROOT/coverage/CMakeLists.txt" \
+     | xargs -i{} cmake-format -i {}

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/ci/detect-clang-format.sh
+++ b/ci/detect-clang-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/ci/detect-clang-format.sh
+++ b/ci/detect-clang-format.sh
@@ -2,17 +2,40 @@
 
 set -e
 
-CLANG_FORMAT="clang-format-12"
+is_clang_format_usable()
+{
+    if [[ $(builtin type -p $1) ]]; then
+        local output=$($1 --version)
+        if [[ $output =~ ^(.)*clang-format\ version\ $2(.)*$ ]]; then
+            echo "0"
+        else
+            echo $output
+        fi
+    else
+        echo "1"
+    fi
+}
+
+CLANG_FORMAT=""
 CLANG_FORMAT_VERSION="12"
 
-if ! [ $(builtin type -p "$CLANG_FORMAT") ]; then
-	echo "'$CLANG_FORMAT' could not be detected in your PATH. Do you have it installed?"
-	exit 1
-fi
+clang_format_attempts=("clang-format"
+                       "clang-format-$CLANG_FORMAT_VERSION")
 
-VERSION_OUTPUT=$($CLANG_FORMAT --version)
-if ! [[ $VERSION_OUTPUT =~ ^(.)*clang-format\ version\ $CLANG_FORMAT_VERSION(.)*$ ]]; then
-	echo "Your '$CLANG_FORMAT' version is not '$CLANG_FORMAT_VERSION', but '$VERSION_OUTPUT'." \
-	     "Please up/down grade it."
-	exit 1
+for itr in ${clang_format_attempts[@]}; do
+    result=$(is_clang_format_usable $itr $CLANG_FORMAT_VERSION)
+    if [[ $result == "0" ]]; then
+        CLANG_FORMAT=$itr
+        break
+    elif [[ $result == "1" ]]; then
+        continue
+    else
+        echo "Detected '$itr' with version '$result' " \
+             "(different than '$CLANG_FORMAT_VERSION'), skipping it."
+    fi
+done
+
+if [[ -z $CLANG_FORMAT ]]; then
+    echo "No 'clang-format' of version '$CLANG_FORMAT_VERSION' could be detected in your PATH."
+    exit 1
 fi

--- a/ci/detect-clang-format.sh
+++ b/ci/detect-clang-format.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+CLANG_FORMAT="clang-format"
+CLANG_FORMAT_VERSION="12"
+
+if ! [ $(builtin type -p "$CLANG_FORMAT") ]; then
+	echo "'$CLANG_FORMAT' could not be detected in your PATH. Do you have it installed?"
+	exit 1
+fi
+
+VERSION_OUTPUT=$($CLANG_FORMAT --version)
+if ! [[ $VERSION_OUTPUT =~ ^(.)*clang-format\ version\ $CLANG_FORMAT_VERSION(.)*$ ]]; then
+	echo "Your '$CLANG_FORMAT' version is not '$CLANG_FORMAT_VERSION'. Please up/down grade it."
+	exit 1
+fi

--- a/ci/detect-clang-format.sh
+++ b/ci/detect-clang-format.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CLANG_FORMAT="clang-format"
+CLANG_FORMAT="clang-format-12"
 CLANG_FORMAT_VERSION="12"
 
 if ! [ $(builtin type -p "$CLANG_FORMAT") ]; then
@@ -12,6 +12,7 @@ fi
 
 VERSION_OUTPUT=$($CLANG_FORMAT --version)
 if ! [[ $VERSION_OUTPUT =~ ^(.)*clang-format\ version\ $CLANG_FORMAT_VERSION(.)*$ ]]; then
-	echo "Your '$CLANG_FORMAT' version is not '$CLANG_FORMAT_VERSION'. Please up/down grade it."
+	echo "Your '$CLANG_FORMAT' version is not '$CLANG_FORMAT_VERSION', but '$VERSION_OUTPUT'." \
+	     "Please up/down grade it."
 	exit 1
 fi

--- a/ci/update-clang-format
+++ b/ci/update-clang-format
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-ci_dir="$(dirname "${BASH_SOURCE[0]}")"
-
 set -e
 
-cd "${ci_dir}/.."
+source "$(dirname "$BASH_SOURCE")/common.sh"
+
+cd "$REPO_ROOT"
 
 retval='1'
 

--- a/ci/update-clang-format
+++ b/ci/update-clang-format
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 ci_dir="$(dirname "${BASH_SOURCE[0]}")"
 


### PR DESCRIPTION
~~Merging this into `ci-clang-format-fix` (PR #3450) and then that one into `develop` for easier reviewing.~~

Decided to merge #3450 first so then I rebased this on `develop` and targeting it towards `develop`.

GitHub actions still need some tweaking so that the correct `clang-format` version is installed and detected by the CI scripts.

Reviewable, but not merge-able yet.