### PR TITLE
Add reverse link store for fast receive block lookups by only their send block hashes

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -2014,6 +2014,41 @@ TEST (block_store, final_vote)
 	}
 }
 
+/**
+ * This test case tests insertion, finding and clearing of reverse links.
+ */
+TEST (block_store, reverse_link)
+{
+	nano::logger_mt logger;
+	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	ASSERT_TRUE (!store->init_error ());
+
+	// Insert some reverse links and check if count got increased
+	{
+		auto transaction = store->tx_begin_write ();
+		store->reverse_link.put (transaction, nano::block_hash (100), nano::block_hash (1));
+		ASSERT_EQ (store->reverse_link.count_accurate (transaction), 1);
+		store->reverse_link.put (transaction, nano::block_hash (200), nano::block_hash (2));
+		ASSERT_EQ (store->reverse_link.count_accurate (transaction), 2);
+		store->reverse_link.put (transaction, nano::block_hash (300), nano::block_hash (3));
+		ASSERT_EQ (store->reverse_link.count_accurate (transaction), 3);
+	}
+
+	// Request recently added reverse links and check if results are matching
+	{
+		auto transaction = store->tx_begin_read ();
+		ASSERT_EQ (store->reverse_link.get (transaction, nano::block_hash (300)), nano::block_hash (3));
+		ASSERT_EQ (store->reverse_link.get (transaction, nano::block_hash (200)), nano::block_hash (2));
+		ASSERT_EQ (store->reverse_link.get (transaction, nano::block_hash (100)), nano::block_hash (1));
+		// Request a not existing reverse link and check if the result is a zero block hash
+		ASSERT_EQ (store->reverse_link.get (transaction, nano::block_hash (400)), nano::block_hash (0));
+	}
+
+	// Remove all reverse links and check if count equals zero
+	store->reverse_link.clear (store->tx_begin_write ());
+	ASSERT_EQ (store->reverse_link.count_accurate (store->tx_begin_read ()), 0);
+}
+
 // Ledger versions are not forward compatible
 TEST (block_store, incompatible_version)
 {

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -87,6 +87,8 @@ std::string nano::error_common_messages::message (int ev) const
 			return "Must be a state block";
 		case nano::error_common::numeric_conversion:
 			return "Numeric conversion error";
+		case nano::error_common::reverse_link_not_found:
+			return "Reverse link not found";
 		case nano::error_common::tracking_not_enabled:
 			return "Database transaction tracking is not enabled in the config";
 		case nano::error_common::wallet_lmdb_max_dbs:

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -55,6 +55,7 @@ enum class error_common
 	insufficient_balance,
 	is_not_state_block,
 	numeric_conversion,
+	reverse_link_not_found,
 	tracking_not_enabled,
 	wallet_lmdb_max_dbs,
 	wallet_locked,

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -100,6 +100,8 @@ add_library(
   lmdb/pending_store.cpp
   lmdb/pruned_store.hpp
   lmdb/pruned_store.cpp
+  lmdb/reverse_link_store.hpp
+  lmdb/reverse_link_store.cpp
   lmdb/version_store.hpp
   lmdb/version_store.cpp
   lmdb/unchecked_store.hpp
@@ -161,6 +163,8 @@ add_library(
   rocksdb/pending_store.cpp
   rocksdb/pruned_store.hpp
   rocksdb/pruned_store.cpp
+  rocksdb/reverse_link_store.hpp
+  rocksdb/reverse_link_store.cpp
   rocksdb/unchecked_store.hpp
   rocksdb/unchecked_store.cpp
   rocksdb/version_store.hpp

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -163,6 +163,16 @@ void nano::active_transactions::confirm_prioritized_frontiers (nano::transaction
 
 void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::block> const & block_a)
 {
+	if (node.config.enable_reverse_links)
+	{
+		auto transaction = node.store.tx_begin_write ({ tables::reverse_links });
+		nano::block_hash source = node.ledger.block_source (transaction, *block_a);
+		if (!source.is_zero ())
+		{
+			node.store.reverse_link.put (transaction, source, block_a->hash ());
+		}
+	}
+
 	auto transaction = node.store.tx_begin_read ();
 
 	boost::optional<nano::election_status_type> election_status_type;

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -97,6 +97,8 @@ public:
 	void representatives ();
 	void representatives_online ();
 	void republish ();
+	void reverse_link ();
+	void reverse_links ();
 	void search_pending ();
 	void search_receivable ();
 	void search_pending_all ();

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -53,6 +53,7 @@ nano::lmdb::store::store (nano::logger_mt & logger_a, boost::filesystem::path co
 		peer_store,
 		confirmation_height_store,
 		final_vote_store,
+		reverse_link_store,
 		version_store
 	},
 	// clang-format on
@@ -65,6 +66,7 @@ nano::lmdb::store::store (nano::logger_mt & logger_a, boost::filesystem::path co
 	peer_store{ *this },
 	confirmation_height_store{ *this },
 	final_vote_store{ *this },
+	reverse_link_store{ *this },
 	unchecked_store{ *this },
 	version_store{ *this },
 	logger (logger_a),
@@ -222,6 +224,7 @@ void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const 
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pending", flags, &pending_store.pending_v0_handle) != 0;
 	pending_store.pending_handle = pending_store.pending_v0_handle;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "final_votes", flags, &final_vote_store.final_votes_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "reverse_links", flags, &reverse_link_store.reverse_links_handle) != 0;
 
 	auto version_l = version.get (transaction_a);
 	if (version_l < 19)
@@ -306,6 +309,9 @@ bool nano::lmdb::store::do_upgrades (nano::write_transaction & transaction_a, na
 			upgrade_v20_to_v21 (transaction_a);
 			[[fallthrough]];
 		case 21:
+			upgrade_v21_to_v22 (transaction_a);
+			[[fallthrough]];
+		case 22:
 			break;
 		default:
 			logger.always_log (boost::str (boost::format ("The version of the ledger (%1%) is too high for this node") % version_l));
@@ -779,6 +785,14 @@ void nano::lmdb::store::upgrade_v20_to_v21 (nano::write_transaction const & tran
 	logger.always_log ("Finished creating new final_vote table");
 }
 
+void nano::lmdb::store::upgrade_v21_to_v22 (nano::write_transaction const & transaction_a)
+{
+	logger.always_log ("Preparing v21 to v22 database upgrade...");
+	mdb_dbi_open (env.tx (transaction_a), "reverse_links", MDB_CREATE, &reverse_link_store.reverse_links_handle);
+	version.put (transaction_a, 22);
+	logger.always_log ("Finished creating new reverse_links table");
+}
+
 /** Takes a filepath, appends '_backup_<timestamp>' to the end (but before any extension) and saves that file in the same directory */
 void nano::lmdb::store::create_backup_file (nano::mdb_env & env_a, boost::filesystem::path const & filepath_a, nano::logger_mt & logger_a)
 {
@@ -882,6 +896,8 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 			return confirmation_height_store.confirmation_height_handle;
 		case tables::final_votes:
 			return final_vote_store.final_votes_handle;
+		case tables::reverse_links:
+			return reverse_link_store.reverse_links_handle;
 		default:
 			release_assert (false);
 			return peer_store.peers_handle;

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -16,6 +16,7 @@
 #include <nano/node/lmdb/peer_store.hpp>
 #include <nano/node/lmdb/pending_store.hpp>
 #include <nano/node/lmdb/pruned_store.hpp>
+#include <nano/node/lmdb/reverse_link_store.hpp>
 #include <nano/node/lmdb/unchecked_store.hpp>
 #include <nano/node/lmdb/version_store.hpp>
 #include <nano/secure/common.hpp>
@@ -57,6 +58,7 @@ namespace lmdb
 		nano::lmdb::peer_store peer_store;
 		nano::lmdb::pending_store pending_store;
 		nano::lmdb::pruned_store pruned_store;
+		nano::lmdb::reverse_link_store reverse_link_store;
 		nano::lmdb::unchecked_store unchecked_store;
 		nano::lmdb::version_store version_store;
 
@@ -69,6 +71,7 @@ namespace lmdb
 		friend class nano::lmdb::peer_store;
 		friend class nano::lmdb::pending_store;
 		friend class nano::lmdb::pruned_store;
+		friend class nano::lmdb::reverse_link_store;
 		friend class nano::lmdb::unchecked_store;
 		friend class nano::lmdb::version_store;
 
@@ -136,6 +139,7 @@ namespace lmdb
 		void upgrade_v18_to_v19 (nano::write_transaction const &);
 		void upgrade_v19_to_v20 (nano::write_transaction const &);
 		void upgrade_v20_to_v21 (nano::write_transaction const &);
+		void upgrade_v21_to_v22 (nano::write_transaction const &);
 
 		std::shared_ptr<nano::block> block_get_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 		nano::mdb_val block_raw_get_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_type & type_a) const;

--- a/nano/node/lmdb/reverse_link_store.cpp
+++ b/nano/node/lmdb/reverse_link_store.cpp
@@ -1,0 +1,73 @@
+#include <nano/node/lmdb/reverse_link_store.hpp>
+#include <nano/node/lmdb/lmdb.hpp>
+#include <nano/secure/parallel_traversal.hpp>
+
+nano::lmdb::reverse_link_store::reverse_link_store (nano::lmdb::store & store) :
+	store{ store } {};
+
+void nano::lmdb::reverse_link_store::put (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a, nano::block_hash const & receive_block_hash_a)
+{
+	auto status = store.put (transaction_a, tables::reverse_links, send_block_hash_a, receive_block_hash_a);
+	store.release_assert_success (status);
+}
+
+nano::block_hash nano::lmdb::reverse_link_store::get (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const
+{
+	nano::mdb_val value;
+	auto status = store.get (transaction_a, tables::reverse_links, send_block_hash_a, value);
+	release_assert (store.success (status) || store.not_found (status));
+	nano::block_hash result{ 0 };
+	if (store.success (status))
+	{
+		result = static_cast<nano::block_hash> (value);
+	}
+	return result;
+}
+
+void nano::lmdb::reverse_link_store::del (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a)
+{
+	auto status = store.del (transaction_a, tables::reverse_links, send_block_hash_a);
+	store.release_assert_success (status);
+}
+
+bool nano::lmdb::reverse_link_store::exists (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const
+{
+	nano::mdb_val value;
+	auto status = store.get (transaction_a, tables::reverse_links, send_block_hash_a, value);
+	release_assert (store.success (status) || store.not_found (status));
+	return store.success (status);
+}
+
+size_t nano::lmdb::reverse_link_store::count (nano::transaction const & transaction_a) const
+{
+	return store.count (transaction_a, tables::reverse_links);
+}
+
+void nano::lmdb::reverse_link_store::clear (nano::write_transaction const & transaction_a)
+{
+	store.drop (transaction_a, tables::reverse_links);
+}
+
+nano::store_iterator<nano::block_hash, nano::block_hash> nano::lmdb::reverse_link_store::begin (nano::transaction const & transaction_a) const
+{
+	return store.make_iterator<nano::block_hash, nano::block_hash> (transaction_a, tables::reverse_links);
+}
+
+nano::store_iterator<nano::block_hash, nano::block_hash> nano::lmdb::reverse_link_store::begin (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const
+{
+	return store.make_iterator<nano::block_hash, nano::block_hash> (transaction_a, tables::reverse_links, send_block_hash_a);
+}
+
+nano::store_iterator<nano::block_hash, nano::block_hash> nano::lmdb::reverse_link_store::end () const
+{
+	return nano::store_iterator<nano::block_hash, nano::block_hash> (nullptr);
+}
+
+void nano::lmdb::reverse_link_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::block_hash>, nano::store_iterator<nano::block_hash, nano::block_hash>)> const & action_a) const
+{
+	parallel_traversal<nano::uint256_t> (
+	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
+		auto transaction = this->store.tx_begin_read ();
+		action_a (transaction, this->begin (transaction, start), !is_last ? this->begin (transaction, end) : this->end ());
+	});
+}

--- a/nano/node/lmdb/reverse_link_store.cpp
+++ b/nano/node/lmdb/reverse_link_store.cpp
@@ -1,5 +1,5 @@
-#include <nano/node/lmdb/reverse_link_store.hpp>
 #include <nano/node/lmdb/lmdb.hpp>
+#include <nano/node/lmdb/reverse_link_store.hpp>
 #include <nano/secure/parallel_traversal.hpp>
 
 nano::lmdb::reverse_link_store::reverse_link_store (nano::lmdb::store & store) :

--- a/nano/node/lmdb/reverse_link_store.hpp
+++ b/nano/node/lmdb/reverse_link_store.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <nano/secure/store.hpp>
+
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
+namespace nano
+{
+namespace lmdb
+{
+	class store;
+	class reverse_link_store : public nano::reverse_link_store
+	{
+	private:
+		nano::lmdb::store & store;
+
+	public:
+		explicit reverse_link_store (nano::lmdb::store & store);
+		void put (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a, nano::block_hash const & receive_block_hash_a) override;
+		nano::block_hash get (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const override;
+		void del (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::block_hash, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_hash> begin (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_hash> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::block_hash>, nano::store_iterator<nano::block_hash, nano::block_hash>)> const & action_a) const override;
+
+		/**
+		 * Maps a send block hash to its corresponding receive block hash.
+		 * nano::block_hash -> nano::block_hash
+		 */
+		MDB_dbi reverse_links_handle{ 0 };
+	};
+}
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -163,6 +163,23 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	};
 	if (!init_error ())
 	{
+		if (config.enable_reverse_links)
+		{
+			auto transaction = store.tx_begin_write ();
+			if (store.reverse_link.begin (transaction) == store.reverse_link.end ())
+			{
+				create_reverse_links (transaction);
+			}
+		}
+		else
+		{
+			auto transaction = store.tx_begin_write ();
+			if (store.reverse_link.begin (transaction) != store.reverse_link.end ())
+			{
+				store.reverse_link.clear (transaction);
+			}
+		}
+
 		telemetry->start ();
 
 		active.vacancy_update = [this] () { scheduler.notify (); };
@@ -801,6 +818,50 @@ nano::uint128_t nano::node::minimum_principal_weight ()
 nano::uint128_t nano::node::minimum_principal_weight (nano::uint128_t const & online_stake)
 {
 	return online_stake / network_params.network.principal_weight_factor;
+}
+
+void nano::node::create_reverse_links (nano::write_transaction const & transaction_a)
+{
+	logger.always_log ("Start creating reverse links...");
+	auto blocks_count (store.block.count (transaction_a));
+	auto blocks_processed = 0u;
+	for (auto i = store.block.begin (transaction_a), n = store.block.end (); i != n && !stopped.load (); ++i, ++blocks_processed)
+	{
+		nano::block_hash const & block_hash = i->first;
+		nano::block_w_sideband const & block_w_sideband = i->second;
+		nano::block const & block = *block_w_sideband.block;
+
+		// Every so often output to the log to indicate progress
+		constexpr auto output_cutoff = 1000000;
+		if (blocks_processed > 0 && blocks_processed % output_cutoff == 0)
+		{
+			logger.always_log (boost::str (boost::format ("Create reverse links: %1% million blocks processed (out of %2%)") % (blocks_processed / output_cutoff) % blocks_count));
+		}
+
+		// Skip unconfirmed blocks
+		nano::confirmation_height_info confirmation_height_info;
+		store.confirmation_height.get (transaction_a, block.account ().is_zero () ? block.sideband ().account : block.account (), confirmation_height_info);
+		if (confirmation_height_info.height < block.sideband ().height)
+		{
+			continue;
+		}
+
+		// Create a reverse link for receive blocks
+		nano::block_hash send_block_hash = ledger.block_source (transaction_a, block);
+		if (!send_block_hash.is_zero ())
+		{
+			store.reverse_link.put (transaction_a, send_block_hash, block_hash);
+		}
+	}
+	if (blocks_processed >= blocks_count)
+	{
+		logger.always_log ("Finished creating reverse links");
+	}
+	else
+	{
+		logger.always_log ("Stopped creating reverse links");
+		store.reverse_link.clear (transaction_a);
+	}
 }
 
 void nano::node::long_inactivity_cleanup ()

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -214,6 +214,7 @@ public:
 	boost::optional<uint64_t> work_generate_blocking (nano::root const &);
 
 private:
+	void create_reverse_links (nano::write_transaction const &);
 	void long_inactivity_cleanup ();
 	void epoch_upgrader_impl (nano::raw_key const &, nano::epoch, uint64_t, uint64_t);
 	nano::locked<std::future<void>> epoch_upgrading;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -96,6 +96,7 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("work_threads", work_threads, "Number of threads dedicated to CPU generated work. Defaults to all available CPU threads.\ntype:uint64");
 	toml.put ("signature_checker_threads", signature_checker_threads, "Number of additional threads dedicated to signature verification. Defaults to number of CPU threads / 2.\ntype:uint64");
 	toml.put ("enable_voting", enable_voting, "Enable or disable voting. Enabling this option requires additional system resources, namely increased CPU, bandwidth and disk usage.\ntype:bool");
+	toml.put ("enable_reverse_links", enable_reverse_links, "Enable or disable reverse links. Enabling this option speeds up receive block lookups, but takes additional disk storage.\ntype:bool");
 	toml.put ("bootstrap_connections", bootstrap_connections, "Number of outbound bootstrap connections. Must be a power of 2. Defaults to 4.\nWarning: a larger amount of connections may use substantially more system memory.\ntype:uint64");
 	toml.put ("bootstrap_connections_max", bootstrap_connections_max, "Maximum number of inbound bootstrap connections. Defaults to 64.\nWarning: a larger amount of connections may use additional system memory.\ntype:uint64");
 	toml.put ("bootstrap_initiator_threads", bootstrap_initiator_threads, "Number of threads dedicated to concurrent bootstrap attempts. Defaults to 1.\nWarning: a larger amount of attempts may use additional system memory and disk IO.\ntype:uint64");
@@ -337,6 +338,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get<unsigned> ("bootstrap_initiator_threads", bootstrap_initiator_threads);
 		toml.get<uint32_t> ("bootstrap_frontier_request_count", bootstrap_frontier_request_count);
 		toml.get<bool> ("enable_voting", enable_voting);
+		toml.get<bool> ("enable_reverse_links", enable_reverse_links);
 		toml.get<bool> ("allow_local_peers", allow_local_peers);
 		toml.get<unsigned> (signature_checker_threads_key, signature_checker_threads);
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -62,6 +62,7 @@ public:
 	/* Use half available threads on the system for signature checking. The calling thread does checks as well, so these are extra worker threads */
 	unsigned signature_checker_threads{ std::thread::hardware_concurrency () / 2 };
 	bool enable_voting{ false };
+	bool enable_reverse_links{ false };
 	unsigned bootstrap_connections{ 4 };
 	unsigned bootstrap_connections_max{ 64 };
 	unsigned bootstrap_initiator_threads{ 1 };

--- a/nano/node/rocksdb/reverse_link_store.cpp
+++ b/nano/node/rocksdb/reverse_link_store.cpp
@@ -1,0 +1,73 @@
+#include <nano/node/rocksdb/reverse_link_store.hpp>
+#include <nano/node/rocksdb/rocksdb.hpp>
+#include <nano/secure/parallel_traversal.hpp>
+
+nano::rocksdb::reverse_link_store::reverse_link_store (nano::rocksdb::store & store) :
+	store{ store } {};
+
+void nano::rocksdb::reverse_link_store::put (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a, nano::block_hash const & receive_block_hash_a)
+{
+	auto status = store.put (transaction_a, tables::reverse_links, send_block_hash_a, receive_block_hash_a);
+	store.release_assert_success (status);
+}
+
+nano::block_hash nano::rocksdb::reverse_link_store::get (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const
+{
+	nano::rocksdb_val value;
+	auto status = store.get (transaction_a, tables::reverse_links, send_block_hash_a, value);
+	release_assert (store.success (status) || store.not_found (status));
+	nano::block_hash result{ 0 };
+	if (store.success (status))
+	{
+		result = static_cast<nano::block_hash> (value);
+	}
+	return result;
+}
+
+void nano::rocksdb::reverse_link_store::del (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a)
+{
+	auto status = store.del (transaction_a, tables::reverse_links, send_block_hash_a);
+	store.release_assert_success (status);
+}
+
+bool nano::rocksdb::reverse_link_store::exists (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const
+{
+	nano::rocksdb_val value;
+	auto status = store.get (transaction_a, tables::reverse_links, send_block_hash_a, value);
+	release_assert (store.success (status) || store.not_found (status));
+	return store.success (status);
+}
+
+size_t nano::rocksdb::reverse_link_store::count (nano::transaction const & transaction_a) const
+{
+	return store.count (transaction_a, tables::reverse_links);
+}
+
+void nano::rocksdb::reverse_link_store::clear (nano::write_transaction const & transaction_a)
+{
+	store.drop (transaction_a, tables::reverse_links);
+}
+
+nano::store_iterator<nano::block_hash, nano::block_hash> nano::rocksdb::reverse_link_store::begin (nano::transaction const & transaction_a) const
+{
+	return store.make_iterator<nano::block_hash, nano::block_hash> (transaction_a, tables::reverse_links);
+}
+
+nano::store_iterator<nano::block_hash, nano::block_hash> nano::rocksdb::reverse_link_store::begin (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const
+{
+	return store.make_iterator<nano::block_hash, nano::block_hash> (transaction_a, tables::reverse_links, send_block_hash_a);
+}
+
+nano::store_iterator<nano::block_hash, nano::block_hash> nano::rocksdb::reverse_link_store::end () const
+{
+	return nano::store_iterator<nano::block_hash, nano::block_hash> (nullptr);
+}
+
+void nano::rocksdb::reverse_link_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::block_hash>, nano::store_iterator<nano::block_hash, nano::block_hash>)> const & action_a) const
+{
+	parallel_traversal<nano::uint256_t> (
+	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {
+		auto transaction = this->store.tx_begin_read ();
+		action_a (transaction, this->begin (transaction, start), !is_last ? this->begin (transaction, end) : this->end ());
+	});
+}

--- a/nano/node/rocksdb/reverse_link_store.hpp
+++ b/nano/node/rocksdb/reverse_link_store.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <nano/secure/store.hpp>
+
+namespace nano
+{
+namespace rocksdb
+{
+	class store;
+	class reverse_link_store : public nano::reverse_link_store
+	{
+	private:
+		nano::rocksdb::store & store;
+
+	public:
+		explicit reverse_link_store (nano::rocksdb::store & store);
+		void put (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a, nano::block_hash const & receive_block_hash_a) override;
+		nano::block_hash get (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const override;
+		void del (nano::write_transaction const & transaction_a, nano::block_hash const & send_block_hash_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::block_hash, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_hash> begin (nano::transaction const & transaction_a, nano::block_hash const & send_block_hash_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_hash> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::block_hash>, nano::store_iterator<nano::block_hash, nano::block_hash>)> const & action_a) const override;
+	};
+}
+}

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -12,6 +12,7 @@
 #include <nano/node/rocksdb/peer_store.hpp>
 #include <nano/node/rocksdb/pending_store.hpp>
 #include <nano/node/rocksdb/pruned_store.hpp>
+#include <nano/node/rocksdb/reverse_link_store.hpp>
 #include <nano/node/rocksdb/rocksdb_iterator.hpp>
 #include <nano/node/rocksdb/unchecked_store.hpp>
 #include <nano/node/rocksdb/version_store.hpp>
@@ -48,6 +49,7 @@ namespace rocksdb
 		nano::rocksdb::peer_store peer_store;
 		nano::rocksdb::pending_store pending_store;
 		nano::rocksdb::pruned_store pruned_store;
+		nano::rocksdb::reverse_link_store reverse_link_store;
 		nano::rocksdb::unchecked_store unchecked_store;
 		nano::rocksdb::version_store version_store;
 
@@ -61,6 +63,7 @@ namespace rocksdb
 		friend class nano::rocksdb::peer_store;
 		friend class nano::rocksdb::pending_store;
 		friend class nano::rocksdb::pruned_store;
+		friend class nano::rocksdb::reverse_link_store;
 		friend class nano::rocksdb::unchecked_store;
 		friend class nano::rocksdb::version_store;
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1251,6 +1251,13 @@ std::shared_ptr<nano::block> nano::ledger::find_receive_block_by_send_hash (nano
 	std::shared_ptr<nano::block> result;
 	debug_assert (send_block_hash != 0);
 
+	// try to find the receive block by a confirmed reverse link
+	nano::block_hash receive_hash = store.reverse_link.get (transaction, send_block_hash);
+	if (!receive_hash.is_zero ())
+	{
+		return store.block.get (transaction, receive_hash);
+	}
+
 	// get the cemented frontier
 	nano::confirmation_height_info info;
 	if (store.confirmation_height.get (transaction, destination, info))

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1258,6 +1258,12 @@ std::shared_ptr<nano::block> nano::ledger::find_receive_block_by_send_hash (nano
 		return store.block.get (transaction, receive_hash);
 	}
 
+	// avoid unneccessary searches in case the send block is receivable
+	if (store.pending.exists (transaction, nano::pending_key (destination, send_block_hash)))
+	{
+		return nullptr;
+	}
+
 	// get the cemented frontier
 	nano::confirmation_height_info info;
 	if (store.confirmation_height.get (transaction, destination, info))

--- a/nano/secure/store.cpp
+++ b/nano/secure/store.cpp
@@ -118,6 +118,7 @@ nano::store::store (
 	nano::peer_store & peer_store_a,
 	nano::confirmation_height_store & confirmation_height_store_a,
 	nano::final_vote_store & final_vote_store_a,
+	nano::reverse_link_store & reverse_link_store_a,
 	nano::version_store & version_store_a
 ) :
 	block (block_store_a),
@@ -130,6 +131,7 @@ nano::store::store (
 	peer (peer_store_a),
 	confirmation_height (confirmation_height_store_a),
 	final_vote (final_vote_store_a),
+	reverse_link (reverse_link_store_a),
 	version (version_store_a)
 {
 }

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -550,6 +550,7 @@ enum class tables
 	peers,
 	pending,
 	pruned,
+	reverse_links,
 	unchecked,
 	vote
 };
@@ -849,6 +850,24 @@ public:
 	virtual uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 };
 
+/**
+ * Manages reverse link storage and iteration
+ */
+class reverse_link_store : public iterable_store<nano::block_hash, nano::block_hash>
+{
+public:
+	virtual void put (nano::write_transaction const & transaction_a, nano::block_hash const &, nano::block_hash const &) = 0;
+	virtual nano::block_hash get (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual void del (nano::write_transaction const & transaction_a, nano::block_hash const &) = 0;
+	virtual bool exists (nano::transaction const & transaction_a, nano::block_hash const &) const = 0;
+	virtual size_t count (nano::transaction const & transaction_a) const = 0;
+	virtual void clear (nano::write_transaction const & transaction_a) = 0;
+	virtual nano::store_iterator<nano::block_hash, nano::block_hash> begin (nano::transaction const & transaction_a) const = 0;
+	virtual nano::store_iterator<nano::block_hash, nano::block_hash> begin (nano::transaction const &, nano::block_hash const &) const = 0;
+	virtual nano::store_iterator<nano::block_hash, nano::block_hash> end () const = 0;
+	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::block_hash>, nano::store_iterator<nano::block_hash, nano::block_hash>)> const & action_a) const = 0;
+};
+
 class unchecked_map;
 /**
  * Store manager
@@ -868,6 +887,7 @@ public:
 		nano::peer_store &,
 		nano::confirmation_height_store &,
 		nano::final_vote_store &,
+		nano::reverse_link_store &,
 		nano::version_store &
 	);
 	// clang-format on
@@ -885,7 +905,7 @@ public:
 	account_store & account;
 	pending_store & pending;
 	static int constexpr version_minimum{ 14 };
-	static int constexpr version_current{ 21 };
+	static int constexpr version_current{ 22 };
 
 private:
 	unchecked_store & unchecked;
@@ -896,6 +916,7 @@ public:
 	peer_store & peer;
 	confirmation_height_store & confirmation_height;
 	final_vote_store & final_vote;
+	reverse_link_store & reverse_link;
 	version_store & version;
 
 	virtual unsigned max_block_write_batch_num () const = 0;

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -621,9 +621,36 @@ private:
 class ledger_cache;
 
 /**
+ * This class declares two abstract methods to iterate over the elements of a store and implements a method for accurate counting.
+ */
+template <typename T, typename U>
+class iterable_store
+{
+public:
+	virtual nano::store_iterator<T, U> begin (nano::transaction const &) const = 0;
+	virtual nano::store_iterator<T, U> end () const = 0;
+
+	/**
+	 * Function to count the entries of a store one by one, because the rocksdb count feature is not accurate.
+	 * Counting accurate may be slow depending on the amount of elements in the store.
+	 */
+	size_t count_accurate (nano::transaction const & transaction_a)
+	{
+		size_t count = 0;
+		auto i = begin (transaction_a);
+		auto n = end ();
+		for (; i != n; ++i)
+		{
+			++count;
+		}
+		return count;
+	}
+};
+
+/**
  * Manages frontier storage and iteration
  */
-class frontier_store
+class frontier_store : public iterable_store<nano::block_hash, nano::account>
 {
 public:
 	virtual void put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) = 0;
@@ -638,7 +665,7 @@ public:
 /**
  * Manages account storage and iteration
  */
-class account_store
+class account_store : public iterable_store<nano::account, nano::account_info>
 {
 public:
 	virtual void put (nano::write_transaction const &, nano::account const &, nano::account_info const &) = 0;
@@ -656,7 +683,7 @@ public:
 /**
  * Manages pending storage and iteration
  */
-class pending_store
+class pending_store : public iterable_store<nano::pending_key, nano::pending_info>
 {
 public:
 	virtual void put (nano::write_transaction const &, nano::pending_key const &, nano::pending_info const &) = 0;
@@ -673,7 +700,7 @@ public:
 /**
  * Manages peer storage and iteration
  */
-class peer_store
+class peer_store : public iterable_store<nano::endpoint_key, nano::no_value>
 {
 public:
 	virtual void put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) = 0;
@@ -688,7 +715,7 @@ public:
 /**
  * Manages online weight storage and iteration
  */
-class online_weight_store
+class online_weight_store : public iterable_store<uint64_t, nano::amount>
 {
 public:
 	virtual void put (nano::write_transaction const &, uint64_t, nano::amount const &) = 0;
@@ -703,7 +730,7 @@ public:
 /**
  * Manages pruned storage and iteration
  */
-class pruned_store
+class pruned_store : public iterable_store<nano::block_hash, std::nullptr_t>
 {
 public:
 	virtual void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) = 0;
@@ -721,7 +748,7 @@ public:
 /**
  * Manages confirmation height storage and iteration
  */
-class confirmation_height_store
+class confirmation_height_store : public iterable_store<nano::account, nano::confirmation_height_info>
 {
 public:
 	virtual void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) = 0;
@@ -747,7 +774,7 @@ public:
 /**
  * Manages unchecked storage and iteration
  */
-class unchecked_store
+class unchecked_store : public iterable_store<nano::unchecked_key, nano::unchecked_info>
 {
 public:
 	using iterator = nano::store_iterator<nano::unchecked_key, nano::unchecked_info>;
@@ -769,7 +796,7 @@ public:
 /**
  * Manages final vote storage and iteration
  */
-class final_vote_store
+class final_vote_store : public iterable_store<nano::qualified_root, nano::block_hash>
 {
 public:
 	virtual bool put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
@@ -797,7 +824,7 @@ public:
 /**
  * Manages block storage and iteration
  */
-class block_store
+class block_store : public iterable_store<nano::block_hash, block_w_sideband>
 {
 public:
 	virtual void put (nano::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -18,22 +18,6 @@
 
 using namespace std::chrono_literals;
 
-/**
- * function to count the block in the pruned store one by one
- * we manually count the blocks one by one because the rocksdb count feature is not accurate
- */
-size_t manually_count_pruned_blocks (nano::store & store)
-{
-	size_t count = 0;
-	auto transaction = store.tx_begin_read ();
-	auto i = store.pruned.begin (transaction);
-	for (; i != store.pruned.end (); ++i)
-	{
-		++count;
-	}
-	return count;
-}
-
 TEST (system, generate_mass_activity)
 {
 	nano::system system;
@@ -513,14 +497,14 @@ TEST (store, pruned_load)
 				}
 			}
 		}
-		ASSERT_EQ (expected_result, manually_count_pruned_blocks (*store));
+		ASSERT_EQ (expected_result, store->pruned.count_accurate (store->tx_begin_read ()));
 	}
 
 	// Reinitialize store
 	{
 		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_FALSE (store->init_error ());
-		ASSERT_EQ (expected_result, manually_count_pruned_blocks (*store));
+		ASSERT_EQ (expected_result, store->pruned.count_accurate (store->tx_begin_read ()));
 	}
 }
 


### PR DESCRIPTION
- Added reverse_link_store to persist the [send block hash] -> [receive block hash] pairs.
- Implemented LMDB v21 -> v22 migration to create the new reverse_links table on startup.
- Implemented node.enable_reverse_links option (default disabled)
- Hooked into block_cemented_callback to store the reverse links of new cemented blocks.
    - I'm still not sure if this is the best place to do that, but it seems to work.
- Implemented initial reverse link pair loading into the node constructor.
    - I'm still not sure if this is the best place to start this relatively long loading process (it took around an hour on my system to process all cemented blocks from the live ledger), but it works.
- Added some reverse link test cases
    - Test case for the initial reverse link loading in the nano::node constructor is missing, because I was not yet able to find a proper solution to modify/inject the nano::store before nano::node creation.

This PR will drastically improve the performance of #3702