### PR TITLE
Disable intermittently failing unit test

### DIFF
--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -49,6 +49,9 @@ TEST (conflicts, add_existing)
 	ASSERT_NE (votes.end (), votes.find (key2.pub));
 }
 
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled:
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3535
 TEST (conflicts, add_two)
 {
 	nano::system system (1);

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -50,9 +50,9 @@ TEST (conflicts, add_existing)
 }
 
 // Test disabled because it's failing intermittently.
-// PR in which it got disabled:
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3536
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3535
-TEST (conflicts, add_two)
+TEST (conflicts, DISABLED_add_two)
 {
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);


### PR DESCRIPTION
Disabled unit tests:
- conflicts.add_two test (failed [here](https://github.com/nanocurrency/nano-node/runs/4038550570?check_suite_focus=true) issue [here](https://github.com/nanocurrency/nano-node/issues/3535))