### PR TITLE
Fix confirmation_height.election_winner_details_clearing

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1312,7 +1312,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 
 		node->process_confirmed (nano::election_status{ send2 });
 		ASSERT_TIMELY (5s, node->block_confirmed (send2->hash ()));
-		ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
+		ASSERT_TIMELY (5s, 1 == node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
 
 		node->process_confirmed (nano::election_status{ send3 });
 		ASSERT_TIMELY (5s, node->block_confirmed (send3->hash ()));


### PR DESCRIPTION
There is a race condition between a block getting confirmed and setting
of statistics counters. In this case, the counter is incremented in an
observer callback that is executed after the block is confirmed.

One could say that the problem is that the stat counters should updated
before the block is confirmed but I think that is unrealistic to achieve
and possibly not even the right approach.

Converting the check to an ASSERT_TIMELY fixes the problem.
It seems likely that other test cases will have this problem too.