### PR TITLE
Introduce support for binding sockets to ports picked by the OS

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -212,7 +212,7 @@ public:
 	}
 	unsigned short port () const
 	{
-		return endpoint.port ();
+		return acceptor.local_endpoint ().port ();
 	}
 	std::atomic<size_t> generations_good{ 0 };
 	std::atomic<size_t> generations_bad{ 0 };

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2260,9 +2260,10 @@ TEST (node, rep_remove)
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block4).code);
 	}
 	// Add inactive UDP representative channel
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	std::shared_ptr<nano::transport::channel> channel0 (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint0, node.network_params.network.protocol_version));
 	auto channel_udp = node.network.udp_channels.insert (endpoint0, node.network_params.network.protocol_version);
+	ASSERT_NE (channel_udp, nullptr);
 	auto vote1 = std::make_shared<nano::vote> (keypair1.pub, keypair1.prv, 0, 0, nano::dev::genesis);
 	ASSERT_FALSE (node.rep_crawler.response (channel0, vote1));
 	ASSERT_TIMELY (5s, node.rep_crawler.representative_count () == 1);

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -163,7 +163,7 @@ TEST (peer_container, reachout)
 	// Make sure having been contacted by them already indicates we shouldn't reach out
 	node1.network.udp_channels.insert (endpoint0, node1.network_params.network.protocol_version);
 	ASSERT_TRUE (node1.network.reachout (endpoint0));
-	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	ASSERT_FALSE (node1.network.reachout (endpoint1));
 	// Reaching out to them once should signal we shouldn't reach out again.
 	ASSERT_TRUE (node1.network.reachout (endpoint1));
@@ -178,7 +178,7 @@ TEST (peer_container, reachout)
 TEST (peer_container, depeer)
 {
 	nano::system system (1);
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	nano::keepalive message{ nano::dev::network_params.network };
 	const_cast<uint8_t &> (message.header.version_using) = 1;
 	auto bytes (message.to_bytes ());

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -21,8 +21,7 @@ TEST (socket, max_connections)
 	auto node = system.add_node ();
 
 	auto server_port = nano::get_available_port ();
-	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
-	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
+	boost::asio::ip::tcp::endpoint listen_endpoint (boost::asio::ip::address_v6::any (), server_port);
 
 	// start a server socket that allows max 2 live connections
 	auto server_socket = std::make_shared<nano::server_socket> (*node, listen_endpoint, 2);
@@ -45,6 +44,8 @@ TEST (socket, max_connections)
 	};
 
 	// start 3 clients, 2 will persist but 1 will be dropped
+
+	boost::asio::ip::tcp::endpoint dst_endpoint (boost::asio::ip::address_v6::loopback (), server_socket->listening_port ());
 
 	auto client1 = std::make_shared<nano::socket> (*node);
 	client1->async_connect (dst_endpoint, connect_handler);
@@ -409,7 +410,7 @@ TEST (socket, drop_policy)
 		nano::transport::channel_tcp channel{ *node, client };
 		nano::util::counted_completion write_completion (static_cast<unsigned> (total_message_count));
 
-		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), server_port),
+		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), server_socket->listening_port ()),
 		[&channel, total_message_count, node, &write_completion, &drop_policy, client] (boost::system::error_code const & ec_a) mutable {
 			for (int i = 0; i < total_message_count; i++)
 			{

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -29,7 +29,7 @@ TEST (websocket, subscription_edge)
 	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
 
 	auto task = ([config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json");
 		client.await_ack ();
 		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
@@ -60,7 +60,7 @@ TEST (websocket, confirmation)
 	std::atomic<bool> ack_ready{ false };
 	std::atomic<bool> unsubscribed{ false };
 	auto task = ([&ack_ready, &unsubscribed, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -127,7 +127,7 @@ TEST (websocket, stopped_election)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "stopped_election", "ack": "true"})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -170,7 +170,7 @@ TEST (websocket, confirmation_options)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "accounts": ["xrb_invalid"]}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -209,7 +209,7 @@ TEST (websocket, confirmation_options)
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true", "include_election_info": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -271,7 +271,7 @@ TEST (websocket, confirmation_options)
 
 	ack_ready = false;
 	auto task3 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -305,7 +305,7 @@ TEST (websocket, confirmation_options_votes)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "include_election_info_with_votes": "true", "include_block": "false"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -394,7 +394,7 @@ TEST (websocket, confirmation_options_update)
 	std::atomic<bool> added{ false };
 	std::atomic<bool> deleted{ false };
 	auto task = ([&added, &deleted, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		// Subscribe initially with empty options, everything will be filtered
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {}})json");
 		client.await_ack ();
@@ -468,7 +468,7 @@ TEST (websocket, vote)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -518,7 +518,7 @@ TEST (websocket, vote_options_type)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": true, "options": {"include_replays": "true", "include_indeterminate": "false"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -559,7 +559,7 @@ TEST (websocket, vote_options_representatives)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		std::string message = boost::str (boost::format (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["%1%"]}})json") % nano::dev::genesis_key.pub.to_account ());
 		client.send_message (message);
 		client.await_ack ();
@@ -603,7 +603,7 @@ TEST (websocket, vote_options_representatives)
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["xrb_invalid"]}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -637,7 +637,7 @@ TEST (websocket, work)
 	// Subscribe to work and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "work", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -707,7 +707,7 @@ TEST (websocket, bootstrap)
 	// Subscribe to bootstrap and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "bootstrap", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -774,7 +774,7 @@ TEST (websocket, bootstrap_exited)
 	// Subscribe to bootstrap and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "bootstrap", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -817,8 +817,8 @@ TEST (websocket, ws_keepalive)
 	config.websocket_config.port = nano::get_available_port ();
 	auto node1 (system.add_node (config));
 
