### PR TITLE
Changes the silent connection timeouts to consider full-duplex communication flow

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -11,7 +11,7 @@ using namespace std::chrono_literals;
 TEST (bulk_pull, no_address)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = 1;
 	req->end = 2;
@@ -24,7 +24,7 @@ TEST (bulk_pull, no_address)
 TEST (bulk_pull, genesis_to_end)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end.clear ();
@@ -38,7 +38,7 @@ TEST (bulk_pull, genesis_to_end)
 TEST (bulk_pull, no_end)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end = 1;
@@ -63,7 +63,7 @@ TEST (bulk_pull, end_not_owned)
 	open.signature = nano::sign_message (key2.prv, key2.pub, open.hash ());
 	system.nodes[0]->work_generate_blocking (open);
 	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = key2.pub;
 	req->end = nano::dev::genesis->hash ();
@@ -75,7 +75,7 @@ TEST (bulk_pull, end_not_owned)
 TEST (bulk_pull, none)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end = nano::dev::genesis->hash ();
@@ -88,7 +88,7 @@ TEST (bulk_pull, none)
 TEST (bulk_pull, get_next_on_open)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
 	req->end.clear ();
@@ -104,7 +104,7 @@ TEST (bulk_pull, get_next_on_open)
 TEST (bulk_pull, by_block)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis->hash ();
 	req->end.clear ();
@@ -121,7 +121,7 @@ TEST (bulk_pull, by_block)
 TEST (bulk_pull, by_block_single)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis->hash ();
 	req->end = nano::dev::genesis->hash ();
@@ -145,7 +145,7 @@ TEST (bulk_pull, count_limit)
 	auto receive1 (std::make_shared<nano::receive_block> (send1->hash (), send1->hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1->hash ())));
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive1).code);
 
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node0), node0));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node0, nano::socket::endpoint_type_t::server), node0));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = receive1->hash ();
 	req->set_count_present (true);
@@ -1418,7 +1418,7 @@ TEST (frontier_req_response, DISABLED_destruction)
 TEST (frontier_req, begin)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1432,7 +1432,7 @@ TEST (frontier_req, begin)
 TEST (frontier_req, end)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub.number () + 1;
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1474,7 +1474,7 @@ TEST (frontier_req, count)
 	node1->work_generate_blocking (*receive1);
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive1).code);
 
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1488,7 +1488,7 @@ TEST (frontier_req, count)
 TEST (frontier_req, time_bound)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = 1;
@@ -1502,7 +1502,7 @@ TEST (frontier_req, time_bound)
 	req2->start.clear ();
 	req2->age = 1;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
-	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	connection2->requests.push (std::unique_ptr<nano::message>{});
 	auto request2 (std::make_shared<nano::frontier_req_server> (connection, std::move (req2)));
 	ASSERT_TRUE (request2->current.is_zero ());
@@ -1511,7 +1511,7 @@ TEST (frontier_req, time_bound)
 TEST (frontier_req, time_cutoff)
 {
 	nano::system system (1);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = 3;
@@ -1526,7 +1526,7 @@ TEST (frontier_req, time_cutoff)
 	req2->start.clear ();
 	req2->age = 3;
 	req2->count = std::numeric_limits<decltype (req2->count)>::max ();
-	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	connection2->requests.push (std::unique_ptr<nano::message>{});
 	auto request2 (std::make_shared<nano::frontier_req_server> (connection, std::move (req2)));
 	ASSERT_TRUE (request2->frontier.is_zero ());
@@ -1599,7 +1599,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive2).code);
 
 	// Request for all accounts (confirmed only)
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
 	req->age = std::numeric_limits<decltype (req->age)>::max ();
@@ -1613,7 +1613,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (nano::dev::genesis->hash (), request->frontier);
 
 	// Request starting with account before genesis (confirmed only)
-	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection2 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req2 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req2->start = key_before_genesis.pub;
 	req2->age = std::numeric_limits<decltype (req2->age)>::max ();
@@ -1627,7 +1627,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (nano::dev::genesis->hash (), request2->frontier);
 
 	// Request starting with account after genesis (confirmed only)
-	auto connection3 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection3 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req3 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req3->start = key_after_genesis.pub;
 	req3->age = std::numeric_limits<decltype (req3->age)>::max ();
