### PR TITLE
Better move semantics & fix clang-tidy warnings

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -199,9 +199,8 @@ public:
 	fake_work_peer () = delete;
 	fake_work_peer (nano::work_pool & pool_a, asio::io_context & ioc_a, unsigned short port_a, work_peer_type const type_a, nano::work_version const version_a = nano::work_version::work_1) :
 		pool (pool_a),
-		endpoint (tcp::v4 (), port_a),
 		ioc (ioc_a),
-		acceptor (ioc_a, endpoint),
+		acceptor (ioc_a, tcp::endpoint{ tcp::v4 (), port_a }),
 		type (type_a),
 		version (version_a)
 	{
@@ -254,8 +253,8 @@ private:
 			}
 		});
 	}
+
 	nano::work_pool & pool;
-	tcp::endpoint endpoint;
 	asio::io_context & ioc;
 	tcp::acceptor acceptor;
 	work_peer_type const type;

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -179,7 +179,7 @@ void nano::bootstrap_connections::connect_client (nano::tcp_endpoint const & end
 	});
 }
 
-unsigned nano::bootstrap_connections::target_connections (std::size_t pulls_remaining, std::size_t attempts_count)
+unsigned nano::bootstrap_connections::target_connections (std::size_t pulls_remaining, std::size_t attempts_count) const
 {
 	auto const attempts_factor = nano::narrow_cast<unsigned> (node.config.bootstrap_connections * attempts_count);
 	if (attempts_factor >= node.config.bootstrap_connections_max)
@@ -477,7 +477,7 @@ void nano::bootstrap_connections::stop ()
 	lock.unlock ();
 	condition.notify_all ();
 	lock.lock ();
-	for (auto i : clients)
+	for (auto const & i : clients)
 	{
 		if (auto client = i.lock ())
 		{

--- a/nano/node/bootstrap/bootstrap_connections.hpp
+++ b/nano/node/bootstrap/bootstrap_connections.hpp
@@ -23,7 +23,6 @@ class bootstrap_client final : public std::enable_shared_from_this<bootstrap_cli
 public:
 	bootstrap_client (std::shared_ptr<nano::node> const & node_a, nano::bootstrap_connections & connections_a, std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a);
 	~bootstrap_client ();
-	std::shared_ptr<nano::bootstrap_client> shared ();
 	void stop (bool force);
 	double sample_block_rate ();
 	double elapsed_seconds () const;
@@ -46,14 +45,13 @@ private:
 class bootstrap_connections final : public std::enable_shared_from_this<bootstrap_connections>
 {
 public:
-	bootstrap_connections (nano::node & node_a);
-	std::shared_ptr<nano::bootstrap_connections> shared ();
+	explicit bootstrap_connections (nano::node & node_a);
 	std::shared_ptr<nano::bootstrap_client> connection (std::shared_ptr<nano::bootstrap_attempt> const & attempt_a = nullptr, bool use_front_connection = false);
 	void pool_connection (std::shared_ptr<nano::bootstrap_client> const & client_a, bool new_client = false, bool push_front = false);
 	void add_connection (nano::endpoint const & endpoint_a);
 	std::shared_ptr<nano::bootstrap_client> find_connection (nano::tcp_endpoint const & endpoint_a);
 	void connect_client (nano::tcp_endpoint const & endpoint_a, bool push_front = false);
-	unsigned target_connections (std::size_t pulls_remaining, std::size_t attempts_count);
+	unsigned target_connections (std::size_t pulls_remaining, std::size_t attempts_count) const;
 	void populate_connections (bool repeat = true);
 	void start_populate_connections ();
 	void add_pull (nano::pull_info const & pull_a);

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -62,7 +62,7 @@ public:
 	virtual ~socket ();
 	void async_connect (boost::asio::ip::tcp::endpoint const &, std::function<void (boost::system::error_code const &)>);
 	void async_read (std::shared_ptr<std::vector<uint8_t>> const &, std::size_t, std::function<void (boost::system::error_code const &, std::size_t)>);
-	void async_write (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr);
+	void async_write (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> = {});
 
 	void close ();
 	boost::asio::ip::tcp::endpoint remote_endpoint () const;
@@ -177,7 +177,6 @@ private:
 	boost::asio::ip::tcp::endpoint local;
 	std::size_t max_inbound_connections;
 	void evict_dead_connections ();
-	bool is_temporary_error (boost::system::error_code const ec_a);
 	void on_connection_requeue_delayed (std::function<bool (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const &)>);
 	/** Checks whether the maximum number of connections per IP was reached. If so, it returns true. */
 	bool limit_reached_for_incoming_ip_connections (std::shared_ptr<nano::socket> const & new_connection);

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -34,9 +34,11 @@ namespace transport
 
 	public:
 		channel_tcp (nano::node &, std::weak_ptr<nano::socket>);
-		~channel_tcp ();
+		~channel_tcp () override;
 		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
+		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
+		//
 		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_tcp const & other_a) const
@@ -75,7 +77,7 @@ namespace transport
 		friend class telemetry_simultaneous_requests_Test;
 
 	public:
-		tcp_channels (nano::node &, std::function<void (nano::message const &, std::shared_ptr<nano::transport::channel> const &)> = nullptr);
+		explicit tcp_channels (nano::node &, std::function<void (nano::message const &, std::shared_ptr<nano::transport::channel> const &)> = nullptr);
 		bool insert (std::shared_ptr<nano::transport::channel_tcp> const &, std::shared_ptr<nano::socket> const &, std::shared_ptr<nano::bootstrap_server> const &);
 		void erase (nano::tcp_endpoint const &);
 		std::size_t size () const;
@@ -99,7 +101,6 @@ namespace transport
 		std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 		void purge (std::chrono::steady_clock::time_point const &);
 		void ongoing_keepalive ();
-		void list_below_version (std::vector<std::shared_ptr<nano::transport::channel>> &, uint8_t);
 		void list (std::deque<std::shared_ptr<nano::transport::channel>> &, uint8_t = 0, bool = true);
 		void modify (std::shared_ptr<nano::transport::channel_tcp> const &, std::function<void (std::shared_ptr<nano::transport::channel_tcp> const &)>);
 		void update (nano::tcp_endpoint const &);
@@ -145,8 +146,8 @@ namespace transport
 			std::shared_ptr<nano::transport::channel_tcp> channel;
 			std::shared_ptr<nano::socket> socket;
 			std::shared_ptr<nano::bootstrap_server> response_server;
-			channel_tcp_wrapper (std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::socket> const & socket_a, std::shared_ptr<nano::bootstrap_server> const & server_a) :
-				channel (channel_a), socket (socket_a), response_server (server_a)
+			channel_tcp_wrapper (std::shared_ptr<nano::transport::channel_tcp> channel_a, std::shared_ptr<nano::socket> socket_a, std::shared_ptr<nano::bootstrap_server> server_a) :
+				channel (std::move (channel_a)), socket (std::move (socket_a)), response_server (std::move (server_a))
 			{
 			}
 			nano::tcp_endpoint endpoint () const

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -14,9 +14,9 @@ class bandwidth_limiter final
 {
 public:
 	// initialize with limit 0 = unbounded
-	bandwidth_limiter (double const, std::size_t const);
+	bandwidth_limiter (double, std::size_t);
 	bool should_drop (std::size_t const &);
-	void reset (double const, std::size_t const);
+	void reset (double, std::size_t);
 
 private:
 	nano::rate::token_bucket bucket;
@@ -24,7 +24,6 @@ private:
 
 namespace transport
 {
-	class message;
 	nano::endpoint map_endpoint_to_v6 (nano::endpoint const &);
 	nano::endpoint map_tcp_to_endpoint (nano::tcp_endpoint const &);
 	nano::tcp_endpoint map_endpoint_to_tcp (nano::endpoint const &);
@@ -47,11 +46,13 @@ namespace transport
 	class channel
 	{
 	public:
-		channel (nano::node &);
+		explicit channel (nano::node &);
 		virtual ~channel () = default;
 		virtual std::size_t hash_code () const = 0;
 		virtual bool operator== (nano::transport::channel const &) const = 0;
 		void send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a = nullptr, nano::buffer_drop_policy policy_a = nano::buffer_drop_policy::limiter);
+		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
+		//
 		virtual void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) = 0;
 		virtual std::string to_string () const = 0;
 		virtual nano::endpoint get_endpoint () const = 0;
@@ -145,9 +146,11 @@ namespace transport
 	class channel_loopback final : public nano::transport::channel
 	{
 	public:
-		channel_loopback (nano::node &);
+		explicit channel_loopback (nano::node &);
 		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
+		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
+		//
 		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_loopback const & other_a) const

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<nano::transport::channel_udp> nano::transport::udp_channels::ins
 		else
 		{
 			result = std::make_shared<nano::transport::channel_udp> (*this, endpoint_a, network_version_a);
-			channels.get<endpoint_tag> ().insert (result);
+			channels.get<endpoint_tag> ().insert (channel_udp_wrapper{ result });
 			attempts.get<endpoint_tag> ().erase (endpoint_a);
 			lock.unlock ();
 			node.network.channel_observer (result);
@@ -731,16 +731,6 @@ void nano::transport::udp_channels::ongoing_keepalive ()
 			node_l->network.udp_channels.ongoing_keepalive ();
 		}
 	});
-}
-
-void nano::transport::udp_channels::list_below_version (std::vector<std::shared_ptr<nano::transport::channel>> & channels_a, uint8_t cutoff_version_a)
-{
-	nano::lock_guard<nano::mutex> lock (mutex);
-	// clang-format off
-	nano::transform_if (channels.get<random_access_tag> ().begin (), channels.get<random_access_tag> ().end (), std::back_inserter (channels_a),
-		[cutoff_version_a](auto & channel_a) { return channel_a.channel->get_network_version () < cutoff_version_a; },
-		[](auto const & channel) { return channel.channel; });
-	// clang-format on
 }
 
 void nano::transport::udp_channels::list (std::deque<std::shared_ptr<nano::transport::channel>> & deque_a, uint8_t minimum_version_a)

--- a/nano/node/transport/udp.hpp
+++ b/nano/node/transport/udp.hpp
@@ -29,6 +29,8 @@ namespace transport
 		channel_udp (nano::transport::udp_channels &, nano::endpoint const &, uint8_t protocol_version);
 		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
+		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
+		//
 		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_udp const & other_a) const
