### PR TITLE
Bootstrap cleanup

### DIFF
--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -237,7 +237,7 @@ std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_atte
 std::shared_ptr<nano::bootstrap_attempt_lazy> nano::bootstrap_initiator::current_lazy_attempt ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
-	return dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (find_attempt (nano::bootstrap_mode::lazy));
+	return std::dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (find_attempt (nano::bootstrap_mode::lazy));
 }
 
 std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_wallet_attempt ()

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -8,6 +8,7 @@
 #include <boost/format.hpp>
 
 #include <algorithm>
+#include <memory>
 
 nano::bootstrap_initiator::bootstrap_initiator (nano::node & node_a) :
 	node (node_a)
@@ -233,10 +234,10 @@ std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_atte
 	return find_attempt (nano::bootstrap_mode::legacy);
 }
 
-std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_lazy_attempt ()
+std::shared_ptr<nano::bootstrap_attempt_lazy> nano::bootstrap_initiator::current_lazy_attempt ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
-	return find_attempt (nano::bootstrap_mode::lazy);
+	return dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (find_attempt (nano::bootstrap_mode::lazy));
 }
 
 std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_wallet_attempt ()

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -240,10 +240,10 @@ std::shared_ptr<nano::bootstrap_attempt_lazy> nano::bootstrap_initiator::current
 	return std::dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (find_attempt (nano::bootstrap_mode::lazy));
 }
 
-std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_wallet_attempt ()
+std::shared_ptr<nano::bootstrap_attempt_wallet> nano::bootstrap_initiator::current_wallet_attempt ()
 {
 	nano::lock_guard<nano::mutex> lock (mutex);
-	return find_attempt (nano::bootstrap_mode::wallet_lazy);
+	return std::dynamic_pointer_cast<nano::bootstrap_attempt_wallet> (find_attempt (nano::bootstrap_mode::wallet_lazy));
 }
 
 void nano::bootstrap_initiator::stop_attempts ()

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -81,6 +81,7 @@ public:
 };
 
 class bootstrap_attempt_lazy;
