### PR TITLE
Update confirmation_info RPC call to include representatives final votes for monitoring purposes

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2130,22 +2130,34 @@ void nano::json_handler::confirmation_info ()
 				}
 				if (representatives)
 				{
-					boost::property_tree::ptree representatives_final;
-					boost::property_tree::ptree representatives_list;
+					std::multimap<nano::uint128_t, nano::account, std::greater<nano::uint128_t>> representatives;
+					std::multimap<nano::uint128_t, nano::account, std::greater<nano::uint128_t>> representatives_final;
 					for (auto const & [representative, vote] : info.votes)
 					{
 						if (block->hash () == vote.hash)
 						{
 							auto amount (node.ledger.cache.rep_weights.representation_get (representative));
-							representatives_list.put (representative.to_account (), amount.convert_to<std::string> ());
+							representatives.emplace (amount, representative);
 							if (vote.timestamp == std::numeric_limits<uint64_t>::max ())
 							{
-								representatives_final.put (representative.to_account (), amount.convert_to<std::string> ());
+								representatives_final.emplace (amount, representative);
 							}
 						}
 					}
-					entry.add_child ("representatives", representatives_list);
-					entry.add_child ("representatives_final", representatives_final);
+
+					boost::property_tree::ptree representatives_ptree;
+					boost::property_tree::ptree representatives_ptree_final;
+					for (auto const & [amount, representative] : representatives)
+					{
+						representatives_ptree.put (representative.to_account (), amount.convert_to<std::string> ());
+					}
+					for (auto const & [amount, representative] : representatives_final)
+					{
+						representatives_ptree_final.put (representative.to_account (), amount.convert_to<std::string> ());
+					}
+
+					entry.add_child ("representatives", representatives_ptree);
+					entry.add_child ("representatives_final", representatives_ptree_final);
 				}
 				blocks.add_child ((block->hash ()).to_string (), entry);
 			}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2130,21 +2130,24 @@ void nano::json_handler::confirmation_info ()
 				}
 				if (representatives)
 				{
-					std::multimap<nano::uint128_t, nano::account, std::greater<nano::uint128_t>> representatives;
+					boost::property_tree::ptree representatives_final;
+					boost::property_tree::ptree representatives_list;
 					for (auto const & [representative, vote] : info.votes)
 					{
 						if (block->hash () == vote.hash)
 						{
 							auto amount (node.ledger.cache.rep_weights.representation_get (representative));
-							representatives.emplace (std::move (amount), representative);
+							representatives_list.put (representative.to_account (), amount.convert_to<std::string> ());
+							if (vote.timestamp == std::numeric_limits<uint64_t>::max ())
+							{
+								representatives_final.put (representative.to_account (), amount.convert_to<std::string> ());
+							}
 						}
 					}
-					boost::property_tree::ptree representatives_list;
-					for (auto const & [amount, representative] : representatives)
-					{
-						representatives_list.put (representative.to_account (), amount.convert_to<std::string> ());
-					}
-					entry.add_child ("representatives", representatives_list);
+					boost::property_tree::ptree representatives_ptree;
+					representatives_ptree.add_child ("total", representatives_list);
+					representatives_ptree.add_child ("final", representatives_final);
+					entry.add_child ("representatives", representatives_ptree);
 				}
 				blocks.add_child ((block->hash ()).to_string (), entry);
 			}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2144,10 +2144,8 @@ void nano::json_handler::confirmation_info ()
 							}
 						}
 					}
