### PR TITLE
Moves the LDMB table handles to their respective type of store class

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1326,7 +1326,7 @@ namespace lmdb
 			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "accounts_v1", MDB_CREATE,
 			&store.account_store.accounts_v1_handle));
 			ASSERT_FALSE (
-			mdb_dbi_open (store.env.tx (transaction), "pending_v1", MDB_CREATE, &store.pending_v1_handle));
+			mdb_dbi_open (store.env.tx (transaction), "pending_v1", MDB_CREATE, &store.pending_store.pending_v1_handle));
 			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.open_blocks_handle));
 			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "send", MDB_CREATE, &store.send_blocks_handle));
 			ASSERT_FALSE (
@@ -1353,13 +1353,13 @@ namespace lmdb
 			store.block.del (transaction, epoch.hash ());
 
 			// Turn pending into v14
-			ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v0_handle,
+			ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_store.pending_v0_handle,
 			nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, send.hash ())),
 			nano::mdb_val (
 			nano::pending_info_v14 (nano::dev::genesis->account (), nano::Gxrb_ratio,
 			nano::epoch::epoch_0)),
 			0));
-			ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_v1_handle,
+			ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_store.pending_v1_handle,
 			nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send.hash ())),
 			nano::mdb_val (
 			nano::pending_info_v14 (nano::dev::genesis->account (), nano::Gxrb_ratio,
@@ -1404,7 +1404,7 @@ namespace lmdb
 		auto error_get_accounts_v1 (mdb_get (store.env.tx (transaction), store.account_store.accounts_v1_handle,
 		nano::mdb_val (nano::dev::genesis->account ()), value));
 		ASSERT_NE (error_get_accounts_v1, MDB_SUCCESS);
-		auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_v1_handle, nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send.hash ())), value));
+		auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_store.pending_v1_handle, nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send.hash ())), value));
 		ASSERT_NE (error_get_pending_v1, MDB_SUCCESS);
 		auto error_get_state_v1 (
 		mdb_get (store.env.tx (transaction), store.state_blocks_v1_handle, nano::mdb_val (state_send.hash ()),

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1375,7 +1375,7 @@ namespace lmdb
 			store.account.del (transaction, nano::dev::genesis->account ());
 
 			// Confirmation height for the account should be deleted
-			ASSERT_TRUE (mdb_get (store.env.tx (transaction), store.confirmation_height_handle,
+			ASSERT_TRUE (mdb_get (store.env.tx (transaction), store.confirmation_height_store.confirmation_height_handle,
 			nano::mdb_val (nano::dev::genesis->account ()), value));
 		}
 
@@ -2191,7 +2191,7 @@ namespace lmdb
 
 	void modify_confirmation_height_to_v15 (nano::lmdb::store & store, nano::transaction const & transaction, nano::account const & account, uint64_t confirmation_height)
 	{
-		auto status (mdb_put (store.env.tx (transaction), store.confirmation_height_handle, nano::mdb_val (account), nano::mdb_val (confirmation_height), 0));
+		auto status (mdb_put (store.env.tx (transaction), store.confirmation_height_store.confirmation_height_handle, nano::mdb_val (account), nano::mdb_val (confirmation_height), 0));
 		ASSERT_EQ (status, 0);
 	}
 }

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -965,30 +965,36 @@ TEST (block_store, pruned_random)
 	ASSERT_EQ (hash1, random_hash);
 }
 
-// Databases need to be dropped in order to convert to dupsort compatible
-TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort table
+namespace nano
 {
-	auto path (nano::unique_path ());
-	nano::logger_mt logger{};
-	nano::lmdb::store store{ logger, path, nano::dev::constants };
-	nano::unchecked_map unchecked{ store, false };
-	auto transaction (store.tx_begin_write ());
-	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 1));
-	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked_handle));
-	std::shared_ptr<nano::block> send1 = std::make_shared<nano::send_block> (0, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
-	std::shared_ptr<nano::block> send2 = std::make_shared<nano::send_block> (1, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
-	ASSERT_NE (send1->hash (), send2->hash ());
-	unchecked.put (send1->hash (), send1);
-	unchecked.put (send1->hash (), send2);
-	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 0));
-	mdb_dbi_close (store.env, store.unchecked_handle);
-	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_handle));
-	unchecked.put (send1->hash (), send1);
-	unchecked.put (send1->hash (), send2);
-	ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_handle, 1));
-	ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_handle));
-	unchecked.put (send1->hash (), send1);
-	unchecked.put (send1->hash (), send2);
+namespace lmdb
+{
+	// Databases need to be dropped in order to convert to dupsort compatible
+	TEST (block_store, DISABLED_change_dupsort) // Unchecked is no longer dupsort table
+	{
+		auto path (nano::unique_path ());
+		nano::logger_mt logger{};
+		nano::lmdb::store store{ logger, path, nano::dev::constants };
+		nano::unchecked_map unchecked{ store, false };
+		auto transaction (store.tx_begin_write ());
+		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_store.unchecked_handle, 1));
+		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked_store.unchecked_handle));
+		std::shared_ptr<nano::block> send1 = std::make_shared<nano::send_block> (0, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		std::shared_ptr<nano::block> send2 = std::make_shared<nano::send_block> (1, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		ASSERT_NE (send1->hash (), send2->hash ());
+		unchecked.put (send1->hash (), send1);
+		unchecked.put (send1->hash (), send2);
+		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_store.unchecked_handle, 0));
+		mdb_dbi_close (store.env, store.unchecked_store.unchecked_handle);
+		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_store.unchecked_handle));
+		unchecked.put (send1->hash (), send1);
+		unchecked.put (send1->hash (), send2);
+		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_store.unchecked_handle, 1));
+		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_store.unchecked_handle));
+		unchecked.put (send1->hash (), send1);
+		unchecked.put (send1->hash (), send2);
+	}
+}
 }
 
 TEST (block_store, state_block)

