### PR TITLE
Changes the accounts_balances RPC to return per account results

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -891,18 +891,23 @@ void nano::json_handler::account_weight ()
 void nano::json_handler::accounts_balances ()
 {
 	boost::property_tree::ptree balances;
-	for (auto & accounts : request.get_child ("accounts"))
+	for (auto & account_from_request : request.get_child ("accounts"))
 	{
-		auto account (account_impl (accounts.second.data ()));
+		boost::property_tree::ptree entry;
+		auto account = account_impl (account_from_request.second.data ());
 		if (!ec)
 		{
-			boost::property_tree::ptree entry;
-			auto balance (node.balance_pending (account, false));
+			auto balance = node.balance_pending (account, false);
 			entry.put ("balance", balance.first.convert_to<std::string> ());
 			entry.put ("pending", balance.second.convert_to<std::string> ());
 			entry.put ("receivable", balance.second.convert_to<std::string> ());
-			balances.push_back (std::make_pair (account.to_account (), entry));
 		}
+		else
+		{
+			entry.put ("error", ec.message ());
+			ec = {};
+		}
+		balances.push_back (std::make_pair (account_from_request.second.data (), entry));
 	}
 	response_l.add_child ("balances", balances);
 	response_errors ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -905,7 +905,7 @@ void nano::json_handler::accounts_balances ()
 				entry.put ("balance", balance.first.convert_to<std::string> ());
 				entry.put ("pending", balance.second.convert_to<std::string> ());
 				entry.put ("receivable", balance.second.convert_to<std::string> ());
-				balances.push_back (std::make_pair (account_from_request.second.data (), entry));
+				balances.put_child (account_from_request.second.data (), entry);
 				continue;
 			}
 			else
@@ -914,7 +914,7 @@ void nano::json_handler::accounts_balances ()
 			}
 		}
 		entry.put ("error", ec.message ());
-		balances.push_back (std::make_pair (account_from_request.second.data (), entry));
+		balances.put_child (account_from_request.second.data (), entry);
 		ec = {};
 	}
 	response_l.add_child ("balances", balances);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -891,23 +891,31 @@ void nano::json_handler::account_weight ()
 void nano::json_handler::accounts_balances ()
 {
 	boost::property_tree::ptree balances;
+	auto transaction = node.store.tx_begin_read ();
 	for (auto & account_from_request : request.get_child ("accounts"))
 	{
 		boost::property_tree::ptree entry;
 		auto account = account_impl (account_from_request.second.data ());
 		if (!ec)
 		{
-			auto balance = node.balance_pending (account, false);
-			entry.put ("balance", balance.first.convert_to<std::string> ());
-			entry.put ("pending", balance.second.convert_to<std::string> ());
-			entry.put ("receivable", balance.second.convert_to<std::string> ());
+			nano::account_info info;
+			if (!node.store.account.get (transaction, account, info))
+			{
+				auto balance = node.balance_pending (account, false);
+				entry.put ("balance", balance.first.convert_to<std::string> ());
+				entry.put ("pending", balance.second.convert_to<std::string> ());
+				entry.put ("receivable", balance.second.convert_to<std::string> ());
+				balances.push_back (std::make_pair (account_from_request.second.data (), entry));
+				continue;
+			}
+			else
+			{
+				ec = nano::error_common::account_not_found;
+			}
 		}
-		else
-		{
-			entry.put ("error", ec.message ());
-			ec = {};
-		}
+		entry.put ("error", ec.message ());
 		balances.push_back (std::make_pair (account_from_request.second.data (), entry));
+		ec = {};
 	}
 	response_l.add_child ("balances", balances);
 	response_errors ();


### PR DESCRIPTION
The previous implementation returned only an error result in case any of the accounts were invalid. This implementation now handles each account separately returning per account results.

```
    "balances": {
        "nano_3wfddg7a1paogrcwi3yhwnaerboukbr7rs3z3ino5toyq3yyhimo6f6egij6": {
            "balance": "442000000000000000000000000000",
            "pending": "0",
            "receivable": "0"
        },
        "nano_36uccgpjzhjsdbj44wm1y5hyz8gefx3wjpp1jircxt84nopxkxti5bzq1rnz": {
            "error": "Bad account number"
        },
        "nano_1hrts7hcoozxccnffoq9hqhngnn9jz783usapejm57ejtqcyz9dpso1bibuy": {
            "error": "Account not found"
        }
    }
```
Reference issue: https://github.com/nanocurrency/nano-node/issues/3752