@@ -104,7 +106,6 @@ namespace transport
 		std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 		void purge (std::chrono::steady_clock::time_point const &);
 		void ongoing_keepalive ();
-		void list_below_version (std::vector<std::shared_ptr<nano::transport::channel>> &, uint8_t);
 		void list (std::deque<std::shared_ptr<nano::transport::channel>> &, uint8_t = 0);
 		void modify (std::shared_ptr<nano::transport::channel_udp> const &, std::function<void (std::shared_ptr<nano::transport::channel_udp> const &)>);
 		nano::node & node;
@@ -140,8 +141,8 @@ namespace transport
 		{
 		public:
 			std::shared_ptr<nano::transport::channel_udp> channel;
-			channel_udp_wrapper (std::shared_ptr<nano::transport::channel_udp> const & channel_a) :
-				channel (channel_a)
+			explicit channel_udp_wrapper (std::shared_ptr<nano::transport::channel_udp> channel_a) :
+				channel (std::move (channel_a))
 			{
 			}
 			nano::endpoint endpoint () const

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -400,7 +400,7 @@ TEST (store, unchecked_load)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
-	auto block (std::make_shared<nano::send_block> (0, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	std::shared_ptr<nano::block> block = std::make_shared<nano::send_block> (0, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
 	constexpr auto num_unchecked = 1000000;
 	for (auto i (0); i < num_unchecked; ++i)
 	{


### PR DESCRIPTION
This is a PR born from the work that I've been doing lately in the networking areas -- things that did not belong to any specific PR, but generally fixing a few clang-tidy warnings and better usage of move semantics.

For a more thorough explanation of why some pass-by-ref is replaced with pass-by-value (and subsequent `std::move`s), check out [this comment](https://github.com/nanocurrency/nano-node/pull/3576#discussion_r768701381), I think it explains it pretty well, but also feel free to bring up any thought you have here, I am open to discuss about it. Thanks!  