### PR TITLE
Fix compatibility with Boost 1.78

### DIFF
--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -280,6 +280,7 @@ std::string nano::error_config_messages::message (int ev) const
 	return "Invalid error code";
 }
 
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 char const * nano::error_conversion::detail::generic_category::name () const noexcept
 {
 	return boost::system::generic_category ().name ();
@@ -307,16 +308,19 @@ std::error_code nano::error_conversion::convert (boost::system::error_code const
 	debug_assert (false);
 	return nano::error_common::invalid_type_conversion;
 }
+#endif
 
 nano::error::error (std::error_code code_a)
 {
 	code = code_a;
 }
 
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 nano::error::error (boost::system::error_code const & code_a)
 {
 	code = std::make_error_code (static_cast<std::errc> (code_a.value ()));
 }
+#endif
 
 nano::error::error (std::string message_a)
 {
@@ -352,6 +356,7 @@ nano::error & nano::error::operator= (std::error_code const code_a)
 	return *this;
 }
 
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 /** Assign boost error code (as converted to std::error_code) */
 nano::error & nano::error::operator= (boost::system::error_code const & code_a)
 {
@@ -367,6 +372,7 @@ nano::error & nano::error::operator= (boost::system::errc::errc_t const & code_a
 	message.clear ();
 	return *this;
 }
+#endif
 
 /** Set the error to nano::error_common::generic and the error message to \p message_a */
 nano::error & nano::error::operator= (std::string message_a)
@@ -390,11 +396,13 @@ bool nano::error::operator== (std::error_code const code_a) const
 	return code == code_a;
 }
 
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 /** Return true if this#error_code equals the parameter */
 bool nano::error::operator== (boost::system::error_code const code_a) const
 {
 	return code.value () == code_a.value ();
 }
+#endif
 
 /** Call the function iff the current error is zero */
 nano::error & nano::error::then (std::function<nano::error &()> next)
@@ -486,6 +494,7 @@ nano::error & nano::error::clear ()
 	return *this;
 }
 
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 // TODO: theoretically, nothing besides template (partial) specializations should ever be added inside std...
 namespace std
 {
@@ -494,3 +503,4 @@ std::error_code make_error_code (boost::system::errc::errc_t const & e)
 	return std::error_code (static_cast<int> (e), ::nano::error_conversion::generic_category ());
 }
 }
+#endif

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -196,6 +196,13 @@ REGISTER_ERROR_CODES (nano, error_rpc);
 REGISTER_ERROR_CODES (nano, error_process);
 REGISTER_ERROR_CODES (nano, error_config);
 
+#if BOOST_VERSION >= 107800
+/* no need for error_code bridge */
+#else
+# define NANO_USE_BOOST_TO_STD_ERROR_BRIDGE
+#endif
+
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 /* boost->std error_code bridge */
 namespace nano
 {
@@ -232,6 +239,7 @@ namespace error_conversion
 	std::error_code convert (boost::system::error_code const & error);
 }
 }
+#endif
 
 namespace nano
 {
@@ -244,18 +252,24 @@ public:
 	error (nano::error && error_a) = default;
 
 	error (std::error_code code_a);
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 	error (boost::system::error_code const & code_a);
+#endif
 	error (std::string message_a);
 	error (std::exception const & exception_a);
 	error & operator= (nano::error const & err_a);
 	error & operator= (nano::error && err_a);
 	error & operator= (std::error_code code_a);
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 	error & operator= (boost::system::error_code const & code_a);
 	error & operator= (boost::system::errc::errc_t const & code_a);
+#endif
 	error & operator= (std::string message_a);
 	error & operator= (std::exception const & exception_a);
 	bool operator== (std::error_code code_a) const;
+#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
 	bool operator== (boost::system::error_code code_a) const;
+#endif
 	error & then (std::function<nano::error &()> next);
 	template <typename... ErrorCode>
 	error & accept (ErrorCode... err)

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
 namespace nano


### PR DESCRIPTION
This PR fixes build errors when building node with Boost version 1.78 and later with AppleClang 13.1.6. Boost 1.78 already provides conversions between `boost::system::error_code` and `std::error_code`. 