### PR TITLE
Disable intermittently failing UT `confirmation_height.election_winner_details_clearing`

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1262,7 +1262,10 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 	test_mode (nano::confirmation_height_mode::unbounded);
 }
 
-TEST (confirmation_height, election_winner_details_clearing)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3607
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3608
+TEST (confirmation_height, DISABLED_election_winner_details_clearing)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		nano::system system;


### PR DESCRIPTION
Caught one more failing UT:

- issue for investigating it: [here](https://github.com/nanocurrency/nano-node/issues/3608)
- CI run in which it failed: [here](https://github.com/nanocurrency/nano-node/runs/4513429321?check_suite_focus=true#step:5:3401)
