### PR TITLE
Socket timeout tidyup

### DIFF
--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -360,7 +360,7 @@ TEST (socket, disconnection_of_silent_connections)
 	nano::node_config config;
 	// Increasing the timer timeout, so we don't let the connection to timeout due to the timer checker.
 	config.tcp_io_timeout = std::chrono::seconds::max ();
-	config.network_params.network.socket_dev_idle_timeout = std::chrono::seconds::max ();
+	config.network_params.network.idle_timeout = std::chrono::seconds::max ();
 	// Silent connections are connections open by external peers that don't contribute with any data.
 	config.network_params.network.silent_connection_tolerance_time = std::chrono::seconds{ 5 };
 

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -155,7 +155,6 @@ public:
 																				: 47000;
 		request_interval_ms = is_dev_network () ? 20 : 500;
 		cleanup_period = is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (60);
-		socket_dev_idle_timeout = std::chrono::seconds (2);
 		idle_timeout = is_dev_network () ? cleanup_period * 15 : cleanup_period * 2;
 		silent_connection_tolerance_time = std::chrono::seconds (120);
 		syn_cookie_cutoff = std::chrono::seconds (5);
@@ -190,7 +189,6 @@ public:
 		return cleanup_period * 5;
 	}
 	/** Default maximum idle time for a socket before it's automatically closed */
