### PR TITLE
Renaming nano::transport::channel_loopback to nano::transport::inproc::channel.

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -647,10 +648,10 @@ TEST (votes, check_signature)
 	ASSERT_EQ (1, election1->votes ().size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, send1));
 	vote1->signature.bytes[0] ^= 1;
-	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::channel_loopback> (node1)));
+	ASSERT_EQ (nano::vote_code::invalid, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::inproc::channel> (node1, node1)));
 	vote1->signature.bytes[0] ^= 1;
-	ASSERT_EQ (nano::vote_code::vote, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::channel_loopback> (node1)));
-	ASSERT_EQ (nano::vote_code::replay, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::channel_loopback> (node1)));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::inproc::channel> (node1, node1)));
+	ASSERT_EQ (nano::vote_code::replay, node1.vote_processor.vote_blocking (vote1, std::make_shared<nano::transport::inproc::channel> (node1, node1)));
 }
 
 TEST (votes, add_one)
@@ -785,7 +786,7 @@ TEST (votes, add_old)
 	node1.scheduler.flush ();
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 2, 0, send1));
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node1));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	node1.vote_processor.vote_blocking (vote1, channel);
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key2.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
@@ -827,7 +828,7 @@ TEST (votes, DISABLED_add_old_different_account)
 	ASSERT_EQ (1, election1->votes ().size ());
 	ASSERT_EQ (1, election2->votes ().size ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 2, 0, send1));
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node1));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	auto vote_result1 (node1.vote_processor.vote_blocking (vote1, channel));
 	ASSERT_EQ (nano::vote_code::vote, vote_result1);
 	ASSERT_EQ (2, election1->votes ().size ());
@@ -861,7 +862,7 @@ TEST (votes, add_cooldown)
 	node1.scheduler.flush ();
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, send1));
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node1));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	node1.vote_processor.vote_blocking (vote1, channel);
 	nano::keypair key2;
 	auto send2 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key2.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,4 +1,5 @@
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/node/transport/udp.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
@@ -1256,14 +1257,14 @@ TEST (network, loopback_channel)
 	nano::system system (2);
 	auto & node1 = *system.nodes[0];
 	auto & node2 = *system.nodes[1];
-	nano::transport::channel_loopback channel1 (node1);
+	nano::transport::inproc::channel channel1 (node1, node1);
 	ASSERT_EQ (channel1.get_type (), nano::transport::transport_type::loopback);
 	ASSERT_EQ (channel1.get_endpoint (), node1.network.endpoint ());
 	ASSERT_EQ (channel1.get_tcp_endpoint (), nano::transport::map_endpoint_to_tcp (node1.network.endpoint ()));
 	ASSERT_EQ (channel1.get_network_version (), node1.network_params.network.protocol_version);
 	ASSERT_EQ (channel1.get_node_id (), node1.node_id.pub);
 	ASSERT_EQ (channel1.get_node_id_optional ().value_or (0), node1.node_id.pub);
-	nano::transport::channel_loopback channel2 (node2);
+	nano::transport::inproc::channel channel2 (node2, node2);
 	ASSERT_TRUE (channel1 == channel1);
 	ASSERT_FALSE (channel1 == channel2);
 	++node1.network.port;
@@ -1277,10 +1278,10 @@ TEST (network, filter)
 	auto & node1 = *system.nodes[0];
 	nano::keepalive keepalive{ nano::dev::network_params.network };
 	const_cast<nano::networks &> (keepalive.header.network) = nano::networks::nano_dev_network;
-	node1.network.inbound (keepalive, std::make_shared<nano::transport::channel_loopback> (node1));
+	node1.network.inbound (keepalive, std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::message, nano::stat::detail::invalid_network));
 	const_cast<nano::networks &> (keepalive.header.network) = nano::networks::invalid;
-	node1.network.inbound (keepalive, std::make_shared<nano::transport::channel_loopback> (node1));
+	node1.network.inbound (keepalive, std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	ASSERT_EQ (1, node1.stats.count (nano::stat::type::message, nano::stat::detail::invalid_network));
 }
 

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -1,3 +1,4 @@
+#include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -182,4 +183,18 @@ TEST (system, rep_initialize_many)
 	auto node1 = system.add_node ();
 	ASSERT_EQ ((nano::dev::constants.genesis_amount - nano::Gxrb_ratio) / 2, node1->balance (key0.pub));
 	ASSERT_EQ ((nano::dev::constants.genesis_amount - nano::Gxrb_ratio) / 2, node1->balance (key1.pub));
