### PR TITLE
Fix `node.pruning_*` unit tests

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4301,6 +4301,8 @@ TEST (rep_crawler, local)
 }
 }
 
+// Test that a node configured with `enable_pruning` and `max_pruning_age = 1s` will automatically
+// prune old confirmed blocks without explicitly saying `node.ledger_pruning` in the unit test
 TEST (node, pruning_automatic)
 {
 	nano::system system{};
@@ -4355,10 +4357,7 @@ TEST (node, pruning_automatic)
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send2->hash ()));
 }
 
-// Test disabled because it's failing intermittently.
-// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3629
-// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3641
-TEST (node, DISABLED_pruning_age)
+TEST (node, pruning_age)
 {
 	nano::system system{};
 
@@ -4419,6 +4418,8 @@ TEST (node, DISABLED_pruning_age)
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send2->hash ()));
 }
 
+// Test that a node configured with `enable_pruning` will
+// prune DEEP-enough confirmed blocks by explicitly saying `node.ledger_pruning` in the unit test
 TEST (node, pruning_depth)
 {
 	nano::system system{};

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4303,54 +4303,55 @@ TEST (rep_crawler, local)
 
 TEST (node, pruning_automatic)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::system system{};
+
+	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	// TODO: remove after allowing pruned voting
+	node_config.enable_voting = false;
 	node_config.max_pruning_age = std::chrono::seconds (1);
-	node_config.enable_voting = false; // Remove after allowing pruned voting
-	nano::node_flags node_flags;
+
+	nano::node_flags node_flags{};
 	node_flags.enable_pruning = true;
+
 	auto & node1 = *system.add_node (node_config, node_flags);
-	nano::keypair key1;
-	auto send1 = nano::send_block_builder ()
-				 .previous (nano::dev::genesis->hash ())
+	nano::keypair key1{};
+	nano::send_block_builder builder{};
+	auto latest_hash = nano::dev::genesis->hash ();
+
+	auto send1 = builder.make_block ()
+				 .previous (latest_hash)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	auto send2 = nano::send_block_builder ()
-				 .previous (send1->hash ())
+	node1.process_active (send1);
+
+	latest_hash = send1->hash ();
+	auto send2 = builder.make_block ()
+				 .previous (latest_hash)
 				 .destination (key1.pub)
 				 .balance (0)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (send1->hash ()))
+				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	// Process as local blocks
-	node1.process_active (send1);
 	node1.process_active (send2);
-	node1.block_processor.flush ();
-	node1.scheduler.flush ();
-	// Confirm last block to prune previous
-	{
-		auto election = node1.active.election (send1->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		election->force_confirm ();
-	}
-	ASSERT_TIMELY (2s, node1.block_confirmed (send1->hash ()) && node1.active.active (send2->qualified_root ()));
-	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	{
-		auto election = node1.active.election (send2->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		election->force_confirm ();
-	}
-	ASSERT_TIMELY (2s, node1.active.empty () && node1.block_confirmed (send2->hash ()));
+
+	// Force-confirm both blocks
+	node1.process_confirmed (nano::election_status{ send1 });
+	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
+	node1.process_confirmed (nano::election_status{ send2 });
+	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
+
 	// Check pruning result
-	ASSERT_TIMELY (3s, node1.ledger.cache.pruned_count == 1);
-	ASSERT_TIMELY (2s, node1.store.pruned.count (node1.store.tx_begin_read ()) == 1); // Transaction commit
+	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_TIMELY (5s, node1.ledger.cache.pruned_count == 1);
+	ASSERT_TIMELY (5s, node1.store.pruned.count (node1.store.tx_begin_read ()) == 1);
 	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (nano::dev::genesis->hash ()));
-	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ())); // true for pruned
+	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ()));
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send2->hash ()));
 }
 
@@ -4359,108 +4360,122 @@ TEST (node, pruning_automatic)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3641
 TEST (node, DISABLED_pruning_age)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
-	node_config.enable_voting = false; // Remove after allowing pruned voting
-	nano::node_flags node_flags;
+	nano::system system{};
+
+	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	// TODO: remove after allowing pruned voting
+	node_config.enable_voting = false;
+
+	nano::node_flags node_flags{};
 	node_flags.enable_pruning = true;
+
 	auto & node1 = *system.add_node (node_config, node_flags);
