### PR TITLE
Fix unit test rpc.confirmation_info (remove scheduler flush)

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6246,7 +6246,7 @@ TEST (rpc, confirmation_info)
 
 	auto send (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::public_key (), nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
 	node1->process_active (send);
-	ASSERT_TIMELY (10s, node1->active.empty () == false);
+	ASSERT_TIMELY (5s, !node1->active.empty ());
 
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_info");

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6246,9 +6246,7 @@ TEST (rpc, confirmation_info)
 
 	auto send (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::public_key (), nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
 	node1->process_active (send);
-	node1->block_processor.flush ();
-	node1->scheduler.flush ();
-	ASSERT_FALSE (node1->active.empty ());
+	ASSERT_TIMELY (10s, node1->active.empty () == false);
 
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_info");


### PR DESCRIPTION
Removed the need for scheduler flush, which is broken.