### PR TITLE
Add db backend namespaces

### DIFF
--- a/nano/node/lmdb/account_store.cpp
+++ b/nano/node/lmdb/account_store.cpp
@@ -1,16 +1,16 @@
 #include <nano/node/lmdb/account_store.hpp>
 #include <nano/node/lmdb/lmdb.hpp>
 
-nano::account_store_mdb::account_store_mdb (nano::mdb_store & store_a) :
+nano::lmdb::account_store::account_store (nano::mdb_store & store_a) :
 	store (store_a){};
 
-void nano::account_store_mdb::put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info)
+void nano::lmdb::account_store::put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info)
 {
 	auto status = store.put (transaction, tables::accounts, account, info);
 	store.release_assert_success (status);
 }
 
-bool nano::account_store_mdb::get (nano::transaction const & transaction, nano::account const & account, nano::account_info & info)
+bool nano::lmdb::account_store::get (nano::transaction const & transaction, nano::account const & account, nano::account_info & info)
 {
 	nano::mdb_val value;
 	auto status1 (store.get (transaction, tables::accounts, account, value));
@@ -24,44 +24,44 @@ bool nano::account_store_mdb::get (nano::transaction const & transaction, nano::
 	return result;
 }
 
-void nano::account_store_mdb::del (nano::write_transaction const & transaction_a, nano::account const & account_a)
+void nano::lmdb::account_store::del (nano::write_transaction const & transaction_a, nano::account const & account_a)
 {
 	auto status = store.del (transaction_a, tables::accounts, account_a);
 	release_assert_success (store, status);
 }
 
-bool nano::account_store_mdb::exists (nano::transaction const & transaction_a, nano::account const & account_a)
+bool nano::lmdb::account_store::exists (nano::transaction const & transaction_a, nano::account const & account_a)
 {
 	auto iterator (begin (transaction_a, account_a));
 	return iterator != end () && nano::account (iterator->first) == account_a;
 }
 
-size_t nano::account_store_mdb::count (nano::transaction const & transaction_a)
+size_t nano::lmdb::account_store::count (nano::transaction const & transaction_a)
 {
 	return store.count (transaction_a, tables::accounts);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_mdb::begin (nano::transaction const & transaction, nano::account const & account) const
+nano::store_iterator<nano::account, nano::account_info> nano::lmdb::account_store::begin (nano::transaction const & transaction, nano::account const & account) const
 {
 	return store.make_iterator<nano::account, nano::account_info> (transaction, tables::accounts, account);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::account, nano::account_info> nano::lmdb::account_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::account, nano::account_info> (transaction, tables::accounts);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_mdb::rbegin (nano::transaction const & transaction_a) const
+nano::store_iterator<nano::account, nano::account_info> nano::lmdb::account_store::rbegin (nano::transaction const & transaction_a) const
 {
 	return store.make_iterator<nano::account, nano::account_info> (transaction_a, tables::accounts, false);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_mdb::end () const
+nano::store_iterator<nano::account, nano::account_info> nano::lmdb::account_store::end () const
 {
 	return nano::store_iterator<nano::account, nano::account_info> (nullptr);
 }
 
-void nano::account_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const
+void nano::lmdb::account_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/lmdb/account_store.hpp
+++ b/nano/node/lmdb/account_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class mdb_store;
-class account_store_mdb : public account_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class account_store : public nano::account_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	explicit account_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info) override;
-	bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::account_info & info_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::account const & account_a) override;
-	size_t count (nano::transaction const & transaction_a) override;
-	nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
-	nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::account, nano::account_info> rbegin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::account, nano::account_info> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const override;
-};
+	public:
+		explicit account_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info) override;
+		bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::account_info & info_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::account const & account_a) override;
+		size_t count (nano::transaction const & transaction_a) override;
+		nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
+		nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::account, nano::account_info> rbegin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::account, nano::account_info> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -7,38 +7,41 @@ namespace nano
 class mdb_store;
 using mdb_val = db_val<MDB_val>;
 class block_predecessor_mdb_set;
-class block_store_mdb : public block_store
+namespace lmdb
 {
-	friend class block_predecessor_mdb_set;
-	nano::mdb_store & store;
+	class block_store : public nano::block_store
+	{
+		friend class nano::block_predecessor_mdb_set;
+		nano::mdb_store & store;
 
-public:
-	explicit block_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, nano::block const & block_a) override;
-	void raw_put (nano::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override;
-	nano::block_hash successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	void successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	std::shared_ptr<nano::block> get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	std::shared_ptr<nano::block> get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	std::shared_ptr<nano::block> random (nano::transaction const & transaction_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	uint64_t count (nano::transaction const & transaction_a) override;
-	nano::account account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::account account_calculated (nano::block const & block_a) const override;
-	nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
-	nano::uint128_t balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const & block_a) const override;
-	nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
-	// Converts a block hash to a block height
-	uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+	public:
+		explicit block_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, nano::block const & block_a) override;
+		void raw_put (nano::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override;
+		nano::block_hash successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		void successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		std::shared_ptr<nano::block> get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		std::shared_ptr<nano::block> get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		std::shared_ptr<nano::block> random (nano::transaction const & transaction_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		uint64_t count (nano::transaction const & transaction_a) override;
+		nano::account account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::account account_calculated (nano::block const & block_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
+		nano::uint128_t balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const & block_a) const override;
+		nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
+		// Converts a block hash to a block height
+		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 
-protected:
-	void block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::mdb_val & value) const;
-	size_t block_successor_offset (nano::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
-	static nano::block_type block_type_from_raw (void * data_a);
-};
+	protected:
+		void block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::mdb_val & value) const;
+		size_t block_successor_offset (nano::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
+		static nano::block_type block_type_from_raw (void * data_a);
+	};
+}
 }

--- a/nano/node/lmdb/confirmation_height_store.cpp
+++ b/nano/node/lmdb/confirmation_height_store.cpp
@@ -1,18 +1,18 @@
 #include <nano/node/lmdb/confirmation_height_store.hpp>
 #include <nano/node/lmdb/lmdb.hpp>
 
-nano::confirmation_height_store_mdb::confirmation_height_store_mdb (nano::mdb_store & store) :
+nano::lmdb::confirmation_height_store::confirmation_height_store (nano::mdb_store & store) :
 	store{ store }
 {
 }
 
-void nano::confirmation_height_store_mdb::put (nano::write_transaction const & transaction, nano::account const & account, nano::confirmation_height_info const & confirmation_height_info)
+void nano::lmdb::confirmation_height_store::put (nano::write_transaction const & transaction, nano::account const & account, nano::confirmation_height_info const & confirmation_height_info)
 {
 	auto status = store.put (transaction, tables::confirmation_height, account, confirmation_height_info);
 	release_assert_success (store, status);
 }
 
-bool nano::confirmation_height_store_mdb::get (nano::transaction const & transaction, nano::account const & account, nano::confirmation_height_info & confirmation_height_info)
+bool nano::lmdb::confirmation_height_store::get (nano::transaction const & transaction, nano::account const & account, nano::confirmation_height_info & confirmation_height_info)
 {
 	nano::mdb_val value;
 	auto status = store.get (transaction, tables::confirmation_height, account, value);
@@ -32,48 +32,48 @@ bool nano::confirmation_height_store_mdb::get (nano::transaction const & transac
 	return result;
 }
 
-bool nano::confirmation_height_store_mdb::exists (nano::transaction const & transaction, nano::account const & account) const
+bool nano::lmdb::confirmation_height_store::exists (nano::transaction const & transaction, nano::account const & account) const
 {
 	return store.exists (transaction, tables::confirmation_height, account);
 }
 
-void nano::confirmation_height_store_mdb::del (nano::write_transaction const & transaction, nano::account const & account)
+void nano::lmdb::confirmation_height_store::del (nano::write_transaction const & transaction, nano::account const & account)
 {
 	auto status = store.del (transaction, tables::confirmation_height, account);
 	release_assert_success (store, status);
 }
 
-uint64_t nano::confirmation_height_store_mdb::count (nano::transaction const & transaction_a)
+uint64_t nano::lmdb::confirmation_height_store::count (nano::transaction const & transaction_a)
 {
 	return store.count (transaction_a, tables::confirmation_height);
 }
 
-void nano::confirmation_height_store_mdb::clear (nano::write_transaction const & transaction_a, nano::account const & account_a)
+void nano::lmdb::confirmation_height_store::clear (nano::write_transaction const & transaction_a, nano::account const & account_a)
 {
 	del (transaction_a, account_a);
 }
 
-void nano::confirmation_height_store_mdb::clear (nano::write_transaction const & transaction_a)
+void nano::lmdb::confirmation_height_store::clear (nano::write_transaction const & transaction_a)
 {
 	store.drop (transaction_a, nano::tables::confirmation_height);
 }
 
-nano::store_iterator<nano::account, nano::confirmation_height_info> nano::confirmation_height_store_mdb::begin (nano::transaction const & transaction, nano::account const & account) const
+nano::store_iterator<nano::account, nano::confirmation_height_info> nano::lmdb::confirmation_height_store::begin (nano::transaction const & transaction, nano::account const & account) const
 {
 	return store.make_iterator<nano::account, nano::confirmation_height_info> (transaction, tables::confirmation_height, account);
 }
 
-nano::store_iterator<nano::account, nano::confirmation_height_info> nano::confirmation_height_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::account, nano::confirmation_height_info> nano::lmdb::confirmation_height_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::account, nano::confirmation_height_info> (transaction, tables::confirmation_height);
 }
 
-nano::store_iterator<nano::account, nano::confirmation_height_info> nano::confirmation_height_store_mdb::end () const
+nano::store_iterator<nano::account, nano::confirmation_height_info> nano::lmdb::confirmation_height_store::end () const
 {
 	return nano::store_iterator<nano::account, nano::confirmation_height_info> (nullptr);
 }
 
-void nano::confirmation_height_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const
+void nano::lmdb::confirmation_height_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/lmdb/confirmation_height_store.hpp
+++ b/nano/node/lmdb/confirmation_height_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class mdb_store;
-class confirmation_height_store_mdb : public confirmation_height_store
+namespace lmdb
 {
-	nano::mdb_store & store;
+	class confirmation_height_store : public nano::confirmation_height_store
+	{
+		nano::mdb_store & store;
 
-public:
-	explicit confirmation_height_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override;
-	bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::account const & account_a) const override;
-	void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
-	uint64_t count (nano::transaction const & transaction_a) override;
-	void clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
-	nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::account, nano::confirmation_height_info> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override;
-};
+	public:
+		explicit confirmation_height_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override;
+		bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::account const & account_a) const override;
+		void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
+		uint64_t count (nano::transaction const & transaction_a) override;
+		void clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
+		nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::account, nano::confirmation_height_info> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/lmdb/final_vote_store.cpp
+++ b/nano/node/lmdb/final_vote_store.cpp
@@ -1,10 +1,10 @@
 #include <nano/node/lmdb/final_vote_store.hpp>
 #include <nano/node/lmdb/lmdb.hpp>
 
-nano::final_vote_store_mdb::final_vote_store_mdb (nano::mdb_store & store) :
+nano::lmdb::final_vote_store::final_vote_store (nano::mdb_store & store) :
 	store{ store } {};
 
