### PR TITLE
Add wallets::start() function for deferred start.

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -641,6 +641,7 @@ void nano::node::start ()
 	{
 		port_mapping.start ();
 	}
+	wallets.start ();
 	if (config.frontiers_confirmation != nano::frontiers_confirmation_mode::disabled)
 	{
 		workers.push_task ([this_l = shared ()] () {

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1339,11 +1339,7 @@ nano::wallets::wallets (bool error_a, nano::node & node_a) :
 	kdf{ node_a.config.network_params.kdf_work },
 	node (node_a),
 	env (boost::polymorphic_downcast<nano::mdb_wallets_store *> (node_a.wallets_store_impl.get ())->environment),
-	stopped (false),
-	thread ([this] () {
-		nano::thread_role::set (nano::thread_role::name::wallet_actions);
-		do_wallet_actions ();
-	})
+	stopped (false)
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	if (!error_a)
@@ -1604,6 +1600,14 @@ void nano::wallets::stop ()
 	{
 		thread.join ();
 	}
+}
+
+void nano::wallets::start ()
+{
+	thread = std::thread{ [this] () {
+		nano::thread_role::set (nano::thread_role::name::wallet_actions);
+		do_wallet_actions ();
+	} };
 }
 
 nano::write_transaction nano::wallets::tx_begin_write ()

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -206,6 +206,7 @@ public:
 	void queue_wallet_action (nano::uint128_t const &, std::shared_ptr<nano::wallet> const &, std::function<void (nano::wallet &)>);
 	void foreach_representative (std::function<void (nano::public_key const &, nano::raw_key const &)> const &);
 	bool exists (nano::transaction const &, nano::account const &);
+	void start ();
 	void stop ();
 	void clear_send_ids (nano::transaction const &);
 	nano::wallet_representatives reps () const;


### PR DESCRIPTION
The thread running nano::wallets::do_wallet_actions may need to obtain a shared_ptr to the node. This is not available until after the constructor completes, causing a race condition on startup which can lead to a crash.

This adds nano::wallets::start() which does a deferred start from nano::node::start ().

Fixes: https://github.com/nanocurrency/nano-node/issues/3491