### PR TITLE
Use OS picked ports in `core_test`

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -212,7 +212,7 @@ public:
 	}
 	unsigned short port () const
 	{
-		return endpoint.port ();
+		return acceptor.local_endpoint ().port ();
 	}
 	std::atomic<size_t> generations_good{ 0 };
 	std::atomic<size_t> generations_bad{ 0 };

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -35,7 +35,7 @@ TEST (network, tcp_connection)
 	boost::asio::ip::tcp::socket connector (io_ctx);
 	std::atomic<bool> done2 (false);
 	std::string message2;
-	connector.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), port),
+	connector.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), acceptor.local_endpoint ().port ()),
 	[&done2, &message2] (boost::system::error_code const & ec_a) {
 		if (ec_a)
 		{
@@ -52,13 +52,24 @@ TEST (network, tcp_connection)
 	ASSERT_EQ (0, message2.size ());
 }
 
-TEST (network, construction)
+TEST (network, construction_with_specified_port)
 {
-	auto port = nano::get_available_port ();
-	nano::system system;
-	system.add_node (nano::node_config (port, system.logging));
-	ASSERT_EQ (1, system.nodes.size ());
-	ASSERT_EQ (port, system.nodes[0]->network.endpoint ().port ());
+	nano::system system{};
+	auto const port = nano::test_node_port ();
+	auto const node = system.add_node (nano::node_config{ port, system.logging });
+	EXPECT_EQ (port, node->network.port);
+	EXPECT_EQ (port, node->network.endpoint ().port ());
+	EXPECT_EQ (port, node->bootstrap.endpoint ().port ());
+}
+
+TEST (network, construction_without_specified_port)
+{
+	nano::system system{};
+	auto const node = system.add_node ();
+	auto const port = node->network.port.load ();
+	EXPECT_NE (0, port);
+	EXPECT_EQ (port, node->network.endpoint ().port ());
+	EXPECT_EQ (port, node->bootstrap.endpoint ().port ());
 }
 
 TEST (network, self_discard)
@@ -513,7 +524,7 @@ TEST (network, ipv6_bind_send_ipv4)
 	auto port2 = nano::get_available_port ();
 	nano::endpoint endpoint1 (boost::asio::ip::address_v6::any (), port1);
 	nano::endpoint endpoint2 (boost::asio::ip::address_v4::any (), port2);
-	std::array<uint8_t, 16> bytes1;
+	std::array<uint8_t, 16> bytes1{};
 	auto finish1 (false);
 	nano::endpoint endpoint3;
 	boost::asio::ip::udp::socket socket1 (io_ctx, endpoint1);
@@ -523,8 +534,8 @@ TEST (network, ipv6_bind_send_ipv4)
 		finish1 = true;
 	});
 	boost::asio::ip::udp::socket socket2 (io_ctx, endpoint2);
-	nano::endpoint endpoint5 (boost::asio::ip::address_v4::loopback (), port1);
-	nano::endpoint endpoint6 (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4::loopback ()), port2);
+	nano::endpoint endpoint5 (boost::asio::ip::address_v4::loopback (), socket1.local_endpoint ().port ());
+	nano::endpoint endpoint6 (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4::loopback ()), socket2.local_endpoint ().port ());
 	socket2.async_send_to (boost::asio::buffer (std::array<uint8_t, 16>{}, 16), endpoint5, [] (boost::system::error_code const & error, size_t size_a) {
 		ASSERT_FALSE (error);
 		ASSERT_EQ (16, size_a);
@@ -877,7 +888,7 @@ TEST (network, replace_port)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	node1->start ();
 	system.nodes.push_back (node1);
-	auto wrong_endpoint = nano::endpoint (node1->network.endpoint ().address (), nano::get_available_port ());
+	auto wrong_endpoint = nano::endpoint (node1->network.endpoint ().address (), nano::test_node_port ());
 	auto channel0 (node0->network.udp_channels.insert (wrong_endpoint, node1->network_params.network.protocol_version));
 	ASSERT_NE (nullptr, channel0);
 	node0->network.udp_channels.modify (channel0, [&node1] (std::shared_ptr<nano::transport::channel> const & channel_a) {

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2260,9 +2260,10 @@ TEST (node, rep_remove)
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block4).code);
 	}
 	// Add inactive UDP representative channel
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	std::shared_ptr<nano::transport::channel> channel0 (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint0, node.network_params.network.protocol_version));
 	auto channel_udp = node.network.udp_channels.insert (endpoint0, node.network_params.network.protocol_version);
+	ASSERT_NE (channel_udp, nullptr);
 	auto vote1 = std::make_shared<nano::vote> (keypair1.pub, keypair1.prv, 0, nano::dev::genesis);
 	ASSERT_FALSE (node.rep_crawler.response (channel0, vote1));
 	ASSERT_TIMELY (5s, node.rep_crawler.representative_count () == 1);

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -163,7 +163,7 @@ TEST (peer_container, reachout)
 	// Make sure having been contacted by them already indicates we shouldn't reach out
 	node1.network.udp_channels.insert (endpoint0, node1.network_params.network.protocol_version);
 	ASSERT_TRUE (node1.network.reachout (endpoint0));
-	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	ASSERT_FALSE (node1.network.reachout (endpoint1));
 	// Reaching out to them once should signal we shouldn't reach out again.
 	ASSERT_TRUE (node1.network.reachout (endpoint1));
