### PR TITLE
Introduce `ledger.rollback_failed` stat counter

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -650,11 +650,6 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		nano::state_block_builder builder{};
 		auto const genesis_hash = nano::dev::genesis->hash ();
 
-		// redirect standard error boost logging to a software stream so we can look for the rollback message later
-		boost::iostreams::stream_buffer<nano::stringstream_mt_sink> stream_buffer{};
-		stream_buffer.open (nano::stringstream_mt_sink{});
-		nano::boost_log_cerr_redirect redirect_cerr{ &stream_buffer };
-
 		nano::system system{};
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
@@ -720,8 +715,7 @@ TEST (confirmation_height, conflict_rollback_cemented)
 
 		// node2 already has send2 forced confirmed whilst node1 should have confirmed send1 and therefore we have a cemented fork on node2
 		// and node2 should print an error message on the log that it cannot rollback send2 because it is already cemented
-		auto rollback_log_entry = boost::str (boost::format ("Failed to roll back %1%") % send2->hash ().to_string ());
-		ASSERT_TIMELY (20s, stream_buffer.component ()->str ().find (rollback_log_entry) != std::string::npos);
+		ASSERT_TIMELY (5s, 1 == node2->stats.count (nano::stat::type::ledger, nano::stat::detail::rollback_failed));
 
 		// get the tally for election the election on node1
 		// we expect the winner to be send1 and we expect send1 to have "genesis balance" vote weight

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -612,6 +612,9 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 		case nano::stat::detail::gap_source:
 			res = "gap_source";
 			break;
+        case nano::stat::detail::rollback_failed:
+            res = "rollback_failed";
+            break;
 		case nano::stat::detail::frontier_confirmation_failed:
 			res = "frontier_confirmation_failed";
 			break;

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -612,9 +612,9 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 		case nano::stat::detail::gap_source:
 			res = "gap_source";
 			break;
-        case nano::stat::detail::rollback_failed:
-            res = "rollback_failed";
-            break;
+		case nano::stat::detail::rollback_failed:
+			res = "rollback_failed";
+			break;
 		case nano::stat::detail::frontier_confirmation_failed:
 			res = "frontier_confirmation_failed";
 			break;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -272,6 +272,7 @@ public:
 		old,
 		gap_previous,
 		gap_source,
+		rollback_failed,
 
 		// message specific
 		keepalive,

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -280,6 +280,7 @@ void nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 				std::vector<std::shared_ptr<nano::block>> rollback_list;
 				if (node.ledger.rollback (transaction, successor->hash (), rollback_list))
 				{
+					node.stats.inc (nano::stat::type::ledger, nano::stat::detail::rollback_failed);
 					node.logger.always_log (nano::severity_level::error, boost::str (boost::format ("Failed to roll back %1% because it or a successor was confirmed") % successor->hash ().to_string ()));
 				}
 				else if (node.config.logging.ledger_rollback_logging ())


### PR DESCRIPTION
Also, use that counter in `confirmation_height.conflict_rollback_cemented` unit test.

Based off of #3745 