-	auto task = ([config] () {
-		fake_websocket_client client (config.websocket_config.port);
+	auto task = ([&node1] () {
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "ping"})json");
 		client.await_ack ();
 	});
@@ -847,7 +847,7 @@ TEST (websocket, telemetry)
 
 	std::atomic<bool> done{ false };
 	auto task = ([config = node1->config, &node1, &done] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "telemetry", "ack": true})json");
 		client.await_ack ();
 		done = true;
@@ -897,7 +897,7 @@ TEST (websocket, new_unconfirmed_block)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "new_unconfirmed_block", "ack": "true"})json");
 		client.await_ack ();
 		ack_ready = true;

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -25,7 +25,42 @@ void nano::bootstrap_listener::start ()
 		node.logger.always_log (boost::str (boost::format ("Network: Error while binding for incoming TCP/bootstrap on port %1%: %2%") % listening_socket->listening_port () % ec.message ()));
 		throw std::runtime_error (ec.message ());
 	}
-	debug_assert (node.network.endpoint ().port () == listening_socket->listening_port ());
+
+	// the user can either specify a port value in the config or it can leave the choice up to the OS;
+	// independently of user's port choice, he may have also opted to disable UDP or not; this gives us 4 possibilities:
+	// (1): UDP enabled, port specified
+	// (2): UDP enabled, port not specified
+	// (3): UDP disabled, port specified
+	// (4): UDP disabled, port not specified
+	//
+	const auto listening_port = listening_socket->listening_port ();
+	if (!node.flags.disable_udp)
+	{
+		// (1) and (2) -- no matter if (1) or (2), since UDP socket binding happens before this TCP socket binding,
+		// we must have already been constructed with a valid port value, so check that it really is the same everywhere
+		//
+		debug_assert (port == listening_port);
+		debug_assert (port == node.network.port);
+		debug_assert (port == node.network.endpoint ().port ());
+	}
+	else
+	{
+		// (3) -- nothing to do, just check that port values match everywhere
+		//
+		if (port == listening_port)
+		{
+			debug_assert (port == node.network.port);
+			debug_assert (port == node.network.endpoint ().port ());
+		}
+		// (4) -- OS port choice happened at TCP socket bind time, so propagate this port value back
+		//
+		else
+		{
+			port = listening_port;
+			node.network.port = listening_port;
+		}
+	}
+
 	listening_socket->on_connection ([this] (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const & ec_a) {
 		if (!ec_a)
 		{
@@ -81,7 +116,7 @@ boost::asio::ip::tcp::endpoint nano::bootstrap_listener::endpoint ()
 	nano::lock_guard<nano::mutex> lock (mutex);
 	if (on && listening_socket)
 	{
-		return boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), listening_socket->listening_port ());
+		return boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), port);
 	}
 	else
 	{
@@ -612,8 +647,8 @@ namespace
 class request_response_visitor : public nano::message_visitor
 {
 public:
-	explicit request_response_visitor (std::shared_ptr<nano::bootstrap_server> const & connection_a) :
-		connection (connection_a)
+	explicit request_response_visitor (std::shared_ptr<nano::bootstrap_server> connection_a) :
+		connection (std::move (connection_a))
 	{
 	}
 	void keepalive (nano::keepalive const & message_a) override

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -53,9 +53,9 @@ void nano::bootstrap_listener::start ()
 			debug_assert (port == node.network.endpoint ().port ());
 		}
 		// (4) -- OS port choice happened at TCP socket bind time, so propagate this port value back;
-        // the propagation is done here for the `bootstrap_listener` itself, whereas for `network`, the node does it
+		// the propagation is done here for the `bootstrap_listener` itself, whereas for `network`, the node does it
 		// after calling `bootstrap_listener.start ()`
-        //
+		//
 		else
 		{
 			port = listening_port;

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -52,12 +52,13 @@ void nano::bootstrap_listener::start ()
 			debug_assert (port == node.network.port);
 			debug_assert (port == node.network.endpoint ().port ());
 		}
-		// (4) -- OS port choice happened at TCP socket bind time, so propagate this port value back
-		//
+		// (4) -- OS port choice happened at TCP socket bind time, so propagate this port value back;
+        // the propagation is done here for the `bootstrap_listener` itself, whereas for `network`, the node does it
+		// after calling `bootstrap_listener.start ()`
+        //
 		else
 		{
 			port = listening_port;
-			node.network.port = listening_port;
 		}
 	}
 

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -26,8 +26,6 @@ public:
 	bool on{ false };
 	std::atomic<std::size_t> bootstrap_count{ 0 };
 	std::atomic<std::size_t> realtime_count{ 0 };