-	std::chrono::seconds socket_dev_idle_timeout;
 	std::chrono::seconds idle_timeout;
 	std::chrono::seconds silent_connection_tolerance_time;
 	std::chrono::seconds syn_cookie_cutoff;

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -97,7 +97,7 @@ void nano::bootstrap_connections::pool_connection (std::shared_ptr<nano::bootstr
 	auto const & socket_l = client_a->socket;
 	if (!stopped && !client_a->pending_stop && !node.network.excluded_peers.check (client_a->channel->get_tcp_endpoint ()))
 	{
-		socket_l->set_next_deadline (node.network_params.network.idle_timeout);
+		socket_l->set_timeout (node.network_params.network.idle_timeout);
 		// Push into idle deque
 		if (!push_front)
 		{

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -97,7 +97,7 @@ void nano::bootstrap_connections::pool_connection (std::shared_ptr<nano::bootstr
 	auto const & socket_l = client_a->socket;
 	if (!stopped && !client_a->pending_stop && !node.network.excluded_peers.check (client_a->channel->get_tcp_endpoint ()))
 	{
-		socket_l->start_timer (node.network_params.network.idle_timeout);
+		socket_l->set_next_deadline (node.network_params.network.idle_timeout);
 		// Push into idle deque
 		if (!push_front)
 		{

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -179,7 +179,7 @@ void nano::bootstrap_server::stop ()
 void nano::bootstrap_server::receive ()
 {
 	// Increase timeout to receive TCP header (idle server socket)
-	socket->timeout_set (node->network_params.network.idle_timeout);
+	socket->set_default_timeout_value (node->network_params.network.idle_timeout);
 	auto this_l (shared_from_this ());
 	socket->async_read (receive_buffer, 8, [this_l] (boost::system::error_code const & ec, std::size_t size_a) {
 		// Set remote_endpoint
@@ -188,7 +188,7 @@ void nano::bootstrap_server::receive ()
 			this_l->remote_endpoint = this_l->socket->remote_endpoint ();
 		}
 		// Decrease timeout to default
-		this_l->socket->timeout_set (this_l->node->config.tcp_io_timeout);
+		this_l->socket->set_default_timeout_value (this_l->node->config.tcp_io_timeout);
 		// Receive header
 		this_l->receive_header_action (ec, size_a);
 	});

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -199,7 +199,7 @@ void nano::socket::checkup ()
 			}
 
 			// if there is no activity for timeout seconds then disconnect
-			if (this_l->timeout != std::numeric_limits<uint64_t>::max () && (now - this_l->last_completion_time_or_init) > this_l->timeout)
+			if ((now - this_l->last_completion_time_or_init) > this_l->timeout)
 			{
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_io_timeout_drop,
 				this_l->endpoint_type () == endpoint_type_t::server ? nano::stat::dir::in : nano::stat::dir::out);

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -434,7 +434,7 @@ void nano::server_socket::on_connection (std::function<bool (std::shared_ptr<nan
 				// Make sure the new connection doesn't idle. Note that in most cases, the callback is going to start
 				// an IO operation immediately, which will start a timer.
 				new_connection->checkup ();
-				new_connection->set_next_deadline (this_l->node.network_params.network.is_dev_network () ? this_l->node.network_params.network.socket_dev_idle_timeout : this_l->node.network_params.network.idle_timeout);
+				new_connection->set_next_deadline (this_l->node.network_params.network.idle_timeout);
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 				this_l->connections_per_address.emplace (new_connection->remote.address (), new_connection);
 				if (cbk (new_connection, ec_a))

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -190,18 +190,22 @@ void nano::socket::checkup ()
 		{
 			uint64_t now (nano::seconds_since_epoch ());
 			auto condition_to_disconnect{ false };
+
+			// if this is a server socket, and no data is received for silent_connection_tolerance_time seconds then disconnect
 			if (this_l->endpoint_type () == endpoint_type_t::server && (now - this_l->last_receive_time_or_init) > this_l->silent_connection_tolerance_time.count ())
 			{
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_silent_connection_drop, nano::stat::dir::in);
 				condition_to_disconnect = true;
 			}
 
+			// if there is no activity for timeout seconds then disconnect
 			if (this_l->timeout != std::numeric_limits<uint64_t>::max () && (now - this_l->last_completion_time_or_init) > this_l->timeout)
 			{
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_io_timeout_drop,
 				this_l->endpoint_type () == endpoint_type_t::server ? nano::stat::dir::in : nano::stat::dir::out);
 				condition_to_disconnect = true;
 			}
+
 			if (condition_to_disconnect)
 			{
 				if (this_l->node.config.logging.network_timeout_logging ())

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -95,7 +95,7 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buf
 					{
 						this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
 						this_l->set_last_completion ();
-						this_l->update_last_receive_time ();
+						this_l->set_last_receive_time ();
 					}
 					cbk (ec, size_a);
 				}));
@@ -172,7 +172,7 @@ void nano::socket::set_last_completion ()
 	last_completion_time_or_init = nano::seconds_since_epoch ();
 }
 
-void nano::socket::update_last_receive_time ()
+void nano::socket::set_last_receive_time ()
 {
 	last_receive_time_or_init = nano::seconds_since_epoch ();
 }

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -68,7 +68,7 @@ void nano::socket::async_connect (nano::tcp_endpoint const & endpoint_a, std::fu
 		}
 		else
 		{
-			this_l->stop_timer ();
+			this_l->set_last_completion ();
 		}
 		this_l->remote = endpoint_a;
 		callback (ec);
@@ -94,7 +94,7 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buf
 					else
 					{
 						this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::in, size_a);
-						this_l->stop_timer ();
+						this_l->set_last_completion ();
 						this_l->update_last_receive_time ();
 					}
 					cbk (ec, size_a);
@@ -130,7 +130,7 @@ void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std:
 					else
 					{
 						this_l->node.stats.add (nano::stat::type::traffic_tcp, nano::stat::dir::out, size_a);
-						this_l->stop_timer ();
+						this_l->set_last_completion ();
 					}
 					if (cbk)
 					{
@@ -165,7 +165,7 @@ void nano::socket::start_timer (std::chrono::seconds deadline_a)
 	next_deadline = deadline_a.count ();
 }
 
-void nano::socket::stop_timer ()
+void nano::socket::set_last_completion ()
 {
 	last_completion_time_or_init = nano::seconds_since_epoch ();
 }

--- a/nano/node/socket.cpp
+++ b/nano/node/socket.cpp
@@ -40,10 +40,10 @@ nano::socket::socket (nano::node & node_a, endpoint_type_t endpoint_type_a) :
 	tcp_socket{ node_a.io_ctx },
 	node{ node_a },
 	endpoint_type_m{ endpoint_type_a },
-	next_deadline{ std::numeric_limits<uint64_t>::max () },
+	timeout{ std::numeric_limits<uint64_t>::max () },
 	last_completion_time_or_init{ nano::seconds_since_epoch () },
 	last_receive_time_or_init{ nano::seconds_since_epoch () },
-	io_timeout{ node_a.config.tcp_io_timeout },
+	default_timeout{ node_a.config.tcp_io_timeout },
 	silent_connection_tolerance_time{ node_a.network_params.network.silent_connection_tolerance_time }
 {
 }
@@ -58,7 +58,7 @@ void nano::socket::async_connect (nano::tcp_endpoint const & endpoint_a, std::fu
 	debug_assert (endpoint_type () == endpoint_type_t::client);
 	checkup ();
 	auto this_l (shared_from_this ());
-	set_next_deadline ();
+	set_default_timeout ();
 	this_l->tcp_socket.async_connect (endpoint_a,
 	boost::asio::bind_executor (this_l->strand,
 	[this_l, callback = std::move (callback_a), endpoint_a] (boost::system::error_code const & ec) {
@@ -82,7 +82,7 @@ void nano::socket::async_read (std::shared_ptr<std::vector<uint8_t>> const & buf
 		auto this_l (shared_from_this ());
 		if (!closed)
 		{
-			set_next_deadline ();
+			set_default_timeout ();
 			boost::asio::post (strand, boost::asio::bind_executor (strand, [buffer_a, callback = std::move (callback_a), size_a, this_l] () mutable {
 				boost::asio::async_read (this_l->tcp_socket, boost::asio::buffer (buffer_a->data (), size_a),
 				boost::asio::bind_executor (this_l->strand,
@@ -118,7 +118,7 @@ void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std:
 		boost::asio::post (strand, boost::asio::bind_executor (strand, [buffer_a, callback = std::move (callback_a), this_l = shared_from_this ()] () mutable {
 			if (!this_l->closed)
 			{
-				this_l->set_next_deadline ();
+				this_l->set_default_timeout ();
 				nano::async_write (this_l->tcp_socket, buffer_a,
 				boost::asio::bind_executor (this_l->strand,
 				[buffer_a, cbk = std::move (callback), this_l] (boost::system::error_code ec, std::size_t size_a) {
@@ -155,16 +155,21 @@ void nano::socket::async_write (nano::shared_const_buffer const & buffer_a, std:
 	}
 }
 
-/** sets the next deadline on this socket.
- */
-void nano::socket::set_next_deadline ()
+/** Call set_timeout with default_timeout as parameter */
+void nano::socket::set_default_timeout ()
 {
-	set_next_deadline (io_timeout);
+	set_timeout (default_timeout);
 }
 
-void nano::socket::set_next_deadline (std::chrono::seconds deadline_a)
+/** Set the current timeout of the socket in seconds
+ *  timeout occurs when the last socket completion is more than timeout seconds in the past
+ *  timeout always applies, the socket always has a timeout
+ *  to set infinite timeout, use std::numeric_limits<uint64_t>::max ()
+ *  the function checkup() checks for timeout on a regular interval
+ */
+void nano::socket::set_timeout (std::chrono::seconds timeout_a)
 {
-	next_deadline = deadline_a.count ();
+	timeout = timeout_a.count ();
 }
 
 void nano::socket::set_last_completion ()
@@ -190,7 +195,8 @@ void nano::socket::checkup ()
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_silent_connection_drop, nano::stat::dir::in);
 				condition_to_disconnect = true;
 			}
-			if (this_l->next_deadline != std::numeric_limits<uint64_t>::max () && (now - this_l->last_completion_time_or_init) > this_l->next_deadline)
+
+			if (this_l->timeout != std::numeric_limits<uint64_t>::max () && (now - this_l->last_completion_time_or_init) > this_l->timeout)
 			{
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_io_timeout_drop,
 				this_l->endpoint_type () == endpoint_type_t::server ? nano::stat::dir::in : nano::stat::dir::out);
@@ -224,9 +230,9 @@ bool nano::socket::has_timed_out () const
 	return timed_out;
 }
 
-void nano::socket::timeout_set (std::chrono::seconds io_timeout_a)
+void nano::socket::set_default_timeout_value (std::chrono::seconds timeout_a)
 {
-	io_timeout = io_timeout_a;
+	default_timeout = timeout_a;
 }
 
 void nano::socket::set_silent_connection_tolerance_time (std::chrono::seconds tolerance_time_a)
@@ -250,7 +256,7 @@ void nano::socket::close_internal ()
 {
 	if (!closed.exchange (true))
 	{
-		io_timeout = std::chrono::seconds (0);
+		default_timeout = std::chrono::seconds (0);
 		boost::system::error_code ec;
 
 		// Ignore error code for shutdown as it is best-effort
@@ -280,7 +286,7 @@ nano::server_socket::server_socket (nano::node & node_a, boost::asio::ip::tcp::e
 	local{ std::move (local_a) },
 	max_inbound_connections{ max_connections_a }
 {
-	io_timeout = std::chrono::seconds::max ();
+	default_timeout = std::chrono::seconds::max ();
 }
 
 void nano::server_socket::start (boost::system::error_code & ec_a)
@@ -434,7 +440,7 @@ void nano::server_socket::on_connection (std::function<bool (std::shared_ptr<nan
 				// Make sure the new connection doesn't idle. Note that in most cases, the callback is going to start
 				// an IO operation immediately, which will start a timer.
 				new_connection->checkup ();
-				new_connection->set_next_deadline (this_l->node.network_params.network.idle_timeout);
+				new_connection->set_timeout (this_l->node.network_params.network.idle_timeout);
 				this_l->node.stats.inc (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 				this_l->connections_per_address.emplace (new_connection->remote.address (), new_connection);
 				if (cbk (new_connection, ec_a))

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -46,11 +46,13 @@ public:
 		realtime,
 		realtime_response_server // special type for tcp channel response server
 	};
+
 	enum class endpoint_type_t
 	{
 		server,
 		client
 	};
+
 	/**
 	 * Constructor
 	 * @param node Owning node
@@ -68,8 +70,8 @@ public:
 	/** Returns true if the socket has timed out */
 	bool has_timed_out () const;
 	/** This can be called to change the maximum idle time, e.g. based on the type of traffic detected. */
-	void timeout_set (std::chrono::seconds io_timeout_a);
-	void set_next_deadline (std::chrono::seconds deadline_a);
+	void set_default_timeout_value (std::chrono::seconds);
+	void set_timeout (std::chrono::seconds);
 	void set_silent_connection_tolerance_time (std::chrono::seconds tolerance_time_a);
 	bool max () const
 	{
@@ -116,11 +118,11 @@ protected:
 	/** The other end of the connection */
 	boost::asio::ip::tcp::endpoint remote;
 
-	std::atomic<uint64_t> next_deadline;
+	std::atomic<uint64_t> timeout;
 	std::atomic<uint64_t> last_completion_time_or_init;
 	std::atomic<uint64_t> last_receive_time_or_init;
 	std::atomic<bool> timed_out{ false };
-	std::atomic<std::chrono::seconds> io_timeout;
+	std::atomic<std::chrono::seconds> default_timeout;
 	std::chrono::seconds silent_connection_tolerance_time;
 	std::atomic<std::size_t> queue_size{ 0 };
 
@@ -128,7 +130,7 @@ protected:
 	 error codes as the OS may have already completed the async operation. */
 	std::atomic<bool> closed{ false };
 	void close_internal ();
-	void set_next_deadline ();
+	void set_default_timeout ();
 	void set_last_completion ();
 	void set_last_receive_time ();
 	void checkup ();

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -12,15 +12,9 @@
 #include <memory>
 #include <vector>
 
-namespace boost
+namespace boost::asio::ip
 {
-namespace asio
-{
-	namespace ip
-	{
-		class network_v6;
-	}
-}
+class network_v6;
 }
 
 namespace nano

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -136,7 +136,7 @@ protected:
 	void close_internal ();
 	void set_next_deadline ();
 	void set_last_completion ();
-	void update_last_receive_time ();
+	void set_last_receive_time ();
 	void checkup ();
 
 private:

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -75,7 +75,7 @@ public:
 	bool has_timed_out () const;
 	/** This can be called to change the maximum idle time, e.g. based on the type of traffic detected. */
 	void timeout_set (std::chrono::seconds io_timeout_a);
-	void start_timer (std::chrono::seconds deadline_a);
+	void set_next_deadline (std::chrono::seconds deadline_a);
 	void set_silent_connection_tolerance_time (std::chrono::seconds tolerance_time_a);
 	bool max () const
 	{
@@ -134,7 +134,7 @@ protected:
 	 error codes as the OS may have already completed the async operation. */
 	std::atomic<bool> closed{ false };
 	void close_internal ();
-	void start_timer ();
+	void set_next_deadline ();
 	void set_last_completion ();
 	void update_last_receive_time ();
 	void checkup ();

--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -135,7 +135,7 @@ protected:
 	std::atomic<bool> closed{ false };
 	void close_internal ();
 	void start_timer ();
-	void stop_timer ();
+	void set_last_completion ();
 	void update_last_receive_time ();
 	void checkup ();
 


### PR DESCRIPTION
Tidy up of how timeouts are handled in socket class. 

* Use guard ifs to make nano::socket::async_write more readable
* Removed needless code
* Added comments to nano::socket class
* Renamed the nano::socket concept of deadline to timeout  
    A deadline makes people imagine a fixed point in time, a timestamp.
    However, socket::next_deadline is a timeout value and not a deadline.
    It signifies the seconds of inactivity that would cause a socket timeout.
* Remove network constant socket_dev_idle_timeout
* Rename socket::stop_timer to socket:set_last_completion    
    All stop timer does is to set a variable. It is a simply setter function.
    It is confusing to call it stop_timer because it implies that it does
    something more than just set a timestamp.
* Added some socket_timeout unit tests