-					boost::property_tree::ptree representatives_ptree;
-					representatives_ptree.add_child ("total", representatives_list);
-					representatives_ptree.add_child ("final", representatives_final);
-					entry.add_child ("representatives", representatives_ptree);
+					entry.add_child ("representatives", representatives_list);
+					entry.add_child ("representatives_final", representatives_final);
 				}
 				blocks.add_child ((block->hash ()).to_string (), entry);
 			}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6844,6 +6844,91 @@ TEST (rpc, confirmation_active)
 TEST (rpc, confirmation_info)
 {
 	nano::test::system system;
+	nano::node_config node_config;
+	node_config.backlog_scan.enable = false; // Disable backlog scan to avoid unwanted elections
+	auto node = add_ipc_enabled_node (system, node_config);
+	auto const rpc_ctx = add_rpc (system, node);
+
+	auto rep1 = nano::test::setup_rep (system, *node, 100 * nano::Knano_ratio);
+	auto rep2 = nano::test::setup_rep (system, *node, 1000 * nano::Knano_ratio);
+	auto rep3 = nano::test::setup_rep (system, *node, 2000 * nano::Knano_ratio);
+	auto rep4 = nano::keypair{}; // Representative with zero weight
+	auto rep5 = nano::test::setup_rep (system, *node, 1500 * nano::Knano_ratio); // Additional final representative
+
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (node->latest (nano::dev::genesis_key.pub))
+				.link (nano::public_key{})
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - 10000 * nano::Knano_ratio)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (node->latest (nano::dev::genesis_key.pub)))
+				.build ();
+	node->process_active (send);
+
+	ASSERT_TIMELY (5s, !node->active.empty ());
+
+	auto election = node->active.election (send->qualified_root ());
+	ASSERT_NE (nullptr, election);
+
+	auto vote1 = nano::test::make_vote (rep1, { send });
+	auto vote2 = nano::test::make_vote (rep2, { send });
+	auto vote3 = nano::test::make_final_vote (rep3, { send });
+	auto vote4 = nano::test::make_vote (rep4, { send }); // Add vote from zero-weight representative
+	auto vote5 = nano::test::make_final_vote (rep5, { send }); // Add another final vote
+
+	node->vote_processor.vote_blocking (vote1, nano::test::fake_channel (*node));
+	node->vote_processor.vote_blocking (vote2, nano::test::fake_channel (*node));
+	node->vote_processor.vote_blocking (vote3, nano::test::fake_channel (*node));
+	node->vote_processor.vote_blocking (vote4, nano::test::fake_channel (*node));
+	node->vote_processor.vote_blocking (vote5, nano::test::fake_channel (*node));
+
+	boost::property_tree::ptree request;
+	request.put ("action", "confirmation_info");
+	request.put ("root", send->qualified_root ().to_string ());
+	request.put ("representatives", "true");
+	request.put ("json_block", "true");
+	{
+		auto response (wait_response (system, rpc_ctx, request));
+
+		ASSERT_EQ (0, response.get<unsigned> ("announcements"));
+		// FIXME: The voters and representatives list always contains a "ghost" representative with zero weight, investigate why
+		ASSERT_EQ (6, response.get<unsigned> ("voters"));
+		ASSERT_EQ (send->hash ().to_string (), response.get<std::string> ("last_winner"));
+		ASSERT_EQ ("4600000000000000000000000000000000000", response.get<std::string> ("total_tally"));
+		ASSERT_EQ ("3500000000000000000000000000000000000", response.get<std::string> ("final_tally"));
+
+		auto & blocks (response.get_child ("blocks"));
+		ASSERT_EQ (1, blocks.size ());
+
+		auto block_info = blocks.find (send->hash ().to_string ());
+		ASSERT_NE (block_info, blocks.not_found ());
+
+		ASSERT_EQ ("4600000000000000000000000000000000000", block_info->second.get<std::string> ("tally"));
+
+		auto & representatives = block_info->second.get_child ("representatives");
+		ASSERT_EQ (6, representatives.size ());
+		ASSERT_EQ ("100000000000000000000000000000000000", representatives.get<std::string> (rep1.pub.to_account ()));
+		ASSERT_EQ ("1000000000000000000000000000000000000", representatives.get<std::string> (rep2.pub.to_account ()));
+		ASSERT_EQ ("2000000000000000000000000000000000000", representatives.get<std::string> (rep3.pub.to_account ()));
+		ASSERT_EQ ("0", representatives.get<std::string> (rep4.pub.to_account ()));
+		ASSERT_EQ ("1500000000000000000000000000000000000", representatives.get<std::string> (rep5.pub.to_account ()));
+
+		auto & representatives_final = block_info->second.get_child ("representatives_final");
+		ASSERT_EQ (2, representatives_final.size ());
+		ASSERT_EQ ("2000000000000000000000000000000000000", representatives_final.get<std::string> (rep3.pub.to_account ()));
+		ASSERT_EQ ("1500000000000000000000000000000000000", representatives_final.get<std::string> (rep5.pub.to_account ()));
+
+		// Verify the contents field exists
+		ASSERT_TRUE (block_info->second.get_child_optional ("contents").is_initialized ());
+	}
+}
+
+TEST (rpc, confirmation_info_empty)
+{
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 
@@ -6867,6 +6952,7 @@ TEST (rpc, confirmation_info)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		ASSERT_EQ (1, response.count ("announcements"));
+		// FIXME: The voters and representatives list always contains a "ghost" representative with zero weight, investigate why
 		ASSERT_EQ (1, response.get<unsigned> ("voters"));
 		ASSERT_EQ (send->hash ().to_string (), response.get<std::string> ("last_winner"));
 		auto & blocks (response.get_child ("blocks"));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6873,7 +6873,10 @@ TEST (rpc, confirmation_info)
 		ASSERT_EQ (1, blocks.size ());
 		auto & representatives (blocks.front ().second.get_child ("representatives"));
 		ASSERT_EQ (1, representatives.size ());
+		auto & representatives_final (blocks.front ().second.get_child ("representatives_final"));
+		ASSERT_EQ (0, representatives_final.size ());
 		ASSERT_EQ (0, response.get<unsigned> ("total_tally"));
+		ASSERT_EQ (0, response.get<unsigned> ("final_tally"));
 	}
 }
 

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -246,7 +246,7 @@ std::vector<std::shared_ptr<nano::block>> nano::test::clone (std::vector<std::sh
 	return clones;
 }
 
-std::shared_ptr<nano::transport::fake::channel> nano::test::fake_channel (nano::node & node, nano::account node_id)
+std::shared_ptr<nano::transport::channel> nano::test::fake_channel (nano::node & node, nano::account node_id)
 {
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	if (!node_id.is_zero ())

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -385,7 +385,7 @@ namespace test
 	/*
 	 * Creates a new fake channel associated with `node`
 	 */
-	std::shared_ptr<nano::transport::fake::channel> fake_channel (nano::node & node, nano::account node_id = { 0 });
+	std::shared_ptr<nano::transport::channel> fake_channel (nano::node & node, nano::account node_id = { 0 });
 	/*
 	 * Creates a new test channel associated with `node`
 	 */


### PR DESCRIPTION
This is the same as https://github.com/nanocurrency/nano-node/pull/3618 without the unrelated commits.

This PR adds a list of representatives_final to the confirmation_info RPC which are representatives which have voted with final votes. 

It's backwards compatible. This also adds a check for final_tally in the tests which was already implemented on the RPC previously.