### PR TITLE
Make code formatting compliant with clang-format 12

### DIFF
--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -90,8 +90,8 @@ TEST (work, opencl)
 		{
 			// 0 threads, should add 1 for managing OpenCL
 			nano::work_pool pool{ nano::dev::network_params.network, 0, std::chrono::nanoseconds (0), [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
-				return opencl->generate_work (version_a, root_a, difficulty_a);
-			} };
+									 return opencl->generate_work (version_a, root_a, difficulty_a);
+								 } };
 			ASSERT_NE (nullptr, pool.opencl);
 			nano::root root;
 			uint64_t difficulty (0xff00000000000000);

--- a/nano/crypto_lib/secure_memory.cpp
+++ b/nano/crypto_lib/secure_memory.cpp
@@ -42,7 +42,7 @@ void NOT_OPTIMIZED nano::secure_wipe_memory (void * v, size_t n)
 #elif defined(HAVE_EXPLICIT_BZERO)
 	explicit_bzero (v, n);
 #else
-	static void * (*const volatile memset_sec) (void *, int, size_t) = &memset;
+	static void * (*const volatile memset_sec)(void *, int, size_t) = &memset;
 	memset_sec (v, 0, n);
 #endif
 }

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -141,10 +141,18 @@ public:
 		// A representative is classified as principal based on its weight and this factor
 		principal_weight_factor = 1000; // 0.1%
 
-		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000 : is_test_network () ? test_node_port () : 44000;
-		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000 : is_test_network () ? test_rpc_port () : 45000;
-		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000 : is_test_network () ? test_ipc_port () : 46000;
-		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000 : is_test_network () ? test_websocket_port () : 47000;
+		default_node_port = is_live_network () ? 7075 : is_beta_network () ? 54000
+		: is_test_network ()                                               ? test_node_port ()
+																		   : 44000;
+		default_rpc_port = is_live_network () ? 7076 : is_beta_network () ? 55000
+		: is_test_network ()                                              ? test_rpc_port ()
+																		  : 45000;
+		default_ipc_port = is_live_network () ? 7077 : is_beta_network () ? 56000
+		: is_test_network ()                                              ? test_ipc_port ()
+																		  : 46000;
+		default_websocket_port = is_live_network () ? 7078 : is_beta_network () ? 57000
+		: is_test_network ()                                                    ? test_websocket_port ()
+																				: 47000;
 		request_interval_ms = is_dev_network () ? 20 : 500;
 		cleanup_period = is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (60);
 		idle_timeout = is_dev_network () ? cleanup_period * 15 : cleanup_period * 2;
@@ -237,7 +245,9 @@ public:
 
 	const char * get_current_network_as_string ()
 	{
-		return is_live_network () ? "live" : is_beta_network () ? "beta" : is_test_network () ? "test" : "dev";
+		return is_live_network () ? "live" : is_beta_network () ? "beta"
+		: is_test_network ()                                    ? "test"
+																: "dev";
 	}
 
 	bool is_live_network () const

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -53,7 +53,8 @@ public:
 	unsigned io_threads{ (4 < std::thread::hardware_concurrency ()) ? std::thread::hardware_concurrency () : 4 };
 	std::string ipc_address;
 	uint16_t ipc_port{ network_constants.default_ipc_port };
