### PR TITLE
Fix request loop unblocking during continuous inflood of votes

### DIFF
--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -41,6 +41,7 @@ public:
 	/** Note: node.active.mutex lock is required */
 	nano::vote_code vote_blocking (std::shared_ptr<nano::vote> const &, std::shared_ptr<nano::transport::channel> const &, bool = false);
 	void verify_votes (std::deque<std::pair<std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>>> const &);
+	/** Block until all queued votes are processed */
 	void flush ();
 	/** Block until the currently active processing cycle finishes */
 	void flush_active ();
@@ -70,7 +71,8 @@ private:
 	std::unordered_set<nano::account> representatives_1;
 	std::unordered_set<nano::account> representatives_2;
 	std::unordered_set<nano::account> representatives_3;
-	nano::condition_variable condition;
+	nano::condition_variable vote_condition;
+	nano::condition_variable flush_condition;
 	nano::mutex mutex{ mutex_identifier (mutexes::vote_processor) };
 	bool started;
 	bool stopped;


### PR DESCRIPTION
In case there is an continuous inflood of votes, is_active often does not equal false long enough to unblock the request loop thread which is then stuck in flush_active for multiple seconds or even minutes. This can be solved by only checking once for is_active in flush_active and unblocking the request loop thread by a separate flush notification.