### PR TITLE
Remove election limiter from call site in confirmation height processor

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -244,10 +244,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 		// Next-block activations are only done for blocks with previously active elections
 		bool const was_active{ *election_status_type == nano::election_status_type::active_confirmed_quorum || *election_status_type == nano::election_status_type::active_confirmation_height };
 
-		// Activations are only done if there is not a large amount of active elections, ensuring frontier confirmation takes place
-		auto const low_active_elections = [this] { return this->size () < nano::active_transactions::max_active_elections_frontier_insertion / 2; };
-
-		if (cemented_bootstrap_count_reached && was_active && low_active_elections ())
+		if (cemented_bootstrap_count_reached && was_active)
 		{
 			// Start or vote for the next unconfirmed block
 			scheduler.activate (account, transaction);


### PR DESCRIPTION
Community Patch 1 (from VoxPopuli Team) - removed low_active_elections check as if active elections> 500. Election limiting in handled by the election scheduler rather than by individual call sites.

This is https://github.com/nanocurrency/nano-node/pull/3312 rebased on V23.

Before the introduction of the election scheduler, each call site that started an election would individually make a load determination to see if a new election should be started. This is now the responsibility of the election scheduler and call sites should no longer make this determination.