### PR TITLE
Adds the code-inspector script

### DIFF
--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -30,3 +30,11 @@ jobs:
             cmake-format
       - name: Check cmake-format
         run: ci/cmake-format-check.sh
+
+  code_inspector:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - name: Run code-inspector
+        run: ci/code-inspector-check.sh

--- a/ci/build-travis.sh
+++ b/ci/build-travis.sh
@@ -7,24 +7,9 @@ set -o nounset
 set -o xtrace
 OS=$(uname)
 
-# This is to prevent out of scope access in async_write from asio which is not picked up by static analysers
-if [[ $(grep -rl --exclude="*asio.hpp" "asio::async_write" ./nano) ]]; then
-    echo "Using boost::asio::async_write directly is not permitted (except in nano/lib/asio.hpp). Use nano::async_write instead"
-    exit 1
-fi
+source "$(dirname "$BASH_SOURCE")/impl/code-inspector.sh"
+code_inspect "${ROOTPATH:-.}"
 
-# prevent unsolicited use of std::lock_guard, std::unique_lock, std::condition_variable & std::mutex outside of allowed areas
-if [[ $(grep -rl --exclude={"*random_pool.cpp","*random_pool.hpp","*random_pool_shuffle.hpp","*locks.hpp","*locks.cpp"} "std::unique_lock\|std::lock_guard\|std::condition_variable\|std::mutex" ./nano) ]]; then
-    echo "Using std::unique_lock, std::lock_guard, std::condition_variable or std::mutex is not permitted (except in nano/lib/locks.hpp and non-nano dependent libraries). Use the nano::* versions instead"
-    exit 1
-fi
-
-if [[ $(grep -rlP "^\s*assert \(" ./nano) ]]; then
-    echo "Using assert is not permitted. Use debug_assert instead."
-    exit 1
-fi
-
-# prevent unsolicited use of std::lock_guard & std::unique_lock outside of allowed areas
 mkdir build
 pushd build
 

--- a/ci/code-inspector-check.sh
+++ b/ci/code-inspector-check.sh
@@ -3,30 +3,15 @@
 ###################################################################################################
 
 source "$(dirname "$BASH_SOURCE")/impl/common.sh"
+source "$(dirname "$BASH_SOURCE")/impl/code-inspector.sh"
 
 ###################################################################################################
 
 set -o errexit
 set -o nounset
 
-# This is to prevent out of scope access in async_write from asio which is not picked up by static analysers
-if [[ $(grep -rl --exclude="*asio.hpp" "asio::async_write" $ROOTPATH/nano) ]]; then
-    echo "Using boost::asio::async_write directly is not permitted (except in nano/lib/asio.hpp). Use nano::async_write instead"
-    exit 1
-fi
-
-# prevent unsolicited use of std::lock_guard, std::unique_lock, std::condition_variable & std::mutex outside of allowed areas
-if [[ $(grep -rl --exclude={"*random_pool.cpp","*random_pool.hpp","*random_pool_shuffle.hpp","*locks.hpp","*locks.cpp"} "std::unique_lock\|std::lock_guard\|std::condition_variable\|std::mutex" $ROOTPATH/nano) ]]; then
-    echo "Using std::unique_lock, std::lock_guard, std::condition_variable or std::mutex is not permitted (except in nano/lib/locks.hpp and non-nano dependent libraries). Use the nano::* versions instead"
-    exit 1
-fi
-
-if [[ $(grep -rlP "^\s*assert \(" $ROOTPATH/nano) ]]; then
-    echo "Using assert is not permitted. Use debug_assert instead."
-    exit 1
-fi
+code_inspect "${ROOTPATH:-.}"
 
 echo "code-inspector check passed"
-
 
 ###################################################################################################

--- a/ci/code-inspector-check.sh
+++ b/ci/code-inspector-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+###################################################################################################
+
+source "$(dirname "$BASH_SOURCE")/impl/common.sh"
+
+###################################################################################################
+
+set -o errexit
+set -o nounset
+
+# This is to prevent out of scope access in async_write from asio which is not picked up by static analysers
+if [[ $(grep -rl --exclude="*asio.hpp" "asio::async_write" $ROOTPATH/nano) ]]; then
+    echo "Using boost::asio::async_write directly is not permitted (except in nano/lib/asio.hpp). Use nano::async_write instead"
+    exit 1
+fi
+
+# prevent unsolicited use of std::lock_guard, std::unique_lock, std::condition_variable & std::mutex outside of allowed areas
+if [[ $(grep -rl --exclude={"*random_pool.cpp","*random_pool.hpp","*random_pool_shuffle.hpp","*locks.hpp","*locks.cpp"} "std::unique_lock\|std::lock_guard\|std::condition_variable\|std::mutex" $ROOTPATH/nano) ]]; then
+    echo "Using std::unique_lock, std::lock_guard, std::condition_variable or std::mutex is not permitted (except in nano/lib/locks.hpp and non-nano dependent libraries). Use the nano::* versions instead"
+    exit 1
+fi
+
+if [[ $(grep -rlP "^\s*assert \(" $ROOTPATH/nano) ]]; then
+    echo "Using assert is not permitted. Use debug_assert instead."
+    exit 1
+fi
+
+echo "code-inspector check passed"
+
+
+###################################################################################################

--- a/ci/impl/code-inspector.sh
+++ b/ci/impl/code-inspector.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+###################################################################################################
+
+code_inspect()
+{
+    local SOURCE_ROOT_PATH=$1
+    if [[ $SOURCE_ROOT_PATH == "" ]]; then
+        echo "Missing the source code path" >&2
+        return 1
+    fi
+
+    # This is to prevent out of scope access in async_write from asio which is not picked up by static analysers
+    if [[ $(grep -rl --exclude="*asio.hpp" "asio::async_write" $SOURCE_ROOT_PATH/nano) ]]; then
+        echo "Using boost::asio::async_write directly is not permitted (except in nano/lib/asio.hpp). Use nano::async_write instead" >&2
+        return 1
+    fi
+
+    # prevent unsolicited use of std::lock_guard, std::unique_lock, std::condition_variable & std::mutex outside of allowed areas
+    if [[ $(grep -rl --exclude={"*random_pool.cpp","*random_pool.hpp","*random_pool_shuffle.hpp","*locks.hpp","*locks.cpp"} "std::unique_lock\|std::lock_guard\|std::condition_variable\|std::mutex" $SOURCE_ROOT_PATH/nano) ]]; then
+        echo "Using std::unique_lock, std::lock_guard, std::condition_variable or std::mutex is not permitted (except in nano/lib/locks.hpp and non-nano dependent libraries). Use the nano::* versions instead" >&2
+        return 1
+    fi
+
+    if [[ $(grep -rlP "^\s*assert \(" $SOURCE_ROOT_PATH/nano) ]]; then
+        echo "Using assert is not permitted. Use debug_assert instead." >&2
+        return 1
+    fi
+
+    return 0
+}
+
+###################################################################################################


### PR DESCRIPTION
Attends the issue https://github.com/nanocurrency/nano-node/issues/3674. This script is part of `build-travis.sh` that may be removed from the CI directory soon (https://github.com/nanocurrency/nano-node/issues/3673). It is also better to have a dedicated script for these code inspections.

Modifies the GitHub - Static Analyzers to run also the `code-inspector-check.sh`.