### PR TITLE
Impove election result logging

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -724,6 +724,12 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::election_restart:
 			res = "election_restart";
 			break;
+		case nano::stat::detail::election_confirmed:
+			res = "election_confirmed";
+			break;
+		case nano::stat::detail::election_not_confirmed:
+			res = "election_not_confirmed";
+			break;
 		case nano::stat::detail::blocking:
 			res = "blocking";
 			break;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -323,6 +323,8 @@ public:
 		election_drop_overflow,
 		election_drop_all,
 		election_restart,
+		election_confirmed,
+		election_not_confirmed,
 
 		// udp
 		blocking,

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -381,7 +381,12 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 			node.network.publish_filter.clear (block);
 		}
 	}
-	node.logger.try_log (boost::str (boost::format ("Election erased for root %1%, confirmed: %2$b") % election.qualified_root.to_string () % election.confirmed ()));
+
+	node.stats.inc (nano::stat::type::election, election.confirmed () ? nano::stat::detail::election_confirmed : nano::stat::detail::election_not_confirmed);
+	if (node.config.logging.election_result_logging ())
+	{
+		node.logger.try_log (boost::str (boost::format ("Election erased for root %1%, confirmed: %2$b") % election.qualified_root.to_string () % election.confirmed ()));
+	}
 }
 
 std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active (std::size_t max_a)

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -166,6 +166,7 @@ nano::error nano::logging::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("upnp_details", upnp_details_logging_value, "Log UPNP discovery details..\nWarning: this may include information.\nabout discovered devices, such as product identification. Please review before sharing logs.\ntype:bool");
 	toml.put ("timing", timing_logging_value, "Log detailed timing information for various node operations.\ntype:bool");
 	toml.put ("active_update", active_update_value, "Log when a block is updated while in active transactions.\ntype:bool");
+	toml.put ("election_result", election_result_logging_value, "Log election result when cleaning up election from active election container.\ntype:bool");
 	toml.put ("log_to_cerr", log_to_cerr_value, "Log to standard error in addition to the log file. Not recommended for production systems.\ntype:bool");
 	toml.put ("max_size", max_size, "Maximum log file size in bytes.\ntype:uint64");
 	toml.put ("rotation_size", rotation_size, "Log file rotation size in character count.\ntype:uint64");
@@ -203,6 +204,7 @@ nano::error nano::logging::deserialize_toml (nano::tomlconfig & toml)
 	toml.get<bool> ("upnp_details", upnp_details_logging_value);
 	toml.get<bool> ("timing", timing_logging_value);
 	toml.get<bool> ("active_update", active_update_value);
+	toml.get<bool> ("election_result", election_result_logging_value);
 	toml.get<bool> ("log_to_cerr", log_to_cerr_value);
 	toml.get<bool> ("flush", flush);
 	toml.get<bool> ("single_line_record", single_line_record_value);
@@ -339,6 +341,11 @@ bool nano::logging::timing_logging () const
 bool nano::logging::active_update_logging () const
 {
 	return active_update_value;
+}
+
+bool nano::logging::election_result_logging () const
+{
+	return election_result_logging_value;
 }
 
 bool nano::logging::log_to_cerr () const

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -63,6 +63,7 @@ public:
 	bool callback_logging () const;
 	bool work_generation_time () const;
 	bool active_update_logging () const;
+	bool election_result_logging () const;
 	bool log_to_cerr () const;
 	bool single_line_record () const;
 	void init (boost::filesystem::path const &);
@@ -91,6 +92,7 @@ public:
 	bool upnp_details_logging_value{ false };
 	bool timing_logging_value{ false };
 	bool active_update_value{ false };
+	bool election_result_logging_value{ false };
 	bool log_to_cerr_value{ false };
 	bool flush{ true };
 	uintmax_t max_size{ 128 * 1024 * 1024 };


### PR DESCRIPTION
Right now, node logs result of every election, which makes log not only unreadable but also, in case of logging to terminal, uses surprisingly large amount of gpu to render the text alone. This PR adds a new log configuration option `election_result` that users can use to configure this behavior. Additionally two new stat types are added that I found very useful to track election results without resorting to staring at text log, `nano::stat::detail::election_confirmed` and `nano::stat::detail::election_not_confirmed`.