### PR TITLE
Include election.confirmed outcome in log

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -382,7 +382,7 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 			node.network.publish_filter.clear (block);
 		}
 	}
-	node.logger.try_log (boost::str (boost::format ("Election erased for root %1%") % election.qualified_root.to_string ()));
+	node.logger.try_log (boost::str (boost::format ("Election erased for root %1%, confirmed: %2$b") % election.qualified_root.to_string () % election.confirmed ()));
 }
 
 std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active (std::size_t max_a)


### PR DESCRIPTION
Noted by @RickiNano on beta-testing that its not clear the outcome of an election when it is being erased (confirmed or dropped) by reviewing node logs. Added true/false to log string.

Co-authored-by: RickiNano <81099017+RickiNano@users.noreply.github.com>