-bool nano::final_vote_store_mdb::put (nano::write_transaction const & transaction, nano::qualified_root const & root, nano::block_hash const & hash)
+bool nano::lmdb::final_vote_store::put (nano::write_transaction const & transaction, nano::qualified_root const & root, nano::block_hash const & hash)
 {
 	nano::mdb_val value;
 	auto status = store.get (transaction, tables::final_votes, root, value);
@@ -22,7 +22,7 @@ bool nano::final_vote_store_mdb::put (nano::write_transaction const & transactio
 	return result;
 }
 
-std::vector<nano::block_hash> nano::final_vote_store_mdb::get (nano::transaction const & transaction, nano::root const & root_a)
+std::vector<nano::block_hash> nano::lmdb::final_vote_store::get (nano::transaction const & transaction, nano::root const & root_a)
 {
 	std::vector<nano::block_hash> result;
 	nano::qualified_root key_start{ root_a.raw, 0 };
@@ -33,7 +33,7 @@ std::vector<nano::block_hash> nano::final_vote_store_mdb::get (nano::transaction
 	return result;
 }
 
-void nano::final_vote_store_mdb::del (nano::write_transaction const & transaction, nano::root const & root)
+void nano::lmdb::final_vote_store::del (nano::write_transaction const & transaction, nano::root const & root)
 {
 	std::vector<nano::qualified_root> final_vote_qualified_roots;
 	for (auto i = begin (transaction, nano::qualified_root{ root.raw, 0 }), n = end (); i != n && nano::qualified_root{ i->first }.root () == root; ++i)
@@ -48,37 +48,37 @@ void nano::final_vote_store_mdb::del (nano::write_transaction const & transactio
 	}
 }
 
-size_t nano::final_vote_store_mdb::count (nano::transaction const & transaction_a) const
+size_t nano::lmdb::final_vote_store::count (nano::transaction const & transaction_a) const
 {
 	return store.count (transaction_a, tables::final_votes);
 }
 
-void nano::final_vote_store_mdb::clear (nano::write_transaction const & transaction_a, nano::root const & root_a)
+void nano::lmdb::final_vote_store::clear (nano::write_transaction const & transaction_a, nano::root const & root_a)
 {
 	del (transaction_a, root_a);
 }
 
-void nano::final_vote_store_mdb::clear (nano::write_transaction const & transaction_a)
+void nano::lmdb::final_vote_store::clear (nano::write_transaction const & transaction_a)
 {
 	store.drop (transaction_a, nano::tables::final_votes);
 }
 
-nano::store_iterator<nano::qualified_root, nano::block_hash> nano::final_vote_store_mdb::begin (nano::transaction const & transaction, nano::qualified_root const & root) const
+nano::store_iterator<nano::qualified_root, nano::block_hash> nano::lmdb::final_vote_store::begin (nano::transaction const & transaction, nano::qualified_root const & root) const
 {
 	return store.make_iterator<nano::qualified_root, nano::block_hash> (transaction, tables::final_votes, root);
 }
 
-nano::store_iterator<nano::qualified_root, nano::block_hash> nano::final_vote_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::qualified_root, nano::block_hash> nano::lmdb::final_vote_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::qualified_root, nano::block_hash> (transaction, tables::final_votes);
 }
 
-nano::store_iterator<nano::qualified_root, nano::block_hash> nano::final_vote_store_mdb::end () const
+nano::store_iterator<nano::qualified_root, nano::block_hash> nano::lmdb::final_vote_store::end () const
 {
 	return nano::store_iterator<nano::qualified_root, nano::block_hash> (nullptr);
 }
 
-void nano::final_vote_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const
+void nano::lmdb::final_vote_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const
 {
 	parallel_traversal<nano::uint512_t> (
 	[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {

--- a/nano/node/lmdb/final_vote_store.hpp
+++ b/nano/node/lmdb/final_vote_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class mdb_store;
-class final_vote_store_mdb : public final_vote_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class final_vote_store : public nano::final_vote_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	explicit final_vote_store_mdb (nano::mdb_store & store);
-	bool put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
-	std::vector<nano::block_hash> get (nano::transaction const & transaction_a, nano::root const & root_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const override;
-	nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::qualified_root, nano::block_hash> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const override;
-};
+	public:
+		explicit final_vote_store (nano::mdb_store & store);
+		bool put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
+		std::vector<nano::block_hash> get (nano::transaction const & transaction_a, nano::root const & root_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const override;
+		nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::qualified_root, nano::block_hash> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/lmdb/frontier_store.cpp
+++ b/nano/node/lmdb/frontier_store.cpp
@@ -1,18 +1,18 @@
 #include <nano/node/lmdb/frontier_store.hpp>
 #include <nano/node/lmdb/lmdb.hpp>
 
-nano::frontier_store_mdb::frontier_store_mdb (nano::mdb_store & store) :
+nano::lmdb::frontier_store::frontier_store (nano::mdb_store & store) :
 	store{ store }
 {
 }
 
-void nano::frontier_store_mdb::put (nano::write_transaction const & transaction, nano::block_hash const & hash, nano::account const & account)
+void nano::lmdb::frontier_store::put (nano::write_transaction const & transaction, nano::block_hash const & hash, nano::account const & account)
 {
 	auto status = store.put (transaction, tables::frontiers, hash, account);
 	release_assert_success (store, status);
 }
 
-nano::account nano::frontier_store_mdb::get (nano::transaction const & transaction, nano::block_hash const & hash) const
+nano::account nano::lmdb::frontier_store::get (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
 	nano::db_val<MDB_val> value;
 	auto status = store.get (transaction, tables::frontiers, hash, value);
@@ -25,28 +25,28 @@ nano::account nano::frontier_store_mdb::get (nano::transaction const & transacti
 	return result;
 }
 
-void nano::frontier_store_mdb::del (nano::write_transaction const & transaction, nano::block_hash const & hash)
+void nano::lmdb::frontier_store::del (nano::write_transaction const & transaction, nano::block_hash const & hash)
 {
 	auto status = store.del (transaction, tables::frontiers, hash);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::block_hash, nano::account> nano::frontier_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::block_hash, nano::account> nano::lmdb::frontier_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::block_hash, nano::account> (transaction, tables::frontiers);
 }
 
-nano::store_iterator<nano::block_hash, nano::account> nano::frontier_store_mdb::begin (nano::transaction const & transaction, nano::block_hash const & hash) const
+nano::store_iterator<nano::block_hash, nano::account> nano::lmdb::frontier_store::begin (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
 	return store.make_iterator<nano::block_hash, nano::account> (transaction, tables::frontiers, nano::db_val<MDB_val> (hash));
 }
 
-nano::store_iterator<nano::block_hash, nano::account> nano::frontier_store_mdb::end () const
+nano::store_iterator<nano::block_hash, nano::account> nano::lmdb::frontier_store::end () const
 {
 	return nano::store_iterator<nano::block_hash, nano::account> (nullptr);
 }
 
-void nano::frontier_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const
+void nano::lmdb::frontier_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/lmdb/frontier_store.hpp
+++ b/nano/node/lmdb/frontier_store.hpp
@@ -5,20 +5,22 @@
 namespace nano
 {
 class mdb_store;
-class frontier_store_mdb : public frontier_store
+namespace lmdb
 {
-public:
-	frontier_store_mdb (nano::mdb_store & store);
-	void put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) override;
-	nano::account get (nano::transaction const &, nano::block_hash const &) const override;
-	void del (nano::write_transaction const &, nano::block_hash const &) override;
-	nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &) const override;
-	nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &, nano::block_hash const &) const override;
-	nano::store_iterator<nano::block_hash, nano::account> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const override;
+	class frontier_store : public nano::frontier_store
+	{
+	public:
+		frontier_store (nano::mdb_store & store);
+		void put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) override;
+		nano::account get (nano::transaction const &, nano::block_hash const &) const override;
+		void del (nano::write_transaction const &, nano::block_hash const &) override;
+		nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &) const override;
+		nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &, nano::block_hash const &) const override;
+		nano::store_iterator<nano::block_hash, nano::account> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const override;
 
-private:
-	nano::mdb_store & store;
-};
-
+	private:
+		nano::mdb_store & store;
+	};
+}
 }

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -48,29 +48,29 @@ class transaction;
 class mdb_store : public store_partial<MDB_val, mdb_store>
 {
 private:
-	nano::block_store_mdb block_store;
-	nano::frontier_store_mdb frontier_store;
-	nano::account_store_mdb account_store;
-	nano::pending_store_mdb pending_store;
-	nano::unchecked_store_mdb unchecked_store;
-	nano::online_weight_store_mdb online_weight_store;
-	nano::pruned_store_mdb pruned_store;
-	nano::peer_store_mdb peer_store;
-	nano::confirmation_height_store_mdb confirmation_height_store;
-	nano::final_vote_store_mdb final_vote_store;
-	nano::version_store_mdb version_store;
+	nano::lmdb::account_store account_store;
+	nano::lmdb::block_store block_store;
+	nano::lmdb::confirmation_height_store confirmation_height_store;
+	nano::lmdb::final_vote_store final_vote_store;
+	nano::lmdb::frontier_store frontier_store;
+	nano::lmdb::online_weight_store online_weight_store;
+	nano::lmdb::peer_store peer_store;
+	nano::lmdb::pending_store pending_store;
+	nano::lmdb::pruned_store pruned_store;
+	nano::lmdb::unchecked_store unchecked_store;
+	nano::lmdb::version_store version_store;
 
-	friend class nano::account_store_mdb;
-	friend class nano::block_store_mdb;
-	friend class nano::confirmation_height_store_mdb;
-	friend class nano::final_vote_store_mdb;
-	friend class nano::frontier_store_mdb;
-	friend class nano::online_weight_store_mdb;
-	friend class nano::peer_store_mdb;
-	friend class nano::pending_store_mdb;
-	friend class nano::pruned_store_mdb;
-	friend class nano::unchecked_store_mdb;
-	friend class nano::version_store_mdb;
+	friend class nano::lmdb::account_store;
+	friend class nano::lmdb::block_store;
+	friend class nano::lmdb::confirmation_height_store;
+	friend class nano::lmdb::final_vote_store;
+	friend class nano::lmdb::frontier_store;
+	friend class nano::lmdb::online_weight_store;
+	friend class nano::lmdb::peer_store;
+	friend class nano::lmdb::pending_store;
+	friend class nano::lmdb::pruned_store;
+	friend class nano::lmdb::unchecked_store;
+	friend class nano::lmdb::version_store;
 
 public:
 	mdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);

--- a/nano/node/lmdb/online_weight_store.cpp
+++ b/nano/node/lmdb/online_weight_store.cpp
@@ -1,44 +1,44 @@
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/online_weight_store.hpp>
 
-nano::online_weight_store_mdb::online_weight_store_mdb (nano::mdb_store & store_a) :
+nano::lmdb::online_weight_store::online_weight_store (nano::mdb_store & store_a) :
 	store{ store_a }
 {
 }
 
-void nano::online_weight_store_mdb::put (nano::write_transaction const & transaction, uint64_t time, nano::amount const & amount)
+void nano::lmdb::online_weight_store::put (nano::write_transaction const & transaction, uint64_t time, nano::amount const & amount)
 {
 	auto status = store.put (transaction, tables::online_weight, time, amount);
 	release_assert_success (store, status);
 }
 
-void nano::online_weight_store_mdb::del (nano::write_transaction const & transaction, uint64_t time)
+void nano::lmdb::online_weight_store::del (nano::write_transaction const & transaction, uint64_t time)
 {
 	auto status = store.del (transaction, tables::online_weight, time);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<uint64_t, nano::amount> nano::online_weight_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<uint64_t, nano::amount> nano::lmdb::online_weight_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<uint64_t, nano::amount> (transaction, tables::online_weight);
 }
 
-nano::store_iterator<uint64_t, nano::amount> nano::online_weight_store_mdb::rbegin (nano::transaction const & transaction) const
+nano::store_iterator<uint64_t, nano::amount> nano::lmdb::online_weight_store::rbegin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<uint64_t, nano::amount> (transaction, tables::online_weight, false);
 }
 
-nano::store_iterator<uint64_t, nano::amount> nano::online_weight_store_mdb::end () const
+nano::store_iterator<uint64_t, nano::amount> nano::lmdb::online_weight_store::end () const
 {
 	return nano::store_iterator<uint64_t, nano::amount> (nullptr);
 }
 
-size_t nano::online_weight_store_mdb::count (nano::transaction const & transaction) const
+size_t nano::lmdb::online_weight_store::count (nano::transaction const & transaction) const
 {
 	return store.count (transaction, tables::online_weight);
 }
 
-void nano::online_weight_store_mdb::clear (nano::write_transaction const & transaction)
+void nano::lmdb::online_weight_store::clear (nano::write_transaction const & transaction)
 {
 	auto status = store.drop (transaction, tables::online_weight);
 	release_assert_success (store, status);

--- a/nano/node/lmdb/online_weight_store.hpp
+++ b/nano/node/lmdb/online_weight_store.hpp
@@ -5,19 +5,22 @@
 namespace nano
 {
 class mdb_store;
-class online_weight_store_mdb : public online_weight_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class online_weight_store : public nano::online_weight_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	explicit online_weight_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, uint64_t time_a, nano::amount const & amount_a) override;
-	void del (nano::write_transaction const & transaction_a, uint64_t time_a) override;
-	nano::store_iterator<uint64_t, nano::amount> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<uint64_t, nano::amount> rbegin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<uint64_t, nano::amount> end () const override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a) override;
-};
+	public:
+		explicit online_weight_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, uint64_t time_a, nano::amount const & amount_a) override;
+		void del (nano::write_transaction const & transaction_a, uint64_t time_a) override;
+		nano::store_iterator<uint64_t, nano::amount> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<uint64_t, nano::amount> rbegin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<uint64_t, nano::amount> end () const override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+	};
+}
 }

--- a/nano/node/lmdb/peer_store.cpp
+++ b/nano/node/lmdb/peer_store.cpp
@@ -1,43 +1,43 @@
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/peer_store.hpp>
 
-nano::peer_store_mdb::peer_store_mdb (nano::mdb_store & store) :
+nano::lmdb::peer_store::peer_store (nano::mdb_store & store) :
 	store{ store } {};
 
