### PR TITLE
Disable batch of intermittently failing unit tests

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -333,7 +333,10 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
-TEST (active_transactions, inactive_votes_cache_multiple_votes)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3632
+TEST (active_transactions, DISABLED_inactive_votes_cache_multiple_votes)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);
@@ -933,7 +936,10 @@ TEST (active_transactions, confirmation_consistency)
 }
 }
 
-TEST (active_transactions, confirm_new)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3634
+TEST (active_transactions, DISABLED_confirm_new)
 {
 	nano::system system (1);
 	auto & node1 = *system.nodes[0];

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -867,7 +867,10 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	node1->stop ();
 }
 
-TEST (bootstrap_processor, lazy_unclear_state_link)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3640
+TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 {
 	nano::system system;
 	nano::node_config config (nano::get_available_port (), system.logging);

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -640,7 +640,10 @@ TEST (confirmation_height, all_block_types)
 }
 
 /* Bulk of the this test was taken from the node.fork_flip test */
-TEST (confirmation_height, conflict_rollback_cemented)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3633
+TEST (confirmation_height, DISABLED_conflict_rollback_cemented)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		boost::iostreams::stream_buffer<nano::stringstream_mt_sink> sb;

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -185,7 +185,10 @@ TEST (distributed_work, peer_malicious)
 	ASSERT_EQ (0, malicious_peer2->cancels);
 }
 
-TEST (distributed_work, peer_multi)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3630
+TEST (distributed_work, DISABLED_peer_multi)
 {
 	nano::system system (1);
 	auto node (system.nodes[0]);

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -16,7 +16,10 @@ TEST (election, construction)
 	election->transition_active ();
 }
 
-TEST (election, quorum_minimum_flip_success)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3635
+TEST (election, DISABLED_quorum_minimum_flip_success)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -805,7 +805,10 @@ TEST (votes, add_old)
 }
 
 // Lower timestamps are accepted for different accounts
-TEST (votes, add_old_different_account)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3631
+TEST (votes, DISABLED_add_old_different_account)
 {
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3039,7 +3039,10 @@ TEST (node, DISABLED_vote_by_hash_republish)
 	ASSERT_TIMELY (10s, node1.balance (key2.pub) == node1.config.receive_minimum.number () * 2);
 }
 
-TEST (node, vote_by_hash_epoch_block_republish)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3638
+TEST (node, DISABLED_vote_by_hash_epoch_block_republish)
 {
 	nano::system system (2);
 	auto & node1 (*system.nodes[0]);
@@ -4733,7 +4736,10 @@ TEST (node, pruning_automatic)
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send2->hash ()));
 }
 
-TEST (node, pruning_age)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3641
+TEST (node, DISABLED_pruning_age)
 {
 	nano::system system;
 	nano::node_config node_config (nano::get_available_port (), system.logging);

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -345,7 +345,10 @@ TEST (wallet, send_locked)
 	}
 }
 
-TEST (wallet, process_block)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3642
+TEST (wallet, DISABLED_process_block)
 {
 	nano_qt::eventloop_processor processor;
 	nano::system system (1);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2226,7 +2226,10 @@ TEST (rpc, work_peer_bad)
 	ASSERT_TIMELY (5s, nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash1, work) >= nano::dev::network_params.work.threshold_base (nano::work_version::work_1));
 }
 
-TEST (rpc, work_peer_one)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3639
+TEST (rpc, DISABLED_work_peer_one)
 {
 	nano::system system;
 	auto node1 = add_ipc_enabled_node (system);
@@ -2242,7 +2245,10 @@ TEST (rpc, work_peer_one)
 	ASSERT_TIMELY (5s, nano::dev::network_params.work.difficulty (nano::work_version::work_1, key1.pub, work) >= nano::dev::network_params.work.threshold_base (nano::work_version::work_1));
 }
 
-TEST (rpc, work_peer_many)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3636
+TEST (rpc, DISABLED_work_peer_many)
 {
 	nano::system system1 (1);
 	nano::system system2;
@@ -2277,7 +2283,10 @@ TEST (rpc, work_peer_many)
 	node1.stop ();
 }
 
-TEST (rpc, work_version_invalid)
+// Test disabled because it's failing intermittently.
+// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
+// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3637
+TEST (rpc, DISABLED_work_version_invalid)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -227,8 +227,8 @@ public:
 	confirmation_height_info (uint64_t, nano::block_hash const &);
 	void serialize (nano::stream &) const;
 	bool deserialize (nano::stream &);
-	uint64_t height;
-	nano::block_hash frontier;
+	uint64_t height{};
+	nano::block_hash frontier{};
 };
 
 namespace confirmation_height


### PR DESCRIPTION
Disabling a batch of failing unit tests:

- `distributed_work.peer_multi`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3630)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4691644731?check_suite_focus=true#step:5:1868)

- `votes.add_old_different_account`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3631)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4691644731?check_suite_focus=true#step:5:1869)

- `active_transactions.inactive_votes_cache_multiple_votes`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3632)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4691644987?check_suite_focus=true#step:5:2109)

- `confirmation_height.conflict_rollback_cemented`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3633)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4691644987?check_suite_focus=true#step:5:2514)

- `active_transactions.confirm_new`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3634)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4691644987?check_suite_focus=true#step:5:5355)

- `election.quorum_minimum_flip_success`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3635)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4569162762?check_suite_focus=true#step:5:8374)

- `rpc.work_peer_many`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3636)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4551148941?check_suite_focus=true#step:5:10868)

- `rpc.work_version_invalid`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3637)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4551148941?check_suite_focus=true#step:5:10871)

- `node.vote_by_hash_epoch_block_republish`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3638)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4684839338?check_suite_focus=true#step:6:1857)

- `rpc.work_peer_one`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3639)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4336022506?check_suite_focus=true#step:6:2241)

- `bootstrap_processor.lazy_unclear_state_link`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3640)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4507281068?check_suite_focus=true#step:5:410)

- `node.pruning_age`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3641)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4569228026?check_suite_focus=true#step:5:1180)

- `wallet.process_block`
    - issue: [here](https://github.com/nanocurrency/nano-node/issues/3642)
    - CI: [here](https://github.com/nanocurrency/nano-node/runs/4540057657?check_suite_focus=true#step:6:2272)
