### PR TITLE
Allow overriding initial peering DNS by environment variable

### DIFF
--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -15,9 +15,9 @@ namespace
 char const * preconfigured_peers_key = "preconfigured_peers";
 char const * signature_checker_threads_key = "signature_checker_threads";
 char const * pow_sleep_interval_key = "pow_sleep_interval";
-char const * default_live_peer_network = "peering.nano.org";
-std::string const default_beta_peer_network = nano::get_env_or_default ("NANO_BETA_PEER_NETWORK", "peering-beta.nano.org");
-std::string const default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
+std::string const default_live_peer_network = nano::get_env_or_default ("NANO_DEFAULT_PEER", "peering.nano.org");
+std::string const default_beta_peer_network = nano::get_env_or_default ("NANO_DEFAULT_PEER", "peering-beta.nano.org");
+std::string const default_test_peer_network = nano::get_env_or_default ("NANO_DEFAULT_PEER", "peering-test.nano.org");
 }
 
 nano::node_config::node_config (nano::network_params & network_params) :

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -15,8 +15,8 @@ namespace
 char const * preconfigured_peers_key = "preconfigured_peers";
 char const * signature_checker_threads_key = "signature_checker_threads";
 char const * pow_sleep_interval_key = "pow_sleep_interval";
-char const * default_beta_peer_network = "peering-beta.nano.org";
 char const * default_live_peer_network = "peering.nano.org";
+std::string const default_beta_peer_network = nano::get_env_or_default ("NANO_BETA_PEER_NETWORK", "peering-beta.nano.org");
 std::string const default_test_peer_network = nano::get_env_or_default ("NANO_TEST_PEER_NETWORK", "peering-test.nano.org");
 }
 


### PR DESCRIPTION
The initial peering DNS is peering.nano.org.
This commit allows to set NANO_DEFAULT_PEER to override it.
This allows for more flexibility when running private test networks.