--- a/nano/node/lmdb/account_store.hpp
+++ b/nano/node/lmdb/account_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -24,6 +26,30 @@ namespace lmdb
 		nano::store_iterator<nano::account, nano::account_info> rbegin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::account, nano::account_info> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::account_info>, nano::store_iterator<nano::account, nano::account_info>)> const & action_a) const override;
+
+		/**
+		 * Maps account v1 to account information, head, rep, open, balance, timestamp and block count. (Removed)
+		 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
+		 */
+		MDB_dbi accounts_v0_handle{ 0 };
+
+		/**
+		 * Maps account v0 to account information, head, rep, open, balance, timestamp and block count. (Removed)
+		 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
+		 */
+		MDB_dbi accounts_v1_handle{ 0 };
+
+		/**
+		 * Maps account v0 to account information, head, rep, open, balance, timestamp, block count and epoch
+		 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t, nano::epoch
+		 */
+		MDB_dbi accounts_handle{ 0 };
+
+		/**
+		 * Representative weights. (Removed)
+		 * nano::account -> nano::uint128_t
+		 */
+		MDB_dbi representation_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 using mdb_val = db_val<MDB_val>;
@@ -37,6 +39,60 @@ namespace lmdb
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
 		// Converts a block hash to a block height
 		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+
+		/**
+		 * Maps block hash to send block. (Removed)
+		 * nano::block_hash -> nano::send_block
+		 */
+		MDB_dbi send_blocks_handle{ 0 };
+
+		/**
+		 * Maps block hash to receive block. (Removed)
+		 * nano::block_hash -> nano::receive_block
+		 */
+		MDB_dbi receive_blocks_handle{ 0 };
+
+		/**
+		 * Maps block hash to open block. (Removed)
+		 * nano::block_hash -> nano::open_block
+		 */
+		MDB_dbi open_blocks_handle{ 0 };
+
+		/**
+		 * Maps block hash to change block. (Removed)
+		 * nano::block_hash -> nano::change_block
+		 */
+		MDB_dbi change_blocks_handle{ 0 };
+
+		/**
+		 * Maps block hash to v0 state block. (Removed)
+		 * nano::block_hash -> nano::state_block
+		 */
+		MDB_dbi state_blocks_v0_handle{ 0 };
+
+		/**
+		 * Maps block hash to v1 state block. (Removed)
+		 * nano::block_hash -> nano::state_block
+		 */
+		MDB_dbi state_blocks_v1_handle{ 0 };
+
+		/**
+		 * Maps block hash to state block. (Removed)
+		 * nano::block_hash -> nano::state_block
+		 */
+		MDB_dbi state_blocks_handle{ 0 };
+
+		/**
+		 * Meta information about block store, such as versions.
+		 * nano::uint256_union (arbitrary key) -> blob
+		 */
+		MDB_dbi meta_handle{ 0 };
+
+		/**
+		 * Contains block_sideband and block for all block types (legacy send/change/open/receive & state blocks)
+		 * nano::block_hash -> nano::block_sideband, nano::block
+		 */
+		MDB_dbi blocks_handle{ 0 };
 
 	protected:
 		void block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::mdb_val & value) const;

