### PR TITLE
Remove short election expiration time for dev network

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -193,7 +193,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			debug_assert (false);
 			break;
 	}
-	auto const optimistic_expiration_time = node.network_params.network.is_dev_network () ? 500 : 60 * 1000;
+	auto const optimistic_expiration_time = 60 * 1000;
 	auto const expire_time = std::chrono::milliseconds (optimistic () ? optimistic_expiration_time : 5 * 60 * 1000);
 	if (!confirmed () && expire_time < std::chrono::steady_clock::now () - election_start)
 	{


### PR DESCRIPTION
It makes it difficult/impossible to access election objects in unit tests
and it increases complexity for no obvious benefit.

This change could potentially fix a lot of unit test race conditions.

Fixes #3584 and probably many other unit tests.