@@ -1641,7 +1641,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_TRUE (request3->frontier.is_zero ());
 
 	// Request for all accounts (unconfirmed blocks)
-	auto connection4 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection4 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req4 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req4->start.clear ();
 	req4->age = std::numeric_limits<decltype (req4->age)>::max ();
@@ -1653,7 +1653,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (receive1->hash (), request4->frontier);
 
 	// Request starting with account after genesis (unconfirmed blocks)
-	auto connection5 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection5 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req5 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req5->start = key_after_genesis.pub;
 	req5->age = std::numeric_limits<decltype (req5->age)>::max ();
@@ -1667,7 +1667,7 @@ TEST (frontier_req, confirmed_frontier)
 	// Confirm account before genesis (confirmed only)
 	nano::blocks_confirm (*node1, { send1, receive1 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()));
-	auto connection6 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection6 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req6 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req6->start = key_before_genesis.pub;
 	req6->age = std::numeric_limits<decltype (req6->age)>::max ();
@@ -1683,7 +1683,7 @@ TEST (frontier_req, confirmed_frontier)
 	// Confirm account after genesis (confirmed only)
 	nano::blocks_confirm (*node1, { send2, receive2 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send2->hash ()) && node1->block_confirmed (receive2->hash ()));
-	auto connection7 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1), node1));
+	auto connection7 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req7 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req7->start = key_after_genesis.pub;
 	req7->age = std::numeric_limits<decltype (req7->age)>::max ();
@@ -1858,7 +1858,7 @@ TEST (bulk_pull_account, basics)
 	auto send2 (system.wallet (0)->send_action (nano::dev::genesis->account (), key1.pub, 10));
 	auto send3 (system.wallet (0)->send_action (nano::dev::genesis->account (), key1.pub, 2));
 	ASSERT_TIMELY (5s, system.nodes[0]->balance (key1.pub) == 25);
