### PR TITLE
Refine election scheduler lock.

### DIFF
--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -116,18 +116,22 @@ void nano::election_scheduler::run ()
 		{
 			if (overfill_predicate ())
 			{
+				lock.unlock ();
 				node.active.erase_oldest ();
 			}
 			else if (manual_queue_predicate ())
 			{
 				auto const [block, previous_balance, election_behavior, confirmation_action] = manual_queue.front ();
+				manual_queue.pop_front ();
+				lock.unlock ();
 				nano::unique_lock<nano::mutex> lock2 (node.active.mutex);
 				node.active.insert_impl (lock2, block, previous_balance, election_behavior, confirmation_action);
-				manual_queue.pop_front ();
 			}
 			else if (priority_queue_predicate ())
 			{
 				auto block = priority.top ();
+				priority.pop ();
+				lock.unlock ();
 				std::shared_ptr<nano::election> election;
 				nano::unique_lock<nano::mutex> lock2 (node.active.mutex);
 				election = node.active.insert_impl (lock2, block).election;
@@ -135,9 +139,9 @@ void nano::election_scheduler::run ()
 				{
 					election->transition_active ();
 				}
-				priority.pop ();
 			}
 			notify ();
+			lock.lock ();
 		}
 	}
 }


### PR DESCRIPTION
This is a change to release the election scheduler lock while doing active_transactions operations. This ensures the election scheduler is always available to producers while the queue is being consumed.