### PR TITLE
Fix unchecked_map destructor.

### DIFF
--- a/nano/node/unchecked_map.cpp
+++ b/nano/node/unchecked_map.cpp
@@ -63,8 +63,10 @@ size_t nano::unchecked_map::count (nano::transaction const & transaction) const
 
 void nano::unchecked_map::stop ()
 {
-	if (!stopped.exchange (true))
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	if (!stopped)
 	{
+		stopped = true;
 		condition.notify_all (); // Notify flush (), run ()
 	}
 }

--- a/nano/node/unchecked_map.hpp
+++ b/nano/node/unchecked_map.hpp
@@ -56,7 +56,7 @@ private:
 	std::deque<boost::variant<insert, query>> buffer;
 	std::deque<boost::variant<insert, query>> back_buffer;
 	bool writing_back_buffer{ false };
-	std::atomic<bool> stopped{ false };
+	bool stopped{ false };
 	nano::condition_variable condition;
 	nano::mutex mutex;
 	std::thread thread;


### PR DESCRIPTION
Fix an issue with unchecked_map::~unchecked_map where the condition variable signal can be missed since the object mutex isn't acquired while setting stopped=true.