### PR TITLE
Double max_peers_per_ip and max_peers_per_subnet (5 -> 10 and 20 -> 40)

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -159,7 +159,7 @@ public:
 		silent_connection_tolerance_time = std::chrono::seconds (120);
 		syn_cookie_cutoff = std::chrono::seconds (5);
 		bootstrap_interval = std::chrono::seconds (15 * 60);
-		max_peers_per_ip = is_dev_network () ? 10 : 5;
+		max_peers_per_ip = is_dev_network () ? 20 : 10;
 		max_peers_per_subnetwork = max_peers_per_ip * 4;
 		ipv6_subnetwork_prefix_for_limiting = 64; // Equivalent to network prefix /64.
 		peer_dump_interval = is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);


### PR DESCRIPTION
We are getting complaints that nodes are hitting this limit. We do not
think it is really a problem but we are increasing this limit to see if
the warnings stop. These complaints could be diverting focus away from
the real problems.

max_peers_per_ip was 5 and now it is 10
max_peers_per_subnet was 20 and now it is 40