### PR TITLE
Improvements in const correctness and 'const' positioning

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -32,7 +32,7 @@ enum class work_peer_type
 
 class work_peer_connection : public std::enable_shared_from_this<work_peer_connection>
 {
-	const std::string generic_error = "Unable to parse JSON";
+	std::string const generic_error = "Unable to parse JSON";
 
 public:
 	work_peer_connection (asio::io_context & ioc_a, work_peer_type const type_a, nano::work_version const version_a, nano::work_pool & pool_a, std::function<void (bool const)> on_generation_a, std::function<void ()> on_cancel_a) :
@@ -155,7 +155,7 @@ private:
 				beast::ostream (this_l->response.body ()) << ostream.str ();
 				// Delay response by 500ms as a slow peer, immediate async call for a good peer
 				this_l->timer.expires_from_now (boost::posix_time::milliseconds (this_l->type == work_peer_type::slow ? 500 : 0));
-				this_l->timer.async_wait ([this_l, result] (const boost::system::error_code & ec) {
+				this_l->timer.async_wait ([this_l, result] (boost::system::error_code const & ec) {
 					if (this_l->on_generation)
 					{
 						this_l->on_generation (result != 0);

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -158,7 +158,7 @@ TEST (ledger_walker, ladder_geometry)
 	std::vector<nano::uint128_t> amounts_to_send (10);
 	std::iota (amounts_to_send.begin (), amounts_to_send.end (), 1);
 
-    nano::account const * last_destination{};
+	nano::account const * last_destination{};
 	for (auto itr = 0; itr != amounts_to_send.size (); ++itr)
 	{
 		auto const source_index = itr % keys.size ();

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -14,13 +14,13 @@ using namespace std::chrono_literals;
 TEST (ledger_walker, genesis_block)
 {
 	nano::system system{};
-	const auto node = system.add_node ();
+	auto const node = system.add_node ();
 
 	nano::ledger_walker ledger_walker{ node->ledger };
 
 	std::size_t walked_blocks_count = 0;
 	ledger_walker.walk_backward (nano::dev::genesis->hash (),
-	[&] (const auto & block) {
+	[&] (auto const & block) {
 		++walked_blocks_count;
 		EXPECT_EQ (block->hash (), nano::dev::genesis->hash ());
 	});
@@ -29,7 +29,7 @@ TEST (ledger_walker, genesis_block)
 
 	walked_blocks_count = 0;
 	ledger_walker.walk (nano::dev::genesis->hash (),
-	[&] (const auto & block) {
+	[&] (auto const & block) {
 		++walked_blocks_count;
 		EXPECT_EQ (block->hash (), nano::dev::genesis->hash ());
 	});
@@ -46,24 +46,24 @@ TEST (ledger_walker, genesis_account_longer)
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
-	const auto node = system.add_node (node_config);
+	auto const node = system.add_node (node_config);
 
 	nano::ledger_walker ledger_walker{ node->ledger };
 	EXPECT_TRUE (ledger_walker.walked_blocks.empty ());
 	EXPECT_LE (ledger_walker.walked_blocks.bucket_count (), 1);
 	EXPECT_TRUE (ledger_walker.blocks_to_walk.empty ());
 
-	const auto get_number_of_walked_blocks = [&ledger_walker] (const auto & start_block_hash) {
+	auto const get_number_of_walked_blocks = [&ledger_walker] (auto const & start_block_hash) {
 		std::size_t walked_blocks_count = 0;
 		ledger_walker.walk_backward (start_block_hash,
-		[&] (const auto & block) {
+		[&] (auto const & block) {
 			++walked_blocks_count;
 		});
 
 		return walked_blocks_count;
 	};
 
-	const auto transaction = node->ledger.store.tx_begin_read ();
+	auto const transaction = node->ledger.store.tx_begin_read ();
 	nano::account_info genesis_account_info{};
 	ASSERT_FALSE (node->ledger.store.account.get (transaction, nano::dev::genesis_key.pub, genesis_account_info));
 	EXPECT_EQ (get_number_of_walked_blocks (genesis_account_info.open_block), 1);
@@ -72,7 +72,7 @@ TEST (ledger_walker, genesis_account_longer)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	for (auto itr = 1; itr <= 5; ++itr)
 	{
-		const auto send = system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 1);
+		auto const send = system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 1);
 		ASSERT_TRUE (send);
 		EXPECT_EQ (get_number_of_walked_blocks (send->hash ()), 1 + itr * 2 - 1);
 		ASSERT_TIMELY (3s, 1 + itr * 2 == node->ledger.cache.cemented_count);
@@ -95,7 +95,7 @@ TEST (ledger_walker, cross_account)
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
-	const auto node = system.add_node (node_config);
+	auto const node = system.add_node (node_config);
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	ASSERT_TRUE (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 1));
@@ -106,22 +106,22 @@ TEST (ledger_walker, cross_account)
 	ASSERT_TRUE (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 1));
 	ASSERT_TIMELY (3s, 5 == node->ledger.cache.cemented_count);
 
-	const auto transaction = node->ledger.store.tx_begin_read ();
+	auto const transaction = node->ledger.store.tx_begin_read ();
 	nano::account_info account_info{};
 	ASSERT_FALSE (node->ledger.store.account.get (transaction, key.pub, account_info));
 
 	//    TODO: check issue with account head
-	//    const auto first = node->ledger.store.block.get_no_sideband(transaction, account_info.head);
-	//    const auto second = node->ledger.store.block.get_no_sideband(transaction, first->previous());
-	//    const auto third = node->ledger.store.block.get_no_sideband(transaction, second->previous());
-	//    const auto fourth = node->ledger.store.block.get_no_sideband(transaction, third->previous());
-	//    const auto fifth = node->ledger.store.block.get_no_sideband(transaction, fourth->previous());
+	//    auto const first = node->ledger.store.block.get_no_sideband(transaction, account_info.head);
+	//    auto const second = node->ledger.store.block.get_no_sideband(transaction, first->previous());
+	//    auto const third = node->ledger.store.block.get_no_sideband(transaction, second->previous());
+	//    auto const fourth = node->ledger.store.block.get_no_sideband(transaction, third->previous());
+	//    auto const fifth = node->ledger.store.block.get_no_sideband(transaction, fourth->previous());
 	//
-	//    const auto expected_blocks_to_walk = { first, second, third, fourth, fifth };
+	//    auto const expected_blocks_to_walk = { first, second, third, fourth, fifth };
 	//    auto expected_blocks_to_walk_itr = expected_blocks_to_walk.begin();
 	//
 	//    nano::ledger_walker ledger_walker{ node->ledger };
-	//    ledger_walker.walk_backward (account_info.block_count, [&] (const auto & block) {
+	//    ledger_walker.walk_backward (account_info.block_count, [&] (auto const & block) {
 	//        if (expected_blocks_to_walk_itr == expected_blocks_to_walk.end())
 	//        {
 	//            EXPECT_TRUE(false);
@@ -143,14 +143,14 @@ TEST (ledger_walker, ladder_geometry)
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
-	const auto node = system.add_node (node_config);
+	auto const node = system.add_node (node_config);
 	std::array<nano::keypair, 3> keys{};
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	for (auto itr = 0; itr != keys.size (); ++itr)
 	{
 		system.wallet (0)->insert_adhoc (keys[itr].prv);
-		const auto block = system.wallet (0)->send_action (nano::dev::genesis_key.pub, keys[itr].pub, 1000);
+		auto const block = system.wallet (0)->send_action (nano::dev::genesis_key.pub, keys[itr].pub, 1000);
 		ASSERT_TRUE (block);
 		ASSERT_TIMELY (3s, 1 + (itr + 1) * 2 == node->ledger.cache.cemented_count);
 	}
@@ -158,21 +158,21 @@ TEST (ledger_walker, ladder_geometry)
 	std::vector<nano::uint128_t> amounts_to_send (10);
 	std::iota (amounts_to_send.begin (), amounts_to_send.end (), 1);
 
-	const nano::account * last_destination{};
+    nano::account const * last_destination{};
 	for (auto itr = 0; itr != amounts_to_send.size (); ++itr)
 	{
-		const auto source_index = itr % keys.size ();
-		const auto destination_index = (source_index + 1) % keys.size ();
+		auto const source_index = itr % keys.size ();
+		auto const destination_index = (source_index + 1) % keys.size ();
 		last_destination = &keys[destination_index].pub;
 
-		const auto send = system.wallet (0)->send_action (keys[source_index].pub, keys[destination_index].pub, amounts_to_send[itr]);
+		auto const send = system.wallet (0)->send_action (keys[source_index].pub, keys[destination_index].pub, amounts_to_send[itr]);
 		ASSERT_TRUE (send);
 		ASSERT_TIMELY (3s, 1 + keys.size () * 2 + (itr + 1) * 2 == node->ledger.cache.cemented_count);
 	}
 
 	ASSERT_TRUE (last_destination);
 	nano::account_info last_destination_info{};
-	const auto last_destination_read_error = node->ledger.store.account.get (node->ledger.store.tx_begin_read (), *last_destination, last_destination_info);
+	auto const last_destination_read_error = node->ledger.store.account.get (node->ledger.store.tx_begin_read (), *last_destination, last_destination_info);
 	ASSERT_FALSE (last_destination_read_error);
 
 	// This is how we expect chains to look like (for 3 accounts and 10 amounts to be sent)
@@ -185,13 +185,13 @@ TEST (ledger_walker, ladder_geometry)
 
 	nano::ledger_walker ledger_walker{ node->ledger };
 	ledger_walker.walk_backward (last_destination_info.head,
-	[&] (const auto & block) {
+	[&] (auto const & block) {
 		if (block->sideband ().details.is_receive)
 		{
 			nano::amount previous_balance{};
 			if (!block->previous ().is_zero ())
 			{
-				const auto previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
+				auto const previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
 				previous_balance = previous_block->balance ();
 			}
 
@@ -204,13 +204,13 @@ TEST (ledger_walker, ladder_geometry)
 	auto amounts_expected_itr = amounts_expected_backwards.crbegin ();
 
 	ledger_walker.walk (last_destination_info.head,
-	[&] (const auto & block) {
+	[&] (auto const & block) {
 		if (block->sideband ().details.is_receive)
 		{
 			nano::amount previous_balance{};
 			if (!block->previous ().is_zero ())
 			{
-				const auto previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
+				auto const previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
 				previous_balance = previous_block->balance ();
 			}
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -22,7 +22,7 @@ void add_required_children_node_config_tree (nano::jsonconfig & tree);
 
 TEST (node, null_account)
 {
-	const auto & null_account = nano::account::null ();
+	auto const & null_account = nano::account::null ();
 	ASSERT_TRUE (null_account == nullptr);
 	ASSERT_FALSE (null_account != nullptr);
 
@@ -949,7 +949,7 @@ TEST (json, backup)
 	};
 
 	auto get_file_count = [&dir] () {
-		return std::count_if (boost::filesystem::directory_iterator (dir), boost::filesystem::directory_iterator (), static_cast<bool (*) (const boost::filesystem::path &)> (boost::filesystem::is_regular_file));
+		return std::count_if (boost::filesystem::directory_iterator (dir), boost::filesystem::directory_iterator (), static_cast<bool (*) (boost::filesystem::path const &)> (boost::filesystem::is_regular_file));
 	};
 
 	// There should only be the original file in this directory

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -125,7 +125,7 @@ TEST (peer_container, list_fanout)
 	ASSERT_EQ (0, node.network.fanout ());
 	auto list1 (node.network.list (node.network.fanout ()));
 	ASSERT_TRUE (list1.empty ());
-	auto add_peer = [&node] (const uint16_t port_a) {
+	auto add_peer = [&node] (uint16_t const port_a) {
 		ASSERT_NE (nullptr, node.network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), port_a), node.network_params.network.protocol_version));
 	};
 	add_peer (9998);

--- a/nano/fuzzer_test/fuzz_bignum.cpp
+++ b/nano/fuzzer_test/fuzz_bignum.cpp
@@ -1,7 +1,7 @@
 #include <nano/node/common.hpp>
 
 /** Fuzz decimal, hex and account parsing */
-void fuzz_bignum_parsers (const uint8_t * Data, size_t Size)
+void fuzz_bignum_parsers (uint8_t const * Data, size_t Size)
 {
 	try
 	{
@@ -29,7 +29,7 @@ void fuzz_bignum_parsers (const uint8_t * Data, size_t Size)
 }
 
 /** Fuzzer entry point */
-extern "C" int LLVMFuzzerTestOneInput (const uint8_t * Data, size_t Size)
+extern "C" int LLVMFuzzerTestOneInput (uint8_t const * Data, size_t Size)
 {
 	fuzz_bignum_parsers (Data, Size);
 	return 0;

--- a/nano/fuzzer_test/fuzz_buffer.cpp
+++ b/nano/fuzzer_test/fuzz_buffer.cpp
@@ -56,7 +56,7 @@ public:
 }
 
 /** Fuzz live message parsing. This covers parsing and block/vote uniquing. */
-void fuzz_message_parser (const uint8_t * Data, size_t Size)
+void fuzz_message_parser (uint8_t const * Data, size_t Size)
 {
 	static bool initialized = false;
 	if (!initialized)
@@ -73,7 +73,7 @@ void fuzz_message_parser (const uint8_t * Data, size_t Size)
 }
 
 /** Fuzzer entry point */
-extern "C" int LLVMFuzzerTestOneInput (const uint8_t * Data, size_t Size)
+extern "C" int LLVMFuzzerTestOneInput (uint8_t const * Data, size_t Size)
 {
 	fuzz_message_parser (Data, Size);
 	return 0;

--- a/nano/fuzzer_test/fuzz_endpoint_parsing.cpp
+++ b/nano/fuzzer_test/fuzz_endpoint_parsing.cpp
@@ -1,7 +1,7 @@
 #include <nano/node/common.hpp>
 
 /** Fuzz endpoint parsing */
-void fuzz_endpoint_parsing (const uint8_t * Data, size_t Size)
+void fuzz_endpoint_parsing (uint8_t const * Data, size_t Size)
 {
 	auto data (std::string (reinterpret_cast<char *> (const_cast<uint8_t *> (Data)), Size));
 	nano::endpoint endpoint;
@@ -11,7 +11,7 @@ void fuzz_endpoint_parsing (const uint8_t * Data, size_t Size)
 }
 
 /** Fuzzer entry point */
-extern "C" int LLVMFuzzerTestOneInput (const uint8_t * Data, size_t Size)
+extern "C" int LLVMFuzzerTestOneInput (uint8_t const * Data, size_t Size)
 {
 	fuzz_endpoint_parsing (Data, Size);
 	return 0;

--- a/nano/lib/asio.cpp
+++ b/nano/lib/asio.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/asio.hpp>
 
-nano::shared_const_buffer::shared_const_buffer (const std::vector<uint8_t> & data) :
+nano::shared_const_buffer::shared_const_buffer (std::vector<uint8_t> const & data) :
 	m_data (std::make_shared<std::vector<uint8_t>> (data)),
 	m_buffer (boost::asio::buffer (*m_data))
 {
@@ -29,17 +29,17 @@ nano::shared_const_buffer::shared_const_buffer (std::shared_ptr<std::vector<uint
 {
 }
 
-const boost::asio::const_buffer * nano::shared_const_buffer::begin () const
+boost::asio::const_buffer const * nano::shared_const_buffer::begin () const
 {
 	return &m_buffer;
 }
 
-const boost::asio::const_buffer * nano::shared_const_buffer::end () const
+boost::asio::const_buffer const * nano::shared_const_buffer::end () const
 {
 	return &m_buffer + 1;
 }
 
-size_t nano::shared_const_buffer::size () const
+std::size_t nano::shared_const_buffer::size () const
 {
 	return m_buffer.size ();
 }

--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -16,7 +16,7 @@ public:
 	explicit shared_const_buffer (std::vector<uint8_t> && data);
 	explicit shared_const_buffer (std::shared_ptr<std::vector<uint8_t>> const & data);
 
-    boost::asio::const_buffer const * begin () const;
+	boost::asio::const_buffer const * begin () const;
 	boost::asio::const_buffer const * end () const;
 
 	std::size_t size () const;

--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -8,7 +8,7 @@ class shared_const_buffer
 {
 public:
 	using value_type = boost::asio::const_buffer;
-	using const_iterator = const boost::asio::const_buffer *;
+	using const_iterator = boost::asio::const_buffer const *;
 
 	explicit shared_const_buffer (std::vector<uint8_t> const & data);
 	explicit shared_const_buffer (uint8_t data);
@@ -16,10 +16,10 @@ public:
 	explicit shared_const_buffer (std::vector<uint8_t> && data);
 	explicit shared_const_buffer (std::shared_ptr<std::vector<uint8_t>> const & data);
 
-	const boost::asio::const_buffer * begin () const;
-	const boost::asio::const_buffer * end () const;
+    boost::asio::const_buffer const * begin () const;
+	boost::asio::const_buffer const * end () const;
 
-	size_t size () const;
+	std::size_t size () const;
 
 private:
 	std::shared_ptr<std::vector<uint8_t>> m_data;

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -139,7 +139,7 @@ public:
 	nano::block_hash previous;
 	nano::account destination;
 	nano::amount balance;
-	static size_t constexpr size = sizeof (previous) + sizeof (destination) + sizeof (balance);
+	static std::size_t constexpr size = sizeof (previous) + sizeof (destination) + sizeof (balance);
 };
 class send_block : public nano::block
 {
@@ -173,7 +173,7 @@ public:
 	send_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
-	static size_t constexpr size = nano::send_hashables::size + sizeof (signature) + sizeof (work);
+	static std::size_t constexpr size = nano::send_hashables::size + sizeof (signature) + sizeof (work);
 };
 class receive_hashables
 {
@@ -185,7 +185,7 @@ public:
 	void hash (blake2b_state &) const;
 	nano::block_hash previous;
 	nano::block_hash source;
-	static size_t constexpr size = sizeof (previous) + sizeof (source);
+	static std::size_t constexpr size = sizeof (previous) + sizeof (source);
 };
 class receive_block : public nano::block
 {
@@ -218,7 +218,7 @@ public:
 	receive_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
-	static size_t constexpr size = nano::receive_hashables::size + sizeof (signature) + sizeof (work);
+	static std::size_t constexpr size = nano::receive_hashables::size + sizeof (signature) + sizeof (work);
 };
 class open_hashables
 {
@@ -231,7 +231,7 @@ public:
 	nano::block_hash source;
 	nano::account representative;
 	nano::account account;
-	static size_t constexpr size = sizeof (source) + sizeof (representative) + sizeof (account);
+	static std::size_t constexpr size = sizeof (source) + sizeof (representative) + sizeof (account);
 };
 class open_block : public nano::block
 {
@@ -267,7 +267,7 @@ public:
 	nano::open_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
-	static size_t constexpr size = nano::open_hashables::size + sizeof (signature) + sizeof (work);
+	static std::size_t constexpr size = nano::open_hashables::size + sizeof (signature) + sizeof (work);
 };
 class change_hashables
 {
@@ -279,7 +279,7 @@ public:
 	void hash (blake2b_state &) const;
 	nano::block_hash previous;
 	nano::account representative;
-	static size_t constexpr size = sizeof (previous) + sizeof (representative);
+	static std::size_t constexpr size = sizeof (previous) + sizeof (representative);
 };
 class change_block : public nano::block
 {
@@ -312,7 +312,7 @@ public:
 	nano::change_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
-	static size_t constexpr size = nano::change_hashables::size + sizeof (signature) + sizeof (work);
+	static std::size_t constexpr size = nano::change_hashables::size + sizeof (signature) + sizeof (work);
 };
 class state_hashables
 {
@@ -337,7 +337,7 @@ public:
 	// Link field contains source block_hash if receiving, destination account if sending
 	nano::link link;
 	// Serialized size
-	static size_t constexpr size = sizeof (account) + sizeof (previous) + sizeof (representative) + sizeof (balance) + sizeof (link);
+	static std::size_t constexpr size = sizeof (account) + sizeof (previous) + sizeof (representative) + sizeof (balance) + sizeof (link);
 };
 class state_block : public nano::block
 {
@@ -373,7 +373,7 @@ public:
 	nano::state_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
-	static size_t constexpr size = nano::state_hashables::size + sizeof (signature) + sizeof (work);
+	static std::size_t constexpr size = nano::state_hashables::size + sizeof (signature) + sizeof (work);
 };
 class block_visitor
 {
@@ -401,7 +401,7 @@ public:
 class block_uniquer
 {
 public:
-	using value_type = std::pair<const nano::uint256_union, std::weak_ptr<nano::block>>;
+	using value_type = std::pair<nano::uint256_union const, std::weak_ptr<nano::block>>;
 
 	std::shared_ptr<nano::block> unique (std::shared_ptr<nano::block> const &);
 	size_t size ();

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -210,7 +210,7 @@ bool nano::work_thresholds::validate_entry (nano::block const & block_a) const
 
 namespace nano
 {
-const char * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
+char const * network_constants::active_network_err_msg = "Invalid network. Valid values are live, test, beta and dev.";
 
 uint8_t get_major_node_version ()
 {

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -22,26 +22,26 @@ namespace filesystem
 /**
 * Returns build version information
 */
-const char * const NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
-const char * const NANO_MAJOR_VERSION_STRING = xstr (MAJOR_VERSION_STRING);
-const char * const NANO_MINOR_VERSION_STRING = xstr (MINOR_VERSION_STRING);
-const char * const NANO_PATCH_VERSION_STRING = xstr (PATCH_VERSION_STRING);
-const char * const NANO_PRE_RELEASE_VERSION_STRING = xstr (PRE_RELEASE_VERSION_STRING);
+char const * const NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
+char const * const NANO_MAJOR_VERSION_STRING = xstr (MAJOR_VERSION_STRING);
+char const * const NANO_MINOR_VERSION_STRING = xstr (MINOR_VERSION_STRING);
+char const * const NANO_PATCH_VERSION_STRING = xstr (PATCH_VERSION_STRING);
+char const * const NANO_PRE_RELEASE_VERSION_STRING = xstr (PRE_RELEASE_VERSION_STRING);
 
-const char * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
+char const * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
 
 /** Is TSAN/ASAN dev build */
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
-const bool is_sanitizer_build = true;
+bool const is_sanitizer_build = true;
 #else
-const bool is_sanitizer_build = false;
+bool const is_sanitizer_build = false;
 #endif
 // GCC builds
 #elif defined(__SANITIZE_THREAD__) || defined(__SANITIZE_ADDRESS__)
 const bool is_sanitizer_build = true;
 #else
-const bool is_sanitizer_build = false;
+bool const is_sanitizer_build = false;
 #endif
 
 namespace nano
@@ -125,10 +125,10 @@ public:
 	bool validate_entry (nano::block const &) const;
 
 	/** Network work thresholds. Define these inline as constexpr when moving to cpp17. */
-	static const nano::work_thresholds publish_full;
-	static const nano::work_thresholds publish_beta;
-	static const nano::work_thresholds publish_dev;
-	static const nano::work_thresholds publish_test;
+	static nano::work_thresholds const publish_full;
+	static nano::work_thresholds const publish_beta;
+	static nano::work_thresholds const publish_dev;
+	static nano::work_thresholds const publish_test;
 };
 
 class network_constants
@@ -164,7 +164,7 @@ public:
 	}
 
 	/** Error message when an invalid network is specified */
-	static const char * active_network_err_msg;
+	static char const * active_network_err_msg;
 
 	/** The network this param object represents. This may differ from the global active network; this is needed for certain --debug... commands */
 	nano::networks current_network{ nano::network_constants::active_network };
@@ -243,7 +243,7 @@ public:
 		return error;
 	}
 
-	const char * get_current_network_as_string ()
+	char const * get_current_network_as_string ()
 	{
 		return is_live_network () ? "live" : is_beta_network () ? "beta"
 		: is_test_network ()                                    ? "test"

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -462,7 +462,7 @@ nano::error & nano::error::on_error (std::error_code code_a, std::string message
 /** Set an error message and an error code */
 nano::error & nano::error::set (std::string message_a, std::error_code code_a)
 {
-	message = message_a;
+	message = std::move (message_a);
 	code = code_a;
 	return *this;
 }
@@ -486,6 +486,7 @@ nano::error & nano::error::clear ()
 	return *this;
 }
 
+// TODO: theoretically, nothing besides template (partial) specializations should ever be added inside std...
 namespace std
 {
 std::error_code make_error_code (boost::system::errc::errc_t const & e)

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -280,30 +280,31 @@ std::string nano::error_config_messages::message (int ev) const
 	return "Invalid error code";
 }
 
-const char * nano::error_conversion::detail::generic_category::name () const noexcept
+char const * nano::error_conversion::detail::generic_category::name () const noexcept
 {
 	return boost::system::generic_category ().name ();
 }
+
 std::string nano::error_conversion::detail::generic_category::message (int value) const
 {
 	return boost::system::generic_category ().message (value);
 }
 
-const std::error_category & nano::error_conversion::generic_category ()
+std::error_category const & nano::error_conversion::generic_category ()
 {
 	static detail::generic_category instance;
 	return instance;
 }
 
-std::error_code nano::error_conversion::convert (const boost::system::error_code & error)
+std::error_code nano::error_conversion::convert (boost::system::error_code const & error)
 {
 	if (error.category () == boost::system::generic_category ())
 	{
 		return std::error_code (error.value (),
-		nano::error_conversion::generic_category ());
+                                nano::error_conversion::generic_category ());
 	}
-	debug_assert (false);
 
+	debug_assert (false);
 	return nano::error_common::invalid_type_conversion;
 }
 
@@ -344,7 +345,7 @@ nano::error & nano::error::operator= (nano::error && err_a)
 }
 
 /** Assign error code */
-nano::error & nano::error::operator= (const std::error_code code_a)
+nano::error & nano::error::operator= (std::error_code const code_a)
 {
 	code = code_a;
 	message.clear ();
@@ -352,7 +353,7 @@ nano::error & nano::error::operator= (const std::error_code code_a)
 }
 
 /** Assign boost error code (as converted to std::error_code) */
-nano::error & nano::error::operator= (const boost::system::error_code & code_a)
+nano::error & nano::error::operator= (boost::system::error_code const & code_a)
 {
 	code = nano::error_conversion::convert (code_a);
 	message.clear ();
@@ -360,7 +361,7 @@ nano::error & nano::error::operator= (const boost::system::error_code & code_a)
 }
 
 /** Assign boost error code (as converted to std::error_code) */
-nano::error & nano::error::operator= (const boost::system::errc::errc_t & code_a)
+nano::error & nano::error::operator= (boost::system::errc::errc_t const & code_a)
 {
 	code = nano::error_conversion::convert (boost::system::errc::make_error_code (code_a));
 	message.clear ();
@@ -368,7 +369,7 @@ nano::error & nano::error::operator= (const boost::system::errc::errc_t & code_a
 }
 
 /** Set the error to nano::error_common::generic and the error message to \p message_a */
-nano::error & nano::error::operator= (const std::string message_a)
+nano::error & nano::error::operator= (std::string message_a)
 {
 	code = nano::error_common::generic;
 	message = std::move (message_a);
@@ -384,13 +385,13 @@ nano::error & nano::error::operator= (std::exception const & exception_a)
 }
 
 /** Return true if this#error_code equals the parameter */
-bool nano::error::operator== (const std::error_code code_a) const
+bool nano::error::operator== (std::error_code const code_a) const
 {
 	return code == code_a;
 }
 
 /** Return true if this#error_code equals the parameter */
-bool nano::error::operator== (const boost::system::error_code code_a) const
+bool nano::error::operator== (boost::system::error_code const code_a) const
 {
 	return code.value () == code_a.value ();
 }

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -301,7 +301,7 @@ std::error_code nano::error_conversion::convert (boost::system::error_code const
 	if (error.category () == boost::system::generic_category ())
 	{
 		return std::error_code (error.value (),
-                                nano::error_conversion::generic_category ());
+		nano::error_conversion::generic_category ());
 	}
 
 	debug_assert (false);

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -201,7 +201,7 @@ namespace nano
 {
 namespace error_conversion
 {
-    std::error_category const & generic_category ();
+	std::error_category const & generic_category ();
 }
 }
 

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -163,7 +163,7 @@ enum class error_config
 		class enum_type##_messages : public std::error_category                                                \
 		{                                                                                                      \
 		public:                                                                                                \
-			const char * name () const noexcept override                                                       \
+			char const * name () const noexcept override                                                       \
 			{                                                                                                  \
 				return #enum_type;                                                                             \
 			}                                                                                                  \
@@ -171,7 +171,7 @@ enum class error_config
 			std::string message (int ev) const override;                                                       \
 		};                                                                                                     \
                                                                                                                \
-		inline const std::error_category & enum_type##_category ()                                             \
+		inline std::error_category const & enum_type##_category ()                                             \
 		{                                                                                                      \
 			static enum_type##_messages instance;                                                              \
 			return instance;                                                                                   \
@@ -201,7 +201,7 @@ namespace nano
 {
 namespace error_conversion
 {
-	const std::error_category & generic_category ();
+    std::error_category const & generic_category ();
 }
 }
 
@@ -224,12 +224,12 @@ namespace error_conversion
 		class generic_category : public std::error_category
 		{
 		public:
-			const char * name () const noexcept override;
+			char const * name () const noexcept override;
 			std::string message (int value) const override;
 		};
 	}
-	const std::error_category & generic_category ();
-	std::error_code convert (const boost::system::error_code & error);
+	std::error_category const & generic_category ();
+	std::error_code convert (boost::system::error_code const & error);
 }
 }
 
@@ -249,13 +249,13 @@ public:
 	error (std::exception const & exception_a);
 	error & operator= (nano::error const & err_a);
 	error & operator= (nano::error && err_a);
-	error & operator= (const std::error_code code_a);
-	error & operator= (const boost::system::error_code & code_a);
-	error & operator= (const boost::system::errc::errc_t & code_a);
-	error & operator= (const std::string message_a);
+	error & operator= (std::error_code code_a);
+	error & operator= (boost::system::error_code const & code_a);
+	error & operator= (boost::system::errc::errc_t const & code_a);
+	error & operator= (std::string message_a);
 	error & operator= (std::exception const & exception_a);
-	bool operator== (const std::error_code code_a) const;
-	bool operator== (const boost::system::error_code code_a) const;
+	bool operator== (std::error_code code_a) const;
+	bool operator== (boost::system::error_code code_a) const;
 	error & then (std::function<nano::error &()> next);
 	template <typename... ErrorCode>
 	error & accept (ErrorCode... err)

--- a/nano/lib/ipc.cpp
+++ b/nano/lib/ipc.cpp
@@ -11,7 +11,7 @@ void nano::ipc::socket_base::timer_start (std::chrono::seconds timeout_a)
 	if (timeout_a < std::chrono::seconds::max ())
 	{
 		io_timer.expires_from_now (boost::posix_time::seconds (static_cast<long> (timeout_a.count ())));
-		io_timer.async_wait ([this] (const boost::system::error_code & ec) {
+		io_timer.async_wait ([this] (boost::system::error_code const & ec) {
 			if (!ec)
 			{
 				this->timer_expired ();

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -208,7 +208,7 @@ public:
 		tcp_client->async_resolve (host_a, port_a, [this, callback_a] (boost::system::error_code const & ec_resolve_a, boost::asio::ip::tcp::endpoint endpoint_a) {
 			if (!ec_resolve_a)
 			{
-				this->tcp_client->async_connect ([callback_a] (const boost::system::error_code & ec_connect_a) {
+				this->tcp_client->async_connect ([callback_a] (boost::system::error_code const & ec_connect_a) {
 					callback_a (nano::error (ec_connect_a));
 				});
 			}
@@ -278,7 +278,7 @@ nano::error nano::ipc::ipc_client::connect (std::string const & host, uint16_t p
 void nano::ipc::ipc_client::async_write (nano::shared_const_buffer const & buffer_a, std::function<void (nano::error, size_t)> callback_a)
 {
 	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
-	client->get_channel ().async_write (buffer_a, [callback_a] (const boost::system::error_code & ec_a, size_t bytes_written_a) {
+	client->get_channel ().async_write (buffer_a, [callback_a] (boost::system::error_code const & ec_a, size_t bytes_written_a) {
 		callback_a (nano::error (ec_a), bytes_written_a);
 	});
 }
@@ -286,7 +286,7 @@ void nano::ipc::ipc_client::async_write (nano::shared_const_buffer const & buffe
 void nano::ipc::ipc_client::async_read (std::shared_ptr<std::vector<uint8_t>> const & buffer_a, size_t size_a, std::function<void (nano::error, size_t)> callback_a)
 {
 	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
-	client->get_channel ().async_read (buffer_a, size_a, [callback_a, buffer_a] (const boost::system::error_code & ec_a, size_t bytes_read_a) {
+	client->get_channel ().async_read (buffer_a, size_a, [callback_a, buffer_a] (boost::system::error_code const & ec_a, size_t bytes_read_a) {
 		callback_a (nano::error (ec_a), bytes_read_a);
 	});
 }
@@ -295,7 +295,7 @@ void nano::ipc::ipc_client::async_read (std::shared_ptr<std::vector<uint8_t>> co
 void nano::ipc::ipc_client::async_read_message (std::shared_ptr<std::vector<uint8_t>> const & buffer_a, std::chrono::seconds timeout_a, std::function<void (nano::error, size_t)> callback_a)
 {
 	auto client (boost::polymorphic_downcast<client_impl *> (impl.get ()));
-	client->get_channel ().async_read_message (buffer_a, timeout_a, [callback_a, buffer_a] (const boost::system::error_code & ec_a, size_t bytes_read_a) {
+	client->get_channel ().async_read_message (buffer_a, timeout_a, [callback_a, buffer_a] (boost::system::error_code const & ec_a, size_t bytes_read_a) {
 		callback_a (nano::error (ec_a), bytes_read_a);
 	});
 }

--- a/nano/lib/locks.cpp
+++ b/nano/lib/locks.cpp
@@ -10,9 +10,9 @@
 #if USING_NANO_TIMED_LOCKS
 namespace nano
 {
-// These mutexes must have std::mutex interface in addition to "const char* get_name ()" method
+// These mutexes must have std::mutex interface in addition to "char const * get_name ()" method
 template <typename Mutex>
-void output (const char * str, std::chrono::milliseconds time, Mutex & mutex)
+void output (char const * str, std::chrono::milliseconds time, Mutex & mutex)
 {
 	static nano::mutex cout_mutex;
 	auto stacktrace = nano::generate_stacktrace ();
@@ -232,7 +232,7 @@ void condition_variable::wait (nano::unique_lock<nano::mutex> & lk)
 nano::mutex * mutex_to_filter{ nullptr };
 nano::mutex mutex_to_filter_mutex;
 
-bool should_be_filtered (const char * name)
+bool should_be_filtered (char const * name)
 {
 	return std::strcmp (name, xstr (NANO_TIMED_LOCKS_FILTER)) == 0;
 }

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -14,7 +14,7 @@ namespace nano
 class mutex;
 extern nano::mutex * mutex_to_filter;
 extern nano::mutex mutex_to_filter_mutex;
-bool should_be_filtered (const char * name);
+bool should_be_filtered (char const * name);
 bool any_filters_registered ();
 
 enum class mutexes
@@ -45,7 +45,7 @@ class mutex
 {
 public:
 	mutex () = default;
-	mutex (const char * name_a)
+	mutex (char const * name_a)
 #if USING_NANO_TIMED_LOCKS
 		:
 		name (name_a)
@@ -90,7 +90,7 @@ public:
 	}
 
 #if USING_NANO_TIMED_LOCKS
-	const char * get_name () const
+	char const * get_name () const
 	{
 		return name ? name : "";
 	}
@@ -98,14 +98,14 @@ public:
 
 private:
 #if USING_NANO_TIMED_LOCKS
-	const char * name{ nullptr };
+	char const * name{ nullptr };
 #endif
 	std::mutex mutex_m;
 };
 
 #if USING_NANO_TIMED_LOCKS
 template <typename Mutex>
-void output (const char * str, std::chrono::milliseconds time, Mutex & mutex);
+void output (char const * str, std::chrono::milliseconds time, Mutex & mutex);
 
 template <typename Mutex>
 void output_if_held_long_enough (nano::timer<std::chrono::milliseconds> & timer, Mutex & mutex);

--- a/nano/lib/logger_mt.hpp
+++ b/nano/lib/logger_mt.hpp
@@ -26,7 +26,7 @@ struct severity_tag;
 inline boost::log::formatting_ostream & operator<< (boost::log::formatting_ostream & strm, boost::log::to_log_manip<nano::severity_level, severity_tag> const & manip)
 {
 	// Needs to match order in the severity_level enum
-	static std::array<const char *, 2> strings = {
+	static std::array<char const *, 2> strings = {
 		"",
 		"Error: "
 	};

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -67,7 +67,7 @@ nano::public_key::public_key () :
 {
 }
 
-const nano::public_key & nano::public_key::null ()
+nano::public_key const & nano::public_key::null ()
 {
 	return nano::hardened_constants::get ().not_an_account;
 }
@@ -656,7 +656,7 @@ void format_frac (std::ostringstream & stream, nano::uint128_t value, nano::uint
 	}
 }
 
-void format_dec (std::ostringstream & stream, nano::uint128_t value, char group_sep, const std::string & groupings)
+void format_dec (std::ostringstream & stream, nano::uint128_t value, char group_sep, std::string const & groupings)
 {
 	auto largestPow10 = nano::uint256_t (1);
 	int dec_count = 1;
@@ -760,7 +760,7 @@ std::string nano::uint128_union::format_balance (nano::uint128_t scale, int prec
 	return ::format_balance (number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
 }
 
-std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits, const std::locale & locale) const
+std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits, std::locale const & locale) const
 {
 	auto thousands_sep = std::use_facet<std::moneypunct<char>> (locale).thousands_sep ();
 	auto decimal_point = std::use_facet<std::moneypunct<char>> (locale).decimal_point ();

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -35,7 +35,7 @@ public:
 	bool decode_dec (std::string const &, bool = false);
 	bool decode_dec (std::string const &, nano::uint128_t);
 	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits) const;
-	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits, const std::locale & locale) const;
+	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits, std::locale const & locale) const;
 	nano::uint128_t number () const;
 	void clear ();
 	bool is_zero () const;
@@ -247,7 +247,7 @@ nano::signature sign_message (nano::raw_key const &, nano::public_key const &, n
 nano::signature sign_message (nano::raw_key const &, nano::public_key const &, uint8_t const *, size_t);
 bool validate_message (nano::public_key const &, nano::uint256_union const &, nano::signature const &);
 bool validate_message (nano::public_key const &, uint8_t const *, size_t, nano::signature const &);
-bool validate_message_batch (unsigned const char **, size_t *, unsigned const char **, unsigned const char **, size_t, int *);
+bool validate_message_batch (unsigned char const **, size_t *, unsigned char const **, unsigned char const **, size_t, int *);
 nano::raw_key deterministic_key (nano::raw_key const &, uint32_t);
 nano::public_key pub_key (nano::raw_key const &);
 

--- a/nano/lib/plat/linux/debugging.cpp
+++ b/nano/lib/plat/linux/debugging.cpp
@@ -16,13 +16,13 @@ int create_load_memory_address_file (dl_phdr_info * info, size_t, void *)
 	static int counter = 0;
 	debug_assert (counter <= 99);
 	// Create filename
-	const char file_prefix[] = "nano_node_crash_load_address_dump_";
+	char const file_prefix[] = "nano_node_crash_load_address_dump_";
 	// Holds the filename prefix, a unique (max 2 digits) number and extension (null terminator is included in file_prefix size)
 	char filename[sizeof (file_prefix) + 2 + 4];
 	snprintf (filename, sizeof (filename), "%s%d.txt", file_prefix, counter);
 
 	// Open file
-	const auto file_descriptor = ::open (filename, O_CREAT | O_WRONLY | O_TRUNC,
+	auto const file_descriptor = ::open (filename, O_CREAT | O_WRONLY | O_TRUNC,
 #if defined(S_IWRITE) && defined(S_IREAD)
 	S_IWRITE | S_IREAD
 #else

--- a/nano/lib/rep_weights.hpp
+++ b/nano/lib/rep_weights.hpp
@@ -28,8 +28,8 @@ private:
 	void put (nano::account const & account_a, nano::uint128_union const & representation_a);
 	nano::uint128_t get (nano::account const & account_a) const;
 
-	friend std::unique_ptr<container_info_component> collect_container_info (rep_weights const &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (rep_weights const &, std::string const &);
 };
 
-std::unique_ptr<container_info_component> collect_container_info (rep_weights const &, const std::string &);
+std::unique_ptr<container_info_component> collect_container_info (rep_weights const &, std::string const &);
 }

--- a/nano/lib/signal_manager.cpp
+++ b/nano/lib/signal_manager.cpp
@@ -42,14 +42,14 @@ void nano::signal_manager::register_signal_handler (int signum, std::function<vo
 	descriptor_list.push_back (descriptor);
 
 	// asynchronously listen for signals from this signal set
-	sigset->async_wait ([descriptor] (const boost::system::error_code & error, int signum) {
+	sigset->async_wait ([descriptor] (boost::system::error_code const & error, int signum) {
 		nano::signal_manager::base_handler (descriptor, error, signum);
 	});
 
 	log (boost::str (boost::format ("Registered signal handler for signal %d") % signum));
 }
 
-void nano::signal_manager::base_handler (nano::signal_manager::signal_descriptor descriptor, const boost::system::error_code & error, int signum)
+void nano::signal_manager::base_handler (nano::signal_manager::signal_descriptor descriptor, boost::system::error_code const & error, int signum)
 {
 	if (!error)
 	{
@@ -64,7 +64,7 @@ void nano::signal_manager::base_handler (nano::signal_manager::signal_descriptor
 		// continue asynchronously listening for signals from this signal set
 		if (descriptor.repeat)
 		{
-			descriptor.sigset->async_wait ([descriptor] (const boost::system::error_code & error, int signum) {
+			descriptor.sigset->async_wait ([descriptor] (boost::system::error_code const & error, int signum) {
 				nano::signal_manager::base_handler (descriptor, error, signum);
 			});
 		}

--- a/nano/lib/signal_manager.hpp
+++ b/nano/lib/signal_manager.hpp
@@ -61,7 +61,7 @@ private:
 	 * This is the actual handler that is registered with boost asio.
 	 * It calls the caller supplied function (if one is given) and sets the handler to repeat (or not).
 	 */
-	static void base_handler (nano::signal_manager::signal_descriptor descriptor, const boost::system::error_code & error, int signum);
+	static void base_handler (nano::signal_manager::signal_descriptor descriptor, boost::system::error_code const & error, int signum);
 
 	/** boost asio context to use */
 	boost::asio::io_context ioc;

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -243,7 +243,7 @@ void nano::thread_pool::add_timed_task (std::chrono::steady_clock::time_point co
 	if (!stopped && thread_pool_m)
 	{
 		auto timer = std::make_shared<boost::asio::steady_timer> (thread_pool_m->get_executor (), expiry_time);
-		timer->async_wait ([this, task, timer] (const boost::system::error_code & ec) {
+		timer->async_wait ([this, task, timer] (boost::system::error_code const & ec) {
 			if (!ec)
 			{
 				push_task (task);

--- a/nano/lib/tomlconfig.cpp
+++ b/nano/lib/tomlconfig.cpp
@@ -152,7 +152,7 @@ nano::tomlconfig & nano::tomlconfig::erase (std::string const & key_a)
 	return *this;
 }
 
-std::shared_ptr<cpptoml::array> nano::tomlconfig::create_array (std::string const & key, boost::optional<const char *> documentation_a)
+std::shared_ptr<cpptoml::array> nano::tomlconfig::create_array (std::string const & key, boost::optional<char const *> documentation_a)
 {
 	if (!has_key (key))
 	{

--- a/nano/lib/tomlconfig.hpp
+++ b/nano/lib/tomlconfig.hpp
@@ -46,14 +46,14 @@ public:
 	tomlconfig & replace_child (std::string const & key_a, nano::tomlconfig & conf_a);
 	bool has_key (std::string const & key_a);
 	tomlconfig & erase (std::string const & key_a);
-	std::shared_ptr<cpptoml::array> create_array (std::string const & key, boost::optional<const char *> documentation_a);
+	std::shared_ptr<cpptoml::array> create_array (std::string const & key, boost::optional<char const *> documentation_a);
 	void erase_default_values (tomlconfig & defaults_a);
 	std::string to_string ();
 	std::string to_string_commented_entries ();
 
 	/** Set value for the given key. Any existing value will be overwritten. */
 	template <typename T>
-	tomlconfig & put (std::string const & key, T const & value, boost::optional<const char *> documentation_a = boost::none)
+	tomlconfig & put (std::string const & key, T const & value, boost::optional<char const *> documentation_a = boost::none)
 	{
 		tree->insert (key, value);
 		if (documentation_a)

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -94,12 +94,12 @@ void nano::container_info_composite::add_component (std::unique_ptr<container_in
 	children.push_back (std::move (child));
 }
 
-const std::vector<std::unique_ptr<nano::container_info_component>> & nano::container_info_composite::get_children () const
+std::vector<std::unique_ptr<nano::container_info_component>> const & nano::container_info_composite::get_children () const
 {
 	return children;
 }
 
-const std::string & nano::container_info_composite::get_name () const
+std::string const & nano::container_info_composite::get_name () const
 {
 	return name;
 }
@@ -114,7 +114,7 @@ bool nano::container_info_leaf::is_composite () const
 	return false;
 }
 
-const nano::container_info & nano::container_info_leaf::get_info () const
+nano::container_info const & nano::container_info_leaf::get_info () const
 {
 	return info;
 }
@@ -159,7 +159,7 @@ void nano::move_all_files_to_dir (boost::filesystem::path const & from, boost::f
 /*
  * Backing code for "release_assert" & "debug_assert", which are macros
  */
-void assert_internal (const char * check_expr, const char * func, const char * file, unsigned int line, bool is_release_assert, std::string_view error_msg)
+void assert_internal (char const * check_expr, char const * func, char const * file, unsigned int line, bool is_release_assert, std::string_view error_msg)
 {
 	std::cerr << "Assertion (" << check_expr << ") failed\n"
 			  << func << "\n"

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -76,7 +76,7 @@ public:
 	container_info_composite (std::string const & name);
 	bool is_composite () const override;
 	void add_component (std::unique_ptr<container_info_component> child);
-    std::vector<std::unique_ptr<container_info_component>> const & get_children () const;
+	std::vector<std::unique_ptr<container_info_component>> const & get_children () const;
 	std::string const & get_name () const;
 
 private:

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -24,7 +24,7 @@ namespace system
 }
 }
 
-void assert_internal (const char * check_expr, const char * func, const char * file, unsigned int line, bool is_release_assert, std::string_view error = "");
+void assert_internal (char const * check_expr, char const * func, char const * file, unsigned int line, bool is_release_assert, std::string_view error = "");
 
 #define release_assert_1(check) check ? (void)0 : assert_internal (#check, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, true)
 #define release_assert_2(check, error_msg) check ? (void)0 : assert_internal (#check, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, true, error_msg)
@@ -76,8 +76,8 @@ public:
 	container_info_composite (std::string const & name);
 	bool is_composite () const override;
 	void add_component (std::unique_ptr<container_info_component> child);
-	const std::vector<std::unique_ptr<container_info_component>> & get_children () const;
-	const std::string & get_name () const;
+    std::vector<std::unique_ptr<container_info_component>> const & get_children () const;
+	std::string const & get_name () const;
 
 private:
 	std::string name;
@@ -89,7 +89,7 @@ class container_info_leaf : public container_info_component
 public:
 	container_info_leaf (container_info const & info);
 	bool is_composite () const override;
-	const container_info & get_info () const;
+	container_info const & get_info () const;
 
 private:
 	container_info info;

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -88,7 +88,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 			logger.always_log (initialization_text);
 
 			nano::set_file_descriptor_limit (OPEN_FILE_DESCRIPTORS_LIMIT);
-			const auto file_descriptor_limit = nano::get_file_descriptor_limit ();
+			auto const file_descriptor_limit = nano::get_file_descriptor_limit ();
 			if (file_descriptor_limit < OPEN_FILE_DESCRIPTORS_LIMIT)
 			{
 				logger.always_log (boost::format ("WARNING: open file descriptors limit is %1%, lower than the %2% recommended. Node was unable to change it.") % file_descriptor_limit % OPEN_FILE_DESCRIPTORS_LIMIT);
@@ -208,7 +208,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 				std::cerr << "Error initializing node\n";
 			}
 		}
-		catch (const std::runtime_error & e)
+		catch (std::runtime_error const & e)
 		{
 			std::cerr << "Error while running node (" << e.what () << ")\n";
 		}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -357,7 +357,7 @@ int main (int argc, char * const * argv)
 								  << "Account: " << rep.pub.to_account () << "\n";
 					}
 					nano::uint128_t balance (std::numeric_limits<nano::uint128_t>::max ());
-					nano::open_block genesis_block (reinterpret_cast<const nano::block_hash &> (genesis.pub), genesis.pub, genesis.pub, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, genesis.pub, network_params.work.epoch_1));
+					nano::open_block genesis_block (reinterpret_cast<nano::block_hash const &> (genesis.pub), genesis.pub, genesis.pub, genesis.prv, genesis.pub, *work.generate (nano::work_version::work_1, genesis.pub, network_params.work.epoch_1));
 					std::cout << genesis_block.to_json ();
 					std::cout.flush ();
 					nano::block_hash previous (genesis_block.hash ());
@@ -773,7 +773,7 @@ int main (int argc, char * const * argv)
 						}
 						else
 						{
-							for (const auto & text : results)
+							for (auto const & text : results)
 							{
 								uint64_from_hex address_hex;
 								if (boost::conversion::try_lexical_convert (text, address_hex))
@@ -1317,7 +1317,7 @@ int main (int argc, char * const * argv)
 			for (;;)
 			{
 				nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
-				std::cout.write (reinterpret_cast<const char *> (seed.bytes.data ()), seed.bytes.size ());
+				std::cout.write (reinterpret_cast<char const *> (seed.bytes.data ()), seed.bytes.size ());
 			}
 		}
 		else if (vm.count ("debug_rpc"))
@@ -1385,7 +1385,7 @@ int main (int argc, char * const * argv)
 				++errors;
 			};
 
-			auto start_threads = [node, &threads_count, &threads, &mutex, &condition, &finished] (const auto & function_a, auto & deque_a) {
+			auto start_threads = [node, &threads_count, &threads, &mutex, &condition, &finished] (auto const & function_a, auto & deque_a) {
 				for (auto i (0U); i < threads_count; ++i)
 				{
 					threads.emplace_back ([&function_a, node, &mutex, &condition, &finished, &deque_a] () {
@@ -1646,7 +1646,7 @@ int main (int argc, char * const * argv)
 					if (accounts.size () > accounts_deque_overflow)
 					{
 						auto wait_ms (250 * accounts.size () / accounts_deque_overflow);
-						const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
+						auto const wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
 						condition.wait_until (lock, wakeup);
 					}
 					accounts.emplace_back (i->first, i->second);
@@ -1757,7 +1757,7 @@ int main (int argc, char * const * argv)
 					if (pending.size () > pending_deque_overflow)
 					{
 						auto wait_ms (50 * pending.size () / pending_deque_overflow);
-						const auto wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
+						auto const wakeup (std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms));
 						condition.wait_until (lock, wakeup);
 					}
 					pending.emplace_back (i->first, i->second);

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -71,7 +71,7 @@ void run (boost::filesystem::path const & data_path, std::vector<std::string> co
 				rpc->stop ();
 			}
 		}
-		catch (const std::runtime_error & e)
+		catch (std::runtime_error const & e)
 		{
 			std::cerr << "Error while running rpc (" << e.what () << ")\n";
 		}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -14,7 +14,7 @@
 
 using namespace std::chrono;
 
-size_t constexpr nano::active_transactions::max_active_elections_frontier_insertion;
+std::size_t constexpr nano::active_transactions::max_active_elections_frontier_insertion;
 
 constexpr std::chrono::minutes nano::active_transactions::expired_optimistic_election_info_cutoff;
 
@@ -294,18 +294,18 @@ void nano::active_transactions::request_confirm (nano::unique_lock<nano::mutex> 
 {
 	debug_assert (lock_a.owns_lock ());
 
-	size_t const this_loop_target_l (roots.size ());
+	std::size_t const this_loop_target_l (roots.size ());
 	auto const elections_l{ list_active_impl (this_loop_target_l) };
 
 	lock_a.unlock ();
 
 	nano::confirmation_solicitor solicitor (node.network, node.config);
-	solicitor.prepare (node.rep_crawler.principal_representatives (std::numeric_limits<size_t>::max ()));
+	solicitor.prepare (node.rep_crawler.principal_representatives (std::numeric_limits<std::size_t>::max ()));
 	nano::vote_generator_session generator_session (generator);
 	nano::vote_generator_session final_generator_session (generator);
 
 	auto const election_ttl_cutoff_l (std::chrono::steady_clock::now () - election_time_to_live);
-	size_t unconfirmed_count_l (0);
+	std::size_t unconfirmed_count_l (0);
 	nano::timer<std::chrono::milliseconds> elapsed (nano::timer_state::started);
 
 	/*
@@ -388,19 +388,19 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 	node.logger.try_log (boost::str (boost::format ("Election erased for root %1%") % election.qualified_root.to_string ()));
 }
 
-std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active (size_t max_a)
+std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active (std::size_t max_a)
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return list_active_impl (max_a);
 }
 
-std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active_impl (size_t max_a) const
+std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active_impl (std::size_t max_a) const
 {
 	std::vector<std::shared_ptr<nano::election>> result_l;
 	result_l.reserve (std::min (max_a, roots.size ()));
 	{
 		auto & sorted_roots_l (roots.get<tag_random_access> ());
-		size_t count_l{ 0 };
+		std::size_t count_l{ 0 };
 		for (auto i = sorted_roots_l.begin (), n = sorted_roots_l.end (); i != n && count_l < max_a; ++i, ++count_l)
 		{
 			result_l.push_back (i->election);
@@ -582,20 +582,20 @@ void nano::active_transactions::request_loop ()
 		}
 		lock.lock ();
 
-		const auto stamp_l = std::chrono::steady_clock::now ();
+		auto const stamp_l = std::chrono::steady_clock::now ();
 
 		request_confirm (lock);
 
 		if (!stopped)
 		{
-			const auto min_sleep_l = std::chrono::milliseconds (node.network_params.network.request_interval_ms / 2);
-			const auto wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
+			auto const min_sleep_l = std::chrono::milliseconds (node.network_params.network.request_interval_ms / 2);
+			auto const wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
 			condition.wait_until (lock, wakeup_l, [&wakeup_l, &stopped = stopped] { return stopped || std::chrono::steady_clock::now () >= wakeup_l; });
 		}
 	}
 }
 
-bool nano::active_transactions::prioritize_account_for_confirmation (nano::active_transactions::prioritize_num_uncemented & cementable_frontiers_a, size_t & cementable_frontiers_size_a, nano::account const & account_a, nano::account_info const & info_a, uint64_t confirmation_height_a)
+bool nano::active_transactions::prioritize_account_for_confirmation (nano::active_transactions::prioritize_num_uncemented & cementable_frontiers_a, std::size_t & cementable_frontiers_size_a, nano::account const & account_a, nano::account_info const & info_a, uint64_t confirmation_height_a)
 {
 	auto inserted_new{ false };
 	if (info_a.block_count > confirmation_height_a && !confirmation_height_processor.is_processing_block (info_a.head))
@@ -644,8 +644,8 @@ void nano::active_transactions::prioritize_frontiers_for_confirmation (nano::tra
 	// Don't try to prioritize when there are a large number of pending confirmation heights as blocks can be cemented in the meantime, making the prioritization less reliable
 	if (confirmation_height_processor.awaiting_processing_size () < confirmed_frontiers_max_pending_size)
 	{
-		size_t priority_cementable_frontiers_size;
-		size_t priority_wallet_cementable_frontiers_size;
+		std::size_t priority_cementable_frontiers_size;
+		std::size_t priority_wallet_cementable_frontiers_size;
 		{
 			nano::lock_guard<nano::mutex> guard (mutex);
 			priority_cementable_frontiers_size = priority_cementable_frontiers.size ();
@@ -1040,7 +1040,7 @@ bool nano::active_transactions::empty ()
 	return roots.empty ();
 }
 
-size_t nano::active_transactions::size ()
+std::size_t nano::active_transactions::size ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
 	return roots.size ();
@@ -1109,19 +1109,19 @@ boost::optional<nano::election_status_type> nano::active_transactions::confirm_b
 	return status_type;
 }
 
-size_t nano::active_transactions::priority_cementable_frontiers_size ()
+std::size_t nano::active_transactions::priority_cementable_frontiers_size ()
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return priority_cementable_frontiers.size ();
 }
 
-size_t nano::active_transactions::priority_wallet_cementable_frontiers_size ()
+std::size_t nano::active_transactions::priority_wallet_cementable_frontiers_size ()
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return priority_wallet_cementable_frontiers.size ();
 }
 
-size_t nano::active_transactions::inactive_votes_cache_size ()
+std::size_t nano::active_transactions::inactive_votes_cache_size ()
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return inactive_votes_cache.size ();
@@ -1255,7 +1255,7 @@ nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_
 	return inactive_votes_bootstrap_check_impl (lock_a, tally, voters_a.size (), hash_a, previously_a);
 }
 
-nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_check_impl (nano::unique_lock<nano::mutex> & lock_a, nano::uint128_t const & tally_a, size_t voters_size_a, nano::block_hash const & hash_a, nano::inactive_cache_status const & previously_a)
+nano::inactive_cache_status nano::active_transactions::inactive_votes_bootstrap_check_impl (nano::unique_lock<nano::mutex> & lock_a, nano::uint128_t const & tally_a, std::size_t voters_size_a, nano::block_hash const & hash_a, nano::inactive_cache_status const & previously_a)
 {
 	debug_assert (!lock_a.owns_lock ());
 	nano::inactive_cache_status status (previously_a);
@@ -1304,13 +1304,13 @@ bool nano::purge_singleton_inactive_votes_cache_pool_memory ()
 	return boost::singleton_pool<boost::fast_pool_allocator_tag, sizeof (nano::active_transactions::ordered_cache::node_type)>::purge_memory ();
 }
 
-size_t nano::active_transactions::election_winner_details_size ()
+std::size_t nano::active_transactions::election_winner_details_size ()
 {
 	nano::lock_guard<nano::mutex> guard (election_winner_details_mutex);
 	return election_winner_details.size ();
 }
 
-nano::cementable_account::cementable_account (nano::account const & account_a, size_t blocks_uncemented_a) :
+nano::cementable_account::cementable_account (nano::account const & account_a, std::size_t blocks_uncemented_a) :
 	account (account_a), blocks_uncemented (blocks_uncemented_a)
 {
 }
@@ -1328,10 +1328,10 @@ bool nano::frontiers_confirmation_info::can_start_elections () const
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (active_transactions & active_transactions, std::string const & name)
 {
-	size_t roots_count;
-	size_t blocks_count;
-	size_t recently_confirmed_count;
-	size_t recently_cemented_count;
+	std::size_t roots_count;
+	std::size_t blocks_count;
+	std::size_t recently_confirmed_count;
+	std::size_t recently_cemented_count;
 
 	{
 		nano::lock_guard<nano::mutex> guard (active_transactions.mutex);

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -39,7 +39,7 @@ class stat;
 class cementable_account final
 {
 public:
-	cementable_account (nano::account const & account_a, size_t blocks_uncemented_a);
+	cementable_account (nano::account const & account_a, std::size_t blocks_uncemented_a);
 	nano::account account;
 	uint64_t blocks_uncemented{ 0 };
 };
@@ -103,7 +103,7 @@ class frontiers_confirmation_info
 public:
 	bool can_start_elections () const;
 
-	size_t max_elections{ 0 };
+	std::size_t max_elections{ 0 };
 	bool aggressive_mode{ false };
 };
 
@@ -162,12 +162,12 @@ public:
 	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
 	std::shared_ptr<nano::block> winner (nano::block_hash const &) const;
 	// Returns a list of elections sorted by difficulty
-	std::vector<std::shared_ptr<nano::election>> list_active (size_t = std::numeric_limits<size_t>::max ());
+	std::vector<std::shared_ptr<nano::election>> list_active (std::size_t = std::numeric_limits<std::size_t>::max ());
 	void erase (nano::block const &);
 	void erase_hash (nano::block_hash const &);
 	void erase_oldest ();
 	bool empty ();
-	size_t size ();
+	std::size_t size ();
 	void stop ();
 	bool publish (std::shared_ptr<nano::block> const &);
 	boost::optional<nano::election_status_type> confirm_block (nano::transaction const &, std::shared_ptr<nano::block> const &);
@@ -193,10 +193,10 @@ public:
 	nano::confirmation_height_processor & confirmation_height_processor;
 	nano::node & node;
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::active) };
-	size_t priority_cementable_frontiers_size ();
-	size_t priority_wallet_cementable_frontiers_size ();
-	size_t inactive_votes_cache_size ();
-	size_t election_winner_details_size ();
+	std::size_t priority_cementable_frontiers_size ();
+	std::size_t priority_wallet_cementable_frontiers_size ();
+	std::size_t inactive_votes_cache_size ();
+	std::size_t election_winner_details_size ();
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
 	void remove_election_winner_details (nano::block_hash const &);
 
@@ -233,7 +233,7 @@ private:
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void cleanup_election (nano::unique_lock<nano::mutex> & lock_a, nano::election const &);
 	// Returns a list of elections sorted by difficulty, mutex must be locked
-	std::vector<std::shared_ptr<nano::election>> list_active_impl (size_t) const;
+	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
 
 	nano::condition_variable condition;
 	bool started{ false };
@@ -242,7 +242,7 @@ private:
 	// Maximum time an election can be kept active if it is extending the container
 	std::chrono::seconds const election_time_to_live;
 
-	static size_t constexpr recently_confirmed_size{ 65536 };
+	static std::size_t constexpr recently_confirmed_size{ 65536 };
 	using recent_confirmation = std::pair<nano::qualified_root, nano::block_hash>;
 	// clang-format off
 	boost::multi_index_container<recent_confirmation,
@@ -281,7 +281,7 @@ private:
 	bool insert_election_from_frontiers_confirmation (std::shared_ptr<nano::block> const &, nano::account const &, nano::uint128_t, nano::election_behavior);
 	nano::account next_frontier_account{};
 	std::chrono::steady_clock::time_point next_frontier_check{ std::chrono::steady_clock::now () };
-	constexpr static size_t max_active_elections_frontier_insertion{ 1000 };
+	constexpr static std::size_t max_active_elections_frontier_insertion{ 1000 };
 	prioritize_num_uncemented priority_wallet_cementable_frontiers;
 	prioritize_num_uncemented priority_cementable_frontiers;
 	std::unordered_set<nano::wallet_id> wallet_ids_already_iterated;
@@ -289,24 +289,24 @@ private:
 	bool skip_wallets{ false };
 	std::atomic<unsigned> optimistic_elections_count{ 0 };
 	void prioritize_frontiers_for_confirmation (nano::transaction const &, std::chrono::milliseconds, std::chrono::milliseconds);
-	bool prioritize_account_for_confirmation (prioritize_num_uncemented &, size_t &, nano::account const &, nano::account_info const &, uint64_t);
+	bool prioritize_account_for_confirmation (prioritize_num_uncemented &, std::size_t &, nano::account const &, nano::account_info const &, uint64_t);
 	unsigned max_optimistic ();
 	void set_next_frontier_check (bool);
 	void add_expired_optimistic_election (nano::election const &);
 	bool should_do_frontiers_confirmation () const;
-	static size_t constexpr max_priority_cementable_frontiers{ 100000 };
-	static size_t constexpr confirmed_frontiers_max_pending_size{ 10000 };
+	static std::size_t constexpr max_priority_cementable_frontiers{ 100000 };
+	static std::size_t constexpr confirmed_frontiers_max_pending_size{ 10000 };
 	static std::chrono::minutes constexpr expired_optimistic_election_info_cutoff{ 30 };
 	ordered_cache inactive_votes_cache;
 	nano::inactive_cache_status inactive_votes_bootstrap_check (nano::unique_lock<nano::mutex> &, std::vector<std::pair<nano::account, uint64_t>> const &, nano::block_hash const &, nano::inactive_cache_status const &);
 	nano::inactive_cache_status inactive_votes_bootstrap_check (nano::unique_lock<nano::mutex> &, nano::account const &, nano::block_hash const &, nano::inactive_cache_status const &);
-	nano::inactive_cache_status inactive_votes_bootstrap_check_impl (nano::unique_lock<nano::mutex> &, nano::uint128_t const &, size_t, nano::block_hash const &, nano::inactive_cache_status const &);
+	nano::inactive_cache_status inactive_votes_bootstrap_check_impl (nano::unique_lock<nano::mutex> &, nano::uint128_t const &, std::size_t, nano::block_hash const &, nano::inactive_cache_status const &);
 	nano::inactive_cache_information find_inactive_votes_cache_impl (nano::block_hash const &);
 	boost::thread thread;
 
 	friend class election;
 	friend class election_scheduler;
-	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, std::string const &);
 
 	friend class active_transactions_vote_replays_Test;
 	friend class frontiers_confirmation_prioritize_frontiers_Test;

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -81,7 +81,7 @@ void nano::block_processor::flush ()
 	flushing = false;
 }
 
-size_t nano::block_processor::size ()
+std::size_t nano::block_processor::size ()
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	return (blocks.size () + state_block_signature_verification.size () + forced.size ());
@@ -337,7 +337,7 @@ void nano::block_processor::process_live (nano::transaction const & transaction_
 	}
 }
 
-nano::process_return nano::block_processor::process_one (nano::write_transaction const & transaction_a, block_post_events & events_a, nano::unchecked_info info_a, const bool forced_a, nano::block_origin const origin_a)
+nano::process_return nano::block_processor::process_one (nano::write_transaction const & transaction_a, block_post_events & events_a, nano::unchecked_info info_a, bool const forced_a, nano::block_origin const origin_a)
 {
 	nano::process_return result;
 	auto block (info_a.block);
@@ -542,8 +542,8 @@ void nano::block_processor::requeue_invalid (nano::block_hash const & hash_a, na
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_processor & block_processor, std::string const & name)
 {
-	size_t blocks_count;
-	size_t forced_count;
+	std::size_t blocks_count;
+	std::size_t forced_count;
 
 	{
 		nano::lock_guard<nano::mutex> guard (block_processor.mutex);

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -51,7 +51,7 @@ public:
 	~block_processor ();
 	void stop ();
 	void flush ();
-	size_t size ();
+	std::size_t size ();
 	bool full ();
 	bool half_full ();
 	void add_local (nano::unchecked_info const & info_a);
@@ -63,7 +63,7 @@ public:
 	bool have_blocks_ready ();
 	bool have_blocks ();
 	void process_blocks ();
-	nano::process_return process_one (nano::write_transaction const &, block_post_events &, nano::unchecked_info, const bool = false, nano::block_origin const = nano::block_origin::remote);
+	nano::process_return process_one (nano::write_transaction const &, block_post_events &, nano::unchecked_info, bool const = false, nano::block_origin const = nano::block_origin::remote);
 	nano::process_return process_one (nano::write_transaction const &, block_post_events &, std::shared_ptr<nano::block> const &);
 	std::atomic<bool> flushing{ false };
 	// Delay required for average network propagartion before requesting confirmation

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -17,7 +17,7 @@ nano::bootstrap_initiator::bootstrap_initiator (nano::node & node_a) :
 		nano::thread_role::set (nano::thread_role::name::bootstrap_connections);
 		connections->run ();
 	}));
-	for (size_t i = 0; i < node.config.bootstrap_initiator_threads; ++i)
+	for (std::size_t i = 0; i < node.config.bootstrap_initiator_threads; ++i)
 	{
 		bootstrap_initiator_threads.push_back (boost::thread ([this] () {
 			nano::thread_role::set (nano::thread_role::name::bootstrap_initiator);
@@ -287,8 +287,8 @@ void nano::bootstrap_initiator::notify_listeners (bool in_progress_a)
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (bootstrap_initiator & bootstrap_initiator, std::string const & name)
 {
-	size_t count;
-	size_t cache_count;
+	std::size_t count;
+	std::size_t cache_count;
 	{
 		nano::lock_guard<nano::mutex> guard (bootstrap_initiator.observers_mutex);
 		count = bootstrap_initiator.observers.size ();
@@ -387,7 +387,7 @@ std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_attempts::find (uint64_
 	}
 }
 
-size_t nano::bootstrap_attempts::size ()
+std::size_t nano::bootstrap_attempts::size ()
 {
 	nano::lock_guard<nano::mutex> lock (bootstrap_attempts_mutex);
 	return attempts.size ();

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -61,7 +61,7 @@ public:
 			mi::member<nano::cached_pulls, nano::uint512_union, &nano::cached_pulls::account_head>>>>
 	cache;
 	// clang-format on
-	constexpr static size_t cache_size_max = 10000;
+	constexpr static std::size_t cache_size_max = 10000;
 };
 class bootstrap_attempts final
 {
@@ -70,7 +70,7 @@ public:
 	void remove (uint64_t);
 	void clear ();
 	std::shared_ptr<nano::bootstrap_attempt> find (uint64_t);
-	size_t size ();
+	std::size_t size ();
 	std::atomic<uint64_t> incremental{ 0 };
 	nano::mutex bootstrap_attempts_mutex;
 	std::map<uint64_t, std::shared_ptr<nano::bootstrap_attempt>> attempts;
@@ -135,6 +135,6 @@ public:
 	static constexpr std::chrono::seconds lazy_flush_delay_sec = std::chrono::seconds (5);
 	static constexpr uint64_t lazy_batch_pull_count_resize_blocks_limit = 4 * 1024 * 1024;
 	static constexpr double lazy_batch_pull_count_resize_ratio = 2.0;
-	static constexpr size_t lazy_blocks_restart_limit = 1024 * 1024;
+	static constexpr std::size_t lazy_blocks_restart_limit = 1024 * 1024;
 };
 }

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -194,7 +194,7 @@ void nano::bootstrap_attempt::wallet_start (std::deque<nano::account> &)
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
 }
 
-size_t nano::bootstrap_attempt::wallet_size ()
+std::size_t nano::bootstrap_attempt::wallet_size ()
 {
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
 	return 0;

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -36,7 +36,7 @@ public:
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void requeue_pending (nano::account const &);
 	virtual void wallet_start (std::deque<nano::account> &);
-	virtual size_t wallet_size ();
+	virtual std::size_t wallet_size ();
 	virtual void get_information (boost::property_tree::ptree &) = 0;
 	nano::mutex next_log_mutex;
 	std::chrono::steady_clock::time_point next_log{ std::chrono::steady_clock::now () };

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -83,7 +83,7 @@ void nano::bulk_pull_client::request ()
 	}
 	auto this_l (shared_from_this ());
 	connection->channel->send (
-	req, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	req, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (!ec)
 		{
 			this_l->throttled_receive_block ();
@@ -122,7 +122,7 @@ void nano::bulk_pull_client::throttled_receive_block ()
 void nano::bulk_pull_client::receive_block ()
 {
 	auto this_l (shared_from_this ());
-	connection->socket->async_read (connection->receive_buffer, 1, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->socket->async_read (connection->receive_buffer, 1, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (!ec)
 		{
 			this_l->received_type ();
@@ -149,35 +149,35 @@ void nano::bulk_pull_client::received_type ()
 	{
 		case nano::block_type::send:
 		{
-			socket_l->async_read (connection->receive_buffer, nano::send_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			socket_l->async_read (connection->receive_buffer, nano::send_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
 		}
 		case nano::block_type::receive:
 		{
-			socket_l->async_read (connection->receive_buffer, nano::receive_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			socket_l->async_read (connection->receive_buffer, nano::receive_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
 		}
 		case nano::block_type::open:
 		{
-			socket_l->async_read (connection->receive_buffer, nano::open_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			socket_l->async_read (connection->receive_buffer, nano::open_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
 		}
 		case nano::block_type::change:
 		{
-			socket_l->async_read (connection->receive_buffer, nano::change_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			socket_l->async_read (connection->receive_buffer, nano::change_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
 		}
 		case nano::block_type::state:
 		{
-			socket_l->async_read (connection->receive_buffer, nano::state_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			socket_l->async_read (connection->receive_buffer, nano::state_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
@@ -202,7 +202,7 @@ void nano::bulk_pull_client::received_type ()
 	}
 }
 
-void nano::bulk_pull_client::received_block (boost::system::error_code const & ec, size_t size_a, nano::block_type type_a)
+void nano::bulk_pull_client::received_block (boost::system::error_code const & ec, std::size_t size_a, nano::block_type type_a)
 {
 	if (!ec)
 	{
@@ -314,7 +314,7 @@ void nano::bulk_pull_account_client::request ()
 	}
 	auto this_l (shared_from_this ());
 	connection->channel->send (
-	req, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	req, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (!ec)
 		{
 			this_l->receive_pending ();
@@ -335,8 +335,8 @@ void nano::bulk_pull_account_client::request ()
 void nano::bulk_pull_account_client::receive_pending ()
 {
 	auto this_l (shared_from_this ());
-	size_t size_l (sizeof (nano::uint256_union) + sizeof (nano::uint128_union));
-	connection->socket->async_read (connection->receive_buffer, size_l, [this_l, size_l] (boost::system::error_code const & ec, size_t size_a) {
+	std::size_t size_l (sizeof (nano::uint256_union) + sizeof (nano::uint128_union));
+	connection->socket->async_read (connection->receive_buffer, size_l, [this_l, size_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		// An issue with asio is that sometimes, instead of reporting a bad file descriptor during disconnect,
 		// we simply get a size of 0.
 		if (size_a == size_l)
@@ -494,7 +494,7 @@ void nano::bulk_pull_server::send_next ()
 		{
 			connection->node->logger.try_log (boost::str (boost::format ("Sending block: %1%") % block->hash ().to_string ()));
 		}
-		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 			this_l->sent_action (ec, size_a);
 		});
 	}
@@ -575,7 +575,7 @@ std::shared_ptr<nano::block> nano::bulk_pull_server::get_next ()
 	return result;
 }
 
-void nano::bulk_pull_server::sent_action (boost::system::error_code const & ec, size_t size_a)
+void nano::bulk_pull_server::sent_action (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -598,12 +598,12 @@ void nano::bulk_pull_server::send_finished ()
 	{
 		connection->node->logger.try_log ("Bulk sending finished");
 	}
-	connection->socket->async_write (send_buffer, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->socket->async_write (send_buffer, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		this_l->no_block_sent (ec, size_a);
 	});
 }
 
-void nano::bulk_pull_server::no_block_sent (boost::system::error_code const & ec, size_t size_a)
+void nano::bulk_pull_server::no_block_sent (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -700,7 +700,7 @@ void nano::bulk_pull_account_server::send_frontier ()
 
 		// Send the buffer to the requestor
 		auto this_l (shared_from_this ());
-		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 			this_l->sent_action (ec, size_a);
 		});
 	}
@@ -756,7 +756,7 @@ void nano::bulk_pull_account_server::send_next_block ()
 		}
 
 		auto this_l (shared_from_this ());
-		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 			this_l->sent_action (ec, size_a);
 		});
 	}
@@ -853,7 +853,7 @@ std::pair<std::unique_ptr<nano::pending_key>, std::unique_ptr<nano::pending_info
 	return result;
 }
 
-void nano::bulk_pull_account_server::sent_action (boost::system::error_code const & ec, size_t size_a)
+void nano::bulk_pull_account_server::sent_action (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -903,12 +903,12 @@ void nano::bulk_pull_account_server::send_finished ()
 		connection->node->logger.try_log ("Bulk sending for an account finished");
 	}
 
-	connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		this_l->complete (ec, size_a);
 	});
 }
 
-void nano::bulk_pull_account_server::complete (boost::system::error_code const & ec, size_t size_a)
+void nano::bulk_pull_account_server::complete (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{

--- a/nano/node/bootstrap/bootstrap_bulk_pull.hpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.hpp
@@ -34,7 +34,7 @@ public:
 	void receive_block ();
 	void throttled_receive_block ();
 	void received_type ();
-	void received_block (boost::system::error_code const &, size_t, nano::block_type);
+	void received_block (boost::system::error_code const &, std::size_t, nano::block_type);
 	nano::block_hash first ();
 	std::shared_ptr<nano::bootstrap_client> connection;
 	std::shared_ptr<nano::bootstrap_attempt> attempt;
@@ -66,9 +66,9 @@ public:
 	void set_current_end ();
 	std::shared_ptr<nano::block> get_next ();
 	void send_next ();
-	void sent_action (boost::system::error_code const &, size_t);
+	void sent_action (boost::system::error_code const &, std::size_t);
 	void send_finished ();
-	void no_block_sent (boost::system::error_code const &, size_t);
+	void no_block_sent (boost::system::error_code const &, std::size_t);
 	std::shared_ptr<nano::bootstrap_server> connection;
 	std::unique_ptr<nano::bulk_pull> request;
 	nano::block_hash current;
@@ -85,9 +85,9 @@ public:
 	std::pair<std::unique_ptr<nano::pending_key>, std::unique_ptr<nano::pending_info>> get_next ();
 	void send_frontier ();
 	void send_next_block ();
-	void sent_action (boost::system::error_code const &, size_t);
+	void sent_action (boost::system::error_code const &, std::size_t);
 	void send_finished ();
-	void complete (boost::system::error_code const &, size_t);
+	void complete (boost::system::error_code const &, std::size_t);
 	std::shared_ptr<nano::bootstrap_server> connection;
 	std::unique_ptr<nano::bulk_pull_account> request;
 	std::unordered_set<nano::uint256_union> deduplication;

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -20,7 +20,7 @@ void nano::bulk_push_client::start ()
 	nano::bulk_push message{ connection->node->network_params.network };
 	auto this_l (shared_from_this ());
 	connection->channel->send (
-	message, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	message, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (!ec)
 		{
 			this_l->push ();
@@ -77,7 +77,7 @@ void nano::bulk_push_client::send_finished ()
 {
 	nano::shared_const_buffer buffer (static_cast<uint8_t> (nano::block_type::not_a_block));
 	auto this_l (shared_from_this ());
-	connection->channel->send_buffer (buffer, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->channel->send_buffer (buffer, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		try
 		{
 			this_l->promise.set_value (false);
@@ -96,7 +96,7 @@ void nano::bulk_push_client::push_block (nano::block const & block_a)
 		nano::serialize_block (stream, block_a);
 	}
 	auto this_l (shared_from_this ());
-	connection->channel->send_buffer (nano::shared_const_buffer (std::move (buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->channel->send_buffer (nano::shared_const_buffer (std::move (buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (!ec)
 		{
 			this_l->push ();
@@ -148,7 +148,7 @@ void nano::bulk_push_server::receive ()
 	else
 	{
 		auto this_l (shared_from_this ());
-		connection->socket->async_read (receive_buffer, 1, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+		connection->socket->async_read (receive_buffer, 1, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 			if (!ec)
 			{
 				this_l->received_type ();
@@ -173,7 +173,7 @@ void nano::bulk_push_server::received_type ()
 		case nano::block_type::send:
 		{
 			connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::send, nano::stat::dir::in);
-			connection->socket->async_read (receive_buffer, nano::send_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_read (receive_buffer, nano::send_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
@@ -181,7 +181,7 @@ void nano::bulk_push_server::received_type ()
 		case nano::block_type::receive:
 		{
 			connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::receive, nano::stat::dir::in);
-			connection->socket->async_read (receive_buffer, nano::receive_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_read (receive_buffer, nano::receive_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
@@ -189,7 +189,7 @@ void nano::bulk_push_server::received_type ()
 		case nano::block_type::open:
 		{
 			connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::open, nano::stat::dir::in);
-			connection->socket->async_read (receive_buffer, nano::open_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_read (receive_buffer, nano::open_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
@@ -197,7 +197,7 @@ void nano::bulk_push_server::received_type ()
 		case nano::block_type::change:
 		{
 			connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::change, nano::stat::dir::in);
-			connection->socket->async_read (receive_buffer, nano::change_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_read (receive_buffer, nano::change_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
@@ -205,7 +205,7 @@ void nano::bulk_push_server::received_type ()
 		case nano::block_type::state:
 		{
 			connection->node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::state_block, nano::stat::dir::in);
-			connection->socket->async_read (receive_buffer, nano::state_block::size, [this_l, type] (boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_read (receive_buffer, nano::state_block::size, [this_l, type] (boost::system::error_code const & ec, std::size_t size_a) {
 				this_l->received_block (ec, size_a, type);
 			});
 			break;
@@ -226,7 +226,7 @@ void nano::bulk_push_server::received_type ()
 	}
 }
 
-void nano::bulk_push_server::received_block (boost::system::error_code const & ec, size_t size_a, nano::block_type type_a)
+void nano::bulk_push_server::received_block (boost::system::error_code const & ec, std::size_t size_a, nano::block_type type_a)
 {
 	if (!ec)
 	{

--- a/nano/node/bootstrap/bootstrap_bulk_push.hpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.hpp
@@ -30,7 +30,7 @@ public:
 	void throttled_receive ();
 	void receive ();
 	void received_type ();
-	void received_block (boost::system::error_code const &, size_t, nano::block_type);
+	void received_block (boost::system::error_code const &, std::size_t, nano::block_type);
 	std::shared_ptr<std::vector<uint8_t>> receive_buffer;
 	std::shared_ptr<nano::bootstrap_server> connection;
 };

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -179,7 +179,7 @@ void nano::bootstrap_connections::connect_client (nano::tcp_endpoint const & end
 	});
 }
 
-unsigned nano::bootstrap_connections::target_connections (size_t pulls_remaining, size_t attempts_count)
+unsigned nano::bootstrap_connections::target_connections (std::size_t pulls_remaining, std::size_t attempts_count)
 {
 	auto const attempts_factor = nano::narrow_cast<unsigned> (node.config.bootstrap_connections * attempts_count);
 	if (attempts_factor >= node.config.bootstrap_connections_max)
@@ -195,7 +195,7 @@ unsigned nano::bootstrap_connections::target_connections (size_t pulls_remaining
 
 struct block_rate_cmp
 {
-	bool operator() (const std::shared_ptr<nano::bootstrap_client> & lhs, const std::shared_ptr<nano::bootstrap_client> & rhs) const
+	bool operator() (std::shared_ptr<nano::bootstrap_client> const & lhs, std::shared_ptr<nano::bootstrap_client> const & rhs) const
 	{
 		return lhs->block_rate > rhs->block_rate;
 	}
@@ -204,8 +204,8 @@ struct block_rate_cmp
 void nano::bootstrap_connections::populate_connections (bool repeat)
 {
 	double rate_sum = 0.0;
-	size_t num_pulls = 0;
-	size_t attempts_count = node.bootstrap_initiator.attempts.size ();
+	std::size_t num_pulls = 0;
+	std::size_t attempts_count = node.bootstrap_initiator.attempts.size ();
 	std::priority_queue<std::shared_ptr<nano::bootstrap_client>, std::vector<std::shared_ptr<nano::bootstrap_client>>, block_rate_cmp> sorted_connections;
 	std::unordered_set<nano::tcp_endpoint> endpoints;
 	{

--- a/nano/node/bootstrap/bootstrap_connections.hpp
+++ b/nano/node/bootstrap/bootstrap_connections.hpp
@@ -53,7 +53,7 @@ public:
 	void add_connection (nano::endpoint const & endpoint_a);
 	std::shared_ptr<nano::bootstrap_client> find_connection (nano::tcp_endpoint const & endpoint_a);
 	void connect_client (nano::tcp_endpoint const & endpoint_a, bool push_front = false);
-	unsigned target_connections (size_t pulls_remaining, size_t attempts_count);
+	unsigned target_connections (std::size_t pulls_remaining, std::size_t attempts_count);
 	void populate_connections (bool repeat = true);
 	void start_populate_connections ();
 	void add_pull (nano::pull_info const & pull_a);

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -10,7 +10,7 @@ constexpr double nano::bootstrap_limits::bootstrap_minimum_elapsed_seconds_block
 constexpr double nano::bootstrap_limits::bootstrap_minimum_frontier_blocks_per_sec;
 constexpr unsigned nano::bootstrap_limits::bulk_push_cost_limit;
 
-constexpr size_t nano::frontier_req_client::size_frontier;
+constexpr std::size_t nano::frontier_req_client::size_frontier;
 
 void nano::frontier_req_client::run (nano::account const & start_account_a, uint32_t const frontiers_age_a, uint32_t const count_a)
 {
@@ -24,7 +24,7 @@ void nano::frontier_req_client::run (nano::account const & start_account_a, uint
 	next (); // Load accounts from disk
 	auto this_l (shared_from_this ());
 	connection->channel->send (
-	request, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	request, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (!ec)
 		{
 			this_l->receive_frontier ();
@@ -51,7 +51,7 @@ nano::frontier_req_client::frontier_req_client (std::shared_ptr<nano::bootstrap_
 void nano::frontier_req_client::receive_frontier ()
 {
 	auto this_l (shared_from_this ());
-	connection->socket->async_read (connection->receive_buffer, nano::frontier_req_client::size_frontier, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->socket->async_read (connection->receive_buffer, nano::frontier_req_client::size_frontier, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		// An issue with asio is that sometimes, instead of reporting a bad file descriptor during disconnect,
 		// we simply get a size of 0.
 		if (size_a == nano::frontier_req_client::size_frontier)
@@ -89,7 +89,7 @@ void nano::frontier_req_client::unsynced (nano::block_hash const & head, nano::b
 	}
 }
 
-void nano::frontier_req_client::received_frontier (boost::system::error_code const & ec, size_t size_a)
+void nano::frontier_req_client::received_frontier (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -216,7 +216,7 @@ void nano::frontier_req_client::next ()
 	// Filling accounts deque to prevent often read transactions
 	if (accounts.empty ())
 	{
-		size_t max_size (128);
+		std::size_t max_size (128);
 		auto transaction (connection->node->store.tx_begin_read ());
 		for (auto i (connection->node->store.account.begin (transaction, current.number () + 1)), n (connection->node->store.account.end ()); i != n && accounts.size () != max_size; ++i)
 		{
@@ -266,7 +266,7 @@ void nano::frontier_req_server::send_next ()
 			connection->node->logger.try_log (boost::str (boost::format ("Sending frontier for %1% %2%") % current.to_account () % frontier.to_string ()));
 		}
 		next ();
-		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+		connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 			this_l->sent_action (ec, size_a);
 		});
 	}
@@ -290,12 +290,12 @@ void nano::frontier_req_server::send_finished ()
 	{
 		connection->node->logger.try_log ("Frontier sending finished");
 	}
-	connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	connection->socket->async_write (nano::shared_const_buffer (std::move (send_buffer)), [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		this_l->no_block_sent (ec, size_a);
 	});
 }
 
-void nano::frontier_req_server::no_block_sent (boost::system::error_code const & ec, size_t size_a)
+void nano::frontier_req_server::no_block_sent (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -310,7 +310,7 @@ void nano::frontier_req_server::no_block_sent (boost::system::error_code const &
 	}
 }
 
-void nano::frontier_req_server::sent_action (boost::system::error_code const & ec, size_t size_a)
+void nano::frontier_req_server::sent_action (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -333,7 +333,7 @@ void nano::frontier_req_server::next ()
 	{
 		auto now (nano::seconds_since_epoch ());
 		bool disable_age_filter (request->age == std::numeric_limits<decltype (request->age)>::max ());
-		size_t max_size (128);
+		std::size_t max_size (128);
 		auto transaction (connection->node->store.tx_begin_read ());
 		if (!send_confirmed ())
 		{

--- a/nano/node/bootstrap/bootstrap_frontier.hpp
+++ b/nano/node/bootstrap/bootstrap_frontier.hpp
@@ -15,7 +15,7 @@ public:
 	explicit frontier_req_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt> const &);
 	void run (nano::account const & start_account_a, uint32_t const frontiers_age_a, uint32_t const count_a);
 	void receive_frontier ();
-	void received_frontier (boost::system::error_code const &, size_t);
+	void received_frontier (boost::system::error_code const &, std::size_t);
 	bool bulk_push_available ();
 	void unsynced (nano::block_hash const &, nano::block_hash const &);
 	void next ();
@@ -32,7 +32,7 @@ public:
 	std::deque<std::pair<nano::account, nano::block_hash>> accounts;
 	uint32_t frontiers_age{ std::numeric_limits<uint32_t>::max () };
 	uint32_t count_limit{ std::numeric_limits<uint32_t>::max () };
-	static size_t constexpr size_frontier = sizeof (nano::account) + sizeof (nano::block_hash);
+	static std::size_t constexpr size_frontier = sizeof (nano::account) + sizeof (nano::block_hash);
 };
 class bootstrap_server;
 class frontier_req;
@@ -41,16 +41,16 @@ class frontier_req_server final : public std::enable_shared_from_this<nano::fron
 public:
 	frontier_req_server (std::shared_ptr<nano::bootstrap_server> const &, std::unique_ptr<nano::frontier_req>);
 	void send_next ();
-	void sent_action (boost::system::error_code const &, size_t);
+	void sent_action (boost::system::error_code const &, std::size_t);
 	void send_finished ();
-	void no_block_sent (boost::system::error_code const &, size_t);
+	void no_block_sent (boost::system::error_code const &, std::size_t);
 	void next ();
 	bool send_confirmed ();
 	std::shared_ptr<nano::bootstrap_server> connection;
 	nano::account current;
 	nano::block_hash frontier;
 	std::unique_ptr<nano::frontier_req> request;
-	size_t count;
+	std::size_t count;
 	std::deque<std::pair<nano::account, nano::block_hash>> accounts;
 };
 }

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -11,7 +11,7 @@
 constexpr std::chrono::seconds nano::bootstrap_limits::lazy_flush_delay_sec;
 constexpr uint64_t nano::bootstrap_limits::lazy_batch_pull_count_resize_blocks_limit;
 constexpr double nano::bootstrap_limits::lazy_batch_pull_count_resize_ratio;
-constexpr size_t nano::bootstrap_limits::lazy_blocks_restart_limit;
+constexpr std::size_t nano::bootstrap_limits::lazy_blocks_restart_limit;
 
 nano::bootstrap_attempt_lazy::bootstrap_attempt_lazy (std::shared_ptr<nano::node> const & node_a, uint64_t incremental_id_a, std::string const & id_a) :
 	nano::bootstrap_attempt (node_a, nano::bootstrap_mode::lazy, incremental_id_a, id_a)
@@ -30,7 +30,7 @@ bool nano::bootstrap_attempt_lazy::lazy_start (nano::hash_or_account const & has
 	nano::unique_lock<nano::mutex> lock (mutex);
 	bool inserted (false);
 	// Add start blocks, limit 1024 (4k with disabled legacy bootstrap)
-	size_t max_keys (node->flags.disable_legacy_bootstrap ? 4 * 1024 : 1024);
+	std::size_t max_keys (node->flags.disable_legacy_bootstrap ? 4 * 1024 : 1024);
 	if (lazy_keys.size () < max_keys && lazy_keys.find (hash_or_account_a.as_block_hash ()) == lazy_keys.end () && !lazy_blocks_processed (hash_or_account_a.as_block_hash ()))
 	{
 		lazy_keys.insert (hash_or_account_a.as_block_hash ());
@@ -92,13 +92,13 @@ uint32_t nano::bootstrap_attempt_lazy::lazy_batch_size ()
 
 void nano::bootstrap_attempt_lazy::lazy_pull_flush (nano::unique_lock<nano::mutex> & lock_a)
 {
-	static size_t const max_pulls (static_cast<size_t> (nano::bootstrap_limits::bootstrap_connection_scale_target_blocks) * 3);
+	static std::size_t const max_pulls (static_cast<std::size_t> (nano::bootstrap_limits::bootstrap_connection_scale_target_blocks) * 3);
 	if (pulling < max_pulls)
 	{
 		debug_assert (node->network_params.bootstrap.lazy_max_pull_blocks <= std::numeric_limits<nano::pull_info::count_t>::max ());
 		nano::pull_info::count_t batch_count (lazy_batch_size ());
 		uint64_t read_count (0);
-		size_t count (0);
+		std::size_t count (0);
 		auto transaction (node->store.tx_begin_read ());
 		while (!lazy_pulls.empty () && count < max_pulls)
 		{
@@ -413,7 +413,7 @@ void nano::bootstrap_attempt_lazy::lazy_blocks_erase (nano::block_hash const & h
 	if (erased)
 	{
 		--lazy_blocks_count;
-		debug_assert (lazy_blocks_count != std::numeric_limits<size_t>::max ());
+		debug_assert (lazy_blocks_count != std::numeric_limits<std::size_t>::max ());
 	}
 }
 
@@ -555,7 +555,7 @@ void nano::bootstrap_attempt_wallet::run ()
 	condition.notify_all ();
 }
 
-size_t nano::bootstrap_attempt_wallet::wallet_size ()
+std::size_t nano::bootstrap_attempt_wallet::wallet_size ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
 	return wallet_accounts.size ();

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -48,15 +48,15 @@ public:
 	bool lazy_processed_or_exists (nano::block_hash const &) override;
 	unsigned lazy_retry_limit_confirmed ();
 	void get_information (boost::property_tree::ptree &) override;
-	std::unordered_set<size_t> lazy_blocks;
+	std::unordered_set<std::size_t> lazy_blocks;
 	std::unordered_map<nano::block_hash, nano::lazy_state_backlog_item> lazy_state_backlog;
 	std::unordered_set<nano::block_hash> lazy_undefined_links;
 	std::unordered_map<nano::block_hash, nano::uint128_t> lazy_balances;
 	std::unordered_set<nano::block_hash> lazy_keys;
 	std::deque<std::pair<nano::hash_or_account, unsigned>> lazy_pulls;
 	std::chrono::steady_clock::time_point lazy_start_time;
-	std::atomic<size_t> lazy_blocks_count{ 0 };
-	size_t peer_count{ 0 };
+	std::atomic<std::size_t> lazy_blocks_count{ 0 };
+	std::size_t peer_count{ 0 };
 	/** The maximum number of records to be read in while iterating over long lazy containers */
 	static uint64_t constexpr batch_read_size = 256;
 };
@@ -70,7 +70,7 @@ public:
 	void run () override;
 	void wallet_start (std::deque<nano::account> &) override;
 	bool wallet_finished ();
-	size_t wallet_size () override;
+	std::size_t wallet_size () override;
 	void get_information (boost::property_tree::ptree &) override;
 	std::deque<nano::account> wallet_accounts;
 };

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -51,7 +51,7 @@ void nano::bootstrap_listener::stop ()
 	}
 }
 
-size_t nano::bootstrap_listener::connection_count ()
+std::size_t nano::bootstrap_listener::connection_count ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
 	return connections.size ();
@@ -145,7 +145,7 @@ void nano::bootstrap_server::receive ()
 	// Increase timeout to receive TCP header (idle server socket)
 	socket->set_timeout (node->network_params.network.idle_timeout);
 	auto this_l (shared_from_this ());
-	socket->async_read (receive_buffer, 8, [this_l] (boost::system::error_code const & ec, size_t size_a) {
+	socket->async_read (receive_buffer, 8, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		// Set remote_endpoint
 		if (this_l->remote_endpoint.port () == 0)
 		{
@@ -158,7 +158,7 @@ void nano::bootstrap_server::receive ()
 	});
 }
 
-void nano::bootstrap_server::receive_header_action (boost::system::error_code const & ec, size_t size_a)
+void nano::bootstrap_server::receive_header_action (boost::system::error_code const & ec, std::size_t size_a)
 {
 	if (!ec)
 	{
@@ -174,7 +174,7 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 				case nano::message_type::bulk_pull:
 				{
 					node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull, nano::stat::dir::in);
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_bulk_pull_action (ec, size_a, header);
 					});
 					break;
@@ -182,7 +182,7 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 				case nano::message_type::bulk_pull_account:
 				{
 					node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_account, nano::stat::dir::in);
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_bulk_pull_account_action (ec, size_a, header);
 					});
 					break;
@@ -190,7 +190,7 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 				case nano::message_type::frontier_req:
 				{
 					node->stats.inc (nano::stat::type::bootstrap, nano::stat::detail::frontier_req, nano::stat::dir::in);
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_frontier_req_action (ec, size_a, header);
 					});
 					break;
@@ -206,35 +206,35 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 				}
 				case nano::message_type::keepalive:
 				{
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_keepalive_action (ec, size_a, header);
 					});
 					break;
 				}
 				case nano::message_type::publish:
 				{
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_publish_action (ec, size_a, header);
 					});
 					break;
 				}
 				case nano::message_type::confirm_ack:
 				{
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_confirm_ack_action (ec, size_a, header);
 					});
 					break;
 				}
 				case nano::message_type::confirm_req:
 				{
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_confirm_req_action (ec, size_a, header);
 					});
 					break;
 				}
 				case nano::message_type::node_id_handshake:
 				{
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_node_id_handshake_action (ec, size_a, header);
 					});
 					break;
@@ -260,7 +260,7 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 				}
 				case nano::message_type::telemetry_ack:
 				{
-					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, size_t size_a) {
+					socket->async_read (receive_buffer, header.payload_length_bytes (), [this_l, header] (boost::system::error_code const & ec, std::size_t size_a) {
 						this_l->receive_telemetry_ack_action (ec, size_a, header);
 					});
 					break;
@@ -285,7 +285,7 @@ void nano::bootstrap_server::receive_header_action (boost::system::error_code co
 	}
 }
 
-void nano::bootstrap_server::receive_bulk_pull_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_bulk_pull_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -307,7 +307,7 @@ void nano::bootstrap_server::receive_bulk_pull_action (boost::system::error_code
 	}
 }
 
-void nano::bootstrap_server::receive_bulk_pull_account_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_bulk_pull_account_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -330,7 +330,7 @@ void nano::bootstrap_server::receive_bulk_pull_account_action (boost::system::er
 	}
 }
 
-void nano::bootstrap_server::receive_frontier_req_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_frontier_req_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -359,7 +359,7 @@ void nano::bootstrap_server::receive_frontier_req_action (boost::system::error_c
 	}
 }
 
-void nano::bootstrap_server::receive_keepalive_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_keepalive_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -384,7 +384,7 @@ void nano::bootstrap_server::receive_keepalive_action (boost::system::error_code
 	}
 }
 
-void nano::bootstrap_server::receive_telemetry_ack_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_telemetry_ack_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -409,7 +409,7 @@ void nano::bootstrap_server::receive_telemetry_ack_action (boost::system::error_
 	}
 }
 
-void nano::bootstrap_server::receive_publish_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_publish_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -450,7 +450,7 @@ void nano::bootstrap_server::receive_publish_action (boost::system::error_code c
 	}
 }
 
-void nano::bootstrap_server::receive_confirm_req_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_confirm_req_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -472,7 +472,7 @@ void nano::bootstrap_server::receive_confirm_req_action (boost::system::error_co
 	}
 }
 
-void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -513,7 +513,7 @@ void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_co
 	}
 }
 
-void nano::bootstrap_server::receive_node_id_handshake_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a)
+void nano::bootstrap_server::receive_node_id_handshake_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a)
 {
 	if (!ec)
 	{
@@ -666,7 +666,7 @@ public:
 			auto cookie (connection->node->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (connection->remote_endpoint)));
 			nano::node_id_handshake response_message (connection->node->network_params.network, cookie, response);
 			auto shared_const_buffer = response_message.to_shared_const_buffer ();
-			connection->socket->async_write (shared_const_buffer, [connection = std::weak_ptr<nano::bootstrap_server> (connection)] (boost::system::error_code const & ec, size_t size_a) {
+			connection->socket->async_write (shared_const_buffer, [connection = std::weak_ptr<nano::bootstrap_server> (connection)] (boost::system::error_code const & ec, std::size_t size_a) {
 				if (auto connection_l = connection.lock ())
 				{
 					if (ec)

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -16,7 +16,7 @@ public:
 	void start ();
 	void stop ();
 	void accept_action (boost::system::error_code const &, std::shared_ptr<nano::socket> const &);
-	size_t connection_count ();
+	std::size_t connection_count ();
 
 	nano::mutex mutex;
 	std::unordered_map<nano::bootstrap_server *, std::weak_ptr<nano::bootstrap_server>> connections;
@@ -24,8 +24,8 @@ public:
 	nano::node & node;
 	std::shared_ptr<nano::server_socket> listening_socket;
 	bool on{ false };
-	std::atomic<size_t> bootstrap_count{ 0 };
-	std::atomic<size_t> realtime_count{ 0 };
+	std::atomic<std::size_t> bootstrap_count{ 0 };
+	std::atomic<std::size_t> realtime_count{ 0 };
 
 private:
 	uint16_t port;
@@ -41,16 +41,16 @@ public:
 	~bootstrap_server ();
 	void stop ();
 	void receive ();
-	void receive_header_action (boost::system::error_code const &, size_t);
-	void receive_bulk_pull_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_bulk_pull_account_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_frontier_req_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_keepalive_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_publish_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_confirm_req_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_confirm_ack_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_node_id_handshake_action (boost::system::error_code const &, size_t, nano::message_header const &);
-	void receive_telemetry_ack_action (boost::system::error_code const & ec, size_t size_a, nano::message_header const & header_a);
+	void receive_header_action (boost::system::error_code const &, std::size_t);
+	void receive_bulk_pull_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_bulk_pull_account_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_frontier_req_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_keepalive_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_publish_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_confirm_req_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_confirm_ack_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_node_id_handshake_action (boost::system::error_code const &, std::size_t, nano::message_header const &);
+	void receive_telemetry_ack_action (boost::system::error_code const & ec, std::size_t size_a, nano::message_header const & header_a);
 	void add_request (std::unique_ptr<nano::message>);
 	void finish_request ();
 	void finish_request_async ();

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -156,32 +156,32 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 		flags_a.disable_block_processor_unchecked_deletion = true;
 		flags_a.block_processor_batch_size = 256 * 1024;
 		flags_a.block_processor_full_size = 1024 * 1024;
-		flags_a.block_processor_verification_size = std::numeric_limits<size_t>::max ();
+		flags_a.block_processor_verification_size = std::numeric_limits<std::size_t>::max ();
 	}
 	auto block_processor_batch_size_it = vm.find ("block_processor_batch_size");
 	if (block_processor_batch_size_it != vm.end ())
 	{
-		flags_a.block_processor_batch_size = block_processor_batch_size_it->second.as<size_t> ();
+		flags_a.block_processor_batch_size = block_processor_batch_size_it->second.as<std::size_t> ();
 	}
 	auto block_processor_full_size_it = vm.find ("block_processor_full_size");
 	if (block_processor_full_size_it != vm.end ())
 	{
-		flags_a.block_processor_full_size = block_processor_full_size_it->second.as<size_t> ();
+		flags_a.block_processor_full_size = block_processor_full_size_it->second.as<std::size_t> ();
 	}
 	auto block_processor_verification_size_it = vm.find ("block_processor_verification_size");
 	if (block_processor_verification_size_it != vm.end ())
 	{
-		flags_a.block_processor_verification_size = block_processor_verification_size_it->second.as<size_t> ();
+		flags_a.block_processor_verification_size = block_processor_verification_size_it->second.as<std::size_t> ();
 	}
 	auto inactive_votes_cache_size_it = vm.find ("inactive_votes_cache_size");
 	if (inactive_votes_cache_size_it != vm.end ())
 	{
-		flags_a.inactive_votes_cache_size = inactive_votes_cache_size_it->second.as<size_t> ();
+		flags_a.inactive_votes_cache_size = inactive_votes_cache_size_it->second.as<std::size_t> ();
 	}
 	auto vote_processor_capacity_it = vm.find ("vote_processor_capacity");
 	if (vote_processor_capacity_it != vm.end ())
 	{
-		flags_a.vote_processor_capacity = vote_processor_capacity_it->second.as<size_t> ();
+		flags_a.vote_processor_capacity = vote_processor_capacity_it->second.as<std::size_t> ();
 	}
 	// Config overriding
 	auto config (vm.find ("config"));
@@ -414,7 +414,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				std::cerr << "Vacuum failed. RocksDB is enabled but the node has not been built with RocksDB support" << std::endl;
 			}
 		}
-		catch (const boost::filesystem::filesystem_error & ex)
+		catch (boost::filesystem::filesystem_error const & ex)
 		{
 			std::cerr << "Vacuum failed during a file operation: " << ex.what () << std::endl;
 		}
@@ -461,7 +461,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				std::cerr << "Snapshot failed. RocksDB is enabled but the node has not been built with RocksDB support" << std::endl;
 			}
 		}
-		catch (const boost::filesystem::filesystem_error & ex)
+		catch (boost::filesystem::filesystem_error const & ex)
 		{
 			std::cerr << "Snapshot failed during a file operation: " << ex.what () << std::endl;
 		}

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -195,7 +195,7 @@ bool nano::message_header::node_id_handshake_is_response () const
 	return result;
 }
 
-size_t nano::message_header::payload_length_bytes () const
+std::size_t nano::message_header::payload_length_bytes () const
 {
 	switch (type)
 	{
@@ -250,7 +250,7 @@ size_t nano::message_header::payload_length_bytes () const
 }
 
 // MTU - IP header - UDP header
-const size_t nano::message_parser::max_safe_udp_message_size = 508;
+std::size_t const nano::message_parser::max_safe_udp_message_size = 508;
 
 std::string nano::message_parser::status_string ()
 {
@@ -326,7 +326,7 @@ nano::message_parser::message_parser (nano::network_filter & publish_filter_a, n
 {
 }
 
-void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t size_a)
+void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, std::size_t size_a)
 {
 	status = parse_status::success;
 	auto error (false);
@@ -731,7 +731,7 @@ bool nano::confirm_req::deserialize (nano::stream & stream_a, nano::block_unique
 			result = block == nullptr;
 		}
 	}
-	catch (const std::runtime_error &)
+	catch (std::runtime_error const &)
 	{
 		result = true;
 	}
@@ -766,9 +766,9 @@ std::string nano::confirm_req::roots_string () const
 	return result;
 }
 
-size_t nano::confirm_req::size (nano::block_type type_a, size_t count)
+std::size_t nano::confirm_req::size (nano::block_type type_a, std::size_t count)
 {
-	size_t result (0);
+	std::size_t result (0);
 	if (type_a != nano::block_type::invalid && type_a != nano::block_type::not_a_block)
 	{
 		result = nano::block::size (type_a);
@@ -826,9 +826,9 @@ void nano::confirm_ack::visit (nano::message_visitor & visitor_a) const
 	visitor_a.confirm_ack (*this);
 }
 
-size_t nano::confirm_ack::size (nano::block_type type_a, size_t count)
+std::size_t nano::confirm_ack::size (nano::block_type type_a, std::size_t count)
 {
-	size_t result (sizeof (nano::account) + sizeof (nano::signature) + sizeof (uint64_t));
+	std::size_t result (sizeof (nano::account) + sizeof (nano::signature) + sizeof (uint64_t));
 	if (type_a != nano::block_type::invalid && type_a != nano::block_type::not_a_block)
 	{
 		result += nano::block::size (type_a);
@@ -1414,14 +1414,14 @@ void nano::node_id_handshake::visit (nano::message_visitor & visitor_a) const
 	visitor_a.node_id_handshake (*this);
 }
 
-size_t nano::node_id_handshake::size () const
+std::size_t nano::node_id_handshake::size () const
 {
 	return size (header);
 }
 
-size_t nano::node_id_handshake::size (nano::message_header const & header_a)
+std::size_t nano::node_id_handshake::size (nano::message_header const & header_a)
 {
-	size_t result (0);
+	std::size_t result (0);
 	if (header_a.node_id_handshake_is_query ())
 	{
 		result = sizeof (nano::uint256_union);

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -36,18 +36,18 @@ uint64_t endpoint_hash_raw (nano::tcp_endpoint const & endpoint_a)
 	return result;
 }
 
-template <size_t size>
+template <std::size_t size>
 struct endpoint_hash
 {
 };
 template <>
 struct endpoint_hash<8>
 {
-	size_t operator() (nano::endpoint const & endpoint_a) const
+	std::size_t operator() (nano::endpoint const & endpoint_a) const
 	{
 		return endpoint_hash_raw (endpoint_a);
 	}
-	size_t operator() (nano::tcp_endpoint const & endpoint_a) const
+	std::size_t operator() (nano::tcp_endpoint const & endpoint_a) const
 	{
 		return endpoint_hash_raw (endpoint_a);
 	}
@@ -55,27 +55,27 @@ struct endpoint_hash<8>
 template <>
 struct endpoint_hash<4>
 {
-	size_t operator() (nano::endpoint const & endpoint_a) const
+	std::size_t operator() (nano::endpoint const & endpoint_a) const
 	{
 		uint64_t big (endpoint_hash_raw (endpoint_a));
 		uint32_t result (static_cast<uint32_t> (big) ^ static_cast<uint32_t> (big >> 32));
 		return result;
 	}
-	size_t operator() (nano::tcp_endpoint const & endpoint_a) const
+	std::size_t operator() (nano::tcp_endpoint const & endpoint_a) const
 	{
 		uint64_t big (endpoint_hash_raw (endpoint_a));
 		uint32_t result (static_cast<uint32_t> (big) ^ static_cast<uint32_t> (big >> 32));
 		return result;
 	}
 };
-template <size_t size>
+template <std::size_t size>
 struct ip_address_hash
 {
 };
 template <>
 struct ip_address_hash<8>
 {
-	size_t operator() (boost::asio::ip::address const & ip_address_a) const
+	std::size_t operator() (boost::asio::ip::address const & ip_address_a) const
 	{
 		return nano::ip_address_hash_raw (ip_address_a);
 	}
@@ -83,7 +83,7 @@ struct ip_address_hash<8>
 template <>
 struct ip_address_hash<4>
 {
-	size_t operator() (boost::asio::ip::address const & ip_address_a) const
+	std::size_t operator() (boost::asio::ip::address const & ip_address_a) const
 	{
 		uint64_t big (nano::ip_address_hash_raw (ip_address_a));
 		uint32_t result (static_cast<uint32_t> (big) ^ static_cast<uint32_t> (big >> 32));
@@ -97,18 +97,18 @@ namespace std
 template <>
 struct hash<::nano::endpoint>
 {
-	size_t operator() (::nano::endpoint const & endpoint_a) const
+	std::size_t operator() (::nano::endpoint const & endpoint_a) const
 	{
-		endpoint_hash<sizeof (size_t)> ehash;
+		endpoint_hash<sizeof (std::size_t)> ehash;
 		return ehash (endpoint_a);
 	}
 };
 template <>
 struct hash<::nano::tcp_endpoint>
 {
-	size_t operator() (::nano::tcp_endpoint const & endpoint_a) const
+	std::size_t operator() (::nano::tcp_endpoint const & endpoint_a) const
 	{
-		endpoint_hash<sizeof (size_t)> ehash;
+		endpoint_hash<sizeof (std::size_t)> ehash;
 		return ehash (endpoint_a);
 	}
 };
@@ -116,9 +116,9 @@ struct hash<::nano::tcp_endpoint>
 template <>
 struct hash<boost::asio::ip::address>
 {
-	size_t operator() (boost::asio::ip::address const & ip_a) const
+	std::size_t operator() (boost::asio::ip::address const & ip_a) const
 	{
-		ip_address_hash<sizeof (size_t)> ihash;
+		ip_address_hash<sizeof (std::size_t)> ihash;
 		return ihash (ip_a);
 	}
 };
@@ -129,7 +129,7 @@ namespace boost
 template <>
 struct hash<::nano::endpoint>
 {
-	size_t operator() (::nano::endpoint const & endpoint_a) const
+	std::size_t operator() (::nano::endpoint const & endpoint_a) const
 	{
 		std::hash<::nano::endpoint> hash;
 		return hash (endpoint_a);
@@ -138,7 +138,7 @@ struct hash<::nano::endpoint>
 template <>
 struct hash<::nano::tcp_endpoint>
 {
-	size_t operator() (::nano::tcp_endpoint const & endpoint_a) const
+	std::size_t operator() (::nano::tcp_endpoint const & endpoint_a) const
 	{
 		std::hash<::nano::tcp_endpoint> hash;
 		return hash (endpoint_a);
@@ -147,7 +147,7 @@ struct hash<::nano::tcp_endpoint>
 template <>
 struct hash<boost::asio::ip::address>
 {
-	size_t operator() (boost::asio::ip::address const & ip_a) const
+	std::size_t operator() (boost::asio::ip::address const & ip_a) const
 	{
 		std::hash<boost::asio::ip::address> hash;
 		return hash (ip_a);
@@ -205,7 +205,7 @@ public:
 public:
 	nano::message_type type;
 	std::bitset<16> extensions;
-	static size_t constexpr size = sizeof (nano::networks) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min) + sizeof (type) + sizeof (/* extensions */ uint16_t);
+	static std::size_t constexpr size = sizeof (nano::networks) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min) + sizeof (type) + sizeof (/* extensions */ uint16_t);
 
 	void flag_set (uint8_t);
 	static uint8_t constexpr bulk_pull_count_present_flag = 0;
@@ -218,7 +218,7 @@ public:
 	bool node_id_handshake_is_response () const;
 
 	/** Size of the payload in bytes. For some messages, the payload size is based on header flags. */
-	size_t payload_length_bytes () const;
+	std::size_t payload_length_bytes () const;
 
 	static std::bitset<16> constexpr block_type_mask{ 0x0f00 };
 	static std::bitset<16> constexpr count_mask{ 0xf000 };
@@ -259,7 +259,7 @@ public:
 		duplicate_publish_message
 	};
 	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &, nano::network_constants const & protocol);
-	void deserialize_buffer (uint8_t const *, size_t);
+	void deserialize_buffer (uint8_t const *, std::size_t);
 	void deserialize_keepalive (nano::stream &, nano::message_header const &);
 	void deserialize_publish (nano::stream &, nano::message_header const &, nano::uint128_t const & = 0);
 	void deserialize_confirm_req (nano::stream &, nano::message_header const &);
@@ -276,7 +276,7 @@ public:
 	parse_status status;
 	nano::network_constants const & network;
 	std::string status_string ();
-	static const size_t max_safe_udp_message_size;
+	static std::size_t const max_safe_udp_message_size;
 };
 class keepalive final : public message
 {
@@ -288,7 +288,7 @@ public:
 	bool deserialize (nano::stream &);
 	bool operator== (nano::keepalive const &) const;
 	std::array<nano::endpoint, 8> peers;
-	static size_t constexpr size = 8 * (16 + 2);
+	static std::size_t constexpr size = 8 * (16 + 2);
 };
 class publish final : public message
 {
@@ -316,7 +316,7 @@ public:
 	std::shared_ptr<nano::block> block;
 	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes;
 	std::string roots_string () const;
-	static size_t size (nano::block_type, size_t = 0);
+	static std::size_t size (nano::block_type, std::size_t = 0);
 };
 class confirm_ack final : public message
 {
@@ -327,7 +327,7 @@ public:
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_ack const &) const;
 	std::shared_ptr<nano::vote> vote;
-	static size_t size (nano::block_type, size_t = 0);
+	static std::size_t size (nano::block_type, std::size_t = 0);
 };
 class frontier_req final : public message
 {
@@ -341,7 +341,7 @@ public:
 	nano::account start;
 	uint32_t age;
 	uint32_t count;
-	static size_t constexpr size = sizeof (start) + sizeof (age) + sizeof (count);
+	static std::size_t constexpr size = sizeof (start) + sizeof (age) + sizeof (count);
 };
 
 enum class telemetry_maker : uint8_t
@@ -426,9 +426,9 @@ public:
 	count_t count{ 0 };
 	bool is_count_present () const;
 	void set_count_present (bool);
-	static size_t constexpr count_present_flag = nano::message_header::bulk_pull_count_present_flag;
-	static size_t constexpr extended_parameters_size = 8;
-	static size_t constexpr size = sizeof (start) + sizeof (end);
+	static std::size_t constexpr count_present_flag = nano::message_header::bulk_pull_count_present_flag;
+	static std::size_t constexpr extended_parameters_size = 8;
+	static std::size_t constexpr size = sizeof (start) + sizeof (end);
 };
 class bulk_pull_account final : public message
 {
@@ -441,7 +441,7 @@ public:
 	nano::account account;
 	nano::amount minimum_amount;
 	bulk_pull_account_flags flags;
-	static size_t constexpr size = sizeof (account) + sizeof (minimum_amount) + sizeof (bulk_pull_account_flags);
+	static std::size_t constexpr size = sizeof (account) + sizeof (minimum_amount) + sizeof (bulk_pull_account_flags);
 };
 class bulk_push final : public message
 {
@@ -463,8 +463,8 @@ public:
 	bool operator== (nano::node_id_handshake const &) const;
 	boost::optional<nano::uint256_union> query;
 	boost::optional<std::pair<nano::account, nano::signature>> response;
-	size_t size () const;
-	static size_t size (nano::message_header const &);
+	std::size_t size () const;
+	static std::size_t size (nano::message_header const &);
 };
 class message_visitor
 {

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -378,8 +378,8 @@ void nano::confirmation_height_bounded::cement_blocks (nano::write_guard & scope
 		// of blocks to retain consistent cementing across all account chains to genesis.
 		while (!error && !pending_writes.empty ())
 		{
-			const auto & pending = pending_writes.front ();
-			const auto & account = pending.account;
+			auto const & pending = pending_writes.front ();
+			auto const & account = pending.account;
 
 			auto write_confirmation_height = [&account, &ledger = ledger, &transaction] (uint64_t num_blocks_cemented, uint64_t confirmation_height, nano::block_hash const & confirmed_frontier) {
 #ifndef NDEBUG

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -105,7 +105,7 @@ private:
 	class receive_source_pair final
 	{
 	public:
-		receive_source_pair (receive_chain_details const &, const nano::block_hash &);
+		receive_source_pair (receive_chain_details const &, nano::block_hash const &);
 
 		receive_chain_details receive_details;
 		nano::block_hash source_hash;

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -62,7 +62,7 @@ void nano::confirmation_height_processor::run (confirmation_height_mode mode_a)
 
 			set_next_hash ();
 
-			const auto num_blocks_to_use_unbounded = confirmation_height::unbounded_cutoff;
+			auto const num_blocks_to_use_unbounded = confirmation_height::unbounded_cutoff;
 			auto blocks_within_automatic_unbounded_selection = (ledger.cache.block_count < num_blocks_to_use_unbounded || ledger.cache.block_count - num_blocks_to_use_unbounded < ledger.cache.cemented_count);
 
 			// Don't want to mix up pending writes across different processors
@@ -204,8 +204,8 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (co
 {
 	auto composite = std::make_unique<container_info_composite> (name_a);
 
-	size_t cemented_observers_count = confirmation_height_processor_a.cemented_observers.size ();
-	size_t block_already_cemented_observers_count = confirmation_height_processor_a.block_already_cemented_observers.size ();
+	std::size_t cemented_observers_count = confirmation_height_processor_a.cemented_observers.size ();
+	std::size_t block_already_cemented_observers_count = confirmation_height_processor_a.block_already_cemented_observers.size ();
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cemented_observers", cemented_observers_count, sizeof (decltype (confirmation_height_processor_a.cemented_observers)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "block_already_cemented_observers", block_already_cemented_observers_count, sizeof (decltype (confirmation_height_processor_a.block_already_cemented_observers)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "awaiting_processing", confirmation_height_processor_a.awaiting_processing_size (), sizeof (decltype (confirmation_height_processor_a.awaiting_processing)::value_type) }));
@@ -214,7 +214,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (co
 	return composite;
 }
 
-size_t nano::confirmation_height_processor::awaiting_processing_size () const
+std::size_t nano::confirmation_height_processor::awaiting_processing_size () const
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return awaiting_processing.size ();

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -39,7 +39,7 @@ public:
 	void stop ();
 	void add (std::shared_ptr<nano::block> const &);
 	void run (confirmation_height_mode);
-	size_t awaiting_processing_size () const;
+	std::size_t awaiting_processing_size () const;
 	bool is_processing_added_block (nano::block_hash const & hash_a) const;
 	bool is_processing_block (nano::block_hash const &) const;
 	nano::block_hash current () const;
@@ -100,7 +100,7 @@ private:
 	void notify_observers (std::vector<std::shared_ptr<nano::block>> const &);
 	void notify_observers (nano::block_hash const &);
 
-	friend std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, std::string const &);
 	friend class confirmation_height_pending_observer_callbacks_Test;
 	friend class confirmation_height_dependent_election_Test;
 	friend class confirmation_height_dependent_election_after_already_cemented_Test;
@@ -112,5 +112,5 @@ private:
 	friend class active_transactions_pessimistic_elections_Test;
 };
 
-std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, const std::string &);
+std::unique_ptr<container_info_component> collect_container_info (confirmation_height_processor &, std::string const &);
 }

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -52,7 +52,7 @@ private:
 	class receive_source_pair final
 	{
 	public:
-		receive_source_pair (std::shared_ptr<conf_height_details> const &, const nano::block_hash &);
+		receive_source_pair (std::shared_ptr<conf_height_details> const &, nano::block_hash const &);
 
 		std::shared_ptr<conf_height_details> receive_details;
 		nano::block_hash source_hash;

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -7,7 +7,7 @@ using namespace std::chrono_literals;
 nano::confirmation_solicitor::confirmation_solicitor (nano::network & network_a, nano::node_config const & config_a) :
 	max_block_broadcasts (config_a.network_params.network.is_dev_network () ? 4 : 30),
 	max_election_requests (50),
-	max_election_broadcasts (std::max<size_t> (network_a.fanout () / 2, 1)),
+	max_election_broadcasts (std::max<std::size_t> (network_a.fanout () / 2, 1)),
 	network (network_a),
 	config (config_a)
 {

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -24,11 +24,11 @@ public:
 	/** Dispatch bundled requests to each channel*/
 	void flush ();
 	/** Global maximum amount of block broadcasts */
-	size_t const max_block_broadcasts;
+	std::size_t const max_block_broadcasts;
 	/** Maximum amount of requests to be sent per election, bypassed if an existing vote is for a different hash*/
-	size_t const max_election_requests;
+	std::size_t const max_election_requests;
 	/** Maximum amount of directed broadcasts to be sent per election */
-	size_t const max_election_broadcasts;
+	std::size_t const max_election_broadcasts;
 
 private:
 	nano::network & network;

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -154,11 +154,11 @@ void nano::distributed_work::do_request (nano::tcp_endpoint const & endpoint_a)
 			auto peer_request (connection->get_prepared_json_request (request_string));
 			boost::beast::http::async_write (connection->socket, *peer_request,
 			boost::asio::bind_executor (this_l->strand,
-			[this_l, connection, peer_request] (boost::system::error_code const & ec, size_t size_a) {
+			[this_l, connection, peer_request] (boost::system::error_code const & ec, std::size_t size_a) {
 				if (!ec && !this_l->stopped)
 				{
 					boost::beast::http::async_read (connection->socket, connection->buffer, connection->response,
-					boost::asio::bind_executor (this_l->strand, [this_l, connection] (boost::system::error_code const & ec, size_t size_a) {
+					boost::asio::bind_executor (this_l->strand, [this_l, connection] (boost::system::error_code const & ec, std::size_t size_a) {
 						if (!ec && !this_l->stopped)
 						{
 							if (connection->response.result () == boost::beast::http::status::ok)
@@ -217,7 +217,7 @@ void nano::distributed_work::do_cancel (nano::tcp_endpoint const & endpoint_a)
 			auto peer_cancel (cancelling_l->get_prepared_json_request (request_string));
 			boost::beast::http::async_write (cancelling_l->socket, *peer_cancel,
 			boost::asio::bind_executor (this_l->strand,
-			[this_l, peer_cancel, cancelling_l] (boost::system::error_code const & ec, size_t bytes_transferred) {
+			[this_l, peer_cancel, cancelling_l] (boost::system::error_code const & ec, std::size_t bytes_transferred) {
 				if (ec && ec != boost::system::errc::operation_canceled)
 				{
 					this_l->node.logger.try_log (boost::str (boost::format ("Unable to send work_cancel to work_peer %1% %2%: %3% (%4%)") % cancelling_l->endpoint.address () % cancelling_l->endpoint.port () % ec.message () % ec.value ()));

--- a/nano/node/distributed_work_factory.cpp
+++ b/nano/node/distributed_work_factory.cpp
@@ -88,7 +88,7 @@ void nano::distributed_work_factory::stop ()
 	}
 }
 
-size_t nano::distributed_work_factory::size () const
+std::size_t nano::distributed_work_factory::size () const
 {
 	nano::lock_guard<nano::mutex> guard_l (mutex);
 	return items.size ();

--- a/nano/node/distributed_work_factory.hpp
+++ b/nano/node/distributed_work_factory.hpp
@@ -26,7 +26,7 @@ public:
 	void cancel (nano::root const &);
 	void cleanup_finished ();
 	void stop ();
-	size_t size () const;
+	std::size_t size () const;
 
 private:
 	std::unordered_multimap<nano::root, std::weak_ptr<nano::distributed_work>> items;
@@ -35,7 +35,7 @@ private:
 	mutable nano::mutex mutex;
 	std::atomic<bool> stopped{ false };
 
-	friend std::unique_ptr<container_info_component> collect_container_info (distributed_work_factory &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (distributed_work_factory &, std::string const &);
 };
 
 std::unique_ptr<container_info_component> collect_container_info (distributed_work_factory & distributed_work, std::string const & name);

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -437,7 +437,7 @@ bool nano::election::publish (std::shared_ptr<nano::block> const & block_a)
 	return result;
 }
 
-size_t nano::election::insert_inactive_votes_cache (nano::inactive_cache_information const & cache_a)
+std::size_t nano::election::insert_inactive_votes_cache (nano::inactive_cache_information const & cache_a)
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	for (auto const & [rep, timestamp] : cache_a.voters)

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -106,7 +106,7 @@ public: // Interface
 	std::shared_ptr<nano::block> find (nano::block_hash const &) const;
 	nano::election_vote_result vote (nano::account const &, uint64_t, nano::block_hash const &);
 	bool publish (std::shared_ptr<nano::block> const & block_a);
-	size_t insert_inactive_votes_cache (nano::inactive_cache_information const &);
+	std::size_t insert_inactive_votes_cache (nano::inactive_cache_information const &);
 	// Confirm this block if quorum is met
 	void confirm_if_quorum (nano::unique_lock<nano::mutex> &);
 
@@ -142,7 +142,7 @@ private:
 	mutable nano::mutex mutex;
 
 	static std::chrono::seconds constexpr late_blocks_delay{ 5 };
-	static size_t constexpr max_blocks{ 10 };
+	static std::size_t constexpr max_blocks{ 10 };
 
 	friend class active_transactions;
 	friend class confirmation_solicitor;

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -65,7 +65,7 @@ void nano::election_scheduler::notify ()
 	condition.notify_all ();
 }
 
-size_t nano::election_scheduler::size () const
+std::size_t nano::election_scheduler::size () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return priority.size () + manual_queue.size ();
@@ -82,7 +82,7 @@ bool nano::election_scheduler::empty () const
 	return empty_locked ();
 }
 
-size_t nano::election_scheduler::priority_queue_size () const
+std::size_t nano::election_scheduler::priority_queue_size () const
 {
 	return priority.size ();
 }

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -29,9 +29,9 @@ public:
 	// Blocks until no more elections can be activated or there are no more elections to activate
 	void flush ();
 	void notify ();
-	size_t size () const;
+	std::size_t size () const;
 	bool empty () const;
-	size_t priority_queue_size () const;
+	std::size_t priority_queue_size () const;
 
 private:
 	void run ();

--- a/nano/node/gap_cache.cpp
+++ b/nano/node/gap_cache.cpp
@@ -121,7 +121,7 @@ nano::uint128_t nano::gap_cache::bootstrap_threshold ()
 	return result;
 }
 
-size_t nano::gap_cache::size ()
+std::size_t nano::gap_cache::size ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
 	return blocks.size ();

--- a/nano/node/gap_cache.hpp
+++ b/nano/node/gap_cache.hpp
@@ -41,7 +41,7 @@ public:
 	bool bootstrap_check (std::vector<nano::account> const &, nano::block_hash const &);
 	void bootstrap_start (nano::block_hash const & hash_a);
 	nano::uint128_t bootstrap_threshold ();
-	size_t size ();
+	std::size_t size ();
 	// clang-format off
 	class tag_arrival {};
 	class tag_hash {};
@@ -53,7 +53,7 @@ public:
 			boost::multi_index::member<gap_information, nano::block_hash, &gap_information::hash>>>>;
 	ordered_gaps blocks;
 	// clang-format on
-	size_t const max = 256;
+	std::size_t const max = 256;
 	nano::mutex mutex{ mutex_identifier (mutexes::gap_cache) };
 	nano::node & node;
 };

--- a/nano/node/ipc/flatbuffers_handler.cpp
+++ b/nano/node/ipc/flatbuffers_handler.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<flatbuffers::Parser> nano::ipc::flatbuffers_handler::make_flatbu
 		throw nano::error ("Internal IPC error: unable to find api path");
 	}
 
-	const char * include_directories[] = { api_path->string ().c_str (), nullptr };
+	char const * include_directories[] = { api_path->string ().c_str (), nullptr };
 	std::string schemafile;
 	if (!flatbuffers::LoadFile ((*api_path / "nanoapi.fbs").string ().c_str (), false, &schemafile))
 	{
@@ -84,7 +84,7 @@ std::shared_ptr<flatbuffers::Parser> nano::ipc::flatbuffers_handler::make_flatbu
 	return parser;
 }
 
-void nano::ipc::flatbuffers_handler::process_json (const uint8_t * message_buffer_a, size_t buffer_size_a,
+void nano::ipc::flatbuffers_handler::process_json (uint8_t const * message_buffer_a, std::size_t buffer_size_a,
 std::function<void (std::shared_ptr<std::string> const &)> const & response_handler)
 {
 	try
@@ -97,7 +97,7 @@ std::function<void (std::shared_ptr<std::string> const &)> const & response_hand
 		// Convert request from JSON
 		auto body (std::string (reinterpret_cast<char *> (const_cast<uint8_t *> (message_buffer_a)), buffer_size_a));
 		body += '\0';
-		if (parser->Parse (reinterpret_cast<const char *> (body.data ())))
+		if (parser->Parse (reinterpret_cast<char const *> (body.data ())))
 		{
 			process (parser->builder_.GetBufferPointer (), parser->builder_.GetSize (), [parser = parser, response_handler] (std::shared_ptr<flatbuffers::FlatBufferBuilder> const & fbb) {
 				// Convert response to JSON
@@ -134,7 +134,7 @@ std::function<void (std::shared_ptr<std::string> const &)> const & response_hand
 	}
 }
 
-void nano::ipc::flatbuffers_handler::process (const uint8_t * message_buffer_a, size_t buffer_size_a,
+void nano::ipc::flatbuffers_handler::process (uint8_t const * message_buffer_a, std::size_t buffer_size_a,
 std::function<void (std::shared_ptr<flatbuffers::FlatBufferBuilder> const &)> const & response_handler)
 {
 	auto buffer_l (std::make_shared<flatbuffers::FlatBufferBuilder> ());

--- a/nano/node/ipc/flatbuffers_handler.hpp
+++ b/nano/node/ipc/flatbuffers_handler.hpp
@@ -42,12 +42,12 @@ namespace ipc
 		 * @param response_handler Receives a shared pointer to the flatbuffer builder, from which the buffer and size can be queried
 		 * @throw Throws std:runtime_error on deserialization or processing errors
 		 */
-		void process (const uint8_t * message_buffer_a, size_t buffer_size_a, std::function<void (std::shared_ptr<flatbuffers::FlatBufferBuilder> const &)> const & response_handler);
+		void process (uint8_t const * message_buffer_a, std::size_t buffer_size_a, std::function<void (std::shared_ptr<flatbuffers::FlatBufferBuilder> const &)> const & response_handler);
 
 		/**
 		 * Parses a JSON encoded requests into Flatbuffer format, calls process(), yields the result as a JSON string
 		 */
-		void process_json (const uint8_t * message_buffer_a, size_t buffer_size_a, std::function<void (std::shared_ptr<std::string> const &)> const & response_handler);
+		void process_json (uint8_t const * message_buffer_a, std::size_t buffer_size_a, std::function<void (std::shared_ptr<std::string> const &)> const & response_handler);
 
 		/**
 		 * Creates a Flatbuffers parser with the schema preparsed. This can then be used to parse and produce JSON.

--- a/nano/node/ipc/ipc_broker.cpp
+++ b/nano/node/ipc/ipc_broker.cpp
@@ -195,11 +195,11 @@ void nano::ipc::broker::broadcast (std::shared_ptr<nanoapi::EventConfirmationT> 
 						throw nano::error ("Couldn't serialize response to JSON");
 					}
 
-					subscriber_l->async_send_message (reinterpret_cast<uint8_t const *> (json->data ()), json->size (), [json] (const nano::error & err) {});
+					subscriber_l->async_send_message (reinterpret_cast<uint8_t const *> (json->data ()), json->size (), [json] (nano::error const & err) {});
 				}
 				else
 				{
-					subscriber_l->async_send_message (fb->GetBufferPointer (), fb->GetSize (), [fb] (const nano::error & err) {});
+					subscriber_l->async_send_message (fb->GetBufferPointer (), fb->GetSize (), [fb] (nano::error const & err) {});
 				}
 			}
 
@@ -222,7 +222,7 @@ void nano::ipc::broker::broadcast (std::shared_ptr<nanoapi::EventConfirmationT> 
 	}
 }
 
-size_t nano::ipc::broker::confirmation_subscriber_count () const
+std::size_t nano::ipc::broker::confirmation_subscriber_count () const
 {
 	return confirmation_subscribers->size ();
 }
@@ -246,7 +246,7 @@ void nano::ipc::broker::service_stop (std::string const & service_name_a)
 			{
 				nanoapi::EventServiceStopT event_stop;
 				auto fb (nano::ipc::flatbuffer_producer::make_buffer (event_stop));
-				subscriber_l->async_send_message (fb->GetBufferPointer (), fb->GetSize (), [fb] (const nano::error & err) {});
+				subscriber_l->async_send_message (fb->GetBufferPointer (), fb->GetSize (), [fb] (nano::error const & err) {});
 
 				break;
 			}

--- a/nano/node/ipc/ipc_broker.hpp
+++ b/nano/node/ipc/ipc_broker.hpp
@@ -35,7 +35,7 @@ namespace ipc
 		 * @param length_a Length of payload message in bytes
 		 * @param broadcast_completion_handler_a Called once sending is completed
 		 */
-		virtual void async_send_message (uint8_t const * data_a, size_t length_a, std::function<void (nano::error const &)> broadcast_completion_handler_a) = 0;
+		virtual void async_send_message (uint8_t const * data_a, std::size_t length_a, std::function<void (nano::error const &)> broadcast_completion_handler_a) = 0;
 		/** Returns the unique id of the associated session */
 		virtual uint64_t get_id () const = 0;
 		/** Returns the service name associated with the session */
@@ -86,7 +86,7 @@ namespace ipc
 		void subscribe (std::weak_ptr<nano::ipc::subscriber> const & subscriber_a, std::shared_ptr<nanoapi::TopicServiceStopT> const & service_stop_a);
 
 		/** Returns the number of confirmation subscribers */
-		size_t confirmation_subscriber_count () const;
+		std::size_t confirmation_subscriber_count () const;
 		/** Associate the service name with the subscriber */
 		void service_register (std::string const & service_name_a, std::weak_ptr<nano::ipc::subscriber> const & subscriber_a);
 		/** Sends a notification to the session associated with the given service (if the session has subscribed to TopicServiceStop) */

--- a/nano/node/ipc/ipc_config.cpp
+++ b/nano/node/ipc/ipc_config.cpp
@@ -43,7 +43,7 @@ nano::error nano::ipc::ipc_config::deserialize_toml (nano::tomlconfig & toml)
 		tcp_l->get<bool> ("allow_unsafe", transport_tcp.allow_unsafe);
 		tcp_l->get<bool> ("enable", transport_tcp.enabled);
 		tcp_l->get<uint16_t> ("port", transport_tcp.port);
-		tcp_l->get<size_t> ("io_timeout", transport_tcp.io_timeout);
+		tcp_l->get<std::size_t> ("io_timeout", transport_tcp.io_timeout);
 	}
 
 	auto domain_l (toml.get_optional_child ("local"));
@@ -53,7 +53,7 @@ nano::error nano::ipc::ipc_config::deserialize_toml (nano::tomlconfig & toml)
 		domain_l->get<bool> ("allow_unsafe", transport_domain.allow_unsafe);
 		domain_l->get<bool> ("enable", transport_domain.enabled);
 		domain_l->get<std::string> ("path", transport_domain.path);
-		domain_l->get<size_t> ("io_timeout", transport_domain.io_timeout);
+		domain_l->get<std::size_t> ("io_timeout", transport_domain.io_timeout);
 	}
 
 	auto flatbuffers_l (toml.get_optional_child ("flatbuffers"));
@@ -102,7 +102,7 @@ nano::error nano::ipc::ipc_config::deserialize_json (bool & upgraded_a, nano::js
 		tcp_l->get_optional<bool> ("allow_unsafe", transport_tcp.allow_unsafe);
 		tcp_l->get<bool> ("enable", transport_tcp.enabled);
 		tcp_l->get<uint16_t> ("port", transport_tcp.port);
-		tcp_l->get<size_t> ("io_timeout", transport_tcp.io_timeout);
+		tcp_l->get<std::size_t> ("io_timeout", transport_tcp.io_timeout);
 	}
 
 	auto domain_l (json.get_optional_child ("local"));
@@ -112,7 +112,7 @@ nano::error nano::ipc::ipc_config::deserialize_json (bool & upgraded_a, nano::js
 		domain_l->get_optional<bool> ("allow_unsafe", transport_domain.allow_unsafe);
 		domain_l->get<bool> ("enable", transport_domain.enabled);
 		domain_l->get<std::string> ("path", transport_domain.path);
-		domain_l->get<size_t> ("io_timeout", transport_domain.io_timeout);
+		domain_l->get<std::size_t> ("io_timeout", transport_domain.io_timeout);
 	}
 
 	return json.get_error ();

--- a/nano/node/ipc/ipc_config.hpp
+++ b/nano/node/ipc/ipc_config.hpp
@@ -18,7 +18,7 @@ namespace ipc
 		virtual ~ipc_config_transport () = default;
 		bool enabled{ false };
 		bool allow_unsafe{ false };
-		size_t io_timeout{ 15 };
+		std::size_t io_timeout{ 15 };
 		long io_threads{ -1 };
 	};
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -22,7 +22,7 @@ using ipc_json_handler_no_arg_func_map = std::unordered_map<std::string, std::fu
 ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ();
 auto ipc_json_handler_no_arg_funcs = create_ipc_json_handler_no_arg_func_map ();
 bool block_confirmed (nano::node & node, nano::transaction & transaction, nano::block_hash const & hash, bool include_active, bool include_only_confirmed);
-const char * epoch_as_string (nano::epoch);
+char const * epoch_as_string (nano::epoch);
 }
 
 nano::json_handler::json_handler (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a, std::string const & body_a, std::function<void (std::string const &)> const & response_a, std::function<void ()> stop_callback_a) :
@@ -285,7 +285,7 @@ nano::amount nano::json_handler::amount_impl ()
 
 std::shared_ptr<nano::block> nano::json_handler::block_impl (bool signature_work_required)
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	std::shared_ptr<nano::block> result{ nullptr };
 	if (!ec)
 	{
@@ -459,7 +459,7 @@ namespace
 bool decode_unsigned (std::string const & text, uint64_t & number)
 {
 	bool result;
-	size_t end;
+	std::size_t end;
 	try
 	{
 		number = std::stoull (text, &end);
@@ -523,7 +523,7 @@ void nano::json_handler::account_balance ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+		bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
 		auto balance (node.balance_pending (account, include_only_confirmed));
 		response_l.put ("balance", balance.first.convert_to<std::string> ());
 		response_l.put ("pending", balance.second.convert_to<std::string> ());
@@ -552,7 +552,7 @@ void nano::json_handler::account_create ()
 		auto wallet (rpc_l->wallet_impl ());
 		if (!rpc_l->ec)
 		{
-			const bool generate_work = rpc_l->request.get<bool> ("work", true);
+			bool const generate_work = rpc_l->request.get<bool> ("work", true);
 			nano::account new_key;
 			auto index_text (rpc_l->request.get_optional<std::string> ("index"));
 			if (index_text.is_initialized ())
@@ -608,10 +608,10 @@ void nano::json_handler::account_info ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		const bool representative = request.get<bool> ("representative", false);
-		const bool weight = request.get<bool> ("weight", false);
-		const bool pending = request.get<bool> ("pending", false);
-		const bool include_confirmed = request.get<bool> ("include_confirmed", false);
+		bool const representative = request.get<bool> ("representative", false);
+		bool const weight = request.get<bool> ("weight", false);
+		bool const pending = request.get<bool> ("pending", false);
+		bool const include_confirmed = request.get<bool> ("include_confirmed", false);
 		auto transaction (node.store.tx_begin_read ());
 		auto info (account_info_impl (transaction, account));
 		nano::confirmation_height_info confirmation_height_info;
@@ -910,7 +910,7 @@ void nano::json_handler::accounts_create ()
 		auto count (rpc_l->count_impl ());
 		if (!rpc_l->ec)
 		{
-			const bool generate_work = rpc_l->request.get<bool> ("work", false);
+			bool const generate_work = rpc_l->request.get<bool> ("work", false);
 			boost::property_tree::ptree accounts;
 			for (auto i (0); accounts.size () < count; ++i)
 			{
@@ -952,10 +952,10 @@ void nano::json_handler::accounts_pending ()
 {
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	const bool source = request.get<bool> ("source", false);
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
-	const bool sorting = request.get<bool> ("sorting", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !sorting); // if simple, response is a list of hashes for each account
 	boost::property_tree::ptree pending;
 	auto transaction (node.store.tx_begin_read ());
@@ -1000,13 +1000,13 @@ void nano::json_handler::accounts_pending ()
 			{
 				if (source)
 				{
-					peers_l.sort ([] (const auto & child1, const auto & child2) -> bool {
+					peers_l.sort ([] (auto const & child1, auto const & child2) -> bool {
 						return child1.second.template get<nano::uint128_t> ("amount") > child2.second.template get<nano::uint128_t> ("amount");
 					});
 				}
 				else
 				{
-					peers_l.sort ([] (const auto & child1, const auto & child2) -> bool {
+					peers_l.sort ([] (auto const & child1, auto const & child2) -> bool {
 						return child1.second.template get<nano::uint128_t> ("") > child2.second.template get<nano::uint128_t> ("");
 					});
 				}
@@ -1162,7 +1162,7 @@ void nano::json_handler::block_confirm ()
 
 void nano::json_handler::blocks ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	boost::property_tree::ptree blocks;
 	auto transaction (node.store.tx_begin_read ());
 	for (boost::property_tree::ptree::value_type & hashes : request.get_child ("hashes"))
@@ -1206,10 +1206,10 @@ void nano::json_handler::blocks ()
 
 void nano::json_handler::blocks_info ()
 {
-	const bool pending = request.get<bool> ("pending", false);
-	const bool source = request.get<bool> ("source", false);
-	const bool json_block_l = request.get<bool> ("json_block", false);
-	const bool include_not_found = request.get<bool> ("include_not_found", false);
+	bool const pending = request.get<bool> ("pending", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
+	bool const include_not_found = request.get<bool> ("include_not_found", false);
 
 	boost::property_tree::ptree blocks;
 	boost::property_tree::ptree blocks_not_found;
@@ -1736,7 +1736,7 @@ void nano::json_handler::bootstrap ()
 
 void nano::json_handler::bootstrap_any ()
 {
-	const bool force = request.get<bool> ("force", false);
+	bool const force = request.get<bool> ("force", false);
 	if (!node.flags.disable_legacy_bootstrap)
 	{
 		nano::account start_account{};
@@ -1759,7 +1759,7 @@ void nano::json_handler::bootstrap_any ()
 void nano::json_handler::bootstrap_lazy ()
 {
 	auto hash (hash_impl ());
-	const bool force = request.get<bool> ("force", false);
+	bool const force = request.get<bool> ("force", false);
 	if (!ec)
 	{
 		if (!node.flags.disable_lazy_bootstrap)
@@ -1947,9 +1947,9 @@ void nano::json_handler::confirmation_history ()
 
 void nano::json_handler::confirmation_info ()
 {
-	const bool representatives = request.get<bool> ("representatives", false);
-	const bool contents = request.get<bool> ("contents", true);
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const representatives = request.get<bool> ("representatives", false);
+	bool const contents = request.get<bool> ("contents", true);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	std::string root_text (request.get<std::string> ("root"));
 	nano::qualified_root root;
 	if (!root.decode_hex (root_text))
@@ -2465,7 +2465,7 @@ public:
 void nano::json_handler::account_history ()
 {
 	std::vector<nano::public_key> accounts_to_filter;
-	const auto accounts_filter_node = request.get_child_optional ("account_filter");
+	auto const accounts_filter_node = request.get_child_optional ("account_filter");
 	if (accounts_filter_node.is_initialized ())
 	{
 		for (auto & a : (*accounts_filter_node))
@@ -2637,10 +2637,10 @@ void nano::json_handler::ledger ()
 				ec = nano::error_rpc::invalid_timestamp;
 			}
 		}
-		const bool sorting = request.get<bool> ("sorting", false);
-		const bool representative = request.get<bool> ("representative", false);
-		const bool weight = request.get<bool> ("weight", false);
-		const bool pending = request.get<bool> ("pending", false);
+		bool const sorting = request.get<bool> ("sorting", false);
+		bool const representative = request.get<bool> ("representative", false);
+		bool const weight = request.get<bool> ("weight", false);
+		bool const pending = request.get<bool> ("pending", false);
 		boost::property_tree::ptree accounts;
 		auto transaction (node.store.tx_begin_read ());
 		if (!ec && !sorting) // Simple
@@ -2883,9 +2883,9 @@ void nano::json_handler::password_valid (bool wallet_locked)
 void nano::json_handler::peers ()
 {
 	boost::property_tree::ptree peers_l;
-	const bool peer_details = request.get<bool> ("peer_details", false);
-	auto peers_list (node.network.list (std::numeric_limits<size_t>::max ()));
-	std::sort (peers_list.begin (), peers_list.end (), [] (const auto & lhs, const auto & rhs) {
+	bool const peer_details = request.get<bool> ("peer_details", false);
+	auto peers_list (node.network.list (std::numeric_limits<std::size_t>::max ()));
+	std::sort (peers_list.begin (), peers_list.end (), [] (auto const & lhs, auto const & rhs) {
 		return lhs->get_endpoint () < rhs->get_endpoint ();
 	});
 	for (auto i (peers_list.begin ()), n (peers_list.end ()); i != n; ++i)
@@ -2923,13 +2923,13 @@ void nano::json_handler::pending ()
 	auto account (account_impl ());
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	const bool source = request.get<bool> ("source", false);
-	const bool min_version = request.get<bool> ("min_version", false);
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
-	const bool sorting = request.get<bool> ("sorting", false);
+	bool const source = request.get<bool> ("source", false);
+	bool const min_version = request.get<bool> ("min_version", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !min_version && !sorting); // if simple, response is a list of hashes
-	const bool should_sort = sorting && !simple;
+	bool const should_sort = sorting && !simple;
 	if (!ec)
 	{
 		boost::property_tree::ptree peers_l;
@@ -2995,7 +2995,7 @@ void nano::json_handler::pending ()
 			if (source || min_version)
 			{
 				auto mid = hash_ptree_pairs.size () <= count ? hash_ptree_pairs.end () : hash_ptree_pairs.begin () + count;
-				std::partial_sort (hash_ptree_pairs.begin (), mid, hash_ptree_pairs.end (), [] (const auto & lhs, const auto & rhs) {
+				std::partial_sort (hash_ptree_pairs.begin (), mid, hash_ptree_pairs.end (), [] (auto const & lhs, auto const & rhs) {
 					return lhs.second.template get<nano::uint128_t> ("amount") > rhs.second.template get<nano::uint128_t> ("amount");
 				});
 				for (auto i = 0; i < hash_ptree_pairs.size () && i < count; ++i)
@@ -3006,7 +3006,7 @@ void nano::json_handler::pending ()
 			else
 			{
 				auto mid = hash_amount_pairs.size () <= count ? hash_amount_pairs.end () : hash_amount_pairs.begin () + count;
-				std::partial_sort (hash_amount_pairs.begin (), mid, hash_amount_pairs.end (), [] (const auto & lhs, const auto & rhs) {
+				std::partial_sort (hash_amount_pairs.begin (), mid, hash_amount_pairs.end (), [] (auto const & lhs, auto const & rhs) {
 					return lhs.second > rhs.second;
 				});
 
@@ -3024,8 +3024,8 @@ void nano::json_handler::pending ()
 void nano::json_handler::pending_exists ()
 {
 	auto hash (hash_impl ());
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
 	if (!ec)
 	{
 		auto transaction (node.store.tx_begin_read ());
@@ -3052,7 +3052,7 @@ void nano::json_handler::pending_exists ()
 void nano::json_handler::process ()
 {
 	node.workers.push_task (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
-		const bool is_async = rpc_l->request.get<bool> ("async", false);
+		bool const is_async = rpc_l->request.get<bool> ("async", false);
 		auto block (rpc_l->block_impl (true));
 
 		// State blocks subtype check
@@ -3184,7 +3184,7 @@ void nano::json_handler::process ()
 						}
 						case nano::process_result::fork:
 						{
-							const bool force = rpc_l->request.get<bool> ("force", false);
+							bool const force = rpc_l->request.get<bool> ("force", false);
 							if (force)
 							{
 								rpc_l->node.active.erase (*block);
@@ -3365,7 +3365,7 @@ void nano::json_handler::representatives ()
 	auto count (count_optional_impl ());
 	if (!ec)
 	{
-		const bool sorting = request.get<bool> ("sorting", false);
+		bool const sorting = request.get<bool> ("sorting", false);
 		boost::property_tree::ptree representatives;
 		auto rep_amounts = node.ledger.cache.rep_weights.get_rep_amounts ();
 		if (!sorting) // Simple
@@ -3407,8 +3407,8 @@ void nano::json_handler::representatives ()
 
 void nano::json_handler::representatives_online ()
 {
-	const auto accounts_node = request.get_child_optional ("accounts");
-	const bool weight = request.get<bool> ("weight", false);
+	auto const accounts_node = request.get_child_optional ("accounts");
+	bool const weight = request.get<bool> ("weight", false);
 	std::vector<nano::public_key> accounts_to_filter;
 	if (accounts_node.is_initialized ())
 	{
@@ -3675,7 +3675,7 @@ void nano::json_handler::send ()
 
 void nano::json_handler::sign ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	// Retrieving hash
 	nano::block_hash hash (0);
 	boost::optional<std::string> hash_text (request.get_optional<std::string> ("hash"));
@@ -3995,7 +3995,7 @@ void nano::json_handler::telemetry ()
 
 void nano::json_handler::unchecked ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto count (count_optional_impl ());
 	if (!ec)
 	{
@@ -4034,7 +4034,7 @@ void nano::json_handler::unchecked_clear ()
 
 void nano::json_handler::unchecked_get ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto hash (hash_impl ());
 	if (!ec)
 	{
@@ -4072,7 +4072,7 @@ void nano::json_handler::unchecked_get ()
 
 void nano::json_handler::unchecked_keys ()
 {
-	const bool json_block_l = request.get<bool> ("json_block", false);
+	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto count (count_optional_impl ());
 	nano::block_hash key (0);
 	boost::optional<std::string> hash_text (request.get_optional<std::string> ("key"));
@@ -4211,7 +4211,7 @@ void nano::json_handler::wallet_add ()
 			nano::raw_key key;
 			if (!key.decode_hex (key_text))
 			{
-				const bool generate_work = rpc_l->request.get<bool> ("work", true);
+				bool const generate_work = rpc_l->request.get<bool> ("work", true);
 				auto pub (wallet->insert_adhoc (key, generate_work));
 				if (!pub.is_zero ())
 				{
@@ -4574,9 +4574,9 @@ void nano::json_handler::wallet_key_valid ()
 
 void nano::json_handler::wallet_ledger ()
 {
-	const bool representative = request.get<bool> ("representative", false);
-	const bool weight = request.get<bool> ("weight", false);
-	const bool pending = request.get<bool> ("pending", false);
+	bool const representative = request.get<bool> ("representative", false);
+	bool const weight = request.get<bool> ("weight", false);
+	bool const pending = request.get<bool> ("pending", false);
 	uint64_t modified_since (0);
 	boost::optional<std::string> modified_since_text (request.get_optional<std::string> ("modified_since"));
 	if (modified_since_text.is_initialized ())
@@ -4648,10 +4648,10 @@ void nano::json_handler::wallet_pending ()
 	auto wallet (wallet_impl ());
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	const bool source = request.get<bool> ("source", false);
-	const bool min_version = request.get<bool> ("min_version", false);
-	const bool include_active = request.get<bool> ("include_active", false);
-	const bool include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	bool const source = request.get<bool> ("source", false);
+	bool const min_version = request.get<bool> ("min_version", false);
+	bool const include_active = request.get<bool> ("include_active", false);
+	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
 	if (!ec)
 	{
 		boost::property_tree::ptree pending;
@@ -5110,7 +5110,7 @@ void nano::inprocess_rpc_handler::process_request_v2 (rpc_handler_request_params
 {
 	std::string body_l = params_a.json_envelope (body_a);
 	auto handler (std::make_shared<nano::ipc::flatbuffers_handler> (node, ipc_server, nullptr, node.config.ipc_config));
-	handler->process_json (reinterpret_cast<const uint8_t *> (body_l.data ()), body_l.size (), response_a);
+	handler->process_json (reinterpret_cast<uint8_t const *> (body_l.data ()), body_l.size (), response_a);
 }
 
 namespace
@@ -5279,7 +5279,7 @@ bool block_confirmed (nano::node & node, nano::transaction & transaction, nano::
 	return is_confirmed;
 }
 
-const char * epoch_as_string (nano::epoch epoch)
+char const * epoch_as_string (nano::epoch epoch)
 {
 	switch (epoch)
 	{

--- a/nano/node/ledger_walker.cpp
+++ b/nano/node/ledger_walker.cpp
@@ -24,23 +24,23 @@ nano::ledger_walker::ledger_walker (nano::ledger const & ledger_a) :
 
 void nano::ledger_walker::walk_backward (nano::block_hash const & start_block_hash_a, should_visit_callback const & should_visit_callback_a, visitor_callback const & visitor_callback_a)
 {
-	const auto transaction = ledger.store.tx_begin_read ();
+	auto const transaction = ledger.store.tx_begin_read ();
 
 	enqueue_block (start_block_hash_a);
 	while (!blocks_to_walk.empty ())
 	{
-		const auto block = dequeue_block (transaction);
+		auto const block = dequeue_block (transaction);
 		if (!should_visit_callback_a (block))
 		{
 			continue;
 		}
 
 		visitor_callback_a (block);
-		for (const auto & hash : ledger.dependent_blocks (transaction, *block))
+		for (auto const & hash : ledger.dependent_blocks (transaction, *block))
 		{
 			if (!hash.is_zero ())
 			{
-				const auto dependent_block = ledger.store.block.get (transaction, hash);
+				auto const dependent_block = ledger.store.block.get (transaction, hash);
 				if (dependent_block)
 				{
 					enqueue_block (dependent_block);
@@ -59,21 +59,21 @@ void nano::ledger_walker::walk (nano::block_hash const & end_block_hash_a, shoul
 
 	walk_backward (end_block_hash_a,
 	should_visit_callback_a,
-	[&] (const auto & block) {
+	[&] (auto const & block) {
 		walked_blocks_order.insert (std::to_string (++last_walked_block_order_index).c_str (), block->hash ());
 	});
 
-	const auto transaction = ledger.store.tx_begin_read ();
+	auto const transaction = ledger.store.tx_begin_read ();
 	for (auto walked_block_order_index = last_walked_block_order_index; walked_block_order_index != 0; --walked_block_order_index)
 	{
-		const auto * block_hash = walked_blocks_order.lookup (std::to_string (walked_block_order_index).c_str ());
+		auto const * block_hash = walked_blocks_order.lookup (std::to_string (walked_block_order_index).c_str ());
 		if (!block_hash)
 		{
 			debug_assert (false);
 			continue;
 		}
 
-		const auto block = ledger.store.block.get (transaction, *block_hash);
+		auto const block = ledger.store.block.get (transaction, *block_hash);
 		if (!block)
 		{
 			debug_assert (false);
@@ -88,7 +88,7 @@ void nano::ledger_walker::walk_backward (nano::block_hash const & start_block_ha
 {
 	walk_backward (
 	start_block_hash_a,
-	[&] (const auto & /* block */) {
+	[&] (auto const & /* block */) {
 		return true;
 	},
 	visitor_callback_a);
@@ -98,7 +98,7 @@ void nano::ledger_walker::walk (nano::block_hash const & end_block_hash_a, visit
 {
 	walk (
 	end_block_hash_a,
-	[&] (const auto & /* block */) {
+	[&] (auto const & /* block */) {
 		return true;
 	},
 	visitor_callback_a);
@@ -132,7 +132,7 @@ bool nano::ledger_walker::add_to_walked_blocks (nano::block_hash const & block_h
 		debug_assert (!walked_blocks_disk.has_value ());
 		walked_blocks_disk.emplace (nano::unique_path ().c_str (), sizeof (nano::block_hash::bytes) + 1, dht::DHOpenRW);
 
-		for (const auto & walked_block_hash : walked_blocks)
+		for (auto const & walked_block_hash : walked_blocks)
 		{
 			if (!add_to_walked_blocks_disk (walked_block_hash))
 			{

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -22,13 +22,13 @@ void * mdb_val::data () const
 }
 
 template <>
-size_t mdb_val::size () const
+std::size_t mdb_val::size () const
 {
 	return value.mv_size;
 }
 
 template <>
-mdb_val::db_val (size_t size_a, void * data_a) :
+mdb_val::db_val (std::size_t size_a, void * data_a) :
 	value ({ size_a, data_a })
 {
 }
@@ -199,10 +199,10 @@ nano::mdb_txn_callbacks nano::mdb_store::create_txn_callbacks () const
 	nano::mdb_txn_callbacks mdb_txn_callbacks;
 	if (txn_tracking_enabled)
 	{
-		mdb_txn_callbacks.txn_start = ([&mdb_txn_tracker = mdb_txn_tracker] (const nano::transaction_impl * transaction_impl) {
+		mdb_txn_callbacks.txn_start = ([&mdb_txn_tracker = mdb_txn_tracker] (nano::transaction_impl const * transaction_impl) {
 			mdb_txn_tracker.add (transaction_impl);
 		});
-		mdb_txn_callbacks.txn_end = ([&mdb_txn_tracker = mdb_txn_tracker] (const nano::transaction_impl * transaction_impl) {
+		mdb_txn_callbacks.txn_end = ([&mdb_txn_tracker = mdb_txn_tracker] (nano::transaction_impl const * transaction_impl) {
 			mdb_txn_tracker.erase (transaction_impl);
 		});
 	}
@@ -838,7 +838,7 @@ int nano::mdb_store::get (nano::transaction const & transaction_a, tables table_
 	return mdb_get (env.tx (transaction_a), table_to_dbi (table_a), key_a, value_a);
 }
 
-int nano::mdb_store::put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, const nano::mdb_val & value_a) const
+int nano::mdb_store::put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, nano::mdb_val const & value_a) const
 {
 	return (mdb_put (env.tx (transaction_a), table_to_dbi (table_a), key_a, value_a, 0));
 }
@@ -1077,7 +1077,7 @@ nano::uint128_t nano::mdb_store::block_balance_v18 (nano::transaction const & tr
 }
 
 // All the v14 functions below are only needed during upgrades
-size_t nano::mdb_store::block_successor_offset_v14 (nano::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const
+std::size_t nano::mdb_store::block_successor_offset_v14 (nano::transaction const & transaction_a, std::size_t entry_size_a, nano::block_type type_a) const
 {
 	return entry_size_a - nano::block_sideband_v14::size (type_a);
 }

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -231,7 +231,7 @@ public:
 	bool exists (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 
 	int get (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, nano::mdb_val & value_a) const;
-	int put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, const nano::mdb_val & value_a) const;
+	int put (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, nano::mdb_val const & value_a) const;
 	int del (nano::write_transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 
 	bool copy_db (boost::filesystem::path const & destination_file) override;
@@ -256,7 +256,7 @@ public:
 
 	// These are only use in the upgrade process.
 	std::shared_ptr<nano::block> block_get_v14 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_sideband_v14 * sideband_a = nullptr, bool * is_state_v1 = nullptr) const;
-	size_t block_successor_offset_v14 (nano::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
+	std::size_t block_successor_offset_v14 (nano::transaction const & transaction_a, std::size_t entry_size_a, nano::block_type type_a) const;
 	nano::block_hash block_successor_v14 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 	nano::mdb_val block_raw_get_v14 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_type & type_a, bool * is_state_v1 = nullptr) const;
 	boost::optional<nano::mdb_val> block_raw_get_by_type_v14 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_type & type_a, bool * is_state_v1) const;
@@ -311,9 +311,9 @@ private:
 template <>
 void * mdb_val::data () const;
 template <>
-size_t mdb_val::size () const;
+std::size_t mdb_val::size () const;
 template <>
-mdb_val::db_val (size_t size_a, void * data_a);
+mdb_val::db_val (std::size_t size_a, void * data_a);
 template <>
 void mdb_val::convert_buffer_to_value ();
 

--- a/nano/node/lmdb/lmdb_env.hpp
+++ b/nano/node/lmdb/lmdb_env.hpp
@@ -36,7 +36,7 @@ public:
 		}
 
 		/** Used by the wallet to override the config map size */
-		options & override_config_map_size (size_t map_size_a)
+		options & override_config_map_size (std::size_t map_size_a)
 		{
 			config.map_size = map_size_a;
 			return *this;

--- a/nano/node/lmdb/lmdb_txn.cpp
+++ b/nano/node/lmdb/lmdb_txn.cpp
@@ -34,7 +34,7 @@ namespace
 class matches_txn final
 {
 public:
-	explicit matches_txn (const nano::transaction_impl * transaction_impl_a) :
+	explicit matches_txn (nano::transaction_impl const * transaction_impl_a) :
 		transaction_impl (transaction_impl_a)
 	{
 	}
@@ -45,7 +45,7 @@ public:
 	}
 
 private:
-	const nano::transaction_impl * transaction_impl;
+	nano::transaction_impl const * transaction_impl;
 };
 }
 
@@ -149,12 +149,12 @@ void nano::mdb_txn_tracker::serialize_json (boost::property_tree::ptree & json, 
 	// Get the time difference now as creating stacktraces (Debug/Windows for instance) can take a while so results won't be as accurate
 	std::vector<std::chrono::milliseconds> times_since_start;
 	times_since_start.reserve (copy_stats.size ());
-	std::transform (copy_stats.cbegin (), copy_stats.cend (), std::back_inserter (times_since_start), [] (const auto & stat) {
+	std::transform (copy_stats.cbegin (), copy_stats.cend (), std::back_inserter (times_since_start), [] (auto const & stat) {
 		return stat.timer.since_start ();
 	});
 	debug_assert (times_since_start.size () == copy_stats.size ());
 
-	for (size_t i = 0; i < times_since_start.size (); ++i)
+	for (std::size_t i = 0; i < times_since_start.size (); ++i)
 	{
 		auto const & stat = copy_stats[i];
 		auto time_held_open = times_since_start[i];
@@ -207,7 +207,7 @@ void nano::mdb_txn_tracker::log_if_held_long_enough (nano::mdb_txn_stats const &
 	}
 }
 
-void nano::mdb_txn_tracker::add (const nano::transaction_impl * transaction_impl)
+void nano::mdb_txn_tracker::add (nano::transaction_impl const * transaction_impl)
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	debug_assert (std::find_if (stats.cbegin (), stats.cend (), matches_txn (transaction_impl)) == stats.cend ());
@@ -215,7 +215,7 @@ void nano::mdb_txn_tracker::add (const nano::transaction_impl * transaction_impl
 }
 
 /** Can be called without error if transaction does not exist */
-void nano::mdb_txn_tracker::erase (const nano::transaction_impl * transaction_impl)
+void nano::mdb_txn_tracker::erase (nano::transaction_impl const * transaction_impl)
 {
 	nano::unique_lock<nano::mutex> lk (mutex);
 	auto it = std::find_if (stats.begin (), stats.end (), matches_txn (transaction_impl));
@@ -228,7 +228,7 @@ void nano::mdb_txn_tracker::erase (const nano::transaction_impl * transaction_im
 	}
 }
 
-nano::mdb_txn_stats::mdb_txn_stats (const nano::transaction_impl * transaction_impl) :
+nano::mdb_txn_stats::mdb_txn_stats (nano::transaction_impl const * transaction_impl) :
 	transaction_impl (transaction_impl),
 	thread_name (nano::thread_role::get_string ()),
 	stacktrace (std::make_shared<boost::stacktrace::stacktrace> ())
@@ -238,5 +238,5 @@ nano::mdb_txn_stats::mdb_txn_stats (const nano::transaction_impl * transaction_i
 
 bool nano::mdb_txn_stats::is_write () const
 {
-	return (dynamic_cast<const nano::write_transaction_impl *> (transaction_impl) != nullptr);
+	return (dynamic_cast<nano::write_transaction_impl const *> (transaction_impl) != nullptr);
 }

--- a/nano/node/lmdb/lmdb_txn.hpp
+++ b/nano/node/lmdb/lmdb_txn.hpp
@@ -20,8 +20,8 @@ class mdb_env;
 class mdb_txn_callbacks
 {
 public:
-	std::function<void (const nano::transaction_impl *)> txn_start{ [] (const nano::transaction_impl *) {} };
-	std::function<void (const nano::transaction_impl *)> txn_end{ [] (const nano::transaction_impl *) {} };
+	std::function<void (nano::transaction_impl const *)> txn_start{ [] (nano::transaction_impl const *) {} };
+	std::function<void (nano::transaction_impl const *)> txn_end{ [] (nano::transaction_impl const *) {} };
 };
 
 class read_mdb_txn final : public read_transaction_impl
@@ -54,10 +54,10 @@ public:
 class mdb_txn_stats
 {
 public:
-	mdb_txn_stats (const nano::transaction_impl * transaction_impl_a);
+	mdb_txn_stats (nano::transaction_impl const * transaction_impl_a);
 	bool is_write () const;
 	nano::timer<std::chrono::milliseconds> timer;
-	const nano::transaction_impl * transaction_impl;
+	nano::transaction_impl const * transaction_impl;
 	std::string thread_name;
 
 	// Smart pointer so that we don't need the full definition which causes min/max issues on Windows
@@ -69,8 +69,8 @@ class mdb_txn_tracker
 public:
 	mdb_txn_tracker (nano::logger_mt & logger_a, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a);
 	void serialize_json (boost::property_tree::ptree & json, std::chrono::milliseconds min_read_time, std::chrono::milliseconds min_write_time);
-	void add (const nano::transaction_impl * transaction_impl);
-	void erase (const nano::transaction_impl * transaction_impl);
+	void add (nano::transaction_impl const * transaction_impl);
+	void erase (nano::transaction_impl const * transaction_impl);
 
 private:
 	nano::mutex mutex;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -21,7 +21,7 @@ class message_buffer final
 {
 public:
 	uint8_t * buffer{ nullptr };
-	size_t size{ 0 };
+	std::size_t size{ 0 };
 	nano::endpoint endpoint;
 };
 /**
@@ -38,7 +38,7 @@ public:
 	// Stats - Statistics
 	// Size - Size of each individual buffer
 	// Count - Number of buffers to allocate
-	message_buffer_manager (nano::stat & stats, size_t, size_t);
+	message_buffer_manager (nano::stat & stats, std::size_t, std::size_t);
 	// Return a buffer where message data can be put
 	// Method will attempt to return the first free buffer
 	// If there are no free buffers, an unserviced buffer will be dequeued and returned
@@ -92,7 +92,7 @@ private:
 class syn_cookies final
 {
 public:
-	syn_cookies (size_t);
+	syn_cookies (std::size_t);
 	void purge (std::chrono::steady_clock::time_point const &);
 	// Returns boost::none if the IP is rate capped on syn cookie requests,
 	// or if the endpoint already has a syn cookie query
@@ -101,7 +101,7 @@ public:
 	// Also removes the syn cookie from the store if valid
 	bool validate (nano::endpoint const &, nano::account const &, nano::signature const &);
 	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
-	size_t cookies_size ();
+	std::size_t cookies_size ();
 
 private:
 	class syn_cookie_info final
@@ -113,7 +113,7 @@ private:
 	mutable nano::mutex syn_cookie_mutex;
 	std::unordered_map<nano::endpoint, syn_cookie_info> cookies;
 	std::unordered_map<boost::asio::ip::address, unsigned> cookies_per_ip;
-	size_t max_cookies_per_ip;
+	std::size_t max_cookies_per_ip;
 };
 class network final
 {
@@ -148,14 +148,14 @@ public:
 	bool not_a_peer (nano::endpoint const &, bool);
 	// Should we reach out to this endpoint with a keepalive message
 	bool reachout (nano::endpoint const &, bool = false);
-	std::deque<std::shared_ptr<nano::transport::channel>> list (size_t, uint8_t = 0, bool = true);
-	std::deque<std::shared_ptr<nano::transport::channel>> list_non_pr (size_t);
+	std::deque<std::shared_ptr<nano::transport::channel>> list (std::size_t, uint8_t = 0, bool = true);
+	std::deque<std::shared_ptr<nano::transport::channel>> list_non_pr (std::size_t);
 	// Desired fanout for a given scale
-	size_t fanout (float scale = 1.0f) const;
+	std::size_t fanout (float scale = 1.0f) const;
 	void random_fill (std::array<nano::endpoint, 8> &) const;
 	void fill_keepalive_self (std::array<nano::endpoint, 8> &) const;
 	// Note: The minimum protocol version is used after the random selection, so number of peers can be less than expected.
-	std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (size_t, uint8_t = 0, bool = false) const;
+	std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (std::size_t, uint8_t = 0, bool = false) const;
 	// Get the next peer for attempting a tcp bootstrap connection
 	nano::tcp_endpoint bootstrap_peer (bool = false);
 	nano::endpoint endpoint ();
@@ -165,11 +165,11 @@ public:
 	nano::syn_cookies syn_cookies;
 	void ongoing_syn_cookie_cleanup ();
 	void ongoing_keepalive ();
-	size_t size () const;
+	std::size_t size () const;
 	float size_sqrt () const;
 	bool empty () const;
 	void erase (nano::transport::channel const &);
-	void set_bandwidth_params (double, size_t);
+	void set_bandwidth_params (double, std::size_t);
 
 private:
 	void process_message (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
@@ -192,9 +192,9 @@ public:
 	std::function<void (std::shared_ptr<nano::transport::channel>)> channel_observer;
 	std::atomic<bool> stopped{ false };
 	static unsigned const broadcast_interval_ms = 10;
-	static size_t const buffer_size = 512;
-	static size_t const confirm_req_hashes_max = 7;
-	static size_t const confirm_ack_hashes_max = 12;
+	static std::size_t const buffer_size = 512;
+	static std::size_t const confirm_req_hashes_max = 7;
+	static std::size_t const confirm_ack_hashes_max = 12;
 };
 std::unique_ptr<container_info_component> collect_container_info (network & network, std::string const & name);
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (re
 		count = rep_crawler.active.size ();
 	}
 
-	auto sizeof_element = sizeof (decltype (rep_crawler.active)::value_type);
+	const auto sizeof_element = sizeof (decltype (rep_crawler.active)::value_type);
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "active", count, sizeof_element }));
 	return composite;
@@ -318,7 +318,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 		logger.always_log ("Build information: ", BUILD_INFO);
 		logger.always_log ("Database backend: ", store.vendor_get ());
 
-		auto network_label = network_params.network.get_current_network_as_string ();
+		const auto network_label = network_params.network.get_current_network_as_string ();
 		logger.always_log ("Active network: ", network_label);
 
 		logger.always_log (boost::str (boost::format ("Work pool running %1% threads %2%") % work.threads.size () % (work.opencl ? "(1 for OpenCL)" : "")));
@@ -338,13 +338,13 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 		// First do a pass with a read to see if any writing needs doing, this saves needing to open a write lock (and potentially blocking)
 		auto is_initialized (false);
 		{
-			auto transaction (store.tx_begin_read ());
+			auto const transaction (store.tx_begin_read ());
 			is_initialized = (store.account.begin (transaction) != store.account.end ());
 		}
 
 		if (!is_initialized && !flags.read_only)
 		{
-			auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers }));
+			const auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::confirmation_height, tables::frontiers }));
 			// Store was empty meaning we just created it, add the genesis block
 			store.initialize (transaction, ledger.cache);
 		}
@@ -358,7 +358,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 			{
 				ss << " Beta network may have reset, try clearing database files";
 			}
-			auto str = ss.str ();
+			const auto str = ss.str ();
 
 			logger.always_log (str);
 			std::cerr << str << std::endl;
@@ -386,9 +386,9 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 
 		if ((network_params.network.is_live_network () || network_params.network.is_beta_network ()) && !flags.inactive_node)
 		{
-			auto bootstrap_weights = get_bootstrap_weights ();
+			const auto bootstrap_weights = get_bootstrap_weights ();
 			// Use bootstrap weights if initial bootstrap is not completed
-			bool use_bootstrap_weight = ledger.cache.block_count < bootstrap_weights.first;
+			const bool use_bootstrap_weight = ledger.cache.block_count < bootstrap_weights.first;
 			if (use_bootstrap_weight)
 			{
 				ledger.bootstrap_weights = bootstrap_weights.second;
@@ -402,7 +402,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 			// Drop unchecked blocks if initial bootstrap is completed
 			if (!flags.disable_unchecked_drop && !use_bootstrap_weight && !flags.read_only)
 			{
-				auto transaction (store.tx_begin_write ({ tables::unchecked }));
+				auto const transaction (store.tx_begin_write ({ tables::unchecked }));
 				store.unchecked.clear (transaction);
 				logger.always_log ("Dropping unchecked blocks");
 			}
@@ -556,7 +556,7 @@ void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 
 nano::process_return nano::node::process (nano::block & block_a)
 {
-	auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
+	const auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
 	auto result (ledger.process (transaction, block_a));
 	return result;
 }
@@ -571,7 +571,7 @@ nano::process_return nano::node::process_local (std::shared_ptr<nano::block> con
 	block_processor.wait_write ();
 	// Process block
 	block_post_events post_events ([&store = store] { return store.tx_begin_read (); });
-	auto transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
+	auto const transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
 	return block_processor.process_one (transaction, post_events, info, false, nano::block_origin::local);
 }
 
@@ -695,26 +695,26 @@ void nano::node::keepalive_preconfigured (std::vector<std::string> const & peers
 
 nano::block_hash nano::node::latest (nano::account const & account_a)
 {
-	auto transaction (store.tx_begin_read ());
+	const auto transaction (store.tx_begin_read ());
 	return ledger.latest (transaction, account_a);
 }
 
 nano::uint128_t nano::node::balance (nano::account const & account_a)
 {
-	auto transaction (store.tx_begin_read ());
+	const auto transaction (store.tx_begin_read ());
 	return ledger.account_balance (transaction, account_a);
 }
 
 std::shared_ptr<nano::block> nano::node::block (nano::block_hash const & hash_a)
 {
-	auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	return store.block.get (transaction, hash_a);
 }
 
 std::pair<nano::uint128_t, nano::uint128_t> nano::node::balance_pending (nano::account const & account_a, bool only_confirmed_a)
 {
 	std::pair<nano::uint128_t, nano::uint128_t> result;
-	auto transaction (store.tx_begin_read ());
+	const auto transaction (store.tx_begin_read ());
 	result.first = ledger.account_balance (transaction, account_a, only_confirmed_a);
 	result.second = ledger.account_pending (transaction, account_a, only_confirmed_a);
 	return result;
@@ -727,7 +727,7 @@ nano::uint128_t nano::node::weight (nano::account const & account_a)
 
 nano::block_hash nano::node::rep_block (nano::account const & account_a)
 {
-	auto transaction (store.tx_begin_read ());
+	const auto transaction (store.tx_begin_read ());
 	nano::account_info info;
 	nano::block_hash result (0);
 	if (!store.account.get (transaction, account_a, info))
@@ -750,7 +750,7 @@ nano::uint128_t nano::node::minimum_principal_weight (nano::uint128_t const & on
 void nano::node::long_inactivity_cleanup ()
 {
 	bool perform_cleanup = false;
-	auto transaction (store.tx_begin_write ({ tables::online_weight, tables::peers }));
+	auto const transaction (store.tx_begin_write ({ tables::online_weight, tables::peers }));
 	if (store.online_weight.count (transaction) > 0)
 	{
 		auto sample (store.online_weight.rbegin (transaction));
@@ -842,7 +842,7 @@ void nano::node::ongoing_bootstrap ()
 
 void nano::node::ongoing_peer_store ()
 {
-	bool stored (network.tcp_channels.store_all (true));
+	const bool stored (network.tcp_channels.store_all (true));
 	network.udp_channels.store_all (!stored);
 	std::weak_ptr<nano::node> node_w (shared_from_this ());
 	workers.add_timed_task (std::chrono::steady_clock::now () + network_params.network.peer_dump_interval, [node_w] () {
@@ -888,7 +888,7 @@ void nano::node::bootstrap_wallet ()
 	std::deque<nano::account> accounts;
 	{
 		nano::lock_guard<nano::mutex> lock (wallets.mutex);
-		auto transaction (wallets.tx_begin_read ());
+		const auto transaction (wallets.tx_begin_read ());
 		for (auto i (wallets.items.begin ()), n (wallets.items.end ()); i != n && accounts.size () < 128; ++i)
 		{
 			auto & wallet (*i->second);
@@ -910,13 +910,13 @@ void nano::node::unchecked_cleanup ()
 {
 	std::vector<nano::uint128_t> digests;
 	std::deque<nano::unchecked_key> cleaning_list;
-	auto attempt (bootstrap_initiator.current_attempt ());
-	bool long_attempt (attempt != nullptr && std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - attempt->attempt_start).count () > config.unchecked_cutoff_time.count ());
+	const auto attempt (bootstrap_initiator.current_attempt ());
+	const bool long_attempt (attempt != nullptr && std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - attempt->attempt_start).count () > config.unchecked_cutoff_time.count ());
 	// Collect old unchecked keys
 	if (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks && !long_attempt)
 	{
-		auto now (nano::seconds_since_epoch ());
-		auto transaction (store.tx_begin_read ());
+		const auto now (nano::seconds_since_epoch ());
+		const auto transaction (store.tx_begin_read ());
 		// Max 1M records to clean, max 2 minutes reading to prevent slow i/o systems issues
 		for (auto i (store.unchecked.begin (transaction)), n (store.unchecked.end ()); i != n && cleaning_list.size () < 1024 * 1024 && nano::seconds_since_epoch () - now < 120; ++i)
 		{
@@ -937,7 +937,7 @@ void nano::node::unchecked_cleanup ()
 	while (!cleaning_list.empty ())
 	{
 		std::size_t deleted_count (0);
-		auto transaction (store.tx_begin_write ({ tables::unchecked }));
+		auto const transaction (store.tx_begin_write ({ tables::unchecked }));
 		while (deleted_count++ < 2 * 1024 && !cleaning_list.empty ())
 		{
 			auto key (cleaning_list.front ());
@@ -973,7 +973,7 @@ bool nano::node::collect_ledger_pruning_targets (std::deque<nano::block_hash> & 
 {
 	uint64_t read_operations (0);
 	bool finish_transaction (false);
-	auto transaction (store.tx_begin_read ());
+	auto const transaction (store.tx_begin_read ());
 	for (auto i (store.confirmation_height.begin (transaction, last_account_a)), n (store.confirmation_height.end ()); i != n && !finish_transaction;)
 	{
 		++read_operations;
@@ -1043,7 +1043,7 @@ void nano::node::ledger_pruning (uint64_t const batch_size_a, bool bootstrap_wei
 		if (!pruning_targets.empty () && !stopped)
 		{
 			auto scoped_write_guard = write_database_queue.wait (nano::writer::pruning);
-			auto write_transaction (store.tx_begin_write ({ tables::blocks, tables::pruned }));
+			const auto write_transaction (store.tx_begin_write ({ tables::blocks, tables::pruned }));
 			while (!pruning_targets.empty () && transaction_write_count < batch_size_a && !stopped)
 			{
 				auto const & pruning_hash (pruning_targets.front ());
@@ -1063,7 +1063,7 @@ void nano::node::ledger_pruning (uint64_t const batch_size_a, bool bootstrap_wei
 			}
 		}
 	}
-	auto log_message (boost::str (boost::format ("Total recently pruned block count: %1%") % pruned_count));
+	const auto log_message (boost::str (boost::format ("Total recently pruned block count: %1%") % pruned_count));
 	if (!log_to_cout_a)
 	{
 		logger.always_log (log_message);
@@ -1078,7 +1078,7 @@ void nano::node::ongoing_ledger_pruning ()
 {
 	auto bootstrap_weight_reached (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks);
 	ledger_pruning (flags.block_processor_batch_size != 0 ? flags.block_processor_batch_size : 2 * 1024, bootstrap_weight_reached, false);
-	auto ledger_pruning_interval (bootstrap_weight_reached ? config.max_pruning_age : std::min (config.max_pruning_age, std::chrono::seconds (15 * 60)));
+	const auto ledger_pruning_interval (bootstrap_weight_reached ? config.max_pruning_age : std::min (config.max_pruning_age, std::chrono::seconds (15 * 60)));
 	auto this_l (shared ());
 	workers.add_timed_task (std::chrono::steady_clock::now () + ledger_pruning_interval, [this_l] () {
 		this_l->workers.push_task ([this_l] () {

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -74,7 +74,7 @@ public:
 	arrival;
 	// clang-format on
 	nano::mutex mutex{ mutex_identifier (mutexes::block_arrival) };
-	static size_t constexpr arrival_size_min = 8 * 1024;
+	static std::size_t constexpr arrival_size_min = 8 * 1024;
 	static std::chrono::seconds constexpr arrival_time_min = std::chrono::seconds (300);
 };
 
@@ -148,7 +148,7 @@ public:
 	bool online () const;
 	bool init_error () const;
 	bool epoch_upgrader (nano::raw_key const &, nano::epoch, uint64_t, uint64_t);
-	void set_bandwidth_params (size_t limit, double ratio);
+	void set_bandwidth_params (std::size_t limit, double ratio);
 	std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> get_bootstrap_weights () const;
 	void populate_backlog ();
 	nano::write_database_queue write_database_queue;
@@ -192,7 +192,7 @@ public:
 	nano::election_scheduler scheduler;
 	nano::request_aggregator aggregator;
 	nano::wallets wallets;
-	const std::chrono::steady_clock::time_point startup_time;
+    std::chrono::steady_clock::time_point const startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> unresponsive_work_peers{ false };
 	std::atomic<bool> stopped{ false };

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -192,7 +192,7 @@ public:
 	nano::election_scheduler scheduler;
 	nano::request_aggregator aggregator;
 	nano::wallets wallets;
-    std::chrono::steady_clock::time_point const startup_time;
+	std::chrono::steady_clock::time_point const startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> unresponsive_work_peers{ false };
 	std::atomic<bool> stopped{ false };

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -12,12 +12,12 @@
 
 namespace
 {
-const char * preconfigured_peers_key = "preconfigured_peers";
-const char * signature_checker_threads_key = "signature_checker_threads";
-const char * pow_sleep_interval_key = "pow_sleep_interval";
-const char * default_beta_peer_network = "peering-beta.nano.org";
-const char * default_live_peer_network = "peering.nano.org";
-const std::string default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
+char const * preconfigured_peers_key = "preconfigured_peers";
+char const * signature_checker_threads_key = "signature_checker_threads";
+char const * pow_sleep_interval_key = "pow_sleep_interval";
+char const * default_beta_peer_network = "peering-beta.nano.org";
+char const * default_live_peer_network = "peering.nano.org";
+std::string const default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 
 nano::node_config::node_config (nano::network_params & network_params) :
@@ -341,9 +341,9 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get (pow_sleep_interval_key, pow_sleep_interval_l);
 		pow_sleep_interval = std::chrono::nanoseconds (pow_sleep_interval_l);
 		toml.get<bool> ("use_memory_pools", use_memory_pools);
-		toml.get<size_t> ("confirmation_history_size", confirmation_history_size);
-		toml.get<size_t> ("active_elections_size", active_elections_size);
-		toml.get<size_t> ("bandwidth_limit", bandwidth_limit);
+		toml.get<std::size_t> ("confirmation_history_size", confirmation_history_size);
+		toml.get<std::size_t> ("active_elections_size", active_elections_size);
+		toml.get<std::size_t> ("bandwidth_limit", bandwidth_limit);
 		toml.get<double> ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio);
 		toml.get<bool> ("backup_before_upgrade", backup_before_upgrade);
 
@@ -395,7 +395,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ("active_elections_size must be greater than 250");
 		}
-		if (bandwidth_limit > std::numeric_limits<size_t>::max ())
+		if (bandwidth_limit > std::numeric_limits<std::size_t>::max ())
 		{
 			toml.get_error ().set ("bandwidth_limit unbounded = 0, default = 10485760, max = 18446744073709551615");
 		}
@@ -674,9 +674,9 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		json.get (pow_sleep_interval_key, pow_sleep_interval_l);
 		pow_sleep_interval = std::chrono::nanoseconds (pow_sleep_interval_l);
 		json.get<bool> ("use_memory_pools", use_memory_pools);
-		json.get<size_t> ("confirmation_history_size", confirmation_history_size);
-		json.get<size_t> ("active_elections_size", active_elections_size);
-		json.get<size_t> ("bandwidth_limit", bandwidth_limit);
+		json.get<std::size_t> ("confirmation_history_size", confirmation_history_size);
+		json.get<std::size_t> ("active_elections_size", active_elections_size);
+		json.get<std::size_t> ("bandwidth_limit", bandwidth_limit);
 		json.get<bool> ("backup_before_upgrade", backup_before_upgrade);
 
 		auto conf_height_processor_batch_min_time_l (conf_height_processor_batch_min_time.count ());
@@ -696,7 +696,7 @@ nano::error nano::node_config::deserialize_json (bool & upgraded_a, nano::jsonco
 		{
 			json.get_error ().set ("active_elections_size must be greater than 250");
 		}
-		if (bandwidth_limit > std::numeric_limits<size_t>::max ())
+		if (bandwidth_limit > std::numeric_limits<std::size_t>::max ())
 		{
 			json.get_error ().set ("bandwidth_limit unbounded = 0, default = 10485760, max = 18446744073709551615");
 		}
@@ -767,7 +767,7 @@ void nano::node_config::deserialize_address (std::string const & entry_a, std::v
 nano::account nano::node_config::random_representative () const
 {
 	debug_assert (!preconfigured_representatives.empty ());
-	size_t index (nano::random_pool::generate_word32 (0, static_cast<CryptoPP::word32> (preconfigured_representatives.size () - 1)));
+	std::size_t index (nano::random_pool::generate_word32 (0, static_cast<CryptoPP::word32> (preconfigured_representatives.size () - 1)));
 	auto result (preconfigured_representatives[index]);
 	return result;
 }

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -69,7 +69,7 @@ public:
 	uint32_t bootstrap_frontier_request_count{ 1024 * 1024 };
 	nano::websocket::config websocket_config;
 	nano::diagnostics_config diagnostics_config;
-	size_t confirmation_history_size{ 2048 };
+	std::size_t confirmation_history_size{ 2048 };
 	std::string callback_address;
 	uint16_t callback_port{ 0 };
 	std::string callback_target;
@@ -83,7 +83,7 @@ public:
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_dev_network () && !is_sanitizer_build) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
-	size_t active_elections_size{ 5000 };
+	std::size_t active_elections_size{ 5000 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
 	unsigned tcp_incoming_connections_max{ 2048 };
 	bool use_memory_pools{ true };
@@ -91,7 +91,7 @@ public:
 	static std::chrono::seconds constexpr keepalive_cutoff = keepalive_period * 5;
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
 	/** Default outbound traffic shaping is 10MB/s */
-	size_t bandwidth_limit{ 10 * 1024 * 1024 };
+	std::size_t bandwidth_limit{ 10 * 1024 * 1024 };
 	/** By default, allow bursts of 15MB/s (not sustainable) */
 	double bandwidth_limit_burst_ratio{ 3. };
 	std::chrono::milliseconds conf_height_processor_batch_min_time{ 50 };
@@ -152,11 +152,11 @@ public:
 	nano::confirmation_height_mode confirmation_height_processor_mode{ nano::confirmation_height_mode::automatic };
 	nano::generate_cache generate_cache;
 	bool inactive_node{ false };
-	size_t block_processor_batch_size{ 0 };
-	size_t block_processor_full_size{ 65536 };
-	size_t block_processor_verification_size{ 0 };
-	size_t inactive_votes_cache_size{ 16 * 1024 };
-	size_t vote_processor_capacity{ 144 * 1024 };
-	size_t bootstrap_interval{ 0 }; // For testing only
+	std::size_t block_processor_batch_size{ 0 };
+	std::size_t block_processor_full_size{ 65536 };
+	std::size_t block_processor_verification_size{ 0 };
+	std::size_t inactive_votes_cache_size{ 16 * 1024 };
+	std::size_t vote_processor_capacity{ 144 * 1024 };
+	std::size_t bootstrap_interval{ 0 }; // For testing only
 };
 }

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -118,7 +118,7 @@ void nano::online_reps::clear ()
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (online_reps & online_reps, std::string const & name)
 {
-	size_t count;
+	std::size_t count;
 	{
 		nano::lock_guard<nano::mutex> guard (online_reps.mutex);
 		count = online_reps.reps.size ();

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -161,7 +161,7 @@ void nano::opencl_environment::dump (std::ostream & stream)
 	if (nano::opencl_loaded)
 	{
 		auto index (0);
-		size_t device_count (0);
+		std::size_t device_count (0);
 		for (auto & i : platforms)
 		{
 			device_count += i.devices.size ();
@@ -173,7 +173,7 @@ void nano::opencl_environment::dump (std::ostream & stream)
 			stream << "Platform: " << index << std::endl;
 			for (auto j (queries.begin ()), m (queries.end ()); j != m; ++j)
 			{
-				size_t platformInfoCount = 0;
+				std::size_t platformInfoCount = 0;
 				clGetPlatformInfo (i->platform, *j, 0, nullptr, &platformInfoCount);
 				std::vector<char> info (platformInfoCount);
 				clGetPlatformInfo (i->platform, *j, info.size (), info.data (), nullptr);
@@ -185,13 +185,13 @@ void nano::opencl_environment::dump (std::ostream & stream)
 				stream << "Device: " << j - i->devices.begin () << std::endl;
 				for (auto k (queries.begin ()), o (queries.end ()); k != o; ++k)
 				{
-					size_t platformInfoCount = 0;
+					std::size_t platformInfoCount = 0;
 					clGetDeviceInfo (*j, *k, 0, nullptr, &platformInfoCount);
 					std::vector<char> info (platformInfoCount);
 					clGetDeviceInfo (*j, *k, info.size (), info.data (), nullptr);
 					stream << '\t' << info.data () << std::endl;
 				}
-				size_t deviceTypeCount = 0;
+				std::size_t deviceTypeCount = 0;
 				clGetDeviceInfo (*j, CL_DEVICE_TYPE, 0, nullptr, &deviceTypeCount);
 				std::vector<uint8_t> deviceTypeInfo (deviceTypeCount);
 				clGetDeviceInfo (*j, CL_DEVICE_TYPE, deviceTypeCount, deviceTypeInfo.data (), 0);
@@ -218,12 +218,12 @@ void nano::opencl_environment::dump (std::ostream & stream)
 						break;
 				}
 				stream << '\t' << device_type_string << std::endl;
-				size_t compilerAvailableCount = 0;
+				std::size_t compilerAvailableCount = 0;
 				clGetDeviceInfo (*j, CL_DEVICE_COMPILER_AVAILABLE, 0, nullptr, &compilerAvailableCount);
 				std::vector<uint8_t> compilerAvailableInfo (compilerAvailableCount);
 				clGetDeviceInfo (*j, CL_DEVICE_COMPILER_AVAILABLE, compilerAvailableCount, compilerAvailableInfo.data (), 0);
 				stream << "\tCompiler available: " << (compilerAvailableInfo[0] ? "true" : "false") << std::endl;
-				size_t computeUnitsAvailableCount = 0;
+				std::size_t computeUnitsAvailableCount = 0;
 				clGetDeviceInfo (*j, CL_DEVICE_MAX_COMPUTE_UNITS, 0, nullptr, &computeUnitsAvailableCount);
 				std::vector<uint8_t> computeUnitsAvailableInfo (computeUnitsAvailableCount);
 				clGetDeviceInfo (*j, CL_DEVICE_MAX_COMPUTE_UNITS, computeUnitsAvailableCount, computeUnitsAvailableInfo.data (), 0);
@@ -299,7 +299,7 @@ nano::opencl_work::opencl_work (bool & error_a, nano::opencl_config const & conf
 						if (!error_a)
 						{
 							cl_int item_error (0);
-							size_t item_size (sizeof (nano::uint256_union));
+							std::size_t item_size (sizeof (nano::uint256_union));
 							item_buffer = clCreateBuffer (context, CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY, item_size, nullptr, &item_error);
 							error_a |= item_error != CL_SUCCESS;
 							if (!error_a)
@@ -311,7 +311,7 @@ nano::opencl_work::opencl_work (bool & error_a, nano::opencl_config const & conf
 								{
 									cl_int program_error (0);
 									char const * program_data (opencl_program.data ());
-									size_t program_length (opencl_program.size ());
+									std::size_t program_length (opencl_program.size ());
 									program = clCreateProgramWithSource (context, 1, &program_data, &program_length, &program_error);
 									error_a |= program_error != CL_SUCCESS;
 									if (!error_a)
@@ -372,7 +372,7 @@ nano::opencl_work::opencl_work (bool & error_a, nano::opencl_config const & conf
 											logger.always_log (boost::str (boost::format ("Build program error %1%") % clBuildProgramError));
 											for (auto i (selected_devices.begin ()), n (selected_devices.end ()); i != n; ++i)
 											{
-												size_t log_size (0);
+												std::size_t log_size (0);
 												clGetProgramBuildInfo (program, *i, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size);
 												std::vector<char> log (log_size);
 												clGetProgramBuildInfo (program, *i, CL_PROGRAM_BUILD_LOG, log.size (), log.data (), nullptr);
@@ -455,7 +455,7 @@ boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version c
 	int ticket_l (ticket_a);
 	uint64_t result (0);
 	unsigned thread_count (config.threads);
-	size_t work_size[] = { thread_count, 0, 0 };
+	std::size_t work_size[] = { thread_count, 0, 0 };
 	while (work.difficulty (version_a, root_a, result) < difficulty_a && !error && ticket_a == ticket_l)
 	{
 		result = rand.next ();

--- a/nano/node/peer_exclusion.cpp
+++ b/nano/node/peer_exclusion.cpp
@@ -2,10 +2,10 @@
 
 constexpr std::chrono::hours nano::peer_exclusion::exclude_time_hours;
 constexpr std::chrono::hours nano::peer_exclusion::exclude_remove_hours;
-constexpr size_t nano::peer_exclusion::size_max;
+constexpr std::size_t nano::peer_exclusion::size_max;
 constexpr double nano::peer_exclusion::peers_percentage_limit;
 
-uint64_t nano::peer_exclusion::add (nano::tcp_endpoint const & endpoint_a, size_t const network_peers_count_a)
+uint64_t nano::peer_exclusion::add (nano::tcp_endpoint const & endpoint_a, std::size_t const network_peers_count_a)
 {
 	uint64_t result (0);
 	nano::lock_guard<nano::mutex> guard (mutex);
@@ -72,12 +72,12 @@ void nano::peer_exclusion::remove (nano::tcp_endpoint const & endpoint_a)
 	peers.get<tag_endpoint> ().erase (endpoint_a.address ());
 }
 
-size_t nano::peer_exclusion::limited_size (size_t const network_peers_count_a) const
+std::size_t nano::peer_exclusion::limited_size (std::size_t const network_peers_count_a) const
 {
-	return std::min (size_max, static_cast<size_t> (network_peers_count_a * peers_percentage_limit));
+	return std::min (size_max, static_cast<std::size_t> (network_peers_count_a * peers_percentage_limit));
 }
 
-size_t nano::peer_exclusion::size () const
+std::size_t nano::peer_exclusion::size () const
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return peers.size ();
@@ -87,7 +87,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (na
 {
 	auto composite = std::make_unique<container_info_composite> (name);
 
-	size_t excluded_peers_count = excluded_peers.size ();
+	std::size_t excluded_peers_count = excluded_peers.size ();
 	auto sizeof_excluded_peers_element = sizeof (nano::peer_exclusion::ordered_endpoints::value_type);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "peers", excluded_peers_count, sizeof_excluded_peers_element }));
 

--- a/nano/node/peer_exclusion.hpp
+++ b/nano/node/peer_exclusion.hpp
@@ -40,17 +40,17 @@ private:
 	mutable nano::mutex mutex;
 
 public:
-	constexpr static size_t size_max = 5000;
+	constexpr static std::size_t size_max = 5000;
 	constexpr static double peers_percentage_limit = 0.5;
 	constexpr static uint64_t score_limit = 2;
 	constexpr static std::chrono::hours exclude_time_hours = std::chrono::hours (1);
 	constexpr static std::chrono::hours exclude_remove_hours = std::chrono::hours (24);
 
-	uint64_t add (nano::tcp_endpoint const &, size_t const);
+	uint64_t add (nano::tcp_endpoint const &, std::size_t const);
 	bool check (nano::tcp_endpoint const &);
 	void remove (nano::tcp_endpoint const &);
-	size_t limited_size (size_t const) const;
-	size_t size () const;
+	std::size_t limited_size (std::size_t const) const;
+	std::size_t size () const;
 
 	friend class telemetry_remove_peer_different_genesis_Test;
 	friend class telemetry_remove_peer_different_genesis_udp_Test;

--- a/nano/node/plat/posix/openclapi.cpp
+++ b/nano/node/plat/posix/openclapi.cpp
@@ -44,23 +44,23 @@ public:
 	}
 	void * opencl_library;
 	cl_int (*clGetPlatformIDs) (cl_uint, cl_platform_id *, cl_uint *);
-	cl_int (*clGetPlatformInfo) (cl_platform_id, cl_platform_info, size_t, void *, size_t *);
+	cl_int (*clGetPlatformInfo) (cl_platform_id, cl_platform_info, std::size_t, void *, std::size_t *);
 	cl_int (*clGetDeviceIDs) (cl_platform_id, cl_device_type, cl_uint, cl_device_id *, cl_uint *);
-	cl_int (*clGetDeviceInfo) (cl_device_id, cl_device_info, size_t, void *, size_t *);
-	cl_context (*clCreateContext) (cl_context_properties const *, cl_uint, cl_device_id const *, void (*) (const char *, const void *, size_t, void *), void *, cl_int *);
+	cl_int (*clGetDeviceInfo) (cl_device_id, cl_device_info, std::size_t, void *, std::size_t *);
+	cl_context (*clCreateContext) (cl_context_properties const *, cl_uint, cl_device_id const *, void (*) (char const *, const void *, std::size_t, void *), void *, cl_int *);
 	cl_command_queue (*clCreateCommandQueue) (cl_context, cl_device_id, cl_command_queue_properties, cl_int *);
-	cl_mem (*clCreateBuffer) (cl_context, cl_mem_flags, size_t, void *, cl_int *);
-	cl_program (*clCreateProgramWithSource) (cl_context, cl_uint, char const **, size_t const *, cl_int *);
+	cl_mem (*clCreateBuffer) (cl_context, cl_mem_flags, std::size_t, void *, cl_int *);
+	cl_program (*clCreateProgramWithSource) (cl_context, cl_uint, char const **, std::size_t const *, cl_int *);
 	cl_int (*clBuildProgram) (cl_program, cl_uint, cl_device_id const *, char const *, void (*) (cl_program, void *), void *);
-	cl_int (*clGetProgramBuildInfo) (cl_program, cl_device_id, cl_program_build_info, size_t, void *, size_t *);
+	cl_int (*clGetProgramBuildInfo) (cl_program, cl_device_id, cl_program_build_info, std::size_t, void *, std::size_t *);
 	cl_kernel (*clCreateKernel) (cl_program, char const *, cl_int *);
-	cl_int (*clSetKernelArg) (cl_kernel, cl_uint, size_t, void const *);
+	cl_int (*clSetKernelArg) (cl_kernel, cl_uint, std::size_t, void const *);
 	cl_int (*clReleaseKernel) (cl_kernel);
 	cl_int (*clReleaseProgram) (cl_program);
 	cl_int (*clReleaseContext) (cl_context);
-	cl_int (*clEnqueueWriteBuffer) (cl_command_queue, cl_mem, cl_bool, size_t, size_t, void const *, cl_uint, cl_event const *, cl_event *);
-	cl_int (*clEnqueueNDRangeKernel) (cl_command_queue, cl_kernel, cl_uint, size_t const *, size_t const *, size_t const *, cl_uint, cl_event const *, cl_event *);
-	cl_int (*clEnqueueReadBuffer) (cl_command_queue, cl_mem, cl_bool, size_t, size_t, void *, cl_uint, cl_event const *, cl_event *);
+	cl_int (*clEnqueueWriteBuffer) (cl_command_queue, cl_mem, cl_bool, std::size_t, std::size_t, void const *, cl_uint, cl_event const *, cl_event *);
+	cl_int (*clEnqueueNDRangeKernel) (cl_command_queue, cl_kernel, cl_uint, std::size_t const *, std::size_t const *, std::size_t const *, cl_uint, cl_event const *, cl_event *);
+	cl_int (*clEnqueueReadBuffer) (cl_command_queue, cl_mem, cl_bool, std::size_t, std::size_t, void *, cl_uint, cl_event const *, cl_event *);
 	cl_int (*clFinish) (cl_command_queue);
 	static opencl_initializer initializer;
 };
@@ -86,7 +86,7 @@ cl_int clGetPlatformIDs (cl_uint num_entries, cl_platform_id * platforms, cl_uin
 	return result;
 }
 
-cl_int clGetPlatformInfo (cl_platform_id platform, cl_platform_info param_name, size_t param_value_size, void * param_value, size_t * param_value_size_ret)
+cl_int clGetPlatformInfo (cl_platform_id platform, cl_platform_info param_name, std::size_t param_value_size, void * param_value, std::size_t * param_value_size_ret)
 {
 	return opencl_initializer::initializer.clGetPlatformInfo (platform, param_name, param_value_size, param_value, param_value_size_ret);
 }
@@ -96,12 +96,12 @@ cl_int clGetDeviceIDs (cl_platform_id platform, cl_device_type device_type, cl_u
 	return opencl_initializer::initializer.clGetDeviceIDs (platform, device_type, num_entries, devices, num_devices);
 }
 
-cl_int clGetDeviceInfo (cl_device_id device, cl_device_info param_name, size_t param_value_size, void * param_value, size_t * param_value_size_ret)
+cl_int clGetDeviceInfo (cl_device_id device, cl_device_info param_name, std::size_t param_value_size, void * param_value, std::size_t * param_value_size_ret)
 {
 	return opencl_initializer::initializer.clGetDeviceInfo (device, param_name, param_value_size, param_value, param_value_size_ret);
 }
 
-cl_context clCreateContext (cl_context_properties const * properties, cl_uint num_devices, cl_device_id const * devices, void (*pfn_notify) (const char *, const void *, size_t, void *), void * user_data, cl_int * errcode_ret)
+cl_context clCreateContext (cl_context_properties const * properties, cl_uint num_devices, cl_device_id const * devices, void (*pfn_notify) (char const *, const void *, std::size_t, void *), void * user_data, cl_int * errcode_ret)
 {
 	return opencl_initializer::initializer.clCreateContext (properties, num_devices, devices, pfn_notify, user_data, errcode_ret);
 }
@@ -111,12 +111,12 @@ cl_command_queue clCreateCommandQueue (cl_context context, cl_device_id device, 
 	return opencl_initializer::initializer.clCreateCommandQueue (context, device, properties, errcode_ret);
 }
 
-cl_mem clCreateBuffer (cl_context context, cl_mem_flags flags, size_t size, void * host_ptr, cl_int * errcode_ret)
+cl_mem clCreateBuffer (cl_context context, cl_mem_flags flags, std::size_t size, void * host_ptr, cl_int * errcode_ret)
 {
 	return opencl_initializer::initializer.clCreateBuffer (context, flags, size, host_ptr, errcode_ret);
 }
 
-cl_program clCreateProgramWithSource (cl_context context, cl_uint count, char const ** strings, size_t const * lengths, cl_int * errcode_ret)
+cl_program clCreateProgramWithSource (cl_context context, cl_uint count, char const ** strings, std::size_t const * lengths, cl_int * errcode_ret)
 {
 	return opencl_initializer::initializer.clCreateProgramWithSource (context, count, strings, lengths, errcode_ret);
 }
@@ -126,7 +126,7 @@ cl_int clBuildProgram (cl_program program, cl_uint num_devices, cl_device_id con
 	return opencl_initializer::initializer.clBuildProgram (program, num_devices, device_list, options, pfn_notify, user_data);
 }
 
-cl_int clGetProgramBuildInfo (cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void * param_value, size_t * param_value_size_ret)
+cl_int clGetProgramBuildInfo (cl_program program, cl_device_id device, cl_program_build_info param_name, std::size_t param_value_size, void * param_value, std::size_t * param_value_size_ret)
 {
 	return opencl_initializer::initializer.clGetProgramBuildInfo (program, device, param_name, param_value_size, param_value, param_value_size_ret);
 }
@@ -136,7 +136,7 @@ cl_kernel clCreateKernel (cl_program program, char const * kernel_name, cl_int *
 	return opencl_initializer::initializer.clCreateKernel (program, kernel_name, errcode_ret);
 }
 
-cl_int clSetKernelArg (cl_kernel kernel, cl_uint arg_index, size_t arg_size, void const * arg_value)
+cl_int clSetKernelArg (cl_kernel kernel, cl_uint arg_index, std::size_t arg_size, void const * arg_value)
 {
 	return opencl_initializer::initializer.clSetKernelArg (kernel, arg_index, arg_size, arg_value);
 }
@@ -156,17 +156,17 @@ cl_int clReleaseContext (cl_context context)
 	return opencl_initializer::initializer.clReleaseContext (context);
 }
 
-cl_int clEnqueueWriteBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_write, size_t offset, size_t size, void const * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
+cl_int clEnqueueWriteBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_write, std::size_t offset, std::size_t size, void const * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
 {
 	return opencl_initializer::initializer.clEnqueueWriteBuffer (command_queue, buffer, blocking_write, offset, size, ptr, num_events_in_wait_list, event_wait_list, event);
 }
 
-cl_int clEnqueueNDRangeKernel (cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim, size_t const * global_work_offset, size_t const * global_work_size, size_t const * local_work_size, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
+cl_int clEnqueueNDRangeKernel (cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim, std::size_t const * global_work_offset, std::size_t const * global_work_size, std::size_t const * local_work_size, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
 {
 	return opencl_initializer::initializer.clEnqueueNDRangeKernel (command_queue, kernel, work_dim, global_work_offset, global_work_size, local_work_size, num_events_in_wait_list, event_wait_list, event);
 }
 
-cl_int clEnqueueReadBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read, size_t offset, size_t size, void * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
+cl_int clEnqueueReadBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read, std::size_t offset, std::size_t size, void * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
 {
 	return opencl_initializer::initializer.clEnqueueReadBuffer (command_queue, buffer, blocking_read, offset, size, ptr, num_events_in_wait_list, event_wait_list, event);
 }

--- a/nano/node/plat/windows/openclapi.cpp
+++ b/nano/node/plat/windows/openclapi.cpp
@@ -44,23 +44,23 @@ public:
 	}
 	HMODULE opencl_library;
 	cl_int (CL_API_CALL * clGetPlatformIDs) (cl_uint, cl_platform_id *, cl_uint *);
-	cl_int (CL_API_CALL * clGetPlatformInfo) (cl_platform_id, cl_platform_info, size_t, void *, size_t *);
+	cl_int (CL_API_CALL * clGetPlatformInfo) (cl_platform_id, cl_platform_info, std::size_t, void *, std::size_t *);
 	cl_int (CL_API_CALL * clGetDeviceIDs) (cl_platform_id, cl_device_type, cl_uint, cl_device_id *, cl_uint *);
-	cl_int (CL_API_CALL * clGetDeviceInfo) (cl_device_id, cl_device_info, size_t, void *, size_t *);
-	cl_context (CL_API_CALL * clCreateContext) (cl_context_properties const *, cl_uint, cl_device_id const *, void (CL_CALLBACK *) (const char *, const void *, size_t, void *), void *, cl_int *);
+	cl_int (CL_API_CALL * clGetDeviceInfo) (cl_device_id, cl_device_info, std::size_t, void *, std::size_t *);
+	cl_context (CL_API_CALL * clCreateContext) (cl_context_properties const *, cl_uint, cl_device_id const *, void (CL_CALLBACK *) (char const *, const void *, std::size_t, void *), void *, cl_int *);
 	cl_command_queue (CL_API_CALL * clCreateCommandQueue) (cl_context, cl_device_id, cl_command_queue_properties, cl_int *);
-	cl_mem (CL_API_CALL * clCreateBuffer) (cl_context, cl_mem_flags, size_t, void *, cl_int *);
-	cl_program (CL_API_CALL * clCreateProgramWithSource) (cl_context, cl_uint, char const **, size_t const *, cl_int *);
+	cl_mem (CL_API_CALL * clCreateBuffer) (cl_context, cl_mem_flags, std::size_t, void *, cl_int *);
+	cl_program (CL_API_CALL * clCreateProgramWithSource) (cl_context, cl_uint, char const **, std::size_t const *, cl_int *);
 	cl_int (CL_API_CALL * clBuildProgram) (cl_program, cl_uint, cl_device_id const *, char const *, void (CL_CALLBACK *) (cl_program, void *), void *);
-	cl_int (CL_API_CALL * clGetProgramBuildInfo) (cl_program, cl_device_id, cl_program_build_info, size_t, void *, size_t *);
+	cl_int (CL_API_CALL * clGetProgramBuildInfo) (cl_program, cl_device_id, cl_program_build_info, std::size_t, void *, std::size_t *);
 	cl_kernel (CL_API_CALL * clCreateKernel) (cl_program, char const *, cl_int *);
-	cl_int (CL_API_CALL * clSetKernelArg) (cl_kernel, cl_uint, size_t, void const *);
+	cl_int (CL_API_CALL * clSetKernelArg) (cl_kernel, cl_uint, std::size_t, void const *);
 	cl_int (CL_API_CALL * clReleaseKernel) (cl_kernel);
 	cl_int (CL_API_CALL * clReleaseProgram) (cl_program);
 	cl_int (CL_API_CALL * clReleaseContext) (cl_context);
-	cl_int (CL_API_CALL * clEnqueueWriteBuffer) (cl_command_queue, cl_mem, cl_bool, size_t, size_t, void const *, cl_uint, cl_event const *, cl_event *);
-	cl_int (CL_API_CALL * clEnqueueNDRangeKernel) (cl_command_queue, cl_kernel, cl_uint, size_t const *, size_t const *, size_t const *, cl_uint, cl_event const *, cl_event *);
-	cl_int (CL_API_CALL * clEnqueueReadBuffer) (cl_command_queue, cl_mem, cl_bool, size_t, size_t, void *, cl_uint, cl_event const *, cl_event *);
+	cl_int (CL_API_CALL * clEnqueueWriteBuffer) (cl_command_queue, cl_mem, cl_bool, std::size_t, std::size_t, void const *, cl_uint, cl_event const *, cl_event *);
+	cl_int (CL_API_CALL * clEnqueueNDRangeKernel) (cl_command_queue, cl_kernel, cl_uint, std::size_t const *, std::size_t const *, std::size_t const *, cl_uint, cl_event const *, cl_event *);
+	cl_int (CL_API_CALL * clEnqueueReadBuffer) (cl_command_queue, cl_mem, cl_bool, std::size_t, std::size_t, void *, cl_uint, cl_event const *, cl_event *);
 	cl_int (CL_API_CALL * clFinish) (cl_command_queue);
 	static opencl_initializer initializer;
 };
@@ -86,7 +86,7 @@ cl_int CL_API_CALL clGetPlatformIDs (cl_uint num_entries, cl_platform_id * platf
 	return result;
 }
 
-cl_int CL_API_CALL clGetPlatformInfo (cl_platform_id platform, cl_platform_info param_name, size_t param_value_size, void * param_value, size_t * param_value_size_ret)
+cl_int CL_API_CALL clGetPlatformInfo (cl_platform_id platform, cl_platform_info param_name, std::size_t param_value_size, void * param_value, std::size_t * param_value_size_ret)
 {
 	return opencl_initializer::initializer.clGetPlatformInfo (platform, param_name, param_value_size, param_value, param_value_size_ret);
 }
@@ -96,12 +96,12 @@ cl_int CL_API_CALL clGetDeviceIDs (cl_platform_id platform, cl_device_type devic
 	return opencl_initializer::initializer.clGetDeviceIDs (platform, device_type, num_entries, devices, num_devices);
 }
 
-cl_int CL_API_CALL clGetDeviceInfo (cl_device_id device, cl_device_info param_name, size_t param_value_size, void * param_value, size_t * param_value_size_ret)
+cl_int CL_API_CALL clGetDeviceInfo (cl_device_id device, cl_device_info param_name, std::size_t param_value_size, void * param_value, std::size_t * param_value_size_ret)
 {
 	return opencl_initializer::initializer.clGetDeviceInfo (device, param_name, param_value_size, param_value, param_value_size_ret);
 }
 
-cl_context CL_API_CALL clCreateContext (cl_context_properties const * properties, cl_uint num_devices, cl_device_id const * devices, void (CL_CALLBACK * pfn_notify) (const char *, const void *, size_t, void *), void * user_data, cl_int * errcode_ret)
+cl_context CL_API_CALL clCreateContext (cl_context_properties const * properties, cl_uint num_devices, cl_device_id const * devices, void (CL_CALLBACK * pfn_notify) (char const *, const void *, std::size_t, void *), void * user_data, cl_int * errcode_ret)
 {
 	return opencl_initializer::initializer.clCreateContext (properties, num_devices, devices, pfn_notify, user_data, errcode_ret);
 }
@@ -111,12 +111,12 @@ cl_command_queue CL_API_CALL clCreateCommandQueue (cl_context context, cl_device
 	return opencl_initializer::initializer.clCreateCommandQueue (context, device, properties, errcode_ret);
 }
 
-cl_mem CL_API_CALL clCreateBuffer (cl_context context, cl_mem_flags flags, size_t size, void * host_ptr, cl_int * errcode_ret)
+cl_mem CL_API_CALL clCreateBuffer (cl_context context, cl_mem_flags flags, std::size_t size, void * host_ptr, cl_int * errcode_ret)
 {
 	return opencl_initializer::initializer.clCreateBuffer (context, flags, size, host_ptr, errcode_ret);
 }
 
-cl_program CL_API_CALL clCreateProgramWithSource (cl_context context, cl_uint count, char const ** strings, size_t const * lengths, cl_int * errcode_ret)
+cl_program CL_API_CALL clCreateProgramWithSource (cl_context context, cl_uint count, char const ** strings, std::size_t const * lengths, cl_int * errcode_ret)
 {
 	return opencl_initializer::initializer.clCreateProgramWithSource (context, count, strings, lengths, errcode_ret);
 }
@@ -126,7 +126,7 @@ cl_int CL_API_CALL clBuildProgram (cl_program program, cl_uint num_devices, cl_d
 	return opencl_initializer::initializer.clBuildProgram (program, num_devices, device_list, options, pfn_notify, user_data);
 }
 
-cl_int CL_API_CALL clGetProgramBuildInfo (cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void * param_value, size_t * param_value_size_ret)
+cl_int CL_API_CALL clGetProgramBuildInfo (cl_program program, cl_device_id device, cl_program_build_info param_name, std::size_t param_value_size, void * param_value, std::size_t * param_value_size_ret)
 {
 	return opencl_initializer::initializer.clGetProgramBuildInfo (program, device, param_name, param_value_size, param_value, param_value_size_ret);
 }
@@ -136,7 +136,7 @@ cl_kernel CL_API_CALL clCreateKernel (cl_program program, char const * kernel_na
 	return opencl_initializer::initializer.clCreateKernel (program, kernel_name, errcode_ret);
 }
 
-cl_int CL_API_CALL clSetKernelArg (cl_kernel kernel, cl_uint arg_index, size_t arg_size, void const * arg_value)
+cl_int CL_API_CALL clSetKernelArg (cl_kernel kernel, cl_uint arg_index, std::size_t arg_size, void const * arg_value)
 {
 	return opencl_initializer::initializer.clSetKernelArg (kernel, arg_index, arg_size, arg_value);
 }
@@ -156,17 +156,17 @@ cl_int CL_API_CALL clReleaseContext (cl_context context)
 	return opencl_initializer::initializer.clReleaseContext (context);
 }
 
-cl_int CL_API_CALL clEnqueueWriteBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_write, size_t offset, size_t size, void const * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
+cl_int CL_API_CALL clEnqueueWriteBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_write, std::size_t offset, std::size_t size, void const * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
 {
 	return opencl_initializer::initializer.clEnqueueWriteBuffer (command_queue, buffer, blocking_write, offset, size, ptr, num_events_in_wait_list, event_wait_list, event);
 }
 
-cl_int CL_API_CALL clEnqueueNDRangeKernel (cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim, size_t const * global_work_offset, size_t const * global_work_size, size_t const * local_work_size, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
+cl_int CL_API_CALL clEnqueueNDRangeKernel (cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim, std::size_t const * global_work_offset, std::size_t const * global_work_size, std::size_t const * local_work_size, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
 {
 	return opencl_initializer::initializer.clEnqueueNDRangeKernel (command_queue, kernel, work_dim, global_work_offset, global_work_size, local_work_size, num_events_in_wait_list, event_wait_list, event);
 }
 
-cl_int CL_API_CALL clEnqueueReadBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read, size_t offset, size_t size, void * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
+cl_int CL_API_CALL clEnqueueReadBuffer (cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read, std::size_t offset, std::size_t size, void * ptr, cl_uint num_events_in_wait_list, cl_event const * event_wait_list, cl_event * event)
 {
 	return opencl_initializer::initializer.clEnqueueReadBuffer (command_queue, buffer, blocking_read, offset, size, ptr, num_events_in_wait_list, event_wait_list, event);
 }

--- a/nano/node/prioritization.cpp
+++ b/nano/node/prioritization.cpp
@@ -26,7 +26,7 @@ void nano::prioritization::next ()
 void nano::prioritization::seek ()
 {
 	next ();
-	for (size_t i = 0, n = schedule.size (); buckets[*current].empty () && i < n; ++i)
+	for (std::size_t i = 0, n = schedule.size (); buckets[*current].empty () && i < n; ++i)
 	{
 		next ();
 	}
@@ -44,7 +44,7 @@ nano::prioritization::prioritization (uint64_t maximum, std::function<void (std:
 	drop{ drop_a },
 	maximum{ maximum }
 {
-	static size_t constexpr bucket_count = 129;
+	static std::size_t constexpr bucket_count = 129;
 	buckets.resize (bucket_count);
 	nano::uint128_t minimum{ 1 };
 	minimums.push_back (0);
@@ -93,9 +93,9 @@ void nano::prioritization::pop ()
 	seek ();
 }
 
-size_t nano::prioritization::size () const
+std::size_t nano::prioritization::size () const
 {
-	size_t result{ 0 };
+	std::size_t result{ 0 };
 	for (auto const & queue : buckets)
 	{
 		result += queue.size ();
@@ -103,12 +103,12 @@ size_t nano::prioritization::size () const
 	return result;
 }
 
-size_t nano::prioritization::bucket_count () const
+std::size_t nano::prioritization::bucket_count () const
 {
 	return buckets.size ();
 }
 
-size_t nano::prioritization::bucket_size (size_t index) const
+std::size_t nano::prioritization::bucket_size (std::size_t index) const
 {
 	return buckets[index].size ();
 }

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -34,9 +34,9 @@ public:
 	void push (uint64_t time, std::shared_ptr<nano::block> block);
 	std::shared_ptr<nano::block> top () const;
 	void pop ();
-	size_t size () const;
-	size_t bucket_count () const;
-	size_t bucket_size (size_t index) const;
+	std::size_t size () const;
+	std::size_t bucket_count () const;
+	std::size_t bucket_size (std::size_t index) const;
 	bool empty () const;
 	void dump ();
 	uint64_t const maximum;

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -104,8 +104,8 @@ void nano::rep_crawler::ongoing_crawl ()
 
 std::vector<std::shared_ptr<nano::transport::channel>> nano::rep_crawler::get_crawl_targets (nano::uint128_t total_weight_a)
 {
-	constexpr size_t conservative_count = 10;
-	constexpr size_t aggressive_count = 40;
+	constexpr std::size_t conservative_count = 10;
+	constexpr std::size_t aggressive_count = 40;
 
 	// Crawl more aggressively if we lack sufficient total peer weight.
 	bool sufficient_weight (total_weight_a > node.online_reps.delta ());
@@ -325,7 +325,7 @@ void nano::rep_crawler::update_weights ()
 	}
 }
 
-std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, nano::uint128_t const weight_a, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a)
+std::vector<nano::representative> nano::rep_crawler::representatives (std::size_t count_a, nano::uint128_t const weight_a, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a)
 {
 	auto version_min (opt_version_min_a.value_or (node.network_params.network.protocol_version_min));
 	std::vector<representative> result;
@@ -340,12 +340,12 @@ std::vector<nano::representative> nano::rep_crawler::representatives (size_t cou
 	return result;
 }
 
-std::vector<nano::representative> nano::rep_crawler::principal_representatives (size_t count_a, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a)
+std::vector<nano::representative> nano::rep_crawler::principal_representatives (std::size_t count_a, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a)
 {
 	return representatives (count_a, node.minimum_principal_weight (), opt_version_min_a);
 }
 
-std::vector<std::shared_ptr<nano::transport::channel>> nano::rep_crawler::representative_endpoints (size_t count_a)
+std::vector<std::shared_ptr<nano::transport::channel>> nano::rep_crawler::representative_endpoints (std::size_t count_a)
 {
 	std::vector<std::shared_ptr<nano::transport::channel>> result;
 	auto reps (representatives (count_a));
@@ -357,7 +357,7 @@ std::vector<std::shared_ptr<nano::transport::channel>> nano::rep_crawler::repres
 }
 
 /** Total number of representatives */
-size_t nano::rep_crawler::representative_count ()
+std::size_t nano::rep_crawler::representative_count ()
 {
 	nano::lock_guard<nano::mutex> lock (probable_reps_mutex);
 	return probable_reps.size ();

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -106,16 +106,16 @@ public:
 	nano::uint128_t total_weight () const;
 
 	/** Request a list of the top \p count_a known representatives in descending order of weight, with at least \p weight_a voting weight, and optionally with a minimum version \p opt_version_min_a */
-	std::vector<representative> representatives (size_t count_a = std::numeric_limits<size_t>::max (), nano::uint128_t const weight_a = 0, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a = boost::none);
+	std::vector<representative> representatives (std::size_t count_a = std::numeric_limits<std::size_t>::max (), nano::uint128_t const weight_a = 0, boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a = boost::none);
 
 	/** Request a list of the top \p count_a known principal representatives in descending order of weight, optionally with a minimum version \p opt_version_min_a */
-	std::vector<representative> principal_representatives (size_t count_a = std::numeric_limits<size_t>::max (), boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a = boost::none);
+	std::vector<representative> principal_representatives (std::size_t count_a = std::numeric_limits<std::size_t>::max (), boost::optional<decltype (nano::network_constants::protocol_version)> const & opt_version_min_a = boost::none);
 
 	/** Request a list of the top \p count_a known representative endpoints. */
-	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (size_t count_a);
+	std::vector<std::shared_ptr<nano::transport::channel>> representative_endpoints (std::size_t count_a);
 
 	/** Total number of representatives */
-	size_t representative_count ();
+	std::size_t representative_count ();
 
 private:
 	nano::node & node;

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -169,7 +169,7 @@ void nano::request_aggregator::erase_duplicates (std::vector<std::pair<nano::blo
 std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr<nano::block>>> nano::request_aggregator::aggregate (std::vector<std::pair<nano::block_hash, nano::root>> const & requests_a, std::shared_ptr<nano::transport::channel> & channel_a) const
 {
 	auto transaction (ledger.store.tx_begin_read ());
-	size_t cached_hashes = 0;
+	std::size_t cached_hashes = 0;
 	std::vector<std::shared_ptr<nano::block>> to_generate;
 	std::vector<std::shared_ptr<nano::block>> to_generate_final;
 	std::vector<std::shared_ptr<nano::vote>> cached_votes;

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -65,13 +65,13 @@ public:
 	void add (std::shared_ptr<nano::transport::channel> const & channel_a, std::vector<std::pair<nano::block_hash, nano::root>> const & hashes_roots_a);
 	void stop ();
 	/** Returns the number of currently queued request pools */
-	size_t size ();
+	std::size_t size ();
 	bool empty ();
 
 	nano::node_config const & config;
-	const std::chrono::milliseconds max_delay;
-	const std::chrono::milliseconds small_delay;
-	const size_t max_channel_requests;
+	std::chrono::milliseconds const max_delay;
+	std::chrono::milliseconds const small_delay;
+	std::size_t const max_channel_requests;
 
 private:
 	void run ();
@@ -105,7 +105,7 @@ private:
 	nano::mutex mutex{ mutex_identifier (mutexes::request_aggregator) };
 	std::thread thread;
 
-	friend std::unique_ptr<container_info_component> collect_container_info (request_aggregator &, const std::string &);
+	friend std::unique_ptr<container_info_component> collect_container_info (request_aggregator &, std::string const &);
 };
-std::unique_ptr<container_info_component> collect_container_info (request_aggregator &, const std::string &);
+std::unique_ptr<container_info_component> collect_container_info (request_aggregator &, std::string const &);
 }

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -197,7 +197,7 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_common_cf_options (std::sh
 	cf_options.max_bytes_for_level_multiplier = 8;
 
 	// Although this should be the default provided by RocksDB, not setting this is causing sequence conflict checks if not using
-	cf_options.max_write_buffer_std::size_to_maintain = memtable_size_bytes_a * num_memtables;
+	cf_options.max_write_buffer_size_to_maintain = memtable_size_bytes_a * num_memtables;
 
 	// Files older than this (1 day) will be scheduled for compaction when there is no other background work. This can lead to more writes however.
 	cf_options.ttl = 1 * 24 * 60 * 60;

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -45,21 +45,21 @@ void * rocksdb_val::data () const
 }
 
 template <>
-size_t rocksdb_val::size () const
+std::size_t rocksdb_val::size () const
 {
 	return value.size ();
 }
 
 template <>
-rocksdb_val::db_val (size_t size_a, void * data_a) :
-	value (static_cast<const char *> (data_a), size_a)
+rocksdb_val::db_val (std::size_t size_a, void * data_a) :
+	value (static_cast<char const *> (data_a), size_a)
 {
 }
 
 template <>
 void rocksdb_val::convert_buffer_to_value ()
 {
-	value = rocksdb::Slice (reinterpret_cast<const char *> (buffer->data ()), buffer->size ());
+	value = rocksdb::Slice (reinterpret_cast<char const *> (buffer->data ()), buffer->size ());
 }
 }
 
@@ -114,9 +114,9 @@ nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesyste
 	}
 }
 
-std::unordered_map<const char *, nano::tables> nano::rocksdb_store::create_cf_name_table_map () const
+std::unordered_map<char const *, nano::tables> nano::rocksdb_store::create_cf_name_table_map () const
 {
-	std::unordered_map<const char *, nano::tables> map{ { rocksdb::kDefaultColumnFamilyName.c_str (), tables::default_unused },
+	std::unordered_map<char const *, nano::tables> map{ { rocksdb::kDefaultColumnFamilyName.c_str (), tables::default_unused },
 		{ "frontiers", tables::frontiers },
 		{ "accounts", tables::accounts },
 		{ "blocks", tables::blocks },
@@ -197,7 +197,7 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_common_cf_options (std::sh
 	cf_options.max_bytes_for_level_multiplier = 8;
 
 	// Although this should be the default provided by RocksDB, not setting this is causing sequence conflict checks if not using
-	cf_options.max_write_buffer_size_to_maintain = memtable_size_bytes_a * num_memtables;
+	cf_options.max_write_buffer_std::size_to_maintain = memtable_size_bytes_a * num_memtables;
 
 	// Files older than this (1 day) will be scheduled for compaction when there is no other background work. This can lead to more writes however.
 	cf_options.ttl = 1 * 24 * 60 * 60;
@@ -357,7 +357,7 @@ std::string nano::rocksdb_store::vendor_get () const
 rocksdb::ColumnFamilyHandle * nano::rocksdb_store::table_to_column_family (tables table_a) const
 {
 	auto & handles_l = handles;
-	auto get_handle = [&handles_l] (const char * name) {
+	auto get_handle = [&handles_l] (char const * name) {
 		auto iter = std::find_if (handles_l.begin (), handles_l.end (), [name] (auto & handle) {
 			return (handle->GetName () == name);
 		});
@@ -709,7 +709,7 @@ rocksdb::Options nano::rocksdb_store::get_db_options ()
 	return db_options;
 }
 
-rocksdb::BlockBasedTableOptions nano::rocksdb_store::get_active_table_options (size_t lru_size) const
+rocksdb::BlockBasedTableOptions nano::rocksdb_store::get_active_table_options (std::size_t lru_size) const
 {
 	rocksdb::BlockBasedTableOptions table_options;
 

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -132,7 +132,7 @@ private:
 	};
 
 	std::unordered_map<nano::tables, tombstone_info> tombstone_map;
-	std::unordered_map<const char *, nano::tables> cf_name_table_map;
+	std::unordered_map<char const *, nano::tables> cf_name_table_map;
 
 	rocksdb::Transaction * tx (nano::transaction const & transaction_a) const;
 	std::vector<nano::tables> all_tables () const;
@@ -152,7 +152,7 @@ private:
 	rocksdb::ColumnFamilyOptions get_common_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const;
 	rocksdb::ColumnFamilyOptions get_active_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const;
 	rocksdb::ColumnFamilyOptions get_small_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a) const;
-	rocksdb::BlockBasedTableOptions get_active_table_options (size_t lru_size) const;
+	rocksdb::BlockBasedTableOptions get_active_table_options (std::size_t lru_size) const;
 	rocksdb::BlockBasedTableOptions get_small_table_options () const;
 	rocksdb::ColumnFamilyOptions get_cf_options (std::string const & cf_name_a) const;
 
@@ -160,7 +160,7 @@ private:
 	void flush_table (nano::tables table_a);
 	void flush_tombstones_check (nano::tables table_a);
 	void generate_tombstone_map ();
-	std::unordered_map<const char *, nano::tables> create_cf_name_table_map () const;
+	std::unordered_map<char const *, nano::tables> create_cf_name_table_map () const;
 
 	std::vector<rocksdb::ColumnFamilyDescriptor> create_column_families ();
 	unsigned long long base_memtable_size_bytes () const;

--- a/nano/node/rocksdb/rocksdb_iterator.hpp
+++ b/nano/node/rocksdb/rocksdb_iterator.hpp
@@ -13,7 +13,7 @@ namespace
 {
 inline bool is_read (nano::transaction const & transaction_a)
 {
-	return (dynamic_cast<const nano::read_transaction *> (&transaction_a) != nullptr);
+	return (dynamic_cast<nano::read_transaction const *> (&transaction_a) != nullptr);
 }
 
 inline rocksdb::ReadOptions & snapshot_options (nano::transaction const & transaction_a)

--- a/nano/node/signatures.cpp
+++ b/nano/node/signatures.cpp
@@ -32,8 +32,8 @@ void nano::signature_checker::verify (nano::signature_check_set & check_a)
 	// Split up the tasks equally over the calling thread and the thread pool.
 	// Any overflow on the modulus of the batch_size is given to the calling thread, so the thread pool
 	// only ever operates on batch_size sizes.
-	size_t overflow_size = check_a.size % batch_size;
-	size_t num_full_batches = check_a.size / batch_size;
+	std::size_t overflow_size = check_a.size % batch_size;
+	std::size_t num_full_batches = check_a.size / batch_size;
 
 	auto const num_threads = thread_pool.get_num_threads ();
 	auto total_threads_to_split_over = num_threads + 1;
@@ -86,7 +86,7 @@ void nano::signature_checker::flush ()
 		;
 }
 
-bool nano::signature_checker::verify_batch (const nano::signature_check_set & check_a, size_t start_index, size_t size)
+bool nano::signature_checker::verify_batch (nano::signature_check_set const & check_a, std::size_t start_index, std::size_t size)
 {
 	nano::validate_message_batch (check_a.messages + start_index, check_a.message_lengths + start_index, check_a.pub_keys + start_index, check_a.signatures + start_index, size, check_a.verifications + start_index);
 	return std::all_of (check_a.verifications + start_index, check_a.verifications + start_index + size, [] (int verification) { return verification == 0 || verification == 1; });
@@ -95,12 +95,12 @@ bool nano::signature_checker::verify_batch (const nano::signature_check_set & ch
 /* This operates on a number of signatures of size (num_batches * batch_size) from the beginning of the check_a pointers.
  * Caller should check the value of the promise which indicates when the work has been completed.
  */
-void nano::signature_checker::verify_async (nano::signature_check_set & check_a, size_t num_batches, std::promise<void> & promise)
+void nano::signature_checker::verify_async (nano::signature_check_set & check_a, std::size_t num_batches, std::promise<void> & promise)
 {
 	auto task = std::make_shared<Task> (check_a, num_batches);
 	++tasks_remaining;
 
-	for (size_t batch = 0; batch < num_batches; ++batch)
+	for (std::size_t batch = 0; batch < num_batches; ++batch)
 	{
 		auto size = batch_size;
 		auto start_index = batch * batch_size;

--- a/nano/node/signatures.hpp
+++ b/nano/node/signatures.hpp
@@ -12,14 +12,14 @@ namespace nano
 class signature_check_set final
 {
 public:
-	signature_check_set (size_t size, unsigned char const ** messages, size_t * message_lengths, unsigned char const ** pub_keys, unsigned char const ** signatures, int * verifications) :
+	signature_check_set (std::size_t size, unsigned char const ** messages, std::size_t * message_lengths, unsigned char const ** pub_keys, unsigned char const ** signatures, int * verifications) :
 		size (size), messages (messages), message_lengths (message_lengths), pub_keys (pub_keys), signatures (signatures), verifications (verifications)
 	{
 	}
 
-	size_t size;
+	std::size_t size;
 	unsigned char const ** messages;
-	size_t * message_lengths;
+	std::size_t * message_lengths;
 	unsigned char const ** pub_keys;
 	unsigned char const ** signatures;
 	int * verifications;
@@ -35,7 +35,7 @@ public:
 	void stop ();
 	void flush ();
 
-	static size_t constexpr batch_size = 256;
+	static std::size_t constexpr batch_size = 256;
 
 private:
 	std::atomic<int> tasks_remaining{ 0 };
@@ -44,7 +44,7 @@ private:
 
 	struct Task final
 	{
-		Task (nano::signature_check_set & check, size_t pending) :
+		Task (nano::signature_check_set & check, std::size_t pending) :
 			check (check), pending (pending)
 		{
 		}
@@ -53,11 +53,11 @@ private:
 			release_assert (pending == 0);
 		}
 		nano::signature_check_set & check;
-		std::atomic<size_t> pending;
+		std::atomic<std::size_t> pending;
 	};
 
-	bool verify_batch (const nano::signature_check_set & check_a, size_t index, size_t size);
-	void verify_async (nano::signature_check_set & check_a, size_t num_batches, std::promise<void> & promise);
+	bool verify_batch (nano::signature_check_set const & check_a, std::size_t index, std::size_t size);
+	void verify_async (nano::signature_check_set & check_a, std::size_t num_batches, std::promise<void> & promise);
 	bool single_threaded () const;
 };
 }

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -41,7 +41,7 @@ void nano::socket::async_connect (nano::tcp_endpoint const & endpoint_a, std::fu
 	}));
 }
 
-void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buffer_a, size_t size_a, std::function<void (boost::system::error_code const &, size_t)> callback_a)
+void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buffer_a, std::size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a)
 {
 	if (size_a <= buffer_a->size ())
 	{
@@ -52,7 +52,7 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buf
 			boost::asio::post (strand, boost::asio::bind_executor (strand, [buffer_a, callback_a, size_a, this_l] () {
 				boost::asio::async_read (this_l->tcp_socket, boost::asio::buffer (buffer_a->data (), size_a),
 				boost::asio::bind_executor (this_l->strand,
-				[this_l, buffer_a, callback_a] (boost::system::error_code const & ec, size_t size_a) {
+				[this_l, buffer_a, callback_a] (boost::system::error_code const & ec, std::size_t size_a) {
 					this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
 					this_l->stop_timer ();
 					callback_a (ec, size_a);
@@ -68,7 +68,7 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buf
 	}
 }
 
-void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a)
+void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a)
 {
 	if (!closed)
 	{
@@ -201,7 +201,7 @@ nano::tcp_endpoint nano::socket::local_endpoint () const
 	return tcp_socket.local_endpoint ();
 }
 
-nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a) :
+nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, std::size_t max_connections_a) :
 	socket{ node_a, std::chrono::seconds::max () },
 	acceptor{ node_a.io_ctx },
 	local{ local_a },

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -49,8 +49,8 @@ public:
 	explicit socket (nano::node & node, boost::optional<std::chrono::seconds> io_timeout = boost::none);
 	virtual ~socket ();
 	void async_connect (boost::asio::ip::tcp::endpoint const &, std::function<void (boost::system::error_code const &)>);
-	void async_read (std::shared_ptr<std::vector<uint8_t>> const &, size_t, std::function<void (boost::system::error_code const &, size_t)>);
-	void async_write (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, size_t)> const & = nullptr);
+	void async_read (std::shared_ptr<std::vector<uint8_t>> const &, std::size_t, std::function<void (boost::system::error_code const &, std::size_t)>);
+	void async_write (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr);
 
 	void close ();
 	boost::asio::ip::tcp::endpoint remote_endpoint () const;
@@ -83,7 +83,7 @@ protected:
 	{
 	public:
 		nano::shared_const_buffer buffer;
-		std::function<void (boost::system::error_code const &, size_t)> callback;
+		std::function<void (boost::system::error_code const &, std::size_t)> callback;
 	};
 
 	boost::asio::strand<boost::asio::io_context::executor_type> strand;
@@ -97,7 +97,7 @@ protected:
 	std::atomic<uint64_t> last_completion_time;
 	std::atomic<bool> timed_out{ false };
 	boost::optional<std::chrono::seconds> io_timeout;
-	std::atomic<size_t> queue_size{ 0 };
+	std::atomic<std::size_t> queue_size{ 0 };
 
 	/** Set by close() - completion handlers must check this. This is more reliable than checking
 	 error codes as the OS may have already completed the async operation. */
@@ -111,7 +111,7 @@ private:
 	type_t type_m{ type_t::undefined };
 
 public:
-	static size_t constexpr queue_size_max = 128;
+	static std::size_t constexpr queue_size_max = 128;
 };
 
 /** Socket class for TCP servers */
@@ -125,7 +125,7 @@ public:
 	 * @param max_connections_a Maximum number of concurrent connections
 	 * @param concurrency_a Write concurrency for new connections
 	 */
-	explicit server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, size_t max_connections_a);
+	explicit server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, std::size_t max_connections_a);
 	/**Start accepting new connections */
 	void start (boost::system::error_code &);
 	/** Stop accepting new connections */
@@ -141,7 +141,7 @@ private:
 	std::vector<std::weak_ptr<nano::socket>> connections;
 	boost::asio::ip::tcp::acceptor acceptor;
 	boost::asio::ip::tcp::endpoint local;
-	size_t max_inbound_connections;
+	std::size_t max_inbound_connections;
 	void evict_dead_connections ();
 	bool is_temporary_error (boost::system::error_code const ec_a);
 	void on_connection_requeue_delayed (std::function<bool (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const &)>);

--- a/nano/node/state_block_signature_verification.cpp
+++ b/nano/node/state_block_signature_verification.cpp
@@ -47,7 +47,7 @@ void nano::state_block_signature_verification::run (uint64_t state_block_signatu
 	{
 		if (!state_blocks.empty ())
 		{
-			size_t const max_verification_batch (state_block_signature_verification_size != 0 ? state_block_signature_verification_size : nano::signature_checker::batch_size * (node_config.signature_checker_threads + 1));
+			std::size_t const max_verification_batch (state_block_signature_verification_size != 0 ? state_block_signature_verification_size : nano::signature_checker::batch_size * (node_config.signature_checker_threads + 1));
 			active = true;
 			while (!state_blocks.empty () && !stopped)
 			{
@@ -83,13 +83,13 @@ void nano::state_block_signature_verification::add (nano::unchecked_info const &
 	condition.notify_one ();
 }
 
-size_t nano::state_block_signature_verification::size ()
+std::size_t nano::state_block_signature_verification::size ()
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return state_blocks.size ();
 }
 
-std::deque<nano::unchecked_info> nano::state_block_signature_verification::setup_items (size_t max_count)
+std::deque<nano::unchecked_info> nano::state_block_signature_verification::setup_items (std::size_t max_count)
 {
 	std::deque<nano::unchecked_info> items;
 	if (state_blocks.size () <= max_count)
@@ -119,7 +119,7 @@ void nano::state_block_signature_verification::verify_state_blocks (std::deque<n
 		hashes.reserve (size);
 		std::vector<unsigned char const *> messages;
 		messages.reserve (size);
-		std::vector<size_t> lengths;
+		std::vector<std::size_t> lengths;
 		lengths.reserve (size);
 		std::vector<nano::account> accounts;
 		accounts.reserve (size);

--- a/nano/node/state_block_signature_verification.hpp
+++ b/nano/node/state_block_signature_verification.hpp
@@ -20,7 +20,7 @@ public:
 	state_block_signature_verification (nano::signature_checker &, nano::epochs &, nano::node_config &, nano::logger_mt &, uint64_t);
 	~state_block_signature_verification ();
 	void add (nano::unchecked_info const & info_a);
-	size_t size ();
+	std::size_t size ();
 	void stop ();
 	bool is_active ();
 
@@ -41,7 +41,7 @@ private:
 	std::thread thread;
 
 	void run (uint64_t block_processor_verification_size);
-	std::deque<nano::unchecked_info> setup_items (size_t);
+	std::deque<nano::unchecked_info> setup_items (std::size_t);
 	void verify_state_blocks (std::deque<nano::unchecked_info> &);
 };
 

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -175,7 +175,7 @@ void nano::telemetry::ongoing_req_all_peers (std::chrono::milliseconds next_requ
 
 				{
 					// Copy peers to the multi index container so can get better asymptotic complexity in future operations
-					auto temp_peers = this_l->network.list (std::numeric_limits<size_t>::max ());
+					auto temp_peers = this_l->network.list (std::numeric_limits<std::size_t>::max ());
 					peers.insert (temp_peers.begin (), temp_peers.end ());
 				}
 
@@ -254,7 +254,7 @@ std::unordered_map<nano::endpoint, nano::telemetry_data> nano::telemetry::get_me
 	// clang-format off
 	nano::transform_if (range.begin (), range.end (), std::inserter (telemetry_data, telemetry_data.end ()),
 		[this](auto const & telemetry_info) { return this->within_cache_plus_buffer_cutoff (telemetry_info); },
-		[](auto const & telemetry_info) { return std::pair<const nano::endpoint, nano::telemetry_data>{ telemetry_info.endpoint, telemetry_info.data }; });
+		[](auto const & telemetry_info) { return std::pair<nano::endpoint const, nano::telemetry_data>{ telemetry_info.endpoint, telemetry_info.data }; });
 	// clang-format on
 
 	return telemetry_data;
@@ -354,7 +354,7 @@ void nano::telemetry::fire_request_message (std::shared_ptr<nano::transport::cha
 	std::weak_ptr<nano::telemetry> this_w (shared_from_this ());
 	nano::telemetry_req message{ network_params.network };
 	// clang-format off
-	channel_a->send (message, [this_w, endpoint = channel_a->get_endpoint (), round_l](boost::system::error_code const & ec, size_t size_a) {
+	channel_a->send (message, [this_w, endpoint = channel_a->get_endpoint (), round_l](boost::system::error_code const & ec, std::size_t size_a) {
 		if (auto this_l = this_w.lock ())
 		{
 			if (ec)
@@ -447,7 +447,7 @@ void nano::telemetry::invoke_callbacks (nano::endpoint const & endpoint_a, bool 
 	}
 }
 
-size_t nano::telemetry::telemetry_data_size ()
+std::size_t nano::telemetry::telemetry_data_size ()
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return recent_or_initial_request_telemetry_data.size ();
@@ -469,11 +469,11 @@ bool nano::telemetry_info::awaiting_first_response () const
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (telemetry & telemetry, std::string const & name)
 {
 	auto composite = std::make_unique<container_info_composite> (name);
-	size_t callbacks_count;
+	std::size_t callbacks_count;
 	{
 		nano::lock_guard<nano::mutex> guard (telemetry.mutex);
 		std::unordered_map<nano::endpoint, std::vector<std::function<void (telemetry_data_response const &)>>> callbacks;
-		callbacks_count = std::accumulate (callbacks.begin (), callbacks.end (), static_cast<size_t> (0), [] (auto total, auto const & callback_a) {
+		callbacks_count = std::accumulate (callbacks.begin (), callbacks.end (), static_cast<std::size_t> (0), [] (auto total, auto const & callback_a) {
 			return total += callback_a.second.size ();
 		});
 	}
@@ -573,7 +573,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 		consolidated_data.timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (boost::numeric_cast<uint64_t> (timestamp_sum / timestamps.size ())));
 	}
 
-	auto set_mode_or_average = [] (auto const & collection, auto & var, auto const & sum, size_t size) {
+	auto set_mode_or_average = [] (auto const & collection, auto & var, auto const & sum, std::size_t size) {
 		auto max = std::max_element (collection.begin (), collection.end (), [] (auto const & lhs, auto const & rhs) {
 			return lhs.second < rhs.second;
 		});
@@ -587,7 +587,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 		}
 	};
 
-	auto set_mode = [] (auto const & collection, auto & var, size_t size) {
+	auto set_mode = [] (auto const & collection, auto & var, std::size_t size) {
 		auto max = std::max_element (collection.begin (), collection.end (), [] (auto const & lhs, auto const & rhs) {
 			return lhs.second < rhs.second;
 		});

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -88,7 +88,7 @@ public:
 	/*
 	 * Return the number of node metrics collected
 	 */
-	size_t telemetry_data_size ();
+	std::size_t telemetry_data_size ();
 
 	/*
 	 * Returns the time for the cache, response and a small buffer for alarm operations to be scheduled and completed
@@ -142,7 +142,7 @@ private:
 	bool within_cache_cutoff (nano::telemetry_info const &) const;
 	bool within_cache_plus_buffer_cutoff (telemetry_info const &) const;
 	bool verify_message (nano::telemetry_ack const &, nano::transport::channel const &);
-	friend std::unique_ptr<nano::container_info_component> collect_container_info (telemetry &, const std::string &);
+	friend std::unique_ptr<nano::container_info_component> collect_container_info (telemetry &, std::string const &);
 	friend class telemetry_remove_peer_invalid_signature_Test;
 };
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -35,9 +35,9 @@ namespace transport
 	public:
 		channel_tcp (nano::node &, std::weak_ptr<nano::socket>);
 		~channel_tcp ();
-		size_t hash_code () const override;
+		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
-		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
+		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_tcp const & other_a) const
 		{
@@ -78,10 +78,10 @@ namespace transport
 		tcp_channels (nano::node &, std::function<void (nano::message const &, std::shared_ptr<nano::transport::channel> const &)> = nullptr);
 		bool insert (std::shared_ptr<nano::transport::channel_tcp> const &, std::shared_ptr<nano::socket> const &, std::shared_ptr<nano::bootstrap_server> const &);
 		void erase (nano::tcp_endpoint const &);
-		size_t size () const;
+		std::size_t size () const;
 		std::shared_ptr<nano::transport::channel_tcp> find_channel (nano::tcp_endpoint const &) const;
 		void random_fill (std::array<nano::endpoint, 8> &) const;
-		std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (size_t, uint8_t = 0, bool = false) const;
+		std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (std::size_t, uint8_t = 0, bool = false) const;
 		bool store_all (bool = true);
 		std::shared_ptr<nano::transport::channel_tcp> find_node_id (nano::account const &);
 		// Get the next peer for attempting a tcp connection

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -100,7 +100,7 @@ nano::transport::channel::channel (nano::node & node_a) :
 	set_network_version (node_a.network_params.network.protocol_version);
 }
 
-void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
+void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
 	callback_visitor visitor;
 	message_a.visit (visitor);
@@ -138,7 +138,7 @@ nano::transport::channel_loopback::channel_loopback (nano::node & node_a) :
 	set_network_version (node_a.network_params.network.protocol_version);
 }
 
-size_t nano::transport::channel_loopback::hash_code () const
+std::size_t nano::transport::channel_loopback::hash_code () const
 {
 	std::hash<::nano::endpoint> hash;
 	return hash (endpoint);
@@ -149,7 +149,7 @@ bool nano::transport::channel_loopback::operator== (nano::transport::channel con
 	return endpoint == other_a.get_endpoint ();
 }
 
-void nano::transport::channel_loopback::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
+void nano::transport::channel_loopback::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
 	release_assert (false && "sending to a loopback channel is not supported");
 }
@@ -268,17 +268,17 @@ bool nano::transport::reserved_address (nano::endpoint const & endpoint_a, bool 
 
 using namespace std::chrono_literals;
 
-nano::bandwidth_limiter::bandwidth_limiter (const double limit_burst_ratio_a, const size_t limit_a) :
-	bucket (static_cast<size_t> (limit_a * limit_burst_ratio_a), limit_a)
+nano::bandwidth_limiter::bandwidth_limiter (double const limit_burst_ratio_a, std::size_t const limit_a) :
+	bucket (static_cast<std::size_t> (limit_a * limit_burst_ratio_a), limit_a)
 {
 }
 
-bool nano::bandwidth_limiter::should_drop (const size_t & message_size_a)
+bool nano::bandwidth_limiter::should_drop (std::size_t const & message_size_a)
 {
 	return !bucket.try_consume (nano::narrow_cast<unsigned int> (message_size_a));
 }
 
-void nano::bandwidth_limiter::reset (const double limit_burst_ratio_a, const size_t limit_a)
+void nano::bandwidth_limiter::reset (double const limit_burst_ratio_a, std::size_t const limit_a)
 {
-	bucket.reset (static_cast<size_t> (limit_a * limit_burst_ratio_a), limit_a);
+	bucket.reset (static_cast<std::size_t> (limit_a * limit_burst_ratio_a), limit_a);
 }

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -14,9 +14,9 @@ class bandwidth_limiter final
 {
 public:
 	// initialize with limit 0 = unbounded
-	bandwidth_limiter (const double, const size_t);
-	bool should_drop (const size_t &);
-	void reset (const double, const size_t);
+	bandwidth_limiter (double const, std::size_t const);
+	bool should_drop (std::size_t const &);
+	void reset (double const, std::size_t const);
 
 private:
 	nano::rate::token_bucket bucket;
@@ -45,10 +45,10 @@ namespace transport
 	public:
 		channel (nano::node &);
 		virtual ~channel () = default;
-		virtual size_t hash_code () const = 0;
+		virtual std::size_t hash_code () const = 0;
 		virtual bool operator== (nano::transport::channel const &) const = 0;
-		void send (nano::message & message_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a = nullptr, nano::buffer_drop_policy policy_a = nano::buffer_drop_policy::limiter);
-		virtual void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) = 0;
+		void send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a = nullptr, nano::buffer_drop_policy policy_a = nano::buffer_drop_policy::limiter);
+		virtual void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) = 0;
 		virtual std::string to_string () const = 0;
 		virtual nano::endpoint get_endpoint () const = 0;
 		virtual nano::tcp_endpoint get_tcp_endpoint () const = 0;
@@ -142,9 +142,9 @@ namespace transport
 	{
 	public:
 		channel_loopback (nano::node &);
-		size_t hash_code () const override;
+		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
-		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
+		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_loopback const & other_a) const
 		{
@@ -177,7 +177,7 @@ namespace std
 template <>
 struct hash<::nano::transport::channel>
 {
-	size_t operator() (::nano::transport::channel const & channel_a) const
+	std::size_t operator() (::nano::transport::channel const & channel_a) const
 	{
 		return channel_a.hash_code ();
 	}
@@ -197,7 +197,7 @@ namespace boost
 template <>
 struct hash<::nano::transport::channel>
 {
-	size_t operator() (::nano::transport::channel const & channel_a) const
+	std::size_t operator() (::nano::transport::channel const & channel_a) const
 	{
 		std::hash<::nano::transport::channel> hash;
 		return hash (channel_a);
@@ -206,7 +206,7 @@ struct hash<::nano::transport::channel>
 template <>
 struct hash<std::reference_wrapper<::nano::transport::channel const>>
 {
-	size_t operator() (std::reference_wrapper<::nano::transport::channel const> const & channel_a) const
+	std::size_t operator() (std::reference_wrapper<::nano::transport::channel const> const & channel_a) const
 	{
 		std::hash<::nano::transport::channel> hash;
 		return hash (channel_a.get ());

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -27,9 +27,9 @@ namespace transport
 
 	public:
 		channel_udp (nano::transport::udp_channels &, nano::endpoint const &, uint8_t protocol_version);
-		size_t hash_code () const override;
+		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
-		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
+		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_udp const & other_a) const
 		{
@@ -78,10 +78,10 @@ namespace transport
 		udp_channels (nano::node &, uint16_t, std::function<void (nano::message const &, std::shared_ptr<nano::transport::channel> const &)> sink);
 		std::shared_ptr<nano::transport::channel_udp> insert (nano::endpoint const &, unsigned);
 		void erase (nano::endpoint const &);
-		size_t size () const;
+		std::size_t size () const;
 		std::shared_ptr<nano::transport::channel_udp> channel (nano::endpoint const &) const;
 		void random_fill (std::array<nano::endpoint, 8> &) const;
-		std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (size_t, uint8_t = 0) const;
+		std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (std::size_t, uint8_t = 0) const;
 		bool store_all (bool = true);
 		std::shared_ptr<nano::transport::channel_udp> find_node_id (nano::account const &);
 		void clean_node_id (nano::account const &);
@@ -91,7 +91,7 @@ namespace transport
 		void receive ();
 		void start ();
 		void stop ();
-		void send (nano::shared_const_buffer const & buffer_a, nano::endpoint endpoint_a, std::function<void (boost::system::error_code const &, size_t)> const & callback_a);
+		void send (nano::shared_const_buffer const & buffer_a, nano::endpoint endpoint_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a);
 		nano::endpoint get_local_endpoint () const;
 		void receive_action (nano::message_buffer *);
 		void process_packets ();

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -140,7 +140,7 @@ void nano::vote_processor::verify_votes (decltype (votes) const & votes_a)
 	messages.reserve (size);
 	std::vector<nano::block_hash> hashes;
 	hashes.reserve (size);
-	std::vector<size_t> lengths (size, sizeof (nano::block_hash));
+	std::vector<std::size_t> lengths (size, sizeof (nano::block_hash));
 	std::vector<unsigned char const *> pub_keys;
 	pub_keys.reserve (size);
 	std::vector<unsigned char const *> signatures;
@@ -234,7 +234,7 @@ void nano::vote_processor::flush_active ()
 	}
 }
 
-size_t nano::vote_processor::size ()
+std::size_t nano::vote_processor::size ()
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return votes.size ();
@@ -283,10 +283,10 @@ void nano::vote_processor::calculate_weights ()
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (vote_processor & vote_processor, std::string const & name)
 {
-	size_t votes_count;
-	size_t representatives_1_count;
-	size_t representatives_2_count;
-	size_t representatives_3_count;
+	std::size_t votes_count;
+	std::size_t representatives_1_count;
+	std::size_t representatives_2_count;
+	std::size_t representatives_3_count;
 
 	{
 		nano::lock_guard<nano::mutex> guard (vote_processor.mutex);

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -44,7 +44,7 @@ public:
 	void flush ();
 	/** Block until the currently active processing cycle finishes */
 	void flush_active ();
-	size_t size ();
+	std::size_t size ();
 	bool empty ();
 	bool half_full ();
 	void calculate_weights ();
@@ -64,7 +64,7 @@ private:
 	nano::rep_crawler & rep_crawler;
 	nano::ledger & ledger;
 	nano::network_params & network_params;
-	size_t max_votes;
+	std::size_t max_votes;
 	std::deque<std::pair<std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>>> votes;
 	/** Representatives levels for random early detection */
 	std::unordered_set<nano::account> representatives_1;

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -44,7 +44,7 @@ void nano::vote_spacing::flag (nano::root const & root_a, nano::block_hash const
 	}
 }
 
-size_t nano::vote_spacing::size () const
+std::size_t nano::vote_spacing::size () const
 {
 	return recent.size ();
 }
@@ -145,7 +145,7 @@ void nano::local_vote_history::clean ()
 	}
 }
 
-size_t nano::local_vote_history::size () const
+std::size_t nano::local_vote_history::size () const
 {
 	nano::lock_guard<nano::mutex> guard (mutex);
 	return history.size ();
@@ -153,7 +153,7 @@ size_t nano::local_vote_history::size () const
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::local_vote_history & history, std::string const & name)
 {
-	size_t history_count = history.size ();
+	std::size_t history_count = history.size ();
 	auto sizeof_element = sizeof (decltype (history.history)::value_type);
 	auto composite = std::make_unique<container_info_composite> (name);
 	/* This does not currently loop over each element inside the cache to get the sizes of the votes inside history*/
@@ -230,7 +230,7 @@ void nano::vote_generator::stop ()
 	}
 }
 
-size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::block>> const & blocks_a, std::shared_ptr<nano::transport::channel> const & channel_a)
+std::size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::block>> const & blocks_a, std::shared_ptr<nano::transport::channel> const & channel_a)
 {
 	request_t::first_type req_candidates;
 	{
@@ -366,7 +366,7 @@ void nano::vote_generator::vote (std::vector<nano::block_hash> const & hashes_a,
 	});
 	for (auto const & vote_l : votes_l)
 	{
-		for (size_t i (0), n (hashes_a.size ()); i != n; ++i)
+		for (std::size_t i (0), n (hashes_a.size ()); i != n; ++i)
 		{
 			history.add (roots_a[i], hashes_a[i], vote_l);
 			spacing.flag (roots_a[i], hashes_a[i]);
@@ -439,8 +439,8 @@ void nano::vote_generator_session::flush ()
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::vote_generator & vote_generator, std::string const & name)
 {
-	size_t candidates_count = 0;
-	size_t requests_count = 0;
+	std::size_t candidates_count = 0;
+	std::size_t requests_count = 0;
 	{
 		nano::lock_guard<nano::mutex> guard (vote_generator.mutex);
 		candidates_count = vote_generator.candidates.size ();

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -59,7 +59,7 @@ public:
 	}
 	bool votable (nano::root const & root_a, nano::block_hash const & hash_a) const;
 	void flag (nano::root const & root_a, nano::block_hash const & hash_a);
-	size_t size () const;
+	std::size_t size () const;
 };
 
 class local_vote_history final
@@ -88,7 +88,7 @@ public:
 
 	std::vector<std::shared_ptr<nano::vote>> votes (nano::root const & root_a, nano::block_hash const & hash_a, bool const is_final_a = false) const;
 	bool exists (nano::root const &) const;
-	size_t size () const;
+	std::size_t size () const;
 
 private:
 	// clang-format off
@@ -124,7 +124,7 @@ public:
 	/** Queue items for vote generation, or broadcast votes already in cache */
 	void add (nano::root const &, nano::block_hash const &);
 	/** Queue blocks for vote generation, returning the number of successful candidates.*/
-	size_t generate (std::vector<std::shared_ptr<nano::block>> const & blocks_a, std::shared_ptr<nano::transport::channel> const & channel_a);
+	std::size_t generate (std::vector<std::shared_ptr<nano::block>> const & blocks_a, std::shared_ptr<nano::transport::channel> const & channel_a);
 	void set_reply_action (std::function<void (std::shared_ptr<nano::vote> const &, std::shared_ptr<nano::transport::channel> const &)>);
 	void stop ();
 
@@ -145,7 +145,7 @@ private:
 	nano::stat & stats;
 	mutable nano::mutex mutex;
 	nano::condition_variable condition;
-	static size_t constexpr max_requests{ 2048 };
+	static std::size_t constexpr max_requests{ 2048 };
 	std::deque<request_t> requests;
 	std::deque<candidate_t> candidates;
 	std::atomic<bool> stopped{ false };

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1393,7 +1393,7 @@ nano::wallets::wallets (bool error_a, nano::node & node_a) :
 	{
 		char const * store_path;
 		mdb_env_get_path (env, &store_path);
-        boost::filesystem::path const path (store_path);
+		boost::filesystem::path const path (store_path);
 		nano::mdb_store::create_backup_file (env, path, node_a.logger);
 	}
 	for (auto & item : items)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -199,7 +199,7 @@ void nano::wallet_store::derive_key (nano::raw_key & prv_a, nano::transaction co
 	kdf.phs (prv_a, password_a, salt_l);
 }
 
-nano::fan::fan (nano::raw_key const & key, size_t count_a)
+nano::fan::fan (nano::raw_key const & key, std::size_t count_a)
 {
 	auto first (std::make_unique<nano::raw_key> (key));
 	for (auto i (1); i < count_a; ++i)
@@ -252,8 +252,8 @@ nano::account const nano::wallet_store::seed_special (5);
 // Current key index for deterministic keys
 nano::account const nano::wallet_store::deterministic_index_special (6);
 int const nano::wallet_store::special_count (7);
-size_t const nano::wallet_store::check_iv_index (0);
-size_t const nano::wallet_store::seed_iv_index (1);
+std::size_t const nano::wallet_store::check_iv_index (0);
+std::size_t const nano::wallet_store::seed_iv_index (1);
 
 nano::wallet_store::wallet_store (bool & init_a, nano::kdf & kdf_a, nano::transaction & transaction_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a, std::string const & json_a) :
 	password (0, fanout_a),
@@ -941,7 +941,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 		id_mdb_val = nano::mdb_val (id_a->size (), const_cast<char *> (id_a->data ()));
 	}
 
-	auto prepare_send = [&id_mdb_val, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a] (const auto & transaction) {
+	auto prepare_send = [&id_mdb_val, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a] (auto const & transaction) {
 		auto block_transaction (wallets.node.store.tx_begin_read ());
 		auto error (false);
 		auto cached_block (false);
@@ -1391,9 +1391,9 @@ nano::wallets::wallets (bool error_a, nano::node & node_a) :
 	}
 	if (backup_required)
 	{
-		const char * store_path;
+		char const * store_path;
 		mdb_env_get_path (env, &store_path);
-		const boost::filesystem::path path (store_path);
+        boost::filesystem::path const path (store_path);
 		nano::mdb_store::create_backup_file (env, path, node_a.logger);
 	}
 	for (auto & item : items)
@@ -1629,7 +1629,7 @@ nano::wallet_representatives nano::wallets::reps () const
 	return representatives;
 }
 
-bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t const & half_principal_weight_a, const bool acquire_lock_a)
+bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t const & half_principal_weight_a, bool const acquire_lock_a)
 {
 	auto weight = node.ledger.weight (account_a);
 
@@ -1832,8 +1832,8 @@ MDB_txn * nano::wallet_store::tx (nano::transaction const & transaction_a) const
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (wallets & wallets, std::string const & name)
 {
-	size_t items_count;
-	size_t actions_count;
+	std::size_t items_count;
+	std::size_t actions_count;
 	{
 		nano::lock_guard<nano::mutex> guard (wallets.mutex);
 		items_count = wallets.items.size ();

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -22,7 +22,7 @@ class wallets;
 class fan final
 {
 public:
-	fan (nano::raw_key const &, size_t);
+	fan (nano::raw_key const &, std::size_t);
 	void value (nano::raw_key &);
 	void value_set (nano::raw_key const &);
 	std::vector<std::unique_ptr<nano::raw_key>> values;
@@ -110,8 +110,8 @@ public:
 	static nano::account const representative_special;
 	static nano::account const seed_special;
 	static nano::account const deterministic_index_special;
-	static size_t const check_iv_index;
-	static size_t const seed_iv_index;
+	static std::size_t const check_iv_index;
+	static std::size_t const seed_iv_index;
 	static int const special_count;
 	nano::kdf & kdf;
 	std::atomic<MDB_dbi> handle{ 0 };
@@ -209,7 +209,7 @@ public:
 	void stop ();
 	void clear_send_ids (nano::transaction const &);
 	nano::wallet_representatives reps () const;
-	bool check_rep (nano::account const &, nano::uint128_t const &, const bool = true);
+	bool check_rep (nano::account const &, nano::uint128_t const &, bool const = true);
 	void compute_reps ();
 	void ongoing_compute_reps ();
 	void split_if_needed (nano::transaction &, nano::store &);

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -66,7 +66,7 @@ namespace websocket
 		/** Auxiliary length, not a valid topic, must be the last enum */
 		_length
 	};
-	constexpr size_t number_topics{ static_cast<size_t> (topic::_length) - static_cast<size_t> (topic::invalid) };
+	constexpr std::size_t number_topics{ static_cast<std::size_t> (topic::_length) - static_cast<std::size_t> (topic::invalid) };
 
 	/** A message queued for broadcasting */
 	class message final
@@ -184,11 +184,11 @@ namespace websocket
 			return include_election_info_with_votes;
 		}
 
-		static constexpr const uint8_t type_active_quorum = 1;
-		static constexpr const uint8_t type_active_confirmation_height = 2;
-		static constexpr const uint8_t type_inactive = 4;
-		static constexpr const uint8_t type_all_active = type_active_quorum | type_active_confirmation_height;
-		static constexpr const uint8_t type_all = type_all_active | type_inactive;
+		static constexpr uint8_t const type_active_quorum = 1;
+		static constexpr uint8_t const type_active_confirmation_height = 2;
+		static constexpr uint8_t const type_inactive = 4;
+		static constexpr uint8_t const type_all_active = type_active_quorum | type_active_confirmation_height;
+		static constexpr uint8_t const type_all = type_all_active | type_inactive;
 
 	private:
 		void check_filter_empty () const;
@@ -321,7 +321,7 @@ namespace websocket
 			return subscriber_count (topic_a) > 0;
 		}
 		/** Getter for subscriber count of a specific topic*/
-		size_t subscriber_count (nano::websocket::topic const & topic_a) const
+		std::size_t subscriber_count (nano::websocket::topic const & topic_a) const
 		{
 			return topic_subscriber_count[static_cast<std::size_t> (topic_a)];
 		}

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -845,7 +845,7 @@ void nano_qt::stats_viewer::refresh_stats ()
 	if (json)
 	{
 		// Format the stat data to make totals and values easier to read
-		BOOST_FOREACH (const boost::property_tree::ptree::value_type & child, json->get_child ("entries"))
+		BOOST_FOREACH (boost::property_tree::ptree::value_type const & child, json->get_child ("entries"))
 		{
 			auto time = child.second.get<std::string> ("time");
 			auto type = child.second.get<std::string> ("type");
@@ -860,7 +860,7 @@ void nano_qt::stats_viewer::refresh_stats ()
 
 			if (type == "traffic_udp" || type == "traffic_tcp")
 			{
-				const std::vector<std::string> units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
+				std::vector<std::string> const units = { " bytes", " KB", " MB", " GB", " TB", " PB" };
 				double bytes = std::stod (value);
 				auto index = bytes == 0 ? 0 : std::min (units.size () - 1, static_cast<size_t> (std::floor (std::log2 (bytes) / 10)));
 				std::string unit = units[index];
@@ -1917,7 +1917,7 @@ void nano_qt::advanced_actions::refresh_peers ()
 {
 	peers_model->removeRows (0, peers_model->rowCount ());
 	auto list (wallet.node.network.list (std::numeric_limits<size_t>::max ()));
-	std::sort (list.begin (), list.end (), [] (const auto & lhs, const auto & rhs) {
+	std::sort (list.begin (), list.end (), [] (auto const & lhs, auto const & rhs) {
 		return lhs->get_endpoint () < rhs->get_endpoint ();
 	});
 	for (auto i (list.begin ()), n (list.end ()); i != n; ++i)

--- a/nano/rpc/rpc_connection_secure.cpp
+++ b/nano/rpc/rpc_connection_secure.cpp
@@ -20,13 +20,13 @@ void nano::rpc_connection_secure::parse_connection ()
 	}));
 }
 
-void nano::rpc_connection_secure::on_shutdown (const boost::system::error_code & error)
+void nano::rpc_connection_secure::on_shutdown (boost::system::error_code const & error)
 {
 	// No-op. We initiate the shutdown (since the RPC server kills the connection after each request)
 	// and we'll thus get an expected EOF error. If the client disconnects, a short-read error will be expected.
 }
 
-void nano::rpc_connection_secure::handle_handshake (const boost::system::error_code & error)
+void nano::rpc_connection_secure::handle_handshake (boost::system::error_code const & error)
 {
 	if (!error)
 	{

--- a/nano/rpc/rpc_connection_secure.hpp
+++ b/nano/rpc/rpc_connection_secure.hpp
@@ -17,9 +17,9 @@ public:
 	void parse_connection () override;
 	void write_completion_handler (std::shared_ptr<nano::rpc_connection> const & rpc) override;
 	/** The TLS handshake callback */
-	void handle_handshake (const boost::system::error_code & error);
+	void handle_handshake (boost::system::error_code const & error);
 	/** The TLS async shutdown callback */
-	void on_shutdown (const boost::system::error_code & error);
+	void on_shutdown (boost::system::error_code const & error);
 
 private:
 	boost::asio::ssl::stream<socket_type &> stream;

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -22,17 +22,17 @@ struct ipc_connection
 
 struct rpc_request
 {
-	rpc_request (const std::string & action_a, const std::string & body_a, std::function<void (std::string const &)> response_a) :
+	rpc_request (std::string const & action_a, std::string const & body_a, std::function<void (std::string const &)> response_a) :
 		action (action_a), body (body_a), response (response_a)
 	{
 	}
 
-	rpc_request (int rpc_api_version_a, const std::string & body_a, std::function<void (std::string const &)> response_a) :
+	rpc_request (int rpc_api_version_a, std::string const & body_a, std::function<void (std::string const &)> response_a) :
 		rpc_api_version (rpc_api_version_a), body (body_a), response (response_a)
 	{
 	}
 
-	rpc_request (int rpc_api_version_a, const std::string & action_a, const std::string & body_a, std::function<void (std::string const &)> response_a) :
+	rpc_request (int rpc_api_version_a, std::string const & action_a, std::string const & body_a, std::function<void (std::string const &)> response_a) :
 		rpc_api_version (rpc_api_version_a), action (action_a), body (body_a), response (response_a)
 	{
 	}
@@ -64,8 +64,8 @@ private:
 	bool stopped{ false };
 	std::deque<std::shared_ptr<nano::rpc_request>> requests;
 	nano::condition_variable condition;
-	const std::string ipc_address;
-	const uint16_t ipc_port;
+	std::string const ipc_address;
+	uint16_t const ipc_port;
 	std::thread thread;
 };
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -124,7 +124,7 @@ void reset_confirmation_height (nano::store & store, nano::account const & accou
 	}
 }
 
-void wait_response_impl (nano::system & system, std::shared_ptr<nano::rpc> const & rpc, boost::property_tree::ptree & request, const std::chrono::duration<double, std::nano> & time, boost::property_tree::ptree & response_json)
+void wait_response_impl (nano::system & system, std::shared_ptr<nano::rpc> const & rpc, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json)
 {
 	test_response response (request, rpc->config.port, system.io_ctx);
 	ASSERT_TIMELY (time, response.status != 0);
@@ -132,7 +132,7 @@ void wait_response_impl (nano::system & system, std::shared_ptr<nano::rpc> const
 	response_json = response.json;
 }
 
-boost::property_tree::ptree wait_response (nano::system & system, std::shared_ptr<nano::rpc> const & rpc, boost::property_tree::ptree & request, const std::chrono::duration<double, std::nano> & time = 5s)
+boost::property_tree::ptree wait_response (nano::system & system, std::shared_ptr<nano::rpc> const & rpc, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time = 5s)
 {
 	boost::property_tree::ptree response_json;
 	wait_response_impl (system, rpc, request, time, response_json);
@@ -3219,7 +3219,7 @@ TEST (rpc, pending_exists)
 	auto [rpc, rpc_ctx] = add_rpc (system, node);
 	boost::property_tree::ptree request;
 
-	auto pending_exists = [&system, &request, rpc = rpc] (const char * exists_a) {
+	auto pending_exists = [&system, &request, rpc = rpc] (char const * exists_a) {
 		auto response0 (wait_response (system, rpc, request));
 		std::string exists_text (response0.get<std::string> ("exists"));
 		ASSERT_EQ (exists_a, exists_text);
@@ -5536,7 +5536,7 @@ TEST (rpc, simultaneous_calls)
 
 	promise.get_future ().wait ();
 
-	ASSERT_TIMELY (60s, std::all_of (test_responses.begin (), test_responses.end (), [] (const auto & test_response) { return test_response->status != 0; }));
+	ASSERT_TIMELY (60s, std::all_of (test_responses.begin (), test_responses.end (), [] (auto const & test_response) { return test_response->status != 0; }));
 
 	for (int i = 0; i < num; ++i)
 	{

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -137,7 +137,7 @@ nano::ledger_constants::ledger_constants (nano::work_thresholds & work, nano::ne
 	nano_test_genesis->sideband_set (nano::block_sideband (nano_test_genesis->account (), 0, std::numeric_limits<nano::uint128_t>::max (), 1, nano::seconds_since_epoch (), nano::epoch::epoch_0, false, false, false, nano::epoch::epoch_0));
 
 	nano::link epoch_link_v1;
-	const char * epoch_message_v1 ("epoch v1 block");
+	char const * epoch_message_v1 ("epoch v1 block");
 	strncpy ((char *)epoch_link_v1.bytes.data (), epoch_message_v1, epoch_link_v1.bytes.size ());
 	epochs.add (nano::epoch::epoch_1, genesis->account (), epoch_link_v1);
 
@@ -148,7 +148,7 @@ nano::ledger_constants::ledger_constants (nano::work_thresholds & work, nano::ne
 	auto epoch_v2_signer (network_a == nano::networks::nano_dev_network ? nano::dev::genesis_key.pub : network_a == nano::networks::nano_beta_network ? nano_beta_account
 	: network_a == nano::networks::nano_test_network                                                                                                  ? nano_test_account
 																																					  : nano_live_epoch_v2_signer);
-	const char * epoch_message_v2 ("epoch v2 block");
+	char const * epoch_message_v2 ("epoch v2 block");
 	strncpy ((char *)epoch_link_v2.bytes.data (), epoch_message_v2, epoch_link_v2.bytes.size ());
 	epochs.add (nano::epoch::epoch_2, epoch_v2_signer, epoch_link_v2);
 }
@@ -273,13 +273,13 @@ bool nano::account_info::operator!= (nano::account_info const & other_a) const
 
 size_t nano::account_info::db_size () const
 {
-	debug_assert (reinterpret_cast<const uint8_t *> (this) == reinterpret_cast<const uint8_t *> (&head));
-	debug_assert (reinterpret_cast<const uint8_t *> (&head) + sizeof (head) == reinterpret_cast<const uint8_t *> (&representative));
-	debug_assert (reinterpret_cast<const uint8_t *> (&representative) + sizeof (representative) == reinterpret_cast<const uint8_t *> (&open_block));
-	debug_assert (reinterpret_cast<const uint8_t *> (&open_block) + sizeof (open_block) == reinterpret_cast<const uint8_t *> (&balance));
-	debug_assert (reinterpret_cast<const uint8_t *> (&balance) + sizeof (balance) == reinterpret_cast<const uint8_t *> (&modified));
-	debug_assert (reinterpret_cast<const uint8_t *> (&modified) + sizeof (modified) == reinterpret_cast<const uint8_t *> (&block_count));
-	debug_assert (reinterpret_cast<const uint8_t *> (&block_count) + sizeof (block_count) == reinterpret_cast<const uint8_t *> (&epoch_m));
+	debug_assert (reinterpret_cast<uint8_t const *> (this) == reinterpret_cast<uint8_t const *> (&head));
+	debug_assert (reinterpret_cast<uint8_t const *> (&head) + sizeof (head) == reinterpret_cast<uint8_t const *> (&representative));
+	debug_assert (reinterpret_cast<uint8_t const *> (&representative) + sizeof (representative) == reinterpret_cast<uint8_t const *> (&open_block));
+	debug_assert (reinterpret_cast<uint8_t const *> (&open_block) + sizeof (open_block) == reinterpret_cast<uint8_t const *> (&balance));
+	debug_assert (reinterpret_cast<uint8_t const *> (&balance) + sizeof (balance) == reinterpret_cast<uint8_t const *> (&modified));
+	debug_assert (reinterpret_cast<uint8_t const *> (&modified) + sizeof (modified) == reinterpret_cast<uint8_t const *> (&block_count));
+	debug_assert (reinterpret_cast<uint8_t const *> (&block_count) + sizeof (block_count) == reinterpret_cast<uint8_t const *> (&epoch_m));
 	return sizeof (head) + sizeof (representative) + sizeof (open_block) + sizeof (balance) + sizeof (modified) + sizeof (block_count) + sizeof (epoch_m);
 }
 
@@ -392,12 +392,12 @@ bool nano::unchecked_info::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-nano::endpoint_key::endpoint_key (const std::array<uint8_t, 16> & address_a, uint16_t port_a) :
+nano::endpoint_key::endpoint_key (std::array<uint8_t, 16> const & address_a, uint16_t port_a) :
 	address (address_a), network_port (boost::endian::native_to_big (port_a))
 {
 }
 
-const std::array<uint8_t, 16> & nano::endpoint_key::address_bytes () const
+std::array<uint8_t, 16> const & nano::endpoint_key::address_bytes () const
 {
 	return address;
 }
@@ -594,7 +594,7 @@ std::string nano::vote::hashes_string () const
 	return result;
 }
 
-const std::string nano::vote::hash_prefix = "vote ";
+std::string const nano::vote::hash_prefix = "vote ";
 
 nano::block_hash nano::vote::hash () const
 {

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -149,7 +149,7 @@ public:
 	/*
      * @return The ipv6 address in network byte order
      */
-    std::array<uint8_t, 16> const & address_bytes () const;
+	std::array<uint8_t, 16> const & address_bytes () const;
 
 	/*
      * @return The port in host byte order

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -72,9 +72,9 @@ struct hash<::nano::root>
 namespace nano
 {
 /**
-     * A key pair. The private key is generated from the random pool, or passed in
-     * as a hex string. The public key is derived using ed25519.
-     */
+ * A key pair. The private key is generated from the random pool, or passed in
+ * as a hex string. The public key is derived using ed25519.
+ */
 class keypair
 {
 public:
@@ -86,8 +86,8 @@ public:
 };
 
 /**
-     * Latest information about an account
-     */
+ * Latest information about an account
+ */
 class account_info final
 {
 public:
@@ -109,8 +109,8 @@ public:
 };
 
 /**
-     * Information on an uncollected send
-     */
+ * Information on an uncollected send
+ */
 class pending_info final
 {
 public:
@@ -141,19 +141,19 @@ public:
 	endpoint_key () = default;
 
 	/*
-                 * @param address_a This should be in network byte order
-                 * @param port_a This should be in host byte order
-                 */
-	endpoint_key (const std::array<uint8_t, 16> & address_a, uint16_t port_a);
+     * @param address_a This should be in network byte order
+     * @param port_a This should be in host byte order
+     */
+	endpoint_key (std::array<uint8_t, 16> const & address_a, uint16_t port_a);
 
 	/*
-                 * @return The ipv6 address in network byte order
-                 */
-	const std::array<uint8_t, 16> & address_bytes () const;
+     * @return The ipv6 address in network byte order
+     */
+    std::array<uint8_t, 16> const & address_bytes () const;
 
 	/*
-                 * @return The port in host byte order
-                 */
+     * @return The port in host byte order
+     */
 	uint16_t port () const;
 
 private:
@@ -181,8 +181,8 @@ public:
 };
 
 /**
-     * Tag for block signature verification result
-     */
+ * Tag for block signature verification result
+ */
 enum class signature_verification : uint8_t
 {
 	unknown = 0,
@@ -192,8 +192,8 @@ enum class signature_verification : uint8_t
 };
 
 /**
-     * Information on an unchecked block
-     */
+ * Information on an unchecked block
+ */
 class unchecked_info final
 {
 public:
@@ -272,15 +272,15 @@ public:
 	nano::account account;
 	// Signature of timestamp + block hashes
 	nano::signature signature;
-	static const std::string hash_prefix;
+	static std::string const hash_prefix;
 };
 /**
-     * This class serves to find and return unique variants of a vote in order to minimize memory usage
-     */
+ * This class serves to find and return unique variants of a vote in order to minimize memory usage
+ */
 class vote_uniquer final
 {
 public:
-	using value_type = std::pair<const nano::block_hash, std::weak_ptr<nano::vote>>;
+	using value_type = std::pair<nano::block_hash const, std::weak_ptr<nano::vote>>;
 
 	vote_uniquer (nano::block_uniquer &);
 	std::shared_ptr<nano::vote> unique (std::shared_ptr<nano::vote> const &);

--- a/nano/secure/store/account_store_partial.hpp
+++ b/nano/secure/store/account_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class account_store_partial : public account_store
@@ -22,7 +22,7 @@ class account_store_partial : public account_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit account_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/block_store_partial.hpp
+++ b/nano/secure/store/block_store_partial.hpp
@@ -17,7 +17,7 @@ template <typename Val, typename Derived_Store>
 class block_predecessor_set;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class block_store_partial : public block_store

--- a/nano/secure/store/confirmation_height_store_partial.hpp
+++ b/nano/secure/store/confirmation_height_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class confirmation_height_store_partial : public confirmation_height_store
@@ -22,7 +22,7 @@ class confirmation_height_store_partial : public confirmation_height_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit confirmation_height_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/final_vote_store_partial.hpp
+++ b/nano/secure/store/final_vote_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const & store, const int status);
+void release_assert_success (store_partial<Val, Derived_Store> const & store, int const status);
 
 template <typename Val, typename Derived_Store>
 class final_vote_store_partial : public final_vote_store
@@ -22,7 +22,7 @@ class final_vote_store_partial : public final_vote_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit final_vote_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/frontier_store_partial.hpp
+++ b/nano/secure/store/frontier_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const & store, const int status);
+void release_assert_success (store_partial<Val, Derived_Store> const & store, int const status);
 
 template <typename Val, typename Derived_Store>
 class frontier_store_partial : public frontier_store
@@ -22,7 +22,7 @@ class frontier_store_partial : public frontier_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit frontier_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/online_weight_partial.hpp
+++ b/nano/secure/store/online_weight_partial.hpp
@@ -8,7 +8,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class online_weight_store_partial : public online_weight_store
@@ -16,7 +16,7 @@ class online_weight_store_partial : public online_weight_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit online_weight_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/peer_store_partial.hpp
+++ b/nano/secure/store/peer_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class peer_store_partial : public peer_store
@@ -22,7 +22,7 @@ class peer_store_partial : public peer_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit peer_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/pending_store_partial.hpp
+++ b/nano/secure/store/pending_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class pending_store_partial : public pending_store
@@ -22,7 +22,7 @@ class pending_store_partial : public pending_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit pending_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/pruned_store_partial.hpp
+++ b/nano/secure/store/pruned_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class pruned_store_partial : public pruned_store
@@ -22,7 +22,7 @@ class pruned_store_partial : public pruned_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	explicit pruned_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/unchecked_store_partial.hpp
+++ b/nano/secure/store/unchecked_store_partial.hpp
@@ -14,7 +14,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class unchecked_store_partial : public unchecked_store
@@ -22,7 +22,7 @@ class unchecked_store_partial : public unchecked_store
 private:
 	nano::store_partial<Val, Derived_Store> & store;
 
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 
 public:
 	unchecked_store_partial (nano::store_partial<Val, Derived_Store> & store_a) :

--- a/nano/secure/store/version_store_partial.hpp
+++ b/nano/secure/store/version_store_partial.hpp
@@ -8,7 +8,7 @@ template <typename Val, typename Derived_Store>
 class store_partial;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const &, const int);
+void release_assert_success (store_partial<Val, Derived_Store> const &, int const);
 
 template <typename Val, typename Derived_Store>
 class version_store_partial : public version_store

--- a/nano/secure/store_partial.hpp
+++ b/nano/secure/store_partial.hpp
@@ -35,7 +35,7 @@ template <typename Val, typename Derived_Store>
 class block_predecessor_set;
 
 template <typename Val, typename Derived_Store>
-void release_assert_success (store_partial<Val, Derived_Store> const & store, const int status)
+void release_assert_success (store_partial<Val, Derived_Store> const & store, int const status)
 {
 	if (!store.success (status))
 	{
@@ -56,7 +56,7 @@ class block_store_partial;
 template <typename Val, typename Derived_Store>
 class store_partial : public store
 {
-	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, const int);
+	friend void release_assert_success<Val, Derived_Store> (store_partial<Val, Derived_Store> const &, int const);
 	friend class nano::block_store_partial<Val, Derived_Store>;
 	friend class nano::frontier_store_partial<Val, Derived_Store>;
 	friend class nano::account_store_partial<Val, Derived_Store>;

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -51,13 +51,13 @@ nano::account_info_v14::account_info_v14 (nano::block_hash const & head_a, nano:
 
 size_t nano::account_info_v14::db_size () const
 {
-	debug_assert (reinterpret_cast<const uint8_t *> (this) == reinterpret_cast<const uint8_t *> (&head));
-	debug_assert (reinterpret_cast<const uint8_t *> (&head) + sizeof (head) == reinterpret_cast<const uint8_t *> (&rep_block));
-	debug_assert (reinterpret_cast<const uint8_t *> (&rep_block) + sizeof (rep_block) == reinterpret_cast<const uint8_t *> (&open_block));
-	debug_assert (reinterpret_cast<const uint8_t *> (&open_block) + sizeof (open_block) == reinterpret_cast<const uint8_t *> (&balance));
-	debug_assert (reinterpret_cast<const uint8_t *> (&balance) + sizeof (balance) == reinterpret_cast<const uint8_t *> (&modified));
-	debug_assert (reinterpret_cast<const uint8_t *> (&modified) + sizeof (modified) == reinterpret_cast<const uint8_t *> (&block_count));
-	debug_assert (reinterpret_cast<const uint8_t *> (&block_count) + sizeof (block_count) == reinterpret_cast<const uint8_t *> (&confirmation_height));
+	debug_assert (reinterpret_cast<uint8_t const *> (this) == reinterpret_cast<uint8_t const *> (&head));
+	debug_assert (reinterpret_cast<uint8_t const *> (&head) + sizeof (head) == reinterpret_cast<uint8_t const *> (&rep_block));
+	debug_assert (reinterpret_cast<uint8_t const *> (&rep_block) + sizeof (rep_block) == reinterpret_cast<uint8_t const *> (&open_block));
+	debug_assert (reinterpret_cast<uint8_t const *> (&open_block) + sizeof (open_block) == reinterpret_cast<uint8_t const *> (&balance));
+	debug_assert (reinterpret_cast<uint8_t const *> (&balance) + sizeof (balance) == reinterpret_cast<uint8_t const *> (&modified));
+	debug_assert (reinterpret_cast<uint8_t const *> (&modified) + sizeof (modified) == reinterpret_cast<uint8_t const *> (&block_count));
+	debug_assert (reinterpret_cast<uint8_t const *> (&block_count) + sizeof (block_count) == reinterpret_cast<uint8_t const *> (&confirmation_height));
 	return sizeof (head) + sizeof (rep_block) + sizeof (open_block) + sizeof (balance) + sizeof (modified) + sizeof (block_count) + sizeof (confirmation_height);
 }
 

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1240,7 +1240,7 @@ namespace transport
 		nano::system system;
 		nano::node_flags node_flags;
 		node_flags.disable_initial_telemetry_requests = true;
-		const auto num_nodes = 4;
+		auto const num_nodes = 4;
 		for (int i = 0; i < num_nodes; ++i)
 		{
 			system.add_node (node_flags);
@@ -1249,7 +1249,7 @@ namespace transport
 		wait_peer_connections (system);
 
 		std::vector<std::thread> threads;
-		const auto num_threads = 4;
+		auto const num_threads = 4;
 
 		std::array<data, num_nodes> node_data{};
 		for (auto i = 0; i < num_nodes; ++i)
@@ -1422,7 +1422,7 @@ TEST (telemetry, many_nodes)
 	node_flags.disable_initial_telemetry_requests = true;
 	node_flags.disable_request_loop = true;
 	// The telemetry responses can timeout if using a large number of nodes under sanitizers, so lower the number.
-	const auto num_nodes = (is_sanitizer_build || nano::running_within_valgrind ()) ? 4 : 10;
+	auto const num_nodes = (is_sanitizer_build || nano::running_within_valgrind ()) ? 4 : 10;
 	for (auto i = 0; i < num_nodes; ++i)
 	{
 		nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -41,10 +41,10 @@ public:
 	 * Polls, sleep if there's no work to be done (default 50ms), then check the deadline
 	 * @returns 0 or nano::deadline_expired
 	 */
-	std::error_code poll (const std::chrono::nanoseconds & sleep_time = std::chrono::milliseconds (50));
+	std::error_code poll (std::chrono::nanoseconds const & sleep_time = std::chrono::milliseconds (50));
 	std::error_code poll_until_true (std::chrono::nanoseconds deadline, std::function<bool ()>);
 	void stop ();
-	void deadline_set (const std::chrono::duration<double, std::nano> & delta);
+	void deadline_set (std::chrono::duration<double, std::nano> const & delta);
 	std::shared_ptr<nano::node> add_node (nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
 	std::shared_ptr<nano::node> add_node (nano::node_config const &, nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
 	boost::asio::io_context io_ctx;

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -65,7 +65,7 @@ public:
 		ss << sink.ss.str ();
 	}
 
-	std::streamsize write (const char * string_to_write, std::streamsize size)
+	std::streamsize write (char const * string_to_write, std::streamsize size)
 	{
 		nano::lock_guard<nano::mutex> guard (mutex);
 		ss << std::string (string_to_write, size);


### PR DESCRIPTION
Co-authored-by: marioortizmanero <marioortizmanero@gmail.com>

Supersedes https://github.com/nanocurrency/nano-node/pull/3143

Interesting fact: starting with [`clang-format-14`, we'll be able to automatically check & enforce](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) the type modifiers positioning:
![Screenshot from 2021-10-20 16-16-07](https://user-images.githubusercontent.com/81556890/138107255-37eeebbf-d63f-4473-b76b-8aba716627f4.png)
