### PR TITLE
Node flag to disable calling add_initial_peers function

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -95,6 +95,9 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")
 		("disable_wallet_bootstrap", "Disables wallet lazy bootstrap")
+		("disable_ongoing_bootstrap", "Disable ongoing bootstrap")
+		("disable_rep_crawler", "Disable rep crawler")
+		("disable_request_loop", "Disable request loop")
 		("disable_bootstrap_listener", "Disables bootstrap processing for TCP listener (not including realtime network TCP connections)")
 		("disable_tcp_realtime", "Disables TCP realtime network")
 		("disable_udp", "(Deprecated) UDP is disabled by default")
@@ -122,6 +125,9 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	flags_a.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
 	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);
 	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") > 0);
+	flags_a.disable_ongoing_bootstrap = (vm.count ("disable_ongoing_bootstrap") > 0);
+	flags_a.disable_rep_crawler = (vm.count ("disable_rep_crawler") > 0);
+	flags_a.disable_request_loop = (vm.count ("disable_request_loop") > 0);
 	if (!flags_a.inactive_node)
 	{
 		flags_a.disable_bootstrap_listener = (vm.count ("disable_bootstrap_listener") > 0);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -91,6 +91,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 {
 	// clang-format off
 	description_a.add_options()
+		("disable_add_initial_peers", "Disable contacting the peer in the peers table at startup")
 		("disable_backup", "Disable wallet automatic backups")
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")
@@ -121,6 +122,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_options::variables_map const & vm)
 {
 	std::error_code ec;
+	flags_a.disable_add_initial_peers = (vm.count ("disable_add_initial_peers") > 0);
 	flags_a.disable_backup = (vm.count ("disable_backup") > 0);
 	flags_a.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
 	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1207,6 +1207,12 @@ boost::optional<uint64_t> nano::node::work_generate_blocking (nano::root const &
 
 void nano::node::add_initial_peers ()
 {
+	if (flags.disable_add_initial_peers)
+	{
+		logger.always_log ("Skipping add_initial_peers because disable_add_initial_peers is set");
+		return;
+	}
+
 	auto transaction (store.tx_begin_read ());
 	for (auto i (store.peer.begin (transaction)), n (store.peer.end ()); i != n; ++i)
 	{

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -121,6 +121,7 @@ class node_flags final
 public:
 	std::vector<std::string> config_overrides;
 	std::vector<std::string> rpc_config_overrides;
+	bool disable_add_initial_peers{ false }; // For testing only
 	bool disable_backup{ false };
 	bool disable_lazy_bootstrap{ false };
 	bool disable_legacy_bootstrap{ false };


### PR DESCRIPTION
    Node flag to disable calling add_initial_peers function
    
    The add inital peers function reads the peers table and contacts all
    the peers listed in it. It is called at startup.
    
    To disable outgoing connections set:
    --disable_rep_crawler and --disable_add_initial_peers