-	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0]), system.nodes[0]));
+	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 
 	{
 		auto req = std::make_unique<nano::bulk_pull_account> (nano::dev::network_params.network);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -781,7 +781,7 @@ TEST (message_buffer_manager, stats)
 TEST (tcp_listener, tcp_node_id_handshake)
 {
 	nano::system system (1);
-	auto socket (std::make_shared<nano::socket> (*system.nodes[0]));
+	auto socket (std::make_shared<nano::client_socket> (*system.nodes[0]));
 	auto bootstrap_endpoint (system.nodes[0]->bootstrap.endpoint ());
 	auto cookie (system.nodes[0]->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (bootstrap_endpoint)));
 	nano::node_id_handshake node_id_handshake{ nano::dev::network_params.network, cookie, boost::none };
@@ -814,7 +814,7 @@ TEST (tcp_listener, tcp_listener_timeout_empty)
 {
 	nano::system system (1);
 	auto node0 (system.nodes[0]);
-	auto socket (std::make_shared<nano::socket> (*node0));
+	auto socket (std::make_shared<nano::client_socket> (*node0));
 	std::atomic<bool> connected (false);
 	socket->async_connect (node0->bootstrap.endpoint (), [&connected] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);
@@ -837,7 +837,7 @@ TEST (tcp_listener, tcp_listener_timeout_node_id_handshake)
 {
 	nano::system system (1);
 	auto node0 (system.nodes[0]);
-	auto socket (std::make_shared<nano::socket> (*node0));
+	auto socket (std::make_shared<nano::client_socket> (*node0));
 	auto cookie (node0->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (node0->bootstrap.endpoint ())));
 	nano::node_id_handshake node_id_handshake{ nano::dev::network_params.network, cookie, boost::none };
 	auto channel = std::make_shared<nano::transport::channel_tcp> (*node0, socket);

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -155,6 +155,7 @@ public:
 																				: 47000;
 		request_interval_ms = is_dev_network () ? 20 : 500;
 		cleanup_period = is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (60);
+		socket_dev_idle_timeout = std::chrono::seconds (2);
 		idle_timeout = is_dev_network () ? cleanup_period * 15 : cleanup_period * 2;
 		silent_connection_tolerance_time = std::chrono::seconds (120);
 		syn_cookie_cutoff = std::chrono::seconds (5);
@@ -189,6 +190,7 @@ public:
 		return cleanup_period * 5;
 	}
 	/** Default maximum idle time for a socket before it's automatically closed */
+	std::chrono::seconds socket_dev_idle_timeout;
 	std::chrono::seconds idle_timeout;
 	std::chrono::seconds silent_connection_tolerance_time;
 	std::chrono::seconds syn_cookie_cutoff;

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -144,7 +144,7 @@ std::shared_ptr<nano::bootstrap_client> nano::bootstrap_connections::find_connec
 void nano::bootstrap_connections::connect_client (nano::tcp_endpoint const & endpoint_a, bool push_front)
 {
 	++connections_count;
-	auto socket (std::make_shared<nano::socket> (node));
+	auto socket (std::make_shared<nano::client_socket> (node));
 	auto this_l (shared_from_this ());
 	socket->async_connect (endpoint_a,
 	[this_l, socket, endpoint_a, push_front] (boost::system::error_code const & ec) {

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -15,10 +15,11 @@
 #include <limits>
 #include <memory>
 
-nano::socket::socket (nano::node & node_a) :
+nano::socket::socket (nano::node & node_a, endpoint_type_t endpoint_type_a) :
 	strand{ node_a.io_ctx.get_executor () },
 	tcp_socket{ node_a.io_ctx },
 	node{ node_a },
+	endpoint_type_m{ endpoint_type_a },
 	next_deadline{ std::numeric_limits<uint64_t>::max () },
 	last_completion_time_or_init{ nano::seconds_since_epoch () },
 	last_receive_time_or_init{ nano::seconds_since_epoch () },
@@ -35,6 +36,7 @@ nano::socket::~socket ()
 
 void nano::socket::async_connect (nano::tcp_endpoint const & endpoint_a, std::function<void (boost::system::error_code const &)> callback_a)
 {
+	debug_assert (endpoint_type () == endpoint_type_t::client);
 	checkup ();
 	auto this_l (shared_from_this ());
 	start_timer ();
@@ -152,14 +154,15 @@ void nano::socket::checkup ()
 				auto const silent_for_sending = (time - this_l->last_send_time_or_init) > this_l->silent_connection_tolerance_time.count ();
 				return silent_for_receiving && silent_for_sending;
 			};
-			if (this_l->is_realtime_connection () && is_silent (now))
+			if (this_l->endpoint_type () == endpoint_type_t::server && is_silent (now))
 			{
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_silent_connection_drop, nano::stat::dir::in);
 				condition_to_disconnect = true;
 			}
 			if (this_l->next_deadline != std::numeric_limits<uint64_t>::max () && (now - this_l->last_completion_time_or_init) > this_l->next_deadline)
 			{
-				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_io_timeout_drop, nano::stat::dir::in);
+				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_io_timeout_drop,
+				this_l->endpoint_type () == endpoint_type_t::server ? nano::stat::dir::in : nano::stat::dir::out);
 				condition_to_disconnect = true;
 			}
 			if (condition_to_disconnect)
@@ -241,7 +244,7 @@ nano::tcp_endpoint nano::socket::local_endpoint () const
 }
 
 nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, std::size_t max_connections_a) :
-	socket{ node_a },
+	socket{ node_a, endpoint_type_t::server },
 	acceptor{ node_a.io_ctx },
 	local{ local_a },
 	max_inbound_connections{ max_connections_a }
