### PR TITLE
Fix handling of SIGSEGV and SIGABRT in nano_node

### DIFF
--- a/nano/lib/signal_manager.cpp
+++ b/nano/lib/signal_manager.cpp
@@ -49,14 +49,6 @@ void nano::signal_manager::register_signal_handler (int signum, std::function<vo
 	log (boost::str (boost::format ("Registered signal handler for signal %d") % signum));
 }
 
-std::function<void (int)> nano::signal_manager::get_debug_files_handler (void)
-{
-	return [] (int) {
-		nano::dump_crash_stacktrace ();
-		nano::create_load_memory_address_files ();
-	};
-}
-
 void nano::signal_manager::base_handler (nano::signal_manager::signal_descriptor descriptor, const boost::system::error_code & error, int signum)
 {
 	if (!error)

--- a/nano/lib/signal_manager.hpp
+++ b/nano/lib/signal_manager.hpp
@@ -33,9 +33,6 @@ public:
 	 */
 	void register_signal_handler (int signum, std::function<void (int)> handler, bool repeat);
 
-	/** returns a signal handler that prints a stacktrace and creates some debug files */
-	std::function<void (int)> get_debug_files_handler (void);
-
 private:
 	struct signal_descriptor final
 	{


### PR DESCRIPTION
The handling of SIGSEGV and SIGABRT did not have the desired effect of
generating stack traces of the source code that caused the signal.

That's because the signals were handled by the signal manager, which
first switches stack context to one that is safe to execute any code.
However, for SIGSEGV and SIGABRT we want to print the stacktrace of
the problem and therefore we cannot switch context.

So, I am setting the handling of SIGSEGV and SIGABRT to use the classic
signal function, like before the signal manager was introduced.