### PR TITLE
Compile code that uses diskhash on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,7 +389,8 @@ find_package(Boost 1.70.0 REQUIRED COMPONENTS filesystem log log_setup thread
 
 # diskhash
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
+  add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/os_wrappers.c
+                              ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
   include_directories(diskhash/src)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,11 +388,9 @@ find_package(Boost 1.70.0 REQUIRED COMPONENTS filesystem log log_setup thread
                                               program_options system)
 
 # diskhash
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/os_wrappers.c
-                              ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
-  include_directories(diskhash/src)
-endif()
+add_library(diskhash STATIC ${CMAKE_SOURCE_DIR}/diskhash/src/os_wrappers.c
+                            ${CMAKE_SOURCE_DIR}/diskhash/src/diskhash.c)
+include_directories(diskhash/src)
 
 # RocksDB
 include_directories(rocksdb/include)

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -6,9 +6,6 @@
 
 #include <numeric>
 
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-
 using namespace std::chrono_literals;
 
 TEST (ledger_walker, genesis_block)
@@ -221,5 +218,3 @@ TEST (ledger_walker, ladder_geometry)
 
 	EXPECT_EQ (amounts_expected_itr, amounts_expected_backwards.crend ());
 }
-
-#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -150,10 +150,6 @@ add_library(
   write_database_queue.cpp
   xorshift.hpp)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  set(DISKHASH diskhash)
-endif()
-
 target_link_libraries(
   node
   rpc
@@ -170,7 +166,7 @@ target_link_libraries(
   Boost::thread
   Boost::boost
   rocksdb
-  ${DISKHASH}
+  diskhash
   ${CMAKE_DL_LIBS}
   ${psapi_lib})
 

--- a/nano/node/ledger_walker.cpp
+++ b/nano/node/ledger_walker.cpp
@@ -1,6 +1,3 @@
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/node/ledger_walker.hpp>
@@ -176,5 +173,3 @@ std::shared_ptr<nano::block> nano::ledger_walker::dequeue_block (nano::transacti
 
 	return block;
 }
-
-#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows

--- a/nano/node/ledger_walker.cpp
+++ b/nano/node/ledger_walker.cpp
@@ -5,6 +5,8 @@
 #include <nano/secure/store.hpp>
 #include <nano/secure/utility.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include <algorithm>
 #include <limits>
 #include <utility>
@@ -52,7 +54,7 @@ void nano::ledger_walker::walk_backward (nano::block_hash const & start_block_ha
 void nano::ledger_walker::walk (nano::block_hash const & end_block_hash_a, should_visit_callback const & should_visit_callback_a, visitor_callback const & visitor_callback_a)
 {
 	std::uint64_t last_walked_block_order_index = 0;
-	dht::DiskHash<nano::block_hash> walked_blocks_order{ nano::unique_path ().c_str (), static_cast<int> (std::to_string (std::numeric_limits<std::uint64_t>::max ()).size ()) + 1, dht::DHOpenRW };
+	dht::DiskHash<nano::block_hash> walked_blocks_order{ static_cast<const char*> (nano::unique_path ().string ().c_str ()), static_cast<const int> (std::to_string (std::numeric_limits<std::uint64_t>::max ()).size () + 1), dht::DHOpenRW };
 
 	walk_backward (end_block_hash_a,
 	should_visit_callback_a,
@@ -127,7 +129,7 @@ bool nano::ledger_walker::add_to_walked_blocks (nano::block_hash const & block_h
 		use_in_memory_walked_blocks = false;
 
 		debug_assert (!walked_blocks_disk.has_value ());
-		walked_blocks_disk.emplace (nano::unique_path ().c_str (), sizeof (nano::block_hash::bytes) + 1, dht::DHOpenRW);
+		walked_blocks_disk.emplace ( static_cast<const char*> (nano::unique_path ().string ().c_str ()), static_cast<const int> (sizeof (nano::block_hash::bytes) + 1), dht::DHOpenRW);
 
 		for (const auto & walked_block_hash : walked_blocks)
 		{

--- a/nano/node/ledger_walker.hpp
+++ b/nano/node/ledger_walker.hpp
@@ -1,6 +1,3 @@
-// TODO: keep this until diskhash builds fine on Windows
-#ifndef _WIN32
-
 #pragma once
 
 #include <nano/lib/numbers.hpp>
@@ -61,5 +58,3 @@ private:
 };
 
 }
-
-#endif // _WIN32 -- TODO: keep this until diskhash builds fine on Windows


### PR DESCRIPTION
Such code was being taken out of the build before because diskhash wasn't building on Windows a few months back, but now it is, so this PR should build/run fine on Win.