### PR TITLE
Backlog population is done by a linear scan separated by a 5 minute w…

### DIFF
--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -21,8 +21,9 @@ void nano::election_scheduler::manual (std::shared_ptr<nano::block> const & bloc
 	notify ();
 }
 
-void nano::election_scheduler::activate (nano::account const & account_a, nano::transaction const & transaction)
+bool nano::election_scheduler::activate (nano::account const & account_a, nano::transaction const & transaction)
 {
+	bool result = false;
 	debug_assert (!account_a.is_zero ());
 	nano::account_info account_info;
 	if (!node.store.account.get (transaction, account_a, account_info))
@@ -38,11 +39,12 @@ void nano::election_scheduler::activate (nano::account const & account_a, nano::
 			if (node.ledger.dependents_confirmed (transaction, *block))
 			{
 				nano::lock_guard<nano::mutex> lock{ mutex };
-				priority.push (account_info.modified, block);
+				result = priority.push (account_info.modified, block);
 				notify ();
 			}
 		}
 	}
+	return result;
 }
 
 void nano::election_scheduler::stop ()

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -24,7 +24,7 @@ public:
 	// Call action with confirmed block, may be different than what we started with
 	void manual (std::shared_ptr<nano::block> const &, boost::optional<nano::uint128_t> const & = boost::none, nano::election_behavior = nano::election_behavior::normal, std::function<void (std::shared_ptr<nano::block> const &)> const & = nullptr);
 	// Activates the first unconfirmed block of \p account_a
-	void activate (nano::account const &, nano::transaction const &);
+	bool activate (nano::account const &, nano::transaction const &);
 	void stop ();
 	// Blocks until no more elections can be activated or there are no more elections to activate
 	void flush ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -975,8 +975,12 @@ void nano::node::ongoing_unchecked_cleanup ()
 
 void nano::node::ongoing_backlog_population ()
 {
-	populate_backlog ();
+	auto overflow = populate_backlog ();
 	auto delay = config.network_params.network.is_dev_network () ? std::chrono::seconds{ 1 } : std::chrono::duration_cast<std::chrono::seconds> (std::chrono::minutes{ 5 });
+	if (overflow)
+	{
+		delay = std::chrono::seconds{ 0 };
+	}
 	workers.add_timed_task (std::chrono::steady_clock::now () + delay, [this_l = shared ()] () {
 		this_l->ongoing_backlog_population ();
 	});
@@ -1745,12 +1749,14 @@ std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> nano::node::get_
 	return { max_blocks, weights };
 }
 
-void nano::node::populate_backlog ()
+bool nano::node::populate_backlog ()
 {
+	std::cerr << "<---------------Populating...\n";
 	auto done = false;
 	uint64_t const chunk_size = 65536;
 	nano::account next = 0;
 	uint64_t total = 0;
+	bool overflow = false;
 	while (!stopped && !done)
 	{
 		auto transaction = store.tx_begin_read ();
@@ -1758,11 +1764,14 @@ void nano::node::populate_backlog ()
 		for (auto i = store.account.begin (transaction, next), n = store.account.end (); !stopped && i != n && count < chunk_size; ++i, ++count, ++total)
 		{
 			auto const & account = i->first;
-			scheduler.activate (account, transaction);
+			overflow |= scheduler.activate (account, transaction);
 			next = account.number () + 1;
 		}
 		done = store.account.begin (transaction, next) == store.account.end ();
+
 	}
+	std::cerr << "<---------------Done populating...\n";
+	return overflow;
 }
 
 nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -150,7 +150,7 @@ public:
 	bool epoch_upgrader (nano::raw_key const &, nano::epoch, uint64_t, uint64_t);
 	void set_bandwidth_params (std::size_t limit, double ratio);
 	std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> get_bootstrap_weights () const;
-	void populate_backlog ();
+	bool populate_backlog ();
 	nano::write_database_queue write_database_queue;
 	boost::asio::io_context & io_ctx;
 	boost::latch node_initialized_latch;

--- a/nano/node/prioritization.cpp
+++ b/nano/node/prioritization.cpp
@@ -57,8 +57,9 @@ nano::prioritization::prioritization (uint64_t maximum, std::function<void (std:
 	current = schedule.begin ();
 }
 
-void nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> block)
+bool nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> block)
 {
+	bool result = false;
 	auto was_empty = empty ();
 	auto block_has_balance = block->type () == nano::block_type::state || block->type () == nano::block_type::send;
 	debug_assert (block_has_balance || block->has_sideband ());
@@ -68,12 +69,14 @@ void nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> blo
 	bucket.emplace (value_type{ time, block });
 	if (bucket.size () > std::max (decltype (maximum){ 1 }, maximum / buckets.size ()))
 	{
+		result = true;
 		bucket.erase (--bucket.end ());
 	}
 	if (was_empty)
 	{
 		seek ();
 	}
+	return result;
 }
 
 std::shared_ptr<nano::block> nano::prioritization::top () const

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -31,7 +31,7 @@ class prioritization final
 
 public:
 	prioritization (uint64_t maximum = 250000u, std::function<void (std::shared_ptr<nano::block>)> const & drop_a = nullptr);
-	void push (uint64_t time, std::shared_ptr<nano::block> block);
+	bool push (uint64_t time, std::shared_ptr<nano::block> block);
 	std::shared_ptr<nano::block> top () const;
 	void pop ();
 	std::size_t size () const;


### PR DESCRIPTION
…ait period. In this wait period and even while still scanning it's possible for the election scheduler to empty due to everything being confirmed faster than the scan can operate.

This should be rewritten to not scan at all and instead, a new database table can store the bucket/time as a key and when buckets are emptyied, it can be refilled directly from disk without scanning.