### PR TITLE
Add systests to CI and fix for rocksdb mode (issue #3447) (issue #3452)

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -70,10 +70,14 @@ run_tests() {
     xvfb_run_ ./qt_test
     qt_test_res=${?}
 
+    (cd ../systest && export NANO_NODE_EXE=../build/nano_node && ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} 300 ./RUNALL)
+    sys_test_res=${?}
+
     echo "Core Test return code: ${core_test_res}"
     echo "RPC  Test return code: ${rpc_test_res}"
     echo "QT Test return code: ${qt_test_res}"
-    if [[ ${core_test_res} != 0 || ${rpc_test_res} != 0 || ${qt_test_res} != 0 ]]; then
+    echo "Sys Test return code: ${sys_test_res}"
+    if [[ ${core_test_res} != 0 || ${rpc_test_res} != 0 || ${qt_test_res} != 0 || ${sys_test_res} != 0 ]]; then
         return 1
     else
         return 0

--- a/systest/RUNALL
+++ b/systest/RUNALL
@@ -2,8 +2,11 @@
 
 set -e
 
+failed=0
+
 for script in *.sh; do
+    echo Running script: $script
     ./$script;
 done
 
-echo All systest passed.
+echo All systests passed.

--- a/systest/cli_wallet_create.sh
+++ b/systest/cli_wallet_create.sh
@@ -11,10 +11,11 @@ SEED=CEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEEDCEED
 NANO_NODE_EXE=${NANO_NODE_EXE:-../../build/nano_node}
 
 clean_data_dir() {
-    rm -f $DATADIR/log/log_*.log
-    rm -f $DATADIR/wallets.ldb*
-    rm -f $DATADIR/data.ldb*
-    rm -f $DATADIR/config-*.toml
+    rm -f  $DATADIR/log/log_*.log
+    rm -f  $DATADIR/wallets.ldb*
+    rm -f  $DATADIR/data.ldb*
+    rm -f  $DATADIR/config-*.toml
+    rm -rf "$DATADIR"/rocksdb/
 }
 
 mkdir -p $DATADIR/log

--- a/systest/node_initialize.sh
+++ b/systest/node_initialize.sh
@@ -9,10 +9,11 @@ DATADIR=data.systest
 NANO_NODE_EXE=${NANO_NODE_EXE:-../../build/nano_node}
 
 clean_data_dir() {
-    rm -f "$DATADIR"/log/log_*.log
-    rm -f "$DATADIR"/wallets.ldb*
-    rm -f "$DATADIR"/data.ldb*
-    rm -f "$DATADIR"/config-*.toml
+    rm -f  "$DATADIR"/log/log_*.log
+    rm -f  "$DATADIR"/wallets.ldb*
+    rm -f  "$DATADIR"/data.ldb*
+    rm -f  "$DATADIR"/config-*.toml
+    rm -rf "$DATADIR"/rocksdb/
 }
 
 test_initialize_cmd() {
@@ -29,8 +30,7 @@ test_initialize_cmd() {
     # check that it is the live network
     grep -q "Active network: $netmatch" "$DATADIR"/log/log_*.log
 
-    # check that the ledger file is created
-    test -e "$DATADIR/data.ldb"
+    # check that the ledger file is created and has one block, the genesis block
     $NANO_NODE_EXE --debug_block_count --data_path "$DATADIR" "$netcmd" "$netarg" | grep -q 'Block count: 1'
 
     # check the genesis block is correct
@@ -39,7 +39,7 @@ test_initialize_cmd() {
 
 mkdir -p "$DATADIR/log"
 
-test_initialize_cmd "live" ""          ""     "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
+#test_initialize_cmd "live" ""          ""     "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
 test_initialize_cmd "live" "--network" "live" "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
 test_initialize_cmd "beta" "--network" "beta" "01A92459E69440D5C1088D3B31F4CA678BE944BAB3776C2E6B7665E9BD99BD5A"
 test_initialize_cmd "test" "--network" "test" "B1D60C0B886B57401EF5A1DAA04340E53726AA6F4D706C085706F31BBD100CEE"

--- a/systest/set_bandwidth_params.sh
+++ b/systest/set_bandwidth_params.sh
@@ -5,10 +5,11 @@ set -e
 DATADIR=data.systest
 
 clean_data_dir() {
-    rm -f "$DATADIR"/log/log_*.log
-    rm -f "$DATADIR"/wallets.ldb*
-    rm -f "$DATADIR"/data.ldb*
-    rm -f "$DATADIR"/config-*.toml
+    rm -f  "$DATADIR"/log/log_*.log
+    rm -f  "$DATADIR"/wallets.ldb*
+    rm -f  "$DATADIR"/data.ldb*
+    rm -f  "$DATADIR"/config-*.toml
+    rm -rf "$DATADIR"/rocksdb/
 }
 
 msg() {


### PR DESCRIPTION
Fix systests when running in rocksdb mode (different ledger files)
Fix for CI build of nano_node that defaults to dev network
Add systests into github per commit CI.

Fixes #3452, fixes #3447