-void nano::peer_store_mdb::put (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
+void nano::lmdb::peer_store::put (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
 {
 	auto status = store.put_key (transaction, tables::peers, endpoint);
 	release_assert_success (store, status);
 }
 
-void nano::peer_store_mdb::del (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
+void nano::lmdb::peer_store::del (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
 {
 	auto status = store.del (transaction, tables::peers, endpoint);
 	release_assert_success (store, status);
 }
 
-bool nano::peer_store_mdb::exists (nano::transaction const & transaction, nano::endpoint_key const & endpoint) const
+bool nano::lmdb::peer_store::exists (nano::transaction const & transaction, nano::endpoint_key const & endpoint) const
 {
 	return store.exists (transaction, tables::peers, endpoint);
 }
 
-size_t nano::peer_store_mdb::count (nano::transaction const & transaction) const
+size_t nano::lmdb::peer_store::count (nano::transaction const & transaction) const
 {
 	return store.count (transaction, tables::peers);
 }
 
-void nano::peer_store_mdb::clear (nano::write_transaction const & transaction)
+void nano::lmdb::peer_store::clear (nano::write_transaction const & transaction)
 {
 	auto status = store.drop (transaction, tables::peers);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::endpoint_key, nano::no_value> nano::peer_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::endpoint_key, nano::no_value> nano::lmdb::peer_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::endpoint_key, nano::no_value> (transaction, tables::peers);
 }
 
-nano::store_iterator<nano::endpoint_key, nano::no_value> nano::peer_store_mdb::end () const
+nano::store_iterator<nano::endpoint_key, nano::no_value> nano::lmdb::peer_store::end () const
 {
 	return nano::store_iterator<nano::endpoint_key, nano::no_value> (nullptr);
 }

--- a/nano/node/lmdb/peer_store.hpp
+++ b/nano/node/lmdb/peer_store.hpp
@@ -5,19 +5,22 @@
 namespace nano
 {
 class mdb_store;
-class peer_store_mdb : public peer_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class peer_store : public nano::peer_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	explicit peer_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::endpoint_key, nano::no_value> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::endpoint_key, nano::no_value> end () const override;
-};
+	public:
+		explicit peer_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::endpoint_key, nano::no_value> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::endpoint_key, nano::no_value> end () const override;
+	};
+}
 }

--- a/nano/node/lmdb/pending_store.cpp
+++ b/nano/node/lmdb/pending_store.cpp
@@ -1,22 +1,22 @@
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/pending_store.hpp>
 
-nano::pending_store_mdb::pending_store_mdb (nano::mdb_store & store) :
+nano::lmdb::pending_store::pending_store (nano::mdb_store & store) :
 	store{ store } {};
 
-void nano::pending_store_mdb::put (nano::write_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & pending)
+void nano::lmdb::pending_store::put (nano::write_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & pending)
 {
 	auto status = store.put (transaction, tables::pending, key, pending);
 	release_assert_success (store, status);
 }
 
-void nano::pending_store_mdb::del (nano::write_transaction const & transaction, nano::pending_key const & key)
+void nano::lmdb::pending_store::del (nano::write_transaction const & transaction, nano::pending_key const & key)
 {
 	auto status = store.del (transaction, tables::pending, key);
 	release_assert_success (store, status);
 }
 
-bool nano::pending_store_mdb::get (nano::transaction const & transaction, nano::pending_key const & key, nano::pending_info & pending_a)
+bool nano::lmdb::pending_store::get (nano::transaction const & transaction, nano::pending_key const & key, nano::pending_info & pending_a)
 {
 	nano::mdb_val value;
 	auto status1 = store.get (transaction, tables::pending, key, value);
@@ -30,34 +30,34 @@ bool nano::pending_store_mdb::get (nano::transaction const & transaction, nano::
 	return result;
 }
 
-bool nano::pending_store_mdb::exists (nano::transaction const & transaction_a, nano::pending_key const & key_a)
+bool nano::lmdb::pending_store::exists (nano::transaction const & transaction_a, nano::pending_key const & key_a)
 {
 	auto iterator (begin (transaction_a, key_a));
 	return iterator != end () && nano::pending_key (iterator->first) == key_a;
 }
 
-bool nano::pending_store_mdb::any (nano::transaction const & transaction_a, nano::account const & account_a)
+bool nano::lmdb::pending_store::any (nano::transaction const & transaction_a, nano::account const & account_a)
 {
 	auto iterator (begin (transaction_a, nano::pending_key (account_a, 0)));
 	return iterator != end () && nano::pending_key (iterator->first).account == account_a;
 }
 
-nano::store_iterator<nano::pending_key, nano::pending_info> nano::pending_store_mdb::begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const
+nano::store_iterator<nano::pending_key, nano::pending_info> nano::lmdb::pending_store::begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const
 {
 	return store.make_iterator<nano::pending_key, nano::pending_info> (transaction_a, tables::pending, key_a);
 }
 
-nano::store_iterator<nano::pending_key, nano::pending_info> nano::pending_store_mdb::begin (nano::transaction const & transaction_a) const
+nano::store_iterator<nano::pending_key, nano::pending_info> nano::lmdb::pending_store::begin (nano::transaction const & transaction_a) const
 {
 	return store.make_iterator<nano::pending_key, nano::pending_info> (transaction_a, tables::pending);
 }
 
-nano::store_iterator<nano::pending_key, nano::pending_info> nano::pending_store_mdb::end () const
+nano::store_iterator<nano::pending_key, nano::pending_info> nano::lmdb::pending_store::end () const
 {
 	return nano::store_iterator<nano::pending_key, nano::pending_info> (nullptr);
 }
 
-void nano::pending_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const
+void nano::lmdb::pending_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint512_t> (
 	[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {

--- a/nano/node/lmdb/pending_store.hpp
+++ b/nano/node/lmdb/pending_store.hpp
@@ -5,21 +5,24 @@
 namespace nano
 {
 class mdb_store;
-class pending_store_mdb : public pending_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class pending_store : public nano::pending_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	explicit pending_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info const & pending_info_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::pending_key const & key_a) override;
-	bool get (nano::transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info & pending_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::pending_key const & key_a) override;
-	bool any (nano::transaction const & transaction_a, nano::account const & account_a) override;
-	nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const override;
-	nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::pending_key, nano::pending_info> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const override;
-};
+	public:
+		explicit pending_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info const & pending_info_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::pending_key const & key_a) override;
+		bool get (nano::transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info & pending_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::pending_key const & key_a) override;
+		bool any (nano::transaction const & transaction_a, nano::account const & account_a) override;
+		nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const override;
+		nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::pending_key, nano::pending_info> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/lmdb/pruned_store.cpp
+++ b/nano/node/lmdb/pruned_store.cpp
@@ -1,27 +1,27 @@
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/pruned_store.hpp>
 
-nano::pruned_store_mdb::pruned_store_mdb (nano::mdb_store & store_a) :
+nano::lmdb::pruned_store::pruned_store (nano::mdb_store & store_a) :
 	store{ store_a } {};
 
-void nano::pruned_store_mdb::put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
+void nano::lmdb::pruned_store::put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto status = store.put_key (transaction_a, tables::pruned, hash_a);
 	release_assert_success (store, status);
 }
 
-void nano::pruned_store_mdb::del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
+void nano::lmdb::pruned_store::del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto status = store.del (transaction_a, tables::pruned, hash_a);
 	release_assert_success (store, status);
 }
 
-bool nano::pruned_store_mdb::exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
+bool nano::lmdb::pruned_store::exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	return store.exists (transaction_a, tables::pruned, hash_a);
 }
 
-nano::block_hash nano::pruned_store_mdb::random (nano::transaction const & transaction)
+nano::block_hash nano::lmdb::pruned_store::random (nano::transaction const & transaction)
 {
 	nano::block_hash random_hash;
 	nano::random_pool::generate_block (random_hash.bytes.data (), random_hash.bytes.size ());
@@ -33,33 +33,33 @@ nano::block_hash nano::pruned_store_mdb::random (nano::transaction const & trans
 	return existing != end () ? existing->first : 0;
 }
 
-size_t nano::pruned_store_mdb::count (nano::transaction const & transaction_a) const
+size_t nano::lmdb::pruned_store::count (nano::transaction const & transaction_a) const
 {
 	return store.count (transaction_a, tables::pruned);
 }
 
-void nano::pruned_store_mdb::clear (nano::write_transaction const & transaction_a)
+void nano::lmdb::pruned_store::clear (nano::write_transaction const & transaction_a)
 {
 	auto status = store.drop (transaction_a, tables::pruned);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::block_hash, std::nullptr_t> nano::pruned_store_mdb::begin (nano::transaction const & transaction, nano::block_hash const & hash) const
+nano::store_iterator<nano::block_hash, std::nullptr_t> nano::lmdb::pruned_store::begin (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
 	return store.make_iterator<nano::block_hash, std::nullptr_t> (transaction, tables::pruned, hash);
 }
 
-nano::store_iterator<nano::block_hash, std::nullptr_t> nano::pruned_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::block_hash, std::nullptr_t> nano::lmdb::pruned_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::block_hash, std::nullptr_t> (transaction, tables::pruned);
 }
 
-nano::store_iterator<nano::block_hash, std::nullptr_t> nano::pruned_store_mdb::end () const
+nano::store_iterator<nano::block_hash, std::nullptr_t> nano::lmdb::pruned_store::end () const
 {
 	return nano::store_iterator<nano::block_hash, std::nullptr_t> (nullptr);
 }
 
-void nano::pruned_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const
+void nano::lmdb::pruned_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/lmdb/pruned_store.hpp
+++ b/nano/node/lmdb/pruned_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class mdb_store;
-class pruned_store_mdb : public pruned_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class pruned_store : public nano::pruned_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	explicit pruned_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::block_hash random (nano::transaction const & transaction_a) override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::block_hash, std::nullptr_t> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const override;
-};
+	public:
+		explicit pruned_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::block_hash random (nano::transaction const & transaction_a) override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::block_hash, std::nullptr_t> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/lmdb/unchecked_store.cpp
+++ b/nano/node/lmdb/unchecked_store.cpp
@@ -1,22 +1,22 @@
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/unchecked_store.hpp>
 
-nano::unchecked_store_mdb::unchecked_store_mdb (nano::mdb_store & store_a) :
+nano::lmdb::unchecked_store::unchecked_store (nano::mdb_store & store_a) :
 	store (store_a){};
 
-void nano::unchecked_store_mdb::clear (nano::write_transaction const & transaction_a)
+void nano::lmdb::unchecked_store::clear (nano::write_transaction const & transaction_a)
 {
 	auto status = store.drop (transaction_a, tables::unchecked);
 	release_assert_success (store, status);
 }
 
-void nano::unchecked_store_mdb::put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info)
+void nano::lmdb::unchecked_store::put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info)
 {
 	auto status = store.put (transaction_a, tables::unchecked, nano::unchecked_key{ dependency, info.block->hash () }, info);
 	release_assert_success (store, status);
 }
 
-bool nano::unchecked_store_mdb::exists (nano::transaction const & transaction_a, nano::unchecked_key const & key)
+bool nano::lmdb::unchecked_store::exists (nano::transaction const & transaction_a, nano::unchecked_key const & key)
 {
 	nano::mdb_val value;
 	auto status = store.get (transaction_a, tables::unchecked, key, value);
@@ -24,33 +24,33 @@ bool nano::unchecked_store_mdb::exists (nano::transaction const & transaction_a,
 	return store.success (status);
 }
 
-void nano::unchecked_store_mdb::del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a)
+void nano::lmdb::unchecked_store::del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a)
 {
 	auto status (store.del (transaction_a, tables::unchecked, key_a));
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::unchecked_store_mdb::end () const
+nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::lmdb::unchecked_store::end () const
 {
 	return nano::store_iterator<nano::unchecked_key, nano::unchecked_info> (nullptr);
 }
 
-nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::unchecked_store_mdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::lmdb::unchecked_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction, tables::unchecked);
 }
 
-nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::unchecked_store_mdb::lower_bound (nano::transaction const & transaction, nano::unchecked_key const & key) const
+nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::lmdb::unchecked_store::lower_bound (nano::transaction const & transaction, nano::unchecked_key const & key) const
 {
 	return store.make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction, tables::unchecked, key);
 }
 
-size_t nano::unchecked_store_mdb::count (nano::transaction const & transaction_a)
+size_t nano::lmdb::unchecked_store::count (nano::transaction const & transaction_a)
 {
 	return store.count (transaction_a, tables::unchecked);
 }
 
