### PR TITLE
Extracting nano::bootstrap::block_deserializer class

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1,3 +1,4 @@
+#include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/test_common/system.hpp>
@@ -2031,4 +2032,9 @@ TEST (bulk_pull_account, basics)
 		ASSERT_EQ (nullptr, block_data.first.get ());
 		ASSERT_EQ (nullptr, block_data.second.get ());
 	}
+}
+
+TEST (block_deserializer, construction)
+{
+	auto deserializer = std::make_shared<nano::bootstrap::block_deserializer> ();
 }

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1434,13 +1434,13 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 				 .work (*node0->work_generate_blocking (receive1->hash ()))
 				 .build_shared ();
 
-	// Processing test chain
+	// Processing test c`hain
 	node0->block_processor.add (send1);
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 = system.add_node ();
 	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
@@ -1448,7 +1448,6 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	node1->bootstrap_wallet ();
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->ledger.block_or_pruned_exists (send2->hash ()));
-	node1->stop ();
 }
 
 TEST (bootstrap_processor, multiple_attempts)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1435,7 +1435,7 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 				 .work (*node0->work_generate_blocking (receive1->hash ()))
 				 .build_shared ();
 
-	// Processing test c`hain
+	// Processing test chain
 	node0->block_processor.add (send1);
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
   active_transactions.cpp
   blockprocessor.hpp
   blockprocessor.cpp
+  bootstrap/block_deserializer.hpp
+  bootstrap/block_deserializer.cpp
   bootstrap/bootstrap_attempt.hpp
   bootstrap/bootstrap_attempt.cpp
   bootstrap/bootstrap_bulk_pull.hpp

--- a/nano/node/bootstrap/block_deserializer.cpp
+++ b/nano/node/bootstrap/block_deserializer.cpp
@@ -1,0 +1,65 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/node/bootstrap/block_deserializer.hpp>
+#include <nano/node/socket.hpp>
+#include <nano/secure/buffer.hpp>
+
+nano::bootstrap::block_deserializer::block_deserializer () :
+	read_buffer{ std::make_shared<std::vector<uint8_t>> () }
+{
+}
+
+void nano::bootstrap::block_deserializer::read (nano::socket & socket, callback_type const && callback)
+{
+	debug_assert (callback);
+	read_buffer->resize (1);
+	socket.async_read (read_buffer, 1, [this_l = shared_from_this (), &socket, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
+		if (ec)
+		{
+			callback (ec, nullptr);
+			return;
+		}
+		if (size_a != 1)
+		{
+			callback (boost::asio::error::fault, nullptr);
+			return;
+		}
+		this_l->received_type (socket, std::move (callback));
+	});
+}
+
+void nano::bootstrap::block_deserializer::received_type (nano::socket & socket, callback_type const && callback)
+{
+	nano::block_type type = static_cast<nano::block_type> (read_buffer->data ()[0]);
+	if (type == nano::block_type::not_a_block)
+	{
+		callback (boost::system::error_code{}, nullptr);
+		return;
+	}
+	auto size = nano::block::size (type);
+	if (size == 0)
+	{
+		callback (boost::asio::error::fault, nullptr);
+		return;
+	}
+	read_buffer->resize (size);
+	socket.async_read (read_buffer, size, [this_l = shared_from_this (), size, type, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
+		if (ec)
+		{
+			callback (ec, nullptr);
+			return;
+		}
+		if (size_a != size)
+		{
+			callback (boost::asio::error::fault, nullptr);
+			return;
+		}
+		this_l->received_block (type, std::move (callback));
+	});
+}
+
+void nano::bootstrap::block_deserializer::received_block (nano::block_type type, callback_type const && callback)
+{
+	nano::bufferstream stream{ read_buffer->data (), read_buffer->size () };
+	auto block = nano::deserialize_block (stream, type);
+	callback (boost::system::error_code{}, block);
+}

--- a/nano/node/bootstrap/block_deserializer.hpp
+++ b/nano/node/bootstrap/block_deserializer.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <nano/lib/blocks.hpp>
+
+#include <boost/system/error_code.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace nano
+{
+class block;
+class socket;
+namespace bootstrap
+{
+	/**
+	 * Class to read a block-type byte followed by a serialised block from a stream.
+	 * It is typically used to used to read a series of block-types and blocks terminated by a not-a-block type.
+	 */
+	class block_deserializer : public std::enable_shared_from_this<nano::bootstrap::block_deserializer>
+	{
+	public:
+		using callback_type = std::function<void (boost::system::error_code, std::shared_ptr<nano::block>)>;
+
+		block_deserializer ();
+		/**
+		 * Read a type-prefixed block from 'socket' and pass the result, or an error, to 'callback'
+		 * A normal end to series of blocks is a marked by return no error and a nullptr for block.
+		 */
+		void read (nano::socket & socket, callback_type const && callback);
+
+	private:
+		/**
+		 * Called by read method on receipt of a block type byte.
+		 * The type byte will be in the read_buffer.
+		 */
+		void received_type (nano::socket & socket, callback_type const && callback);
+
+		/**
+		 * Called by received_type when a block is received, it parses the block and calls the callback.
+		 */
+		void received_block (nano::block_type type, callback_type const && callback);
+
+		std::shared_ptr<std::vector<uint8_t>> read_buffer;
+	};
+}
+}

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -19,12 +19,9 @@ nano::pull_info::pull_info (nano::hash_or_account const & account_or_head_a, nan
 }
 
 nano::bulk_pull_client::bulk_pull_client (std::shared_ptr<nano::bootstrap_client> const & connection_a, std::shared_ptr<nano::bootstrap_attempt> const & attempt_a, nano::pull_info const & pull_a) :
