### PR TITLE
Check for representative in wallet more often when running on test net

### DIFF
--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -43,7 +43,7 @@ nano::work_thresholds const nano::work_thresholds::publish_dev (
 0xf000000000000000 // 8x lower than epoch_1
 );
 
-nano::work_thresholds const nano::work_thresholds::publish_test ( //defaults to live network levels
+nano::work_thresholds const nano::work_thresholds::publish_test ( // defaults to live network levels
 get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
 get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
@@ -305,3 +305,9 @@ std::string get_tls_toml_config_path (boost::filesystem::path const & data_path)
 	return (data_path / "config-tls.toml").string ();
 }
 } // namespace nano
+
+uint32_t nano::test_scan_wallet_reps_delay ()
+{
+	auto test_env = nano::get_env_or_default ("NANO_TEST_WALLET_SCAN_REPS_DELAY", "900000"); // 15 minutes by default
+	return boost::lexical_cast<uint32_t> (test_env);
+}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -20,8 +20,8 @@ namespace filesystem
 #define ver_str(a) #a
 
 /**
-* Returns build version information
-*/
+ * Returns build version information
+ */
 char const * const NANO_VERSION_STRING = xstr (TAG_VERSION_STRING);
 char const * const NANO_MAJOR_VERSION_STRING = xstr (MAJOR_VERSION_STRING);
 char const * const NANO_MINOR_VERSION_STRING = xstr (MINOR_VERSION_STRING);
@@ -59,6 +59,10 @@ uint16_t test_rpc_port ();
 uint16_t test_ipc_port ();
 uint16_t test_websocket_port ();
 std::array<uint8_t, 2> test_magic_number ();
+/*
+ * How often to scan for representatives in local wallet, in milliseconds
+ */
+uint32_t test_scan_wallet_reps_delay ();
 
 /**
  * Network variants with different genesis blocks and network parameters

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1692,7 +1692,8 @@ void nano::wallets::ongoing_compute_reps ()
 {
 	compute_reps ();
 	auto & node_l (node);
-	auto compute_delay (network_params.network.is_dev_network () ? std::chrono::milliseconds (10) : std::chrono::milliseconds (15 * 60 * 1000)); // Representation drifts quickly on the test network but very slowly on the live network
+	// Representation drifts quickly on the test network but very slowly on the live network
+	auto compute_delay = network_params.network.is_dev_network () ? std::chrono::milliseconds (10) : (network_params.network.is_test_network () ? std::chrono::milliseconds (nano::test_scan_wallet_reps_delay ()) : std::chrono::minutes (15));
 	node.workers.add_timed_task (std::chrono::steady_clock::now () + compute_delay, [&node_l] () {
 		node_l.wallets.ongoing_compute_reps ();
 	});


### PR DESCRIPTION
When running on test network it's useful to have nodes update their representative status instantly.