@@ -178,7 +178,7 @@ TEST (peer_container, reachout)
 TEST (peer_container, depeer)
 {
 	nano::system system (1);
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	nano::keepalive message{ nano::dev::network_params.network };
 	const_cast<uint8_t &> (message.header.version_using) = 1;
 	auto bytes (message.to_bytes ());

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -21,7 +21,6 @@ TEST (socket, max_connections)
 
 	auto server_port (nano::get_available_port ());
 	boost::asio::ip::tcp::endpoint listen_endpoint (boost::asio::ip::address_v6::any (), server_port);
-	boost::asio::ip::tcp::endpoint dst_endpoint (boost::asio::ip::address_v6::loopback (), server_port);
 
 	// start a server socket that allows max 2 live connections
 	auto server_socket = std::make_shared<nano::server_socket> (*node, listen_endpoint, 2);
@@ -44,6 +43,8 @@ TEST (socket, max_connections)
 	};
 
 	// start 3 clients, 2 will persist but 1 will be dropped
+
+	boost::asio::ip::tcp::endpoint dst_endpoint (boost::asio::ip::address_v6::loopback (), server_socket->listening_port ());
 
 	auto client1 = std::make_shared<nano::socket> (*node);
 	client1->async_connect (dst_endpoint, connect_handler);
@@ -136,7 +137,7 @@ TEST (socket, drop_policy)
 		nano::transport::channel_tcp channel{ *node, client };
 		nano::util::counted_completion write_completion (static_cast<unsigned> (total_message_count));
 
-		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), server_port),
+		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), server_socket->listening_port ()),
 		[&channel, total_message_count, node, &write_completion, &drop_policy, client] (boost::system::error_code const & ec_a) mutable {
 			for (int i = 0; i < total_message_count; i++)
 			{

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -29,7 +29,7 @@ TEST (websocket, subscription_edge)
 	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
 
 	auto task = ([config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json");
 		client.await_ack ();
 		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
@@ -60,7 +60,7 @@ TEST (websocket, confirmation)
 	std::atomic<bool> ack_ready{ false };
 	std::atomic<bool> unsubscribed{ false };
 	auto task = ([&ack_ready, &unsubscribed, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -127,7 +127,7 @@ TEST (websocket, stopped_election)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "stopped_election", "ack": "true"})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -170,7 +170,7 @@ TEST (websocket, confirmation_options)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "accounts": ["xrb_invalid"]}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -209,7 +209,7 @@ TEST (websocket, confirmation_options)
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true", "include_election_info": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -271,7 +271,7 @@ TEST (websocket, confirmation_options)
 
 	ack_ready = false;
 	auto task3 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -305,7 +305,7 @@ TEST (websocket, confirmation_options_votes)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "include_election_info_with_votes": "true", "include_block": "false"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -394,7 +394,7 @@ TEST (websocket, confirmation_options_update)
 	std::atomic<bool> added{ false };
 	std::atomic<bool> deleted{ false };
 	auto task = ([&added, &deleted, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		// Subscribe initially with empty options, everything will be filtered
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {}})json");
 		client.await_ack ();
@@ -468,7 +468,7 @@ TEST (websocket, vote)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -518,7 +518,7 @@ TEST (websocket, vote_options_type)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": true, "options": {"include_replays": "true", "include_indeterminate": "false"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -559,7 +559,7 @@ TEST (websocket, vote_options_representatives)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		std::string message = boost::str (boost::format (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["%1%"]}})json") % nano::dev::genesis_key.pub.to_account ());
 		client.send_message (message);
 		client.await_ack ();
@@ -603,7 +603,7 @@ TEST (websocket, vote_options_representatives)
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["xrb_invalid"]}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -637,7 +637,7 @@ TEST (websocket, work)
 	// Subscribe to work and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "work", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -707,7 +707,7 @@ TEST (websocket, bootstrap)
 	// Subscribe to bootstrap and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "bootstrap", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -774,7 +774,7 @@ TEST (websocket, bootstrap_exited)
 	// Subscribe to bootstrap and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "bootstrap", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -817,8 +817,8 @@ TEST (websocket, ws_keepalive)
 	config.websocket_config.port = nano::get_available_port ();
 	auto node1 (system.add_node (config));
 
-	auto task = ([config] () {
-		fake_websocket_client client (config.websocket_config.port);
+	auto task = ([&node1] () {
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "ping"})json");
 		client.await_ack ();
 	});
@@ -847,7 +847,7 @@ TEST (websocket, telemetry)
 
 	std::atomic<bool> done{ false };
 	auto task = ([config = node1->config, &node1, &done] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "telemetry", "ack": true})json");
 		client.await_ack ();
 		done = true;
@@ -897,7 +897,7 @@ TEST (websocket, new_unconfirmed_block)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket_server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "new_unconfirmed_block", "ack": "true"})json");
 		client.await_ack ();
 		ack_ready = true;


### PR DESCRIPTION
This PR leverages #3554 for the `core_test` unit tests in the sense that all unit tests now rely on ports picked by the OS (for peering and websocket at least) instead of relying on the `nano::get_available_port` functionality.

The PR is based off (and target towards) #3554 for easier reviewing and not having to wait until one gets merged to open the second.