### PR TITLE
Introduce support for and use automatic port binding in `rpc_test` unit tests

### DIFF
--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -557,7 +557,9 @@ private:
 };
 
 using tcp_socket_transport = socket_transport<boost::asio::ip::tcp::acceptor, boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>;
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 using domain_socket_transport = socket_transport<boost::asio::local::stream_protocol::acceptor, boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>;
+#endif
 
 template <typename ACCEPTOR_TYPE, typename SOCKET_TYPE, typename ENDPOINT_TYPE>
 std::optional<std::uint16_t> socket_transport<ACCEPTOR_TYPE, SOCKET_TYPE, ENDPOINT_TYPE>::listening_port () const

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -546,6 +546,8 @@ public:
 		}
 	}
 
+	std::optional<std::uint16_t> listening_port () const;
+
 private:
 	nano::ipc::ipc_server & server;
 	nano::ipc::ipc_config_transport & config_transport;
@@ -553,6 +555,22 @@ private:
 	std::unique_ptr<boost::asio::io_context> io_ctx;
 	std::unique_ptr<ACCEPTOR_TYPE> acceptor;
 };
+
+using tcp_socket_transport = socket_transport<boost::asio::ip::tcp::acceptor, boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>;
+using domain_socket_transport = socket_transport<boost::asio::local::stream_protocol::acceptor, boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>;
+
+template <typename ACCEPTOR_TYPE, typename SOCKET_TYPE, typename ENDPOINT_TYPE>
+std::optional<std::uint16_t> socket_transport<ACCEPTOR_TYPE, SOCKET_TYPE, ENDPOINT_TYPE>::listening_port () const
+{
+	using self = socket_transport<ACCEPTOR_TYPE, SOCKET_TYPE, ENDPOINT_TYPE>;
+	if constexpr (std::is_same_v<self, tcp_socket_transport>)
+	{
+		return acceptor->local_endpoint ().port ();
+	}
+
+	return std::nullopt;
+}
+
 }
 
 /**
@@ -598,7 +616,7 @@ nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config co
 			auto threads = node_a.config.ipc_config.transport_domain.io_threads;
 			file_remover = std::make_unique<dsock_file_remover> (node_a.config.ipc_config.transport_domain.path);
 			boost::asio::local::stream_protocol::endpoint ep{ node_a.config.ipc_config.transport_domain.path };
-			transports.push_back (std::make_shared<socket_transport<boost::asio::local::stream_protocol::acceptor, boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> (*this, ep, node_a.config.ipc_config.transport_domain, threads));
+			transports.push_back (std::make_shared<domain_socket_transport> (*this, ep, node_a.config.ipc_config.transport_domain, threads));
 #else
 			node.logger.always_log ("IPC: Domain sockets are not supported on this platform");
 #endif
@@ -607,7 +625,7 @@ nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config co
 		if (node_a.config.ipc_config.transport_tcp.enabled)
 		{
 			auto threads = node_a.config.ipc_config.transport_tcp.io_threads;
-			transports.push_back (std::make_shared<socket_transport<boost::asio::ip::tcp::acceptor, boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>> (*this, boost::asio::ip::tcp::endpoint (boost::asio::ip::tcp::v6 (), node_a.config.ipc_config.transport_tcp.port), node_a.config.ipc_config.transport_tcp, threads));
+			transports.push_back (std::make_shared<tcp_socket_transport> (*this, boost::asio::ip::tcp::endpoint (boost::asio::ip::tcp::v6 (), node_a.config.ipc_config.transport_tcp.port), node_a.config.ipc_config.transport_tcp, threads));
 		}
 
 		node.logger.always_log ("IPC: server started");
@@ -634,6 +652,20 @@ void nano::ipc::ipc_server::stop ()
 	{
 		transport->stop ();
 	}
+}
+
+std::optional<std::uint16_t> nano::ipc::ipc_server::listening_tcp_port () const
+{
+	for (const auto & transport : transports)
+	{
+		const auto actual_transport = std::dynamic_pointer_cast<tcp_socket_transport> (transport);
+		if (actual_transport)
+		{
+			return actual_transport->listening_port ();
+		}
+	}
+
+	return std::nullopt;
 }
 
 std::shared_ptr<nano::ipc::broker> nano::ipc::ipc_server::get_broker ()

--- a/nano/node/ipc/ipc_server.hpp
+++ b/nano/node/ipc/ipc_server.hpp
@@ -30,6 +30,8 @@ namespace ipc
 		~ipc_server ();
 		void stop ();
 
+		std::optional<std::uint16_t> listening_tcp_port () const;
+
 		nano::node & node;
 		nano::node_rpc_config const & node_rpc_config;
 

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -12,8 +12,8 @@
 #include <nano/rpc/rpc_secure.hpp>
 #endif
 
-nano::rpc::rpc (boost::asio::io_context & io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
-	config (config_a),
+nano::rpc::rpc (boost::asio::io_context & io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
+	config (std::move (config_a)),
 	acceptor (io_ctx_a),
 	logger (std::chrono::milliseconds (0)),
 	io_ctx (io_ctx_a),

--- a/nano/rpc/rpc.hpp
+++ b/nano/rpc/rpc.hpp
@@ -20,11 +20,16 @@ class rpc_handler_interface;
 class rpc
 {
 public:
-	rpc (boost::asio::io_context & io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
+	rpc (boost::asio::io_context & io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
 	virtual ~rpc ();
 	void start ();
 	virtual void accept ();
 	void stop ();
+
+	std::uint16_t listening_port ()
+	{
+		return acceptor.local_endpoint ().port ();
+	}
 
 	nano::rpc_config config;
 	boost::asio::ip::tcp::acceptor acceptor;

--- a/nano/rpc/rpc_request_processor.cpp
+++ b/nano/rpc/rpc_request_processor.cpp
@@ -5,9 +5,9 @@
 
 #include <boost/endian/conversion.hpp>
 
-nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
+nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
 	ipc_address (rpc_config.rpc_process.ipc_address),
-	ipc_port (rpc_config.rpc_process.ipc_port),
+	ipc_port (ipc_port_a),
 	thread ([this] () {
 		nano::thread_role::set (nano::thread_role::name::rpc_request_processor);
 		this->run ();
@@ -25,6 +25,11 @@ nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io
 			connection->is_available = true;
 		});
 	}
+}
+
+nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
+	rpc_request_processor (io_ctx, rpc_config, rpc_config.rpc_process.ipc_port)
+{
 }
 
 nano::rpc_request_processor::~rpc_request_processor ()

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -47,6 +47,7 @@ class rpc_request_processor
 {
 public:
 	rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config);
+	rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a);
 	~rpc_request_processor ();
 	void stop ();
 	void add (std::shared_ptr<rpc_request> const & request);
@@ -74,6 +75,10 @@ class ipc_rpc_processor final : public nano::rpc_handler_interface
 public:
 	ipc_rpc_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
 		rpc_request_processor (io_ctx, rpc_config)
+	{
+	}
+	ipc_rpc_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
+		rpc_request_processor (io_ctx, rpc_config, ipc_port_a)
 	{
 	}
 


### PR DESCRIPTION
Basing this off of #3555 (which is itself based off of #3554) in order to make review easier and conflicts non-existent.

For #3554 I still have to make a pending code review addressing, but other than that everything is reviewable and mergeable after approval.