### PR TITLE
Removes the nano::unchecked_info::confirmed member. 

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -517,7 +517,7 @@ void nano::block_processor::queue_unchecked (nano::write_transaction const & tra
 void nano::block_processor::requeue_invalid (nano::block_hash const & hash_a, nano::unchecked_info const & info_a)
 {
 	debug_assert (hash_a == info_a.block->hash ());
-	node.bootstrap_initiator.lazy_requeue (hash_a, info_a.block->previous (), info_a.confirmed);
+	node.bootstrap_initiator.lazy_requeue (hash_a, info_a.block->previous ());
 }
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_processor & block_processor, std::string const & name)

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -150,12 +150,12 @@ void nano::bootstrap_initiator::run_bootstrap ()
 	}
 }
 
-void nano::bootstrap_initiator::lazy_requeue (nano::block_hash const & hash_a, nano::block_hash const & previous_a, bool confirmed_a)
+void nano::bootstrap_initiator::lazy_requeue (nano::block_hash const & hash_a, nano::block_hash const & previous_a)
 {
 	auto lazy_attempt (current_lazy_attempt ());
 	if (lazy_attempt != nullptr)
 	{
-		lazy_attempt->lazy_requeue (hash_a, previous_a, confirmed_a);
+		lazy_attempt->lazy_requeue (hash_a, previous_a);
 	}
 }
 

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -86,7 +86,7 @@ public:
 	bool bootstrap_lazy (nano::hash_or_account const &, bool force = false, bool confirmed = true, std::string id_a = "");
 	void bootstrap_wallet (std::deque<nano::account> &);
 	void run_bootstrap ();
-	void lazy_requeue (nano::block_hash const &, nano::block_hash const &, bool);
+	void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	void notify_listeners (bool);
 	void add_observer (std::function<void (bool)> const &);
 	bool in_progress ();

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -161,7 +161,7 @@ void nano::bootstrap_attempt::lazy_add (nano::pull_info const &)
 	debug_assert (mode == nano::bootstrap_mode::lazy);
 }
 
-void nano::bootstrap_attempt::lazy_requeue (nano::block_hash const &, nano::block_hash const &, bool)
+void nano::bootstrap_attempt::lazy_requeue (nano::block_hash const &, nano::block_hash const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::lazy);
 }

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -29,7 +29,7 @@ public:
 	virtual void set_start_account (nano::account const &);
 	virtual bool lazy_start (nano::hash_or_account const &, bool confirmed = true);
 	virtual void lazy_add (nano::pull_info const &);
-	virtual void lazy_requeue (nano::block_hash const &, nano::block_hash const &, bool);
+	virtual void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	virtual uint32_t lazy_batch_size ();
 	virtual bool lazy_has_expired () const;
 	virtual bool lazy_processed_or_exists (nano::block_hash const &);

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -59,7 +59,7 @@ void nano::bootstrap_attempt_lazy::lazy_add (nano::pull_info const & pull_a)
 	lazy_add (pull_a.account_or_head, pull_a.retry_limit);
 }
 
-void nano::bootstrap_attempt_lazy::lazy_requeue (nano::block_hash const & hash_a, nano::block_hash const & previous_a, bool confirmed_a)
+void nano::bootstrap_attempt_lazy::lazy_requeue (nano::block_hash const & hash_a, nano::block_hash const & previous_a)
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	// Add only known blocks
@@ -67,7 +67,7 @@ void nano::bootstrap_attempt_lazy::lazy_requeue (nano::block_hash const & hash_a
 	{
 		lazy_blocks_erase (hash_a);
 		lock.unlock ();
-		node->bootstrap_initiator.connections->requeue_pull (nano::pull_info (hash_a, hash_a, previous_a, incremental_id, static_cast<nano::pull_info::count_t> (1), confirmed_a ? lazy_retry_limit_confirmed () : node->network_params.bootstrap.lazy_destinations_retry_limit));
+		node->bootstrap_initiator.connections->requeue_pull (nano::pull_info (hash_a, hash_a, previous_a, incremental_id, static_cast<nano::pull_info::count_t> (1), node->network_params.bootstrap.lazy_destinations_retry_limit));
 	}
 }
 
@@ -268,7 +268,7 @@ bool nano::bootstrap_attempt_lazy::process_block_lazy (std::shared_ptr<nano::blo
 		}
 		lazy_block_state_backlog_check (block_a, hash);
 		lock.unlock ();
-		nano::unchecked_info info (block_a, known_account_a, 0, nano::signature_verification::unknown, retry_limit > node->network_params.bootstrap.lazy_retry_limit);
+		nano::unchecked_info info (block_a, known_account_a, 0, nano::signature_verification::unknown);
 		node->block_processor.add (info);
 	}
 	// Force drop lazy bootstrap connection for long bulk_pull

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -33,7 +33,7 @@ public:
 	bool lazy_start (nano::hash_or_account const &, bool confirmed = true) override;
 	void lazy_add (nano::hash_or_account const &, unsigned);
 	void lazy_add (nano::pull_info const &) override;
-	void lazy_requeue (nano::block_hash const &, nano::block_hash const &, bool) override;
+	void lazy_requeue (nano::block_hash const &, nano::block_hash const &) override;
 	bool lazy_finished ();
 	bool lazy_has_expired () const override;
 	uint32_t lazy_batch_size () override;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -354,12 +354,11 @@ nano::account const & nano::pending_key::key () const
 	return account;
 }
 
-nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, uint64_t modified_a, nano::signature_verification verified_a, bool confirmed_a) :
+nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, uint64_t modified_a, nano::signature_verification verified_a) :
 	block (block_a),
 	account (account_a),
 	modified (modified_a),
-	verified (verified_a),
-	confirmed (confirmed_a)
+	verified (verified_a)
 {
 }
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -199,7 +199,7 @@ class unchecked_info final
 {
 public:
 	unchecked_info () = default;
-	unchecked_info (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::signature_verification = nano::signature_verification::unknown, bool = false);
+	unchecked_info (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::signature_verification = nano::signature_verification::unknown);
 	unchecked_info (std::shared_ptr<nano::block> const &);
 	void serialize (nano::stream &) const;
 	bool deserialize (nano::stream &);
@@ -208,7 +208,6 @@ public:
 	/** Seconds since posix epoch */
 	uint64_t modified{ 0 };
 	nano::signature_verification verified{ nano::signature_verification::unknown };
-	bool confirmed{ false };
 };
 
 class block_info final


### PR DESCRIPTION
This was not serialized to the unchecked table. Additionally, the value was assigned from a comparison of retry counts so the naming of "confirmed" was confusing. Finally, its removal doesn't break any tests so it's not a tested branch of code.