### PR TITLE
Do not ignore socket errors

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -757,6 +757,15 @@ std::string nano::stat::detail_to_string (uint32_t key)
 		case nano::stat::detail::tcp_io_timeout_drop:
 			res = "tcp_io_timeout_drop";
 			break;
+		case nano::stat::detail::tcp_connect_error:
+			res = "tcp_connect_error";
+			break;
+		case nano::stat::detail::tcp_read_error:
+			res = "tcp_read_error";
+			break;
+		case nano::stat::detail::tcp_write_error:
+			res = "tcp_write_error";
+			break;
 		case nano::stat::detail::unreachable_host:
 			res = "unreachable_host";
 			break;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -350,6 +350,9 @@ public:
 		tcp_max_per_subnetwork,
 		tcp_silent_connection_drop,
 		tcp_io_timeout_drop,
+		tcp_connect_error,
+		tcp_read_error,
+		tcp_write_error,
 
 		// ipc
 		invocations,

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -62,7 +62,10 @@ void nano::socket::async_connect (nano::tcp_endpoint const & endpoint_a, std::fu
 	this_l->tcp_socket.async_connect (endpoint_a,
 	boost::asio::bind_executor (this_l->strand,
 	[this_l, callback = std::move (callback_a), endpoint_a] (boost::system::error_code const & ec) {
-		this_l->stop_timer ();
+		if (!ec)
+		{
+			this_l->stop_timer ();
+		}
 		this_l->remote = endpoint_a;
 		callback (ec);
 	}));
@@ -80,9 +83,12 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buf
 				boost::asio::async_read (this_l->tcp_socket, boost::asio::buffer (buffer_a->data (), size_a),
 				boost::asio::bind_executor (this_l->strand,
 				[this_l, buffer_a, cbk = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
-					this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
-					this_l->stop_timer ();
-					this_l->update_last_receive_time ();
+					if (!ec)
+					{
+						this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
+						this_l->stop_timer ();
+						this_l->update_last_receive_time ();
+					}
 					cbk (ec, size_a);
 				}));
 			}));
@@ -109,8 +115,11 @@ void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std:
 				boost::asio::bind_executor (this_l->strand,
 				[buffer_a, cbk = std::move (callback), this_l] (boost::system::error_code ec, std::size_t size_a) {
 					--this_l->queue_size;
-					this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
-					this_l->stop_timer ();
+					if (!ec)
+					{
+						this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
+						this_l->stop_timer ();
+					}
 					if (cbk)
 					{
 						cbk (ec, size_a);


### PR DESCRIPTION
We were not checking the result of the connect, send, recv operations.
We treated failed operations as successful, which
gave at least wrong stats and possibly other minor problems too.

Added counters for tcp connect, read, write errors.