### PR TITLE
Minor bugfix for election scheduler thread name

### DIFF
--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -91,7 +91,7 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 			thread_role_name_string = "Unchecked";
 			break;
 		default:
-			debug_assert (0);
+			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}
 
 	/*

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -86,8 +86,12 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 			break;
 		case nano::thread_role::name::election_scheduler:
 			thread_role_name_string = "Election Sched";
+			break;
 		case nano::thread_role::name::unchecked:
 			thread_role_name_string = "Unchecked";
+			break;
+		default:
+			debug_assert (0);
 	}
 
 	/*

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -43,6 +43,7 @@ namespace thread_role
 		election_scheduler,
 		unchecked,
 	};
+
 	/*
 	 * Get/Set the identifier for the current thread
 	 */


### PR DESCRIPTION
The bug was introduced by commit:
8b428729777e06a1786ce1c9f5bb818352eadfb0:
"Create nano::unchecked_map ADT which is ..."

Missing break which caused the election scheduler
thread name to be wrong.

The bug was found by fikumikudev, many thanks!