--- a/nano/node/lmdb/confirmation_height_store.hpp
+++ b/nano/node/lmdb/confirmation_height_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -24,6 +26,12 @@ namespace lmdb
 		nano::store_iterator<nano::account, nano::confirmation_height_info> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::account, nano::confirmation_height_info> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::account, nano::confirmation_height_info>, nano::store_iterator<nano::account, nano::confirmation_height_info>)> const & action_a) const override;
+
+		/*
+		 * Confirmation height of an account, and the hash for the block at that height
+		 * nano::account -> uint64_t, nano::block_hash
+		 */
+		MDB_dbi confirmation_height_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/final_vote_store.hpp
+++ b/nano/node/lmdb/final_vote_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -24,6 +26,12 @@ namespace lmdb
 		nano::store_iterator<nano::qualified_root, nano::block_hash> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::qualified_root, nano::block_hash> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::qualified_root, nano::block_hash>, nano::store_iterator<nano::qualified_root, nano::block_hash>)> const & action_a) const override;
+
+		/**
+		 * Maps root to block hash for generated final votes.
+		 * nano::qualified_root -> nano::block_hash
+		 */
+		MDB_dbi final_votes_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/frontier_store.hpp
+++ b/nano/node/lmdb/frontier_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -9,6 +11,9 @@ namespace lmdb
 	class store;
 	class frontier_store : public nano::frontier_store
 	{
+	private:
+		nano::lmdb::store & store;
+
 	public:
 		frontier_store (nano::lmdb::store & store);
 		void put (nano::write_transaction const &, nano::block_hash const &, nano::account const &) override;
@@ -19,8 +24,11 @@ namespace lmdb
 		nano::store_iterator<nano::block_hash, nano::account> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, nano::account>, nano::store_iterator<nano::block_hash, nano::account>)> const & action_a) const override;
 
-	private:
-		nano::lmdb::store & store;
+		/**
+		 * Maps head block to owning account
+		 * nano::block_hash -> nano::account
+		 */
+		MDB_dbi frontiers_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -221,7 +221,7 @@ void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const 
 	account_store.accounts_handle = account_store.accounts_v0_handle;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pending", flags, &pending_store.pending_v0_handle) != 0;
 	pending_store.pending_handle = pending_store.pending_v0_handle;
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "final_votes", flags, &final_votes_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "final_votes", flags, &final_vote_store.final_votes_handle) != 0;
 
 	auto version_l = version.get (transaction_a);
 	if (version_l < 19)