+}
+
+TEST (system, transport_basic)
+{
+	nano::system system{ 1 };
+	auto & node0 = *system.nodes[0];
+	nano::system system1{ 1 };
+	auto & node1 = *system1.nodes[0];
+	ASSERT_EQ (0, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in));
+	nano::transport::inproc::channel channel{ node0, node1 };
+	nano::keepalive keepalive{ nano::dev::network_params.network };
+	channel.send (keepalive);
+	std::cerr << &node1.stats << std::endl;
+	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) > 0);
 }

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -189,11 +189,14 @@ TEST (system, transport_basic)
 {
 	nano::system system{ 1 };
 	auto & node0 = *system.nodes[0];
+	// Start nodes in separate systems so they don't automatically connect with each other.
 	nano::system system1{ 1 };
 	auto & node1 = *system1.nodes[0];
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in));
 	nano::transport::inproc::channel channel{ node0, node1 };
-	nano::keepalive keepalive{ nano::dev::network_params.network };
-	channel.send (keepalive);
+	// Send a keepalive message since they are easy to construct
+	nano::keepalive junk{ nano::dev::network_params.network };
+	channel.send (junk);
+	// Ensure the keepalive has been reecived on the target.
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) > 0);
 }

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -195,6 +195,5 @@ TEST (system, transport_basic)
 	nano::transport::inproc::channel channel{ node0, node1 };
 	nano::keepalive keepalive{ nano::dev::network_params.network };
 	channel.send (keepalive);
-	std::cerr << &node1.stats << std::endl;
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) > 0);
 }

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -15,7 +16,7 @@ TEST (vote_processor, codes)
 	auto vote (std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () }));
 	auto vote_invalid = std::make_shared<nano::vote> (*vote);
 	vote_invalid->signature.bytes[0] ^= 1;
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
 
 	// Invalid signature
 	ASSERT_EQ (nano::vote_code::invalid, node.vote_processor.vote_blocking (vote_invalid, channel, false));
@@ -46,7 +47,7 @@ TEST (vote_processor, flush)
 {
 	nano::system system (1);
 	auto & node (*system.nodes[0]);
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
 	for (unsigned i = 0; i < 2000; ++i)
 	{
 		auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * (1 + i), 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
@@ -64,7 +65,7 @@ TEST (vote_processor, invalid_signature)
 	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
 	auto vote_invalid = std::make_shared<nano::vote> (*vote);
 	vote_invalid->signature.bytes[0] ^= 1;
-	auto channel = std::make_shared<nano::transport::channel_loopback> (node);
+	auto channel = std::make_shared<nano::transport::inproc::channel> (node, node);
 
 	node.block_confirm (nano::dev::genesis);
 	auto election = node.active.election (nano::dev::genesis->qualified_root ());
@@ -86,7 +87,7 @@ TEST (vote_processor, no_capacity)
 	auto & node (*system.add_node (node_flags));
 	nano::keypair key;
 	auto vote (std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () }));
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
 	ASSERT_TRUE (node.vote_processor.vote (vote, channel));
 }
 
@@ -98,7 +99,7 @@ TEST (vote_processor, overflow)
 	auto & node (*system.add_node (node_flags));
 	nano::keypair key;
 	auto vote (std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () }));
-	auto channel (std::make_shared<nano::transport::channel_loopback> (node));
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
 
 	// No way to lock the processor, but queueing votes in quick succession must result in overflow
 	size_t not_processed{ 0 };

--- a/nano/lib/asio.cpp
+++ b/nano/lib/asio.cpp
@@ -43,3 +43,14 @@ std::size_t nano::shared_const_buffer::size () const
 {
 	return m_buffer.size ();
 }
+
+std::vector<uint8_t> nano::shared_const_buffer::to_bytes () const
+{
+	std::vector<uint8_t> bytes;
+	for (auto const & buffer : *this)
+	{
+		bytes.resize (bytes.size () + buffer.size ());
+		std::copy ((uint8_t const *)buffer.data (), (uint8_t const *)buffer.data () + buffer.size (), bytes.data () + bytes.size () - buffer.size ());
+	}
+	return bytes;
+}

