### PR TITLE
Refactoring within networking areas

### DIFF
--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -135,7 +135,7 @@ TEST (distributed_work, peer)
 	auto work_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::good));
 	work_peer->start ();
 	decltype (node->config.work_peers) peers;
-	peers.emplace_back ("::ffff:127.0.0.1", work_peer->port ());
+	peers.emplace_back ("::ffff:127.0.0.1", work_peer->local_endpoint ().port ());
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
 	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
@@ -161,7 +161,7 @@ TEST (distributed_work, peer_malicious)
 	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::malicious));
 	malicious_peer->start ();
 	decltype (node->config.work_peers) peers;
-	peers.emplace_back ("::ffff:127.0.0.1", malicious_peer->port ());
+	peers.emplace_back ("::ffff:127.0.0.1", malicious_peer->local_endpoint ().port ());
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
 	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
@@ -178,7 +178,7 @@ TEST (distributed_work, peer_malicious)
 	ASSERT_FALSE (node->local_work_generation_enabled ());
 	auto malicious_peer2 (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::malicious));
 	malicious_peer2->start ();
-	peers[0].second = malicious_peer2->port ();
+	peers[0].second = malicious_peer2->local_endpoint ().port ();
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, {}, nano::account ()));
 	ASSERT_TIMELY (5s, malicious_peer2->generations_bad >= 2);
 	node->distributed_work.cancel (hash);
@@ -205,9 +205,9 @@ TEST (distributed_work, peer_multi)
 	malicious_peer->start ();
 	slow_peer->start ();
 	decltype (node->config.work_peers) peers;
-	peers.emplace_back ("localhost", malicious_peer->port ());
-	peers.emplace_back ("localhost", slow_peer->port ());
-	peers.emplace_back ("localhost", good_peer->port ());
+	peers.emplace_back ("localhost", malicious_peer->local_endpoint ().port ());
+	peers.emplace_back ("localhost", slow_peer->local_endpoint ().port ());
+	peers.emplace_back ("localhost", good_peer->local_endpoint ().port ());
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
 	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -200,19 +200,25 @@ public:
 	fake_work_peer (nano::work_pool & pool_a, asio::io_context & ioc_a, unsigned short port_a, work_peer_type const type_a, nano::work_version const version_a = nano::work_version::work_1) :
 		pool (pool_a),
 		ioc (ioc_a),
-		acceptor (ioc_a, tcp::endpoint{ tcp::v4 (), port_a }),
+		acceptor (ioc_a, nano::tcp_endpoint{ boost::asio::ip::address_v6::any (), port_a }),
 		type (type_a),
 		version (version_a)
 	{
 	}
+
 	void start ()
 	{
 		listen ();
 	}
-	unsigned short port () const
+
+	nano::tcp_endpoint local_endpoint () const
 	{
-		return acceptor.local_endpoint ().port ();
+		boost::system::error_code ec;
+		auto local_endpoint = acceptor.local_endpoint (ec);
+		debug_assert (!ec);
+		return local_endpoint;
 	}
+
 	std::atomic<size_t> generations_good{ 0 };
 	std::atomic<size_t> generations_bad{ 0 };
 	std::atomic<size_t> cancels{ 0 };

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -559,13 +559,13 @@ TEST (node, working)
 TEST (node, price)
 {
 	nano::system system (1);
-	auto price1 (system.nodes[0]->price (nano::Gxrb_ratio, 1));
+	auto price1 = nano::node::price (nano::Gxrb_ratio, 1);
 	ASSERT_EQ (nano::node::price_max * 100.0, price1);
-	auto price2 (system.nodes[0]->price (nano::Gxrb_ratio * int (nano::node::free_cutoff + 1), 1));
+	auto price2 = nano::node::price (nano::Gxrb_ratio * int (nano::node::free_cutoff + 1), 1);
 	ASSERT_EQ (0, price2);
-	auto price3 (system.nodes[0]->price (nano::Gxrb_ratio * int (nano::node::free_cutoff + 2) / 2, 1));
+	auto price3 = nano::node::price (nano::Gxrb_ratio * int (nano::node::free_cutoff + 2) / 2, 1);
 	ASSERT_EQ (nano::node::price_max * 100.0 / 2, price3);
-	auto price4 (system.nodes[0]->price (nano::Gxrb_ratio * int (nano::node::free_cutoff) * 2, 1));
+	auto price4 = nano::node::price (nano::Gxrb_ratio * int (nano::node::free_cutoff) * 2, 1);
 	ASSERT_EQ (0, price4);
 }
 