@@ -774,7 +774,7 @@ void nano::lmdb::store::upgrade_v19_to_v20 (nano::write_transaction const & tran
 void nano::lmdb::store::upgrade_v20_to_v21 (nano::write_transaction const & transaction_a)
 {
 	logger.always_log ("Preparing v20 to v21 database upgrade...");
-	mdb_dbi_open (env.tx (transaction_a), "final_votes", MDB_CREATE, &final_votes_handle);
+	mdb_dbi_open (env.tx (transaction_a), "final_votes", MDB_CREATE, &final_vote_store.final_votes_handle);
 	version.put (transaction_a, 21);
 	logger.always_log ("Finished creating new final_vote table");
 }
@@ -881,7 +881,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 		case tables::confirmation_height:
 			return confirmation_height_store.confirmation_height_handle;
 		case tables::final_votes:
-			return final_votes_handle;
+			return final_vote_store.final_votes_handle;
 		default:
 			release_assert (false);
 			return peer_store.peers_handle;

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -215,7 +215,7 @@ void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const 
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight_store.online_weight_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peers_handle) != 0;
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "pruned", flags, &pruned_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "pruned", flags, &pruned_store.pruned_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "confirmation_height", flags, &confirmation_height_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "accounts", flags, &account_store.accounts_v0_handle) != 0;
 	account_store.accounts_handle = account_store.accounts_v0_handle;
@@ -766,7 +766,7 @@ void nano::lmdb::store::upgrade_v18_to_v19 (nano::write_transaction const & tran
 void nano::lmdb::store::upgrade_v19_to_v20 (nano::write_transaction const & transaction_a)
 {
 	logger.always_log ("Preparing v19 to v20 database upgrade...");
-	mdb_dbi_open (env.tx (transaction_a), "pruned", MDB_CREATE, &pruned_handle);
+	mdb_dbi_open (env.tx (transaction_a), "pruned", MDB_CREATE, &pruned_store.pruned_handle);
 	version.put (transaction_a, 20);
 	logger.always_log ("Finished creating new pruned table");
 }
@@ -877,7 +877,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 		case tables::peers:
 			return peers_handle;
 		case tables::pruned:
-			return pruned_handle;
+			return pruned_store.pruned_handle;
 		case tables::confirmation_height:
 			return confirmation_height_handle;
 		case tables::final_votes:
@@ -916,7 +916,7 @@ bool nano::lmdb::store::copy_db (boost::filesystem::path const & destination_fil
 void nano::lmdb::store::rebuild_db (nano::write_transaction const & transaction_a)
 {
 	// Tables with uint256_union key
-	std::vector<MDB_dbi> tables = { account_store.accounts_handle, blocks_handle, pruned_handle, confirmation_height_handle };
+	std::vector<MDB_dbi> tables = { account_store.accounts_handle, blocks_handle, pruned_store.pruned_handle, confirmation_height_handle };
 	for (auto const & table : tables)
 	{
 		MDB_dbi temp;

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -214,7 +214,7 @@ void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const 
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "unchecked", flags, &unchecked_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight_store.online_weight_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta_handle) != 0;
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peers_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peer_store.peers_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pruned", flags, &pruned_store.pruned_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "confirmation_height", flags, &confirmation_height_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "accounts", flags, &account_store.accounts_v0_handle) != 0;
@@ -875,7 +875,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 		case tables::meta:
 			return meta_handle;
 		case tables::peers:
-			return peers_handle;
+			return peer_store.peers_handle;
 		case tables::pruned:
 			return pruned_store.pruned_handle;
 		case tables::confirmation_height:
@@ -884,7 +884,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 			return final_votes_handle;
 		default:
 			release_assert (false);
-			return peers_handle;
+			return peer_store.peers_handle;
 	}
 }
 

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -212,7 +212,7 @@ void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const 
 {
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "frontiers", flags, &frontier_store.frontiers_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "unchecked", flags, &unchecked_handle) != 0;
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight_store.online_weight_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peers_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "pruned", flags, &pruned_handle) != 0;
@@ -871,7 +871,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 		case tables::unchecked:
 			return unchecked_handle;
 		case tables::online_weight:
