### PR TITLE
Adding unhandled case for message_visitor

### DIFF
--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -499,49 +499,49 @@ class message_visitor
 public:
 	virtual void keepalive (nano::keepalive const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	};
 	virtual void publish (nano::publish const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void confirm_req (nano::confirm_req const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void confirm_ack (nano::confirm_ack const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void bulk_pull (nano::bulk_pull const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void bulk_pull_account (nano::bulk_pull_account const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void bulk_push (nano::bulk_push const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void frontier_req (nano::frontier_req const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void node_id_handshake (nano::node_id_handshake const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void telemetry_req (nano::telemetry_req const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
 	virtual void telemetry_ack (nano::telemetry_ack const & message)
 	{
-		unhandled (message);
+		default_handler (message);
 	}
-	virtual void unhandled (nano::message const &){};
+	virtual void default_handler (nano::message const &){};
 	virtual ~message_visitor ();
 };
 

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -497,17 +497,51 @@ public:
 class message_visitor
 {
 public:
-	virtual void keepalive (nano::keepalive const &) = 0;
-	virtual void publish (nano::publish const &) = 0;
-	virtual void confirm_req (nano::confirm_req const &) = 0;
-	virtual void confirm_ack (nano::confirm_ack const &) = 0;
-	virtual void bulk_pull (nano::bulk_pull const &) = 0;
-	virtual void bulk_pull_account (nano::bulk_pull_account const &) = 0;
-	virtual void bulk_push (nano::bulk_push const &) = 0;
-	virtual void frontier_req (nano::frontier_req const &) = 0;
-	virtual void node_id_handshake (nano::node_id_handshake const &) = 0;
-	virtual void telemetry_req (nano::telemetry_req const &) = 0;
-	virtual void telemetry_ack (nano::telemetry_ack const &) = 0;
+	virtual void keepalive (nano::keepalive const & message)
+	{
+		unhandled (message);
+	};
+	virtual void publish (nano::publish const & message)
+	{
+		unhandled (message);
+	}
+	virtual void confirm_req (nano::confirm_req const & message)
+	{
+		unhandled (message);
+	}
+	virtual void confirm_ack (nano::confirm_ack const & message)
+	{
+		unhandled (message);
+	}
+	virtual void bulk_pull (nano::bulk_pull const & message)
+	{
+		unhandled (message);
+	}
+	virtual void bulk_pull_account (nano::bulk_pull_account const & message)
+	{
+		unhandled (message);
+	}
+	virtual void bulk_push (nano::bulk_push const & message)
+	{
+		unhandled (message);
+	}
+	virtual void frontier_req (nano::frontier_req const & message)
+	{
+		unhandled (message);
+	}
+	virtual void node_id_handshake (nano::node_id_handshake const & message)
+	{
+		unhandled (message);
+	}
+	virtual void telemetry_req (nano::telemetry_req const & message)
+	{
+		unhandled (message);
+	}
+	virtual void telemetry_ack (nano::telemetry_ack const & message)
+	{
+		unhandled (message);
+	}
+	virtual void unhandled (nano::message const &){};
 	virtual ~message_visitor ();
 };
 

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -41,47 +41,7 @@ public:
 	// the channel to reply to, if a reply is generated
 	std::shared_ptr<nano::transport::inproc::channel> channel;
 
-	void keepalive (nano::keepalive const & message)
-	{
-		inbound (message, channel);
-	}
-	void publish (nano::publish const & message)
-	{
-		inbound (message, channel);
-	}
-	void confirm_req (nano::confirm_req const & message)
-	{
-		inbound (message, channel);
-	}
-	void confirm_ack (nano::confirm_ack const & message)
-	{
-		inbound (message, channel);
-	}
-	void bulk_pull (nano::bulk_pull const & message)
-	{
-		inbound (message, channel);
-	}
-	void bulk_pull_account (nano::bulk_pull_account const & message)
-	{
-		inbound (message, channel);
-	}
-	void bulk_push (nano::bulk_push const & message)
-	{
-		inbound (message, channel);
-	}
-	void frontier_req (nano::frontier_req const & message)
-	{
-		inbound (message, channel);
-	}
-	void node_id_handshake (nano::node_id_handshake const & message)
-	{
-		inbound (message, channel);
-	}
-	void telemetry_req (nano::telemetry_req const & message)
-	{
-		inbound (message, channel);
-	}
-	void telemetry_ack (nano::telemetry_ack const & message)
+	void unhandled (nano::message const & message) override
 	{
 		inbound (message, channel);
 	}

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -41,7 +41,7 @@ public:
 	// the channel to reply to, if a reply is generated
 	std::shared_ptr<nano::transport::inproc::channel> channel;
 
-	void unhandled (nano::message const & message) override
+	void default_handler (nano::message const & message) override
 	{
 		inbound (message, channel);
 	}


### PR DESCRIPTION
Add unhandled case for message_visitor which all messages route to by default. This simplifies implementing new message handlers.