--- a/nano/lib/asio.hpp
+++ b/nano/lib/asio.hpp
@@ -20,6 +20,7 @@ public:
 	boost::asio::const_buffer const * end () const;
 
 	std::size_t size () const;
+	std::vector<uint8_t> to_bytes () const;
 
 private:
 	std::shared_ptr<std::vector<uint8_t>> m_data;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -7,6 +7,7 @@
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/transport/inproc.hpp>
 
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -1108,7 +1109,7 @@ int main (int argc, char * const * argv)
 			while (!votes.empty ())
 			{
 				auto vote (votes.front ());
-				auto channel (std::make_shared<nano::transport::channel_loopback> (*node));
+				auto channel (std::make_shared<nano::transport::inproc::channel> (*node, *node));
 				node->vote_processor.vote (vote, channel);
 				votes.pop_front ();
 			}

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -178,6 +178,8 @@ add_library(
   state_block_signature_verification.cpp
   telemetry.hpp
   telemetry.cpp
+  transport/inproc.hpp
+  transport/inproc.cpp
   transport/tcp.hpp
   transport/tcp.cpp
   transport/transport.hpp

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -1,6 +1,5 @@
-#include <nano/node/transport/inproc.hpp>
-
 #include <nano/node/node.hpp>
+#include <nano/node/transport/inproc.hpp>
 
 #include <boost/format.hpp>
 
@@ -27,24 +26,57 @@ bool nano::transport::inproc::channel::operator== (nano::transport::channel cons
 class message_visitor_inbound : public nano::message_visitor
 {
 public:
-	message_visitor_inbound (decltype(nano::network::inbound) & inbound, std::shared_ptr<nano::transport::inproc::channel> channel) :
+	message_visitor_inbound (decltype (nano::network::inbound) & inbound, std::shared_ptr<nano::transport::inproc::channel> channel) :
 		inbound{ inbound },
 		channel{ channel }
 	{
 	}
-	decltype(nano::network::inbound) & inbound;
+	decltype (nano::network::inbound) & inbound;
 	std::shared_ptr<nano::transport::inproc::channel> channel;
-	void keepalive (nano::keepalive const & message) { inbound (message, channel); }
-	void publish (nano::publish const & message) { inbound (message, channel); }
-	void confirm_req (nano::confirm_req const & message) { inbound (message, channel); }
-	void confirm_ack (nano::confirm_ack const & message) { inbound (message, channel); }
-	void bulk_pull (nano::bulk_pull const & message) { inbound (message, channel); }
-	void bulk_pull_account (nano::bulk_pull_account const & message) { inbound (message, channel); }
-	void bulk_push (nano::bulk_push const & message) { inbound (message, channel); }
-	void frontier_req (nano::frontier_req const & message) { inbound (message, channel); }
-	void node_id_handshake (nano::node_id_handshake const & message) { inbound (message, channel); }
-	void telemetry_req (nano::telemetry_req const & message) { inbound (message, channel); }
-	void telemetry_ack (nano::telemetry_ack const & message) { inbound (message, channel); }
+	void keepalive (nano::keepalive const & message)
+	{
+		inbound (message, channel);
+	}
+	void publish (nano::publish const & message)
+	{
+		inbound (message, channel);
+	}
+	void confirm_req (nano::confirm_req const & message)
+	{
+		inbound (message, channel);
+	}
+	void confirm_ack (nano::confirm_ack const & message)
+	{
+		inbound (message, channel);
+	}
+	void bulk_pull (nano::bulk_pull const & message)
+	{
+		inbound (message, channel);
+	}
+	void bulk_pull_account (nano::bulk_pull_account const & message)
+	{
+		inbound (message, channel);
+	}
+	void bulk_push (nano::bulk_push const & message)
+	{
+		inbound (message, channel);
+	}
+	void frontier_req (nano::frontier_req const & message)
+	{
+		inbound (message, channel);
+	}
+	void node_id_handshake (nano::node_id_handshake const & message)
+	{
+		inbound (message, channel);
+	}
+	void telemetry_req (nano::telemetry_req const & message)
+	{
+		inbound (message, channel);
+	}
+	void telemetry_ack (nano::telemetry_ack const & message)
+	{
+		inbound (message, channel);
+	}
 };
 
 void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -23,6 +23,10 @@ bool nano::transport::inproc::channel::operator== (nano::transport::channel cons
 	return endpoint == other_a.get_endpoint ();
 }
 
+/**
+ *  This function is called for every message received by the inproc channel.
+ *  Note that it is called from inside the context of nano::transport::inproc::channel::send_buffer
+ */
 class message_visitor_inbound : public nano::message_visitor
 {
 public:
@@ -31,8 +35,12 @@ public:
 		channel{ channel }
 	{
 	}
+
 	decltype (nano::network::inbound) & inbound;
+
+	// the channel to reply to, if a reply is generated
 	std::shared_ptr<nano::transport::inproc::channel> channel;
+
 	void keepalive (nano::keepalive const & message)
 	{
 		inbound (message, channel);
@@ -79,13 +87,31 @@ public:
 	}
 };
 
+/**
+ * Send the buffer to the peer and call the callback function when done. The call never fails.
+ * Note that the inbound message visitor will be called before the callback because it is called directly whereas the callback is spawned in the background.
+ */
 void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
 {
+	// we create a temporary channel for the reply path, in case the receiver of the message wants to reply
 	auto remote_channel = std::make_shared<nano::transport::inproc::channel> (destination, node);
+
+	// create an inbound message visitor class to handle incoming messages because that's what the message parser expects
 	message_visitor_inbound visitor{ destination.network.inbound, remote_channel };
+
 	nano::message_parser parser{ destination.network.publish_filter, destination.block_uniquer, destination.vote_uniquer, visitor, destination.work, destination.network_params.network };
+
+	// parse the message and action any work that needs to be done on that object via the visitor object
 	auto bytes = buffer_a.to_bytes ();
-	parser.deserialize_buffer (bytes.data (), bytes.size ());
+	auto size = bytes.size ();
+	parser.deserialize_buffer (bytes.data (), size);
+
+	if (callback_a)
+	{
+		node.background ([callback_a, size] () {
+			callback_a (boost::system::errc::make_error_code (boost::system::errc::success), size);
+		});
+	}
 }
 
 std::string nano::transport::inproc::channel::to_string () const

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -84,12 +84,7 @@ void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer co
 	auto remote_channel = std::make_shared<nano::transport::inproc::channel> (destination, node);
 	message_visitor_inbound visitor{ destination.network.inbound, remote_channel };
 	nano::message_parser parser{ destination.network.publish_filter, destination.block_uniquer, destination.vote_uniquer, visitor, destination.work, destination.network_params.network };
-	std::vector<uint8_t> bytes;
-	for (auto const & buffer : buffer_a)
-	{
-		bytes.resize (bytes.size () + buffer.size ());
-		std::copy ((uint8_t const *)buffer.data (), (uint8_t const *)buffer.data () + buffer.size (), bytes.data () + bytes.size () - buffer.size ());
-	}
+	auto bytes = buffer_a.to_bytes ();
 	parser.deserialize_buffer (bytes.data (), bytes.size ());
 }
 

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -1,0 +1,67 @@
+#include <nano/node/transport/inproc.hpp>
+
+#include <nano/node/node.hpp>
+
+#include <boost/format.hpp>
+
+nano::transport::inproc::channel::channel (nano::node & node, nano::node & destination) :
+	transport::channel{ node },
+	destination{ destination },
+	endpoint{ node.network.endpoint () }
+{
+	set_node_id (node.node_id.pub);
+	set_network_version (node.network_params.network.protocol_version);
+}
+
+std::size_t nano::transport::inproc::channel::hash_code () const
+{
+	std::hash<::nano::endpoint> hash;
+	return hash (endpoint);
+}
+
+bool nano::transport::inproc::channel::operator== (nano::transport::channel const & other_a) const
+{
+	return endpoint == other_a.get_endpoint ();
+}
+
+class message_visitor_inbound : public nano::message_visitor
+{
+public:
+	message_visitor_inbound (decltype(nano::network::inbound) & inbound, std::shared_ptr<nano::transport::inproc::channel> channel) :
+		inbound{ inbound },
+		channel{ channel }
+	{
+	}
+	decltype(nano::network::inbound) & inbound;
+	std::shared_ptr<nano::transport::inproc::channel> channel;
+	void keepalive (nano::keepalive const & message) { inbound (message, channel); }
+	void publish (nano::publish const & message) { inbound (message, channel); }
+	void confirm_req (nano::confirm_req const & message) { inbound (message, channel); }
+	void confirm_ack (nano::confirm_ack const & message) { inbound (message, channel); }
+	void bulk_pull (nano::bulk_pull const & message) { inbound (message, channel); }
+	void bulk_pull_account (nano::bulk_pull_account const & message) { inbound (message, channel); }
+	void bulk_push (nano::bulk_push const & message) { inbound (message, channel); }
+	void frontier_req (nano::frontier_req const & message) { inbound (message, channel); }
+	void node_id_handshake (nano::node_id_handshake const & message) { inbound (message, channel); }
+	void telemetry_req (nano::telemetry_req const & message) { inbound (message, channel); }
+	void telemetry_ack (nano::telemetry_ack const & message) { inbound (message, channel); }
+};
+
+void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
+{
+	auto remote_channel = std::make_shared<nano::transport::inproc::channel> (destination, node);
+	message_visitor_inbound visitor{ destination.network.inbound, remote_channel };
+	nano::message_parser parser{ destination.network.publish_filter, destination.block_uniquer, destination.vote_uniquer, visitor, destination.work, destination.network_params.network };
+	std::vector<uint8_t> bytes;
+	for (auto const & buffer : buffer_a)
+	{
+		bytes.resize (bytes.size () + buffer.size ());
+		std::copy ((uint8_t const *)buffer.data (), (uint8_t const *)buffer.data () + buffer.size (), bytes.data () + bytes.size () - buffer.size ());
+	}
+	parser.deserialize_buffer (bytes.data (), bytes.size ());
+}
+
+std::string nano::transport::inproc::channel::to_string () const
+{
+	return boost::str (boost::format ("%1%") % endpoint);
+}

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -6,45 +6,45 @@ namespace nano
 {
 namespace transport
 {
-/**
- * In-process transport channel. Mostly useful for unit tests
-**/
-namespace inproc
-{
-class channel final : public nano::transport::channel
-{
-public:
-	explicit channel (nano::node & node, nano::node & destination);
-	std::size_t hash_code () const override;
-	bool operator== (nano::transport::channel const &) const override;
-	// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
-	//
-	void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
-	std::string to_string () const override;
-	bool operator== (nano::transport::inproc::channel const & other_a) const
+	/**
+	 * In-process transport channel. Mostly useful for unit tests
+	**/
+	namespace inproc
 	{
-		return endpoint == other_a.get_endpoint ();
-	}
+		class channel final : public nano::transport::channel
+		{
+		public:
+			explicit channel (nano::node & node, nano::node & destination);
+			std::size_t hash_code () const override;
+			bool operator== (nano::transport::channel const &) const override;
+			// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
+			//
+			void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
+			std::string to_string () const override;
+			bool operator== (nano::transport::inproc::channel const & other_a) const
+			{
+				return endpoint == other_a.get_endpoint ();
+			}
 
-	nano::endpoint get_endpoint () const override
-	{
-		return endpoint;
-	}
+			nano::endpoint get_endpoint () const override
+			{
+				return endpoint;
+			}
 
-	nano::tcp_endpoint get_tcp_endpoint () const override
-	{
-		return nano::transport::map_endpoint_to_tcp (endpoint);
-	}
+			nano::tcp_endpoint get_tcp_endpoint () const override
+			{
+				return nano::transport::map_endpoint_to_tcp (endpoint);
+			}
 
-	nano::transport::transport_type get_type () const override
-	{
-		return nano::transport::transport_type::loopback;
-	}
+			nano::transport::transport_type get_type () const override
+			{
+				return nano::transport::transport_type::loopback;
+			}
 
-private:
-	nano::node & destination;
-	nano::endpoint const endpoint;
-};
-} // namespace inproc
+		private:
+			nano::node & destination;
+			nano::endpoint const endpoint;
+		};
+	} // namespace inproc
 } // namespace transport
 } // namespace nano

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <nano/node/transport/transport.hpp>
+
+namespace nano
+{
+namespace transport
+{
+/**
+ * In-process transport channel. Mostly useful for unit tests
+**/
+namespace inproc
+{
+class channel final : public nano::transport::channel
+{
+public:
+	explicit channel (nano::node & node, nano::node & destination);
+	std::size_t hash_code () const override;
+	bool operator== (nano::transport::channel const &) const override;
+	// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
+	//
+	void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
+	std::string to_string () const override;
+	bool operator== (nano::transport::inproc::channel const & other_a) const
+	{
+		return endpoint == other_a.get_endpoint ();
+	}
+
+	nano::endpoint get_endpoint () const override
+	{
+		return endpoint;
+	}
+
+	nano::tcp_endpoint get_tcp_endpoint () const override
+	{
+		return nano::transport::map_endpoint_to_tcp (endpoint);
+	}
+
+	nano::transport::transport_type get_type () const override
+	{
+		return nano::transport::transport_type::loopback;
+	}
+
+private:
+	nano::node & destination;
+	nano::endpoint const endpoint;
+};
+} // namespace inproc
+} // namespace transport
+} // namespace nano

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/node/transport/transport.hpp>
 
 #include <boost/asio/ip/address.hpp>
