### PR TITLE
Already-confirmed transactions occupy space in the active_transaction…

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -182,7 +182,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			send_confirm_req (solicitor_a);
 			break;
 		case nano::election::state_t::confirmed:
-			if (base_latency () * confirmed_duration_factor < std::chrono::steady_clock::now ().time_since_epoch () - state_start.load ())
+			//if (base_latency () * confirmed_duration_factor < std::chrono::steady_clock::now ().time_since_epoch () - state_start.load ())
 			{
 				result = true;
 				state_change (nano::election::state_t::confirmed, nano::election::state_t::expired_confirmed);


### PR DESCRIPTION
…s list. This was added to collect extra votes for diagnostics, however, the elections should be moved to another container so they don't occupy space that could be used by unconfirmed transactions.