### PR TITLE
upgraded rocksdb to v6.23.7 and added Nano centric patches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,8 +25,8 @@
 	url = https://github.com/google/flatbuffers.git
 [submodule "rocksdb"]
 	path = rocksdb
-	url = https://github.com/nanocurrency/rocksdb.git
-	branch = 6.13.3
+	url = https://github.com/jamescoxon/rocksdb.git
+	branch = nano_update
 [submodule "diskhash"]
 	path = diskhash
 	url = https://github.com/nanocurrency/diskhash.git


### PR DESCRIPTION
Upgraded rocksdb to v6.23.7 to allow compilation on Ubuntu (gcc 11.2) as newer rocksdb has fixes etc. Also needed for OS X complication on m1 silicon. Rocksdb changes have been tested on both beta and main net nodes with no issues.

Currently uses a forked version of rocksdb on my GitHub, will need upgrade on nanocurrency's repo - I can send a pull request on there as well if needed.

Error when compiling on gcc 11.2:

```
[ 56%] Building CXX object rocksdb/CMakeFiles/rocksdb.dir/table/block_based/block_based_table_iterator.cc.o
/root/beta_build/rocksdb/table/block_based/block_based_table_builder.cc: In member function 'void rocksdb::BlockBasedTableBuilder::EnterUnbuffered()':
/root/beta_build/rocksdb/table/block_based/block_based_table_builder.cc:1555:30: error: 'block_rep' may be used uninitialized [-Werror=maybe-uninitialized]
 1555 |       std::swap(*(block_rep->data), data_block);
      |                  ~~~~~~~~~~~~^~~~~
/root/beta_build/rocksdb/table/block_based/block_based_table_builder.cc:1552:41: note: 'block_rep' declared here
 1552 |       ParallelCompressionRep::BlockRep* block_rep;
      |                                         ^~~~~~~~~
[ 56%] Building CXX object rocksdb/CMakeFiles/rocksdb.dir/table/block_based/block_based_table_reader.cc.o
```