### PR TITLE
Vote timestamp encapsulation

### DIFF
--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -141,7 +141,7 @@ TEST (vote_uniquer, cleanup)
 	nano::vote_uniquer uniquer (block_uniquer);
 	nano::keypair key;
 	auto vote1 (std::make_shared<nano::vote> (key.pub, key.prv, 0, std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0)));
-	auto vote2 (std::make_shared<nano::vote> (key.pub, key.prv, 1, std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0)));
+	auto vote2 (std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0)));
 	auto vote3 (uniquer.unique (vote1));
 	auto vote4 (uniquer.unique (vote2));
 	vote2.reset ();

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -55,7 +55,7 @@ TEST (election, quorum_minimum_flip_success)
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (2, election->blocks ().size ());
-	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), send2));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, send2));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	node1.block_processor.flush ();
 	ASSERT_NE (nullptr, node1.block (send2->hash ()));
@@ -101,7 +101,7 @@ TEST (election, quorum_minimum_flip_fail)
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (2, election->blocks ().size ());
-	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), send2));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, send2));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	node1.block_processor.flush ();
 	ASSERT_NE (nullptr, node1.block (send1->hash ()));
@@ -134,7 +134,7 @@ TEST (election, quorum_minimum_confirm_success)
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
-	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	node1.block_processor.flush ();
 	ASSERT_NE (nullptr, node1.block (send1->hash ()));
@@ -167,7 +167,7 @@ TEST (election, quorum_minimum_confirm_fail)
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
-	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 	node1.block_processor.flush ();
 	ASSERT_NE (nullptr, node1.block (send1->hash ()));
@@ -238,9 +238,9 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
-	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), send1));
+	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, send1));
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
-	auto vote2 (std::make_shared<nano::vote> (key1.pub, key1.prv, std::numeric_limits<uint64_t>::max (), send1));
+	auto vote2 (std::make_shared<nano::vote> (key1.pub, key1.prv, nano::vote::timestamp_max, send1));
 	auto channel = node1.network.find_channel (node2.network.endpoint ());
 	ASSERT_NE (channel, nullptr);
 	ASSERT_TIMELY (10s, !node1.rep_crawler.response (channel, vote2));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2922,7 +2922,7 @@ TEST (node, vote_republish)
 	node1.process_active (send1);
 	ASSERT_TIMELY (5s, node2.block (send1->hash ()));
 	node1.process_active (send2);
-	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), send2));
+	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, send2));
 	ASSERT_TRUE (node1.active.active (*send1));
 	ASSERT_TIMELY (10s, node2.active.active (*send1));
 	node1.vote_processor.vote (vote, std::make_shared<nano::transport::channel_loopback> (node1));
@@ -3017,7 +3017,7 @@ TEST (node, vote_by_hash_republish)
 	node1.process_active (send2);
 	std::vector<nano::block_hash> vote_blocks;
 	vote_blocks.push_back (send2->hash ());
-	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), vote_blocks); // Final vote for confirmation
+	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, vote_blocks); // Final vote for confirmation
 	ASSERT_TRUE (node1.active.active (*send1));
 	ASSERT_TRUE (node2.active.active (*send1));
 	node1.vote_processor.vote (vote, std::make_shared<nano::transport::channel_loopback> (node1));
@@ -3533,7 +3533,7 @@ TEST (node, confirm_back)
 	ASSERT_EQ (3, node.active.size ());
 	std::vector<nano::block_hash> vote_blocks;
 	vote_blocks.push_back (send2->hash ());
-	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), vote_blocks));
+	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, vote_blocks));
 	node.vote_processor.vote_blocking (vote, std::make_shared<nano::transport::channel_loopback> (node));
 	ASSERT_TIMELY (10s, node.active.empty ());
 }
@@ -4083,7 +4083,7 @@ TEST (node, rollback_gap_source)
 		ASSERT_EQ (2, election->blocks ().size ());
 		ASSERT_EQ (1, election->votes ().size ());
 		// Confirm open