@@ -998,7 +998,7 @@ TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 	node_flags.disable_tcp_realtime = true;
 	node_flags.disable_bootstrap_listener = true;
 	auto node2 = system.add_node (node_flags);
-	ASSERT_EQ (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->bootstrap.endpoint ());
+	ASSERT_FALSE (node2->bootstrap.endpoint ().has_value ());
 	ASSERT_NE (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.endpoint ());
 	ASSERT_EQ (1, node1->network.size ());
 	auto list1 (node1->network.list (2));

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -29,7 +29,7 @@ TEST (websocket, subscription_edge)
 	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
 
 	auto task = ([config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json");
 		client.await_ack ();
 		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
@@ -60,7 +60,7 @@ TEST (websocket, confirmation)
 	std::atomic<bool> ack_ready{ false };
 	std::atomic<bool> unsubscribed{ false };
 	auto task = ([&ack_ready, &unsubscribed, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -127,7 +127,7 @@ TEST (websocket, stopped_election)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "stopped_election", "ack": "true"})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -170,7 +170,7 @@ TEST (websocket, confirmation_options)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "accounts": ["xrb_invalid"]}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -209,7 +209,7 @@ TEST (websocket, confirmation_options)
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true", "include_election_info": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -271,7 +271,7 @@ TEST (websocket, confirmation_options)
 
 	ack_ready = false;
 	auto task3 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "all_local_accounts": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -305,7 +305,7 @@ TEST (websocket, confirmation_options_votes)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "include_election_info_with_votes": "true", "include_block": "false"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -394,7 +394,7 @@ TEST (websocket, confirmation_options_update)
 	std::atomic<bool> added{ false };
 	std::atomic<bool> deleted{ false };
 	auto task = ([&added, &deleted, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		// Subscribe initially with empty options, everything will be filtered
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {}})json");
 		client.await_ack ();
@@ -468,7 +468,7 @@ TEST (websocket, vote)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -518,7 +518,7 @@ TEST (websocket, vote_options_type)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": true, "options": {"include_replays": "true", "include_indeterminate": "false"}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -559,7 +559,7 @@ TEST (websocket, vote_options_representatives)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		std::string message = boost::str (boost::format (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["%1%"]}})json") % nano::dev::genesis_key.pub.to_account ());
 		client.send_message (message);
 		client.await_ack ();
@@ -603,7 +603,7 @@ TEST (websocket, vote_options_representatives)
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "vote", "ack": "true", "options": {"representatives": ["xrb_invalid"]}})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -637,7 +637,7 @@ TEST (websocket, work)
 	// Subscribe to work and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "work", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -707,7 +707,7 @@ TEST (websocket, bootstrap)
 	// Subscribe to bootstrap and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "bootstrap", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -774,7 +774,7 @@ TEST (websocket, bootstrap_exited)
 	// Subscribe to bootstrap and wait for response asynchronously
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "bootstrap", "ack": true})json");
 		client.await_ack ();
 		ack_ready = true;
@@ -818,7 +818,7 @@ TEST (websocket, ws_keepalive)
 	auto node1 (system.add_node (config));
 
 	auto task = ([&node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "ping"})json");
 		client.await_ack ();
 	});
@@ -847,7 +847,7 @@ TEST (websocket, telemetry)
 
 	std::atomic<bool> done{ false };
 	auto task = ([config = node1->config, &node1, &done] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "telemetry", "ack": true})json");
 		client.await_ack ();
 		done = true;
