### PR TITLE
Fix telemetry rpc getting stuck if all nodes have bandwidth set to 0

### DIFF
--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -181,6 +181,58 @@ TEST (telemetry, consolidate_data_remove_outliers)
 	ASSERT_EQ (data, consolidated_telemetry_data);
 }
 
+TEST (telemetry, consolidate_data_remove_outliers_with_zero_bandwidth)
+{
+	nano::telemetry_data data1;
+	data1.account_count = 2;
+	data1.block_count = 1;
+	data1.cemented_count = 1;
+	data1.protocol_version = 12;
+	data1.peer_count = 2;
+	data1.bandwidth_cap = 0;
+	data1.unchecked_count = 3;
+	data1.uptime = 6;
+	data1.genesis_block = nano::block_hash (3);
+	data1.major_version = 20;
+	data1.minor_version = 1;
+	data1.patch_version = 5;
+	data1.pre_release_version = 2;
+	data1.maker = 1;
+	data1.timestamp = std::chrono::system_clock::time_point (100ms);
+	data1.active_difficulty = 10;
+
+	// Add a majority of nodes with bandwidth set to 0
+	std::vector<nano::telemetry_data> all_data (100, data1);
+
+	nano::telemetry_data data2;
+	data2.account_count = 2;
+	data2.block_count = 1;
+	data2.cemented_count = 1;
+	data2.protocol_version = 12;
+	data2.peer_count = 2;
+	data2.bandwidth_cap = 100;
+	data2.unchecked_count = 3;
+	data2.uptime = 6;
+	data2.genesis_block = nano::block_hash (3);
+	data2.major_version = 20;
+	data2.minor_version = 1;
+	data2.patch_version = 5;
+	data2.pre_release_version = 2;
+	data2.maker = 1;
+	data2.timestamp = std::chrono::system_clock::time_point (100ms);
+	data2.active_difficulty = 10;
+
+	auto consolidated_telemetry_data1 = nano::consolidate_telemetry_data (all_data);
+	ASSERT_EQ (consolidated_telemetry_data1.bandwidth_cap, 0);
+
+	// And a few nodes with non-zero bandwidth
+	all_data.push_back (data2);
+	all_data.push_back (data2);
+
+	auto consolidated_telemetry_data2 = nano::consolidate_telemetry_data (all_data);
+	ASSERT_EQ (consolidated_telemetry_data2.bandwidth_cap, 0);
+}
+
 TEST (telemetry, signatures)
 {
 	nano::keypair node_id;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -541,6 +541,10 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	auto num_either_side_to_remove = telemetry_datas.size () / 10;
 
 	auto strip_outliers_and_sum = [num_either_side_to_remove] (auto & counts) {
+		if (num_either_side_to_remove * 2 >= counts.size ())
+		{
+			return nano::uint128_t (0);
+		}
 		counts.erase (counts.begin (), std::next (counts.begin (), num_either_side_to_remove));
 		counts.erase (std::next (counts.rbegin (), num_either_side_to_remove).base (), counts.end ());
 		return std::accumulate (counts.begin (), counts.end (), nano::uint128_t (0), [] (nano::uint128_t total, auto count) {


### PR DESCRIPTION
I encountered this bug when I was doing some testing on private network, where all nodes have bandwidth set to 0. In that case the 'bandwidths' set is empty and std::next() has undefined behavior (gets stuck in infinite loop).