-			return online_weight_handle;
+			return online_weight_store.online_weight_handle;
 		case tables::meta:
 			return meta_handle;
 		case tables::peers:

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -211,7 +211,7 @@ nano::mdb_txn_callbacks nano::lmdb::store::create_txn_callbacks () const
 void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const & transaction_a, unsigned flags)
 {
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "frontiers", flags, &frontier_store.frontiers_handle) != 0;
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "unchecked", flags, &unchecked_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "unchecked", flags, &unchecked_store.unchecked_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight_store.online_weight_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "peers", flags, &peer_store.peers_handle) != 0;
@@ -869,7 +869,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 		case tables::pending:
 			return pending_store.pending_handle;
 		case tables::unchecked:
-			return unchecked_handle;
+			return unchecked_store.unchecked_handle;
 		case tables::online_weight:
 			return online_weight_store.online_weight_handle;
 		case tables::meta:

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -210,7 +210,7 @@ nano::mdb_txn_callbacks nano::lmdb::store::create_txn_callbacks () const
 
 void nano::lmdb::store::open_databases (bool & error_a, nano::transaction const & transaction_a, unsigned flags)
 {
-	error_a |= mdb_dbi_open (env.tx (transaction_a), "frontiers", flags, &frontiers_handle) != 0;
+	error_a |= mdb_dbi_open (env.tx (transaction_a), "frontiers", flags, &frontier_store.frontiers_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "unchecked", flags, &unchecked_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "online_weight", flags, &online_weight_handle) != 0;
 	error_a |= mdb_dbi_open (env.tx (transaction_a), "meta", flags, &meta_handle) != 0;
@@ -861,7 +861,7 @@ MDB_dbi nano::lmdb::store::table_to_dbi (tables table_a) const
 	switch (table_a)
 	{
 		case tables::frontiers:
-			return frontiers_handle;
+			return frontier_store.frontiers_handle;
 		case tables::accounts:
 			return accounts_handle;
 		case tables::blocks:

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -148,12 +148,6 @@ namespace lmdb
 	 */
 		MDB_dbi meta_handle{ 0 };
 
-		/**
-	 * Pruned blocks hashes
-	 * nano::block_hash -> none
-	 */
-		MDB_dbi pruned_handle{ 0 };
-
 		/*
 	 * Endpoints for peers
 	 * nano::endpoint_key -> no_value
@@ -267,6 +261,7 @@ namespace lmdb
 		friend class mdb_block_store_supported_version_upgrades_Test;
 		friend class mdb_block_store_upgrade_v14_v15_Test;
 		friend class mdb_block_store_upgrade_v15_v16_Test;
+		friend class mdb_block_store_upgrade_v19_v20_Test;
 		friend void modify_account_info_to_v14 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t, nano::block_hash const &);
 	};
 }

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -143,12 +143,6 @@ namespace lmdb
 		MDB_dbi unchecked_handle{ 0 };
 
 		/**
-	 * Samples of online vote weight
-	 * uint64_t -> nano::amount
-	 */
-		MDB_dbi online_weight_handle{ 0 };
-
-		/**
 	 * Meta information about block store, such as versions.
 	 * nano::uint256_union (arbitrary key) -> blob
 	 */

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -137,24 +137,6 @@ namespace lmdb
 		MDB_dbi state_blocks_handle{ 0 };
 
 		/**
-	 * Maps min_version 0 (destination account, pending block) to (source account, amount). (Removed)
-	 * nano::account, nano::block_hash -> nano::account, nano::amount
-	 */
-		MDB_dbi pending_v0_handle{ 0 };
-
-		/**
-	 * Maps min_version 1 (destination account, pending block) to (source account, amount). (Removed)
-	 * nano::account, nano::block_hash -> nano::account, nano::amount
-	 */
-		MDB_dbi pending_v1_handle{ 0 };
-
-		/**
-	 * Maps (destination account, pending block) to (source account, amount, version). (Removed)
-	 * nano::account, nano::block_hash -> nano::account, nano::amount, nano::epoch
-	 */
-		MDB_dbi pending_handle{ 0 };
-
-		/**
 	 * Unchecked bootstrap blocks info.
 	 * nano::block_hash -> nano::unchecked_info
 	 */

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -137,12 +137,6 @@ namespace lmdb
 		MDB_dbi state_blocks_handle{ 0 };
 
 		/**
-	 * Unchecked bootstrap blocks info.
-	 * nano::block_hash -> nano::unchecked_info
-	 */
-		MDB_dbi unchecked_handle{ 0 };
-
-		/**
 	 * Meta information about block store, such as versions.
 	 * nano::uint256_union (arbitrary key) -> blob
 	 */
@@ -245,6 +239,7 @@ namespace lmdb
 		friend class mdb_block_store_upgrade_v15_v16_Test;
 		friend class mdb_block_store_upgrade_v19_v20_Test;
 		friend class mdb_block_store_upgrade_v20_v21_Test;
+		friend class block_store_DISABLED_change_dupsort_Test;
 		friend void modify_account_info_to_v14 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t, nano::block_hash const &);
 		friend void modify_confirmation_height_to_v15 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t);
 	};

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -149,12 +149,6 @@ namespace lmdb
 		MDB_dbi meta_handle{ 0 };
 
 		/*
-	 * Confirmation height of an account, and the hash for the block at that height
-	 * nano::account -> uint64_t, nano::block_hash
-	 */
-		MDB_dbi confirmation_height_handle{ 0 };
-
-		/*
 	 * Contains block_sideband and block for all block types (legacy send/change/open/receive & state blocks)
 	 * nano::block_hash -> nano::block_sideband, nano::block
 	 */
