### PR TITLE
Disable (intermittently) failing unit tests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -23,7 +23,8 @@ set -o nounset
 set -o xtrace
 
 # Alpine doesn't offer an xvfb
-xvfb_run_() {
+xvfb_run_()
+{
     INIT_DELAY_SEC=3
 
     Xvfb :2 -screen 0 1024x768x24 &
@@ -36,33 +37,18 @@ xvfb_run_() {
     return ${res}
 }
 
-run_tests() {
-    local tries try
-
-    # when busybox pretends to be bash it needs different args
-    #   for the timeout builtin
+run_tests()
+{
+    # when busybox pretends to be bash it needs different args for the timeout builtin
+    #
     if [[ "${BUSYBOX_BASH}" -eq 1 ]]; then
         TIMEOUT_TIME_ARG="-t"
     else
         TIMEOUT_TIME_ARG=""
     fi
 
-    tries=(_initial_)
-
-    for try in "${tries[@]}"; do
-        if [ "${try}" != '_initial_' ]; then
-            echo "core_test failed: ${core_test_res}, retrying (try=${try})"
-
-            # Wait a while for sockets to be all cleaned up by the kernel
-            sleep $((30 + (RANDOM % 30)))
-        fi
-
-        ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_DEFAULT} ./core_test
-        core_test_res=${?}
-        if [ "${core_test_res}" = '0' ]; then
-            break
-        fi
-    done
+    ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_DEFAULT} ./core_test
+    core_test_res=${?}
 
     ${TIMEOUT_CMD} ${TIMEOUT_TIME_ARG} ${TIMEOUT_DEFAULT} ./rpc_test
     rpc_test_res=${?}
@@ -77,6 +63,7 @@ run_tests() {
     echo "RPC  Test return code: ${rpc_test_res}"
     echo "QT Test return code: ${qt_test_res}"
     echo "Sys Test return code: ${sys_test_res}"
+
     if [[ ${core_test_res} != 0 || ${rpc_test_res} != 0 || ${qt_test_res} != 0 || ${sys_test_res} != 0 ]]; then
         return 1
     else

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -11,7 +11,11 @@ using namespace std::chrono_literals;
 
 namespace nano
 {
-TEST (active_transactions, confirm_active)
+
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3522
+TEST (active_transactions, DISABLED_confirm_active)
 {
 	nano::system system;
 	nano::node_flags node_flags;

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -11,7 +11,6 @@ using namespace std::chrono_literals;
 
 namespace nano
 {
-
 // Test disabled because it's failing intermittently.
 // PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3522

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -404,7 +404,7 @@ TEST (bootstrap_processor, push_diamond)
 	node1->stop ();
 }
 
-TEST (bootstrap_processor, push_diamond_pruning)
+TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 {
 	nano::system system;
 	nano::node_config config (nano::get_available_port (), system.logging);

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -404,6 +404,10 @@ TEST (bootstrap_processor, push_diamond)
 	node1->stop ();
 }
 
+// Check that an outgoing bootstrap request can push blocks
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3517
 TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 {
 	nano::system system;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1682,7 +1682,7 @@ TEST (node, DISABLED_fork_stale)
 	}
 }
 
-TEST (node, broadcast_elected)
+TEST (node, DISABLED_broadcast_elected)
 {
 	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
 	for (auto & type : types)
@@ -1904,7 +1904,7 @@ TEST (node, DISABLED_bootstrap_no_publish)
 }
 
 // Check that an outgoing bootstrap request can push blocks
-TEST (node, bootstrap_bulk_push)
+TEST (node, DISABLED_bootstrap_bulk_push)
 {
 	nano::system system0;
 	nano::system system1;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1682,6 +1682,9 @@ TEST (node, DISABLED_fork_stale)
 	}
 }
 
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3516
 TEST (node, DISABLED_broadcast_elected)
 {
 	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
@@ -1904,6 +1907,9 @@ TEST (node, DISABLED_bootstrap_no_publish)
 }
 
 // Check that an outgoing bootstrap request can push blocks
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3515
 TEST (node, DISABLED_bootstrap_bulk_push)
 {
 	nano::system system0;

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -545,7 +545,10 @@ TEST (telemetry, max_possible_size)
 
 namespace nano
 {
-TEST (telemetry, remove_peer_different_genesis)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3524
+TEST (telemetry, DISABLED_remove_peer_different_genesis)
 {
 	nano::system system (1);
 	auto node0 (system.nodes[0]);

--- a/nano/node/peer_exclusion.hpp
+++ b/nano/node/peer_exclusion.hpp
@@ -52,7 +52,7 @@ public:
 	std::size_t limited_size (std::size_t const) const;
 	std::size_t size () const;
 
-	friend class telemetry_remove_peer_different_genesis_Test;
+	friend class telemetry_DISABLED_remove_peer_different_genesis_Test;
 	friend class telemetry_remove_peer_different_genesis_udp_Test;
 	friend class telemetry_remove_peer_invalid_signature_Test;
 	friend class peer_exclusion_validate_Test;

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -150,7 +150,7 @@ private:
 	/** Probable representatives */
 	probably_rep_t probable_reps;
 
-	friend class active_transactions_confirm_active_Test;
+	friend class active_transactions_DISABLED_confirm_active_Test;
 	friend class active_transactions_confirm_frontier_Test;
 	friend class rep_crawler_local_Test;
 	friend class node_online_reps_rep_crawler_Test;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5162,7 +5162,7 @@ TEST (rpc, uptime)
 	ASSERT_LE (1, response.get<int> ("seconds"));
 }
 
-TEST (rpc, wallet_history)
+TEST (rpc, DISABLED_wallet_history)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5162,6 +5162,9 @@ TEST (rpc, uptime)
 	ASSERT_LE (1, response.get<int> ("seconds"));
 }
 
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3512
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3514
 TEST (rpc, DISABLED_wallet_history)
 {
 	nano::system system;


### PR DESCRIPTION
T̶h̶i̶s̶ ̶P̶R̶ ̶m̶a̶k̶e̶s̶ ̶t̶h̶e̶ ̶C̶I̶ ̶t̶i̶m̶e̶o̶u̶t̶ ̶f̶o̶r̶ ̶u̶n̶i̶t̶ ̶t̶e̶s̶t̶s̶ ̶a̶ ̶b̶i̶t̶ ̶l̶a̶r̶g̶e̶r̶.̶

Initially, the PR was about enlarging the timeout, but in fact, the problem for which some jobs were timing out was because there was an intermittent unit test failure and the Bash script kept rerunning `core_test` until it succeeded, which led to the timeout.

What the PR does now is: disable all unit tests that fail intermittently across Linux/OSX/Windows. Purpose for this is to keep a base of tests that always (100% of the runs) pass and make a green CI light a mandatory step for merging PRs. 

I will then open a couple issues to look at disabled tests and see how we can get them enabled again.