### PR TITLE
Disable intermittently failing unit test

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -455,7 +455,10 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	node1->stop ();
 }
 
-TEST (bootstrap_processor, push_one)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3532
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3533
+TEST (bootstrap_processor, DISABLED_push_one)
 {
 	nano::system system;
 	nano::node_config config (nano::get_available_port (), system.logging);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2737,6 +2737,9 @@ TEST (node, local_votes_cache)
 	ASSERT_FALSE (node.history.votes (send3->root (), send3->hash ()).empty ());
 }
 
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3532
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3481
 TEST (node, DISABLED_local_votes_cache_batch)
 {
 	nano::system system;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2737,7 +2737,7 @@ TEST (node, local_votes_cache)
 	ASSERT_FALSE (node.history.votes (send3->root (), send3->hash ()).empty ());
 }
 
-TEST (node, local_votes_cache_batch)
+TEST (node, DISABLED_local_votes_cache_batch)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -174,6 +174,9 @@ TEST (vote_processor, weights)
 }
 }
 
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3532
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3485
 TEST (vote_processor, DISABLED_no_broadcast_local)
 {
 	nano::system system;

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -174,7 +174,7 @@ TEST (vote_processor, weights)
 }
 }
 
-TEST (vote_processor, no_broadcast_local)
+TEST (vote_processor, DISABLED_no_broadcast_local)
 {
 	nano::system system;
 	nano::node_flags flags;


### PR DESCRIPTION
Disabled unit tests:
- vote_processor.no_broadcast_local (failed [here](https://github.com/nanocurrency/nano-node/runs/3734715856?check_suite_focus=true#step:5:1642) issue [here](https://github.com/nanocurrency/nano-node/issues/3485))
- node.local_votes_cache_batch (failed [here](https://github.com/nanocurrency/nano-node/runs/3731928529?check_suite_focus=true) issue [here](https://github.com/nanocurrency/nano-node/issues/3481))
- bootstrap_processor.push_one (failed [here](https://github.com/nanocurrency/nano-node/runs/4036418895?check_suite_focus=true) issue [here](https://github.com/nanocurrency/nano-node/issues/3533))