### PR TITLE
Fix cmake-format-all.sh script + friendlier xargs usage

### DIFF
--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -5,4 +5,4 @@ set -e
 source "$(dirname "$BASH_SOURCE")/detect-clang-format.sh"
 source "$(dirname "$BASH_SOURCE")/common.sh"
 
-find "$REPO_ROOT/nano" -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs "$CLANG_FORMAT" -i -style=file
+find "$REPO_ROOT/nano" -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs -I source "$CLANG_FORMAT" -i -style=file "source"

--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -5,4 +5,10 @@ set -e
 source "$(dirname "$BASH_SOURCE")/detect-clang-format.sh"
 source "$(dirname "$BASH_SOURCE")/common.sh"
 
-find "$REPO_ROOT/nano" -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' | xargs -I source "$CLANG_FORMAT" -i -style=file "source"
+find "$REPO_ROOT/nano" -iname '*.h'   \
+                       -o             \
+                       -iname '*.hpp' \
+                       -o             \
+                       -iname '*.cpp' \
+     | xargs -I sourceFile            \
+             "$CLANG_FORMAT" -i -style=file "sourceFile"

--- a/ci/clang-format-all.sh
+++ b/ci/clang-format-all.sh
@@ -5,10 +5,10 @@ set -e
 source "$(dirname "$BASH_SOURCE")/detect-clang-format.sh"
 source "$(dirname "$BASH_SOURCE")/common.sh"
 
-find "$REPO_ROOT/nano" -iname '*.h'   \
+find "$REPO_ROOT/nano" -iname "*.h"   \
                        -o             \
-                       -iname '*.hpp' \
+                       -iname "*.hpp" \
                        -o             \
-                       -iname '*.cpp' \
+                       -iname "*.cpp" \
      | xargs -I sourceFile            \
              "$CLANG_FORMAT" -i -style=file "sourceFile"

--- a/ci/cmake-format-all.sh
+++ b/ci/cmake-format-all.sh
@@ -16,4 +16,5 @@ find "$REPO_ROOT" -iwholename "$REPO_ROOT/nano/*/CMakeLists.txt"   \
                   -iwholename "$REPO_ROOT/CMakeLists.txt"          \
                   -o                                               \
                   -iwholename "$REPO_ROOT/coverage/CMakeLists.txt" \
-     | xargs -i{} cmake-format -i {}
+     | xargs -I sourceFile                                         \
+             "cmake-format" -i "sourceFile"

--- a/ci/cmake-format-all.sh
+++ b/ci/cmake-format-all.sh
@@ -2,19 +2,13 @@
 
 set -e
 
+source "$(dirname "$BASH_SOURCE")/detect-cmake-format.sh"
 source "$(dirname "$BASH_SOURCE")/common.sh"
-
-if ! [[ $(builtin type -p cmake-format) ]]; then
-    echo "pip install cmake-format to continue"
-    exit 1
-fi
-
-cd "$REPO_ROOT"
 
 find "$REPO_ROOT" -iwholename "$REPO_ROOT/nano/*/CMakeLists.txt"   \
                   -o                                               \
                   -iwholename "$REPO_ROOT/CMakeLists.txt"          \
                   -o                                               \
                   -iwholename "$REPO_ROOT/coverage/CMakeLists.txt" \
-     | xargs -I sourceFile                                         \
-             "cmake-format" -i "sourceFile"
+     | xargs -I cmakeListsFile                                     \
+             "$CMAKE_FORMAT" -i "cmakeListsFile"

--- a/ci/detect-cmake-format.sh
+++ b/ci/detect-cmake-format.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e
+
+is_cmake_format_usable()
+{
+    if [[ $(builtin type -p $1) ]]; then
+        local output=$($1 --version)
+        if [[ $output =~ ^(.)*$2(.)*$ ]]; then
+            echo "0"
+        else
+            echo $output
+        fi
+    else
+        echo "1"
+    fi
+}
+
+CMAKE_FORMAT=""
+CMAKE_FORMAT_VERSION="0.6.13"
+
+cmake_format_attempts=("cmake-format")
+
+for itr in ${cmake_format_attempts[@]}; do
+    result=$(is_cmake_format_usable $itr $CMAKE_FORMAT_VERSION)
+    if [[ $result == "0" ]]; then
+        CMAKE_FORMAT=$itr
+        break
+    elif [[ $result == "1" ]]; then
+        continue
+    else
+        echo "Detected '$itr' with version '$result' " \
+             "(different than '$CMAKE_FORMAT_VERSION'), skipping it."
+    fi
+done
+
+if [[ -z $CMAKE_FORMAT ]]; then
+    echo "No 'cmake-format' of version '$CMAKE_FORMAT_VERSION' could be detected in your PATH." \
+         "Try pip/pip3 install cmake-format. Or try up/down-grading if you installed it differently."
+    exit 1
+fi
+
+echo "Using '$CMAKE_FORMAT' version '$CMAKE_FORMAT_VERSION'"


### PR DESCRIPTION
@cryptocode @clemahieu let me know guys if `./ci/clang-format-all.sh` and especially `./ci/cmake-format-all.sh` run fine on your Macbooks. Just tested on mine and looks good.