@@ -354,7 +357,7 @@ void nano::server_socket::on_connection (std::function<bool (std::shared_ptr<nan
 		}
 
 		// Prepare new connection
-		auto new_connection = std::make_shared<nano::socket> (this_l->node);
+		auto new_connection = std::make_shared<nano::socket> (this_l->node, endpoint_type_t::server);
 		this_l->acceptor.async_accept (new_connection->tcp_socket, new_connection->remote,
 		boost::asio::bind_executor (this_l->strand,
 		[this_l, new_connection, callback_a] (boost::system::error_code const & ec_a) {
@@ -400,7 +403,7 @@ void nano::server_socket::on_connection (std::function<bool (std::shared_ptr<nan
 				// Make sure the new connection doesn't idle. Note that in most cases, the callback is going to start
 				// an IO operation immediately, which will start a timer.
 				new_connection->checkup ();
-				new_connection->start_timer (this_l->node.network_params.network.is_dev_network () ? std::chrono::seconds (2) : this_l->node.network_params.network.idle_timeout);
+				new_connection->start_timer (this_l->node.network_params.network.is_dev_network () ? this_l->node.network_params.network.socket_dev_idle_timeout : this_l->node.network_params.network.idle_timeout);
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 				this_l->connections_per_address.emplace (new_connection->remote.address (), new_connection);
 				if (callback_a (new_connection, ec_a))

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -52,13 +52,17 @@ public:
 		realtime,
 		realtime_response_server // special type for tcp channel response server
 	};
+	enum class endpoint_type_t
+	{
+		server,
+		client
+	};
 	/**
 	 * Constructor
 	 * @param node Owning node
-	 * @param io_timeout If tcp async operation is not completed within the timeout, the socket is closed. If not set, the tcp_io_timeout config option is used.
-	 * @param concurrency write concurrency
+	 * @param endpoint_type_a The endpoint's type: either server or client
 	 */
-	explicit socket (nano::node & node);
+	explicit socket (nano::node & node, endpoint_type_t endpoint_type_a);
 	virtual ~socket ();
 	void async_connect (boost::asio::ip::tcp::endpoint const &, std::function<void (boost::system::error_code const &)>);
 	void async_read (std::shared_ptr<std::vector<uint8_t>> const &, std::size_t, std::function<void (boost::system::error_code const &, std::size_t)>);
@@ -88,6 +92,10 @@ public:
 	void type_set (type_t type_a)
 	{
 		type_m = type_a;
+	}
+	endpoint_type_t endpoint_type () const
+	{
+		return endpoint_type_m;
 	}
 	bool is_realtime_connection ()
 	{
@@ -135,6 +143,7 @@ protected:
 
 private:
 	type_t type_m{ type_t::undefined };
+	endpoint_type_t endpoint_type_m;
 
 public:
 	static std::size_t constexpr queue_size_max = 128;
@@ -159,7 +168,6 @@ public:
 	 * @param node_a Owning node
 	 * @param local_a Address and port to listen on
 	 * @param max_connections_a Maximum number of concurrent connections
-	 * @param concurrency_a Write concurrency for new connections
 	 */
 	explicit server_socket (nano::node & node_a, boost::asio::ip::tcp::endpoint local_a, std::size_t max_connections_a);
 	/**Start accepting new connections */
@@ -184,5 +192,19 @@ private:
 	/** Checks whether the maximum number of connections per IP was reached. If so, it returns true. */
 	bool limit_reached_for_incoming_ip_connections (std::shared_ptr<nano::socket> const & new_connection);
 	bool limit_reached_for_incoming_subnetwork_connections (std::shared_ptr<nano::socket> const & new_connection);
+};
+
+/** Socket class for TCP clients */
+class client_socket final : public socket
+{
+public:
+	/**
+	 * Constructor
+	 * @param node_a Owning node
+	 */
+	explicit client_socket (nano::node & node_a) :
+		socket{ node_a, endpoint_type_t::client }
+	{
+	}
 };
 }

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -117,6 +117,7 @@ protected:
 	std::atomic<uint64_t> next_deadline;
 	std::atomic<uint64_t> last_completion_time_or_init;
 	std::atomic<uint64_t> last_receive_time_or_init;
+	std::atomic<uint64_t> last_send_time_or_init;
 	std::atomic<bool> timed_out{ false };
 	std::atomic<std::chrono::seconds> io_timeout;
 	std::chrono::seconds silent_connection_tolerance_time;
@@ -129,6 +130,7 @@ protected:
 	void start_timer ();
 	void stop_timer ();
 	void update_last_receive_time ();
+	void update_last_send_time ();
 	void checkup ();
 
 private:

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -549,7 +549,7 @@ void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint_a
 		node.network.tcp_channels.udp_fallback (endpoint_a);
 		return;
 	}
-	auto socket = std::make_shared<nano::socket> (node);
+	auto socket = std::make_shared<nano::client_socket> (node);
 	std::weak_ptr<nano::socket> socket_w (socket);
 	auto channel (std::make_shared<nano::transport::channel_tcp> (node, socket_w));
 	std::weak_ptr<nano::node> node_w (node.shared ());


### PR DESCRIPTION
The first implementation wrongly considered the communication to be half-duplex, so talking-only connections were getting shutdown as the checking time was only being set for the `async_read()` function. The new implementation considers now the silent connections to be when there is no communication in any of both directions.

This PR also changes the the silent/drop procedure to be applicable only to the server-side. The `nano::socket` class was changed to get informed on its constructor about the `endpoint_type` that can be either socket or client.