### PR TITLE
Encapsulate detail_to_string with uint32_t overload.

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -538,9 +538,8 @@ std::string nano::stat::type_to_string (uint32_t key)
 	return res;
 }
 
-std::string nano::stat::detail_to_string (uint32_t key)
+std::string nano::stat::detail_to_string (stat::detail detail)
 {
-	auto detail = static_cast<stat::detail> (key >> 8 & 0x000000ff);
 	std::string res;
 	switch (detail)
 	{
@@ -891,6 +890,12 @@ std::string nano::stat::detail_to_string (uint32_t key)
 			break;
 	}
 	return res;
+}
+
+std::string nano::stat::detail_to_string (uint32_t key)
+{
+	auto detail = static_cast<stat::detail> (key >> 8 & 0x000000ff);
+	return detail_to_string (detail);
 }
 
 std::string nano::stat::dir_to_string (uint32_t key)

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -583,7 +583,7 @@ public:
 	std::unique_ptr<stat_log_sink> log_sink_json () const;
 
 	/** Returns string representation of detail */
-	static std::string detail_to_string (uint32_t key);
+	static std::string detail_to_string (stat::detail detail);
 
 	/** Stop stats being output */
 	void stop ();
@@ -591,6 +591,7 @@ public:
 private:
 	static std::string type_to_string (uint32_t key);
 	static std::string dir_to_string (uint32_t key);
+	static std::string detail_to_string (uint32_t key);
 
 	/** Constructs a key given type, detail and direction. This is used as input to update(...) and get_entry(...) */
 	uint32_t key_of (stat::type type, stat::detail detail, stat::dir dir) const

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -128,8 +128,7 @@ void nano::transport::channel::send (nano::message & message_a, std::function<vo
 		node.stats.inc (nano::stat::type::drop, detail, nano::stat::dir::out);
 		if (node.config.logging.network_packet_logging ())
 		{
-			auto key = static_cast<uint8_t> (detail) << 8;
-			node.logger.always_log (boost::str (boost::format ("%1% of size %2% dropped") % node.stats.detail_to_string (key) % buffer.size ()));
+			node.logger.always_log (boost::str (boost::format ("%1% of size %2% dropped") % node.stats.detail_to_string (detail) % buffer.size ()));
 		}
 	}
 }


### PR DESCRIPTION
The uint32_t key is an implementation detail of the stat class. This adds an overload and externally exposes detail_to_string with a stat::detail parameter and hides the uint32_t key overload.