### PR TITLE
Possible race condition fix in ledger_walker.ladder_geometry test

### DIFF
--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -151,6 +151,7 @@ TEST (ledger_walker, ladder_geometry)
 	{
 		system.wallet (0)->insert_adhoc (keys[itr].prv);
 		const auto block = system.wallet (0)->send_action (nano::dev::genesis_key.pub, keys[itr].pub, 1000);
+		ASSERT_TRUE (block);
 		ASSERT_TIMELY (3s, 1 + (itr + 1) * 2 == node->ledger.cache.cemented_count);
 	}
 
@@ -166,14 +167,12 @@ TEST (ledger_walker, ladder_geometry)
 
 		const auto send = system.wallet (0)->send_action (keys[source_index].pub, keys[destination_index].pub, amounts_to_send[itr]);
 		ASSERT_TRUE (send);
-
 		ASSERT_TIMELY (3s, 1 + keys.size () * 2 + (itr + 1) * 2 == node->ledger.cache.cemented_count);
 	}
 
 	ASSERT_TRUE (last_destination);
-	const auto transaction = node->ledger.store.tx_begin_read ();
 	nano::account_info last_destination_info{};
-	const auto last_destination_read_error = node->ledger.store.account.get (transaction, *last_destination, last_destination_info);
+	const auto last_destination_read_error = node->ledger.store.account.get (node->ledger.store.tx_begin_read (), *last_destination, last_destination_info);
 	ASSERT_FALSE (last_destination_read_error);
 
 	// This is how we expect chains to look like (for 3 accounts and 10 amounts to be sent)
@@ -192,7 +191,7 @@ TEST (ledger_walker, ladder_geometry)
 			nano::amount previous_balance{};
 			if (!block->previous ().is_zero ())
 			{
-				const auto previous_block = node->ledger.store.block.get_no_sideband (transaction, block->previous ());
+				const auto previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
 				previous_balance = previous_block->balance ();
 			}
 
@@ -211,7 +210,7 @@ TEST (ledger_walker, ladder_geometry)
 			nano::amount previous_balance{};
 			if (!block->previous ().is_zero ())
 			{
-				const auto previous_block = node->ledger.store.block.get_no_sideband (transaction, block->previous ());
+				const auto previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
 				previous_balance = previous_block->balance ();
 			}
 


### PR DESCRIPTION
This is in regards to https://github.com/nanocurrency/nano-node/issues/3471

Title might be a bit misleading because I haven't managed at all to reproduce the test failure, nor does visually analyzing the code show anything fishy, but there was a read transaction kept open for a large amount of time and that wasn't really necessary. Additionally, an extra assert is done earlier to make sure something bad and uncaught doesn't happen.

But all in all, the test failure could not be reproduced neither locally nor in the CI pipelines for both Linux/OSX. I think at best we should keep an eye on it to see if it ever fails again.