-	nano::keypair key1;
-	auto send1 = nano::send_block_builder ()
-				 .previous (nano::dev::genesis->hash ())
+	nano::keypair key1{};
+	nano::send_block_builder builder{};
+	auto latest_hash = nano::dev::genesis->hash ();
+
+	auto send1 = builder.make_block ()
+				 .previous (latest_hash)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	auto send2 = nano::send_block_builder ()
-				 .previous (send1->hash ())
+	node1.process_active (send1);
+
+	latest_hash = send1->hash ();
+	auto send2 = builder.make_block ()
+				 .previous (latest_hash)
 				 .destination (key1.pub)
 				 .balance (0)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (send1->hash ()))
+				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	// Process as local blocks
-	node1.process_active (send1);
 	node1.process_active (send2);
-	node1.block_processor.flush ();
-	node1.scheduler.flush ();
-	// Confirm last block to prune previous
-	{
-		auto election = node1.active.election (send1->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		election->force_confirm ();
-	}
-	ASSERT_TIMELY (2s, node1.block_confirmed (send1->hash ()) && node1.active.active (send2->qualified_root ()));
+
+	// Force-confirm both blocks
+	node1.process_confirmed (nano::election_status{ send1 });
+	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
+	node1.process_confirmed (nano::election_status{ send2 });
+	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
+
+	// Three blocks in total, nothing pruned yet
 	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	{
-		auto election = node1.active.election (send2->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		election->force_confirm ();
-	}
-	ASSERT_TIMELY (2s, node1.active.empty () && node1.block_confirmed (send2->hash ()));
+	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	// Pruning with default age 1 day
 	node1.ledger_pruning (1, true, false);
 	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	// Pruning with max age 0
-	node1.config.max_pruning_age = std::chrono::seconds (0);
+	node1.config.max_pruning_age = std::chrono::seconds{ 0 };
 	node1.ledger_pruning (1, true, false);
 	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (nano::dev::genesis->hash ()));
-	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ())); // true for pruned
+	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ()));
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send2->hash ()));
 }
 
 TEST (node, pruning_depth)
 {
-	nano::system system;
+	nano::system system{};
+
 	nano::node_config node_config{ nano::get_available_port (), system.logging };
-	node_config.enable_voting = false; // Remove after allowing pruned voting
-	nano::node_flags node_flags;
+	// TODO: remove after allowing pruned voting
+	node_config.enable_voting = false;
+
+	nano::node_flags node_flags{};
 	node_flags.enable_pruning = true;
+
 	auto & node1 = *system.add_node (node_config, node_flags);
-	nano::keypair key1;
-	auto send1 = nano::send_block_builder ()
-				 .previous (nano::dev::genesis->hash ())
+	nano::keypair key1{};
+	nano::send_block_builder builder{};
+	auto latest_hash = nano::dev::genesis->hash ();
+
+	auto send1 = builder.make_block ()
+				 .previous (latest_hash)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	auto send2 = nano::send_block_builder ()
-				 .previous (send1->hash ())
+	node1.process_active (send1);
+
+	latest_hash = send1->hash ();
+	auto send2 = builder.make_block ()
+				 .previous (latest_hash)
 				 .destination (key1.pub)
 				 .balance (0)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (send1->hash ()))
+				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	// Process as local blocks
-	node1.process_active (send1);
 	node1.process_active (send2);
-	node1.block_processor.flush ();
-	node1.scheduler.flush ();
-	// Confirm last block to prune previous
-	auto election1 = node1.active.election (send1->qualified_root ());
-	ASSERT_NE (nullptr, election1);
-	election1->force_confirm ();
-	ASSERT_TIMELY (2s, node1.block_confirmed (send1->hash ()) && node1.active.active (send2->qualified_root ()));
+
+	// Force-confirm both blocks
+	node1.process_confirmed (nano::election_status{ send1 });
+	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
+	node1.process_confirmed (nano::election_status{ send2 });
+	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
+
+	// Three blocks in total, nothing pruned yet
 	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	auto election2 = node1.active.election (send2->qualified_root ());
-	ASSERT_NE (nullptr, election2);
-	election2->force_confirm ();
-	ASSERT_TIMELY (2s, node1.active.empty () && node1.block_confirmed (send2->hash ()));
+	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	// Pruning with default depth (unlimited)
 	node1.ledger_pruning (1, true, false);
 	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	// Pruning with max depth 1
 	node1.config.max_pruning_depth = 1;
 	node1.ledger_pruning (1, true, false);
 	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
+
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (nano::dev::genesis->hash ()));
-	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ())); // true for pruned
+	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ()));
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send2->hash ()));
 }


### PR DESCRIPTION
One more batch of fixes, put them in the same PR due to the tests being fairly similar to one another.

One of them (`node.pruning_age`) just very recently was disabled in #3629, so linking the respective issue (#3641) to this PR.