@@ -131,34 +132,6 @@ void nano::transport::channel::send (nano::message & message_a, std::function<vo
 			node.logger.always_log (boost::str (boost::format ("%1% of size %2% dropped") % node.stats.detail_to_string (detail) % buffer.size ()));
 		}
 	}
-}
-
-nano::transport::channel_loopback::channel_loopback (nano::node & node_a) :
-	channel (node_a), endpoint (node_a.network.endpoint ())
-{
-	set_node_id (node_a.node_id.pub);
-	set_network_version (node_a.network_params.network.protocol_version);
-}
-
-std::size_t nano::transport::channel_loopback::hash_code () const
-{
-	std::hash<::nano::endpoint> hash;
-	return hash (endpoint);
-}
-
-bool nano::transport::channel_loopback::operator== (nano::transport::channel const & other_a) const
-{
-	return endpoint == other_a.get_endpoint ();
-}
-
-void nano::transport::channel_loopback::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::buffer_drop_policy drop_policy_a)
-{
-	release_assert (false && "sending to a loopback channel is not supported");
-}
-
-std::string nano::transport::channel_loopback::to_string () const
-{
-	return boost::str (boost::format ("%1%") % endpoint);
 }
 
 boost::asio::ip::address_v6 nano::transport::mapped_from_v4_bytes (unsigned long address_a)

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -146,40 +146,6 @@ namespace transport
 	protected:
 		nano::node & node;
 	};