-void nano::unchecked_store_mdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const
+void nano::lmdb::unchecked_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint512_t> (
 	[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {

--- a/nano/node/lmdb/unchecked_store.hpp
+++ b/nano/node/lmdb/unchecked_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class mdb_store;
-class unchecked_store_mdb : public unchecked_store
+namespace lmdb
 {
-private:
-	nano::mdb_store & store;
+	class unchecked_store : public nano::unchecked_store
+	{
+	private:
+		nano::mdb_store & store;
 
-public:
-	unchecked_store_mdb (nano::mdb_store & store_a);
+	public:
+		unchecked_store (nano::mdb_store & store_a);
 
-	void clear (nano::write_transaction const & transaction_a) override;
-	void put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override;
-	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> end () const override;
-	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
-	size_t count (nano::transaction const & transaction_a) override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
-};
+		void clear (nano::write_transaction const & transaction_a) override;
+		void put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override;
+		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> end () const override;
+		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
+		size_t count (nano::transaction const & transaction_a) override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/lmdb/version_store.cpp
+++ b/nano/node/lmdb/version_store.cpp
@@ -1,10 +1,10 @@
 #include <nano/node/lmdb/lmdb.hpp>
 #include <nano/node/lmdb/version_store.hpp>
 
-nano::version_store_mdb::version_store_mdb (nano::mdb_store & store_a) :
+nano::lmdb::version_store::version_store (nano::mdb_store & store_a) :
 	store{ store_a } {};
 
-void nano::version_store_mdb::put (nano::write_transaction const & transaction_a, int version)
+void nano::lmdb::version_store::put (nano::write_transaction const & transaction_a, int version)
 {
 	nano::uint256_union version_key{ 1 };
 	nano::uint256_union version_value (version);
@@ -12,7 +12,7 @@ void nano::version_store_mdb::put (nano::write_transaction const & transaction_a
 	release_assert_success (store, status);
 }
 
-int nano::version_store_mdb::get (nano::transaction const & transaction_a) const
+int nano::lmdb::version_store::get (nano::transaction const & transaction_a) const
 {
 	nano::uint256_union version_key{ 1 };
 	nano::mdb_val data;

--- a/nano/node/lmdb/version_store.hpp
+++ b/nano/node/lmdb/version_store.hpp
@@ -5,14 +5,17 @@
 namespace nano
 {
 class mdb_store;
-class version_store_mdb : public version_store
+namespace lmdb
 {
-protected:
-	nano::mdb_store & store;
+	class version_store : public nano::version_store
+	{
+	protected:
+		nano::mdb_store & store;
 
-public:
-	explicit version_store_mdb (nano::mdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, int version_a) override;
-	int get (nano::transaction const & transaction_a) const override;
-};
+	public:
+		explicit version_store (nano::mdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, int version_a) override;
+		int get (nano::transaction const & transaction_a) const override;
+	};
+}
 }

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -43,7 +43,9 @@
 
 namespace nano
 {
-namespace rocksdb{} // Declare a namespace rocksdb inside nano so all references to the rocksdb library need to be globally scoped e.g. ::rocksdb::Slice
+namespace rocksdb
+{
+} // Declare a namespace rocksdb inside nano so all references to the rocksdb library need to be globally scoped e.g. ::rocksdb::Slice
 namespace websocket
 {
 	class listener;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -43,6 +43,7 @@
 
 namespace nano
 {
+namespace rocksdb{} // Declare a namespace rocksdb inside nano so all references to the rocksdb library need to be globally scoped e.g. ::rocksdb::Slice
 namespace websocket
 {
 	class listener;

--- a/nano/node/rocksdb/account_store.cpp
+++ b/nano/node/rocksdb/account_store.cpp
@@ -1,16 +1,16 @@
 #include <nano/node/rocksdb/account_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::account_store_rocksdb::account_store_rocksdb (nano::rocksdb_store & store_a) :
+nano::rocksdb::account_store::account_store (nano::rocksdb_store & store_a) :
 	store (store_a){};
 
-void nano::account_store_rocksdb::put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info)
+void nano::rocksdb::account_store::put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info)
 {
 	auto status = store.put (transaction, tables::accounts, account, info);
 	release_assert_success (store, status);
 }
 
-bool nano::account_store_rocksdb::get (nano::transaction const & transaction, nano::account const & account, nano::account_info & info)
+bool nano::rocksdb::account_store::get (nano::transaction const & transaction, nano::account const & account, nano::account_info & info)
 {
 	nano::rocksdb_val value;
 	auto status1 (store.get (transaction, tables::accounts, account, value));
@@ -24,44 +24,44 @@ bool nano::account_store_rocksdb::get (nano::transaction const & transaction, na
 	return result;
 }
 
-void nano::account_store_rocksdb::del (nano::write_transaction const & transaction_a, nano::account const & account_a)
+void nano::rocksdb::account_store::del (nano::write_transaction const & transaction_a, nano::account const & account_a)
 {
 	auto status = store.del (transaction_a, tables::accounts, account_a);
 	release_assert_success (store, status);
 }
 
-bool nano::account_store_rocksdb::exists (nano::transaction const & transaction_a, nano::account const & account_a)
+bool nano::rocksdb::account_store::exists (nano::transaction const & transaction_a, nano::account const & account_a)
 {
 	auto iterator (begin (transaction_a, account_a));
 	return iterator != end () && nano::account (iterator->first) == account_a;
 }
 
-size_t nano::account_store_rocksdb::count (nano::transaction const & transaction_a)
+size_t nano::rocksdb::account_store::count (nano::transaction const & transaction_a)
 {
 	return store.count (transaction_a, tables::accounts);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_rocksdb::begin (nano::transaction const & transaction, nano::account const & account) const
+nano::store_iterator<nano::account, nano::account_info> nano::rocksdb::account_store::begin (nano::transaction const & transaction, nano::account const & account) const
 {
 	return store.make_iterator<nano::account, nano::account_info> (transaction, tables::accounts, account);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::account, nano::account_info> nano::rocksdb::account_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::account, nano::account_info> (transaction, tables::accounts);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_rocksdb::rbegin (nano::transaction const & transaction_a) const
+nano::store_iterator<nano::account, nano::account_info> nano::rocksdb::account_store::rbegin (nano::transaction const & transaction_a) const
 {
 	return store.make_iterator<nano::account, nano::account_info> (transaction_a, tables::accounts, false);
 }
 
-nano::store_iterator<nano::account, nano::account_info> nano::account_store_rocksdb::end () const
+nano::store_iterator<nano::account, nano::account_info> nano::rocksdb::account_store::end () const
 {
 	return nano::store_iterator<nano::account, nano::account_info> (nullptr);
 }
 
-void nano::account_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const
+void nano::rocksdb::account_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/account_store.hpp
+++ b/nano/node/rocksdb/account_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class rocksdb_store;
-class account_store_rocksdb : public account_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class account_store : public nano::account_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	explicit account_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info) override;
-	bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::account_info & info_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::account const & account_a) override;
-	size_t count (nano::transaction const & transaction_a) override;
-	nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
-	nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::account, nano::account_info> rbegin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::account, nano::account_info> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const override;
-};
+	public:
+		explicit account_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction, nano::account const & account, nano::account_info const & info) override;
+		bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::account_info & info_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::account const & account_a) override;
+		size_t count (nano::transaction const & transaction_a) override;
+		nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
+		nano::store_iterator<nano::account, nano::account_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::account, nano::account_info> rbegin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::account, nano::account_info> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -9,38 +9,41 @@ namespace nano
 class rocksdb_store;
 using rocksdb_val = db_val<::rocksdb::Slice>;
 class block_predecessor_rocksdb_set;
-class block_store_rocksdb : public block_store
+namespace rocksdb
 {
-	friend class block_predecessor_rocksdb_set;
-	nano::rocksdb_store & store;
+	class block_store : public nano::block_store
+	{
+		friend class nano::block_predecessor_rocksdb_set;
+		nano::rocksdb_store & store;
 
-public:
-	explicit block_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, nano::block const & block_a) override;
-	void raw_put (nano::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override;
-	nano::block_hash successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	void successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	std::shared_ptr<nano::block> get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	std::shared_ptr<nano::block> get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	std::shared_ptr<nano::block> random (nano::transaction const & transaction_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	uint64_t count (nano::transaction const & transaction_a) override;
-	nano::account account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::account account_calculated (nano::block const & block_a) const override;
-	nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
-	nano::uint128_t balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const & block_a) const override;
-	nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
-	// Converts a block hash to a block height
-	uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+	public:
+		explicit block_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a, nano::block const & block_a) override;
+		void raw_put (nano::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override;
+		nano::block_hash successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		void successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		std::shared_ptr<nano::block> get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		std::shared_ptr<nano::block> get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		std::shared_ptr<nano::block> random (nano::transaction const & transaction_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		uint64_t count (nano::transaction const & transaction_a) override;
+		nano::account account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::account account_calculated (nano::block const & block_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
+		nano::uint128_t balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const & block_a) const override;
+		nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
+		// Converts a block hash to a block height
+		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 
-protected:
-	void block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::rocksdb_val & value) const;
-	size_t block_successor_offset (nano::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
-	static nano::block_type block_type_from_raw (void * data_a);
-};
+	protected:
+		void block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::rocksdb_val & value) const;
+		size_t block_successor_offset (nano::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
+		static nano::block_type block_type_from_raw (void * data_a);
+	};
+}
 }

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -7,7 +7,7 @@
 namespace nano
 {
 class rocksdb_store;
-using rocksdb_val = db_val<rocksdb::Slice>;
+using rocksdb_val = db_val<::rocksdb::Slice>;
 class block_predecessor_rocksdb_set;
 class block_store_rocksdb : public block_store
 {

--- a/nano/node/rocksdb/confirmation_height_store.cpp
+++ b/nano/node/rocksdb/confirmation_height_store.cpp
@@ -1,18 +1,18 @@
 #include <nano/node/rocksdb/confirmation_height_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::confirmation_height_store_rocksdb::confirmation_height_store_rocksdb (nano::rocksdb_store & store) :
+nano::rocksdb::confirmation_height_store::confirmation_height_store (nano::rocksdb_store & store) :
 	store{ store }
 {
 }
 
-void nano::confirmation_height_store_rocksdb::put (nano::write_transaction const & transaction, nano::account const & account, nano::confirmation_height_info const & confirmation_height_info)
+void nano::rocksdb::confirmation_height_store::put (nano::write_transaction const & transaction, nano::account const & account, nano::confirmation_height_info const & confirmation_height_info)
 {
 	auto status = store.put (transaction, tables::confirmation_height, account, confirmation_height_info);
 	release_assert_success (store, status);
 }
 
-bool nano::confirmation_height_store_rocksdb::get (nano::transaction const & transaction, nano::account const & account, nano::confirmation_height_info & confirmation_height_info)
+bool nano::rocksdb::confirmation_height_store::get (nano::transaction const & transaction, nano::account const & account, nano::confirmation_height_info & confirmation_height_info)
 {
 	nano::rocksdb_val value;
 	auto status = store.get (transaction, tables::confirmation_height, account, value);
@@ -32,48 +32,48 @@ bool nano::confirmation_height_store_rocksdb::get (nano::transaction const & tra
 	return result;
 }
 
-bool nano::confirmation_height_store_rocksdb::exists (nano::transaction const & transaction, nano::account const & account) const
+bool nano::rocksdb::confirmation_height_store::exists (nano::transaction const & transaction, nano::account const & account) const
 {
 	return store.exists (transaction, tables::confirmation_height, account);
 }
 
-void nano::confirmation_height_store_rocksdb::del (nano::write_transaction const & transaction, nano::account const & account)
+void nano::rocksdb::confirmation_height_store::del (nano::write_transaction const & transaction, nano::account const & account)
 {
 	auto status = store.del (transaction, tables::confirmation_height, account);
 	release_assert_success (store, status);
 }
 
-uint64_t nano::confirmation_height_store_rocksdb::count (nano::transaction const & transaction)
+uint64_t nano::rocksdb::confirmation_height_store::count (nano::transaction const & transaction)
 {
 	return store.count (transaction, tables::confirmation_height);
 }
 
-void nano::confirmation_height_store_rocksdb::clear (nano::write_transaction const & transaction, nano::account const & account)
+void nano::rocksdb::confirmation_height_store::clear (nano::write_transaction const & transaction, nano::account const & account)
 {
 	del (transaction, account);
 }
 
-void nano::confirmation_height_store_rocksdb::clear (nano::write_transaction const & transaction)
+void nano::rocksdb::confirmation_height_store::clear (nano::write_transaction const & transaction)
 {
 	store.drop (transaction, nano::tables::confirmation_height);
 }
 
-nano::store_iterator<nano::account, nano::confirmation_height_info> nano::confirmation_height_store_rocksdb::begin (nano::transaction const & transaction, nano::account const & account) const
+nano::store_iterator<nano::account, nano::confirmation_height_info> nano::rocksdb::confirmation_height_store::begin (nano::transaction const & transaction, nano::account const & account) const
 {
 	return store.make_iterator<nano::account, nano::confirmation_height_info> (transaction, tables::confirmation_height, account);
 }
 
-nano::store_iterator<nano::account, nano::confirmation_height_info> nano::confirmation_height_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::account, nano::confirmation_height_info> nano::rocksdb::confirmation_height_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::account, nano::confirmation_height_info> (transaction, tables::confirmation_height);
 }
 
-nano::store_iterator<nano::account, nano::confirmation_height_info> nano::confirmation_height_store_rocksdb::end () const
+nano::store_iterator<nano::account, nano::confirmation_height_info> nano::rocksdb::confirmation_height_store::end () const
 {
 	return nano::store_iterator<nano::account, nano::confirmation_height_info> (nullptr);
 }
 
-void nano::confirmation_height_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const
+void nano::rocksdb::confirmation_height_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/confirmation_height_store.hpp
+++ b/nano/node/rocksdb/confirmation_height_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class rocksdb_store;
-class confirmation_height_store_rocksdb : public confirmation_height_store
+namespace rocksdb
 {
-	nano::rocksdb_store & store;
+	class confirmation_height_store : public nano::confirmation_height_store
+	{
+		nano::rocksdb_store & store;
 
-public:
-	explicit confirmation_height_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override;
-	bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::account const & account_a) const override;
-	void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
-	uint64_t count (nano::transaction const & transaction_a) override;
-	void clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
-	nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::account, nano::confirmation_height_info> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override;
-};
+	public:
+		explicit confirmation_height_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info const & confirmation_height_info_a) override;
+		bool get (nano::transaction const & transaction_a, nano::account const & account_a, nano::confirmation_height_info & confirmation_height_info_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::account const & account_a) const override;
+		void del (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
+		uint64_t count (nano::transaction const & transaction_a) override;
+		void clear (nano::write_transaction const & transaction_a, nano::account const & account_a) override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a, nano::account const & account_a) const override;
+		nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::account, nano::confirmation_height_info> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/rocksdb/final_vote_store.cpp
+++ b/nano/node/rocksdb/final_vote_store.cpp
@@ -1,10 +1,10 @@
 #include <nano/node/rocksdb/final_vote_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::final_vote_store_rocksdb::final_vote_store_rocksdb (nano::rocksdb_store & store) :
+nano::rocksdb::final_vote_store::final_vote_store (nano::rocksdb_store & store) :
 	store{ store } {};
 
-bool nano::final_vote_store_rocksdb::put (nano::write_transaction const & transaction, nano::qualified_root const & root, nano::block_hash const & hash)
+bool nano::rocksdb::final_vote_store::put (nano::write_transaction const & transaction, nano::qualified_root const & root, nano::block_hash const & hash)
 {
 	nano::rocksdb_val value;
 	auto status = store.get (transaction, tables::final_votes, root, value);
@@ -22,7 +22,7 @@ bool nano::final_vote_store_rocksdb::put (nano::write_transaction const & transa
 	return result;
 }
 
-std::vector<nano::block_hash> nano::final_vote_store_rocksdb::get (nano::transaction const & transaction, nano::root const & root_a)
+std::vector<nano::block_hash> nano::rocksdb::final_vote_store::get (nano::transaction const & transaction, nano::root const & root_a)
 {
 	std::vector<nano::block_hash> result;
 	nano::qualified_root key_start{ root_a.raw, 0 };
@@ -33,7 +33,7 @@ std::vector<nano::block_hash> nano::final_vote_store_rocksdb::get (nano::transac
 	return result;
 }
 
-void nano::final_vote_store_rocksdb::del (nano::write_transaction const & transaction, nano::root const & root)
+void nano::rocksdb::final_vote_store::del (nano::write_transaction const & transaction, nano::root const & root)
 {
 	std::vector<nano::qualified_root> final_vote_qualified_roots;
 	for (auto i = begin (transaction, nano::qualified_root{ root.raw, 0 }), n = end (); i != n && nano::qualified_root{ i->first }.root () == root; ++i)
@@ -48,37 +48,37 @@ void nano::final_vote_store_rocksdb::del (nano::write_transaction const & transa
 	}
 }
 
-size_t nano::final_vote_store_rocksdb::count (nano::transaction const & transaction_a) const
+size_t nano::rocksdb::final_vote_store::count (nano::transaction const & transaction_a) const
 {
 	return store.count (transaction_a, tables::final_votes);
 }
 
-void nano::final_vote_store_rocksdb::clear (nano::write_transaction const & transaction_a, nano::root const & root_a)
+void nano::rocksdb::final_vote_store::clear (nano::write_transaction const & transaction_a, nano::root const & root_a)
 {
 	del (transaction_a, root_a);
 }
 
-void nano::final_vote_store_rocksdb::clear (nano::write_transaction const & transaction_a)
+void nano::rocksdb::final_vote_store::clear (nano::write_transaction const & transaction_a)
 {
 	store.drop (transaction_a, nano::tables::final_votes);
 }
 
-nano::store_iterator<nano::qualified_root, nano::block_hash> nano::final_vote_store_rocksdb::begin (nano::transaction const & transaction, nano::qualified_root const & root) const
+nano::store_iterator<nano::qualified_root, nano::block_hash> nano::rocksdb::final_vote_store::begin (nano::transaction const & transaction, nano::qualified_root const & root) const
 {
 	return store.make_iterator<nano::qualified_root, nano::block_hash> (transaction, tables::final_votes, root);
 }
 
-nano::store_iterator<nano::qualified_root, nano::block_hash> nano::final_vote_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::qualified_root, nano::block_hash> nano::rocksdb::final_vote_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::qualified_root, nano::block_hash> (transaction, tables::final_votes);
 }
 
-nano::store_iterator<nano::qualified_root, nano::block_hash> nano::final_vote_store_rocksdb::end () const
+nano::store_iterator<nano::qualified_root, nano::block_hash> nano::rocksdb::final_vote_store::end () const
 {
 	return nano::store_iterator<nano::qualified_root, nano::block_hash> (nullptr);
 }
 
-void nano::final_vote_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const
+void nano::rocksdb::final_vote_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const
 {
 	parallel_traversal<nano::uint512_t> (
 	[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/final_vote_store.hpp
+++ b/nano/node/rocksdb/final_vote_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class rocksdb_store;
-class final_vote_store_rocksdb : public final_vote_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class final_vote_store : public nano::final_vote_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	explicit final_vote_store_rocksdb (nano::rocksdb_store & store);
-	bool put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
-	std::vector<nano::block_hash> get (nano::transaction const & transaction_a, nano::root const & root_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const override;
-	nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::qualified_root, nano::block_hash> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const override;
-};
+	public:
+		explicit final_vote_store (nano::rocksdb_store & store);
+		bool put (nano::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
+		std::vector<nano::block_hash> get (nano::transaction const & transaction_a, nano::root const & root_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a, nano::root const & root_a) override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a, nano::qualified_root const & root_a) const override;
+		nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::qualified_root, nano::block_hash> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/rocksdb/frontier_store.cpp
+++ b/nano/node/rocksdb/frontier_store.cpp
@@ -1,18 +1,18 @@
 #include <nano/node/rocksdb/frontier_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::frontier_store_rocksdb::frontier_store_rocksdb (nano::rocksdb_store & store) :
+nano::rocksdb::frontier_store::frontier_store (nano::rocksdb_store & store) :
 	store{ store }
 {
 }
 
-void nano::frontier_store_rocksdb::put (nano::write_transaction const & transaction, nano::block_hash const & block, nano::account const & account)
+void nano::rocksdb::frontier_store::put (nano::write_transaction const & transaction, nano::block_hash const & block, nano::account const & account)
 {
 	auto status = store.put (transaction, tables::frontiers, block, account);
 	release_assert_success (store, status);
 }
 
-nano::account nano::frontier_store_rocksdb::get (nano::transaction const & transaction, nano::block_hash const & hash) const
+nano::account nano::rocksdb::frontier_store::get (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
 	nano::db_val<::rocksdb::Slice> value;
 	auto status = store.get (transaction, tables::frontiers, hash, value);
@@ -25,28 +25,28 @@ nano::account nano::frontier_store_rocksdb::get (nano::transaction const & trans
 	return result;
 }
 
-void nano::frontier_store_rocksdb::del (nano::write_transaction const & transaction, nano::block_hash const & hash)
+void nano::rocksdb::frontier_store::del (nano::write_transaction const & transaction, nano::block_hash const & hash)
 {
 	auto status = store.del (transaction, tables::frontiers, hash);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::block_hash, nano::account> nano::frontier_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::block_hash, nano::account> nano::rocksdb::frontier_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::block_hash, nano::account> (transaction, tables::frontiers);
 }
 
-nano::store_iterator<nano::block_hash, nano::account> nano::frontier_store_rocksdb::begin (nano::transaction const & transaction, nano::block_hash const & hash) const
+nano::store_iterator<nano::block_hash, nano::account> nano::rocksdb::frontier_store::begin (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
 	return store.make_iterator<nano::block_hash, nano::account> (transaction, tables::frontiers, hash);
 }
 
-nano::store_iterator<nano::block_hash, nano::account> nano::frontier_store_rocksdb::end () const
+nano::store_iterator<nano::block_hash, nano::account> nano::rocksdb::frontier_store::end () const
 {
 	return nano::store_iterator<nano::block_hash, nano::account> (nullptr);
 }
 
-void nano::frontier_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const
+void nano::rocksdb::frontier_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/frontier_store.cpp
+++ b/nano/node/rocksdb/frontier_store.cpp
@@ -14,7 +14,7 @@ void nano::frontier_store_rocksdb::put (nano::write_transaction const & transact
 
 nano::account nano::frontier_store_rocksdb::get (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
-	nano::db_val<rocksdb::Slice> value;
+	nano::db_val<::rocksdb::Slice> value;
 	auto status = store.get (transaction, tables::frontiers, hash, value);
 	release_assert (store.success (status) || store.not_found (status));
 	nano::account result{};

--- a/nano/node/rocksdb/frontier_store.hpp
+++ b/nano/node/rocksdb/frontier_store.hpp
@@ -5,20 +5,22 @@
 namespace nano
 {
 class rocksdb_store;
-class frontier_store_rocksdb : public frontier_store
+namespace rocksdb
 {
-public:
-	frontier_store_rocksdb (nano::rocksdb_store & store);
-	void put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) override;
-	nano::account get (nano::transaction const &, nano::block_hash const &) const override;
-	void del (nano::write_transaction const &, nano::block_hash const &) override;
-	nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &) const override;
-	nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &, nano::block_hash const &) const override;
-	nano::store_iterator<nano::block_hash, nano::account> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const override;
+	class frontier_store : public nano::frontier_store
+	{
+	public:
+		frontier_store (nano::rocksdb_store & store);
+		void put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) override;
+		nano::account get (nano::transaction const &, nano::block_hash const &) const override;
+		void del (nano::write_transaction const &, nano::block_hash const &) override;
+		nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &) const override;
+		nano::store_iterator<nano::block_hash, nano::account> begin (nano::transaction const &, nano::block_hash const &) const override;
+		nano::store_iterator<nano::block_hash, nano::account> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const override;
 
-private:
-	nano::rocksdb_store & store;
-};
-
+	private:
+		nano::rocksdb_store & store;
+	};
+}
 }

--- a/nano/node/rocksdb/online_weight_store.cpp
+++ b/nano/node/rocksdb/online_weight_store.cpp
@@ -1,44 +1,44 @@
 #include <nano/node/rocksdb/online_weight_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::online_weight_store_rocksdb::online_weight_store_rocksdb (nano::rocksdb_store & store_a) :
+nano::rocksdb::online_weight_store::online_weight_store (nano::rocksdb_store & store_a) :
 	store{ store_a }
 {
 }
 
-void nano::online_weight_store_rocksdb::put (nano::write_transaction const & transaction, uint64_t time, nano::amount const & amount)
+void nano::rocksdb::online_weight_store::put (nano::write_transaction const & transaction, uint64_t time, nano::amount const & amount)
 {
 	auto status = store.put (transaction, tables::online_weight, time, amount);
 	release_assert_success (store, status);
 }
 
-void nano::online_weight_store_rocksdb::del (nano::write_transaction const & transaction, uint64_t time)
+void nano::rocksdb::online_weight_store::del (nano::write_transaction const & transaction, uint64_t time)
 {
 	auto status = store.del (transaction, tables::online_weight, time);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<uint64_t, nano::amount> nano::online_weight_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<uint64_t, nano::amount> nano::rocksdb::online_weight_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<uint64_t, nano::amount> (transaction, tables::online_weight);
 }
 
-nano::store_iterator<uint64_t, nano::amount> nano::online_weight_store_rocksdb::rbegin (nano::transaction const & transaction) const
+nano::store_iterator<uint64_t, nano::amount> nano::rocksdb::online_weight_store::rbegin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<uint64_t, nano::amount> (transaction, tables::online_weight, false);
 }
 
-nano::store_iterator<uint64_t, nano::amount> nano::online_weight_store_rocksdb::end () const
+nano::store_iterator<uint64_t, nano::amount> nano::rocksdb::online_weight_store::end () const
 {
 	return nano::store_iterator<uint64_t, nano::amount> (nullptr);
 }
 
-size_t nano::online_weight_store_rocksdb::count (nano::transaction const & transaction) const
+size_t nano::rocksdb::online_weight_store::count (nano::transaction const & transaction) const
 {
 	return store.count (transaction, tables::online_weight);
 }
 
-void nano::online_weight_store_rocksdb::clear (nano::write_transaction const & transaction)
+void nano::rocksdb::online_weight_store::clear (nano::write_transaction const & transaction)
 {
 	auto status = store.drop (transaction, tables::online_weight);
 	release_assert_success (store, status);

--- a/nano/node/rocksdb/online_weight_store.hpp
+++ b/nano/node/rocksdb/online_weight_store.hpp
@@ -5,19 +5,22 @@
 namespace nano
 {
 class rocksdb_store;
-class online_weight_store_rocksdb : public online_weight_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class online_weight_store : public nano::online_weight_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	explicit online_weight_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, uint64_t time_a, nano::amount const & amount_a) override;
-	void del (nano::write_transaction const & transaction_a, uint64_t time_a) override;
-	nano::store_iterator<uint64_t, nano::amount> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<uint64_t, nano::amount> rbegin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<uint64_t, nano::amount> end () const override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a) override;
-};
+	public:
+		explicit online_weight_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, uint64_t time_a, nano::amount const & amount_a) override;
+		void del (nano::write_transaction const & transaction_a, uint64_t time_a) override;
+		nano::store_iterator<uint64_t, nano::amount> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<uint64_t, nano::amount> rbegin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<uint64_t, nano::amount> end () const override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+	};
+}
 }

