### PR TITLE
Include `<csignal>` for `std::signal` usage

### DIFF
--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/format.hpp>
 
+#include <csignal>
 #include <iostream>
 
 namespace


### PR DESCRIPTION
Not exactly sure if this was the reason for [the failure here](https://github.com/nanocurrency/nano-node/runs/4001164403?check_suite_focus=true#step:5:961), or why [Windows jobs are successful otherwise](https://github.com/nanocurrency/nano-node/runs/3953463907?check_suite_focus=true) on normal CI runs, but while that is under investigation we should be able to get a green beta build.