### PR TITLE
Fix network.construction_with_specified_port (uses test network port)

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -56,7 +56,7 @@ TEST (network, tcp_connection)
 TEST (network, construction_with_specified_port)
 {
 	nano::system system{};
-	auto const port = nano::test_node_port ();
+	auto const port = nano::get_available_port ();
 	auto const node = system.add_node (nano::node_config{ port, system.logging });
 	EXPECT_EQ (port, node->network.port);
 	EXPECT_EQ (port, node->network.endpoint ().port ());


### PR DESCRIPTION
The test case network.construction_with_specified_port uses the test
network port as the test port but that means this test fails if there
is a test network node running on that machine.

Convert the test to use nano::get_available_port() to avoid that
problem.