-
-private:
 	uint16_t port;
 };
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -35,6 +35,11 @@ nano::network::network (nano::node & node_a, uint16_t port_a) :
 	port (port_a),
 	disconnect_observer ([] () {})
 {
+	if (!node.flags.disable_udp)
+	{
+		port = udp_channels.get_local_endpoint ().port ();
+	}
+
 	boost::thread::attributes attrs;
 	nano::thread_attributes::set (attrs);
 	// UDP

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -627,10 +627,10 @@ void nano::node::start ()
 		bootstrap.start ();
 		tcp_enabled = true;
 
-        if (flags.disable_udp && network.port != bootstrap.port)
-        {
-            network.port = bootstrap.port;
-        }
+		if (flags.disable_udp && network.port != bootstrap.port)
+		{
+			network.port = bootstrap.port;
+		}
 	}
 	if (!flags.disable_backup)
 	{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -626,6 +626,11 @@ void nano::node::start ()
 	{
 		bootstrap.start ();
 		tcp_enabled = true;
+
+        if (flags.disable_udp && network.port != bootstrap.port)
+        {
+            network.port = bootstrap.port;
+        }
 	}
 	if (!flags.disable_backup)
 	{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -101,7 +101,14 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	network (*this, config.peering_port),
 	telemetry (std::make_shared<nano::telemetry> (network, workers, observers.telemetry, stats, network_params, flags.disable_ongoing_telemetry_requests)),
 	bootstrap_initiator (*this),
-	bootstrap (config.peering_port, *this),
+	// BEWARE: `bootstrap` takes `network.port` instead of `config.peering_port` because when the user doesn't specify
+	//         a peering port and wants the OS to pick one, the picking happens when `network` gets initialized
+	//         (if UDP is active, otherwise it happens when `bootstrap` gets initialized), so then for TCP traffic
+	//         we want to tell `bootstrap` to use the already picked port instead of itself picking a different one.
+	//         Thus, be very careful if you change the order: if `bootstrap` gets constructed before `network`,
+	//         the latter would inherit the port from the former (if TCP is active, otherwise `network` picks first)
+	//
+	bootstrap (network.port, *this),
 	application_path (application_path_a),
 	port_mapping (*this),
 	rep_crawler (*this),

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -168,7 +168,7 @@ public:
 	void on_connection (std::function<bool (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const &)>);
 	uint16_t listening_port ()
 	{
-		return local.port ();
+		return acceptor.local_endpoint ().port ();
 	}
 
 private:

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -300,6 +300,11 @@ namespace websocket
 			return logger;
 		}
 
+		std::uint16_t listening_port ()
+		{
+			return acceptor.local_endpoint ().port ();
+		}
+
 		nano::wallets & get_wallets () const
 		{
 			return wallets;


### PR DESCRIPTION
This PR allows the builder of a `nano::node` not to specify a peering port (specify it as `0`), or a websocket one, and let the OS pick an available port when the socket is bound. He would be able to later retrieve that port by calling `node.network.endpoint ().port()`, amongst other options.

The PR also adds a bunch of comments about how the mechanism works and where to pay attention if stuff gets changed.

Additionally, a couple unrelated changes made their way here and are strictly related to fixing clang-tidy warnings (like shadowed variable declarations, useless copies, etc).