@@ -257,6 +251,7 @@ namespace lmdb
 		friend class mdb_block_store_upgrade_v15_v16_Test;
 		friend class mdb_block_store_upgrade_v19_v20_Test;
 		friend void modify_account_info_to_v14 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t, nano::block_hash const &);
+		friend void modify_confirmation_height_to_v15 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t);
 	};
 }
 

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -95,24 +95,6 @@ namespace lmdb
 		nano::mdb_env env;
 
 		/**
-	 * Maps account v1 to account information, head, rep, open, balance, timestamp and block count. (Removed)
-	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
-	 */
-		MDB_dbi accounts_v0_handle{ 0 };
-
-		/**
-	 * Maps account v0 to account information, head, rep, open, balance, timestamp and block count. (Removed)
-	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
-	 */
-		MDB_dbi accounts_v1_handle{ 0 };
-
-		/**
-	 * Maps account v0 to account information, head, rep, open, balance, timestamp, block count and epoch
-	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t, nano::epoch
-	 */
-		MDB_dbi accounts_handle{ 0 };
-
-		/**
 	 * Maps block hash to send block. (Removed)
 	 * nano::block_hash -> nano::send_block
 	 */
@@ -171,12 +153,6 @@ namespace lmdb
 	 * nano::account, nano::block_hash -> nano::account, nano::amount, nano::epoch
 	 */
 		MDB_dbi pending_handle{ 0 };
-
-		/**
-	 * Representative weights. (Removed)
-	 * nano::account -> nano::uint128_t
-	 */
-		MDB_dbi representation_handle{ 0 };
 
 		/**
 	 * Unchecked bootstrap blocks info.
@@ -311,6 +287,11 @@ namespace lmdb
 			uint64_t after_v0{ 0 };
 			uint64_t after_v1{ 0 };
 		};
+
+		friend class mdb_block_store_supported_version_upgrades_Test;
+		friend class mdb_block_store_upgrade_v14_v15_Test;
+		friend class mdb_block_store_upgrade_v15_v16_Test;
+		friend void modify_account_info_to_v14 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t, nano::block_hash const &);
 	};
 }
 

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -95,12 +95,6 @@ namespace lmdb
 		nano::mdb_env env;
 
 		/**
-	 * Maps head block to owning account
-	 * nano::block_hash -> nano::account
-	 */
-		MDB_dbi frontiers_handle{ 0 };
-
-		/**
 	 * Maps account v1 to account information, head, rep, open, balance, timestamp and block count. (Removed)
 	 * nano::account -> nano::block_hash, nano::block_hash, nano::block_hash, nano::amount, uint64_t, uint64_t
 	 */

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -94,60 +94,6 @@ namespace lmdb
 	public:
 		nano::mdb_env env;
 