-	connection (connection_a),
-	attempt (attempt_a),
-	known_account{},
-	pull (pull_a),
-	pull_blocks (0),
-	unexpected_count (0)
+	connection{ connection_a },
+	attempt{ attempt_a },
+	pull{ pull_a }
 {
 	attempt->condition.notify_all ();
 }

--- a/nano/node/bootstrap/bootstrap_bulk_pull.hpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.hpp
@@ -42,12 +42,31 @@ public:
 	nano::block_hash first ();
 	std::shared_ptr<nano::bootstrap_client> connection;
 	std::shared_ptr<nano::bootstrap_attempt> attempt;
-	nano::block_hash expected;
-	nano::account known_account;
-	nano::pull_info pull;
-	uint64_t pull_blocks;
-	uint64_t unexpected_count;
 	bool network_error{ false };
+
+private:
+	/**
+	 * Tracks the next block expected to be received starting with the block hash that was expected and followed by previous blocks for this account chain
+	 */
+	nano::block_hash expected{ 0 };
+	/**
+	 * Tracks the account number for this account chain
+	 * Used when an account chain has a mix between state blocks and legacy blocks which do not encode the account number in the block
+	 * 0 if the account is unknown
+	*/
+	nano::account known_account{ 0 };
+	/**
+	 * Original pull request
+	 */
+	nano::pull_info pull;
+	/**
+	 * Tracks the number of blocks successfully deserialized
+	 */
+	uint64_t pull_blocks{ 0 };
+	/**
+	 * Tracks the number of times an unexpected block was received
+	 */
+	uint64_t unexpected_count{ 0 };
 };
 class bootstrap_attempt_wallet;
 class bulk_pull_account_client final : public std::enable_shared_from_this<nano::bulk_pull_account_client>

--- a/nano/node/bootstrap/bootstrap_bulk_pull.hpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.hpp
@@ -8,6 +8,10 @@
 namespace nano
 {
 class bootstrap_attempt;
+namespace bootstrap
+{
+	class block_deserializer;
+};
 class pull_info
 {
 public:
@@ -37,8 +41,7 @@ public:
 	void request ();
 	void receive_block ();
 	void throttled_receive_block ();
-	void received_type ();
-	void received_block (boost::system::error_code const &, std::size_t, nano::block_type);
+	void received_block (boost::system::error_code ec, std::shared_ptr<nano::block> block);
 	nano::block_hash first ();
 	std::shared_ptr<nano::bootstrap_client> connection;
 	std::shared_ptr<nano::bootstrap_attempt> attempt;
@@ -67,6 +70,7 @@ private:
 	 * Tracks the number of times an unexpected block was received
 	 */
 	uint64_t unexpected_count{ 0 };
+	std::shared_ptr<nano::bootstrap::block_deserializer> block_deserializer;
 };
 class bootstrap_attempt_wallet;
 class bulk_pull_account_client final : public std::enable_shared_from_this<nano::bulk_pull_account_client>

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -233,25 +233,26 @@ void nano::bulk_push_server::received_block (boost::system::error_code const & e
 	{
 		nano::bufferstream stream (receive_buffer->data (), size_a);
 		auto block (nano::deserialize_block (stream, type_a));
-		if (block != nullptr && !connection->node->network_params.work.validate_entry (*block))
+		if (block != nullptr)
 		{
+			if (connection->node->network_params.work.validate_entry (*block))
+			{
+				if (connection->node->config.logging.bulk_pull_logging ())
+				{
+					connection->node->logger.try_log (boost::str (boost::format ("Insufficient work for bulk push block: %1%") % block->hash ().to_string ()));
+				}
+				connection->node->stats.inc_detail_only (nano::stat::type::error, nano::stat::detail::insufficient_work);
+				return;
+			}
 			connection->node->process_active (std::move (block));
 			throttled_receive ();
 		}
-		else if (block == nullptr)
+		else
 		{
 			if (connection->node->config.logging.bulk_pull_logging ())
 			{
 				connection->node->logger.try_log ("Error deserializing block received from pull request");
 			}
-		}
-		else // Work invalid
-		{
-			if (connection->node->config.logging.bulk_pull_logging ())
-			{
-				connection->node->logger.try_log (boost::str (boost::format ("Insufficient work for bulk push block: %1%") % block->hash ().to_string ()));
-			}
-			connection->node->stats.inc_detail_only (nano::stat::type::error, nano::stat::detail::insufficient_work);
 		}
 	}
 }


### PR DESCRIPTION
The code to deserialize type-prefixed blocks from a stream was tightly coupled to the legacy bootstrap process. This prevented direct testing or reuse of block deserialization code.

Rewriting existing bulk_pull_client in terms of the new block deserializer.