-		auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), std::vector<nano::block_hash> (1, open->hash ())));
+		auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, std::vector<nano::block_hash> (1, open->hash ())));
 		node.vote_processor.vote (vote1, std::make_shared<nano::transport::channel_loopback> (node));
 		ASSERT_TIMELY (5s, election->votes ().size () == 2);
 		ASSERT_TIMELY (3s, election->confirmed ());
@@ -4110,7 +4110,7 @@ TEST (node, rollback_gap_source)
 		node.block_processor.flush ();
 		ASSERT_EQ (2, election->blocks ().size ());
 		// Confirm open (again)
-		auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, std::numeric_limits<uint64_t>::max (), std::vector<nano::block_hash> (1, open->hash ())));
+		auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, std::vector<nano::block_hash> (1, open->hash ())));
 		node.vote_processor.vote (vote1, std::make_shared<nano::transport::channel_loopback> (node));
 		ASSERT_TIMELY (5s, election->votes ().size () == 2);
 	}

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -203,7 +203,7 @@ TEST (vote_processor, no_broadcast_local)
 	auto votes (election->votes ());
 	auto existing (votes.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (votes.end (), existing);
-	ASSERT_EQ (vote->timestamp, existing->second.timestamp);
+	ASSERT_EQ (vote->timestamp (), existing->second.timestamp);
 	// Ensure the vote, from a local representative, was not broadcast on processing - it should be flooded on generation instead
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
@@ -236,7 +236,7 @@ TEST (vote_processor, no_broadcast_local)
 	auto votes2 (election2->votes ());
 	auto existing2 (votes2.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (votes2.end (), existing2);
-	ASSERT_EQ (vote2->timestamp, existing2->second.timestamp);
+	ASSERT_EQ (vote2->timestamp (), existing2->second.timestamp);
 	// Ensure the vote was broadcast
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
@@ -270,7 +270,7 @@ TEST (vote_processor, no_broadcast_local)
 	auto votes3 (election3->votes ());
 	auto existing3 (votes3.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (votes3.end (), existing3);
-	ASSERT_EQ (vote3->timestamp, existing3->second.timestamp);
+	ASSERT_EQ (vote3->timestamp (), existing3->second.timestamp);
 	// Ensure the vote wass not broadcasst
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -37,12 +37,6 @@ TEST (vote_processor, codes)
 	// Invalid takes precedence
 	ASSERT_EQ (nano::vote_code::invalid, node.vote_processor.vote_blocking (vote_invalid, channel));
 
-	// A higher timestamp is not a replay
-	++vote->timestamp;
-	ASSERT_EQ (nano::vote_code::invalid, node.vote_processor.vote_blocking (vote, channel));
-	vote->signature = nano::sign_message (key.prv, key.pub, vote->hash ());
-	ASSERT_EQ (nano::vote_code::vote, node.vote_processor.vote_blocking (vote, channel));
-
 	// Once the election is removed (confirmed / dropped) the vote is again indeterminate
 	node.active.erase (*nano::dev::genesis);
 	ASSERT_EQ (nano::vote_code::indeterminate, node.vote_processor.vote_blocking (vote, channel));

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -52,13 +52,11 @@ TEST (vote_processor, flush)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
-	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 1, std::vector<nano::block_hash>{ nano::dev::genesis->hash () }));
 	auto channel (std::make_shared<nano::transport::channel_loopback> (node));
 	for (unsigned i = 0; i < 2000; ++i)
 	{
-		auto new_vote (std::make_shared<nano::vote> (*vote));
-		node.vote_processor.vote (new_vote, channel);
-		++vote->timestamp; // invalidates votes without signing again
+		auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 1 + i, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
+		node.vote_processor.vote (vote, channel);
 	}
 	node.vote_processor.flush ();
 	ASSERT_TRUE (node.vote_processor.empty ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -875,7 +875,7 @@ nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> con
 				}
 				else if (recently_confirmed_by_hash.count (block_hash) == 0)
 				{
-					add_inactive_votes_cache (lock, block_hash, vote_a->account, vote_a->timestamp);
+					add_inactive_votes_cache (lock, block_hash, vote_a->account, vote_a->timestamp ());
 				}
 				else
 				{
@@ -892,7 +892,7 @@ nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> con
 				}
 				else if (recently_confirmed_by_hash.count (block->hash ()) == 0)
 				{
-					add_inactive_votes_cache (lock, block->hash (), vote_a->account, vote_a->timestamp);
+					add_inactive_votes_cache (lock, block->hash (), vote_a->account, vote_a->timestamp ());
 				}
 				else
 				{
@@ -908,7 +908,7 @@ nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> con
 		bool processed (false);
 		for (auto const & [election, block_hash] : process)
 		{
-			auto const result_l = election->vote (vote_a->account, vote_a->timestamp, block_hash);
+			auto const result_l = election->vote (vote_a->account, vote_a->timestamp (), block_hash);
 			processed = processed || result_l.processed;
 			replay = replay || result_l.replay;
 		}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -474,7 +474,7 @@ public:
 	{
 		if (node.config.logging.network_message_logging ())
 		{
-			node.logger.try_log (boost::str (boost::format ("Received confirm_ack message from %1% for %2% timestamp %3%") % channel->to_string () % message_a.vote->hashes_string () % std::to_string (message_a.vote->timestamp)));
+			node.logger.try_log (boost::str (boost::format ("Received confirm_ack message from %1% for %2% timestamp %3%") % channel->to_string () % message_a.vote->hashes_string () % std::to_string (message_a.vote->timestamp ())));
 		}
 		node.stats.inc (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::in);
 		if (!message_a.vote->account.is_zero ())

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -198,7 +198,7 @@ nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote>
 	}
 	if (config.logging.vote_logging ())
 	{
-		logger.try_log (boost::str (boost::format ("Vote from: %1% timestamp: %2% block(s): %3%status: %4%") % vote_a->account.to_account () % std::to_string (vote_a->timestamp ()) % vote_a->hashes_string () % status));
+		logger.try_log (boost::str (boost::format ("Vote from: %1% timestamp: %2% block(s): %3% status: %4%") % vote_a->account.to_account () % std::to_string (vote_a->timestamp ()) % vote_a->hashes_string () % status));
 	}
 	return result;
 }

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -198,7 +198,7 @@ nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote>
 	}
 	if (config.logging.vote_logging ())
 	{
-		logger.try_log (boost::str (boost::format ("Vote from: %1% timestamp: %2% block(s): %3%status: %4%") % vote_a->account.to_account () % std::to_string (vote_a->timestamp) % vote_a->hashes_string () % status));
+		logger.try_log (boost::str (boost::format ("Vote from: %1% timestamp: %2% block(s): %3%status: %4%") % vote_a->account.to_account () % std::to_string (vote_a->timestamp ()) % vote_a->hashes_string () % status));
 	}
 	return result;
 }

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -361,7 +361,7 @@ void nano::vote_generator::vote (std::vector<nano::block_hash> const & hashes_a,
 	debug_assert (hashes_a.size () == roots_a.size ());
 	std::vector<std::shared_ptr<nano::vote>> votes_l;
 	wallets.foreach_representative ([this, &hashes_a, &votes_l] (nano::public_key const & pub_a, nano::raw_key const & prv_a) {
-		auto timestamp (this->is_final ? std::numeric_limits<uint64_t>::max () : nano::milliseconds_since_epoch ());
+		auto timestamp = this->is_final ? nano::vote::timestamp_max : nano::milliseconds_since_epoch ();
 		votes_l.emplace_back (std::make_shared<nano::vote> (pub_a, prv_a, timestamp, hashes_a));
 	});
 	for (auto const & vote_l : votes_l)

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -75,11 +75,11 @@ void nano::local_vote_history::add (nano::root const & root_a, nano::block_hash 
 	auto range (history_by_root.equal_range (root_a));
 	for (auto i (range.first); i != range.second;)
 	{
-		if (i->hash != hash_a || (vote_a->account == i->vote->account && i->vote->timestamp <= vote_a->timestamp))
+		if (i->hash != hash_a || (vote_a->account == i->vote->account && i->vote->timestamp () <= vote_a->timestamp ()))
 		{
 			i = history_by_root.erase (i);
 		}
-		else if (vote_a->account == i->vote->account && i->vote->timestamp > vote_a->timestamp)
+		else if (vote_a->account == i->vote->account && i->vote->timestamp () > vote_a->timestamp ())
 		{
 			add_vote = false;
 			++i;
@@ -123,7 +123,7 @@ std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::
 	auto range (history.get<tag_root> ().equal_range (root_a));
 	// clang-format off
 	nano::transform_if (range.first, range.second, std::back_inserter (result),
-		[&hash_a, is_final_a](auto const & entry) { return entry.hash == hash_a && (!is_final_a || entry.vote->timestamp == std::numeric_limits<uint64_t>::max ()); },
+		[&hash_a, is_final_a](auto const & entry) { return entry.hash == hash_a && (!is_final_a || entry.vote->timestamp () == std::numeric_limits<uint64_t>::max ()); },
 		[](auto const & entry) { return entry.vote; });
 	// clang-format on
 	return result;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -264,8 +264,11 @@ public:
 	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> begin () const;
 	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> end () const;
 	std::string to_json () const;
+	uint64_t timestamp () const;
+private:
 	// Vote timestamp
-	uint64_t timestamp;
+	uint64_t timestamp_m;
+public:
 	// The blocks, or block hashes, that this vote is for
 	std::vector<boost::variant<std::shared_ptr<nano::block>, nano::block_hash>> blocks;
 	// Account that's voting

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -249,8 +249,8 @@ public:
 	vote (nano::vote const &);
 	vote (bool &, nano::stream &, nano::block_uniquer * = nullptr);
 	vote (bool &, nano::stream &, nano::block_type, nano::block_uniquer * = nullptr);
-	vote (nano::account const &, nano::raw_key const &, uint64_t, std::shared_ptr<nano::block> const &);
-	vote (nano::account const &, nano::raw_key const &, uint64_t, std::vector<nano::block_hash> const &);
+	vote (nano::account const &, nano::raw_key const &, uint64_t timestamp, std::shared_ptr<nano::block> const &);
+	vote (nano::account const &, nano::raw_key const &, uint64_t timestamp, std::vector<nano::block_hash> const &);
 	std::string hashes_string () const;
 	nano::block_hash hash () const;
 	nano::block_hash full_hash () const;
@@ -265,6 +265,8 @@ public:
 	boost::transform_iterator<nano::iterate_vote_blocks_as_hash, nano::vote_blocks_vec_iter> end () const;
 	std::string to_json () const;
 	uint64_t timestamp () const;
+	static uint64_t constexpr timestamp_max = { 0xffff'ffff'ffff'ffffULL };
+	static uint64_t constexpr timestamp_min = { 0x0000'0000'0000'0001ULL };
 private:
 	// Vote timestamp
 	uint64_t timestamp_m;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -267,9 +267,11 @@ public:
 	uint64_t timestamp () const;
 	static uint64_t constexpr timestamp_max = { 0xffff'ffff'ffff'ffffULL };
 	static uint64_t constexpr timestamp_min = { 0x0000'0000'0000'0001ULL };
+
 private:
 	// Vote timestamp
 	uint64_t timestamp_m;
+
 public:
 	// The blocks, or block hashes, that this vote is for
 	std::vector<boost::variant<std::shared_ptr<nano::block>, nano::block_hash>> blocks;


### PR DESCRIPTION
This is the first commit related to https://github.com/nanocurrency/nano-node/issues/3453

It encapsulates the nano::vote::timestamp field and rewrites tests to use the encapsulated field.