### PR TITLE
Adding details to the DB commit () release_asserts

### DIFF
--- a/nano/node/lmdb/lmdb_txn.cpp
+++ b/nano/node/lmdb/lmdb_txn.cpp
@@ -99,8 +99,11 @@ void nano::write_mdb_txn::commit ()
 {
 	if (active)
 	{
-		auto status (mdb_txn_commit (handle));
-		release_assert (status == MDB_SUCCESS, mdb_strerror (status));
+		auto status = mdb_txn_commit (handle);
+		if (status != MDB_SUCCESS)
+		{
+			release_assert (false && "Unable to write to the LMDB database", mdb_strerror (status));
+		}
 		txn_callbacks.txn_end (this);
 		active = false;
 	}

--- a/nano/node/rocksdb/rocksdb_txn.cpp
+++ b/nano/node/rocksdb/rocksdb_txn.cpp
@@ -66,7 +66,10 @@ void nano::write_rocksdb_txn::commit ()
 			++attempt_num;
 		}
 
-		release_assert (status.ok (), status.ToString ());
+		if (!status.ok ())
+		{
+			release_assert (false && "Unable to write to the RocksDB database", status.ToString ());
+		}
 		active = false;
 	}
 }


### PR DESCRIPTION
Just adds complementary info to the assertions. They will fail in case of the disk getting out of space.

Partially address: https://github.com/nanocurrency/nano-node/issues/3552