-	unsigned num_ipc_connections{ (network_constants.is_live_network () || network_constants.is_test_network ()) ? 8u : network_constants.is_beta_network () ? 4u : 1u };
+	unsigned num_ipc_connections{ (network_constants.is_live_network () || network_constants.is_test_network ()) ? 8u : network_constants.is_beta_network () ? 4u
+																																							 : 1u };
 	static unsigned json_version ()
 	{
 		return 1;

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -8,6 +8,7 @@
 #include <nano/lib/utility.hpp>
 
 #include <boost/thread/thread.hpp>
+
 #include <thread>
 
 namespace nano

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -37,7 +37,7 @@
 
 std::size_t nano::get_file_descriptor_limit ()
 {
-	std::size_t fd_limit = (std::numeric_limits<std::size_t>::max) ();
+	std::size_t fd_limit = (std::numeric_limits<std::size_t>::max)();
 #ifndef _WIN32
 	rlimit limit{};
 	if (getrlimit (RLIMIT_NOFILE, &limit) == 0)

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -65,7 +65,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 		nano::work_pool opencl_work (config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
 			return opencl->generate_work (version_a, root_a, difficulty_a, ticket_a);
 		}
-																									  : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
+																																		  : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr));
 		try
 		{
 			// This avoid a blank prompt during any node initialization delays

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -609,9 +609,9 @@ int main (int argc, char * const * argv)
 							nano::opencl_config config (platform, device, threads);
 							auto opencl (nano::opencl_work::create (true, config, logger, network_params.work));
 							nano::work_pool work_pool{ network_params.network, 0, std::chrono::nanoseconds (0), opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
-								return opencl->generate_work (version_a, root_a, difficulty_a);
-							}
-																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
+														  return opencl->generate_work (version_a, root_a, difficulty_a);
+													  }
+																													   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
 							nano::change_block block (0, 0, nano::keypair ().prv, 0, 0);
 							std::cerr << boost::str (boost::format ("Starting OpenCL generation profiling. Platform: %1%. Device: %2%. Threads: %3%. Difficulty: %4$#x (%5%x from base difficulty %6$#x)\n") % platform % device % threads % difficulty % nano::to_string (nano::difficulty::to_multiplier (difficulty, nano::work_thresholds::publish_full.base), 4) % nano::work_thresholds::publish_full.base);
 							for (uint64_t i (0); true; ++i)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -109,9 +109,9 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 		nano::set_application_icon (application);
 		auto opencl (nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.work));
 		nano::work_pool work{ config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl ? [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> &) {
-			return opencl->generate_work (version_a, root_a, difficulty_a);
-		}
-																							   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
+								 return opencl->generate_work (version_a, root_a, difficulty_a);
+							 }
+																																   : std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> (nullptr) };
 		node = std::make_shared<nano::node> (io_ctx, data_path, config.node, work, flags);
 		if (!node->init_error ())
 		{

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1259,7 +1259,8 @@ nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_
 {
 	debug_assert (!lock_a.owns_lock ());
 	nano::inactive_cache_status status (previously_a);
-	const unsigned election_start_voters_min = node.network_params.network.is_dev_network () ? 2 : node.network_params.network.is_beta_network () ? 5 : 15;
+	const unsigned election_start_voters_min = node.network_params.network.is_dev_network () ? 2 : node.network_params.network.is_beta_network () ? 5
+																																				  : 15;
 	status.tally = tally_a;
 	if (!previously_a.confirmed && tally_a >= node.online_reps.delta ())
 	{

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1535,7 +1535,8 @@ bool nano::parse_tcp_endpoint (std::string const & string, nano::tcp_endpoint & 
 
 std::chrono::seconds nano::telemetry_cache_cutoffs::network_to_time (network_constants const & network_constants)
 {
-	return std::chrono::seconds{ (network_constants.is_live_network () || network_constants.is_test_network ()) ? live : network_constants.is_beta_network () ? beta : dev };
+	return std::chrono::seconds{ (network_constants.is_live_network () || network_constants.is_test_network ()) ? live : network_constants.is_beta_network () ? beta
+																																							  : dev };
 }
 
 nano::node_singleton_memory_pool_purge_guard::node_singleton_memory_pool_purge_guard () :

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -91,7 +91,8 @@ void nano::rep_crawler::ongoing_crawl ()
 		node.keepalive_preconfigured (node.config.preconfigured_peers);
 	}
 	// Reduce crawl frequency when there's enough total peer weight
-	unsigned next_run_ms = node.network_params.network.is_dev_network () ? 100 : sufficient_weight ? 7000 : 3000;
+	unsigned next_run_ms = node.network_params.network.is_dev_network () ? 100 : sufficient_weight ? 7000
+																								   : 3000;
 	std::weak_ptr<nano::node> node_w (node.shared ());
 	node.workers.add_timed_task (now + std::chrono::milliseconds (next_run_ms), [node_w, this] () {
 		if (auto node_l = node_w.lock ())

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -793,7 +793,8 @@ nano::websocket::message nano::websocket::message_builder::work_generation (nano
 	// Active difficulty information
 	boost::property_tree::ptree work_l;
 	work_l.put ("success", completed_a ? "true" : "false");
-	work_l.put ("reason", completed_a ? "" : cancelled_a ? "cancelled" : "failure");
+	work_l.put ("reason", completed_a ? "" : cancelled_a ? "cancelled"
+														 : "failure");
 	work_l.put ("duration", duration_a.count ());
 
 	boost::property_tree::ptree request_l;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -86,7 +86,9 @@ nano::ledger_constants & nano::dev::constants{ nano::dev::network_params.ledger 
 std::shared_ptr<nano::block> & nano::dev::genesis = nano::dev::constants.genesis;
 
 nano::network_params::network_params (nano::networks network_a) :
-	work{ network_a == nano::networks::nano_live_network ? nano::work_thresholds::publish_full : network_a == nano::networks::nano_beta_network ? nano::work_thresholds::publish_beta : network_a == nano::networks::nano_test_network ? nano::work_thresholds::publish_test : nano::work_thresholds::publish_dev },
+	work{ network_a == nano::networks::nano_live_network ? nano::work_thresholds::publish_full : network_a == nano::networks::nano_beta_network ? nano::work_thresholds::publish_beta
+		: network_a == nano::networks::nano_test_network                                                                                        ? nano::work_thresholds::publish_test
+																																				: nano::work_thresholds::publish_dev },
 	network{ work, network_a },
 	ledger{ work, network_a },
 	voting{ network },
@@ -109,19 +111,25 @@ nano::ledger_constants::ledger_constants (nano::work_thresholds & work, nano::ne
 	nano_beta_genesis (parse_block_from_genesis_data (beta_genesis_data)),
 	nano_live_genesis (parse_block_from_genesis_data (live_genesis_data)),
 	nano_test_genesis (parse_block_from_genesis_data (test_genesis_data)),
-	genesis (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis : network_a == nano::networks::nano_test_network ? nano_test_genesis : nano_live_genesis),
+	genesis (network_a == nano::networks::nano_dev_network ? nano_dev_genesis : network_a == nano::networks::nano_beta_network ? nano_beta_genesis
+	: network_a == nano::networks::nano_test_network                                                                           ? nano_test_genesis
+																															   : nano_live_genesis),
 	genesis_amount{ std::numeric_limits<nano::uint128_t>::max () },
 	burn_account (0),
 	nano_dev_final_votes_canary_account (dev_public_key_data),
 	nano_beta_final_votes_canary_account (beta_canary_public_key_data),
 	nano_live_final_votes_canary_account (live_canary_public_key_data),
 	nano_test_final_votes_canary_account (test_canary_public_key_data),
-	final_votes_canary_account (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_account : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_account : network_a == nano::networks::nano_test_network ? nano_test_final_votes_canary_account : nano_live_final_votes_canary_account),
+	final_votes_canary_account (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_account : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_account
+	: network_a == nano::networks::nano_test_network                                                                                                                 ? nano_test_final_votes_canary_account
+																																									 : nano_live_final_votes_canary_account),
 	nano_dev_final_votes_canary_height (1),
 	nano_beta_final_votes_canary_height (1),
 	nano_live_final_votes_canary_height (1),
 	nano_test_final_votes_canary_height (1),
-	final_votes_canary_height (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_height : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_height : network_a == nano::networks::nano_test_network ? nano_test_final_votes_canary_height : nano_live_final_votes_canary_height)
+	final_votes_canary_height (network_a == nano::networks::nano_dev_network ? nano_dev_final_votes_canary_height : network_a == nano::networks::nano_beta_network ? nano_beta_final_votes_canary_height
+	: network_a == nano::networks::nano_test_network                                                                                                               ? nano_test_final_votes_canary_height
+																																								   : nano_live_final_votes_canary_height)
 {
 	nano_beta_genesis->sideband_set (nano::block_sideband (nano_beta_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 	nano_dev_genesis->sideband_set (nano::block_sideband (nano_dev_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
@@ -137,7 +145,9 @@ nano::ledger_constants::ledger_constants (nano::work_thresholds & work, nano::ne
 	nano::account nano_live_epoch_v2_signer;
 	auto error (nano_live_epoch_v2_signer.decode_account ("nano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
 	debug_assert (!error);
-	auto epoch_v2_signer (network_a == nano::networks::nano_dev_network ? nano::dev::genesis_key.pub : network_a == nano::networks::nano_beta_network ? nano_beta_account : network_a == nano::networks::nano_test_network ? nano_test_account : nano_live_epoch_v2_signer);
+	auto epoch_v2_signer (network_a == nano::networks::nano_dev_network ? nano::dev::genesis_key.pub : network_a == nano::networks::nano_beta_network ? nano_beta_account
+	: network_a == nano::networks::nano_test_network                                                                                                  ? nano_test_account
+																																					  : nano_live_epoch_v2_signer);
 	const char * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1121,7 +1121,8 @@ nano::uint128_t nano::ledger::amount_safe (nano::transaction const & transaction
 	debug_assert (block);
 	auto block_balance (balance (transaction_a, hash_a));
 	auto previous_balance (balance_safe (transaction_a, block->previous (), error_a));
-	return error_a ? 0 : block_balance > previous_balance ? block_balance - previous_balance : previous_balance - block_balance;
+	return error_a ? 0 : block_balance > previous_balance ? block_balance - previous_balance
+														  : previous_balance - block_balance;
 }
 
 // Return latest block for account


### PR DESCRIPTION
Just ran the new `./ci/clang-format-all.sh` script with version 12 of `clang-format` and this is what it produced.