### PR TITLE
Turns off sub-network connection limiting for IPv4

### DIFF
--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -304,14 +304,15 @@ size_t network_prefix)
 bool nano::server_socket::limit_reached_for_incoming_subnetwork_connections (std::shared_ptr<nano::socket> const & new_connection)
 {
 	debug_assert (strand.running_in_this_thread ());
-	if (node.flags.disable_max_peers_per_subnetwork)
+	if (node.flags.disable_max_peers_per_subnetwork || nano::transport::is_ipv4_or_v4_mapped_address (new_connection->remote.address ()))
 	{
 		// If the limit is disabled, then it is unreachable.
+		// If the address is IPv4 we don't check for a network limit, since its address space isn't big as IPv6 /64.
 		return false;
 	}
 	auto const counted_connections = socket_functions::count_subnetwork_connections (
 	connections_per_address,
-	nano::transport::mapped_from_v4_or_v6 (new_connection->remote.address ()),
+	new_connection->remote.address ().to_v6 (),
 	node.network_params.network.ipv6_subnetwork_prefix_for_limiting);
 	return counted_connections >= node.network_params.network.max_peers_per_subnetwork;
 }

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -172,6 +172,11 @@ boost::asio::ip::address_v6 nano::transport::mapped_from_v4_or_v6 (boost::asio::
 	return address_a.is_v4 () ? boost::asio::ip::address_v6::v4_mapped (address_a.to_v4 ()) : address_a.to_v6 ();
 }
 
+bool nano::transport::is_ipv4_or_v4_mapped_address (boost::asio::ip::address const & address_a)
+{
+	return address_a.is_v4 () || address_a.to_v6 ().is_v4_mapped ();
+}
+
 bool nano::transport::reserved_address (nano::endpoint const & endpoint_a, bool allow_local_peers)
 {
 	debug_assert (endpoint_a.address ().is_v6 ());

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -32,6 +32,8 @@ namespace transport
 	boost::asio::ip::address ipv4_address_or_ipv6_subnet (boost::asio::ip::address const &);
 	boost::asio::ip::address_v6 mapped_from_v4_bytes (unsigned long);
 	boost::asio::ip::address_v6 mapped_from_v4_or_v6 (boost::asio::ip::address const &);
+	bool is_ipv4_or_v4_mapped_address (boost::asio::ip::address const &);
+
 	// Unassigned, reserved, self
 	bool reserved_address (nano::endpoint const &, bool = false);
 	static std::chrono::seconds constexpr syn_cookie_cutoff = std::chrono::seconds (5);


### PR DESCRIPTION
The current prefix limit for a IPv6 sub-network is 64, pretty similar to the most of the ISP provided IP sub-networks. Since the IPv4 address space is much smaller than this it is not necessary to limit it by sub-network.

So, what it does is to turn-off the limiting for when the endpoint IP of the incoming connection is IPv4 or v4 mapped IPv6.
The limit will only work for IPv6 only IPs.