-		/**
-	 * Maps block hash to send block. (Removed)
-	 * nano::block_hash -> nano::send_block
-	 */
-		MDB_dbi send_blocks_handle{ 0 };
-
-		/**
-	 * Maps block hash to receive block. (Removed)
-	 * nano::block_hash -> nano::receive_block
-	 */
-		MDB_dbi receive_blocks_handle{ 0 };
-
-		/**
-	 * Maps block hash to open block. (Removed)
-	 * nano::block_hash -> nano::open_block
-	 */
-		MDB_dbi open_blocks_handle{ 0 };
-
-		/**
-	 * Maps block hash to change block. (Removed)
-	 * nano::block_hash -> nano::change_block
-	 */
-		MDB_dbi change_blocks_handle{ 0 };
-
-		/**
-	 * Maps block hash to v0 state block. (Removed)
-	 * nano::block_hash -> nano::state_block
-	 */
-		MDB_dbi state_blocks_v0_handle{ 0 };
-
-		/**
-	 * Maps block hash to v1 state block. (Removed)
-	 * nano::block_hash -> nano::state_block
-	 */
-		MDB_dbi state_blocks_v1_handle{ 0 };
-
-		/**
-	 * Maps block hash to state block. (Removed)
-	 * nano::block_hash -> nano::state_block
-	 */
-		MDB_dbi state_blocks_handle{ 0 };
-
-		/**
-	 * Meta information about block store, such as versions.
-	 * nano::uint256_union (arbitrary key) -> blob
-	 */
-		MDB_dbi meta_handle{ 0 };
-
-		/*
-	 * Contains block_sideband and block for all block types (legacy send/change/open/receive & state blocks)
-	 * nano::block_hash -> nano::block_sideband, nano::block
-	 */
-		MDB_dbi blocks_handle{ 0 };
-
 		bool exists (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 
 		int get (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, nano::mdb_val & value_a) const;
@@ -237,9 +183,14 @@ namespace lmdb
 		friend class mdb_block_store_supported_version_upgrades_Test;
 		friend class mdb_block_store_upgrade_v14_v15_Test;
 		friend class mdb_block_store_upgrade_v15_v16_Test;
+		friend class mdb_block_store_upgrade_v16_v17_Test;
+		friend class mdb_block_store_upgrade_v17_v18_Test;
+		friend class mdb_block_store_upgrade_v18_v19_Test;
 		friend class mdb_block_store_upgrade_v19_v20_Test;
 		friend class mdb_block_store_upgrade_v20_v21_Test;
 		friend class block_store_DISABLED_change_dupsort_Test;
+		friend void write_sideband_v14 (nano::lmdb::store &, nano::transaction &, nano::block const &, MDB_dbi);
+		friend void write_sideband_v15 (nano::lmdb::store &, nano::transaction &, nano::block const &);
 		friend void modify_account_info_to_v14 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t, nano::block_hash const &);
 		friend void modify_confirmation_height_to_v15 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t);
 	};

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -149,12 +149,6 @@ namespace lmdb
 		MDB_dbi meta_handle{ 0 };
 
 		/*
-	 * Endpoints for peers
-	 * nano::endpoint_key -> no_value
-	*/
-		MDB_dbi peers_handle{ 0 };
-
-		/*
 	 * Confirmation height of an account, and the hash for the block at that height
 	 * nano::account -> uint64_t, nano::block_hash
 	 */

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -154,12 +154,6 @@ namespace lmdb
 	 */
 		MDB_dbi blocks_handle{ 0 };
 
-		/**
-	 * Maps root to block hash for generated final votes.
-	 * nano::qualified_root -> nano::block_hash
-	 */
-		MDB_dbi final_votes_handle{ 0 };
-
 		bool exists (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a) const;
 
 		int get (nano::transaction const & transaction_a, tables table_a, nano::mdb_val const & key_a, nano::mdb_val & value_a) const;
