### PR TITLE
Move semantics fix in the asio header

### DIFF
--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -32,7 +32,7 @@ template <typename AsyncWriteStream, typename WriteHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE (WriteHandler, void (boost::system::error_code, std::size_t))
 async_write (AsyncWriteStream & s, nano::shared_const_buffer const & buffer, WriteHandler && handler)
 {
-	return boost::asio::async_write (s, buffer, std::move (handler));
+	return boost::asio::async_write (s, buffer, std::forward<WriteHandler> (handler));
 }
 
 /**
@@ -44,6 +44,6 @@ template <typename AsyncWriteStream, typename BufferType, typename WriteHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE (WriteHandler, void (boost::system::error_code, std::size_t))
 unsafe_async_write (AsyncWriteStream & s, BufferType && buffer, WriteHandler && handler)
 {
-	return boost::asio::async_write (s, buffer, std::move (handler));
+	return boost::asio::async_write (s, buffer, std::forward<WriteHandler> (handler));
 }
 }


### PR DESCRIPTION
XCode's static analyzer suggests perfect-forwarding the handler in asio.hpp, rather than std::move-casting the handler which could have unexpected side effects (but is unlikely to be an issue in the current codebase as call-sites pass a lambda directly)

This change seems consistent with typical forward-references use, and clang-tidy should presumably catch this as well (https://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html)