### PR TITLE
`open_burn_account` errors and comments

### DIFF
--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -251,7 +251,7 @@ std::string nano::error_process_messages::message (int ev) const
 		case nano::error_process::gap_epoch_open_pending:
 			return "Gap pending for open epoch block";
 		case nano::error_process::opened_burn_account:
-			return "Burning account";
+			return "Block attempts to open the burn account";
 		case nano::error_process::balance_mismatch:
 			return "Balance and amount delta do not match";
 		case nano::error_process::block_position:

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -138,7 +138,7 @@ enum class error_process
 	gap_previous, // Block marked as previous is unknown
 	gap_source, // Block marked as source is unknown
 	gap_epoch_open_pending, // Block marked as pending blocks required for epoch open block are unknown
-	opened_burn_account, // The impossible happened, someone found the private key associated with the public key '0'.
+	opened_burn_account, // Block attempts to open the burn account
 	balance_mismatch, // Balance and amount delta don't match
 	block_position, // This block cannot follow the previous block
 	insufficient_work, // Insufficient work for this block, even though it passed the minimal validation

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -455,7 +455,10 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 		}
 		case nano::process_result::opened_burn_account:
 		{
-			node.logger.always_log (boost::str (boost::format ("*** Rejecting open block for burn account ***: %1%") % hash.to_string ()));
+			if (node.config.logging.ledger_logging ())
+			{
+				node.logger.try_log (boost::str (boost::format ("Rejecting open block for burn account: %1%") % hash.to_string ()));
+			}
 			break;
 		}
 		case nano::process_result::balance_mismatch:

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3312,6 +3312,9 @@ void nano::json_handler::process ()
 							rpc_l->ec = nano::error_process::insufficient_work;
 							break;
 						}
+						case nano::process_result::opened_burn_account:
+							rpc_l->ec = nano::error_process::opened_burn_account;
+							break;
 						default:
 						{
 							rpc_l->ec = nano::error_process::other;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -339,7 +339,7 @@ enum class process_result
 	gap_previous, // Block marked as previous is unknown
 	gap_source, // Block marked as source is unknown
 	gap_epoch_open_pending, // Block marked as pending blocks required for epoch open block are unknown
-	opened_burn_account, // The impossible happened, someone found the private key associated with the public key '0'.
+	opened_burn_account, // Block attempts to open the burn account
 	balance_mismatch, // Balance and amount delta don't match
 	representative_mismatch, // Representative is changed when it is not allowed
 	block_position, // This block cannot follow the previous block


### PR DESCRIPTION
While no private key exists for the burn address, one may still create valid signatures for this account by taking advantage of the fact that it's the 6th torsion of the zero point. As an example, here's a valid block to open the account.
```json
{
  "action": "process",
  "json_block": "true",
  "subtype": "open",
  "block": {
    "type": "state",
    "account": "xrb_1111111111111111111111111111111111111111111111111111hifc8npp",
    "previous": "0000000000000000000000000000000000000000000000000000000000000000",
    "representative": "nano_3mhrc9czyfzzok7xeoeaknq6w5ok9horo7d4a99m8tbtbyogg8apz491pkzt",
    "signature": "c9a3f86aae465f0e56513864510f3997561fa2c9e85ea21dc2292309f3cd60220200000000000000000000000000000000000000000000000000000000000000",
    "work": "2d217e0ef5bbbd29",
    "link": "ECCB8CB65CD3106EDA8CE9AA893FEAD497A91BCA903890CBD7A5C59F06AB9113",
    "link_as_account": "nano_3u8djku7snrifufastfcj6zyoo6qo6fwo63rk57xhbg7mw5cq6amt5a1zq14",
    "balance": "205676479000000000000000000000000000000"
  }
}
```

Right now the RPC returns
```json
{
    "error": "Error processing block"
}
```

Which is less specific than the `opened_burn_account` process error that induces it.

This PR handles this case better by
- Propagating `opened_burn_account` through the RPC
- Reducing log level for `opened_burn_account` so as to reduce the noise potential should someone try publishing lots of these
- Updating the comments to reflect the mundanity of such blocks