### PR TITLE
Fix `ipc_client::async_resolve` when given invalid endpoint

### DIFF
--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -189,3 +189,19 @@ TEST (ipc, permissions_default_user_order)
 	nano::ipc::access access;
 	ASSERT_TRUE (access.deserialize_toml (toml));
 }
+
+TEST (ipc, invalid_endpoint)
+{
+	nano::system system (1);
+	system.nodes[0]->config.ipc_config.transport_tcp.enabled = true;
+	system.nodes[0]->config.ipc_config.transport_tcp.port = 24077;
+	nano::node_rpc_config node_rpc_config;
+	nano::ipc::ipc_client client (system.nodes[0]->io_ctx);
+
+	std::atomic<bool> call_completed{ false };
+	client.async_connect ("::-1", 24077, [&client, &call_completed] (nano::error err) {
+		ASSERT_IS_ERROR (static_cast<std::error_code> (err));
+		call_completed = true;
+	});
+	ASSERT_TIMELY (5s, call_completed);
+}

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -64,7 +64,7 @@ public:
 			}
 			else
 			{
-				callback (ec, *end);
+				callback (ec, boost::asio::ip::tcp::endpoint ());
 			}
 		});
 	}


### PR DESCRIPTION
`ipc_client::async_resolve` was crashing with segfault when given an address it could not resolve. This PR fixes that.