### PR TITLE
Disable intermittently failing unit test

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -176,7 +176,10 @@ TEST (election, quorum_minimum_confirm_fail)
 
 namespace nano
 {
-TEST (election, quorum_minimum_update_weight_before_quorum_checks)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3526
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3528
+TEST (election, DISABLED_quorum_minimum_update_weight_before_quorum_checks)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3159,7 +3159,10 @@ TEST (node, epoch_conflict_confirm)
 	}
 }
 
-TEST (node, fork_invalid_block_signature)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3526
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3527
+TEST (node, DISABLED_fork_invalid_block_signature)
 {
 	nano::system system;
 	nano::node_flags node_flags;

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -68,7 +68,7 @@ private:
 	nano::uint128_t online_m;
 	nano::uint128_t minimum;
 
-	friend class election_quorum_minimum_update_weight_before_quorum_checks_Test;
+	friend class election_DISABLED_quorum_minimum_update_weight_before_quorum_checks_Test;
 	friend std::unique_ptr<container_info_component> collect_container_info (online_reps & online_reps, std::string const & name);
 };
 


### PR DESCRIPTION
Disabled two more tests:
- `node.fork_invalid_block_signature` (failed [here](https://github.com/nanocurrency/nano-node/runs/4003377949?check_suite_focus=true#step:6:1850), issue [here](https://github.com/nanocurrency/nano-node/issues/3527))
- `election.quorum_minimum_update_weight_before_quorum_checks` (failed [here](https://github.com/nanocurrency/nano-node/runs/4008874110?check_suite_focus=true#step:6:562), issue [here](https://github.com/nanocurrency/nano-node/issues/3528))