--- a/nano/node/rocksdb/peer_store.cpp
+++ b/nano/node/rocksdb/peer_store.cpp
@@ -1,43 +1,43 @@
 #include <nano/node/rocksdb/peer_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::peer_store_rocksdb::peer_store_rocksdb (nano::rocksdb_store & store) :
+nano::rocksdb::peer_store::peer_store (nano::rocksdb_store & store) :
 	store{ store } {};
 
-void nano::peer_store_rocksdb::put (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
+void nano::rocksdb::peer_store::put (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
 {
 	auto status = store.put_key (transaction, tables::peers, endpoint);
 	release_assert_success (store, status);
 }
 
-void nano::peer_store_rocksdb::del (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
+void nano::rocksdb::peer_store::del (nano::write_transaction const & transaction, nano::endpoint_key const & endpoint)
 {
 	auto status = store.del (transaction, tables::peers, endpoint);
 	release_assert_success (store, status);
 }
 
-bool nano::peer_store_rocksdb::exists (nano::transaction const & transaction, nano::endpoint_key const & endpoint) const
+bool nano::rocksdb::peer_store::exists (nano::transaction const & transaction, nano::endpoint_key const & endpoint) const
 {
 	return store.exists (transaction, tables::peers, endpoint);
 }
 
-size_t nano::peer_store_rocksdb::count (nano::transaction const & transaction) const
+size_t nano::rocksdb::peer_store::count (nano::transaction const & transaction) const
 {
 	return store.count (transaction, tables::peers);
 }
 
-void nano::peer_store_rocksdb::clear (nano::write_transaction const & transaction)
+void nano::rocksdb::peer_store::clear (nano::write_transaction const & transaction)
 {
 	auto status = store.drop (transaction, tables::peers);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::endpoint_key, nano::no_value> nano::peer_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::endpoint_key, nano::no_value> nano::rocksdb::peer_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::endpoint_key, nano::no_value> (transaction, tables::peers);
 }
 
-nano::store_iterator<nano::endpoint_key, nano::no_value> nano::peer_store_rocksdb::end () const
+nano::store_iterator<nano::endpoint_key, nano::no_value> nano::rocksdb::peer_store::end () const
 {
 	return nano::store_iterator<nano::endpoint_key, nano::no_value> (nullptr);
 }

--- a/nano/node/rocksdb/peer_store.hpp
+++ b/nano/node/rocksdb/peer_store.hpp
@@ -5,19 +5,22 @@
 namespace nano
 {
 class rocksdb_store;
-class peer_store_rocksdb : public peer_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class peer_store : public nano::peer_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	explicit peer_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::endpoint_key, nano::no_value> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::endpoint_key, nano::no_value> end () const override;
-};
+	public:
+		explicit peer_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::endpoint_key const & endpoint_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::endpoint_key const & endpoint_a) const override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::endpoint_key, nano::no_value> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::endpoint_key, nano::no_value> end () const override;
+	};
+}
 }

--- a/nano/node/rocksdb/pending_store.cpp
+++ b/nano/node/rocksdb/pending_store.cpp
@@ -1,22 +1,22 @@
 #include <nano/node/lmdb/pending_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::pending_store_rocksdb::pending_store_rocksdb (nano::rocksdb_store & store) :
+nano::rocksdb::pending_store::pending_store (nano::rocksdb_store & store) :
 	store{ store } {};
 
-void nano::pending_store_rocksdb::put (nano::write_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & pending)
+void nano::rocksdb::pending_store::put (nano::write_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & pending)
 {
 	auto status = store.put (transaction, tables::pending, key, pending);
 	release_assert_success (store, status);
 }
 
-void nano::pending_store_rocksdb::del (nano::write_transaction const & transaction, nano::pending_key const & key)
+void nano::rocksdb::pending_store::del (nano::write_transaction const & transaction, nano::pending_key const & key)
 {
 	auto status = store.del (transaction, tables::pending, key);
 	release_assert_success (store, status);
 }
 
-bool nano::pending_store_rocksdb::get (nano::transaction const & transaction, nano::pending_key const & key, nano::pending_info & pending)
+bool nano::rocksdb::pending_store::get (nano::transaction const & transaction, nano::pending_key const & key, nano::pending_info & pending)
 {
 	nano::rocksdb_val value;
 	auto status1 = store.get (transaction, tables::pending, key, value);
@@ -30,34 +30,34 @@ bool nano::pending_store_rocksdb::get (nano::transaction const & transaction, na
 	return result;
 }
 
-bool nano::pending_store_rocksdb::exists (nano::transaction const & transaction_a, nano::pending_key const & key_a)
+bool nano::rocksdb::pending_store::exists (nano::transaction const & transaction_a, nano::pending_key const & key_a)
 {
 	auto iterator (begin (transaction_a, key_a));
 	return iterator != end () && nano::pending_key (iterator->first) == key_a;
 }
 
-bool nano::pending_store_rocksdb::any (nano::transaction const & transaction_a, nano::account const & account_a)
+bool nano::rocksdb::pending_store::any (nano::transaction const & transaction_a, nano::account const & account_a)
 {
 	auto iterator (begin (transaction_a, nano::pending_key (account_a, 0)));
 	return iterator != end () && nano::pending_key (iterator->first).account == account_a;
 }
 
-nano::store_iterator<nano::pending_key, nano::pending_info> nano::pending_store_rocksdb::begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const
+nano::store_iterator<nano::pending_key, nano::pending_info> nano::rocksdb::pending_store::begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const
 {
 	return store.template make_iterator<nano::pending_key, nano::pending_info> (transaction_a, tables::pending, key_a);
 }
 
-nano::store_iterator<nano::pending_key, nano::pending_info> nano::pending_store_rocksdb::begin (nano::transaction const & transaction_a) const
+nano::store_iterator<nano::pending_key, nano::pending_info> nano::rocksdb::pending_store::begin (nano::transaction const & transaction_a) const
 {
 	return store.template make_iterator<nano::pending_key, nano::pending_info> (transaction_a, tables::pending);
 }
 
-nano::store_iterator<nano::pending_key, nano::pending_info> nano::pending_store_rocksdb::end () const
+nano::store_iterator<nano::pending_key, nano::pending_info> nano::rocksdb::pending_store::end () const
 {
 	return nano::store_iterator<nano::pending_key, nano::pending_info> (nullptr);
 }
 
-void nano::pending_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const
+void nano::rocksdb::pending_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint512_t> (
 	[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/pending_store.hpp
+++ b/nano/node/rocksdb/pending_store.hpp
@@ -5,21 +5,24 @@
 namespace nano
 {
 class rocksdb_store;
-class pending_store_rocksdb : public pending_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class pending_store : public nano::pending_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	explicit pending_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info const & pending_info_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::pending_key const & key_a) override;
-	bool get (nano::transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info & pending_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::pending_key const & key_a) override;
-	bool any (nano::transaction const & transaction_a, nano::account const & account_a) override;
-	nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const override;
-	nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::pending_key, nano::pending_info> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const override;
-};
+	public:
+		explicit pending_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info const & pending_info_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::pending_key const & key_a) override;
+		bool get (nano::transaction const & transaction_a, nano::pending_key const & key_a, nano::pending_info & pending_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::pending_key const & key_a) override;
+		bool any (nano::transaction const & transaction_a, nano::account const & account_a) override;
+		nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a, nano::pending_key const & key_a) const override;
+		nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::pending_key, nano::pending_info> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/rocksdb/pruned_store.cpp
+++ b/nano/node/rocksdb/pruned_store.cpp
@@ -1,27 +1,27 @@
 #include <nano/node/rocksdb/pruned_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::pruned_store_rocksdb::pruned_store_rocksdb (nano::rocksdb_store & store_a) :
