### PR TITLE
Fixes the early drops of not yet timed out connections

### DIFF
--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -115,8 +115,8 @@ protected:
 	boost::asio::ip::tcp::endpoint remote;
 
 	std::atomic<uint64_t> next_deadline;
-	std::atomic<uint64_t> last_completion_time;
-	std::atomic<uint64_t> last_receive_time;
+	std::atomic<uint64_t> last_completion_time_or_init;
+	std::atomic<uint64_t> last_receive_time_or_init;
 	std::atomic<bool> timed_out{ false };
 	std::atomic<std::chrono::seconds> io_timeout;
 	std::chrono::seconds silent_connection_tolerance_time;


### PR DESCRIPTION
Both member variables of nano::socket class, last_receive_time and last_completion_time were being initialized to 0. This won't be a problem if these values were not being used in concurrent access context.

now (current clock in seconds) - 0 would always evaluate true compared greater than an expiration time given in (few) seconds. So initializing them with a clock time makes more sense, since there will be still a valid time even if receive or completion events never happen.