### PR TITLE
Stop clone unchecked blocks being written to disk

### DIFF
--- a/nano/node/lmdb/unchecked_store.cpp
+++ b/nano/node/lmdb/unchecked_store.cpp
@@ -13,6 +13,12 @@ void nano::lmdb::unchecked_store::clear (nano::write_transaction const & transac
 
 void nano::lmdb::unchecked_store::put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info)
 {
+    if (info.block-> block_work () == last_work ){
+        last_work = info.block-> block_work();
+        return;
+    }
+    last_work = info.block-> block_work();
+
 	auto status = store.put (transaction_a, tables::unchecked, nano::unchecked_key{ dependency, info.block->hash () }, info);
 	store.release_assert_success (status);
 }

--- a/nano/node/lmdb/unchecked_store.hpp
+++ b/nano/node/lmdb/unchecked_store.hpp
@@ -26,6 +26,7 @@ namespace lmdb
 		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
 		size_t count (nano::transaction const & transaction_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
+        std::atomic<uint64_t> last_work;
 
 		/**
 		 * Unchecked bootstrap blocks info.

--- a/nano/node/rocksdb/unchecked_store.cpp
+++ b/nano/node/rocksdb/unchecked_store.cpp
@@ -13,6 +13,13 @@ void nano::rocksdb::unchecked_store::clear (nano::write_transaction const & tran
 
 void nano::rocksdb::unchecked_store::put (nano::write_transaction const & transaction_a, nano::hash_or_account const & dependency, nano::unchecked_info const & info)
 {
+
+    if (info.block-> block_work () == last_work ){
+        last_work = info.block-> block_work();
+        return;
+    }
+    last_work = info.block-> block_work();
+
 	auto status = store.put (transaction_a, tables::unchecked, nano::unchecked_key{ dependency, info.block->hash () }, info);
 	store.release_assert_success (status);
 }

--- a/nano/node/rocksdb/unchecked_store.hpp
+++ b/nano/node/rocksdb/unchecked_store.hpp
@@ -24,6 +24,7 @@ namespace rocksdb
 		nano::store_iterator<nano::unchecked_key, nano::unchecked_info> lower_bound (nano::transaction const & transaction_a, nano::unchecked_key const & key_a) const override;
 		size_t count (nano::transaction const & transaction_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>, nano::store_iterator<nano::unchecked_key, nano::unchecked_info>)> const & action_a) const override;
+        std::atomic<uint64_t> last_work;
 	};
 }
 }


### PR DESCRIPTION
One of the attacks is using a high volume of unchecked blocks with different signatures/hashes but using the same work value. They are invalid but are written to disk first as unchecked before they are processed and eventually are dumped. This simple patch compares the work value in the block with the last block, if they are the same it drops the block.

Tested on rocksdb and briefly tested on lmdb.

It is likely there is a far smarter way to do this.