### PR TITLE
Fix broken cli commands: wallet_create, wallet_list (issue #3447), diagnostics (issue  #3452) and other CLI  commands

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -74,6 +74,7 @@ int main (int argc, char * const * argv)
 		("config", boost::program_options::value<std::vector<nano::config_key_value_pair>>()->multitoken(), "Pass node configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.")
 		("daemon", "Start node daemon")
 		("compare_rep_weights", "Display a summarized comparison between the hardcoded bootstrap weights and representative weights from the ledger. Full comparison is output to logs")
+		("debug_block_dump", "Display all the blocks in the ledger in text format")
 		("debug_block_count", "Display the number of blocks")
 		("debug_bootstrap_generate", "Generate bootstrap sequence of blocks")
 		("debug_dump_frontier_unchecked_dependents", "Dump frontiers which have matching unchecked keys")
@@ -305,6 +306,21 @@ int main (int argc, char * const * argv)
 			{
 				std::cout << "Not available for the test network" << std::endl;
 				result = -1;
+			}
+		}
+		else if (vm.count ("debug_block_dump"))
+		{
+			auto inactive_node = nano::default_inactive_node (data_path, vm);
+			auto transaction = inactive_node->node->store.tx_begin_read ();
+			auto i = inactive_node->node->store.block.begin (transaction);
+			auto end = inactive_node->node->store.block.end ();
+			for (; i != end; ++i)
+			{
+				nano::block_hash hash = i->first;
+				nano::block_w_sideband sideband = i->second;
+				std::shared_ptr<nano::block> b = sideband.block;
+				std::cout << hash.to_string () << std::endl
+						  << b->to_json ();
 			}
 		}
 		else if (vm.count ("debug_block_count"))

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -44,6 +44,7 @@ void nano::add_node_options (boost::program_options::options_description & descr
 {
 	// clang-format off
 	description_a.add_options ()
+	("initialize", "Initialize the data folder, if it is not already initialised. This command is meant to be run when the data folder is empty, to populate it with the genesis block.")
 	("account_create", "Insert next deterministic key in to <wallet>")
 	("account_get", "Get account number for the <key>")
 	("account_key", "Get the public key for <account>")
@@ -262,7 +263,14 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	std::error_code ec;
 	boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 
-	if (vm.count ("account_create"))
+	if (vm.count ("initialize"))
+	{
+		auto node_flags = nano::inactive_node_flag_defaults ();
+		node_flags.read_only = false;
+		nano::update_flags (node_flags, vm);
+		nano::inactive_node node (data_path, node_flags);
+	}
+	else if (vm.count ("account_create"))
 	{
 		if (vm.count ("wallet") == 1)
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1762,8 +1762,9 @@ void nano::node::populate_backlog ()
 }
 
 nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
+	network_params{ nano::network_constants::active_network },
 	io_context (std::make_shared<boost::asio::io_context> ()),
-	work{ nano::dev::network_params.network, 1 }
+	work{ network_params.network, 1 }
 {
 	boost::system::error_code error_chmod;
 
@@ -1772,7 +1773,7 @@ nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost:
 	 */
 	boost::filesystem::create_directories (path_a);
 	nano::set_secure_perm_directory (path_a, error_chmod);
-	nano::daemon_config daemon_config{ path_a, nano::dev::network_params };
+	nano::daemon_config daemon_config{ path_a, network_params };
 	auto error = nano::read_node_config_toml (config_path_a, daemon_config, node_flags_a.config_overrides);
 	if (error)
 	{

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -223,6 +223,7 @@ public:
 	node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a);
 	~node_wrapper ();
 
+	nano::network_params network_params;
 	std::shared_ptr<boost::asio::io_context> io_context;
 	nano::work_pool work;
 	std::shared_ptr<nano::node> node;

--- a/systest/.gitignore
+++ b/systest/.gitignore
@@ -1,0 +1,1 @@
+/data.systest

--- a/systest/RUNALL
+++ b/systest/RUNALL
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+for script in *.sh; do
+    ./$script;
+done
+
+echo All systest passed.

--- a/systest/cli_wallet_create.sh
+++ b/systest/cli_wallet_create.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+DATADIR=data.systest
+
+SEED=CEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEED
+
+# the caller should set the env var NANO_NODE_EXE to point to the nano_node executable
+# if NANO_NODE_EXE is unser ot empty then "../../build/nano_node" is used
+NANO_NODE_EXE=${NANO_NODE_EXE:-../../build/nano_node}
+
+clean_data_dir() {
+    rm -f $DATADIR/log/log_*.log
+    rm -f $DATADIR/wallets.ldb*
+    rm -f $DATADIR/data.ldb*
+    rm -f $DATADIR/config-*.toml
+}
+
+mkdir -p $DATADIR/log
+clean_data_dir
+
+# initialise data directory
+$NANO_NODE_EXE --initialize --data_path $DATADIR
+
+# create a wallet and store the wallet ID
+wallet_id=`$NANO_NODE_EXE --wallet_create --data_path $DATADIR --seed $SEED`
+
+# decrypt the wallet and check the seed
+$NANO_NODE_EXE --wallet_decrypt_unsafe --wallet $wallet_id --data_path $DATADIR | grep -q "Seed: $SEED"
+
+# list the wallet and check the wallet ID
+$NANO_NODE_EXE --wallet_list --data_path $DATADIR | grep -q "Wallet ID: $wallet_id"
+
+# if it got this far then it is a pass
+echo $0: PASSED
+exit 0

--- a/systest/node_initialize.sh
+++ b/systest/node_initialize.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e
+
+DATADIR=data.systest
+
+# the caller should set the env var NANO_NODE_EXE to point to the nano_node executable
+# if NANO_NODE_EXE is unser ot empty then "../../build/nano_node" is used
+NANO_NODE_EXE=${NANO_NODE_EXE:-../../build/nano_node}
+
+clean_data_dir() {
+    rm -f "$DATADIR"/log/log_*.log
+    rm -f "$DATADIR"/wallets.ldb*
+    rm -f "$DATADIR"/data.ldb*
+    rm -f "$DATADIR"/config-*.toml
+}
+
+test_initialize_cmd() {
+    netmatch="$1"
+    netcmd="$2"
+    netarg="$3"
+    genesishash="$4"
+
+    clean_data_dir
+
+    # initialise data directory
+    $NANO_NODE_EXE --initialize --data_path "$DATADIR" "$netcmd" "$netarg"
+
+    # check that it is the live network
+    grep -q "Active network: $netmatch" "$DATADIR"/log/log_*.log
+
+    # check that the ledger file is created
+    test -e "$DATADIR/data.ldb"
+    $NANO_NODE_EXE --debug_block_count --data_path "$DATADIR" "$netcmd" "$netarg" | grep -q 'Block count: 1'
+
+    # check the genesis block is correct
+    $NANO_NODE_EXE --debug_block_dump --data_path "$DATADIR" "$netcmd" "$netarg" | head -n 1 | grep -qi "$genesishash"
+}
+
+mkdir -p "$DATADIR/log"
+
+test_initialize_cmd "live" ""          ""     "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
+test_initialize_cmd "live" "--network" "live" "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
+test_initialize_cmd "beta" "--network" "beta" "01A92459E69440D5C1088D3B31F4CA678BE944BAB3776C2E6B7665E9BD99BD5A"
+test_initialize_cmd "test" "--network" "test" "B1D60C0B886B57401EF5A1DAA04340E53726AA6F4D706C085706F31BBD100CEE"
+
+# if it got this far then it is a pass
+echo $0: PASSED
+exit 0

--- a/systest/set_bandwidth_params.sh
+++ b/systest/set_bandwidth_params.sh
@@ -1,24 +1,40 @@
 #!/bin/sh
 
+set -e
+
+DATADIR=data.systest
+
+clean_data_dir() {
+    rm -f "$DATADIR"/log/log_*.log
+    rm -f "$DATADIR"/wallets.ldb*
+    rm -f "$DATADIR"/data.ldb*
+    rm -f "$DATADIR"/config-*.toml
+}
+
+msg() {
+    :
+    #echo "$@"
+}
+
 # the caller should set the env var NANO_NODE_EXE to point to the nano_node executable
-# if NANO_NODE_EXE is unser ot empty then "../../build/nano_node" is used
+# if NANO_NODE_EXE is unset ot empty then "../../build/nano_node" is used
 NANO_NODE_EXE=${NANO_NODE_EXE:-../../build/nano_node}
 
-mkdir -p data/log
-rm data/log/log_*.log
+mkdir -p "$DATADIR/log"
+clean_data_dir
 
 # start nano_node and store its pid so we can later send it
 # the SIGHUP signal and so we can terminate it
-echo start nano_node
-$NANO_NODE_EXE --daemon --data_path data &
+msg start nano_node
+$NANO_NODE_EXE --daemon --data_path "$DATADIR" >/dev/null &
 pid=$!
-echo pid=$pid
+msg pid=$pid
 
 # wait for the node to start-up
 sleep 2
 
 # set bandwidth params 42 and 43 in the config file
-cat > data/config-node.toml <<EOF
+cat > "$DATADIR/config-node.toml" <<EOF
 [node]
 bandwidth_limit = 42
 bandwidth_limit_burst_ratio = 43
@@ -31,7 +47,7 @@ kill -HUP $pid
 sleep 2
 
 # set another set of bandwidth params 44 and 45 in the config file
-cat > data/config-node.toml <<EOF
+cat > "$DATADIR/config-node.toml" <<EOF
 [node]
 bandwidth_limit = 44
 bandwidth_limit_burst_ratio = 45
@@ -50,19 +66,18 @@ wait $pid
 # the bandwidth params are logged in logger and we check for that logging below
 
 # check that the first signal handler got run and the data is correct
-grep -q "set_bandwidth_params(42, 43)" data/log/log_*.log
+grep -q "set_bandwidth_params(42, 43)" "$DATADIR"/log/log_*.log
 rc1=$?
-echo rc1=$rc1
+msg rc1=$rc1
 
 # check that the second signal handler got run and the data is correct
-grep -q "set_bandwidth_params(44, 45)" data/log/log_*.log
+grep -q "set_bandwidth_params(44, 45)" "$DATADIR"/log/log_*.log
 rc2=$?
-echo rc2=$rc2
+msg rc2=$rc2
 
 if [ $rc1 -eq 0 -a $rc2 -eq 0 ]; then
-    echo set_bandwith_params PASSED
+    echo $0: PASSED
     exit 0
-else
-    echo set_bandwith_params FAILED
-    exit 1
 fi
+
+exit 1


### PR DESCRIPTION
The wallet_create and wallet_list CLI commands were broken. Probably many CLI commands were broken.
The problem was that inactive_node class only worked in dev network and inactive_node is used in a lot of CLI commands. In other words the CLI comamnds using inactive_node could not work in live, beta or test networks.

I fixed the diagnostics CLI command so that I could write a test script for the wallet commands.

I introduced the initialize CLI command to initialize the data folder, which was also need in order to write a test case for the wallet  commands.

I introduced the CLI command  debug_block_dump to print ledger blocks so that I can check that initialize commands works correctly for the different networks (live, beta, test).

@zhyatt , I introduces 2 new CLI commands "initialize" and debug_block_dump which we need to document.