### PR TITLE
Fixes/splits vote_processor.no_broadcast_local

### DIFF
--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -218,9 +218,11 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 }
 
+// Issue that tracks last changes on this test: https://github.com/nanocurrency/nano-node/issues/3485
+// Reopen in case the nondeterministic failure appears again.
 // Checks local votes (a vote with a key that is in the node's wallet) are re-broadcast when received.
 // Done without a representative.
-TEST (vote_processor, no_broadcast_local_with_no_representative)
+TEST (vote_processor, local_broadcast_without_a_representative)
 {
 	nano::system system;
 	nano::node_flags flags;
@@ -239,7 +241,7 @@ TEST (vote_processor, no_broadcast_local_with_no_representative)
 										.account (nano::dev::genesis_key.pub)
 										.representative (nano::dev::genesis_key.pub)
 										.previous (nano::dev::genesis->hash ())
-										.balance (2 * node.config.vote_minimum.number ())
+										.balance (node.config.vote_minimum.number ())
 										.link (key.pub)
 										.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 										.work (*system.work.generate (nano::dev::genesis->hash ()))
@@ -247,48 +249,25 @@ TEST (vote_processor, no_broadcast_local_with_no_representative)
 	ASSERT_FALSE (ec);
 	ASSERT_EQ (nano::process_result::progress, node.process_local (send).code);
 	ASSERT_TIMELY (10s, !node.active.empty ());
-	// Insert account in wallet. Votes on node are not enabled.
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	// Ensure that the node knows the genesis key in its wallet.
-	node.wallets.compute_reps ();
-	// Process a vote with a key that is in the local wallet.
+	ASSERT_EQ (node.config.vote_minimum, node.weight (nano::dev::genesis_key.pub));
+	node.block_confirm (send);
+	// Process a vote without a representative
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::milliseconds_since_epoch () & nano::vote::timestamp_max, std::vector<nano::block_hash>{ send->hash () });
 	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote));
-
-	// Erase account from the wallet, so it doesn't have a representative
-	system.wallet (0)->store.erase (node.wallets.tx_begin_write (), nano::dev::genesis_key.pub);
-	node.wallets.compute_reps ();
-	ASSERT_FALSE (node.wallets.reps ().exists (nano::dev::genesis_key.pub));
-
-	std::shared_ptr<nano::block> send2 = builder.state ()
-										 .account (nano::dev::genesis_key.pub)
-										 .representative (nano::dev::genesis_key.pub)
-										 .previous (send->hash ())
-										 .balance (node.config.vote_minimum)
-										 .link (key.pub)
-										 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-										 .work (*system.work.generate (send->hash ()))
-										 .build (ec);
-	ASSERT_FALSE (ec);
-	ASSERT_EQ (nano::process_result::progress, node.process_local (send2).code);
-	ASSERT_TIMELY (10s, !node.active.empty ());
-	ASSERT_EQ (node.config.vote_minimum, node.weight (nano::dev::genesis_key.pub));
-	node.block_confirm (send2);
-	// Process a vote
-	auto vote2 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::milliseconds_since_epoch () * nano::vote::timestamp_max, std::vector<nano::block_hash>{ send2->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote2));
-	// Make sure the vote was processed
-	auto election2 (node.active.election (send2->qualified_root ()));
-	ASSERT_NE (nullptr, election2);
-	auto votes2 (election2->votes ());
-	auto existing2 (votes2.find (nano::dev::genesis_key.pub));
-	ASSERT_NE (votes2.end (), existing2);
-	ASSERT_EQ (vote2->timestamp (), existing2->second.timestamp);
+	// Make sure the vote was processed.
+	auto election (node.active.election (send->qualified_root ()));
+	ASSERT_NE (nullptr, election);
+	auto votes (election->votes ());
+	auto existing (votes.find (nano::dev::genesis_key.pub));
+	ASSERT_NE (votes.end (), existing);
+	ASSERT_EQ (vote->timestamp (), existing->second.timestamp);
 	// Ensure the vote was broadcast
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 }
 
+// Issue that tracks last changes on this test: https://github.com/nanocurrency/nano-node/issues/3485
+// Reopen in case the nondeterministic failure appears again.
 // Checks local votes (a vote with a key that is in the node's wallet) are re-broadcast when received.
 // Done with a principal representative.
 TEST (vote_processor, no_broadcast_local_with_a_principal_representative)


### PR DESCRIPTION
Addresses issue: https://github.com/nanocurrency/nano-node/issues/3485
The test also ended up split into three different tests:
- no_broadcast_local
- local_broadcast_without_a_representative
- no_broadcast_local_with_a_principal_representative