### PR TITLE
to_string function for message_header class

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -203,21 +203,18 @@ TEST (message, confirm_req_hash_batch_serialization)
 	ASSERT_EQ (header.count_get (), req.roots_hashes.size ());
 }
 
-TEST (message, keepalive_to_string)
+// this unit test checks that conversion of message_header to string works as expected
+TEST (message, message_header_to_string)
 {
-	// header identical to keepalive_serialization at the top of this file
-	nano::keepalive request1{ nano::dev::network_params.network };
-	std::vector<uint8_t> bytes;
-	{
-		nano::vectorstream stream (bytes);
-		request1.serialize (stream);
-	}
-	auto error (false);
-	nano::bufferstream stream (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream);
+	// calculate expected string
+	int maxver = nano::dev::network_params.network.protocol_version;
+	int minver = nano::dev::network_params.network.protocol_version_min;
+	std::stringstream ss;
+	ss << "NetID: 5241(dev), VerMaxUsingMin: " << maxver << "/" << maxver << "/" << minver << ", MsgType: 2(keepalive), Extensions: 0000";
+	auto expected_str = ss.str ();
 
-	std::string header_string = header.to_string ();
-
-	ASSERT_TRUE (boost::algorithm::contains (header_string, "MsgType: 2(keepalive)"));
-	ASSERT_FALSE (boost::algorithm::contains (header_string, ": ,"));
+	// check expected vs real
+	nano::keepalive keepalive_msg{ nano::dev::network_params.network };
+	std::string header_string = keepalive_msg.header.to_string ();
+	ASSERT_EQ (expected_str, header_string);
 }

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/variant/get.hpp>
 
 TEST (message, keepalive_serialization)
@@ -200,4 +201,23 @@ TEST (message, confirm_req_hash_batch_serialization)
 	ASSERT_EQ (req2.roots_hashes, roots_hashes);
 	ASSERT_EQ (header.block_type (), nano::block_type::not_a_block);
 	ASSERT_EQ (header.count_get (), req.roots_hashes.size ());
+}
+
+TEST (message, keepalive_to_string)
+{
+	// header identical to keepalive_serialization at the top of this file
+	nano::keepalive request1{ nano::dev::network_params.network };
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream (bytes);
+		request1.serialize (stream);
+	}
+	auto error (false);
+	nano::bufferstream stream (bytes.data (), bytes.size ());
+	nano::message_header header (error, stream);
+
+	std::string header_string = header.to_string ();
+
+	ASSERT_TRUE (boost::algorithm::contains (header_string, "MsgType: 2(keepalive)"));
+	ASSERT_FALSE (boost::algorithm::contains (header_string, ": ,"));
 }

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -870,6 +870,14 @@ std::string nano::to_string_hex (uint64_t const value_a)
 	return stream.str ();
 }
 
