### PR TITLE
Rep crawler weight minimum

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -167,6 +167,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.network_threads, defaults.node.network_threads);
 	ASSERT_EQ (conf.node.secondary_work_peers, defaults.node.secondary_work_peers);
 	ASSERT_EQ (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
+	ASSERT_EQ (conf.node.rep_crawler_weight_minimum, defaults.node.rep_crawler_weight_minimum);
 	ASSERT_EQ (conf.node.election_hint_weight_percent, defaults.node.election_hint_weight_percent);
 	ASSERT_EQ (conf.node.password_fanout, defaults.node.password_fanout);
 	ASSERT_EQ (conf.node.peering_port, defaults.node.peering_port);
@@ -405,6 +406,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	lmdb_max_dbs = 999
 	network_threads = 999
 	online_weight_minimum = "999"
+	rep_crawler_weight_minimum = "999"
 	election_hint_weight_percent = 19
 	password_fanout = 999
 	peering_port = 999
@@ -572,6 +574,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.max_pruning_age, defaults.node.max_pruning_age);
 	ASSERT_NE (conf.node.max_pruning_depth, defaults.node.max_pruning_depth);
 	ASSERT_NE (conf.node.online_weight_minimum, defaults.node.online_weight_minimum);
+	ASSERT_NE (conf.node.rep_crawler_weight_minimum, defaults.node.rep_crawler_weight_minimum);
 	ASSERT_NE (conf.node.election_hint_weight_percent, defaults.node.election_hint_weight_percent);
 	ASSERT_NE (conf.node.password_fanout, defaults.node.password_fanout);
 	ASSERT_NE (conf.node.peering_port, defaults.node.peering_port);

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -213,6 +213,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.logging.active_update_value, defaults.node.logging.active_update_value);
 	ASSERT_EQ (conf.node.logging.upnp_details_logging_value, defaults.node.logging.upnp_details_logging_value);
 	ASSERT_EQ (conf.node.logging.vote_logging_value, defaults.node.logging.vote_logging_value);
+	ASSERT_EQ (conf.node.logging.rep_crawler_logging_value, defaults.node.logging.rep_crawler_logging_value);
 	ASSERT_EQ (conf.node.logging.work_generation_time_value, defaults.node.logging.work_generation_time_value);
 
 	ASSERT_EQ (conf.node.websocket_config.enabled, defaults.node.websocket_config.enabled);
@@ -479,6 +480,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	active_update = true
 	upnp_details = true
 	vote = true
+	rep_crawler = true
 	work_generation_time = false
 
 	[node.statistics.log]
@@ -616,6 +618,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.logging.active_update_value, defaults.node.logging.active_update_value);
 	ASSERT_NE (conf.node.logging.upnp_details_logging_value, defaults.node.logging.upnp_details_logging_value);
 	ASSERT_NE (conf.node.logging.vote_logging_value, defaults.node.logging.vote_logging_value);
+	ASSERT_NE (conf.node.logging.rep_crawler_logging_value, defaults.node.logging.rep_crawler_logging_value);
 	ASSERT_NE (conf.node.logging.work_generation_time_value, defaults.node.logging.work_generation_time_value);
 
 	ASSERT_NE (conf.node.websocket_config.enabled, defaults.node.websocket_config.enabled);

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -146,6 +146,7 @@ nano::error nano::logging::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("ledger_duplicate", ledger_duplicate_logging_value, "Log when a duplicate block is attempted inserted into the ledger.\ntype:bool");
 	toml.put ("ledger_rollback", election_fork_tally_logging_value, "Log when a block is replaced in the ledger.\ntype:bool");
 	toml.put ("vote", vote_logging_value, "Vote logging. Enabling this option leads to a high volume.\nof log messages which may affect node performance.\ntype:bool");
+	toml.put ("rep_crawler", rep_crawler_logging_value, "Rep crawler logging. Enabling this option leads to a high volume.\nof log messages which may affect node performance.\ntype:bool");
 	toml.put ("election_expiration", election_expiration_tally_logging_value, "Log election tally on expiration.\ntype:bool");
 	toml.put ("election_fork", election_fork_tally_logging_value, "Log election tally when more than one block is seen.\ntype:bool");
 	toml.put ("network", network_logging_value, "Log network related messages.\ntype:bool");
@@ -182,6 +183,7 @@ nano::error nano::logging::deserialize_toml (nano::tomlconfig & toml)
 	toml.get<bool> ("ledger_duplicate", ledger_duplicate_logging_value);
 	toml.get<bool> ("ledger_rollback", ledger_rollback_logging_value);
 	toml.get<bool> ("vote", vote_logging_value);
+	toml.get<bool> ("rep_crawler", rep_crawler_logging_value);
 	toml.get<bool> ("election_expiration", election_expiration_tally_logging_value);
 	toml.get<bool> ("election_fork", election_fork_tally_logging_value);
 	toml.get<bool> ("network", network_logging_value);
@@ -220,6 +222,7 @@ nano::error nano::logging::serialize_json (nano::jsonconfig & json) const
 	json.put ("ledger", ledger_logging_value);
 	json.put ("ledger_duplicate", ledger_duplicate_logging_value);
 	json.put ("vote", vote_logging_value);
+	json.put ("rep_crawler", rep_crawler_logging_value);
 	json.put ("network", network_logging_value);
 	json.put ("network_timeout", network_timeout_logging_value);
 	json.put ("network_message", network_message_logging_value);