@@ -250,6 +244,7 @@ namespace lmdb
 		friend class mdb_block_store_upgrade_v14_v15_Test;
 		friend class mdb_block_store_upgrade_v15_v16_Test;
 		friend class mdb_block_store_upgrade_v19_v20_Test;
+		friend class mdb_block_store_upgrade_v20_v21_Test;
 		friend void modify_account_info_to_v14 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t, nano::block_hash const &);
 		friend void modify_confirmation_height_to_v15 (nano::lmdb::store &, nano::transaction const &, nano::account const &, uint64_t);
 	};

--- a/nano/node/lmdb/online_weight_store.hpp
+++ b/nano/node/lmdb/online_weight_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -20,6 +22,12 @@ namespace lmdb
 		nano::store_iterator<uint64_t, nano::amount> end () const override;
 		size_t count (nano::transaction const & transaction_a) const override;
 		void clear (nano::write_transaction const & transaction_a) override;
+
+		/**
+		 * Samples of online vote weight
+		 * uint64_t -> nano::amount
+		 */
+		MDB_dbi online_weight_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/peer_store.hpp
+++ b/nano/node/lmdb/peer_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -21,6 +23,12 @@ namespace lmdb
 		void clear (nano::write_transaction const & transaction_a) override;
 		nano::store_iterator<nano::endpoint_key, nano::no_value> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::endpoint_key, nano::no_value> end () const override;
+
+		/*
+		 * Endpoints for peers
+		 * nano::endpoint_key -> no_value
+		*/
+		MDB_dbi peers_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/pending_store.hpp
+++ b/nano/node/lmdb/pending_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -23,6 +25,24 @@ namespace lmdb
 		nano::store_iterator<nano::pending_key, nano::pending_info> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::pending_key, nano::pending_info> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::pending_key, nano::pending_info>, nano::store_iterator<nano::pending_key, nano::pending_info>)> const & action_a) const override;
+
+		/**
+		 * Maps min_version 0 (destination account, pending block) to (source account, amount). (Removed)
+		 * nano::account, nano::block_hash -> nano::account, nano::amount
+		 */
+		MDB_dbi pending_v0_handle{ 0 };
+
+		/**
+		 * Maps min_version 1 (destination account, pending block) to (source account, amount). (Removed)
+		 * nano::account, nano::block_hash -> nano::account, nano::amount
+		 */
+		MDB_dbi pending_v1_handle{ 0 };
+
+		/**
+		 * Maps (destination account, pending block) to (source account, amount, version). (Removed)
+		 * nano::account, nano::block_hash -> nano::account, nano::amount, nano::epoch
+		 */
+		MDB_dbi pending_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/pruned_store.hpp
+++ b/nano/node/lmdb/pruned_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -24,6 +26,12 @@ namespace lmdb
 		nano::store_iterator<nano::block_hash, std::nullptr_t> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, std::nullptr_t> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, std::nullptr_t>, nano::store_iterator<nano::block_hash, std::nullptr_t>)> const & action_a) const override;
+
+		/**
+		 * Pruned blocks hashes
+		 * nano::block_hash -> none
+		 */
+		MDB_dbi pruned_handle{ 0 };
 	};
 }
 }

--- a/nano/node/lmdb/unchecked_store.hpp
+++ b/nano/node/lmdb/unchecked_store.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/secure/store.hpp>
 
+#include <lmdb/libraries/liblmdb/lmdb.h>
+
 namespace nano
 {
 namespace lmdb
@@ -24,6 +26,12 @@ namespace lmdb
 		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
 		size_t count (nano::transaction const & transaction_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
+
+		/**
+		 * Unchecked bootstrap blocks info.
+		 * nano::block_hash -> nano::unchecked_info
+		 */
+		MDB_dbi unchecked_handle{ 0 };
 	};
 }
 }


### PR DESCRIPTION
- The LMDB handles are now bound to their store types, not to the general class.
- Moves the handles and updates their related tests. Some test classes/functions are now friend of the LMDB store.