+std::string nano::to_string_hex (uint16_t const value_a)
+{
+	std::stringstream stream;
+	stream << std::hex << std::noshowbase << std::setw (4) << std::setfill ('0');
+	stream << value_a;
+	return stream.str ();
+}
+
 bool nano::from_string_hex (std::string const & value_a, uint64_t & target_a)
 {
 	auto error (value_a.empty ());

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -253,6 +253,7 @@ nano::public_key pub_key (nano::raw_key const &);
 
 /* Conversion methods */
 std::string to_string_hex (uint64_t const);
+std::string to_string_hex (uint16_t const);
 bool from_string_hex (std::string const &, uint64_t &);
 
 /**

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -140,10 +140,10 @@ std::string nano::message_header::to_string ()
 
 	std::stringstream stream;
 
-	stream << boost::format ("NetID: %1%, ") % nano::network::to_string (network);
+	stream << boost::format ("NetID: %1%(%2%), ") % nano::to_string_hex (static_cast<uint16_t> (network)) % nano::network::to_string (network);
 	stream << boost::format ("VerMaxUsingMin: %1%/%2%/%3%, ") % version_max_l % version_using_l % version_min_l;
 	stream << boost::format ("MsgType: %1%(%2%), ") % type_l % type_text;
-	stream << boost::format ("Extensions: %1%") % extensions.to_ulong ();
+	stream << boost::format ("Extensions: %1%") % nano::to_string_hex (static_cast<uint16_t> (extensions.to_ulong ()));
 
 	return stream.str ();
 }

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -4,14 +4,17 @@
 #include <nano/node/active_transactions.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/network.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/secure/buffer.hpp>
 
 #include <boost/endian/conversion.hpp>
+#include <boost/format.hpp>
 #include <boost/pool/pool_alloc.hpp>
 #include <boost/variant/get.hpp>
 
 #include <numeric>
+#include <sstream>
 
 std::bitset<16> constexpr nano::message_header::block_type_mask;
 std::bitset<16> constexpr nano::message_header::count_mask;
@@ -88,6 +91,61 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 	}
 
 	return error;
+}
+
+std::string nano::message_type_to_string (nano::message_type message_type_l)
+{
+	switch (message_type_l)
+	{
+		case nano::message_type::invalid:
+			return "invalid";
+		case nano::message_type::not_a_type:
+			return "not_a_type";
+		case nano::message_type::keepalive:
+			return "keepalive";
+		case nano::message_type::publish:
+			return "publish";
+		case nano::message_type::confirm_req:
+			return "confirm_req";
+		case nano::message_type::confirm_ack:
+			return "confirm_ack";
+		case nano::message_type::bulk_pull:
+			return "bulk_pull";
+		case nano::message_type::bulk_push:
+			return "bulk_push";
+		case nano::message_type::frontier_req:
+			return "frontier_req";
+		case nano::message_type::node_id_handshake:
+			return "node_id_handshake";
+		case nano::message_type::bulk_pull_account:
+			return "bulk_pull_account";
+		case nano::message_type::telemetry_req:
+			return "telemetry_req";
+		case nano::message_type::telemetry_ack:
+			return "telemetry_ack";
+			// default case intentionally omitted to cause warnings for unhandled enums
+	}
+
+	return "n/a";
+}
+
+std::string nano::message_header::to_string ()
+{
+	// Cast to uint16_t to get integer value since uint8_t is treated as an unsigned char in string formatting.
+	uint16_t type_l = static_cast<uint16_t> (type);
+	uint16_t version_max_l = static_cast<uint16_t> (version_max);
+	uint16_t version_using_l = static_cast<uint16_t> (version_using);
+	uint16_t version_min_l = static_cast<uint16_t> (version_min);
+	std::string type_text = nano::message_type_to_string (type);
+
+	std::stringstream stream;
+
+	stream << boost::format ("NetID: %1%, ") % nano::network::to_string (network);
+	stream << boost::format ("VerMaxUsingMin: %1%/%2%/%3%, ") % version_max_l % version_using_l % version_min_l;
+	stream << boost::format ("MsgType: %1%(%2%), ") % type_l % type_text;
+	stream << boost::format ("Extensions: %1%") % extensions.to_ulong ();
+
+	return stream.str ();
 }
 
 nano::message::message (nano::network_constants const & constants, nano::message_type type_a) :

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -189,6 +189,8 @@ enum class message_type : uint8_t
 	telemetry_ack = 0x0d
 };
 
+std::string message_type_to_string (message_type);
+
 enum class bulk_pull_account_flags : uint8_t
 {
 	pending_hash_and_amount = 0x0,
@@ -212,6 +214,7 @@ public:
 	uint8_t version_max;
 	uint8_t version_using;
 	uint8_t version_min;
+	std::string to_string ();
 
 public:
 	nano::message_type type;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -1079,3 +1079,23 @@ std::unique_ptr<nano::container_info_component> nano::syn_cookies::collect_conta
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "syn_cookies_per_ip", syn_cookies_per_ip_count, sizeof (decltype (cookies_per_ip)::value_type) }));
 	return composite;
 }
+
+std::string nano::network::to_string (nano::networks network)
+{
+	switch (network)
+	{
+		case nano::networks::invalid:
+			return "invalid";
+		case nano::networks::nano_beta_network:
+			return "B(beta_network)";
+		case nano::networks::nano_dev_network:
+			return "dev_network";
+		case nano::networks::nano_live_network:
+			return "C(live_network)";
+		case nano::networks::nano_test_network:
+			return "A(test_network)";
+			// default case intentionally omitted to cause warnings for unhandled enums
+	}
+
+	return "n/a";
+}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -1087,13 +1087,13 @@ std::string nano::network::to_string (nano::networks network)
 		case nano::networks::invalid:
 			return "invalid";
 		case nano::networks::nano_beta_network:
-			return "B(beta_network)";
+			return "beta";
 		case nano::networks::nano_dev_network:
-			return "dev_network";
+			return "dev";
 		case nano::networks::nano_live_network:
-			return "C(live_network)";
+			return "live";
 		case nano::networks::nano_test_network:
-			return "A(test_network)";
+			return "test";
 			// default case intentionally omitted to cause warnings for unhandled enums
 	}
 

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -170,6 +170,7 @@ public:
 	bool empty () const;
 	void erase (nano::transport::channel const &);
 	void set_bandwidth_params (double, std::size_t);
+	static std::string to_string (nano::networks);
 
 private:
 	void process_message (nano::message const &, std::shared_ptr<nano::transport::channel> const &);


### PR DESCRIPTION
A simple commit adding a to_string() function to message_header.
This was done by Airtune. Hopefully this is the first of a series of commits adding to_string() functionality to many classes.