+class bootstrap_attempt_wallet;
 /**
  * Client side portion to initiate bootstrap sessions. Prevents multiple legacy-type bootstrap sessions from being started at the same time. Does permit
  * lazy/wallet bootstrap sessions to overlap with legacy sessions.
@@ -105,7 +106,7 @@ public:
 	void remove_attempt (std::shared_ptr<nano::bootstrap_attempt>);
 	std::shared_ptr<nano::bootstrap_attempt> current_attempt ();
 	std::shared_ptr<nano::bootstrap_attempt_lazy> current_lazy_attempt ();
-	std::shared_ptr<nano::bootstrap_attempt> current_wallet_attempt ();
+	std::shared_ptr<nano::bootstrap_attempt_wallet> current_wallet_attempt ();
 	nano::pulls_cache cache;
 	nano::bootstrap_attempts attempts;
 	void stop ();

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -80,6 +80,7 @@ public:
 	std::map<uint64_t, std::shared_ptr<nano::bootstrap_attempt>> attempts;
 };
 
+class bootstrap_attempt_lazy;
 /**
  * Client side portion to initiate bootstrap sessions. Prevents multiple legacy-type bootstrap sessions from being started at the same time. Does permit
  * lazy/wallet bootstrap sessions to overlap with legacy sessions.
@@ -103,7 +104,7 @@ public:
 	bool has_new_attempts ();
 	void remove_attempt (std::shared_ptr<nano::bootstrap_attempt>);
 	std::shared_ptr<nano::bootstrap_attempt> current_attempt ();
-	std::shared_ptr<nano::bootstrap_attempt> current_lazy_attempt ();
+	std::shared_ptr<nano::bootstrap_attempt_lazy> current_lazy_attempt ();
 	std::shared_ptr<nano::bootstrap_attempt> current_wallet_attempt ();
 	nano::pulls_cache cache;
 	nano::bootstrap_attempts attempts;

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -154,9 +154,3 @@ void nano::bootstrap_attempt::requeue_pending (nano::account const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
 }
-
-std::size_t nano::bootstrap_attempt::wallet_size ()
-{
-	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
-	return 0;
-}

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -113,11 +113,6 @@ std::string nano::bootstrap_attempt::mode_text ()
 	return mode_text;
 }
 
-void nano::bootstrap_attempt::add_bulk_push_target (nano::block_hash const &, nano::block_hash const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::legacy);
-}
-
 bool nano::bootstrap_attempt::request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &)
 {
 	debug_assert (mode == nano::bootstrap_mode::legacy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -150,11 +150,6 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	return stop_pull;
 }
 
-void nano::bootstrap_attempt::lazy_requeue (nano::block_hash const &, nano::block_hash const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::lazy);
-}
-
 uint32_t nano::bootstrap_attempt::lazy_batch_size ()
 {
 	debug_assert (mode == nano::bootstrap_mode::lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -156,12 +156,6 @@ bool nano::bootstrap_attempt::lazy_processed_or_exists (nano::block_hash const &
 	return false;
 }
 
-bool nano::bootstrap_attempt::lazy_has_expired () const
-{
-	debug_assert (mode == nano::bootstrap_mode::lazy);
-	return true;
-}
-
 void nano::bootstrap_attempt::requeue_pending (nano::account const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -113,12 +113,6 @@ std::string nano::bootstrap_attempt::mode_text ()
 	return mode_text;
 }
 
-bool nano::bootstrap_attempt::request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &)
-{
-	debug_assert (mode == nano::bootstrap_mode::legacy);
-	return true;
-}
-
 void nano::bootstrap_attempt::set_start_account (nano::account const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::legacy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -113,11 +113,6 @@ std::string nano::bootstrap_attempt::mode_text ()
 	return mode_text;
 }
 
-void nano::bootstrap_attempt::add_frontier (nano::pull_info const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::legacy);
-}
-
 void nano::bootstrap_attempt::add_bulk_push_target (nano::block_hash const &, nano::block_hash const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::legacy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -113,11 +113,6 @@ std::string nano::bootstrap_attempt::mode_text ()
 	return mode_text;
 }
 
-void nano::bootstrap_attempt::set_start_account (nano::account const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::legacy);
-}
-
 bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const & block_a, nano::account const & known_account_a, uint64_t pull_blocks_processed, nano::bulk_pull::count_t max_blocks, bool block_expected, unsigned retry_limit)
 {
 	bool stop_pull (false);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -155,11 +155,6 @@ void nano::bootstrap_attempt::requeue_pending (nano::account const &)
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
 }
 
-void nano::bootstrap_attempt::wallet_start (std::deque<nano::account> &)
-{
-	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
-}
-
 std::size_t nano::bootstrap_attempt::wallet_size ()
 {
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -150,12 +150,6 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	return stop_pull;
 }
 
-bool nano::bootstrap_attempt::lazy_processed_or_exists (nano::block_hash const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::lazy);
-	return false;
-}
-
 void nano::bootstrap_attempt::requeue_pending (nano::account const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -149,8 +149,3 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	}
 	return stop_pull;
 }
-
-void nano::bootstrap_attempt::requeue_pending (nano::account const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::wallet_lazy);
-}

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -150,12 +150,6 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	return stop_pull;
 }
 
-bool nano::bootstrap_attempt::lazy_start (nano::hash_or_account const &, bool)
-{
-	debug_assert (mode == nano::bootstrap_mode::lazy);
-	return false;
-}
-
 void nano::bootstrap_attempt::lazy_add (nano::pull_info const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -150,11 +150,6 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	return stop_pull;
 }
 
-void nano::bootstrap_attempt::lazy_add (nano::pull_info const &)
-{
-	debug_assert (mode == nano::bootstrap_mode::lazy);
-}
-
 void nano::bootstrap_attempt::lazy_requeue (nano::block_hash const &, nano::block_hash const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -150,12 +150,6 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	return stop_pull;
 }
 
-uint32_t nano::bootstrap_attempt::lazy_batch_size ()
-{
-	debug_assert (mode == nano::bootstrap_mode::lazy);
-	return node->network_params.bootstrap.lazy_min_pull_blocks;
-}
-
 bool nano::bootstrap_attempt::lazy_processed_or_exists (nano::block_hash const &)
 {
 	debug_assert (mode == nano::bootstrap_mode::lazy);

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -33,7 +33,6 @@ public:
 	virtual void set_start_account (nano::account const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void requeue_pending (nano::account const &);
-	virtual void wallet_start (std::deque<nano::account> &);
 	virtual std::size_t wallet_size ();
 	virtual void get_information (boost::property_tree::ptree &) = 0;
 	nano::mutex next_log_mutex;

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -31,7 +31,6 @@ public:
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
-	virtual void lazy_add (nano::pull_info const &);
 	virtual void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	virtual uint32_t lazy_batch_size ();
 	virtual bool lazy_has_expired () const;

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -27,7 +27,6 @@ public:
 	void pull_finished ();
 	bool should_log ();
 	std::string mode_text ();
-	virtual void add_frontier (nano::pull_info const &);
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -27,7 +27,6 @@ public:
 	void pull_finished ();
 	bool should_log ();
 	std::string mode_text ();
-	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void get_information (boost::property_tree::ptree &) = 0;

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -31,7 +31,6 @@ public:
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
-	virtual bool lazy_processed_or_exists (nano::block_hash const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void requeue_pending (nano::account const &);
 	virtual void wallet_start (std::deque<nano::account> &);

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -31,7 +31,6 @@ public:
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
-	virtual uint32_t lazy_batch_size ();
 	virtual bool lazy_has_expired () const;
 	virtual bool lazy_processed_or_exists (nano::block_hash const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -27,7 +27,6 @@ public:
 	void pull_finished ();
 	bool should_log ();
 	std::string mode_text ();
-	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -33,7 +33,6 @@ public:
 	virtual void set_start_account (nano::account const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void requeue_pending (nano::account const &);
-	virtual std::size_t wallet_size ();
 	virtual void get_information (boost::property_tree::ptree &) = 0;
 	nano::mutex next_log_mutex;
 	std::chrono::steady_clock::time_point next_log{ std::chrono::steady_clock::now () };

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -31,7 +31,6 @@ public:
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
-	virtual bool lazy_start (nano::hash_or_account const &, bool confirmed = true);
 	virtual void lazy_add (nano::pull_info const &);
 	virtual void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	virtual uint32_t lazy_batch_size ();

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -32,7 +32,6 @@ public:
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
-	virtual void requeue_pending (nano::account const &);
 	virtual void get_information (boost::property_tree::ptree &) = 0;
 	nano::mutex next_log_mutex;
 	std::chrono::steady_clock::time_point next_log{ std::chrono::steady_clock::now () };

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -31,7 +31,6 @@ public:
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
-	virtual bool lazy_has_expired () const;
 	virtual bool lazy_processed_or_exists (nano::block_hash const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void requeue_pending (nano::account const &);

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -27,7 +27,6 @@ public:
 	void pull_finished ();
 	bool should_log ();
 	std::string mode_text ();
-	virtual void set_start_account (nano::account const &);
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void get_information (boost::property_tree::ptree &) = 0;
 	nano::mutex next_log_mutex;

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -31,7 +31,6 @@ public:
 	virtual void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	virtual bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	virtual void set_start_account (nano::account const &);
-	virtual void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	virtual uint32_t lazy_batch_size ();
 	virtual bool lazy_has_expired () const;
 	virtual bool lazy_processed_or_exists (nano::block_hash const &);

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -304,13 +304,15 @@ void nano::bulk_pull_account_client::request ()
 	req.account = account;
 	req.minimum_amount = connection->node->config.receive_minimum;
 	req.flags = nano::bulk_pull_account_flags::pending_hash_and_amount;
+	auto wallet = std::dynamic_pointer_cast<nano::bootstrap_attempt_wallet> (attempt);
+	auto wallet_size = wallet ? wallet->wallet_size () : 0;
 	if (connection->node->config.logging.bulk_pull_logging ())
 	{
-		connection->node->logger.try_log (boost::str (boost::format ("Requesting pending for account %1% from %2%. %3% accounts in queue") % req.account.to_account () % connection->channel->to_string () % attempt->wallet_size ()));
+		connection->node->logger.try_log (boost::str (boost::format ("Requesting pending for account %1% from %2%. %3% accounts in queue") % req.account.to_account () % connection->channel->to_string () % wallet_size));
 	}
 	else if (connection->node->config.logging.network_logging () && attempt->should_log ())
 	{
-		connection->node->logger.always_log (boost::str (boost::format ("%1% accounts in pull queue") % attempt->wallet_size ()));
+		connection->node->logger.always_log (boost::str (boost::format ("%1% accounts in pull queue") % wallet_size));
 	}
 	auto this_l (shared_from_this ());
 	connection->channel->send (

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -284,7 +284,7 @@ void nano::bulk_pull_client::received_block (boost::system::error_code const & e
 	}
 }
 
-nano::bulk_pull_account_client::bulk_pull_account_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a, nano::account const & account_a) :
+nano::bulk_pull_account_client::bulk_pull_account_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt_wallet> const & attempt_a, nano::account const & account_a) :
 	connection (connection_a),
 	attempt (attempt_a),
 	account (account_a),
@@ -304,15 +304,13 @@ void nano::bulk_pull_account_client::request ()
 	req.account = account;
 	req.minimum_amount = connection->node->config.receive_minimum;
 	req.flags = nano::bulk_pull_account_flags::pending_hash_and_amount;
-	auto wallet = std::dynamic_pointer_cast<nano::bootstrap_attempt_wallet> (attempt);
-	auto wallet_size = wallet ? wallet->wallet_size () : 0;
 	if (connection->node->config.logging.bulk_pull_logging ())
 	{
-		connection->node->logger.try_log (boost::str (boost::format ("Requesting pending for account %1% from %2%. %3% accounts in queue") % req.account.to_account () % connection->channel->to_string () % wallet_size));
+		connection->node->logger.try_log (boost::str (boost::format ("Requesting pending for account %1% from %2%. %3% accounts in queue") % req.account.to_account () % connection->channel->to_string () % attempt->wallet_size ()));
 	}
 	else if (connection->node->config.logging.network_logging () && attempt->should_log ())
 	{
-		connection->node->logger.always_log (boost::str (boost::format ("%1% accounts in pull queue") % wallet_size));
+		connection->node->logger.always_log (boost::str (boost::format ("%1% accounts in pull queue") % attempt->wallet_size ()));
 	}
 	auto this_l (shared_from_this ());
 	connection->channel->send (

--- a/nano/node/bootstrap/bootstrap_bulk_pull.hpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.hpp
@@ -49,15 +49,16 @@ public:
 	uint64_t unexpected_count;
 	bool network_error{ false };
 };
+class bootstrap_attempt_wallet;
 class bulk_pull_account_client final : public std::enable_shared_from_this<nano::bulk_pull_account_client>
 {
 public:
-	bulk_pull_account_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt> const &, nano::account const &);
+	bulk_pull_account_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt_wallet> const &, nano::account const &);
 	~bulk_pull_account_client ();
 	void request ();
 	void receive_pending ();
 	std::shared_ptr<nano::bootstrap_client> connection;
-	std::shared_ptr<nano::bootstrap_attempt> attempt;
+	std::shared_ptr<nano::bootstrap_attempt_wallet> attempt;
 	nano::account account;
 	uint64_t pull_blocks;
 };

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -1,11 +1,12 @@
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
 #include <nano/node/bootstrap/bootstrap_bulk_push.hpp>
+#include <nano/node/bootstrap/bootstrap_legacy.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/tcp.hpp>
 
 #include <boost/format.hpp>
 
-nano::bulk_push_client::bulk_push_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a) :
+nano::bulk_push_client::bulk_push_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt_legacy> const & attempt_a) :
 	connection (connection_a),
 	attempt (attempt_a)
 {

--- a/nano/node/bootstrap/bootstrap_bulk_push.hpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.hpp
@@ -6,7 +6,7 @@
 
 namespace nano
 {
-class bootstrap_attempt;
+class bootstrap_attempt_legacy;
 class bootstrap_client;
 
 /**
@@ -15,14 +15,14 @@ class bootstrap_client;
 class bulk_push_client final : public std::enable_shared_from_this<nano::bulk_push_client>
 {
 public:
-	explicit bulk_push_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt> const &);
+	explicit bulk_push_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt_legacy> const &);
 	~bulk_push_client ();
 	void start ();
 	void push ();
 	void push_block (nano::block const &);
 	void send_finished ();
 	std::shared_ptr<nano::bootstrap_client> connection;
-	std::shared_ptr<nano::bootstrap_attempt> attempt;
+	std::shared_ptr<nano::bootstrap_attempt_legacy> attempt;
 	std::promise<bool> promise;
 	std::pair<nano::block_hash, nano::block_hash> current_target;
 };

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -1,7 +1,7 @@
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
-#include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/node/bootstrap/bootstrap_connections.hpp>
+#include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/tcp.hpp>

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -387,9 +387,9 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 	if (attempt_l != nullptr)
 	{
 		++attempt_l->requeued_pulls;
-		if (attempt_l->mode == nano::bootstrap_mode::lazy)
+		if (auto lazy = dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (attempt_l))
 		{
-			pull.count = attempt_l->lazy_batch_size ();
+			pull.count = lazy->lazy_batch_size ();
 		}
 		if (attempt_l->mode == nano::bootstrap_mode::legacy && (pull.attempts < pull.retry_limit + (pull.processed / nano::bootstrap_limits::requeued_pulls_processed_blocks_factor)))
 		{

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -1,11 +1,14 @@
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
+#include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/node/bootstrap/bootstrap_connections.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/tcp.hpp>
 
 #include <boost/format.hpp>
+
+#include <memory>
 
 constexpr double nano::bootstrap_limits::bootstrap_connection_scale_target_blocks;
 constexpr double nano::bootstrap_limits::bootstrap_minimum_blocks_per_sec;
@@ -418,9 +421,12 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 			}
 			node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_failed_account, nano::stat::dir::in);
 
-			if (attempt_l->mode == nano::bootstrap_mode::lazy && pull.processed > 0)
+			if (auto lazy = dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (attempt_l))
 			{
-				attempt_l->lazy_add (pull);
+				if (pull.processed > 0)
+				{
+					lazy->lazy_add (pull);
+				}
 			}
 			else if (attempt_l->mode == nano::bootstrap_mode::legacy)
 			{

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
+#include <nano/node/bootstrap/bootstrap_legacy.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/tcp.hpp>
 
@@ -40,7 +41,7 @@ void nano::frontier_req_client::run (nano::account const & start_account_a, uint
 	nano::buffer_drop_policy::no_limiter_drop);
 }
 
-nano::frontier_req_client::frontier_req_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a) :
+nano::frontier_req_client::frontier_req_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt_legacy> const & attempt_a) :
 	connection (connection_a),
 	attempt (attempt_a),
 	count (0),

--- a/nano/node/bootstrap/bootstrap_frontier.hpp
+++ b/nano/node/bootstrap/bootstrap_frontier.hpp
@@ -7,7 +7,7 @@
 
 namespace nano
 {
-class bootstrap_attempt;
+class bootstrap_attempt_legacy;
 class bootstrap_client;
 
 /**
@@ -16,7 +16,7 @@ class bootstrap_client;
 class frontier_req_client final : public std::enable_shared_from_this<nano::frontier_req_client>
 {
 public:
-	explicit frontier_req_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt> const &);
+	explicit frontier_req_client (std::shared_ptr<nano::bootstrap_client> const &, std::shared_ptr<nano::bootstrap_attempt_legacy> const &);
 	void run (nano::account const & start_account_a, uint32_t const frontiers_age_a, uint32_t const count_a);
 	void receive_frontier ();
 	void received_frontier (boost::system::error_code const &, std::size_t);
@@ -24,7 +24,7 @@ public:
 	void unsynced (nano::block_hash const &, nano::block_hash const &);
 	void next ();
 	std::shared_ptr<nano::bootstrap_client> connection;
-	std::shared_ptr<nano::bootstrap_attempt> attempt;
+	std::shared_ptr<nano::bootstrap_attempt_legacy> attempt;
 	nano::account current;
 	nano::block_hash frontier;
 	unsigned count;

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -188,10 +188,9 @@ void nano::bootstrap_attempt_lazy::run ()
 	while ((still_pulling () || !lazy_finished ()) && !lazy_has_expired ())
 	{
 		unsigned iterations (0);
-		auto this_l (shared_from_this ());
 		while (still_pulling () && !lazy_has_expired ())
 		{
-			condition.wait (lock, [&stopped = stopped, &pulling = pulling, &lazy_pulls = lazy_pulls, this_l] { return stopped || pulling == 0 || (pulling < nano::bootstrap_limits::bootstrap_connection_scale_target_blocks && !lazy_pulls.empty ()) || this_l->lazy_has_expired (); });
+			condition.wait (lock, [this, &stopped = stopped, &pulling = pulling, &lazy_pulls = lazy_pulls] { return stopped || pulling == 0 || (pulling < nano::bootstrap_limits::bootstrap_connection_scale_target_blocks && !lazy_pulls.empty ()) || lazy_has_expired (); });
 			++iterations;
 			// Flushing lazy pulls
 			lazy_pull_flush (lock);

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -488,7 +488,7 @@ void nano::bootstrap_attempt_wallet::request_pending (nano::unique_lock<nano::mu
 		auto account (wallet_accounts.front ());
 		wallet_accounts.pop_front ();
 		++pulling;
-		auto this_l (shared_from_this ());
+		auto this_l = std::dynamic_pointer_cast<nano::bootstrap_attempt_wallet> (shared_from_this ());
 		// The bulk_pull_account_client destructor attempt to requeue_pull which can cause a deadlock if this is the last reference
 		// Dispatch request in an external thread in case it needs to be destroyed
 		node->background ([connection_l, this_l, account] () {

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -40,7 +40,7 @@ public:
 	void lazy_add (nano::pull_info const &);
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	bool lazy_finished ();
-	bool lazy_has_expired () const override;
+	bool lazy_has_expired () const;
 	uint32_t lazy_batch_size ();
 	void lazy_pull_flush (nano::unique_lock<nano::mutex> & lock_a);
 	bool process_block_lazy (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, unsigned);

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -77,7 +77,7 @@ public:
 	void request_pending (nano::unique_lock<nano::mutex> &);
 	void requeue_pending (nano::account const &) override;
 	void run () override;
-	void wallet_start (std::deque<nano::account> &) override;
+	void wallet_start (std::deque<nano::account> &);
 	bool wallet_finished ();
 	std::size_t wallet_size () override;
 	void get_information (boost::property_tree::ptree &) override;

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -75,7 +75,7 @@ public:
 	explicit bootstrap_attempt_wallet (std::shared_ptr<nano::node> const & node_a, uint64_t incremental_id_a, std::string id_a = "");
 	~bootstrap_attempt_wallet ();
 	void request_pending (nano::unique_lock<nano::mutex> &);
-	void requeue_pending (nano::account const &) override;
+	void requeue_pending (nano::account const &);
 	void run () override;
 	void wallet_start (std::deque<nano::account> &);
 	bool wallet_finished ();

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -37,7 +37,7 @@ public:
 	void run () override;
 	bool lazy_start (nano::hash_or_account const &, bool confirmed = true);
 	void lazy_add (nano::hash_or_account const &, unsigned);
-	void lazy_add (nano::pull_info const &) override;
+	void lazy_add (nano::pull_info const &);
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &) override;
 	bool lazy_finished ();
 	bool lazy_has_expired () const override;

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -41,7 +41,7 @@ public:
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	bool lazy_finished ();
 	bool lazy_has_expired () const override;
-	uint32_t lazy_batch_size () override;
+	uint32_t lazy_batch_size ();
 	void lazy_pull_flush (nano::unique_lock<nano::mutex> & lock_a);
 	bool process_block_lazy (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, unsigned);
 	void lazy_block_state (std::shared_ptr<nano::block> const &, unsigned);

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -35,7 +35,7 @@ public:
 	~bootstrap_attempt_lazy ();
 	bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned) override;
 	void run () override;
-	bool lazy_start (nano::hash_or_account const &, bool confirmed = true) override;
+	bool lazy_start (nano::hash_or_account const &, bool confirmed = true);
 	void lazy_add (nano::hash_or_account const &, unsigned);
 	void lazy_add (nano::pull_info const &) override;
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &) override;

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -50,7 +50,7 @@ public:
 	void lazy_blocks_insert (nano::block_hash const &);
 	void lazy_blocks_erase (nano::block_hash const &);
 	bool lazy_blocks_processed (nano::block_hash const &);
-	bool lazy_processed_or_exists (nano::block_hash const &) override;
+	bool lazy_processed_or_exists (nano::block_hash const &);
 	unsigned lazy_retry_limit_confirmed ();
 	void get_information (boost::property_tree::ptree &) override;
 	std::unordered_set<std::size_t> lazy_blocks;

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -79,7 +79,7 @@ public:
 	void run () override;
 	void wallet_start (std::deque<nano::account> &);
 	bool wallet_finished ();
-	std::size_t wallet_size () override;
+	std::size_t wallet_size ();
 	void get_information (boost::property_tree::ptree &) override;
 	std::deque<nano::account> wallet_accounts;
 };

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -38,7 +38,7 @@ public:
 	bool lazy_start (nano::hash_or_account const &, bool confirmed = true);
 	void lazy_add (nano::hash_or_account const &, unsigned);
 	void lazy_add (nano::pull_info const &);
-	void lazy_requeue (nano::block_hash const &, nano::block_hash const &) override;
+	void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
 	bool lazy_finished ();
 	bool lazy_has_expired () const override;
 	uint32_t lazy_batch_size () override;

--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -134,8 +134,8 @@ bool nano::bootstrap_attempt_legacy::request_frontier (nano::unique_lock<nano::m
 		endpoint_frontier_request = connection_l->channel->get_tcp_endpoint ();
 		std::future<bool> future;
 		{
-			auto this_l (shared_from_this ());
-			auto client (std::make_shared<nano::frontier_req_client> (connection_l, this_l));
+			auto this_l = std::dynamic_pointer_cast<nano::bootstrap_attempt_legacy> (shared_from_this ());
+			auto client = std::make_shared<nano::frontier_req_client> (connection_l, this_l);
 			client->run (start_account, frontiers_age, node->config.bootstrap_frontier_request_count);
 			frontiers = client;
 			future = client->promise.get_future ();

--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -68,8 +68,8 @@ void nano::bootstrap_attempt_legacy::request_push (nano::unique_lock<nano::mutex
 	{
 		std::future<bool> future;
 		{
-			auto this_l (shared_from_this ());
-			auto client (std::make_shared<nano::bulk_push_client> (connection_l, this_l));
+			auto this_l = std::dynamic_pointer_cast<nano::bootstrap_attempt_legacy> (shared_from_this ());
+			auto client = std::make_shared<nano::bulk_push_client> (connection_l, this_l);
 			client->start ();
 			push = client;
 			future = client->promise.get_future ();

--- a/nano/node/bootstrap/bootstrap_legacy.hpp
+++ b/nano/node/bootstrap/bootstrap_legacy.hpp
@@ -28,7 +28,7 @@ public:
 	void add_frontier (nano::pull_info const &);
 	void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
-	void set_start_account (nano::account const &) override;
+	void set_start_account (nano::account const &);
 	void run_start (nano::unique_lock<nano::mutex> &);
 	void get_information (boost::property_tree::ptree &) override;
 	nano::tcp_endpoint endpoint_frontier_request;

--- a/nano/node/bootstrap/bootstrap_legacy.hpp
+++ b/nano/node/bootstrap/bootstrap_legacy.hpp
@@ -26,7 +26,7 @@ public:
 	bool request_frontier (nano::unique_lock<nano::mutex> &, bool = false);
 	void request_push (nano::unique_lock<nano::mutex> &);
 	void add_frontier (nano::pull_info const &);
-	void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &) override;
+	void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
 	bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &) override;
 	void set_start_account (nano::account const &) override;
 	void run_start (nano::unique_lock<nano::mutex> &);

--- a/nano/node/bootstrap/bootstrap_legacy.hpp
+++ b/nano/node/bootstrap/bootstrap_legacy.hpp
@@ -27,7 +27,7 @@ public:
 	void request_push (nano::unique_lock<nano::mutex> &);
 	void add_frontier (nano::pull_info const &);
 	void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &);
-	bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &) override;
+	bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &);
 	void set_start_account (nano::account const &) override;
 	void run_start (nano::unique_lock<nano::mutex> &);
 	void get_information (boost::property_tree::ptree &) override;

--- a/nano/node/bootstrap/bootstrap_legacy.hpp
+++ b/nano/node/bootstrap/bootstrap_legacy.hpp
@@ -25,7 +25,7 @@ public:
 	void stop () override;
 	bool request_frontier (nano::unique_lock<nano::mutex> &, bool = false);
 	void request_push (nano::unique_lock<nano::mutex> &);
-	void add_frontier (nano::pull_info const &) override;
+	void add_frontier (nano::pull_info const &);
 	void add_bulk_push_target (nano::block_hash const &, nano::block_hash const &) override;
 	bool request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> &) override;
 	void set_start_account (nano::account const &) override;


### PR DESCRIPTION
Removing a number of abstraction holes on nano::bootstrap_attempt that expose implementation details of concrete subtypes.