### PR TITLE
Add `collect_container_info` to election scheduler and prioritization

### DIFF
--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -150,12 +150,12 @@ void nano::election_scheduler::run ()
 	}
 }
 
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (election_scheduler & election_scheduler, std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::election_scheduler::collect_container_info (std::string const & name)
 {
-	nano::unique_lock<nano::mutex> lock{ election_scheduler.mutex };
+	nano::unique_lock<nano::mutex> lock{ mutex };
 
 	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "manual_queue", election_scheduler.manual_queue.size (), sizeof (decltype (election_scheduler.manual_queue)::value_type) }));
-	composite->add_component (collect_container_info (election_scheduler.priority, "priority"));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "manual_queue", manual_queue.size (), sizeof (decltype (manual_queue)::value_type) }));
+	composite->add_component (priority.collect_container_info ("priority"));
 	return composite;
 }

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -149,3 +149,13 @@ void nano::election_scheduler::run ()
 		}
 	}
 }
+
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (election_scheduler & election_scheduler, std::string const & name)
+{
+	nano::unique_lock<nano::mutex> lock{ election_scheduler.mutex };
+
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "manual_queue", election_scheduler.manual_queue.size (), sizeof (decltype (election_scheduler.manual_queue)::value_type) }));
+	composite->add_component (collect_container_info (election_scheduler.priority, "priority"));
+	return composite;
+}

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -46,5 +46,8 @@ private:
 	nano::condition_variable condition;
 	mutable nano::mutex mutex;
 	std::thread thread;
+
+	friend std::unique_ptr<container_info_component> collect_container_info (election_scheduler &, std::string const &);
 };
+std::unique_ptr<container_info_component> collect_container_info (election_scheduler & election_scheduler, std::string const & name);
 }

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -32,6 +32,7 @@ public:
 	std::size_t size () const;
 	bool empty () const;
 	std::size_t priority_queue_size () const;
+	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 
 private:
 	void run ();
@@ -46,8 +47,5 @@ private:
 	nano::condition_variable condition;
 	mutable nano::mutex mutex;
 	std::thread thread;
-
-	friend std::unique_ptr<container_info_component> collect_container_info (election_scheduler &, std::string const &);
 };
-std::unique_ptr<container_info_component> collect_container_info (election_scheduler & election_scheduler, std::string const & name);
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -555,6 +555,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.confirmation_height_processor, "confirmation_height_processor"));
 	composite->add_component (collect_container_info (node.distributed_work, "distributed_work"));
 	composite->add_component (collect_container_info (node.aggregator, "request_aggregator"));
+	composite->add_component (collect_container_info (node.scheduler, "election_scheduler"));
 	return composite;
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -555,7 +555,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.confirmation_height_processor, "confirmation_height_processor"));
 	composite->add_component (collect_container_info (node.distributed_work, "distributed_work"));
 	composite->add_component (collect_container_info (node.aggregator, "request_aggregator"));
-	composite->add_component (collect_container_info (node.scheduler, "election_scheduler"));
+	composite->add_component (node.scheduler.collect_container_info ("election_scheduler"));
 	return composite;
 }
 

--- a/nano/node/prioritization.cpp
+++ b/nano/node/prioritization.cpp
@@ -129,3 +129,14 @@ void nano::prioritization::dump ()
 	}
 	std::cerr << "current: " << std::to_string (*current) << '\n';
 }
+
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (prioritization & prioritization, std::string const & name)
+{
+	auto composite = std::make_unique<container_info_composite> (name);
+	for (auto i = 0; i < prioritization.buckets.size (); ++i)
+	{
+		auto const & bucket = prioritization.buckets[i];
+		composite->add_component (std::make_unique<container_info_leaf> (container_info{ std::to_string (i), bucket.size (), 0 }));
+	}
+	return composite;
+}

--- a/nano/node/prioritization.cpp
+++ b/nano/node/prioritization.cpp
@@ -130,12 +130,12 @@ void nano::prioritization::dump ()
 	std::cerr << "current: " << std::to_string (*current) << '\n';
 }
 
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (prioritization & prioritization, std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::prioritization::collect_container_info (std::string const & name)
 {
 	auto composite = std::make_unique<container_info_composite> (name);
-	for (auto i = 0; i < prioritization.buckets.size (); ++i)
+	for (auto i = 0; i < buckets.size (); ++i)
 	{
-		auto const & bucket = prioritization.buckets[i];
+		auto const & bucket = buckets[i];
 		composite->add_component (std::make_unique<container_info_leaf> (container_info{ std::to_string (i), bucket.size (), 0 }));
 	}
 	return composite;

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/utility.hpp>
 
 #include <cstddef>
 #include <set>

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -40,5 +40,8 @@ public:
 	bool empty () const;
 	void dump ();
 	uint64_t const maximum;
+
+	friend std::unique_ptr<container_info_component> collect_container_info (prioritization &, std::string const &);
 };
+std::unique_ptr<container_info_component> collect_container_info (prioritization & prioritization, std::string const & name);
 }

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -42,7 +42,6 @@ public:
 	void dump ();
 	uint64_t const maximum;
 
-	friend std::unique_ptr<container_info_component> collect_container_info (prioritization &, std::string const &);
+	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const &);
 };
-std::unique_ptr<container_info_component> collect_container_info (prioritization & prioritization, std::string const & name);
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6243,3 +6243,42 @@ TEST (rpc, confirmation_info)
 		ASSERT_EQ (0, response.get<unsigned> ("total_tally"));
 	}
 }
+
+/** Test election scheduler container object stats
+ * The test set the AEC size to 0 and then creates a block which gets stuck
+ * in the election scheduler waiting for a slot in the AEC. Then it confirms that
+ * the stats RPC call shows the corresponding scheduler bucket incrementing
+ */
+TEST (node, election_scheduler_container_info)
+{
+	nano::system system;
+	nano::node_config node_config;
+	node_config.active_elections_size = 0;
+	nano::node_flags node_flags;
+	auto node = add_ipc_enabled_node (system, node_config);
+	auto const rpc_ctx = add_rpc (system, node);
+
+	// create a send block
+	auto send1 = nano::state_block_builder ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 1)
+				 .link (nano::public_key ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
+
+	// process the block and wait for it to show up in the election scheduler
+	node->process_active (send1);
+	ASSERT_TIMELY (10s, node->scheduler.size () == 1);
+
+	// now check the RPC call
+	boost::property_tree::ptree request;
+	request.put ("action", "stats");
+	request.put ("type", "objects");
+	auto response = wait_response (system, rpc_ctx, request);
+	auto es = response.get_child ("node").get_child ("election_scheduler");
+	ASSERT_EQ (es.get_child ("manual_queue").get<std::string> ("count"), "0");
+	ASSERT_EQ (es.get_child ("priority").get_child ("128").get<std::string> ("count"), "1");
+}


### PR DESCRIPTION
When monitoring various network scenarios it is useful to have a nice way to visualize the size of each election prioritization bucket. This PR adds `collect_container_info` logic for `election_scheduler` and `prioritization` classes to allow this. 