-
-	class channel_loopback final : public nano::transport::channel
-	{
-	public:
-		explicit channel_loopback (nano::node &);
-		std::size_t hash_code () const override;
-		bool operator== (nano::transport::channel const &) const override;
-		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
-		//
-		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::buffer_drop_policy = nano::buffer_drop_policy::limiter) override;
-		std::string to_string () const override;
-		bool operator== (nano::transport::channel_loopback const & other_a) const
-		{
-			return endpoint == other_a.get_endpoint ();
-		}
-
-		nano::endpoint get_endpoint () const override
-		{
-			return endpoint;
-		}
-
-		nano::tcp_endpoint get_tcp_endpoint () const override
-		{
-			return nano::transport::map_endpoint_to_tcp (endpoint);
-		}
-
-		nano::transport::transport_type get_type () const override
-		{
-			return nano::transport::transport_type::loopback;
-		}
-
-	private:
-		nano::endpoint const endpoint;
-	};
 } // namespace transport
 } // namespace nano
 

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -3,6 +3,7 @@
 #include <nano/lib/utility.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/voting.hpp>
 #include <nano/node/wallet.hpp>
@@ -380,7 +381,7 @@ void nano::vote_generator::broadcast_action (std::shared_ptr<nano::vote> const &
 {
 	network.flood_vote_pr (vote_a);
 	network.flood_vote (vote_a, 2.0f);
-	vote_processor.vote (vote_a, std::make_shared<nano::transport::channel_loopback> (network.node));
+	vote_processor.vote (vote_a, std::make_shared<nano::transport::inproc::channel> (network.node, network.node));
 }
 
 void nano::vote_generator::run ()

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/node/transport/udp.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/test_common/network.hpp>
@@ -467,7 +468,7 @@ TEST (store, vote_load)
 	for (auto i (0); i < 1000000; ++i)
 	{
 		auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, i, 0, block));
-		node.vote_processor.vote (vote, std::make_shared<nano::transport::channel_loopback> (node));
+		node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
 	}
 }
 


### PR DESCRIPTION
The name 'inproc' better indicates it's implementation through memory transfer, in contrast to the name 'loopback' which might indicate an association with a network stack.

Adding a basic implementation of send_buffer and and test so these channels can be used to transfer messages.