@@ -897,7 +897,7 @@ TEST (websocket, new_unconfirmed_block)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task = ([&ack_ready, config, node1] () {
-		fake_websocket_client client (node1->websocket_server->listening_port ());
+		fake_websocket_client client (node1->websocket_server->local_endpoint ().port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "new_unconfirmed_block", "ack": "true"})json");
 		client.await_ack ();
 		ack_ready = true;

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -217,7 +217,7 @@ void nano::bootstrap_connections::populate_connections (bool repeat)
 			if (auto client = c.lock ())
 			{
 				new_clients.push_back (client);
-				endpoints.insert (client->socket->remote_endpoint ());
+				endpoints.insert (*client->socket->remote_endpoint ());
 				double elapsed_sec = client->elapsed_seconds ();
 				auto blocks_per_sec = client->sample_block_rate ();
 				rate_sum += blocks_per_sec;

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -4,6 +4,7 @@
 #include <nano/node/socket.hpp>
 
 #include <atomic>
+#include <optional>
 #include <queue>
 
 namespace nano
@@ -12,21 +13,20 @@ class bootstrap_server;
 class bootstrap_listener final
 {
 public:
-	bootstrap_listener (uint16_t, nano::node &);
-	void start ();
+	explicit bootstrap_listener (nano::node &);
+	void start (std::uint16_t);
 	void stop ();
 	void accept_action (boost::system::error_code const &, std::shared_ptr<nano::socket> const &);
 	std::size_t connection_count ();
 
 	nano::mutex mutex;
 	std::unordered_map<nano::bootstrap_server *, std::weak_ptr<nano::bootstrap_server>> connections;
-	nano::tcp_endpoint endpoint ();
+	std::optional<nano::tcp_endpoint> endpoint ();
 	nano::node & node;
 	std::shared_ptr<nano::server_socket> listening_socket;
 	bool on{ false };
 	std::atomic<std::size_t> bootstrap_count{ 0 };
 	std::atomic<std::size_t> realtime_count{ 0 };
-	uint16_t port;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (bootstrap_listener & bootstrap_listener, std::string const & name);
@@ -63,7 +63,7 @@ public:
 	std::queue<std::unique_ptr<nano::message>> requests;
 	std::atomic<bool> stopped{ false };
 	// Remote enpoint used to remove response channel even after socket closing
-	nano::tcp_endpoint remote_endpoint{ boost::asio::ip::address_v6::any (), 0 };
+	std::optional<nano::tcp_endpoint> remote_endpoint{};
 	nano::account remote_node_id{};
 	std::chrono::steady_clock::time_point last_telemetry_req{ std::chrono::steady_clock::time_point () };
 };

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -53,7 +53,7 @@ class block_arrival_info final
 {
 public:
 	std::chrono::steady_clock::time_point arrival;
-	nano::block_hash hash;
+	nano::block_hash hash{};
 };
 // This class tracks blocks that are probably live because they arrived in a UDP packet
 // This gives a fairly reliable way to differentiate between blocks being inserted via bootstrap or new, live blocks.
@@ -98,7 +98,7 @@ public:
 	void start ();
 	void stop ();
 	std::shared_ptr<nano::node> shared ();
-	int store_version ();
+	int store_version () const;
 	void receive_confirmed (nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a);
 	void process_confirmed_data (nano::transaction const &, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account &, nano::uint128_t &, bool &, bool &, nano::account &);
 	void process_confirmed (nano::election_status const &, uint64_t = 0);
@@ -109,12 +109,12 @@ public:
 	void keepalive_preconfigured (std::vector<std::string> const &);
 	nano::block_hash latest (nano::account const &);
 	nano::uint128_t balance (nano::account const &);
-	std::shared_ptr<nano::block> block (nano::block_hash const &);
+	std::shared_ptr<nano::block> block (nano::block_hash const &) const;
 	std::pair<nano::uint128_t, nano::uint128_t> balance_pending (nano::account const &, bool only_confirmed);
 	nano::uint128_t weight (nano::account const &);
 	nano::block_hash rep_block (nano::account const &);
-	nano::uint128_t minimum_principal_weight ();
-	nano::uint128_t minimum_principal_weight (nano::uint128_t const &);
+	nano::uint128_t minimum_principal_weight () const;
+	nano::uint128_t minimum_principal_weight (nano::uint128_t const &) const;
 	void ongoing_rep_calculation ();
 	void ongoing_bootstrap ();
 	void ongoing_peer_store ();
@@ -124,25 +124,25 @@ public:
 	void search_pending ();
 	void bootstrap_wallet ();
 	void unchecked_cleanup ();
-	bool collect_ledger_pruning_targets (std::deque<nano::block_hash> &, nano::account &, uint64_t const, uint64_t const, uint64_t const);
-	void ledger_pruning (uint64_t const, bool, bool);
+	bool collect_ledger_pruning_targets (std::deque<nano::block_hash> &, nano::account &, uint64_t, uint64_t, uint64_t) const;
+	void ledger_pruning (uint64_t, bool, bool);
 	void ongoing_ledger_pruning ();
-	int price (nano::uint128_t const &, int);
+	static int price (nano::uint128_t const &, int);
 	// The default difficulty updates to base only when the first epoch_2 block is processed
-	uint64_t default_difficulty (nano::work_version const) const;
-	uint64_t default_receive_difficulty (nano::work_version const) const;
-	uint64_t max_work_generate_difficulty (nano::work_version const) const;
+	uint64_t default_difficulty (nano::work_version) const;
+	uint64_t default_receive_difficulty (nano::work_version) const;
+	uint64_t max_work_generate_difficulty (nano::work_version) const;
 	bool local_work_generation_enabled () const;
 	bool work_generation_enabled () const;
 	bool work_generation_enabled (std::vector<std::pair<std::string, uint16_t>> const &) const;
 	boost::optional<uint64_t> work_generate_blocking (nano::block &, uint64_t);
-	boost::optional<uint64_t> work_generate_blocking (nano::work_version const, nano::root const &, uint64_t, boost::optional<nano::account> const & = boost::none);
-	void work_generate (nano::work_version const, nano::root const &, uint64_t, std::function<void (boost::optional<uint64_t>)>, boost::optional<nano::account> const & = boost::none, bool const = false);
+	boost::optional<uint64_t> work_generate_blocking (nano::work_version, nano::root const &, uint64_t, boost::optional<nano::account> const & = boost::none);
+	void work_generate (nano::work_version, nano::root const &, uint64_t, std::function<void (boost::optional<uint64_t>)>, boost::optional<nano::account> const & = boost::none, bool = false);
 	void add_initial_peers ();
 	void block_confirm (std::shared_ptr<nano::block> const &);
-	bool block_confirmed (nano::block_hash const &);
-	bool block_confirmed_or_being_confirmed (nano::transaction const &, nano::block_hash const &);
-	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
+	bool block_confirmed (nano::block_hash const &) const;
+	bool block_confirmed_or_being_confirmed (nano::transaction const &, nano::block_hash const &) const;
+	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator const & i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
 	void ongoing_online_weight_calculation ();
 	void ongoing_online_weight_calculation_queue ();
 	bool online () const;

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -680,6 +680,14 @@ void nano::websocket::listener::broadcast (nano::websocket::message message_a)
 	}
 }
 
+nano::tcp_endpoint nano::websocket::listener::local_endpoint () const
+{
+	boost::system::error_code ec;
+	auto local_endpoint = acceptor.local_endpoint (ec);
+	debug_assert (!ec);
+	return local_endpoint;
+}
+
 void nano::websocket::listener::increase_subscriber_count (nano::websocket::topic const & topic_a)
 {
 	topic_subscriber_count[static_cast<std::size_t> (topic_a)] += 1;

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -300,10 +300,7 @@ namespace websocket
 			return logger;
 		}
 
-		std::uint16_t listening_port ()
-		{
-			return acceptor.local_endpoint ().port ();
-		}
+		nano::tcp_endpoint local_endpoint () const;
 
 		nano::wallets & get_wallets () const
 		{


### PR DESCRIPTION
This PR cleans up some redundant/unused members/methods and adds better support for working with ports for various purposes.

Also, within `nano::socket` there are a few changes regarding the remote endpoint, which isn't now always guaranteed to exist, but better conveys semantics for the flow and the lifetime of the socket.

There are a couple changes that I missed to pull out in a different PR regarding shadowing member variables, etc, but they should be minimal.
