### PR TITLE
Disable intermittently failing UT `active_transactions.inactive_votes_cache_fork`

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -231,7 +231,10 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, election->tally ().begin ()->first);
 }
 
-TEST (active_transactions, inactive_votes_cache_fork)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3604
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3605
+TEST (active_transactions, DISABLED_inactive_votes_cache_fork)
 {
 	nano::system system (1);
 	auto & node = *system.nodes[0];


### PR DESCRIPTION
Caught one more failing UT:

- issue for investigating it: [here](https://github.com/nanocurrency/nano-node/issues/3605)
- CI run in which it failed: [here](https://github.com/nanocurrency/nano-node/runs/4512404171?check_suite_focus=true#step:5:1034)