@@ -276,6 +279,7 @@ nano::error nano::logging::deserialize_json (bool & upgraded_a, nano::jsonconfig
 	json.get<bool> ("ledger", ledger_logging_value);
 	json.get<bool> ("ledger_duplicate", ledger_duplicate_logging_value);
 	json.get<bool> ("vote", vote_logging_value);
+	json.get<bool> ("rep_crawler", rep_crawler_logging_value);
 	json.get<bool> ("network", network_logging_value);
 	json.get<bool> ("network_timeout", network_timeout_logging_value);
 	json.get<bool> ("network_message", network_message_logging_value);
@@ -319,6 +323,11 @@ bool nano::logging::ledger_rollback_logging () const
 bool nano::logging::vote_logging () const
 {
 	return vote_logging_value;
+}
+
+bool nano::logging::rep_crawler_logging () const
+{
+	return rep_crawler_logging_value;
 }
 
 bool nano::logging::election_expiration_tally_logging () const

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -46,6 +46,7 @@ public:
 	bool ledger_duplicate_logging () const;
 	bool ledger_rollback_logging () const;
 	bool vote_logging () const;
+	bool rep_crawler_logging () const;
 	bool election_fork_tally_logging () const;
 	bool election_expiration_tally_logging () const;
 	bool network_logging () const;
@@ -74,6 +75,7 @@ public:
 	bool ledger_duplicate_logging_value{ false };
 	bool ledger_rollback_logging_value{ false };
 	bool vote_logging_value{ false };
+	bool rep_crawler_logging_value{ false };
 	bool election_fork_tally_logging_value{ false };
 	bool election_expiration_tally_logging_value{ false };
 	bool network_logging_value{ true };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -52,6 +52,7 @@ public:
 	unsigned bootstrap_fraction_numerator{ 1 };
 	nano::amount receive_minimum{ nano::xrb_ratio };
 	nano::amount vote_minimum{ nano::Gxrb_ratio };
+	nano::amount rep_crawler_weight_minimum{ "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" };
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (100) };
 	unsigned vote_generator_threshold{ 3 };
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -33,7 +33,9 @@ void nano::rep_crawler::validate ()
 		responses_l.swap (responses);
 	}
 
-	auto minimum = node.minimum_principal_weight ();
+	// normally the rep_crawler only tracks principal reps but it can be made to track
+	// reps with less weight by setting rep_crawler_weight_minimum to a low value
+	auto minimum = std::min (node.minimum_principal_weight (), node.config.rep_crawler_weight_minimum.number ());
 
 	for (auto const & i : responses_l)
 	{

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -60,20 +60,26 @@ void nano::rep_crawler::validate ()
 			continue;
 		}
 
-		auto updated_or_inserted = false;
+		// temporary data used for logging after dropping the lock
+		auto inserted = false;
+		auto updated = false;
+		std::shared_ptr<nano::transport::channel> prev_channel;
+
 		nano::unique_lock<nano::mutex> lock (probable_reps_mutex);
+
 		auto existing (probable_reps.find (vote->account));
 		if (existing != probable_reps.end ())
 		{
-			probable_reps.modify (existing, [rep_weight, &updated_or_inserted, &vote, &channel] (nano::representative & info) {
+			probable_reps.modify (existing, [rep_weight, &updated, &vote, &channel, &prev_channel] (nano::representative & info) {
 				info.last_response = std::chrono::steady_clock::now ();
 
 				// Update if representative channel was changed
 				if (info.channel->get_endpoint () != channel->get_endpoint ())
 				{
 					debug_assert (info.account == vote->account);
-					updated_or_inserted = true;
+					updated = true;
 					info.weight = rep_weight;
+					prev_channel = info.channel;
 					info.channel = channel;
 				}
 			});
@@ -81,12 +87,19 @@ void nano::rep_crawler::validate ()
 		else
 		{
 			probable_reps.emplace (nano::representative (vote->account, rep_weight, channel));
-			updated_or_inserted = true;
+			inserted = true;
 		}
+
 		lock.unlock ();
-		if (updated_or_inserted)
+
+		if (inserted)
 		{
-			node.logger.try_log (boost::str (boost::format ("Found a representative at %1%") % channel->to_string ()));
+			node.logger.try_log (boost::str (boost::format ("Found representative %1% at %2%") % vote->account.to_account () % channel->to_string ()));
+		}
+
+		if (updated)
+		{
+			node.logger.try_log (boost::str (boost::format ("Updated representative %1% at %2% (was at: %3%)") % vote->account.to_account () % channel->to_string () % prev_channel->to_string ()));
 		}
 	}
 }

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -53,7 +53,7 @@ void nano::rep_crawler::validate ()
 		}
 
 		nano::uint128_t rep_weight = node.ledger.weight (vote->account);
-		if (rep_weight <= minimum)
+		if (rep_weight < minimum)
 		{
 			if (node.config.logging.rep_crawler_logging ())
 			{


### PR DESCRIPTION
Introduce a feature to allow the rep crawler to track reps with weight lower than principal rep.
This is for debugging purposes and for websites that would like to track all online reps irrespective of weight.

I also introduce the framework for rep crawler log messages.
And I updated the Representative Found" to print the channel info and also to distinguish between an addition
and an update. And on update it prints the channel before and after to help us diagnose  problems with reps not having
the correct IP address.

Fixes #2176