### PR TITLE
added cemented, full and pruned to nano_wallet gui

### DIFF
--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -919,10 +919,12 @@ std::string nano_qt::status::text ()
 	debug_assert (!active.empty ());
 	std::string result;
 	size_t unchecked (0);
+	size_t cemented (0);
 	std::string count_string;
 	{
 		auto size (wallet.wallet_m->wallets.node.ledger.cache.block_count.load ());
 		unchecked = wallet.wallet_m->wallets.node.store.unchecked.count (wallet.wallet_m->wallets.node.store.tx_begin_read ());
+		cemented = wallet.wallet_m->wallets.node.ledger.cache.cemented_count.load ();
 		count_string = std::to_string (size);
 	}
 
@@ -957,8 +959,15 @@ std::string nano_qt::status::text ()
 	result += ", Blocks: ";
 	if (unchecked != 0 && wallet.node.bootstrap_initiator.in_progress ())
 	{
-		count_string += ", Queued: " + std::to_string (unchecked);
+		count_string += "\nUnchecked: " + std::to_string (unchecked) + ", Cemented: " + std::to_string(cemented);
 	}
+
+	if (wallet.node.flags.enable_pruning)
+	{
+		count_string += "Full: " + std::to_string (wallet.wallet_m->wallets.node.ledger.cache.block_count - wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
+		count_string += ", Pruned: ", std::to_string (wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
+	}
+
 	result += count_string.c_str ();
 
 	return result;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -959,7 +959,7 @@ std::string nano_qt::status::text ()
 	result += ", Blocks: ";
 	if (unchecked != 0 && wallet.node.bootstrap_initiator.in_progress ())
 	{
-		count_string += "\nUnchecked: " + std::to_string (unchecked) + ", Cemented: " + std::to_string(cemented);
+		count_string += "\nUnchecked: " + std::to_string (unchecked) + ", Cemented: " + std::to_string (cemented);
 	}
 
 	if (wallet.node.flags.enable_pruning)


### PR DESCRIPTION
in response to #3495 . Pruning stats should only appear when pruning is enabled in config.