+nano::rocksdb::pruned_store::pruned_store (nano::rocksdb_store & store_a) :
 	store{ store_a } {};
 
-void nano::pruned_store_rocksdb::put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
+void nano::rocksdb::pruned_store::put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto status = store.put_key (transaction_a, tables::pruned, hash_a);
 	release_assert_success (store, status);
 }
 
-void nano::pruned_store_rocksdb::del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
+void nano::rocksdb::pruned_store::del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto status = store.del (transaction_a, tables::pruned, hash_a);
 	release_assert_success (store, status);
 }
 
-bool nano::pruned_store_rocksdb::exists (nano::transaction const & transaction, nano::block_hash const & hash_a) const
+bool nano::rocksdb::pruned_store::exists (nano::transaction const & transaction, nano::block_hash const & hash_a) const
 {
 	return store.exists (transaction, tables::pruned, hash_a);
 }
 
-nano::block_hash nano::pruned_store_rocksdb::random (nano::transaction const & transaction)
+nano::block_hash nano::rocksdb::pruned_store::random (nano::transaction const & transaction)
 {
 	nano::block_hash random_hash;
 	nano::random_pool::generate_block (random_hash.bytes.data (), random_hash.bytes.size ());
@@ -33,33 +33,33 @@ nano::block_hash nano::pruned_store_rocksdb::random (nano::transaction const & t
 	return existing != end () ? existing->first : 0;
 }
 
-size_t nano::pruned_store_rocksdb::count (nano::transaction const & transaction_a) const
+size_t nano::rocksdb::pruned_store::count (nano::transaction const & transaction_a) const
 {
 	return store.count (transaction_a, tables::pruned);
 }
 
-void nano::pruned_store_rocksdb::clear (nano::write_transaction const & transaction_a)
+void nano::rocksdb::pruned_store::clear (nano::write_transaction const & transaction_a)
 {
 	auto status = store.drop (transaction_a, tables::pruned);
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::block_hash, std::nullptr_t> nano::pruned_store_rocksdb::begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
+nano::store_iterator<nano::block_hash, std::nullptr_t> nano::rocksdb::pruned_store::begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	return store.make_iterator<nano::block_hash, std::nullptr_t> (transaction_a, tables::pruned, hash_a);
 }
 
-nano::store_iterator<nano::block_hash, std::nullptr_t> nano::pruned_store_rocksdb::begin (nano::transaction const & transaction_a) const
+nano::store_iterator<nano::block_hash, std::nullptr_t> nano::rocksdb::pruned_store::begin (nano::transaction const & transaction_a) const
 {
 	return store.make_iterator<nano::block_hash, std::nullptr_t> (transaction_a, tables::pruned);
 }
 
-nano::store_iterator<nano::block_hash, std::nullptr_t> nano::pruned_store_rocksdb::end () const
+nano::store_iterator<nano::block_hash, std::nullptr_t> nano::rocksdb::pruned_store::end () const
 {
 	return nano::store_iterator<nano::block_hash, std::nullptr_t> (nullptr);
 }
 
-void nano::pruned_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const
+void nano::rocksdb::pruned_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (
 	[&action_a, this] (nano::uint256_t const & start, nano::uint256_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/pruned_store.hpp
+++ b/nano/node/rocksdb/pruned_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class rocksdb_store;
-class pruned_store_rocksdb : public pruned_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class pruned_store : public nano::pruned_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	explicit pruned_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::block_hash random (nano::transaction const & transaction_a) override;
-	size_t count (nano::transaction const & transaction_a) const override;
-	void clear (nano::write_transaction const & transaction_a) override;
-	nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::block_hash, std::nullptr_t> end () const override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const override;
-};
+	public:
+		explicit pruned_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::block_hash random (nano::transaction const & transaction_a) override;
+		size_t count (nano::transaction const & transaction_a) const override;
+		void clear (nano::write_transaction const & transaction_a) override;
+		nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+		nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::block_hash, std::nullptr_t> end () const override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -59,7 +59,7 @@ rocksdb_val::db_val (std::size_t size_a, void * data_a) :
 template <>
 void rocksdb_val::convert_buffer_to_value ()
 {
-	value = rocksdb::Slice (reinterpret_cast<char const *> (buffer->data ()), buffer->size ());
+	value = ::rocksdb::Slice (reinterpret_cast<char const *> (buffer->data ()), buffer->size ());
 }
 }
 
@@ -105,7 +105,7 @@ nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesyste
 	if (!error)
 	{
 		generate_tombstone_map ();
-		small_table_factory.reset (rocksdb::NewBlockBasedTableFactory (get_small_table_options ()));
+		small_table_factory.reset (::rocksdb::NewBlockBasedTableFactory (get_small_table_options ()));
 		if (!open_read_only_a)
 		{
 			construct_column_family_mutexes ();
@@ -116,7 +116,7 @@ nano::rocksdb_store::rocksdb_store (nano::logger_mt & logger_a, boost::filesyste
 
 std::unordered_map<char const *, nano::tables> nano::rocksdb_store::create_cf_name_table_map () const
 {
-	std::unordered_map<char const *, nano::tables> map{ { rocksdb::kDefaultColumnFamilyName.c_str (), tables::default_unused },
+	std::unordered_map<char const *, nano::tables> map{ { ::rocksdb::kDefaultColumnFamilyName.c_str (), tables::default_unused },
 		{ "frontiers", tables::frontiers },
 		{ "accounts", tables::accounts },
 		{ "blocks", tables::blocks },
@@ -138,18 +138,18 @@ void nano::rocksdb_store::open (bool & error_a, boost::filesystem::path const & 
 {
 	auto column_families = create_column_families ();
 	auto options = get_db_options ();
-	rocksdb::Status s;
+	::rocksdb::Status s;
 
-	std::vector<rocksdb::ColumnFamilyHandle *> handles_l;
+	std::vector<::rocksdb::ColumnFamilyHandle *> handles_l;
 	if (open_read_only_a)
 	{
-		rocksdb::DB * db_l;
-		s = rocksdb::DB::OpenForReadOnly (options, path_a.string (), column_families, &handles_l, &db_l);
+		::rocksdb::DB * db_l;
+		s = ::rocksdb::DB::OpenForReadOnly (options, path_a.string (), column_families, &handles_l, &db_l);
 		db.reset (db_l);
 	}
 	else
 	{
-		s = rocksdb::OptimisticTransactionDB::Open (options, path_a.string (), column_families, &handles_l, &optimistic_db);
+		s = ::rocksdb::OptimisticTransactionDB::Open (options, path_a.string (), column_families, &handles_l, &optimistic_db);
 		if (optimistic_db)
 		{
 			db.reset (optimistic_db);
@@ -185,9 +185,9 @@ void nano::rocksdb_store::generate_tombstone_map ()
 	tombstone_map.emplace (std::piecewise_construct, std::forward_as_tuple (nano::tables::pending), std::forward_as_tuple (0, 25000));
 }
 
-rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_common_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const
+rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_common_cf_options (std::shared_ptr<::rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const
 {
-	rocksdb::ColumnFamilyOptions cf_options;
+	::rocksdb::ColumnFamilyOptions cf_options;
 	cf_options.table_factory = table_factory_a;
 
 	// (1 active, 1 inactive)
@@ -219,12 +219,12 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_common_cf_options (std::sh
 
 rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_cf_options (std::string const & cf_name_a) const
 {
-	rocksdb::ColumnFamilyOptions cf_options;
+	::rocksdb::ColumnFamilyOptions cf_options;
 	auto const memtable_size_bytes = base_memtable_size_bytes ();
 	auto const block_cache_size_bytes = 1024ULL * 1024 * rocksdb_config.memory_multiplier * base_block_cache_size;
 	if (cf_name_a == "unchecked")
 	{
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 4)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 4)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 
 		// Create prefix bloom for memtable with the size of write_buffer_size * memtable_prefix_bloom_size_ratio
@@ -238,13 +238,13 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_cf_options (std::string co
 	}
 	else if (cf_name_a == "blocks")
 	{
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 4)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 4)));
 		cf_options = get_active_cf_options (table_factory, blocks_memtable_size_bytes ());
 	}
 	else if (cf_name_a == "confirmation_height")
 	{
 		// Entries will not be deleted in the normal case, so can make memtables a lot bigger
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes * 2);
 	}
 	else if (cf_name_a == "meta" || cf_name_a == "online_weight" || cf_name_a == "peers")
@@ -262,7 +262,7 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_cf_options (std::string co
 	else if (cf_name_a == "pending")
 	{
 		// Pending can have a lot of deletions too
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 
 		// Number of files in level 0 which triggers compaction. Size of L0 and L1 should be kept similar as this is the only compaction which is single threaded
@@ -274,32 +274,32 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_cf_options (std::string co
 	else if (cf_name_a == "frontiers")
 	{
 		// Frontiers is only needed during bootstrap for legacy blocks
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 	}
 	else if (cf_name_a == "accounts")
 	{
 		// Can have deletions from rollbacks
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 	}
 	else if (cf_name_a == "vote")
 	{
 		// No deletes it seems, only overwrites.
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 	}
 	else if (cf_name_a == "pruned")
 	{
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 	}
 	else if (cf_name_a == "final_votes")
 	{
-		std::shared_ptr<rocksdb::TableFactory> table_factory (rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
+		std::shared_ptr<::rocksdb::TableFactory> table_factory (::rocksdb::NewBlockBasedTableFactory (get_active_table_options (block_cache_size_bytes * 2)));
 		cf_options = get_active_cf_options (table_factory, memtable_size_bytes);
 	}
-	else if (cf_name_a == rocksdb::kDefaultColumnFamilyName)
+	else if (cf_name_a == ::rocksdb::kDefaultColumnFamilyName)
 	{
 		// Do nothing.
 	}
@@ -313,7 +313,7 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_cf_options (std::string co
 
 std::vector<rocksdb::ColumnFamilyDescriptor> nano::rocksdb_store::create_column_families ()
 {
-	std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
+	std::vector<::rocksdb::ColumnFamilyDescriptor> column_families;
 	for (auto & [cf_name, table] : cf_name_table_map)
 	{
 		(void)table;
@@ -397,15 +397,15 @@ rocksdb::ColumnFamilyHandle * nano::rocksdb_store::table_to_column_family (table
 
 bool nano::rocksdb_store::exists (nano::transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a) const
 {
-	rocksdb::PinnableSlice slice;
-	rocksdb::Status status;
+	::rocksdb::PinnableSlice slice;
+	::rocksdb::Status status;
 	if (is_read (transaction_a))
 	{
 		status = db->Get (snapshot_options (transaction_a), table_to_column_family (table_a), key_a, &slice);
 	}
 	else
 	{
-		rocksdb::ReadOptions options;
+		::rocksdb::ReadOptions options;
 		options.fill_cache = false;
 		status = tx (transaction_a)->Get (options, table_to_column_family (table_a), key_a, &slice);
 	}
@@ -439,21 +439,21 @@ void nano::rocksdb_store::flush_tombstones_check (tables table_a)
 
 void nano::rocksdb_store::flush_table (nano::tables table_a)
 {
-	db->Flush (rocksdb::FlushOptions{}, table_to_column_family (table_a));
+	db->Flush (::rocksdb::FlushOptions{}, table_to_column_family (table_a));
 }
 
 rocksdb::Transaction * nano::rocksdb_store::tx (nano::transaction const & transaction_a) const
 {
 	debug_assert (!is_read (transaction_a));
-	return static_cast<rocksdb::Transaction *> (transaction_a.get_handle ());
+	return static_cast<::rocksdb::Transaction *> (transaction_a.get_handle ());
 }
 
 int nano::rocksdb_store::get (nano::transaction const & transaction_a, tables table_a, nano::rocksdb_val const & key_a, nano::rocksdb_val & value_a) const
 {
-	rocksdb::ReadOptions options;
-	rocksdb::PinnableSlice slice;
+	::rocksdb::ReadOptions options;
+	::rocksdb::PinnableSlice slice;
 	auto handle = table_to_column_family (table_a);
-	rocksdb::Status status;
+	::rocksdb::Status status;
 	if (is_read (transaction_a))
 	{
 		status = db->Get (snapshot_options (transaction_a), handle, key_a, &slice);
@@ -486,12 +486,12 @@ bool nano::rocksdb_store::not_found (int status) const
 
 bool nano::rocksdb_store::success (int status) const
 {
-	return (static_cast<int> (rocksdb::Status::Code::kOk) == status);
+	return (static_cast<int> (::rocksdb::Status::Code::kOk) == status);
 }
 
 int nano::rocksdb_store::status_code_not_found () const
 {
-	return static_cast<int> (rocksdb::Status::Code::kNotFound);
+	return static_cast<int> (::rocksdb::Status::Code::kNotFound);
 }
 
 uint64_t nano::rocksdb_store::count (nano::transaction const & transaction_a, tables table_a) const
@@ -565,7 +565,7 @@ int nano::rocksdb_store::drop (nano::write_transaction const & transaction_a, ta
 	debug_assert (transaction_a.contains (table_a));
 	auto col = table_to_column_family (table_a);
 
-	int status = static_cast<int> (rocksdb::Status::Code::kOk);
+	int status = static_cast<int> (::rocksdb::Status::Code::kOk);
 	if (success (status))
 	{
 		// Dropping/Creating families like in node::ongoing_peer_clear can cause write stalls, just delete them manually.
@@ -587,7 +587,7 @@ int nano::rocksdb_store::drop (nano::write_transaction const & transaction_a, ta
 	return status;
 }
 
-int nano::rocksdb_store::clear (rocksdb::ColumnFamilyHandle * column_family)
+int nano::rocksdb_store::clear (::rocksdb::ColumnFamilyHandle * column_family)
 {
 	// Dropping completely removes the column
 	auto name = column_family->GetName ();
@@ -615,7 +615,7 @@ void nano::rocksdb_store::construct_column_family_mutexes ()
 
 rocksdb::Options nano::rocksdb_store::get_db_options ()
 {
-	rocksdb::Options db_options;
+	::rocksdb::Options db_options;
 	db_options.create_if_missing = true;
 	db_options.create_missing_column_families = true;
 
@@ -624,7 +624,7 @@ rocksdb::Options nano::rocksdb_store::get_db_options ()
 	db_options.memtable_whole_key_filtering = true;
 
 	// Sets the compaction priority
-	db_options.compaction_pri = rocksdb::CompactionPri::kMinOverlappingRatio;
+	db_options.compaction_pri = ::rocksdb::CompactionPri::kMinOverlappingRatio;
 
 	// Start aggressively flushing WAL files when they reach over 1GB
 	db_options.max_total_wal_size = 1 * 1024 * 1024 * 1024LL;
@@ -644,9 +644,9 @@ rocksdb::Options nano::rocksdb_store::get_db_options ()
 	db_options.max_manifest_file_size = 100 * 1024 * 1024ULL;
 
 	// Not compressing any SST files for compatibility reasons.
-	db_options.compression = rocksdb::kNoCompression;
+	db_options.compression = ::rocksdb::kNoCompression;
 
-	auto event_listener_l = new event_listener ([this] (rocksdb::FlushJobInfo const & flush_job_info_a) { this->on_flush (flush_job_info_a); });
+	auto event_listener_l = new event_listener ([this] (::rocksdb::FlushJobInfo const & flush_job_info_a) { this->on_flush (flush_job_info_a); });
 	db_options.listeners.emplace_back (event_listener_l);
 
 	return db_options;
@@ -654,10 +654,10 @@ rocksdb::Options nano::rocksdb_store::get_db_options ()
 
 rocksdb::BlockBasedTableOptions nano::rocksdb_store::get_active_table_options (std::size_t lru_size) const
 {
-	rocksdb::BlockBasedTableOptions table_options;
+	::rocksdb::BlockBasedTableOptions table_options;
 
 	// Improve point lookup performance be using the data block hash index (uses about 5% more space).
-	table_options.data_block_index_type = rocksdb::BlockBasedTableOptions::DataBlockIndexType::kDataBlockBinaryAndHash;
+	table_options.data_block_index_type = ::rocksdb::BlockBasedTableOptions::DataBlockIndexType::kDataBlockBinaryAndHash;
 	table_options.data_block_hash_table_util_ratio = 0.75;
 
 	// Using format_version=4 significantly reduces the index block size, in some cases around 4-5x.
@@ -667,10 +667,10 @@ rocksdb::BlockBasedTableOptions nano::rocksdb_store::get_active_table_options (s
 	table_options.index_block_restart_interval = 16;
 
 	// Block cache for reads
-	table_options.block_cache = rocksdb::NewLRUCache (lru_size);
+	table_options.block_cache = ::rocksdb::NewLRUCache (lru_size);
 
 	// Bloom filter to help with point reads. 10bits gives 1% false positive rate.
-	table_options.filter_policy.reset (rocksdb::NewBloomFilterPolicy (10, false));
+	table_options.filter_policy.reset (::rocksdb::NewBloomFilterPolicy (10, false));
 
 	// Increasing block_size decreases memory usage and space amplification, but increases read amplification.
 	table_options.block_size = 16 * 1024ULL;
@@ -683,15 +683,15 @@ rocksdb::BlockBasedTableOptions nano::rocksdb_store::get_active_table_options (s
 
 rocksdb::BlockBasedTableOptions nano::rocksdb_store::get_small_table_options () const
 {
-	rocksdb::BlockBasedTableOptions table_options;
+	::rocksdb::BlockBasedTableOptions table_options;
 	// Improve point lookup performance be using the data block hash index (uses about 5% more space).
-	table_options.data_block_index_type = rocksdb::BlockBasedTableOptions::DataBlockIndexType::kDataBlockBinaryAndHash;
+	table_options.data_block_index_type = ::rocksdb::BlockBasedTableOptions::DataBlockIndexType::kDataBlockBinaryAndHash;
 	table_options.data_block_hash_table_util_ratio = 0.75;
 	table_options.block_size = 1024ULL;
 	return table_options;
 }
 
-rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_small_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a) const
+rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_small_cf_options (std::shared_ptr<::rocksdb::TableFactory> const & table_factory_a) const
 {
 	auto const memtable_size_bytes = 10000;
 	auto cf_options = get_common_cf_options (table_factory_a, memtable_size_bytes);
@@ -705,7 +705,7 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_small_cf_options (std::sha
 	return cf_options;
 }
 
-rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_active_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const
+::rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_active_cf_options (std::shared_ptr<::rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const
 {
 	auto cf_options = get_common_cf_options (table_factory_a, memtable_size_bytes_a);
 
@@ -721,7 +721,7 @@ rocksdb::ColumnFamilyOptions nano::rocksdb_store::get_active_cf_options (std::sh
 	return cf_options;
 }
 
-void nano::rocksdb_store::on_flush (rocksdb::FlushJobInfo const & flush_job_info_a)
+void nano::rocksdb_store::on_flush (::rocksdb::FlushJobInfo const & flush_job_info_a)
 {
 	// Reset appropriate tombstone counters
 	if (auto it = tombstone_map.find (cf_name_table_map[flush_job_info_a.cf_name.c_str ()]); it != tombstone_map.end ())
@@ -737,16 +737,16 @@ std::vector<nano::tables> nano::rocksdb_store::all_tables () const
 
 bool nano::rocksdb_store::copy_db (boost::filesystem::path const & destination_path)
 {
-	std::unique_ptr<rocksdb::BackupEngine> backup_engine;
+	std::unique_ptr<::rocksdb::BackupEngine> backup_engine;
 	{
-		rocksdb::BackupEngine * backup_engine_raw;
-		rocksdb::BackupableDBOptions backup_options (destination_path.string ());
+		::rocksdb::BackupEngine * backup_engine_raw;
+		::rocksdb::BackupableDBOptions backup_options (destination_path.string ());
 		// Use incremental backups (default)
 		backup_options.share_table_files = true;
 
 		// Increase number of threads used for copying
 		backup_options.max_background_operations = std::thread::hardware_concurrency ();
-		auto status = rocksdb::BackupEngine::Open (rocksdb::Env::Default (), backup_options, &backup_engine_raw);
+		auto status = ::rocksdb::BackupEngine::Open (::rocksdb::Env::Default (), backup_options, &backup_engine_raw);
 		backup_engine.reset (backup_engine_raw);
 		if (!status.ok ())
 		{
@@ -760,7 +760,7 @@ bool nano::rocksdb_store::copy_db (boost::filesystem::path const & destination_p
 		return false;
 	}
 
-	std::vector<rocksdb::BackupInfo> backup_infos;
+	std::vector<::rocksdb::BackupInfo> backup_infos;
 	backup_engine->GetBackupInfo (&backup_infos);
 
 	for (auto const & backup_info : backup_infos)
@@ -773,10 +773,10 @@ bool nano::rocksdb_store::copy_db (boost::filesystem::path const & destination_p
 	}
 
 	{
-		std::unique_ptr<rocksdb::BackupEngineReadOnly> backup_engine_read;
+		std::unique_ptr<::rocksdb::BackupEngineReadOnly> backup_engine_read;
 		{
-			rocksdb::BackupEngineReadOnly * backup_engine_read_raw;
-			status = rocksdb::BackupEngineReadOnly::Open (rocksdb::Env::Default (), rocksdb::BackupableDBOptions (destination_path.string ()), &backup_engine_read_raw);
+			::rocksdb::BackupEngineReadOnly * backup_engine_read_raw;
+			status = ::rocksdb::BackupEngineReadOnly::Open (::rocksdb::Env::Default (), ::rocksdb::BackupableDBOptions (destination_path.string ()), &backup_engine_read_raw);
 		}
 		if (!status.ok ())
 		{
@@ -820,45 +820,45 @@ void nano::rocksdb_store::serialize_memory_stats (boost::property_tree::ptree & 
 	uint64_t val;
 
 	// Approximate size of active and unflushed immutable memtables (bytes).
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kCurSizeAllMemTables, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kCurSizeAllMemTables, &val);
 	json.put ("cur-size-all-mem-tables", val);
 
 	// Approximate size of active, unflushed immutable, and pinned immutable memtables (bytes).
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kSizeAllMemTables, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kSizeAllMemTables, &val);
 	json.put ("size-all-mem-tables", val);
 
 	// Estimated memory used for reading SST tables, excluding memory used in block cache (e.g. filter and index blocks).
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateTableReadersMem, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kEstimateTableReadersMem, &val);
 	json.put ("estimate-table-readers-mem", val);
 
 	//  An estimate of the amount of live data in bytes.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateLiveDataSize, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kEstimateLiveDataSize, &val);
 	json.put ("estimate-live-data-size", val);
 
 	//  Returns 1 if at least one compaction is pending; otherwise, returns 0.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kCompactionPending, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kCompactionPending, &val);
 	json.put ("compaction-pending", val);
 
 	// Estimated number of total keys in the active and unflushed immutable memtables and storage.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimateNumKeys, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kEstimateNumKeys, &val);
 	json.put ("estimate-num-keys", val);
 
 	// Estimated total number of bytes compaction needs to rewrite to get all levels down
 	// to under target size. Not valid for other compactions than level-based.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kEstimatePendingCompactionBytes, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kEstimatePendingCompactionBytes, &val);
 	json.put ("estimate-pending-compaction-bytes", val);
 
 	//  Total size (bytes) of all SST files.
 	//  WARNING: may slow down online queries if there are too many files.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kTotalSstFilesSize, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kTotalSstFilesSize, &val);
 	json.put ("total-sst-files-size", val);
 
 	// Block cache capacity.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kBlockCacheCapacity, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kBlockCacheCapacity, &val);
 	json.put ("block-cache-capacity", val);
 
 	// Memory size for the entries residing in block cache.
-	db->GetAggregatedIntProperty (rocksdb::DB::Properties::kBlockCacheUsage, &val);
+	db->GetAggregatedIntProperty (::rocksdb::DB::Properties::kBlockCacheUsage, &val);
 	json.put ("block-cache-usage", val);
 }
 

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -38,30 +38,30 @@ class rocksdb_store;
 class rocksdb_store : public store_partial<::rocksdb::Slice, rocksdb_store>
 {
 private:
-	nano::block_store_rocksdb block_store;
-	nano::frontier_store_rocksdb frontier_store;
-	nano::account_store_rocksdb account_store;
-	nano::confirmation_height_store_rocksdb confirmation_height_store;
-	nano::pending_store_rocksdb pending_store;
-	nano::unchecked_store_rocksdb unchecked_store;
-	nano::online_weight_store_rocksdb online_weight_store;
-	nano::pruned_store_rocksdb pruned_store;
-	nano::peer_store_rocksdb peer_store;
-	nano::final_vote_store_rocksdb final_vote_store;
-	nano::version_store_rocksdb version_store;
+	nano::rocksdb::account_store account_store;
+	nano::rocksdb::block_store block_store;
+	nano::rocksdb::confirmation_height_store confirmation_height_store;
+	nano::rocksdb::final_vote_store final_vote_store;
+	nano::rocksdb::frontier_store frontier_store;
+	nano::rocksdb::online_weight_store online_weight_store;
+	nano::rocksdb::peer_store peer_store;
+	nano::rocksdb::pending_store pending_store;
+	nano::rocksdb::pruned_store pruned_store;
+	nano::rocksdb::unchecked_store unchecked_store;
+	nano::rocksdb::version_store version_store;
 
 public:
-	friend class nano::account_store_rocksdb;
-	friend class nano::block_store_rocksdb;
-	friend class nano::confirmation_height_store_rocksdb;
-	friend class nano::frontier_store_rocksdb;
-	friend class nano::final_vote_store_rocksdb;
-	friend class nano::online_weight_store_rocksdb;
-	friend class nano::peer_store_rocksdb;
-	friend class nano::pending_store_rocksdb;
-	friend class nano::pruned_store_rocksdb;
-	friend class nano::unchecked_store_rocksdb;
-	friend class nano::version_store_rocksdb;
+	friend class nano::rocksdb::account_store;
+	friend class nano::rocksdb::block_store;
+	friend class nano::rocksdb::confirmation_height_store;
+	friend class nano::rocksdb::final_vote_store;
+	friend class nano::rocksdb::frontier_store;
+	friend class nano::rocksdb::online_weight_store;
+	friend class nano::rocksdb::peer_store;
+	friend class nano::rocksdb::pending_store;
+	friend class nano::rocksdb::pruned_store;
+	friend class nano::rocksdb::unchecked_store;
+	friend class nano::rocksdb::version_store;
 
 	explicit rocksdb_store (nano::logger_mt &, boost::filesystem::path const &, nano::ledger_constants & constants, nano::rocksdb_config const & = nano::rocksdb_config{}, bool open_read_only = false);
 

--- a/nano/node/rocksdb/rocksdb.hpp
+++ b/nano/node/rocksdb/rocksdb.hpp
@@ -35,7 +35,7 @@ class rocksdb_store;
 /**
  * rocksdb implementation of the block store
  */
-class rocksdb_store : public store_partial<rocksdb::Slice, rocksdb_store>
+class rocksdb_store : public store_partial<::rocksdb::Slice, rocksdb_store>
 {
 private:
 	nano::block_store_rocksdb block_store;
@@ -105,10 +105,10 @@ private:
 	nano::logger_mt & logger;
 	nano::ledger_constants & constants;
 	// Optimistic transactions are used in write mode
-	rocksdb::OptimisticTransactionDB * optimistic_db = nullptr;
-	std::unique_ptr<rocksdb::DB> db;
-	std::vector<std::unique_ptr<rocksdb::ColumnFamilyHandle>> handles;
-	std::shared_ptr<rocksdb::TableFactory> small_table_factory;
+	::rocksdb::OptimisticTransactionDB * optimistic_db = nullptr;
+	std::unique_ptr<::rocksdb::DB> db;
+	std::vector<std::unique_ptr<::rocksdb::ColumnFamilyHandle>> handles;
+	std::shared_ptr<::rocksdb::TableFactory> small_table_factory;
 	std::unordered_map<nano::tables, nano::mutex> write_lock_mutexes;
 	nano::rocksdb_config rocksdb_config;
 	unsigned const max_block_write_batch_num_m;
@@ -124,7 +124,7 @@ private:
 	std::unordered_map<nano::tables, tombstone_info> tombstone_map;
 	std::unordered_map<char const *, nano::tables> cf_name_table_map;
 
-	rocksdb::Transaction * tx (nano::transaction const & transaction_a) const;
+	::rocksdb::Transaction * tx (nano::transaction const & transaction_a) const;
 	std::vector<nano::tables> all_tables () const;
 
 	bool not_found (int status) const override;
@@ -132,27 +132,27 @@ private:
 	int status_code_not_found () const override;
 	int drop (nano::write_transaction const &, tables) override;
 
-	rocksdb::ColumnFamilyHandle * table_to_column_family (tables table_a) const;
-	int clear (rocksdb::ColumnFamilyHandle * column_family);
+	::rocksdb::ColumnFamilyHandle * table_to_column_family (tables table_a) const;
+	int clear (::rocksdb::ColumnFamilyHandle * column_family);
 
 	void open (bool & error_a, boost::filesystem::path const & path_a, bool open_read_only_a);
 
 	void construct_column_family_mutexes ();
-	rocksdb::Options get_db_options ();
-	rocksdb::ColumnFamilyOptions get_common_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const;
-	rocksdb::ColumnFamilyOptions get_active_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const;
-	rocksdb::ColumnFamilyOptions get_small_cf_options (std::shared_ptr<rocksdb::TableFactory> const & table_factory_a) const;
-	rocksdb::BlockBasedTableOptions get_active_table_options (std::size_t lru_size) const;
-	rocksdb::BlockBasedTableOptions get_small_table_options () const;
-	rocksdb::ColumnFamilyOptions get_cf_options (std::string const & cf_name_a) const;
+	::rocksdb::Options get_db_options ();
+	::rocksdb::ColumnFamilyOptions get_common_cf_options (std::shared_ptr<::rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const;
+	::rocksdb::ColumnFamilyOptions get_active_cf_options (std::shared_ptr<::rocksdb::TableFactory> const & table_factory_a, unsigned long long memtable_size_bytes_a) const;
+	::rocksdb::ColumnFamilyOptions get_small_cf_options (std::shared_ptr<::rocksdb::TableFactory> const & table_factory_a) const;
+	::rocksdb::BlockBasedTableOptions get_active_table_options (std::size_t lru_size) const;
+	::rocksdb::BlockBasedTableOptions get_small_table_options () const;
+	::rocksdb::ColumnFamilyOptions get_cf_options (std::string const & cf_name_a) const;
 
-	void on_flush (rocksdb::FlushJobInfo const &);
+	void on_flush (::rocksdb::FlushJobInfo const &);
 	void flush_table (nano::tables table_a);
 	void flush_tombstones_check (nano::tables table_a);
 	void generate_tombstone_map ();
 	std::unordered_map<char const *, nano::tables> create_cf_name_table_map () const;
 
-	std::vector<rocksdb::ColumnFamilyDescriptor> create_column_families ();
+	std::vector<::rocksdb::ColumnFamilyDescriptor> create_column_families ();
 	unsigned long long base_memtable_size_bytes () const;
 	unsigned long long blocks_memtable_size_bytes () const;
 
@@ -162,5 +162,5 @@ private:
 	friend class rocksdb_block_store_tombstone_count_Test;
 };
 
-extern template class store_partial<rocksdb::Slice, rocksdb_store>;
+extern template class store_partial<::rocksdb::Slice, rocksdb_store>;
 }

--- a/nano/node/rocksdb/rocksdb_iterator.hpp
+++ b/nano/node/rocksdb/rocksdb_iterator.hpp
@@ -25,7 +25,7 @@ inline rocksdb::ReadOptions & snapshot_options (nano::transaction const & transa
 
 namespace nano
 {
-using rocksdb_val = db_val<rocksdb::Slice>;
+using rocksdb_val = db_val<::rocksdb::Slice>;
 
 template <typename T, typename U>
 class rocksdb_iterator : public store_iterator_impl<T, U>
@@ -33,7 +33,7 @@ class rocksdb_iterator : public store_iterator_impl<T, U>
 public:
 	rocksdb_iterator () = default;
 
-	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a, rocksdb_val const * val_a, bool const direction_asc)
+	rocksdb_iterator (::rocksdb::DB * db, nano::transaction const & transaction_a, ::rocksdb::ColumnFamilyHandle * handle_a, rocksdb_val const * val_a, bool const direction_asc)
 	{
 		// Don't fill the block cache for any blocks read as a result of an iterator
 		if (is_read (transaction_a))
@@ -44,7 +44,7 @@ public:
 		}
 		else
 		{
-			rocksdb::ReadOptions ropts;
+			::rocksdb::ReadOptions ropts;
 			ropts.fill_cache = false;
 			cursor.reset (tx (transaction_a)->GetIterator (ropts, handle_a));
 		}
@@ -73,7 +73,7 @@ public:
 		}
 	}
 
-	rocksdb_iterator (rocksdb::DB * db, nano::transaction const & transaction_a, rocksdb::ColumnFamilyHandle * handle_a) :
+	rocksdb_iterator (::rocksdb::DB * db, nano::transaction const & transaction_a, ::rocksdb::ColumnFamilyHandle * handle_a) :
 		rocksdb_iterator (db, transaction_a, handle_a, nullptr)
 	{
 	}
@@ -194,13 +194,13 @@ public:
 	}
 	nano::store_iterator_impl<T, U> & operator= (nano::store_iterator_impl<T, U> const &) = delete;
 
-	std::unique_ptr<rocksdb::Iterator> cursor;
+	std::unique_ptr<::rocksdb::Iterator> cursor;
 	std::pair<nano::rocksdb_val, nano::rocksdb_val> current;
 
 private:
-	rocksdb::Transaction * tx (nano::transaction const & transaction_a) const
+	::rocksdb::Transaction * tx (nano::transaction const & transaction_a) const
 	{
-		return static_cast<rocksdb::Transaction *> (transaction_a.get_handle ());
+		return static_cast<::rocksdb::Transaction *> (transaction_a.get_handle ());
 	}
 };
 }

--- a/nano/node/rocksdb/rocksdb_txn.hpp
+++ b/nano/node/rocksdb/rocksdb_txn.hpp
@@ -14,21 +14,21 @@ namespace nano
 class read_rocksdb_txn final : public read_transaction_impl
 {
 public:
-	read_rocksdb_txn (rocksdb::DB * db);
+	read_rocksdb_txn (::rocksdb::DB * db);
 	~read_rocksdb_txn ();
 	void reset () override;
 	void renew () override;
 	void * get_handle () const override;
 
 private:
-	rocksdb::DB * db;
-	rocksdb::ReadOptions options;
+	::rocksdb::DB * db;
+	::rocksdb::ReadOptions options;
 };
 
 class write_rocksdb_txn final : public write_transaction_impl
 {
 public:
-	write_rocksdb_txn (rocksdb::OptimisticTransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a);
+	write_rocksdb_txn (::rocksdb::OptimisticTransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a);
 	~write_rocksdb_txn ();
 	void commit () override;
 	void renew () override;
@@ -36,8 +36,8 @@ public:
 	bool contains (nano::tables table_a) const override;
 
 private:
-	rocksdb::Transaction * txn;
-	rocksdb::OptimisticTransactionDB * db;
+	::rocksdb::Transaction * txn;
+	::rocksdb::OptimisticTransactionDB * db;
 	std::vector<nano::tables> tables_requiring_locks;
 	std::vector<nano::tables> tables_no_locks;
 	std::unordered_map<nano::tables, nano::mutex> & mutexes;

--- a/nano/node/rocksdb/unchecked_store.cpp
+++ b/nano/node/rocksdb/unchecked_store.cpp
@@ -1,22 +1,22 @@
 #include <nano/node/lmdb/unchecked_store.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
 
-nano::unchecked_store_rocksdb::unchecked_store_rocksdb (nano::rocksdb_store & store_a) :
+nano::rocksdb::unchecked_store::unchecked_store (nano::rocksdb_store & store_a) :
 	store (store_a){};
 
-void nano::unchecked_store_rocksdb::clear (nano::write_transaction const & transaction_a)
+void nano::rocksdb::unchecked_store::clear (nano::write_transaction const & transaction_a)
 {
 	auto status = store.drop (transaction_a, tables::unchecked);
 	release_assert_success (store, status);
 }
 
-void nano::unchecked_store_rocksdb::put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info)
+void nano::rocksdb::unchecked_store::put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info)
 {
 	auto status = store.put (transaction_a, tables::unchecked, nano::unchecked_key{ dependency, info.block->hash () }, info);
 	release_assert_success (store, status);
 }
 
-bool nano::unchecked_store_rocksdb::exists (nano::transaction const & transaction_a, nano::unchecked_key const & key)
+bool nano::rocksdb::unchecked_store::exists (nano::transaction const & transaction_a, nano::unchecked_key const & key)
 {
 	nano::rocksdb_val value;
 	auto status = store.get (transaction_a, tables::unchecked, key, value);
@@ -24,33 +24,33 @@ bool nano::unchecked_store_rocksdb::exists (nano::transaction const & transactio
 	return store.success (status);
 }
 
-void nano::unchecked_store_rocksdb::del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a)
+void nano::rocksdb::unchecked_store::del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a)
 {
 	auto status (store.del (transaction_a, tables::unchecked, key_a));
 	release_assert_success (store, status);
 }
 
-nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::unchecked_store_rocksdb::end () const
+nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::rocksdb::unchecked_store::end () const
 {
 	return nano::store_iterator<nano::unchecked_key, nano::unchecked_info> (nullptr);
 }
 
-nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::unchecked_store_rocksdb::begin (nano::transaction const & transaction) const
+nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::rocksdb::unchecked_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction, tables::unchecked);
 }
 
-nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::unchecked_store_rocksdb::lower_bound (nano::transaction const & transaction, nano::unchecked_key const & key) const
+nano::store_iterator<nano::unchecked_key, nano::unchecked_info> nano::rocksdb::unchecked_store::lower_bound (nano::transaction const & transaction, nano::unchecked_key const & key) const
 {
 	return store.make_iterator<nano::unchecked_key, nano::unchecked_info> (transaction, tables::unchecked, key);
 }
 
-size_t nano::unchecked_store_rocksdb::count (nano::transaction const & transaction_a)
+size_t nano::rocksdb::unchecked_store::count (nano::transaction const & transaction_a)
 {
 	return store.count (transaction_a, tables::unchecked);
 }
 
-void nano::unchecked_store_rocksdb::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const
+void nano::rocksdb::unchecked_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const
 {
 	parallel_traversal<nano::uint512_t> (
 	[&action_a, this] (nano::uint512_t const & start, nano::uint512_t const & end, bool const is_last) {

--- a/nano/node/rocksdb/unchecked_store.hpp
+++ b/nano/node/rocksdb/unchecked_store.hpp
@@ -5,22 +5,25 @@
 namespace nano
 {
 class mdb_store;
-class unchecked_store_rocksdb : public unchecked_store
+namespace rocksdb
 {
-private:
-	nano::rocksdb_store & store;
+	class unchecked_store : public nano::unchecked_store
+	{
+	private:
+		nano::rocksdb_store & store;
 
-public:
-	unchecked_store_rocksdb (nano::rocksdb_store & store_a);
+	public:
+		unchecked_store (nano::rocksdb_store & store_a);
 
-	void clear (nano::write_transaction const & transaction_a) override;
-	void put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info_a) override;
-	bool exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override;
-	void del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override;
-	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> end () const override;
-	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> begin (nano::transaction const & transaction_a) const override;
-	nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
-	size_t count (nano::transaction const & transaction_a) override;
-	void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
-};
+		void clear (nano::write_transaction const & transaction_a) override;
+		void put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info_a) override;
+		bool exists (nano::transaction const & transaction_a, nano::unchecked_key const & unchecked_key_a) override;
+		void del (nano::write_transaction const & transaction_a, nano::unchecked_key const & key_a) override;
+		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> end () const override;
+		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> begin (nano::transaction const & transaction_a) const override;
+		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
+		size_t count (nano::transaction const & transaction_a) override;
+		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
+	};
+}
 }

--- a/nano/node/rocksdb/version_store.cpp
+++ b/nano/node/rocksdb/version_store.cpp
@@ -1,10 +1,10 @@
 #include <nano/node/rocksdb/rocksdb.hpp>
 #include <nano/node/rocksdb/version_store.hpp>
 
-nano::version_store_rocksdb::version_store_rocksdb (nano::rocksdb_store & store_a) :
+nano::rocksdb::version_store::version_store (nano::rocksdb_store & store_a) :
 	store{ store_a } {};
 
-void nano::version_store_rocksdb::put (nano::write_transaction const & transaction_a, int version)
+void nano::rocksdb::version_store::put (nano::write_transaction const & transaction_a, int version)
 {
 	nano::uint256_union version_key{ 1 };
 	nano::uint256_union version_value (version);
@@ -12,7 +12,7 @@ void nano::version_store_rocksdb::put (nano::write_transaction const & transacti
 	release_assert_success (store, status);
 }
 
-int nano::version_store_rocksdb::get (nano::transaction const & transaction_a) const
+int nano::rocksdb::version_store::get (nano::transaction const & transaction_a) const
 {
 	nano::uint256_union version_key{ 1 };
 	nano::rocksdb_val data;

--- a/nano/node/rocksdb/version_store.hpp
+++ b/nano/node/rocksdb/version_store.hpp
@@ -5,14 +5,17 @@
 namespace nano
 {
 class rocksdb_store;
-class version_store_rocksdb : public version_store
+namespace rocksdb
 {
-protected:
-	nano::rocksdb_store & store;
+	class version_store : public nano::version_store
+	{
+	protected:
+		nano::rocksdb_store & store;
 
-public:
-	explicit version_store_rocksdb (nano::rocksdb_store & store_a);
-	void put (nano::write_transaction const & transaction_a, int version_a) override;
-	int get (nano::transaction const & transaction_a) const override;
-};
+	public:
+		explicit version_store (nano::rocksdb_store & store_a);
+		void put (nano::write_transaction const & transaction_a, int version_a) override;
+		int get (nano::transaction const & transaction_a) const override;
+	};
+}
 }


### PR DESCRIPTION
This change forces classes under the nano namespace to use a global scope when referencing rocksdb library functions. This allows rocksdb to be used as a namespace under the nano namespace.