### PR TITLE
Block constructors to builders conversion in unit tests

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -512,9 +512,9 @@ TEST (unchecked, double_put)
 	auto block_listing1 = unchecked.get (store->tx_begin_read (), block->previous ());
 	ASSERT_TRUE (block_listing1.empty ());
 	// Enqueues the block to be saved in the unchecked table
-	unchecked.put (block->previous (), nano::unchecked_info(block));
+	unchecked.put (block->previous (), nano::unchecked_info (block));
 	// Enqueues the block again in an attempt to have it there twice
-	unchecked.put (block->previous (), nano::unchecked_info(block));
+	unchecked.put (block->previous (), nano::unchecked_info (block));
 	auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 		return unchecked.get (transaction_a, block_hash_a).size () > 0;
 	};
@@ -1231,7 +1231,7 @@ TEST (block_store, state_block)
 				  .sign (key1.prv, key1.pub)
 				  .work (7)
 				  .build ();
-		
+
 	block1->sideband_set ({});
 	{
 		nano::ledger_cache ledger_cache;
@@ -1849,15 +1849,15 @@ namespace lmdb
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::block_builder builder;
 		auto block1 = builder
-						  .state ()
-						  .account (nano::dev::genesis_key.pub)
-						  .previous (nano::dev::genesis->hash ())
-						  .representative (nano::dev::genesis_key.pub)
-						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
-						  .link (nano::dev::genesis_key.pub)
-						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-						  .work (*pool.generate (nano::dev::genesis->hash ()))
-						  .build ();
+					  .state ()
+					  .account (nano::dev::genesis_key.pub)
+					  .previous (nano::dev::genesis->hash ())
+					  .representative (nano::dev::genesis_key.pub)
+					  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					  .link (nano::dev::genesis_key.pub)
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (nano::dev::genesis->hash ()))
+					  .build ();
 		auto block2 = builder
 					  .state ()
 					  .account (nano::dev::genesis_key.pub)
@@ -2247,7 +2247,7 @@ namespace lmdb
 		}
 		auto path (nano::unique_path ());
 		nano::keypair key1;
-		nano::block_builder builder;		
+		nano::block_builder builder;
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		auto send = builder
 					.send ()

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -116,17 +116,25 @@ TEST (block_store, add_item)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
-	block.sideband_set ({});
-	auto hash1 (block.hash ());
+	nano::block_builder builder;
+	auto block = builder
+				 .open ()
+				 .source (0)
+				 .representative (1)
+				 .account (0)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (0)
+				 .build ();
+	block->sideband_set ({});
+	auto hash1 (block->hash ());
 	auto transaction (store->tx_begin_write ());
 	auto latest1 (store->block.get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
 	ASSERT_FALSE (store->block.exists (transaction, hash1));
-	store->block.put (transaction, hash1, block);
+	store->block.put (transaction, hash1, *block);
 	auto latest2 (store->block.get (transaction, hash1));
 	ASSERT_NE (nullptr, latest2);
-	ASSERT_EQ (block, *latest2);
+	ASSERT_EQ (*block, *latest2);
 	ASSERT_TRUE (store->block.exists (transaction, hash1));
 	ASSERT_FALSE (store->block.exists (transaction, hash1.number () - 1));
 	store->block.del (transaction, hash1);
@@ -139,28 +147,43 @@ TEST (block_store, clear_successor)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
-	block1.sideband_set ({});
+	nano::block_builder builder;
+	auto block1 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (0)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block1->sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block.put (transaction, block1.hash (), block1);
-	nano::open_block block2 (0, 2, 0, nano::keypair ().prv, 0, 0);
-	block2.sideband_set ({});
-	store->block.put (transaction, block2.hash (), block2);
-	auto block2_store (store->block.get (transaction, block1.hash ()));
+	store->block.put (transaction, block1->hash (), *block1);
+	auto block2 = builder
+				  .open ()
+				  .source (0)
+				  .representative (2)
+				  .account (0)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block2->sideband_set ({});
+	store->block.put (transaction, block2->hash (), *block2);
+	auto block2_store (store->block.get (transaction, block1->hash ()));
 	ASSERT_NE (nullptr, block2_store);
 	ASSERT_EQ (0, block2_store->sideband ().successor.number ());
 	auto modified_sideband = block2_store->sideband ();
-	modified_sideband.successor = block2.hash ();
-	block1.sideband_set (modified_sideband);
-	store->block.put (transaction, block1.hash (), block1);
+	modified_sideband.successor = block2->hash ();
+	block1->sideband_set (modified_sideband);
+	store->block.put (transaction, block1->hash (), *block1);
 	{
-		auto block1_store (store->block.get (transaction, block1.hash ()));
+		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);
-		ASSERT_EQ (block2.hash (), block1_store->sideband ().successor);
+		ASSERT_EQ (block2->hash (), block1_store->sideband ().successor);
 	}
-	store->block.successor_clear (transaction, block1.hash ());
+	store->block.successor_clear (transaction, block1->hash ());
 	{
-		auto block1_store (store->block.get (transaction, block1.hash ()));
+		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);
 		ASSERT_EQ (0, block1_store->sideband ().successor.number ());
 	}
@@ -172,17 +195,25 @@ TEST (block_store, add_nonempty_block)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
-	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
-	block.sideband_set ({});
-	auto hash1 (block.hash ());
-	block.signature = nano::sign_message (key1.prv, key1.pub, hash1);
+	nano::block_builder builder;
+	auto block = builder
+				 .open ()
+				 .source (0)
+				 .representative (1)
+				 .account (0)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (0)
+				 .build ();
+	block->sideband_set ({});
+	auto hash1 (block->hash ());
+	block->signature = nano::sign_message (key1.prv, key1.pub, hash1);
 	auto transaction (store->tx_begin_write ());
 	auto latest1 (store->block.get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
-	store->block.put (transaction, hash1, block);
+	store->block.put (transaction, hash1, *block);
 	auto latest2 (store->block.get (transaction, hash1));
 	ASSERT_NE (nullptr, latest2);
-	ASSERT_EQ (block, *latest2);
+	ASSERT_EQ (*block, *latest2);
 }
 
 TEST (block_store, add_two_items)
@@ -191,28 +222,43 @@ TEST (block_store, add_two_items)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
-	nano::open_block block (0, 1, 1, nano::keypair ().prv, 0, 0);
-	block.sideband_set ({});
-	auto hash1 (block.hash ());
-	block.signature = nano::sign_message (key1.prv, key1.pub, hash1);
+	nano::block_builder builder;
+	auto block = builder
+				 .open ()
+				 .source (0)
+				 .representative (1)
+				 .account (1)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (0)
+				 .build ();
+	block->sideband_set ({});
+	auto hash1 (block->hash ());
+	block->signature = nano::sign_message (key1.prv, key1.pub, hash1);
 	auto transaction (store->tx_begin_write ());
 	auto latest1 (store->block.get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
-	nano::open_block block2 (0, 1, 3, nano::keypair ().prv, 0, 0);
-	block2.sideband_set ({});
-	block2.hashables.account = 3;
-	auto hash2 (block2.hash ());
-	block2.signature = nano::sign_message (key1.prv, key1.pub, hash2);
+	auto block2 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (3)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block2->sideband_set ({});
+	block2->hashables.account = 3;
+	auto hash2 (block2->hash ());
+	block2->signature = nano::sign_message (key1.prv, key1.pub, hash2);
 	auto latest2 (store->block.get (transaction, hash2));
 	ASSERT_EQ (nullptr, latest2);
-	store->block.put (transaction, hash1, block);
-	store->block.put (transaction, hash2, block2);
+	store->block.put (transaction, hash1, *block);
+	store->block.put (transaction, hash2, *block2);
 	auto latest3 (store->block.get (transaction, hash1));
 	ASSERT_NE (nullptr, latest3);
-	ASSERT_EQ (block, *latest3);
+	ASSERT_EQ (*block, *latest3);
 	auto latest4 (store->block.get (transaction, hash2));
 	ASSERT_NE (nullptr, latest4);
-	ASSERT_EQ (block2, *latest4);
+	ASSERT_EQ (*block2, *latest4);
 	ASSERT_FALSE (*latest3 == *latest4);
 }
 
@@ -223,19 +269,33 @@ TEST (block_store, add_receive)
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key1;
 	nano::keypair key2;
-	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
-	block1.sideband_set ({});
+	nano::block_builder builder;
+	auto block1 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (0)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block1->sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block.put (transaction, block1.hash (), block1);
-	nano::receive_block block (block1.hash (), 1, nano::keypair ().prv, 2, 3);
-	block.sideband_set ({});
-	nano::block_hash hash1 (block.hash ());
+	store->block.put (transaction, block1->hash (), *block1);
+	auto block = builder
+				 .receive ()
+				 .previous (block1->hash ())
+				 .source (1)
+				 .sign (nano::keypair ().prv, 2)
+				 .work (3)
+				 .build ();
+	block->sideband_set ({});
+	nano::block_hash hash1 (block->hash ());
 	auto latest1 (store->block.get (transaction, hash1));
 	ASSERT_EQ (nullptr, latest1);
-	store->block.put (transaction, hash1, block);
+	store->block.put (transaction, hash1, *block);
 	auto latest2 (store->block.get (transaction, hash1));
 	ASSERT_NE (nullptr, latest2);
-	ASSERT_EQ (block, *latest2);
+	ASSERT_EQ (*block, *latest2);
 }
 
 TEST (block_store, add_pending)
@@ -361,12 +421,20 @@ TEST (unchecked, simple)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
 	ASSERT_TRUE (!store->init_error ());
-	std::shared_ptr<nano::block> block = std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5);
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (0)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (5)
+				 .build_shared ();
 	// Asserts the block wasn't added yet to the unchecked table
 	auto block_listing1 = unchecked.get (store->tx_begin_read (), block->previous ());
 	ASSERT_TRUE (block_listing1.empty ());
 	// Enqueues a block to be saved on the unchecked table
-	unchecked.put (block->previous (), block);
+	unchecked.put (block->previous (), nano::unchecked_info (block));
 	// Waits for the block to get written in the database
 	auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 		return unchecked.get (transaction_a, block_hash_a).size () > 0;
@@ -398,14 +466,22 @@ TEST (unchecked, multiple)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
 	ASSERT_TRUE (!store->init_error ());
-	std::shared_ptr<nano::block> block = std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5);
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (4)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (5)
+				 .build_shared ();
 	// Asserts the block wasn't added yet to the unchecked table
 	auto block_listing1 = unchecked.get (store->tx_begin_read (), block->previous ());
 	ASSERT_TRUE (block_listing1.empty ());
 	// Enqueues the first block
-	unchecked.put (block->previous (), block);
+	unchecked.put (block->previous (), nano::unchecked_info (block));
 	// Enqueues a second block
-	unchecked.put (block->source (), block);
+	unchecked.put (block->source (), nano::unchecked_info (block));
 	auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 		return unchecked.get (transaction_a, block_hash_a).size () > 0;
 	};
@@ -423,14 +499,22 @@ TEST (unchecked, double_put)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
 	ASSERT_TRUE (!store->init_error ());
-	std::shared_ptr<nano::block> block = std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5);
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (4)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (5)
+				 .build_shared ();
 	// Asserts the block wasn't added yet to the unchecked table
 	auto block_listing1 = unchecked.get (store->tx_begin_read (), block->previous ());
 	ASSERT_TRUE (block_listing1.empty ());
 	// Enqueues the block to be saved in the unchecked table
-	unchecked.put (block->previous (), block);
+	unchecked.put (block->previous (), nano::unchecked_info(block));
 	// Enqueues the block again in an attempt to have it there twice
-	unchecked.put (block->previous (), block);
+	unchecked.put (block->previous (), nano::unchecked_info(block));
 	auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 		return unchecked.get (transaction_a, block_hash_a).size () > 0;
 	};
@@ -450,18 +534,40 @@ TEST (unchecked, multiple_get)
 	nano::unchecked_map unchecked{ *store, false };
 	ASSERT_TRUE (!store->init_error ());
 	// Instantiates three blocks
-	std::shared_ptr<nano::block> block1 = std::make_shared<nano::send_block> (4, 1, 2, nano::keypair ().prv, 4, 5);
-	std::shared_ptr<nano::block> block2 = std::make_shared<nano::send_block> (3, 1, 2, nano::keypair ().prv, 4, 5);
-	std::shared_ptr<nano::block> block3 = std::make_shared<nano::send_block> (5, 1, 2, nano::keypair ().prv, 4, 5);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (4)
+				  .destination (1)
+				  .balance (2)
+				  .sign (nano::keypair ().prv, 4)
+				  .work (5)
+				  .build_shared ();
+	auto block2 = builder
+				  .send ()
+				  .previous (3)
+				  .destination (1)
+				  .balance (2)
+				  .sign (nano::keypair ().prv, 4)
+				  .work (5)
+				  .build_shared ();
+	auto block3 = builder
+				  .send ()
+				  .previous (5)
+				  .destination (1)
+				  .balance (2)
+				  .sign (nano::keypair ().prv, 4)
+				  .work (5)
+				  .build_shared ();
 	// Add the blocks' info to the unchecked table
-	unchecked.put (block1->previous (), block1); // unchecked1
-	unchecked.put (block1->hash (), block1); // unchecked2
-	unchecked.put (block2->previous (), block2); // unchecked3
-	unchecked.put (block1->previous (), block2); // unchecked1
-	unchecked.put (block1->hash (), block2); // unchecked2
-	unchecked.put (block3->previous (), block3);
-	unchecked.put (block3->hash (), block3); // unchecked4
-	unchecked.put (block1->previous (), block3); // unchecked1
+	unchecked.put (block1->previous (), nano::unchecked_info (block1)); // unchecked1
+	unchecked.put (block1->hash (), nano::unchecked_info (block1)); // unchecked2
+	unchecked.put (block2->previous (), nano::unchecked_info (block2)); // unchecked3
+	unchecked.put (block1->previous (), nano::unchecked_info (block2)); // unchecked1
+	unchecked.put (block1->hash (), nano::unchecked_info (block2)); // unchecked2
+	unchecked.put (block3->previous (), nano::unchecked_info (block3));
+	unchecked.put (block3->hash (), nano::unchecked_info (block3)); // unchecked4
+	unchecked.put (block1->previous (), nano::unchecked_info (block3)); // unchecked1
 
 	// count the number of blocks in the unchecked table by counting them one by one
 	// we cannot trust the count() method if the backend is rocksdb
@@ -531,11 +637,19 @@ TEST (block_store, one_block)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::open_block block1 (0, 1, 0, nano::keypair ().prv, 0, 0);
-	block1.sideband_set ({});
+	nano::block_builder builder;
+	auto block1 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (0)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block1->sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block.put (transaction, block1.hash (), block1);
-	ASSERT_TRUE (store->block.exists (transaction, block1.hash ()));
+	store->block.put (transaction, block1->hash (), *block1);
+	ASSERT_TRUE (store->block.exists (transaction, block1->hash ()));
 }
 
 TEST (block_store, empty_bootstrap)
@@ -555,8 +669,23 @@ TEST (block_store, unchecked_begin_search)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::keypair key0;
-	nano::send_block block1 (0, 1, 2, key0.prv, key0.pub, 3);
-	nano::send_block block2 (5, 6, 7, key0.prv, key0.pub, 8);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (0)
+				  .destination (1)
+				  .balance (2)
+				  .sign (key0.prv, key0.pub)
+				  .work (3)
+				  .build ();
+	auto block2 = builder
+				  .send ()
+				  .previous (5)
+				  .destination (6)
+				  .balance (7)
+				  .sign (key0.prv, key0.pub)
+				  .work (8)
+				  .build ();
 }
 
 TEST (block_store, frontier_retrieval)
@@ -606,22 +735,37 @@ TEST (block_store, two_block)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::open_block block1 (0, 1, 1, nano::keypair ().prv, 0, 0);
-	block1.sideband_set ({});
-	block1.hashables.account = 1;
+	nano::block_builder builder;
+	auto block1 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (1)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block1->sideband_set ({});
+	block1->hashables.account = 1;
 	std::vector<nano::block_hash> hashes;
 	std::vector<nano::open_block> blocks;
-	hashes.push_back (block1.hash ());
-	blocks.push_back (block1);
+	hashes.push_back (block1->hash ());
+	blocks.push_back (*block1);
 	auto transaction (store->tx_begin_write ());
-	store->block.put (transaction, hashes[0], block1);
-	nano::open_block block2 (0, 1, 2, nano::keypair ().prv, 0, 0);
-	block2.sideband_set ({});
-	hashes.push_back (block2.hash ());
-	blocks.push_back (block2);
-	store->block.put (transaction, hashes[1], block2);
-	ASSERT_TRUE (store->block.exists (transaction, block1.hash ()));
-	ASSERT_TRUE (store->block.exists (transaction, block2.hash ()));
+	store->block.put (transaction, hashes[0], *block1);
+	auto block2 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (2)
+				  .sign (nano::keypair ().prv, 0)
+				  .work (0)
+				  .build ();
+	block2->sideband_set ({});
+	hashes.push_back (block2->hash ());
+	blocks.push_back (*block2);
+	store->block.put (transaction, hashes[1], *block2);
+	ASSERT_TRUE (store->block.exists (transaction, block1->hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, block2->hash ()));
 }
 
 TEST (block_store, two_account)
@@ -779,14 +923,41 @@ TEST (block_store, roots)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::send_block send_block (0, 1, 2, nano::keypair ().prv, 4, 5);
-	ASSERT_EQ (send_block.hashables.previous, send_block.root ());
-	nano::change_block change_block (0, 1, nano::keypair ().prv, 3, 4);
-	ASSERT_EQ (change_block.hashables.previous, change_block.root ());
-	nano::receive_block receive_block (0, 1, nano::keypair ().prv, 3, 4);
-	ASSERT_EQ (receive_block.hashables.previous, receive_block.root ());
-	nano::open_block open_block (0, 1, 2, nano::keypair ().prv, 4, 5);
-	ASSERT_EQ (open_block.hashables.account, open_block.root ());
+	nano::block_builder builder;
+	auto send_block = builder
+					  .send ()
+					  .previous (0)
+					  .destination (1)
+					  .balance (2)
+					  .sign (nano::keypair ().prv, 4)
+					  .work (5)
+					  .build ();
+	ASSERT_EQ (send_block->hashables.previous, send_block->root ());
+	auto change_block = builder
+						.change ()
+						.previous (0)
+						.representative (1)
+						.sign (nano::keypair ().prv, 3)
+						.work (4)
+						.build ();
+	ASSERT_EQ (change_block->hashables.previous, change_block->root ());
+	auto receive_block = builder
+						 .receive ()
+						 .previous (0)
+						 .source (1)
+						 .sign (nano::keypair ().prv, 3)
+						 .work (4)
+						 .build ();
+	ASSERT_EQ (receive_block->hashables.previous, receive_block->root ());
+	auto open_block = builder
+					  .open ()
+					  .source (0)
+					  .representative (1)
+					  .account (2)
+					  .sign (nano::keypair ().prv, 4)
+					  .work (5)
+					  .build ();
+	ASSERT_EQ (open_block->hashables.account, open_block->root ());
 }
 
 TEST (block_store, pending_exists)
@@ -875,13 +1046,28 @@ TEST (block_store, block_replace)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::send_block send1 (0, 0, 0, nano::keypair ().prv, 0, 1);
-	send1.sideband_set ({});
-	nano::send_block send2 (0, 0, 0, nano::keypair ().prv, 0, 2);
-	send2.sideband_set ({});
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (0)
+				 .destination (0)
+				 .balance (0)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (1)
+				 .build ();
+	send1->sideband_set ({});
+	auto send2 = builder
+				 .send ()
+				 .previous (0)
+				 .destination (0)
+				 .balance (0)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (2)
+				 .build ();
+	send2->sideband_set ({});
 	auto transaction (store->tx_begin_write ());
-	store->block.put (transaction, 0, send1);
-	store->block.put (transaction, 0, send2);
+	store->block.put (transaction, 0, *send1);
+	store->block.put (transaction, 0, *send2);
 	auto block3 (store->block.get (transaction, 0));
 	ASSERT_NE (nullptr, block3);
 	ASSERT_EQ (2, block3->block_work ());
@@ -895,10 +1081,18 @@ TEST (block_store, block_count)
 	{
 		auto transaction (store->tx_begin_write ());
 		ASSERT_EQ (0, store->block.count (transaction));
-		nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
-		block.sideband_set ({});
-		auto hash1 (block.hash ());
-		store->block.put (transaction, hash1, block);
+		nano::block_builder builder;
+		auto block = builder
+					 .open ()
+					 .source (0)
+					 .representative (1)
+					 .account (0)
+					 .sign (nano::keypair ().prv, 0)
+					 .work (0)
+					 .build ();
+		block->sideband_set ({});
+		auto hash1 (block->hash ());
+		store->block.put (transaction, hash1, *block);
 	}
 	auto transaction (store->tx_begin_read ());
 	ASSERT_EQ (1, store->block.count (transaction));
@@ -951,9 +1145,17 @@ TEST (block_store, pruned_random)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::open_block block (0, 1, 0, nano::keypair ().prv, 0, 0);
-	block.sideband_set ({});
-	auto hash1 (block.hash ());
+	nano::block_builder builder;
+	auto block = builder
+				 .open ()
+				 .source (0)
+				 .representative (1)
+				 .account (0)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (0)
+				 .build ();
+	block->sideband_set ({});
+	auto hash1 (block->hash ());
 	{
 		nano::ledger_cache ledger_cache;
 		auto transaction (store->tx_begin_write ());
@@ -979,20 +1181,35 @@ namespace lmdb
 		auto transaction (store.tx_begin_write ());
 		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_store.unchecked_handle, 1));
 		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE, &store.unchecked_store.unchecked_handle));
-		std::shared_ptr<nano::block> send1 = std::make_shared<nano::send_block> (0, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
-		std::shared_ptr<nano::block> send2 = std::make_shared<nano::send_block> (1, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		nano::block_builder builder;
+		auto send1 = builder
+					 .send ()
+					 .previous (0)
+					 .destination (0)
+					 .balance (0)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
+		auto send2 = builder
+					 .send ()
+					 .previous (1)
+					 .destination (0)
+					 .balance (0)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		ASSERT_NE (send1->hash (), send2->hash ());
-		unchecked.put (send1->hash (), send1);
-		unchecked.put (send1->hash (), send2);
+		unchecked.put (send1->hash (), nano::unchecked_info (send1));
+		unchecked.put (send1->hash (), nano::unchecked_info (send2));
 		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_store.unchecked_handle, 0));
 		mdb_dbi_close (store.env, store.unchecked_store.unchecked_handle);
 		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_store.unchecked_handle));
-		unchecked.put (send1->hash (), send1);
-		unchecked.put (send1->hash (), send2);
+		unchecked.put (send1->hash (), nano::unchecked_info (send1));
+		unchecked.put (send1->hash (), nano::unchecked_info (send2));
 		ASSERT_EQ (0, mdb_drop (store.env.tx (transaction), store.unchecked_store.unchecked_handle, 1));
 		ASSERT_EQ (0, mdb_dbi_open (store.env.tx (transaction), "unchecked", MDB_CREATE | MDB_DUPSORT, &store.unchecked_store.unchecked_handle));
-		unchecked.put (send1->hash (), send1);
-		unchecked.put (send1->hash (), send2);
+		unchecked.put (send1->hash (), nano::unchecked_info (send1));
+		unchecked.put (send1->hash (), nano::unchecked_info (send2));
 	}
 }
 }
@@ -1003,25 +1220,36 @@ TEST (block_store, state_block)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::keypair key1;
-	nano::state_block block1 (1, nano::dev::genesis->hash (), 3, 4, 6, key1.prv, key1.pub, 7);
-	block1.sideband_set ({});
+	nano::block_builder builder;
+	auto block1 = builder
+				  .state ()
+				  .account (1)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (3)
+				  .balance (4)
+				  .link (6)
+				  .sign (key1.prv, key1.pub)
+				  .work (7)
+				  .build ();
+		
+	block1->sideband_set ({});
 	{
 		nano::ledger_cache ledger_cache;
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger_cache, nano::dev::constants);
-		ASSERT_EQ (nano::block_type::state, block1.type ());
-		store->block.put (transaction, block1.hash (), block1);
-		ASSERT_TRUE (store->block.exists (transaction, block1.hash ()));
-		auto block2 (store->block.get (transaction, block1.hash ()));
+		ASSERT_EQ (nano::block_type::state, block1->type ());
+		store->block.put (transaction, block1->hash (), *block1);
+		ASSERT_TRUE (store->block.exists (transaction, block1->hash ()));
+		auto block2 (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block2);
-		ASSERT_EQ (block1, *block2);
+		ASSERT_EQ (*block1, *block2);
 	}
 	{
 		auto transaction (store->tx_begin_write ());
 		auto count (store->block.count (transaction));
 		ASSERT_EQ (2, count);
-		store->block.del (transaction, block1.hash ());
-		ASSERT_FALSE (store->block.exists (transaction, block1.hash ()));
+		store->block.del (transaction, block1->hash ());
+		ASSERT_FALSE (store->block.exists (transaction, block1->hash ()));
 	}
 	auto transaction (store->tx_begin_read ());
 	auto count2 (store->block.count (transaction));
@@ -1043,56 +1271,146 @@ TEST (mdb_block_store, sideband_height)
 	ASSERT_FALSE (store.init_error ());
 	nano::stat stat;
 	nano::ledger ledger (store, stat, nano::dev::constants);
+	nano::block_builder builder;
 	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, ledger.cache, nano::dev::constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-	nano::change_block change (receive.hash (), 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (receive.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
-	nano::state_block state_send1 (nano::dev::genesis_key.pub, change.hash (), 0, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send1).code);
-	nano::state_block state_send2 (nano::dev::genesis_key.pub, state_send1.hash (), 0, nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio, key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send2).code);
-	nano::state_block state_send3 (nano::dev::genesis_key.pub, state_send2.hash (), 0, nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio, key3.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_send2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send3).code);
-	nano::state_block state_open (key1.pub, 0, 0, nano::Gxrb_ratio, state_send1.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_open).code);
-	nano::state_block epoch (key1.pub, state_open.hash (), 0, nano::Gxrb_ratio, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_open.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch).code);
-	ASSERT_EQ (nano::epoch::epoch_1, store.block.version (transaction, epoch.hash ()));
-	nano::state_block epoch_open (key2.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch_open).code);
-	ASSERT_EQ (nano::epoch::epoch_1, store.block.version (transaction, epoch_open.hash ()));
-	nano::state_block state_receive (key2.pub, epoch_open.hash (), 0, nano::Gxrb_ratio, state_send2.hash (), key2.prv, key2.pub, *pool.generate (epoch_open.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive).code);
-	nano::open_block open (state_send3.hash (), nano::dev::genesis_key.pub, key3.pub, key3.prv, key3.pub, *pool.generate (key3.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	auto receive = builder
+				   .receive ()
+				   .previous (send->hash ())
+				   .source (send->hash ())
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (send->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+	auto change = builder
+				  .change ()
+				  .previous (receive->hash ())
+				  .representative (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (receive->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
+	auto state_send1 = builder
+					   .state ()
+					   .account (nano::dev::genesis_key.pub)
+					   .previous (change->hash ())
+					   .representative (0)
+					   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					   .link (key1.pub)
+					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					   .work (*pool.generate (change->hash ()))
+					   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send1).code);
+	auto state_send2 = builder
+					   .state ()
+					   .account (nano::dev::genesis_key.pub)
+					   .previous (state_send1->hash ())
+					   .representative (0)
+					   .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+					   .link (key2.pub)
+					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					   .work (*pool.generate (state_send1->hash ()))
+					   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send2).code);
+	auto state_send3 = builder
+					   .state ()
+					   .account (nano::dev::genesis_key.pub)
+					   .previous (state_send2->hash ())
+					   .representative (0)
+					   .balance (nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio)
+					   .link (key3.pub)
+					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					   .work (*pool.generate (state_send2->hash ()))
+					   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send3).code);
+	auto state_open = builder
+					  .state ()
+					  .account (key1.pub)
+					  .previous (0)
+					  .representative (0)
+					  .balance (nano::Gxrb_ratio)
+					  .link (state_send1->hash ())
+					  .sign (key1.prv, key1.pub)
+					  .work (*pool.generate (key1.pub))
+					  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_open).code);
+	auto epoch = builder
+				 .state ()
+				 .account (key1.pub)
+				 .previous (state_open->hash ())
+				 .representative (0)
+				 .balance (nano::Gxrb_ratio)
+				 .link (ledger.epoch_link (nano::epoch::epoch_1))
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (state_open->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch).code);
+	ASSERT_EQ (nano::epoch::epoch_1, store.block.version (transaction, epoch->hash ()));
+	auto epoch_open = builder
+					  .state ()
+					  .account (key2.pub)
+					  .previous (0)
+					  .representative (0)
+					  .balance (0)
+					  .link (ledger.epoch_link (nano::epoch::epoch_1))
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (key2.pub))
+					  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch_open).code);
+	ASSERT_EQ (nano::epoch::epoch_1, store.block.version (transaction, epoch_open->hash ()));
+	auto state_receive = builder
+						 .state ()
+						 .account (key2.pub)
+						 .previous (epoch_open->hash ())
+						 .representative (0)
+						 .balance (nano::Gxrb_ratio)
+						 .link (state_send2->hash ())
+						 .sign (key2.prv, key2.pub)
+						 .work (*pool.generate (epoch_open->hash ()))
+						 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_receive).code);
+	auto open = builder
+				.open ()
+				.source (state_send3->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.account (key3.pub)
+				.sign (key3.prv, key3.pub)
+				.work (*pool.generate (key3.pub))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	auto block1 (store.block.get (transaction, nano::dev::genesis->hash ()));
 	ASSERT_EQ (block1->sideband ().height, 1);
-	auto block2 (store.block.get (transaction, send.hash ()));
+	auto block2 (store.block.get (transaction, send->hash ()));
 	ASSERT_EQ (block2->sideband ().height, 2);
-	auto block3 (store.block.get (transaction, receive.hash ()));
+	auto block3 (store.block.get (transaction, receive->hash ()));
 	ASSERT_EQ (block3->sideband ().height, 3);
-	auto block4 (store.block.get (transaction, change.hash ()));
+	auto block4 (store.block.get (transaction, change->hash ()));
 	ASSERT_EQ (block4->sideband ().height, 4);
-	auto block5 (store.block.get (transaction, state_send1.hash ()));
+	auto block5 (store.block.get (transaction, state_send1->hash ()));
 	ASSERT_EQ (block5->sideband ().height, 5);
-	auto block6 (store.block.get (transaction, state_send2.hash ()));
+	auto block6 (store.block.get (transaction, state_send2->hash ()));
 	ASSERT_EQ (block6->sideband ().height, 6);
-	auto block7 (store.block.get (transaction, state_send3.hash ()));
+	auto block7 (store.block.get (transaction, state_send3->hash ()));
 	ASSERT_EQ (block7->sideband ().height, 7);
-	auto block8 (store.block.get (transaction, state_open.hash ()));
+	auto block8 (store.block.get (transaction, state_open->hash ()));
 	ASSERT_EQ (block8->sideband ().height, 1);
-	auto block9 (store.block.get (transaction, epoch.hash ()));
+	auto block9 (store.block.get (transaction, epoch->hash ()));
 	ASSERT_EQ (block9->sideband ().height, 2);
-	auto block10 (store.block.get (transaction, epoch_open.hash ()));
+	auto block10 (store.block.get (transaction, epoch_open->hash ()));
 	ASSERT_EQ (block10->sideband ().height, 1);
-	auto block11 (store.block.get (transaction, state_receive.hash ()));
+	auto block11 (store.block.get (transaction, state_receive->hash ()));
 	ASSERT_EQ (block11->sideband ().height, 2);
-	auto block12 (store.block.get (transaction, open.hash ()));
+	auto block12 (store.block.get (transaction, open->hash ()));
 	ASSERT_EQ (block12->sideband ().height, 1);
 }
 
@@ -1236,8 +1554,16 @@ TEST (block_store, pruned_blocks)
 	ASSERT_TRUE (!store->init_error ());
 
 	nano::keypair key1;
-	nano::open_block block1 (0, 1, key1.pub, key1.prv, key1.pub, 0);
-	auto hash1 (block1.hash ());
+	nano::block_builder builder;
+	auto block1 = builder
+				  .open ()
+				  .source (0)
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (0)
+				  .build ();
+	auto hash1 (block1->hash ());
 	{
 		auto transaction (store->tx_begin_write ());
 
@@ -1254,9 +1580,16 @@ TEST (block_store, pruned_blocks)
 	ASSERT_EQ (store->pruned.count (store->tx_begin_read ()), 1);
 
 	// Add another one and check that it (and the existing one) can be found
-	nano::open_block block2 (1, 2, key1.pub, key1.prv, key1.pub, 0);
-	block2.sideband_set ({});
-	auto hash2 (block2.hash ());
+	auto block2 = builder
+				  .open ()
+				  .source (1)
+				  .representative (2)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (0)
+				  .build ();
+	block2->sideband_set ({});
+	auto hash2 (block2->hash ());
 	{
 		auto transaction (store->tx_begin_write ());
 		store->pruned.put (transaction, hash2);
@@ -1274,7 +1607,7 @@ TEST (block_store, pruned_blocks)
 		store->pruned.del (transaction, hash2);
 		ASSERT_FALSE (store->pruned.exists (transaction, hash2)); // Confirm it no longer exists
 		ASSERT_FALSE (store->block.exists (transaction, hash2)); // true for block_exists
-		store->block.put (transaction, hash2, block2); // Add corresponding block
+		store->block.put (transaction, hash2, *block2); // Add corresponding block
 		ASSERT_TRUE (store->block.exists (transaction, hash2));
 		ASSERT_TRUE (store->pruned.exists (transaction, hash1)); // Check first pruned hash is still here
 		ASSERT_FALSE (store->block.exists (transaction, hash1));
@@ -1305,13 +1638,36 @@ namespace lmdb
 		}
 		// Extract confirmation height to a separate database
 		auto path (nano::unique_path ());
+		nano::block_builder builder;
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-		nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub,
-		nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-		nano::state_block epoch (nano::dev::genesis_key.pub, send.hash (), nano::dev::genesis_key.pub,
-		nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
-		nano::state_block state_send (nano::dev::genesis_key.pub, epoch.hash (), nano::dev::genesis_key.pub,
-		nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch.hash ()));
+		auto send = builder
+					.send ()
+					.previous (nano::dev::genesis->hash ())
+					.destination (nano::dev::genesis_key.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.build ();
+		auto epoch = builder
+					 .state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					 .link (nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1))
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*pool.generate (send->hash ()))
+					 .build ();
+		auto state_send = builder
+						  .state ()
+						  .account (nano::dev::genesis_key.pub)
+						  .previous (epoch->hash ())
+						  .representative (nano::dev::genesis_key.pub)
+						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+						  .link (nano::dev::genesis_key.pub)
+						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						  .work (*pool.generate (epoch->hash ()))
+						  .build ();
 		{
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
@@ -1338,35 +1694,35 @@ namespace lmdb
 			ASSERT_FALSE (
 			mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE,
 			&store.block_store.state_blocks_handle));
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send).code);
 			// Lower the database to the previous version
 			store.version.put (transaction, 14);
 			store.confirmation_height.del (transaction, nano::dev::genesis->account ());
 			modify_account_info_to_v14 (store, transaction, nano::dev::genesis->account (),
-			confirmation_height_info.height, state_send.hash ());
+			confirmation_height_info.height, state_send->hash ());
 
-			store.pending.del (transaction, nano::pending_key (nano::dev::genesis->account (), state_send.hash ()));
+			store.pending.del (transaction, nano::pending_key (nano::dev::genesis->account (), state_send->hash ()));
 
-			write_sideband_v14 (store, transaction, state_send, store.block_store.state_blocks_v1_handle);
-			write_sideband_v14 (store, transaction, epoch, store.block_store.state_blocks_v1_handle);
+			write_sideband_v14 (store, transaction, *state_send, store.block_store.state_blocks_v1_handle);
+			write_sideband_v14 (store, transaction, *epoch, store.block_store.state_blocks_v1_handle);
 			write_block_w_sideband_v18 (store, store.block_store.open_blocks_handle, transaction, *nano::dev::genesis);
-			write_block_w_sideband_v18 (store, store.block_store.send_blocks_handle, transaction, send);
+			write_block_w_sideband_v18 (store, store.block_store.send_blocks_handle, transaction, *send);
 
 			// Remove from blocks table
-			store.block.del (transaction, state_send.hash ());
-			store.block.del (transaction, epoch.hash ());
+			store.block.del (transaction, state_send->hash ());
+			store.block.del (transaction, epoch->hash ());
 
 			// Turn pending into v14
 			ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_store.pending_v0_handle,
-			nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, send.hash ())),
+			nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, send->hash ())),
 			nano::mdb_val (
 			nano::pending_info_v14 (nano::dev::genesis->account (), nano::Gxrb_ratio,
 			nano::epoch::epoch_0)),
 			0));
 			ASSERT_FALSE (mdb_put (store.env.tx (transaction), store.pending_store.pending_v1_handle,
-			nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send.hash ())),
+			nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send->hash ())),
 			nano::mdb_val (
 			nano::pending_info_v14 (nano::dev::genesis->account (), nano::Gxrb_ratio,
 			nano::epoch::epoch_1)),
@@ -1410,25 +1766,25 @@ namespace lmdb
 		auto error_get_accounts_v1 (mdb_get (store.env.tx (transaction), store.account_store.accounts_v1_handle,
 		nano::mdb_val (nano::dev::genesis->account ()), value));
 		ASSERT_NE (error_get_accounts_v1, MDB_SUCCESS);
-		auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_store.pending_v1_handle, nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send.hash ())), value));
+		auto error_get_pending_v1 (mdb_get (store.env.tx (transaction), store.pending_store.pending_v1_handle, nano::mdb_val (nano::pending_key (nano::dev::genesis_key.pub, state_send->hash ())), value));
 		ASSERT_NE (error_get_pending_v1, MDB_SUCCESS);
 		auto error_get_state_v1 (
-		mdb_get (store.env.tx (transaction), store.block_store.state_blocks_v1_handle, nano::mdb_val (state_send.hash ()),
+		mdb_get (store.env.tx (transaction), store.block_store.state_blocks_v1_handle, nano::mdb_val (state_send->hash ()),
 		value));
 		ASSERT_NE (error_get_state_v1, MDB_SUCCESS);
 
 		// Check that the epochs are set correctly for the sideband, accounts and pending entries
-		auto block = store.block.get (transaction, state_send.hash ());
+		auto block = store.block.get (transaction, state_send->hash ());
 		ASSERT_NE (block, nullptr);
 		ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
-		block = store.block.get (transaction, send.hash ());
+		block = store.block.get (transaction, send->hash ());
 		ASSERT_NE (block, nullptr);
 		ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_0);
 		ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);
 		nano::pending_info pending_info;
-		store.pending.get (transaction, nano::pending_key (nano::dev::genesis_key.pub, send.hash ()), pending_info);
+		store.pending.get (transaction, nano::pending_key (nano::dev::genesis_key.pub, send->hash ()), pending_info);
 		ASSERT_EQ (pending_info.epoch, nano::epoch::epoch_0);
-		store.pending.get (transaction, nano::pending_key (nano::dev::genesis_key.pub, state_send.hash ()),
+		store.pending.get (transaction, nano::pending_key (nano::dev::genesis_key.pub, state_send->hash ()),
 		pending_info);
 		ASSERT_EQ (pending_info.epoch, nano::epoch::epoch_1);
 
@@ -1491,9 +1847,37 @@ namespace lmdb
 			return;
 		}
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-		nano::state_block block1 (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-		nano::state_block block2 (nano::dev::genesis_key.pub, block1.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio - 1, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-		nano::state_block block3 (nano::dev::genesis_key.pub, block2.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio - 2, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block2.hash ()));
+		nano::block_builder builder;
+		auto block1 = builder
+						  .state ()
+						  .account (nano::dev::genesis_key.pub)
+						  .previous (nano::dev::genesis->hash ())
+						  .representative (nano::dev::genesis_key.pub)
+						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+						  .link (nano::dev::genesis_key.pub)
+						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						  .work (*pool.generate (nano::dev::genesis->hash ()))
+						  .build ();
+		auto block2 = builder
+					  .state ()
+					  .account (nano::dev::genesis_key.pub)
+					  .previous (block1->hash ())
+					  .representative (nano::dev::genesis_key.pub)
+					  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio - 1)
+					  .link (nano::dev::genesis_key.pub)
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (block1->hash ()))
+					  .build ();
+		auto block3 = builder
+					  .state ()
+					  .account (nano::dev::genesis_key.pub)
+					  .previous (block2->hash ())
+					  .representative (nano::dev::genesis_key.pub)
+					  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio - 2)
+					  .link (nano::dev::genesis_key.pub)
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (block2->hash ()))
+					  .build ();
 
 		auto code = [&block1, &block2, &block3] (auto confirmation_height, nano::block_hash const & expected_cemented_frontier) {
 			auto path (nano::unique_path ());
@@ -1505,17 +1889,17 @@ namespace lmdb
 				nano::ledger ledger (store, stats, nano::dev::constants);
 				auto transaction (store.tx_begin_write ());
 				store.initialize (transaction, ledger.cache, nano::dev::constants);
-				ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-				ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-				ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
+				ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+				ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+				ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
 				modify_confirmation_height_to_v15 (store, transaction, nano::dev::genesis->account (), confirmation_height);
 
 				ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.block_store.open_blocks_handle));
 				write_block_w_sideband_v18 (store, store.block_store.open_blocks_handle, transaction, *nano::dev::genesis);
 				ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "state_blocks", MDB_CREATE, &store.block_store.state_blocks_handle));
-				write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, block1);
-				write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, block2);
-				write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, block3);
+				write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *block1);
+				write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *block2);
+				write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *block3);
 
 				// Lower the database to the previous version
 				store.version.put (transaction, 16);
@@ -1540,9 +1924,9 @@ namespace lmdb
 
 		code (0, nano::block_hash (0));
 		code (1, nano::dev::genesis->hash ());
-		code (2, block1.hash ());
-		code (3, block2.hash ());
-		code (4, block3.hash ());
+		code (2, block1->hash ());
+		code (3, block2->hash ());
+		code (4, block3->hash ());
 	}
 
 	TEST (mdb_block_store, upgrade_v17_v18)
@@ -1553,22 +1937,129 @@ namespace lmdb
 			return;
 		}
 		auto path (nano::unique_path ());
+		nano::block_builder builder;
 		nano::keypair key1;
 		nano::keypair key2;
 		nano::keypair key3;
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-		nano::send_block send_zero (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-		nano::state_block state_receive_zero (nano::dev::genesis_key.pub, send_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, send_zero.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send_zero.hash ()));
-		nano::state_block epoch (nano::dev::genesis_key.pub, state_receive_zero.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_receive_zero.hash ()));
-		nano::state_block state_send (nano::dev::genesis_key.pub, epoch.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch.hash ()));
-		nano::state_block state_receive (nano::dev::genesis_key.pub, state_send.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, state_send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_send.hash ()));
-		nano::state_block state_change (nano::dev::genesis_key.pub, state_receive.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_receive.hash ()));
-		nano::state_block state_send_change (nano::dev::genesis_key.pub, state_change.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_change.hash ()));
-		nano::state_block epoch_first (key1.pub, 0, 0, 0, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (key1.pub));
-		nano::state_block state_receive2 (key1.pub, epoch_first.hash (), key1.pub, nano::Gxrb_ratio, state_send_change.hash (), key1.prv, key1.pub, *pool.generate (epoch_first.hash ()));
-		nano::state_block state_send2 (nano::dev::genesis_key.pub, state_send_change.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_send_change.hash ()));
-		nano::state_block state_open (key2.pub, 0, key2.pub, nano::Gxrb_ratio, state_send2.hash (), key2.prv, key2.pub, *pool.generate (key2.pub));
-		nano::state_block state_send_epoch_link (key2.pub, state_open.hash (), key2.pub, 0, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_2), key2.prv, key2.pub, *pool.generate (state_open.hash ()));
+		auto send_zero = builder
+						 .send ()
+						 .previous (nano::dev::genesis->hash ())
+						 .destination (nano::dev::genesis_key.pub)
+						 .balance (nano::dev::constants.genesis_amount)
+						 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						 .work (*pool.generate (nano::dev::genesis->hash ()))
+						 .build ();
+		auto state_receive_zero = builder
+								  .state ()
+								  .account (nano::dev::genesis_key.pub)
+								  .previous (send_zero->hash ())
+								  .representative (nano::dev::genesis_key.pub)
+								  .balance (nano::dev::constants.genesis_amount)
+								  .link (send_zero->hash ())
+								  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+								  .work (*pool.generate (send_zero->hash ()))
+								  .build ();
+		auto epoch = builder
+					 .state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (state_receive_zero->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount)
+					 .link (nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1))
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*pool.generate (state_receive_zero->hash ()))
+					 .build ();
+		auto state_send = builder
+						  .state ()
+						  .account (nano::dev::genesis_key.pub)
+						  .previous (epoch->hash ())
+						  .representative (nano::dev::genesis_key.pub)
+						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+						  .link (nano::dev::genesis_key.pub)
+						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						  .work (*pool.generate (epoch->hash ()))
+						  .build ();
+		auto state_receive = builder
+							 .state ()
+							 .account (nano::dev::genesis_key.pub)
+							 .previous (state_send->hash ())
+							 .representative (nano::dev::genesis_key.pub)
+							 .balance (nano::dev::constants.genesis_amount)
+							 .link (state_send->hash ())
+							 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+							 .work (*pool.generate (state_send->hash ()))
+							 .build ();
+		auto state_change = builder
+							.state ()
+							.account (nano::dev::genesis_key.pub)
+							.previous (state_receive->hash ())
+							.representative (nano::dev::genesis_key.pub)
+							.balance (nano::dev::constants.genesis_amount)
+							.link (0)
+							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+							.work (*pool.generate (state_receive->hash ()))
+							.build ();
+		auto state_send_change = builder
+								 .state ()
+								 .account (nano::dev::genesis_key.pub)
+								 .previous (state_change->hash ())
+								 .representative (key1.pub)
+								 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+								 .link (key1.pub)
+								 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+								 .work (*pool.generate (state_change->hash ()))
+								 .build ();
+		auto epoch_first = builder
+						   .state ()
+						   .account (key1.pub)
+						   .previous (0)
+						   .representative (0)
+						   .balance (0)
+						   .link (nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_2))
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*pool.generate (key1.pub))
+						   .build ();
+		auto state_receive2 = builder
+							  .state ()
+							  .account (key1.pub)
+							  .previous (epoch_first->hash ())
+							  .representative (key1.pub)
+							  .balance (nano::Gxrb_ratio)
+							  .link (state_send_change->hash ())
+							  .sign (key1.prv, key1.pub)
+							  .work (*pool.generate (epoch_first->hash ()))
+							  .build ();
+		auto state_send2 = builder
+						   .state ()
+						   .account (nano::dev::genesis_key.pub)
+						   .previous (state_send_change->hash ())
+						   .representative (key1.pub)
+						   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+						   .link (key2.pub)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*pool.generate (state_send_change->hash ()))
+						   .build ();
+		auto state_open = builder
+						  .state ()
+						  .account (key2.pub)
+						  .previous (0)
+						  .representative (key2.pub)
+						  .balance (nano::Gxrb_ratio)
+						  .link (state_send2->hash ())
+						  .sign (key2.prv, key2.pub)
+						  .work (*pool.generate (key2.pub))
+						  .build ();
+		auto state_send_epoch_link = builder
+									 .state ()
+									 .account (key2.pub)
+									 .previous (state_open->hash ())
+									 .representative (key2.pub)
+									 .balance (0)
+									 .link (nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_2))
+									 .sign (key2.prv, key2.pub)
+									 .work (*pool.generate (state_open->hash ()))
+									 .build ();
 		{
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
@@ -1576,18 +2067,18 @@ namespace lmdb
 			nano::stat stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send_zero).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive_zero).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_change).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send_change).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch_first).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_receive2).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send2).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_open).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send_epoch_link).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send_zero).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_receive_zero).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_receive).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_change).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send_change).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch_first).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_receive2).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send2).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_open).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send_epoch_link).code);
 
 			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "open", MDB_CREATE, &store.block_store.open_blocks_handle));
 			ASSERT_FALSE (mdb_dbi_open (store.env.tx (transaction), "send", MDB_CREATE, &store.block_store.send_blocks_handle));
@@ -1596,30 +2087,30 @@ namespace lmdb
 			// Downgrade the store
 			store.version.put (transaction, 17);
 
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, state_receive);
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, epoch_first);
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, state_send2);
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, state_send_epoch_link);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *state_receive);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *epoch_first);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *state_send2);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *state_send_epoch_link);
 			write_block_w_sideband_v18 (store, store.block_store.open_blocks_handle, transaction, *nano::dev::genesis);
-			write_block_w_sideband_v18 (store, store.block_store.send_blocks_handle, transaction, send_zero);
+			write_block_w_sideband_v18 (store, store.block_store.send_blocks_handle, transaction, *send_zero);
 
 			// Replace with the previous sideband version for state blocks
 			// The upgrade can resume after upgrading some blocks, test this by only downgrading some of them
-			write_sideband_v15 (store, transaction, state_receive_zero);
-			write_sideband_v15 (store, transaction, epoch);
-			write_sideband_v15 (store, transaction, state_send);
-			write_sideband_v15 (store, transaction, state_change);
-			write_sideband_v15 (store, transaction, state_send_change);
-			write_sideband_v15 (store, transaction, state_receive2);
-			write_sideband_v15 (store, transaction, state_open);
+			write_sideband_v15 (store, transaction, *state_receive_zero);
+			write_sideband_v15 (store, transaction, *epoch);
+			write_sideband_v15 (store, transaction, *state_send);
+			write_sideband_v15 (store, transaction, *state_change);
+			write_sideband_v15 (store, transaction, *state_send_change);
+			write_sideband_v15 (store, transaction, *state_receive2);
+			write_sideband_v15 (store, transaction, *state_open);
 
-			store.block.del (transaction, state_receive_zero.hash ());
-			store.block.del (transaction, epoch.hash ());
-			store.block.del (transaction, state_send.hash ());
-			store.block.del (transaction, state_change.hash ());
-			store.block.del (transaction, state_send_change.hash ());
-			store.block.del (transaction, state_receive2.hash ());
-			store.block.del (transaction, state_open.hash ());
+			store.block.del (transaction, state_receive_zero->hash ());
+			store.block.del (transaction, epoch->hash ());
+			store.block.del (transaction, state_send->hash ());
+			store.block.del (transaction, state_change->hash ());
+			store.block.del (transaction, state_send_change->hash ());
+			store.block.del (transaction, state_receive2->hash ());
+			store.block.del (transaction, state_open->hash ());
 		}
 
 		// Now do the upgrade
@@ -1630,13 +2121,13 @@ namespace lmdb
 
 		// Size of state block should equal that set in db (no change)
 		nano::mdb_val value;
-		ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.block_store.blocks_handle, nano::mdb_val (state_send.hash ()), value));
+		ASSERT_FALSE (mdb_get (store.env.tx (transaction), store.block_store.blocks_handle, nano::mdb_val (state_send->hash ()), value));
 		ASSERT_EQ (value.size (), sizeof (nano::block_type) + nano::state_block::size + nano::block_sideband::size (nano::block_type::state));
 
 		// Check that sidebands are correctly populated
 		{
 			// Non-state unaffected
-			auto block = store.block.get (transaction, send_zero.hash ());
+			auto block = store.block.get (transaction, send_zero->hash ());
 			ASSERT_NE (block, nullptr);
 			// All defaults
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_0);
@@ -1646,7 +2137,7 @@ namespace lmdb
 		}
 		{
 			// State receive from old zero send
-			auto block = store.block.get (transaction, state_receive_zero.hash ());
+			auto block = store.block.get (transaction, state_receive_zero->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_0);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1655,7 +2146,7 @@ namespace lmdb
 		}
 		{
 			// Epoch
-			auto block = store.block.get (transaction, epoch.hash ());
+			auto block = store.block.get (transaction, epoch->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_TRUE (block->sideband ().details.is_epoch);
@@ -1664,7 +2155,7 @@ namespace lmdb
 		}
 		{
 			// State send
-			auto block = store.block.get (transaction, state_send.hash ());
+			auto block = store.block.get (transaction, state_send->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1673,7 +2164,7 @@ namespace lmdb
 		}
 		{
 			// State receive
-			auto block = store.block.get (transaction, state_receive.hash ());
+			auto block = store.block.get (transaction, state_receive->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1682,7 +2173,7 @@ namespace lmdb
 		}
 		{
 			// State change
-			auto block = store.block.get (transaction, state_change.hash ());
+			auto block = store.block.get (transaction, state_change->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1691,7 +2182,7 @@ namespace lmdb
 		}
 		{
 			// State send + change
-			auto block = store.block.get (transaction, state_send_change.hash ());
+			auto block = store.block.get (transaction, state_send_change->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1700,7 +2191,7 @@ namespace lmdb
 		}
 		{
 			// Epoch on unopened account
-			auto block = store.block.get (transaction, epoch_first.hash ());
+			auto block = store.block.get (transaction, epoch_first->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_2);
 			ASSERT_TRUE (block->sideband ().details.is_epoch);
@@ -1709,7 +2200,7 @@ namespace lmdb
 		}
 		{
 			// State open following epoch
-			auto block = store.block.get (transaction, state_receive2.hash ());
+			auto block = store.block.get (transaction, state_receive2->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_2);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1718,7 +2209,7 @@ namespace lmdb
 		}
 		{
 			// Another state send
-			auto block = store.block.get (transaction, state_send2.hash ());
+			auto block = store.block.get (transaction, state_send2->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1727,7 +2218,7 @@ namespace lmdb
 		}
 		{
 			// State open
-			auto block = store.block.get (transaction, state_open.hash ());
+			auto block = store.block.get (transaction, state_open->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1736,7 +2227,7 @@ namespace lmdb
 		}
 		{
 			// State send to an epoch link
-			auto block = store.block.get (transaction, state_send_epoch_link.hash ());
+			auto block = store.block.get (transaction, state_send_epoch_link->hash ());
 			ASSERT_NE (block, nullptr);
 			ASSERT_EQ (block->sideband ().details.epoch, nano::epoch::epoch_1);
 			ASSERT_FALSE (block->sideband ().details.is_epoch);
@@ -1756,14 +2247,60 @@ namespace lmdb
 		}
 		auto path (nano::unique_path ());
 		nano::keypair key1;
+		nano::block_builder builder;		
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-		nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-		nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
-		nano::change_block change (receive.hash (), 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (receive.hash ()));
-		nano::state_block state_epoch (nano::dev::genesis_key.pub, change.hash (), 0, nano::dev::constants.genesis_amount, nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change.hash ()));
-		nano::state_block state_send (nano::dev::genesis_key.pub, state_epoch.hash (), 0, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (state_epoch.hash ()));
-		nano::state_block state_open (key1.pub, 0, 0, nano::Gxrb_ratio, state_send.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
-
+		auto send = builder
+					.send ()
+					.previous (nano::dev::genesis->hash ())
+					.destination (nano::dev::genesis_key.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.build ();
+		auto receive = builder
+					   .receive ()
+					   .previous (send->hash ())
+					   .source (send->hash ())
+					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					   .work (*pool.generate (send->hash ()))
+					   .build ();
+		auto change = builder
+					  .change ()
+					  .previous (receive->hash ())
+					  .representative (0)
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (receive->hash ()))
+					  .build ();
+		auto state_epoch = builder
+						   .state ()
+						   .account (nano::dev::genesis_key.pub)
+						   .previous (change->hash ())
+						   .representative (0)
+						   .balance (nano::dev::constants.genesis_amount)
+						   .link (nano::dev::network_params.ledger.epochs.link (nano::epoch::epoch_1))
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*pool.generate (change->hash ()))
+						   .build ();
+		auto state_send = builder
+						  .state ()
+						  .account (nano::dev::genesis_key.pub)
+						  .previous (state_epoch->hash ())
+						  .representative (0)
+						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+						  .link (key1.pub)
+						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						  .work (*pool.generate (state_epoch->hash ()))
+						  .build ();
+		auto state_open = builder
+						  .state ()
+						  .account (key1.pub)
+						  .previous (0)
+						  .representative (0)
+						  .balance (nano::Gxrb_ratio)
+						  .link (state_send->hash ())
+						  .sign (key1.prv, key1.pub)
+						  .work (*pool.generate (key1.pub))
+						  .build ();
 		{
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
@@ -1772,12 +2309,12 @@ namespace lmdb
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
 
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_epoch).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_send).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, state_open).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_epoch).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send).code);
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_open).code);
 
 			// These tables need to be re-opened and populated so that an upgrade can be done
 			auto txn = store.env.tx (transaction);
@@ -1789,12 +2326,12 @@ namespace lmdb
 
 			// Modify blocks back to the old tables
 			write_block_w_sideband_v18 (store, store.block_store.open_blocks_handle, transaction, *nano::dev::genesis);
-			write_block_w_sideband_v18 (store, store.block_store.send_blocks_handle, transaction, send);
-			write_block_w_sideband_v18 (store, store.block_store.receive_blocks_handle, transaction, receive);
-			write_block_w_sideband_v18 (store, store.block_store.change_blocks_handle, transaction, change);
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, state_epoch);
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, state_send);
-			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, state_open);
+			write_block_w_sideband_v18 (store, store.block_store.send_blocks_handle, transaction, *send);
+			write_block_w_sideband_v18 (store, store.block_store.receive_blocks_handle, transaction, *receive);
+			write_block_w_sideband_v18 (store, store.block_store.change_blocks_handle, transaction, *change);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *state_epoch);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *state_send);
+			write_block_w_sideband_v18 (store, store.block_store.state_blocks_handle, transaction, *state_open);
 
 			store.version.put (transaction, 18);
 		}
@@ -1813,21 +2350,21 @@ namespace lmdb
 		ASSERT_EQ (store.block_store.state_blocks_handle, 0);
 
 		// Confirm these blocks all exist after the upgrade
-		ASSERT_TRUE (store.block.get (transaction, send.hash ()));
-		ASSERT_TRUE (store.block.get (transaction, receive.hash ()));
-		ASSERT_TRUE (store.block.get (transaction, change.hash ()));
+		ASSERT_TRUE (store.block.get (transaction, send->hash ()));
+		ASSERT_TRUE (store.block.get (transaction, receive->hash ()));
+		ASSERT_TRUE (store.block.get (transaction, change->hash ()));
 		ASSERT_TRUE (store.block.get (transaction, nano::dev::genesis->hash ()));
-		auto state_epoch_disk (store.block.get (transaction, state_epoch.hash ()));
+		auto state_epoch_disk (store.block.get (transaction, state_epoch->hash ()));
 		ASSERT_NE (nullptr, state_epoch_disk);
 		ASSERT_EQ (nano::epoch::epoch_1, state_epoch_disk->sideband ().details.epoch);
 		ASSERT_EQ (nano::epoch::epoch_0, state_epoch_disk->sideband ().source_epoch); // Not used for epoch state blocks
-		ASSERT_TRUE (store.block.get (transaction, state_send.hash ()));
-		auto state_send_disk (store.block.get (transaction, state_send.hash ()));
+		ASSERT_TRUE (store.block.get (transaction, state_send->hash ()));
+		auto state_send_disk (store.block.get (transaction, state_send->hash ()));
 		ASSERT_NE (nullptr, state_send_disk);
 		ASSERT_EQ (nano::epoch::epoch_1, state_send_disk->sideband ().details.epoch);
 		ASSERT_EQ (nano::epoch::epoch_0, state_send_disk->sideband ().source_epoch); // Not used for send state blocks
-		ASSERT_TRUE (store.block.get (transaction, state_open.hash ()));
-		auto state_open_disk (store.block.get (transaction, state_open.hash ()));
+		ASSERT_TRUE (store.block.get (transaction, state_open->hash ()));
+		auto state_open_disk (store.block.get (transaction, state_open->hash ()));
 		ASSERT_NE (nullptr, state_open_disk);
 		ASSERT_EQ (nano::epoch::epoch_1, state_open_disk->sideband ().details.epoch);
 		ASSERT_EQ (nano::epoch::epoch_1, state_open_disk->sideband ().source_epoch);
@@ -2046,9 +2583,17 @@ TEST (block_store, reset_renew_existing_transaction)
 	ASSERT_TRUE (!store->init_error ());
 
 	nano::keypair key1;
-	nano::open_block block (0, 1, 1, nano::keypair ().prv, 0, 0);
-	block.sideband_set ({});
-	auto hash1 (block.hash ());
+	nano::block_builder builder;
+	auto block = builder
+				 .open ()
+				 .source (0)
+				 .representative (1)
+				 .account (1)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (0)
+				 .build ();
+	block->sideband_set ({});
+	auto hash1 (block->hash ());
 	auto read_transaction = store->tx_begin_read ();
 
 	// Block shouldn't exist yet
@@ -2061,7 +2606,7 @@ TEST (block_store, reset_renew_existing_transaction)
 	// Write the block
 	{
 		auto write_transaction (store->tx_begin_write ());
-		store->block.put (write_transaction, hash1, block);
+		store->block.put (write_transaction, hash1, *block);
 	}
 
 	read_transaction.renew ();
@@ -2105,9 +2650,17 @@ TEST (rocksdb_block_store, tombstone_count)
 		auto store = std::make_unique<nano::rocksdb::store> (logger, nano::unique_path (), nano::dev::constants);
 		nano::unchecked_map unchecked{ *store, false };
 		ASSERT_TRUE (!store->init_error ());
-		std::shared_ptr<nano::block> block = std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5);
+		nano::block_builder builder;
+		auto block = builder
+					 .send ()
+					 .previous (0)
+					 .destination (1)
+					 .balance (2)
+					 .sign (nano::keypair ().prv, 4)
+					 .work (5)
+					 .build_shared ();
 		// Enqueues a block to be saved in the database
-		unchecked.put (block->previous (), block);
+		unchecked.put (block->previous (), nano::unchecked_info (block));
 		auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 			return unchecked.get (transaction_a, block_hash_a).size () > 0;
 		};

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -622,7 +622,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 					 .build ();
 		auto receive1 = builder
 						.receive ()
-						.previous (send1->hash())
+						.previous (send1->hash ())
 						.source (send2->hash ())
 						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						.work (*system.work.generate (send1->hash ()))

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -40,7 +40,17 @@ TEST (confirmation_height, single)
 		nano::keypair key1;
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 		nano::block_hash latest1 (node->latest (nano::dev::genesis_key.pub));
-		auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, latest1, nano::dev::genesis_key.pub, amount - 100, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest1)));
+		nano::block_builder builder;
+		auto send1 = builder
+					 .state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (latest1)
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (amount - 100)
+					 .link (key1.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (latest1))
+					 .build_shared ();
 
 		// Check confirmation heights before, should be uninitialized (1 for genesis).
 		nano::confirmation_height_info confirmation_height_info;
@@ -91,43 +101,119 @@ TEST (confirmation_height, multiple_accounts)
 		nano::keypair key2;
 		nano::keypair key3;
 		nano::block_hash latest1 (system.nodes[0]->latest (nano::dev::genesis_key.pub));
+		nano::block_builder builder;
 
 		// Send to all accounts
-		nano::send_block send1 (latest1, key1.pub, node->online_reps.delta () + 300, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest1));
-		nano::send_block send2 (send1.hash (), key2.pub, node->online_reps.delta () + 200, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::send_block send3 (send2.hash (), key3.pub, node->online_reps.delta () + 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send2.hash ()));
+		auto send1 = builder
+					 .send ()
+					 .previous (latest1)
+					 .destination (key1.pub)
+					 .balance (node->online_reps.delta () + 300)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (latest1))
+					 .build ();
+		auto send2 = builder
+					 .send ()
+					 .previous (send1->hash ())
+					 .destination (key2.pub)
+					 .balance (node->online_reps.delta () + 200)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send1->hash ()))
+					 .build ();
+		auto send3 = builder
+					 .send ()
+					 .previous (send2->hash ())
+					 .destination (key3.pub)
+					 .balance (node->online_reps.delta () + 100)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send2->hash ()))
+					 .build ();
 
 		// Open all accounts
-		nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-		nano::open_block open2 (send2.hash (), nano::dev::genesis->account (), key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
-		nano::open_block open3 (send3.hash (), nano::dev::genesis->account (), key3.pub, key3.prv, key3.pub, *system.work.generate (key3.pub));
+		auto open1 = builder
+					 .open ()
+					 .source (send1->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .account (key1.pub)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (key1.pub))
+					 .build ();
+		auto open2 = builder
+					 .open ()
+					 .source (send2->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .account (key2.pub)
+					 .sign (key2.prv, key2.pub)
+					 .work (*system.work.generate (key2.pub))
+					 .build ();
+		auto open3 = builder
+					 .open ()
+					 .source (send3->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .account (key3.pub)
+					 .sign (key3.prv, key3.pub)
+					 .work (*system.work.generate (key3.pub))
+					 .build ();
 
 		// Send and receive various blocks to these accounts
-		nano::send_block send4 (open1.hash (), key2.pub, 50, key1.prv, key1.pub, *system.work.generate (open1.hash ()));
-		nano::send_block send5 (send4.hash (), key2.pub, 10, key1.prv, key1.pub, *system.work.generate (send4.hash ()));
+		auto send4 = builder
+					 .send ()
+					 .previous (open1->hash ())
+					 .destination (key2.pub)
+					 .balance (50)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (open1->hash ()))
+					 .build ();
+		auto send5 = builder
+					 .send ()
+					 .previous (send4->hash ())
+					 .destination (key2.pub)
+					 .balance (10)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (send4->hash ()))
+					 .build ();
 
-		nano::receive_block receive1 (open2.hash (), send4.hash (), key2.prv, key2.pub, *system.work.generate (open2.hash ()));
-		nano::send_block send6 (receive1.hash (), key3.pub, 10, key2.prv, key2.pub, *system.work.generate (receive1.hash ()));
-		nano::receive_block receive2 (send6.hash (), send5.hash (), key2.prv, key2.pub, *system.work.generate (send6.hash ()));
+		auto receive1 = builder
+						.receive ()
+						.previous (open2->hash ())
+						.source (send4->hash ())
+						.sign (key2.prv, key2.pub)
+						.work (*system.work.generate (open2->hash ()))
+						.build ();
+		auto send6 = builder
+					 .send ()
+					 .previous (receive1->hash ())
+					 .destination (key3.pub)
+					 .balance (10)
+					 .sign (key2.prv, key2.pub)
+					 .work (*system.work.generate (receive1->hash ()))
+					 .build ();
+		auto receive2 = builder
+						.receive ()
+						.previous (send6->hash ())
+						.source (send5->hash ())
+						.sign (key2.prv, key2.pub)
+						.work (*system.work.generate (send6->hash ()))
+						.build ();
 
 		add_callback_stats (*node);
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open3).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send4).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send5).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send5).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send6).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send6).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
 
 			// Check confirmation heights of all the accounts (except genesis) are uninitialized (0),
 			// as we have any just added them to the ledger and not processed any live transactions yet.
@@ -147,7 +233,13 @@ TEST (confirmation_height, multiple_accounts)
 		}
 
 		// The nodes process a live receive which propagates across to all accounts
-		auto receive3 = std::make_shared<nano::receive_block> (open3.hash (), send6.hash (), key3.prv, key3.pub, *system.work.generate (open3.hash ()));
+		auto receive3 = builder
+						.receive ()
+						.previous (open3->hash ())
+						.source (send6->hash ())
+						.sign (key3.prv, key3.pub)
+						.work (*system.work.generate (open3->hash ()))
+						.build_shared ();
 		node->process_active (receive3);
 		node->block_processor.flush ();
 		node->block_confirm (receive3);
@@ -165,17 +257,17 @@ TEST (confirmation_height, multiple_accounts)
 		ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (4, confirmation_height_info.height);
-		ASSERT_EQ (send3.hash (), confirmation_height_info.frontier);
+		ASSERT_EQ (send3->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (4, account_info.block_count);
 		ASSERT_FALSE (store.account.get (transaction, key1.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (2, confirmation_height_info.height);
-		ASSERT_EQ (send4.hash (), confirmation_height_info.frontier);
+		ASSERT_EQ (send4->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (3, account_info.block_count);
 		ASSERT_FALSE (store.account.get (transaction, key2.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key2.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
-		ASSERT_EQ (send6.hash (), confirmation_height_info.frontier);
+		ASSERT_EQ (send6->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (4, account_info.block_count);
 		ASSERT_FALSE (store.account.get (transaction, key3.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key3.pub, confirmation_height_info));
@@ -201,8 +293,8 @@ TEST (confirmation_height, multiple_accounts)
 			ASSERT_TRUE (node->ledger.rollback (transaction, node->latest (nano::dev::genesis_key.pub)));
 
 			// Attempt some others which have been cemented
-			ASSERT_TRUE (node->ledger.rollback (transaction, open1.hash ()));
-			ASSERT_TRUE (node->ledger.rollback (transaction, send2.hash ()));
+			ASSERT_TRUE (node->ledger.rollback (transaction, open1->hash ()));
+			ASSERT_TRUE (node->ledger.rollback (transaction, send2->hash ()));
 		}
 		ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 		ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, get_stats_detail (mode_a), nano::stat::dir::in));
@@ -224,19 +316,66 @@ TEST (confirmation_height, gap_bootstrap)
 		node_flags.confirmation_height_processor_mode = mode_a;
 		auto & node1 = *system.add_node (node_flags);
 		nano::keypair destination{};
-		auto send1 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		nano::block_builder builder;
+		auto send1 = builder
+					 .state ()
+					 .account (nano::dev::genesis->account ())
+					 .previous (nano::dev::genesis->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		node1.work_generate_blocking (*send1);
-		auto send2 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), send1->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		auto send2 = builder
+					 .state ()
+					 .account (nano::dev::genesis->account ())
+					 .previous (send1->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		node1.work_generate_blocking (*send2);
-		auto send3 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), send2->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		auto send3 = builder
+					 .state ()
+					 .account (nano::dev::genesis->account ())
+					 .previous (send2->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .balance (nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		node1.work_generate_blocking (*send3);
-		auto open1 = std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0);
+		auto open1 = builder
+					 .open ()
+					 .source (send1->hash ())
+					 .representative (destination.pub)
+					 .account (destination.pub)
+					 .sign (destination.prv, destination.pub)
+					 .work (0)
+					 .build_shared ();
 		node1.work_generate_blocking (*open1);
 
 		// Receive
-		auto receive1 = std::make_shared<nano::receive_block> (open1->hash (), send2->hash (), destination.prv, destination.pub, 0);
+		auto receive1 = builder
+						.receive ()
+						.previous (open1->hash ())
+						.source (send2->hash ())
+						.sign (destination.prv, destination.pub)
+						.work (0)
+						.build_shared ();
 		node1.work_generate_blocking (*receive1);
-		auto receive2 = std::make_shared<nano::receive_block> (receive1->hash (), send3->hash (), destination.prv, destination.pub, 0);
+		auto receive2 = builder
+						.receive ()
+						.previous (receive1->hash ())
+						.source (send3->hash ())
+						.sign (destination.prv, destination.pub)
+						.work (0)
+						.build_shared ();
 		node1.work_generate_blocking (*receive2);
 
 		node1.block_processor.add (send1);
@@ -310,18 +449,65 @@ TEST (confirmation_height, gap_live)
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 		system.wallet (1)->insert_adhoc (destination.prv);
 
-		auto send1 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 1, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		nano::block_builder builder;
+		auto send1 = builder
+					 .state ()
+					 .account (nano::dev::genesis->account ())
+					 .previous (nano::dev::genesis->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .balance (nano::dev::constants.genesis_amount - 1)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		node->work_generate_blocking (*send1);
-		auto send2 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), send1->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 2, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		auto send2 = builder
+					 .state ()
+					 .account (nano::dev::genesis->account ())
+					 .previous (send1->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .balance (nano::dev::constants.genesis_amount - 2)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		node->work_generate_blocking (*send2);
-		auto send3 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), send2->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 3, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+		auto send3 = builder
+					 .state ()
+					 .account (nano::dev::genesis->account ())
+					 .previous (send2->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .balance (nano::dev::constants.genesis_amount - 3)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (0)
+					 .build_shared ();
 		node->work_generate_blocking (*send3);
 
-		auto open1 = std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0);
+		auto open1 = builder
+					 .open ()
+					 .source (send1->hash ())
+					 .representative (destination.pub)
+					 .account (destination.pub)
+					 .sign (destination.prv, destination.pub)
+					 .work (0)
+					 .build_shared ();
 		node->work_generate_blocking (*open1);
-		auto receive1 = std::make_shared<nano::receive_block> (open1->hash (), send2->hash (), destination.prv, destination.pub, 0);
+		auto receive1 = builder
+						.receive ()
+						.previous (open1->hash ())
+						.source (send2->hash ())
+						.sign (destination.prv, destination.pub)
+						.work (0)
+						.build_shared ();
 		node->work_generate_blocking (*receive1);
-		auto receive2 = std::make_shared<nano::receive_block> (receive1->hash (), send3->hash (), destination.prv, destination.pub, 0);
+		auto receive2 = builder
+						.receive ()
+						.previous (receive1->hash ())
+						.source (send3->hash ())
+						.sign (destination.prv, destination.pub)
+						.work (0)
+						.build_shared ();
 		node->work_generate_blocking (*receive2);
 
 		node->block_processor.add (send1);
@@ -393,38 +579,109 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		nano::keypair key1;
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
 
-		nano::send_block send1 (latest, key1.pub, node->online_reps.delta () + 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-
-		nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-		nano::send_block send2 (open1.hash (), nano::dev::genesis->account (), 1000, key1.prv, key1.pub, *system.work.generate (open1.hash ()));
-		nano::send_block send3 (send2.hash (), nano::dev::genesis->account (), 900, key1.prv, key1.pub, *system.work.generate (send2.hash ()));
-		nano::send_block send4 (send3.hash (), nano::dev::genesis->account (), 500, key1.prv, key1.pub, *system.work.generate (send3.hash ()));
-
-		nano::receive_block receive1 (send1.hash (), send2.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::receive_block receive2 (receive1.hash (), send3.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive1.hash ()));
-		nano::receive_block receive3 (receive2.hash (), send4.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive2.hash ()));
-
-		nano::send_block send5 (receive3.hash (), key1.pub, node->online_reps.delta () + 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive3.hash ()));
-		auto receive4 = std::make_shared<nano::receive_block> (send4.hash (), send5.hash (), key1.prv, key1.pub, *system.work.generate (send4.hash ()));
-		// Unpocketed send
+		nano::block_builder builder;
+		auto send1 = builder
+					 .send ()
+					 .previous (latest)
+					 .destination (key1.pub)
+					 .balance (node->online_reps.delta () + 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (latest))
+					 .build ();
+		auto open1 = builder
+					 .open ()
+					 .source (send1->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .account (key1.pub)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (key1.pub))
+					 .build ();
+		auto send2 = builder
+					 .send ()
+					 .previous (open1->hash ())
+					 .destination (nano::dev::genesis->account ())
+					 .balance (1000)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (open1->hash ()))
+					 .build ();
+		auto send3 = builder
+					 .send ()
+					 .previous (send2->hash ())
+					 .destination (nano::dev::genesis->account ())
+					 .balance (900)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (send2->hash ()))
+					 .build ();
+		auto send4 = builder
+					 .send ()
+					 .previous (send3->hash ())
+					 .destination (nano::dev::genesis->account ())
+					 .balance (500)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (send3->hash ()))
+					 .build ();
+		auto receive1 = builder
+						.receive ()
+						.previous (send1->hash())
+						.source (send2->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (send1->hash ()))
+						.build ();
+		auto receive2 = builder
+						.receive ()
+						.previous (receive1->hash ())
+						.source (send3->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (receive1->hash ()))
+						.build ();
+		auto receive3 = builder
+						.receive ()
+						.previous (receive2->hash ())
+						.source (send4->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (receive2->hash ()))
+						.build ();
+		auto send5 = builder
+					 .send ()
+					 .previous (receive3->hash ())
+					 .destination (key1.pub)
+					 .balance (node->online_reps.delta () + 1)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (receive3->hash ()))
+					 .build ();
+		auto receive4 = builder
+						.receive ()
+						.previous (send4->hash ())
+						.source (send5->hash ())
+						.sign (key1.prv, key1.pub)
+						.work (*system.work.generate (send4->hash ()))
+						.build_shared ();
 		nano::keypair key2;
-		nano::send_block send6 (send5.hash (), key2.pub, node->online_reps.delta (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send5.hash ()));
+		auto send6 = builder
+					 .send ()
+					 .previous (send5->hash ())
+					 .destination (key2.pub)
+					 .balance (node->online_reps.delta () + 1)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send5->hash ()))
+					 .build ();
+		// Unpocketed send
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send4).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive3).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send5).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send6).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send5).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send6).code);
 		}
 
 		add_callback_stats (*node);
@@ -445,7 +702,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		ASSERT_FALSE (node->store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (6, confirmation_height_info.height);
-		ASSERT_EQ (send5.hash (), confirmation_height_info.frontier);
+		ASSERT_EQ (send5->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (7, account_info.block_count);
 
 		ASSERT_FALSE (node->store.account.get (transaction, key1.pub, account_info));
@@ -477,27 +734,73 @@ TEST (confirmation_height, send_receive_self)
 		auto node = system.add_node (node_config, node_flags);
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
 
-		nano::send_block send1 (latest, nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		nano::receive_block receive1 (send1.hash (), send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
-		nano::send_block send2 (receive1.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive1.hash ()));
-		nano::send_block send3 (send2.hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 3, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send2.hash ()));
-
-		nano::receive_block receive2 (send3.hash (), send2.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send3.hash ()));
-		auto receive3 = std::make_shared<nano::receive_block> (receive2.hash (), send3.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive2.hash ()));
+		nano::block_builder builder;
+		auto send1 = builder
+					 .send ()
+					 .previous (latest)
+					 .destination (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (latest))
+					 .build ();
+		auto receive1 = builder
+						.receive ()
+						.previous (send1->hash ())
+						.source (send1->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (send1->hash ()))
+						.build_shared ();
+		auto send2 = builder
+					 .send ()
+					 .previous (receive1->hash ())
+					 .destination (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (receive1->hash ()))
+					 .build ();
+		auto send3 = builder
+					 .send ()
+					 .previous (send2->hash ())
+					 .destination (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 3)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send2->hash ()))
+					 .build ();
+		auto receive2 = builder
+						.receive ()
+						.previous (send3->hash ())
+						.source (send2->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (send3->hash ()))
+						.build ();
+		auto receive3 = builder
+						.receive ()
+						.previous (receive2->hash ())
+						.source (send3->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (receive2->hash ()))
+						.build_shared ();
 
 		// Send to another account to prevent automatic receiving on the genesis account
 		nano::keypair key1;
-		nano::send_block send4 (receive3->hash (), key1.pub, node->online_reps.delta (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive3->hash ()));
+		auto send4 = builder
+					 .send ()
+					 .previous (receive3->hash ())
+					 .destination (key1.pub)
+					 .balance (node->online_reps.delta ())
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (receive3->hash ()))
+					 .build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send4).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
 		}
 
 		add_callback_stats (*node);
@@ -542,60 +845,209 @@ TEST (confirmation_height, all_block_types)
 		nano::keypair key1;
 		nano::keypair key2;
 		auto & store = node->store;
-		nano::send_block send (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		nano::send_block send1 (send.hash (), key2.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		auto send1 = builder
+					 .send ()
+					 .previous (send->hash ())
+					 .destination (key2.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send->hash ()))
+					 .build ();
 
-		nano::open_block open (send.hash (), nano::dev::genesis_key.pub, key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-		nano::state_block state_open (key2.pub, 0, 0, nano::Gxrb_ratio, send1.hash (), key2.prv, key2.pub, *system.work.generate (key2.pub));
+		auto open = builder
+					.open ()
+					.source (send->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.account (key1.pub)
+					.sign (key1.prv, key1.pub)
+					.work (*system.work.generate (key1.pub))
+					.build ();
+		auto state_open = builder
+						  .state ()
+						  .account (key2.pub)
+						  .previous (0)
+						  .representative (0)
+						  .balance (nano::Gxrb_ratio)
+						  .link (send1->hash ())
+						  .sign (key2.prv, key2.pub)
+						  .work (*system.work.generate (key2.pub))
+						  .build ();
 
-		nano::send_block send2 (open.hash (), key2.pub, 0, key1.prv, key1.pub, *system.work.generate (open.hash ()));
-		nano::state_block state_receive (key2.pub, state_open.hash (), 0, nano::Gxrb_ratio * 2, send2.hash (), key2.prv, key2.pub, *system.work.generate (state_open.hash ()));
+		auto send2 = builder
+					 .send ()
+					 .previous (open->hash ())
+					 .destination (key2.pub)
+					 .balance (0)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (open->hash ()))
+					 .build ();
+		auto state_receive = builder
+							 .state ()
+							 .account (key2.pub)
+							 .previous (state_open->hash ())
+							 .representative (0)
+							 .balance (nano::Gxrb_ratio * 2)
+							 .link (send2->hash ())
+							 .sign (key2.prv, key2.pub)
+							 .work (*system.work.generate (state_open->hash ()))
+							 .build ();
 
-		nano::state_block state_send (key2.pub, state_receive.hash (), 0, nano::Gxrb_ratio, key1.pub, key2.prv, key2.pub, *system.work.generate (state_receive.hash ()));
-		nano::receive_block receive (send2.hash (), state_send.hash (), key1.prv, key1.pub, *system.work.generate (send2.hash ()));
+		auto state_send = builder
+						  .state ()
+						  .account (key2.pub)
+						  .previous (state_receive->hash ())
+						  .representative (0)
+						  .balance (nano::Gxrb_ratio)
+						  .link (key1.pub)
+						  .sign (key2.prv, key2.pub)
+						  .work (*system.work.generate (state_receive->hash ()))
+						  .build ();
+		auto receive = builder
+					   .receive ()
+					   .previous (send2->hash ())
+					   .source (state_send->hash ())
+					   .sign (key1.prv, key1.pub)
+					   .work (*system.work.generate (send2->hash ()))
+					   .build ();
 
-		nano::change_block change (receive.hash (), key2.pub, key1.prv, key1.pub, *system.work.generate (receive.hash ()));
+		auto change = builder
+					  .change ()
+					  .previous (receive->hash ())
+					  .representative (key2.pub)
+					  .sign (key1.prv, key1.pub)
+					  .work (*system.work.generate (receive->hash ()))
+					  .build ();
 
-		nano::state_block state_change (key2.pub, state_send.hash (), nano::dev::genesis_key.pub, nano::Gxrb_ratio, 0, key2.prv, key2.pub, *system.work.generate (state_send.hash ()));
+		auto state_change = builder
+							.state ()
+							.account (key2.pub)
+							.previous (state_send->hash ())
+							.representative (nano::dev::genesis_key.pub)
+							.balance (nano::Gxrb_ratio)
+							.link (0)
+							.sign (key2.prv, key2.pub)
+							.work (*system.work.generate (state_send->hash ()))
+							.build ();
 
-		nano::state_block epoch (key2.pub, state_change.hash (), nano::dev::genesis_key.pub, nano::Gxrb_ratio, node->ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (state_change.hash ()));
+		auto epoch = builder
+					 .state ()
+					 .account (key2.pub)
+					 .previous (state_change->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::Gxrb_ratio)
+					 .link (node->ledger.epoch_link (nano::epoch::epoch_1))
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (state_change->hash ()))
+					 .build ();
 
-		nano::state_block epoch1 (key1.pub, change.hash (), key2.pub, nano::Gxrb_ratio, node->ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (change.hash ()));
-		nano::state_block state_send1 (key1.pub, epoch1.hash (), 0, nano::Gxrb_ratio - 1, key2.pub, key1.prv, key1.pub, *system.work.generate (epoch1.hash ()));
-		nano::state_block state_receive2 (key2.pub, epoch.hash (), 0, nano::Gxrb_ratio + 1, state_send1.hash (), key2.prv, key2.pub, *system.work.generate (epoch.hash ()));
+		auto epoch1 = builder
+					  .state ()
+					  .account (key1.pub)
+					  .previous (change->hash ())
+					  .representative (key2.pub)
+					  .balance (nano::Gxrb_ratio)
+					  .link (node->ledger.epoch_link (nano::epoch::epoch_1))
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*system.work.generate (change->hash ()))
+					  .build ();
+		auto state_send1 = builder
+						   .state ()
+						   .account (key1.pub)
+						   .previous (epoch1->hash ())
+						   .representative (0)
+						   .balance (nano::Gxrb_ratio - 1)
+						   .link (key2.pub)
+						   .sign (key1.prv, key1.pub)
+						   .work (*system.work.generate (epoch1->hash ()))
+						   .build ();
+		auto state_receive2 = builder
+							  .state ()
+							  .account (key2.pub)
+							  .previous (epoch->hash ())
+							  .representative (0)
+							  .balance (nano::Gxrb_ratio + 1)
+							  .link (state_send1->hash ())
+							  .sign (key2.prv, key2.pub)
+							  .work (*system.work.generate (epoch->hash ()))
+							  .build ();
 
-		auto state_send2 = std::make_shared<nano::state_block> (key2.pub, state_receive2.hash (), 0, nano::Gxrb_ratio, key1.pub, key2.prv, key2.pub, *system.work.generate (state_receive2.hash ()));
-		nano::state_block state_send3 (key2.pub, state_send2->hash (), 0, nano::Gxrb_ratio - 1, key1.pub, key2.prv, key2.pub, *system.work.generate (state_send2->hash ()));
+		auto state_send2 = builder
+						   .state ()
+						   .account (key2.pub)
+						   .previous (state_receive2->hash ())
+						   .representative (0)
+						   .balance (nano::Gxrb_ratio)
+						   .link (key1.pub)
+						   .sign (key2.prv, key2.pub)
+						   .work (*system.work.generate (state_receive2->hash ()))
+						   .build_shared ();
+		auto state_send3 = builder
+						   .state ()
+						   .account (key2.pub)
+						   .previous (state_send2->hash ())
+						   .representative (0)
+						   .balance (nano::Gxrb_ratio - 1)
+						   .link (key1.pub)
+						   .sign (key2.prv, key2.pub)
+						   .work (*system.work.generate (state_send2->hash ()))
+						   .build ();
 
-		nano::state_block state_send4 (key1.pub, state_send1.hash (), 0, nano::Gxrb_ratio - 2, nano::dev::genesis_key.pub, key1.prv, key1.pub, *system.work.generate (state_send1.hash ()));
-		nano::state_block state_receive3 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2 + 1, state_send4.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
+		auto state_send4 = builder
+						   .state ()
+						   .account (key1.pub)
+						   .previous (state_send1->hash ())
+						   .representative (0)
+						   .balance (nano::Gxrb_ratio - 2)
+						   .link (nano::dev::genesis_key.pub)
+						   .sign (key1.prv, key1.pub)
+						   .work (*system.work.generate (state_send1->hash ()))
+						   .build ();
+		auto state_receive3 = builder
+							  .state ()
+							  .account (nano::dev::genesis->account ())
+							  .previous (send1->hash ())
+							  .representative (nano::dev::genesis->account ())
+							  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2 + 1)
+							  .link (state_send4->hash ())
+							  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+							  .work (*system.work.generate (send1->hash ()))
+							  .build ();
 
 		{
 			auto transaction (store.tx_begin_write ());
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_open).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_open).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_receive).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_receive).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, change).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_change).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *change).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_change).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, epoch).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, epoch1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *epoch).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *epoch1).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_receive2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_receive2).code);
 
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_send3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send3).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_send4).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, state_receive3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send4).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_receive3).code);
 		}
 
 		add_callback_stats (*node);
@@ -613,12 +1065,12 @@ TEST (confirmation_height, all_block_types)
 		ASSERT_FALSE (node->store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
-		ASSERT_EQ (send1.hash (), confirmation_height_info.frontier);
+		ASSERT_EQ (send1->hash (), confirmation_height_info.frontier);
 		ASSERT_LE (4, account_info.block_count);
 
 		ASSERT_FALSE (node->store.account.get (transaction, key1.pub, account_info));
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
-		ASSERT_EQ (state_send1.hash (), confirmation_height_info.frontier);
+		ASSERT_EQ (state_send1->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (6, confirmation_height_info.height);
 		ASSERT_LE (7, account_info.block_count);
 
@@ -761,7 +1213,15 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (nano::dev::genesis->hash ())
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, ledger.cache, ledger.constants);
@@ -793,7 +1253,15 @@ TEST (confirmation_height, observers)
 		nano::keypair key1;
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 		nano::block_hash latest1 (node1->latest (nano::dev::genesis_key.pub));
-		auto send1 (std::make_shared<nano::send_block> (latest1, key1.pub, amount - node1->config.receive_minimum.number (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest1)));
+		nano::block_builder builder;
+		auto send1 = builder
+					 .send ()
+					 .previous (latest1)
+					 .destination (key1.pub)
+					 .balance (amount - node1->config.receive_minimum.number ())
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (latest1))
+					 .build_shared ();
 
 		add_callback_stats (*node1);
 
@@ -837,7 +1305,15 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (nano::dev::genesis->hash ())
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, ledger.cache, ledger.constants);
@@ -907,8 +1383,25 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-		auto open = std::make_shared<nano::state_block> (key1.pub, 0, 0, nano::Gxrb_ratio, send->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (nano::dev::genesis->hash ())
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.build_shared ();
+		auto open = builder
+					.state ()
+					.account (key1.pub)
+					.previous (0)
+					.representative (0)
+					.balance (nano::Gxrb_ratio)
+					.link (send->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (key1.pub))
+					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, ledger.cache, ledger.constants);
@@ -970,12 +1463,27 @@ TEST (confirmation_height, pending_observer_callbacks)
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
 
 		nano::keypair key1;
-		nano::send_block send (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		auto send1 = std::make_shared<nano::send_block> (send.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		auto send1 = builder
+					 .send ()
+					 .previous (send->hash ())
+					 .destination (key1.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send->hash ()))
+					 .build_shared ();
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
 		}
 
@@ -1012,13 +1520,28 @@ TEST (confirmation_height, callback_confirmed_history)
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
 
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build_shared ();
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
 
-		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send->hash ()));
+		auto send1 = builder
+					 .send ()
+					 .previous (send->hash ())
+					 .destination (key1.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send->hash ()))
+					 .build_shared ();
 
 		add_callback_stats (*node);
 
@@ -1093,9 +1616,31 @@ TEST (confirmation_height, dependent_election)
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
 
 		nano::keypair key1;
-		auto send = std::make_shared<nano::send_block> (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send->hash ()));
-		auto send2 = std::make_shared<nano::send_block> (send1->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1->hash ()));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build_shared ();
+		auto send1 = builder
+					 .send ()
+					 .previous (send->hash ())
+					 .destination (key1.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send->hash ()))
+					 .build_shared ();
+		auto send2 = builder
+					 .send ()
+					 .previous (send1->hash ())
+					 .destination (key1.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send1->hash ()))
+					 .build_shared ();
 		{
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
@@ -1143,42 +1688,118 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
 
 		nano::keypair key1;
+		nano::block_builder builder;
 		system.wallet (0)->insert_adhoc (key1.prv);
 
-		nano::send_block send (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		nano::send_block send1 (send.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send.hash ()));
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		auto send1 = builder
+					 .send ()
+					 .previous (send->hash ())
+					 .destination (key1.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send->hash ()))
+					 .build ();
 		nano::keypair dummy_key;
-		nano::send_block dummy_send (send1.hash (), dummy_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
+		auto dummy_send = builder
+						  .send ()
+						  .previous (send1->hash ())
+						  .destination (dummy_key.pub)
+						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
+						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						  .work (*system.work.generate (send1->hash ()))
+						  .build ();
 
-		nano::open_block open (send.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-		nano::receive_block receive1 (open.hash (), send1.hash (), key1.prv, key1.pub, *system.work.generate (open.hash ()));
-		nano::send_block send2 (receive1.hash (), nano::dev::genesis_key.pub, nano::Gxrb_ratio, key1.prv, key1.pub, *system.work.generate (receive1.hash ()));
+		auto open = builder
+					.open ()
+					.source (send->hash ())
+					.representative (nano::dev::genesis->account ())
+					.account (key1.pub)
+					.sign (key1.prv, key1.pub)
+					.work (*system.work.generate (key1.pub))
+					.build ();
+		auto receive1 = builder
+						.receive ()
+						.previous (open->hash ())
+						.source (send1->hash ())
+						.sign (key1.prv, key1.pub)
+						.work (*system.work.generate (open->hash ()))
+						.build ();
+		auto send2 = builder
+					 .send ()
+					 .previous (receive1->hash ())
+					 .destination (nano::dev::genesis_key.pub)
+					 .balance (nano::Gxrb_ratio)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (receive1->hash ()))
+					 .build ();
 
-		nano::receive_block receive2 (dummy_send.hash (), send2.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (dummy_send.hash ()));
-		nano::send_block dummy_send1 (receive2.hash (), dummy_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive2.hash ()));
+		auto receive2 = builder
+						.receive ()
+						.previous (dummy_send->hash ())
+						.source (send2->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (dummy_send->hash ()))
+						.build ();
+		auto dummy_send1 = builder
+						   .send ()
+						   .previous (receive2->hash ())
+						   .destination (dummy_key.pub)
+						   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*system.work.generate (receive2->hash ()))
+						   .build ();
 
 		nano::keypair key2;
 		system.wallet (0)->insert_adhoc (key2.prv);
-		nano::send_block send3 (dummy_send1.hash (), key2.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (dummy_send1.hash ()));
-		nano::send_block dummy_send2 (send3.hash (), dummy_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send3.hash ()));
+		auto send3 = builder
+					 .send ()
+					 .previous (dummy_send1->hash ())
+					 .destination (key2.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (dummy_send1->hash ()))
+					 .build ();
+		auto dummy_send2 = builder
+						   .send ()
+						   .previous (send3->hash ())
+						   .destination (dummy_key.pub)
+						   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*system.work.generate (send3->hash ()))
+						   .build ();
 
-		auto open1 = std::make_shared<nano::open_block> (send3.hash (), nano::dev::genesis->account (), key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
+		auto open1 = builder
+					 .open ()
+					 .source (send3->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .account (key2.pub)
+					 .sign (key2.prv, key2.pub)
+					 .work (*system.work.generate (key2.pub))
+					 .build_shared ();
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, dummy_send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, dummy_send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send1).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, dummy_send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send2).code);
 
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
 		}
@@ -1204,7 +1825,7 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		ASSERT_EQ (0, node->active.election_winner_details_size ());
 
 		// Check that the order of callbacks is correct
-		std::vector<nano::block_hash> expected_order = { send.hash (), open.hash (), send1.hash (), receive1.hash (), send2.hash (), dummy_send.hash (), receive2.hash (), dummy_send1.hash (), send3.hash (), open1->hash () };
+		std::vector<nano::block_hash> expected_order = { send->hash (), open->hash (), send1->hash (), receive1->hash (), send2->hash (), dummy_send->hash (), receive2->hash (), dummy_send1->hash (), send3->hash (), open1->hash () };
 		nano::lock_guard<nano::mutex> guard (mutex);
 		ASSERT_EQ (observer_order, expected_order);
 	};
@@ -1230,40 +1851,116 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		nano::keypair key1;
 		system.wallet (0)->insert_adhoc (key1.prv);
 
-		nano::send_block send (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		nano::send_block send1 (send.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send.hash ()));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key1.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		auto send1 = builder
+					 .send ()
+					 .previous (send->hash ())
+					 .destination (key1.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send->hash ()))
+					 .build ();
 		nano::keypair dummy_key;
-		nano::send_block dummy_send (send1.hash (), dummy_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
+		auto dummy_send = builder
+						  .send ()
+						  .previous (send1->hash ())
+						  .destination (dummy_key.pub)
+						  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
+						  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						  .work (*system.work.generate (send1->hash ()))
+						  .build ();
 
-		nano::open_block open (send.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-		nano::receive_block receive1 (open.hash (), send1.hash (), key1.prv, key1.pub, *system.work.generate (open.hash ()));
-		nano::send_block send2 (receive1.hash (), nano::dev::genesis_key.pub, nano::Gxrb_ratio, key1.prv, key1.pub, *system.work.generate (receive1.hash ()));
+		auto open = builder
+					.open ()
+					.source (send->hash ())
+					.representative (nano::dev::genesis->account ())
+					.account (key1.pub)
+					.sign (key1.prv, key1.pub)
+					.work (*system.work.generate (key1.pub))
+					.build ();
+		auto receive1 = builder
+						.receive ()
+						.previous (open->hash ())
+						.source (send1->hash ())
+						.sign (key1.prv, key1.pub)
+						.work (*system.work.generate (open->hash ()))
+						.build ();
+		auto send2 = builder
+					 .send ()
+					 .previous (receive1->hash ())
+					 .destination (nano::dev::genesis_key.pub)
+					 .balance (nano::Gxrb_ratio)
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (receive1->hash ()))
+					 .build ();
 
-		nano::receive_block receive2 (dummy_send.hash (), send2.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (dummy_send.hash ()));
-		nano::send_block dummy_send1 (receive2.hash (), dummy_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive2.hash ()));
+		auto receive2 = builder
+						.receive ()
+						.previous (dummy_send->hash ())
+						.source (send2->hash ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (dummy_send->hash ()))
+						.build ();
+		auto dummy_send1 = builder
+						   .send ()
+						   .previous (receive2->hash ())
+						   .destination (dummy_key.pub)
+						   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*system.work.generate (receive2->hash ()))
+						   .build ();
 
 		nano::keypair key2;
 		system.wallet (0)->insert_adhoc (key2.prv);
-		nano::send_block send3 (dummy_send1.hash (), key2.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (dummy_send1.hash ()));
-		nano::send_block dummy_send2 (send3.hash (), dummy_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send3.hash ()));
+		auto send3 = builder
+					 .send ()
+					 .previous (dummy_send1->hash ())
+					 .destination (key2.pub)
+					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (dummy_send1->hash ()))
+					 .build ();
+		auto dummy_send2 = builder
+						   .send ()
+						   .previous (send3->hash ())
+						   .destination (dummy_key.pub)
+						   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*system.work.generate (send3->hash ()))
+						   .build ();
 
-		auto open1 = std::make_shared<nano::open_block> (send3.hash (), nano::dev::genesis->account (), key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
+		auto open1 = builder
+					 .open ()
+					 .source (send3->hash ())
+					 .representative (nano::dev::genesis->account ())
+					 .account (key2.pub)
+					 .sign (key2.prv, key2.pub)
+					 .work (*system.work.generate (key2.pub))
+					 .build_shared ();
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, dummy_send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, dummy_send1).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send1).code);
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, dummy_send2).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send2).code);
 
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
 		}
@@ -1271,8 +1968,8 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		// Force some blocks to be cemented so that the cached confirmed info variable is empty
 		{
 			auto transaction (node->store.tx_begin_write ());
-			node->store.confirmation_height.put (transaction, nano::dev::genesis->account (), nano::confirmation_height_info{ 3, send1.hash () });
-			node->store.confirmation_height.put (transaction, key1.pub, nano::confirmation_height_info{ 2, receive1.hash () });
+			node->store.confirmation_height.put (transaction, nano::dev::genesis->account (), nano::confirmation_height_info{ 3, send1->hash () });
+			node->store.confirmation_height.put (transaction, key1.pub, nano::confirmation_height_info{ 2, receive1->hash () });
 		}
 
 		add_callback_stats (*node);
@@ -1371,7 +2068,15 @@ TEST (confirmation_height, election_winner_details_clearing_node_process_confirm
 	nano::system system (1);
 	auto node = system.nodes.front ();
 
-	auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ()));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build_shared ();
 	// Add to election_winner_details. Use an unrealistic iteration so that it should fall into the else case and do a cleanup
 	node->active.add_election_winner_details (send->hash (), nullptr);
 	nano::election_status election;
@@ -1398,8 +2103,23 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::logging logging;
 	nano::keypair key1;
-	auto send = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto send1 = std::make_shared<nano::send_block> (send->hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send->hash ()));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (key1.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build_shared ();
+	auto send1 = builder
+				 .send ()
+				 .previous (send->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send->hash ()))
+				 .build_shared ();
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache, nano::dev::constants);
@@ -1447,11 +2167,57 @@ TEST (confirmation_height, pruned_source)
 	nano::write_database_queue write_database_queue (false);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1, key2;
-	auto send1 = std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 100, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto open1 = std::make_shared<nano::state_block> (key1.pub, 0, key1.pub, 100, send1->hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto send2 = std::make_shared<nano::state_block> (key1.pub, open1->hash (), key1.pub, 50, key2.pub, key1.prv, key1.pub, *pool.generate (open1->hash ()));
-	auto send3 = std::make_shared<nano::state_block> (key1.pub, send2->hash (), key1.pub, 25, key2.pub, key1.prv, key1.pub, *pool.generate (send2->hash ()));
-	auto open2 = std::make_shared<nano::state_block> (key2.pub, 0, key1.pub, 50, send2->hash (), key2.prv, key2.pub, *pool.generate (key2.pub));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build_shared ();
+	auto open1 = builder
+				 .state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (key1.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build_shared ();
+	auto send2 = builder
+				 .state ()
+				 .account (key1.pub)
+				 .previous (open1->hash ())
+				 .representative (key1.pub)
+				 .balance (50)
+				 .link (key2.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (open1->hash ()))
+				 .build_shared ();
+	auto send3 = builder
+				 .state ()
+				 .account (key1.pub)
+				 .previous (send2->hash ())
+				 .representative (key1.pub)
+				 .balance (25)
+				 .link (key2.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (send2->hash ()))
+				 .build_shared ();
+	auto open2 = builder
+				 .state ()
+				 .account (key2.pub)
+				 .previous (0)
+				 .representative (key1.pub)
+				 .balance (50)
+				 .link (send2->hash ())
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build_shared ();
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache, nano::dev::constants);

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -28,7 +28,15 @@ TEST (confirmation_solicitor, batches)
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
-	auto send (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::keypair ().pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::keypair ().pub)
+				.balance (nano::dev::constants.genesis_amount - 100)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build_shared ();
 	send->sideband_set ({});
 	{
 		nano::lock_guard<nano::mutex> guard (node2.active.mutex);
@@ -71,7 +79,15 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
-	auto send (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::keypair ().pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::keypair ().pub)
+				.balance (nano::dev::constants.genesis_amount - 100)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build_shared ();
 	send->sideband_set ({});
 	auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::normal));
 	// Add a vote for something else, not the winner
@@ -107,7 +123,15 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	ASSERT_EQ (max_representatives + 1, representatives.size ());
 	solicitor.prepare (representatives);
 	ASSERT_TIMELY (3s, node2.network.size () == 1);
-	auto send (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), nano::keypair ().pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::keypair ().pub)
+				.balance (nano::dev::constants.genesis_amount - 100)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build_shared ();
 	send->sideband_set ({});
 	auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::normal));
 	// Add a vote for something else, not the winner

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -13,7 +13,15 @@ TEST (conflicts, start_stop)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (0, node1.active.size ());
@@ -30,12 +38,27 @@ TEST (conflicts, add_existing)
 	nano::system system{ 1 };
 	auto & node1 = *system.nodes[0];
 	nano::keypair key1;
-	auto send1 = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	nano::keypair key2;
-	auto send2 = std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key2.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+	auto send2 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key2.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send2);
 	send2->sideband_set ({});
 	node1.block_processor.add (send2);
@@ -146,7 +169,17 @@ TEST (vote_uniquer, vbh_one)
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer uniquer (block_uniquer);
 	nano::keypair key;
-	auto block (std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0));
+	nano::block_builder builder;
+	auto block = builder
+				 .state ()
+				 .account (0)
+				 .previous (0)
+				 .representative (0)
+				 .balance (0)
+				 .link (0)
+				 .sign (key.prv, key.pub)
+				 .work (0)
+				 .build_shared ();
 	std::vector<nano::block_hash> hashes;
 	hashes.push_back (block->hash ());
 	auto vote1 (std::make_shared<nano::vote> (key.pub, key.prv, 0, 0, hashes));
@@ -160,10 +193,29 @@ TEST (vote_uniquer, vbh_two)
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer uniquer (block_uniquer);
 	nano::keypair key;
-	auto block1 (std::make_shared<nano::state_block> (0, 0, 0, 0, 0, key.prv, key.pub, 0));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .state ()
+				  .account (0)
+				  .previous (0)
+				  .representative (0)
+				  .balance (0)
+				  .link (0)
+				  .sign (key.prv, key.pub)
+				  .work (0)
+				  .build_shared ();
 	std::vector<nano::block_hash> hashes1;
 	hashes1.push_back (block1->hash ());
-	auto block2 (std::make_shared<nano::state_block> (1, 0, 0, 0, 0, key.prv, key.pub, 0));
+	auto block2 = builder
+				  .state ()
+				  .account (1)
+				  .previous (0)
+				  .representative (0)
+				  .balance (0)
+				  .link (0)
+				  .sign (key.prv, key.pub)
+				  .work (0)
+				  .build_shared ();
 	std::vector<nano::block_hash> hashes2;
 	hashes2.push_back (block2->hash ());
 	auto vote1 (std::make_shared<nano::vote> (key.pub, key.prv, 0, 0, hashes1));

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -20,51 +20,157 @@ TEST (frontiers_confirmation, prioritize_frontiers)
 	nano::keypair key2;
 	nano::keypair key3;
 	nano::keypair key4;
+	nano::block_builder builder;
 	nano::block_hash latest1 (node->latest (nano::dev::genesis_key.pub));
 
 	// Send different numbers of blocks all accounts
-	nano::send_block send1 (latest1, key1.pub, node->config.online_weight_minimum.number () + 10000, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest1));
-	nano::send_block send2 (send1.hash (), key1.pub, node->config.online_weight_minimum.number () + 8500, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
-	nano::send_block send3 (send2.hash (), key1.pub, node->config.online_weight_minimum.number () + 8000, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send2.hash ()));
-	nano::send_block send4 (send3.hash (), key2.pub, node->config.online_weight_minimum.number () + 7500, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send3.hash ()));
-	nano::send_block send5 (send4.hash (), key3.pub, node->config.online_weight_minimum.number () + 6500, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send4.hash ()));
-	nano::send_block send6 (send5.hash (), key4.pub, node->config.online_weight_minimum.number () + 6000, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send5.hash ()));
+	auto send1 = builder
+				 .send ()
+				 .previous (latest1)
+				 .destination (key1.pub)
+				 .balance (node->config.online_weight_minimum.number () + 10000)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (latest1))
+				 .build ();
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (key1.pub)
+				 .balance (node->config.online_weight_minimum.number () + 8500)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send1->hash ()))
+				 .build ();
+	auto send3 = builder
+				 .send ()
+				 .previous (send2->hash ())
+				 .destination (key1.pub)
+				 .balance (node->config.online_weight_minimum.number () + 8000)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send2->hash ()))
+				 .build ();
+	auto send4 = builder
+				 .send ()
+				 .previous (send3->hash ())
+				 .destination (key2.pub)
+				 .balance (node->config.online_weight_minimum.number () + 7500)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send3->hash ()))
+				 .build ();
+	auto send5 = builder
+				 .send ()
+				 .previous (send4->hash ())
+				 .destination (key3.pub)
+				 .balance (node->config.online_weight_minimum.number () + 6500)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send4->hash ()))
+				 .build ();
+	auto send6 = builder
+				 .send ()
+				 .previous (send5->hash ())
+				 .destination (key4.pub)
+				 .balance (node->config.online_weight_minimum.number () + 6000)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send5->hash ()))
+				 .build ();
 
 	// Open all accounts and add other sends to get different uncemented counts (as well as some which are the same)
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
-	nano::send_block send7 (open1.hash (), nano::dev::genesis_key.pub, 500, key1.prv, key1.pub, *system.work.generate (open1.hash ()));
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key1.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*system.work.generate (key1.pub))
+				 .build ();
+	auto send7 = builder
+				 .send ()
+				 .previous (open1->hash ())
+				 .destination (nano::dev::genesis_key.pub)
+				 .balance (500)
+				 .sign (key1.prv, key1.pub)
+				 .work (*system.work.generate (open1->hash ()))
+				 .build ();
 
-	nano::open_block open2 (send4.hash (), nano::dev::genesis->account (), key2.pub, key2.prv, key2.pub, *system.work.generate (key2.pub));
+	auto open2 = builder
+				 .open ()
+				 .source (send4->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key2.pub)
+				 .sign (key2.prv, key2.pub)
+				 .work (*system.work.generate (key2.pub))
+				 .build ();
 
-	nano::open_block open3 (send5.hash (), nano::dev::genesis->account (), key3.pub, key3.prv, key3.pub, *system.work.generate (key3.pub));
-	nano::send_block send8 (open3.hash (), nano::dev::genesis_key.pub, 500, key3.prv, key3.pub, *system.work.generate (open3.hash ()));
-	nano::send_block send9 (send8.hash (), nano::dev::genesis_key.pub, 200, key3.prv, key3.pub, *system.work.generate (send8.hash ()));
+	auto open3 = builder
+				 .open ()
+				 .source (send5->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key3.pub)
+				 .sign (key3.prv, key3.pub)
+				 .work (*system.work.generate (key3.pub))
+				 .build ();
+	auto send8 = builder
+				 .send ()
+				 .previous (open3->hash ())
+				 .destination (nano::dev::genesis_key.pub)
+				 .balance (500)
+				 .sign (key3.prv, key3.pub)
+				 .work (*system.work.generate (open3->hash ()))
+				 .build ();
+	auto send9 = builder
+				 .send ()
+				 .previous (send8->hash ())
+				 .destination (nano::dev::genesis_key.pub)
+				 .balance (200)
+				 .sign (key3.prv, key3.pub)
+				 .work (*system.work.generate (send8->hash ()))
+				 .build ();
 
-	nano::open_block open4 (send6.hash (), nano::dev::genesis->account (), key4.pub, key4.prv, key4.pub, *system.work.generate (key4.pub));
-	nano::send_block send10 (open4.hash (), nano::dev::genesis_key.pub, 500, key4.prv, key4.pub, *system.work.generate (open4.hash ()));
-	nano::send_block send11 (send10.hash (), nano::dev::genesis_key.pub, 200, key4.prv, key4.pub, *system.work.generate (send10.hash ()));
+	auto open4 = builder
+				 .open ()
+				 .source (send6->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key4.pub)
+				 .sign (key4.prv, key4.pub)
+				 .work (*system.work.generate (key4.pub))
+				 .build ();
+	auto send10 = builder
+				  .send ()
+				  .previous (open4->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (500)
+				  .sign (key4.prv, key4.pub)
+				  .work (*system.work.generate (open4->hash ()))
+				  .build ();
+	auto send11 = builder
+				  .send ()
+				  .previous (send10->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (200)
+				  .sign (key4.prv, key4.pub)
+				  .work (*system.work.generate (send10->hash ()))
+				  .build ();
 
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send3).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send4).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send5).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send6).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send5).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send6).code);
 
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open1).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send7).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send7).code);
 
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open2).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open2).code);
 
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open3).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send8).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send9).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open3).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send8).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send9).code);
 
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open4).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send10).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send11).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open4).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send10).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send11).code);
 	}
 
 	auto transaction = node->store.tx_begin_read ();
@@ -111,20 +217,62 @@ TEST (frontiers_confirmation, prioritize_frontiers)
 	}
 
 	// Check that accounts which already exist have their order modified when the uncemented count changes.
-	nano::send_block send12 (send9.hash (), nano::dev::genesis_key.pub, 100, key3.prv, key3.pub, *system.work.generate (send9.hash ()));
-	nano::send_block send13 (send12.hash (), nano::dev::genesis_key.pub, 90, key3.prv, key3.pub, *system.work.generate (send12.hash ()));
-	nano::send_block send14 (send13.hash (), nano::dev::genesis_key.pub, 80, key3.prv, key3.pub, *system.work.generate (send13.hash ()));
-	nano::send_block send15 (send14.hash (), nano::dev::genesis_key.pub, 70, key3.prv, key3.pub, *system.work.generate (send14.hash ()));
-	nano::send_block send16 (send15.hash (), nano::dev::genesis_key.pub, 60, key3.prv, key3.pub, *system.work.generate (send15.hash ()));
-	nano::send_block send17 (send16.hash (), nano::dev::genesis_key.pub, 50, key3.prv, key3.pub, *system.work.generate (send16.hash ()));
+	auto send12 = builder
+				  .send ()
+				  .previous (send9->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (100)
+				  .sign (key3.prv, key3.pub)
+				  .work (*system.work.generate (send9->hash ()))
+				  .build ();
+	auto send13 = builder
+				  .send ()
+				  .previous (send12->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (90)
+				  .sign (key3.prv, key3.pub)
+				  .work (*system.work.generate (send12->hash ()))
+				  .build ();
+	auto send14 = builder
+				  .send ()
+				  .previous (send13->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (80)
+				  .sign (key3.prv, key3.pub)
+				  .work (*system.work.generate (send13->hash ()))
+				  .build ();
+	auto send15 = builder
+				  .send ()
+				  .previous (send14->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (70)
+				  .sign (key3.prv, key3.pub)
+				  .work (*system.work.generate (send14->hash ()))
+				  .build ();
+	auto send16 = builder
+				  .send ()
+				  .previous (send15->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (60)
+				  .sign (key3.prv, key3.pub)
+				  .work (*system.work.generate (send15->hash ()))
+				  .build ();
+	auto send17 = builder
+				  .send ()
+				  .previous (send16->hash ())
+				  .destination (nano::dev::genesis_key.pub)
+				  .balance (50)
+				  .sign (key3.prv, key3.pub)
+				  .work (*system.work.generate (send16->hash ()))
+				  .build ();
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send12).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send13).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send14).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send15).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send16).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send17).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send12).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send13).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send14).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send15).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send16).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send17).code);
 	}
 	transaction.refresh ();
 	node->active.prioritize_frontiers_for_confirmation (transaction, std::chrono::seconds (1), std::chrono::seconds (1));
@@ -135,7 +283,7 @@ TEST (frontiers_confirmation, prioritize_frontiers)
 	// Check that the active transactions roots contains the frontiers
 	ASSERT_TIMELY (10s, node->active.size () == num_accounts);
 
-	std::array<nano::qualified_root, num_accounts> frontiers{ send17.qualified_root (), send6.qualified_root (), send7.qualified_root (), open2.qualified_root (), send11.qualified_root () };
+	std::array<nano::qualified_root, num_accounts> frontiers{ send17->qualified_root (), send6->qualified_root (), send7->qualified_root (), open2->qualified_root (), send11->qualified_root () };
 	for (auto & frontier : frontiers)
 	{
 		ASSERT_TRUE (node->active.active (frontier));
@@ -161,10 +309,25 @@ TEST (frontiers_confirmation, prioritize_frontiers_max_optimistic_elections)
 		auto transaction = node->store.tx_begin_write ();
 		auto latest = node->latest (nano::dev::genesis->account ());
 		nano::keypair key;
-		nano::send_block send (latest, key.pub, node->config.online_weight_minimum.number () + 10000, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-		nano::open_block open (send.hash (), nano::dev::genesis->account (), key.pub, key.prv, key.pub, *system.work.generate (key.pub));
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (latest)
+					.destination (key.pub)
+					.balance (node->config.online_weight_minimum.number () + 10000)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+		auto open = builder
+					.open ()
+					.source (send->hash ())
+					.representative (nano::dev::genesis->account ())
+					.account (key.pub)
+					.sign (key.prv, key.pub)
+					.work (*system.work.generate (key.pub))
+					.build ();
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 	}
 
 	{
@@ -211,6 +374,7 @@ TEST (frontiers_confirmation, expired_optimistic_elections_removal)
 TEST (frontiers_confirmation, mode)
 {
 	nano::keypair key;
+	nano::block_builder builder;
 	nano::node_flags node_flags;
 	// Always mode
 	{
@@ -218,10 +382,19 @@ TEST (frontiers_confirmation, mode)
 		nano::node_config node_config (nano::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 		auto node = system.add_node (node_config, node_flags);
-		nano::state_block send (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node->work_generate_blocking (nano::dev::genesis->hash ()));
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (nano::dev::genesis->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (key.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
+					.build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
 		ASSERT_TIMELY (5s, node->active.size () == 1);
 	}
@@ -231,10 +404,19 @@ TEST (frontiers_confirmation, mode)
 		nano::node_config node_config (nano::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::automatic;
 		auto node = system.add_node (node_config, node_flags);
-		nano::state_block send (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node->work_generate_blocking (nano::dev::genesis->hash ()));
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (nano::dev::genesis->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (key.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
+					.build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
 		ASSERT_TIMELY (5s, node->active.size () == 1);
 	}
@@ -244,10 +426,19 @@ TEST (frontiers_confirmation, mode)
 		nano::node_config node_config (nano::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
-		nano::state_block send (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node->work_generate_blocking (nano::dev::genesis->hash ()));
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (nano::dev::genesis->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (key.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
+					.build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 		std::this_thread::sleep_for (std::chrono::seconds (1));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -75,9 +75,19 @@ TEST (ledger, process_modifies_sideband)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (store->tx_begin_write (), ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), send1).code);
-	ASSERT_EQ (send1.sideband ().timestamp, store->block.get (store->tx_begin_read (), send1.hash ())->sideband ().timestamp);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), *send1).code);
+	ASSERT_EQ (send1->sideband ().timestamp, store->block.get (store->tx_begin_read (), send1->hash ())->sideband ().timestamp);
 }
 
 // Create a send block and publish it.
@@ -94,19 +104,27 @@ TEST (ledger, process_send)
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	nano::block_hash hash1 (send.hash ());
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (info1.head)
+				.destination (key2.pub)
+				.balance (50)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (info1.head))
+				.build ();
+	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store->frontier.get (transaction, info1.head));
 	ASSERT_EQ (1, info1.block_count);
 	// This was a valid block, it should progress.
-	auto return1 (ledger.process (transaction, send));
-	ASSERT_EQ (nano::dev::genesis_key.pub, send.sideband ().account);
-	ASSERT_EQ (2, send.sideband ().height);
+	auto return1 (ledger.process (transaction, *send));
+	ASSERT_EQ (nano::dev::genesis_key.pub, send->sideband ().account);
+	ASSERT_EQ (2, send->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash1));
 	ASSERT_TRUE (store->frontier.get (transaction, info1.head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store->frontier.get (transaction, hash1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::dev::genesis_key.pub, store->block.account_calculated (send));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store->block.account_calculated (*send));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
 	nano::account_info info2;
@@ -116,19 +134,26 @@ TEST (ledger, process_send)
 	ASSERT_NE (nullptr, latest6);
 	auto latest7 (dynamic_cast<nano::send_block *> (latest6.get ()));
 	ASSERT_NE (nullptr, latest7);
-	ASSERT_EQ (send, *latest7);
+	ASSERT_EQ (*send, *latest7);
 	// Create an open block opening an account accepting the send we just created
-	nano::open_block open (hash1, key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	nano::block_hash hash2 (open.hash ());
+	auto open = builder
+				.open ()
+				.source (hash1)
+				.representative (key2.pub)
+				.account (key2.pub)
+				.sign (key2.prv, key2.pub)
+				.work (*pool.generate (key2.pub))
+				.build ();
+	nano::block_hash hash2 (open->hash ());
 	// This was a valid block, it should progress.
-	auto return2 (ledger.process (transaction, open));
+	auto return2 (ledger.process (transaction, *open));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, open.sideband ().account);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open.sideband ().balance.number ());
-	ASSERT_EQ (1, open.sideband ().height);
+	ASSERT_EQ (key2.pub, open->sideband ().account);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open->sideband ().balance.number ());
+	ASSERT_EQ (1, open->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, store->block.account_calculated (open));
+	ASSERT_EQ (key2.pub, store->block.account_calculated (*open));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (key2.pub, store->frontier.get (transaction, hash2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
@@ -141,14 +166,14 @@ TEST (ledger, process_send)
 	ASSERT_NE (nullptr, latest2);
 	auto latest3 (dynamic_cast<nano::send_block *> (latest2.get ()));
 	ASSERT_NE (nullptr, latest3);
-	ASSERT_EQ (send, *latest3);
+	ASSERT_EQ (*send, *latest3);
 	nano::account_info info4;
 	ASSERT_FALSE (store->account.get (transaction, key2.pub, info4));
 	auto latest4 (store->block.get (transaction, info4.head));
 	ASSERT_NE (nullptr, latest4);
 	auto latest5 (dynamic_cast<nano::open_block *> (latest4.get ()));
 	ASSERT_NE (nullptr, latest5);
-	ASSERT_EQ (open, *latest5);
+	ASSERT_EQ (*open, *latest5);
 	ASSERT_FALSE (ledger.rollback (transaction, hash2));
 	ASSERT_TRUE (store->frontier.get (transaction, hash2).is_zero ());
 	nano::account_info info5;
@@ -193,35 +218,63 @@ TEST (ledger, process_receive)
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	nano::block_hash hash1 (send.hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (info1.head)
+				.destination (key2.pub)
+				.balance (50)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (info1.head))
+				.build ();
+	nano::block_hash hash1 (send->hash ());
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	nano::keypair key3;
-	nano::open_block open (hash1, key3.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	nano::block_hash hash2 (open.hash ());
-	auto return1 (ledger.process (transaction, open));
+	auto open = builder
+				.open ()
+				.source (hash1)
+				.representative (key3.pub)
+				.account (key2.pub)
+				.sign (key2.prv, key2.pub)
+				.work (*pool.generate (key2.pub))
+				.build ();
+	nano::block_hash hash2 (open->hash ());
+	auto return1 (ledger.process (transaction, *open));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (key2.pub, store->block.account_calculated (open));
-	ASSERT_EQ (key2.pub, open.sideband ().account);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open.sideband ().balance.number ());
-	ASSERT_EQ (1, open.sideband ().height);
+	ASSERT_EQ (key2.pub, store->block.account_calculated (*open));
+	ASSERT_EQ (key2.pub, open->sideband ().account);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open->sideband ().balance.number ());
+	ASSERT_EQ (1, open->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (key3.pub));
-	nano::send_block send2 (hash1, key2.pub, 25, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (hash1));
-	nano::block_hash hash3 (send2.hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	nano::receive_block receive (hash2, hash3, key2.prv, key2.pub, *pool.generate (hash2));
-	auto hash4 (receive.hash ());
+	auto send2 = builder
+				 .send ()
+				 .previous (hash1)
+				 .destination (key2.pub)
+				 .balance (25)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (hash1))
+				 .build ();
+	nano::block_hash hash3 (send2->hash ());
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	auto receive = builder
+				   .receive ()
+				   .previous (hash2)
+				   .source (hash3)
+				   .sign (key2.prv, key2.pub)
+				   .work (*pool.generate (hash2))
+				   .build ();
+	auto hash4 (receive->hash ());
 	ASSERT_EQ (key2.pub, store->frontier.get (transaction, hash2));
-	auto return2 (ledger.process (transaction, receive));
-	ASSERT_EQ (key2.pub, receive.sideband ().account);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, receive.sideband ().balance.number ());
-	ASSERT_EQ (2, receive.sideband ().height);
+	auto return2 (ledger.process (transaction, *receive));
+	ASSERT_EQ (key2.pub, receive->sideband ().account);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, receive->sideband ().balance.number ());
+	ASSERT_EQ (2, receive->sideband ().height);
 	ASSERT_EQ (25, ledger.amount (transaction, hash4));
 	ASSERT_TRUE (store->frontier.get (transaction, hash2).is_zero ());
 	ASSERT_EQ (key2.pub, store->frontier.get (transaction, hash4));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, store->block.account_calculated (receive));
+	ASSERT_EQ (key2.pub, store->block.account_calculated (*receive));
 	ASSERT_EQ (hash4, ledger.latest (transaction, key2.pub));
 	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
@@ -256,13 +309,28 @@ TEST (ledger, rollback_receiver)
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	nano::block_hash hash1 (send.hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (info1.head)
+				.destination (key2.pub)
+				.balance (50)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (info1.head))
+				.build ();
+	nano::block_hash hash1 (send->hash ());
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	nano::keypair key3;
-	nano::open_block open (hash1, key3.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	nano::block_hash hash2 (open.hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
+	auto open = builder
+				.open ()
+				.source (hash1)
+				.representative (key3.pub)
+				.account (key2.pub)
+				.sign (key2.prv, key2.pub)
+				.work (*pool.generate (key2.pub))
+				.build ();
+	nano::block_hash hash2 (open->hash ());
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	ASSERT_EQ (hash2, ledger.latest (transaction, key2.pub));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
@@ -293,41 +361,81 @@ TEST (ledger, rollback_representation)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key5;
-	nano::change_block change1 (nano::dev::genesis->hash (), key5.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
+	nano::block_builder builder;
+	auto change1 = builder
+				   .change ()
+				   .previous (nano::dev::genesis->hash ())
+				   .representative (key5.pub)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
 	nano::keypair key3;
-	nano::change_block change2 (change1.hash (), key3.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change2).code);
+	auto change2 = builder
+				   .change ()
+				   .previous (change1->hash ())
+				   .representative (key3.pub)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (change1->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change2).code);
 	nano::keypair key2;
-	nano::send_block send1 (change2.hash (), key2.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+	auto send1 = builder
+				 .send ()
+				 .previous (change2->hash ())
+				 .destination (key2.pub)
+				 .balance (50)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (change2->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair key4;
-	nano::open_block open (send1.hash (), key4.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
-	nano::send_block send2 (send1.hash (), key2.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	nano::receive_block receive1 (open.hash (), send2.hash (), key2.prv, key2.pub, *pool.generate (open.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
+	auto open = builder
+				.open ()
+				.source (send1->hash ())
+				.representative (key4.pub)
+				.account (key2.pub)
+				.sign (key2.prv, key2.pub)
+				.work (*pool.generate (key2.pub))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (key2.pub)
+				 .balance (1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	auto receive1 = builder
+					.receive ()
+					.previous (open->hash ())
+					.source (send2->hash ())
+					.sign (key2.prv, key2.pub)
+					.work (*pool.generate (open->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_EQ (1, ledger.weight (key3.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, ledger.weight (key4.pub));
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, key2.pub, info1));
 	ASSERT_EQ (key4.pub, info1.representative);
-	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	nano::account_info info2;
 	ASSERT_FALSE (store->account.get (transaction, key2.pub, info2));
 	ASSERT_EQ (key4.pub, info2.representative);
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (key4.pub));
-	ASSERT_FALSE (ledger.rollback (transaction, open.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, open->hash ()));
 	ASSERT_EQ (1, ledger.weight (key3.pub));
 	ASSERT_EQ (0, ledger.weight (key4.pub));
-	ledger.rollback (transaction, send1.hash ());
+	ledger.rollback (transaction, send1->hash ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key3.pub));
 	nano::account_info info3;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info3));
 	ASSERT_EQ (key3.pub, info3.representative);
-	ASSERT_FALSE (ledger.rollback (transaction, change2.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, change2->hash ()));
 	nano::account_info info4;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info4));
 	ASSERT_EQ (key5.pub, info4.representative);
@@ -345,11 +453,25 @@ TEST (ledger, receive_rollback)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send (nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-	ASSERT_FALSE (ledger.rollback (transaction, receive.hash ()));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	auto receive = builder
+				   .receive ()
+				   .previous (send->hash ())
+				   .source (send->hash ())
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (send->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+	ASSERT_FALSE (ledger.rollback (transaction, receive->hash ()));
 }
 
 TEST (ledger, process_duplicate)
@@ -365,13 +487,28 @@ TEST (ledger, process_duplicate)
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, key2.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	nano::block_hash hash1 (send.hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, send).code);
-	nano::open_block open (hash1, 1, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, open).code);
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (info1.head)
+				.destination (key2.pub)
+				.balance (50)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (info1.head))
+				.build ();
+	nano::block_hash hash1 (send->hash ());
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *send).code);
+	auto open = builder
+				.open ()
+				.source (hash1)
+				.representative (1)
+				.account (key2.pub)
+				.sign (key2.prv, key2.pub)
+				.work (*pool.generate (key2.pub))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *open).code);
 }
 
 TEST (ledger, representative_genesis)
@@ -415,22 +552,29 @@ TEST (ledger, representative_change)
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-	nano::change_block block (info1.head, key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
+	nano::block_builder builder;
+	auto block = builder
+				 .change ()
+				 .previous (info1.head)
+				 .representative (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (info1.head))
+				 .build ();
 	ASSERT_EQ (nano::dev::genesis_key.pub, store->frontier.get (transaction, info1.head));
-	auto return1 (ledger.process (transaction, block));
-	ASSERT_EQ (0, ledger.amount (transaction, block.hash ()));
+	auto return1 (ledger.process (transaction, *block));
+	ASSERT_EQ (0, ledger.amount (transaction, block->hash ()));
 	ASSERT_TRUE (store->frontier.get (transaction, info1.head).is_zero ());
-	ASSERT_EQ (nano::dev::genesis_key.pub, store->frontier.get (transaction, block.hash ()));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store->frontier.get (transaction, block->hash ()));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::dev::genesis_key.pub, store->block.account_calculated (block));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store->block.account_calculated (*block));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
 	nano::account_info info2;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info2));
-	ASSERT_EQ (block.hash (), info2.head);
+	ASSERT_EQ (block->hash (), info2.head);
 	ASSERT_FALSE (ledger.rollback (transaction, info2.head));
 	ASSERT_EQ (nano::dev::genesis_key.pub, store->frontier.get (transaction, info1.head));
-	ASSERT_TRUE (store->frontier.get (transaction, block.hash ()).is_zero ());
+	ASSERT_TRUE (store->frontier.get (transaction, block->hash ()).is_zero ());
 	nano::account_info info3;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info3));
 	ASSERT_EQ (info1.head, info3.head);
@@ -452,10 +596,25 @@ TEST (ledger, send_fork)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-	nano::send_block block (info1.head, key2.pub, 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
-	nano::send_block block2 (info1.head, key3.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block2).code);
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (info1.head)
+				 .destination (key2.pub)
+				 .balance (100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (info1.head))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
+	auto block2 = builder
+				  .send ()
+				  .previous (info1.head)
+				  .destination (key3.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (info1.head))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
 }
 
 TEST (ledger, receive_fork)
@@ -472,16 +631,50 @@ TEST (ledger, receive_fork)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-	nano::send_block block (info1.head, key2.pub, 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
-	nano::open_block block2 (block.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	nano::change_block block3 (block2.hash (), key3.pub, key2.prv, key2.pub, *pool.generate (block2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
-	nano::send_block block4 (block.hash (), key2.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block4).code);
-	nano::receive_block block5 (block2.hash (), block4.hash (), key2.prv, key2.pub, *pool.generate (block2.hash ()));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block5).code);
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (info1.head)
+				 .destination (key2.pub)
+				 .balance (100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (info1.head))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
+	auto block2 = builder
+				  .open ()
+				  .source (block->hash ())
+				  .representative (key2.pub)
+				  .account (key2.pub)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (key2.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	auto block3 = builder
+				  .change ()
+				  .previous (block2->hash ())
+				  .representative (key3.pub)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (block2->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	auto block4 = builder
+				  .send ()
+				  .previous (block->hash ())
+				  .destination (key2.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
+	auto block5 = builder
+				  .receive ()
+				  .previous (block2->hash ())
+				  .source (block4->hash ())
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (block2->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block5).code);
 }
 
 TEST (ledger, open_fork)
@@ -498,12 +691,34 @@ TEST (ledger, open_fork)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-	nano::send_block block (info1.head, key2.pub, 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block).code);
-	nano::open_block block2 (block.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	nano::open_block block3 (block.hash (), key3.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block3).code);
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (info1.head)
+				 .destination (key2.pub)
+				 .balance (100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (info1.head))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
+	auto block2 = builder
+				  .open ()
+				  .source (block->hash ())
+				  .representative (key2.pub)
+				  .account (key2.pub)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (key2.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	auto block3 = builder
+				  .open ()
+				  .source (block->hash ())
+				  .representative (key3.pub)
+				  .account (key2.pub)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (key2.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block3).code);
 }
 
 TEST (ledger, representation_changes)
@@ -530,59 +745,120 @@ TEST (ledger, representation)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	nano::keypair key2;
-	nano::send_block block1 (nano::dev::genesis->hash (), key2.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key2.pub)
+				  .balance (nano::dev::constants.genesis_amount - 100)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	nano::keypair key3;
-	nano::open_block block2 (block1.hash (), key3.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
+	auto block2 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (key3.pub)
+				  .account (key2.pub)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (key2.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key3.pub));
-	nano::send_block block3 (block1.hash (), key2.pub, nano::dev::constants.genesis_amount - 200, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
+	auto block3 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key2.pub)
+				  .balance (nano::dev::constants.genesis_amount - 200)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key3.pub));
-	nano::receive_block block4 (block2.hash (), block3.hash (), key2.prv, key2.pub, *pool.generate (block2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block4).code);
+	auto block4 = builder
+				  .receive ()
+				  .previous (block2->hash ())
+				  .source (block3->hash ())
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (block2->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (200, rep_weights.representation_get (key3.pub));
 	nano::keypair key4;
-	nano::change_block block5 (block4.hash (), key4.pub, key2.prv, key2.pub, *pool.generate (block4.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block5).code);
+	auto block5 = builder
+				  .change ()
+				  .previous (block4->hash ())
+				  .representative (key4.pub)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (block4->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block5).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (200, rep_weights.representation_get (key4.pub));
 	nano::keypair key5;
-	nano::send_block block6 (block5.hash (), key5.pub, 100, key2.prv, key2.pub, *pool.generate (block5.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block6).code);
+	auto block6 = builder
+				  .send ()
+				  .previous (block5->hash ())
+				  .destination (key5.pub)
+				  .balance (100)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (block5->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block6).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key4.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key5.pub));
 	nano::keypair key6;
-	nano::open_block block7 (block6.hash (), key6.pub, key5.pub, key5.prv, key5.pub, *pool.generate (key5.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block7).code);
+	auto block7 = builder
+				  .open ()
+				  .source (block6->hash ())
+				  .representative (key6.pub)
+				  .account (key5.pub)
+				  .sign (key5.prv, key5.pub)
+				  .work (*pool.generate (key5.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block7).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key4.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key5.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key6.pub));
-	nano::send_block block8 (block6.hash (), key5.pub, 0, key2.prv, key2.pub, *pool.generate (block6.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block8).code);
+	auto block8 = builder
+				  .send ()
+				  .previous (block6->hash ())
+				  .destination (key5.pub)
+				  .balance (0)
+				  .sign (key2.prv, key2.pub)
+				  .work (*pool.generate (block6->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block8).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key4.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key5.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key6.pub));
-	nano::receive_block block9 (block7.hash (), block8.hash (), key5.prv, key5.pub, *pool.generate (block7.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block9).code);
+	auto block9 = builder
+				  .receive ()
+				  .previous (block7->hash ())
+				  .source (block8->hash ())
+				  .sign (key5.prv, key5.pub)
+				  .work (*pool.generate (block7->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block9).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
@@ -602,12 +878,34 @@ TEST (ledger, double_open)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
-	nano::send_block send1 (nano::dev::genesis->hash (), key2.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::open_block open1 (send1.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::open_block open2 (send1.hash (), nano::dev::genesis_key.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, open2).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key2.pub)
+				 .balance (1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (key2.pub)
+				 .account (key2.pub)
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	auto open2 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .account (key2.pub)
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
 }
 
 TEST (ledger, double_receive)
@@ -621,12 +919,33 @@ TEST (ledger, double_receive)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
-	nano::send_block send1 (nano::dev::genesis->hash (), key2.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::open_block open1 (send1.hash (), key2.pub, key2.pub, key2.prv, key2.pub, *pool.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::receive_block receive1 (open1.hash (), send1.hash (), key2.prv, key2.pub, *pool.generate (open1.hash ()));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, receive1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key2.pub)
+				 .balance (1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (key2.pub)
+				 .account (key2.pub)
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	auto receive1 = builder
+					.receive ()
+					.previous (open1->hash ())
+					.source (send1->hash ())
+					.sign (key2.prv, key2.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
 }
 
 TEST (votes, check_signature)
@@ -636,7 +955,15 @@ TEST (votes, check_signature)
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
 	auto & node1 = *system.add_node (node_config);
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	{
 		auto transaction (node1.store.tx_begin_write ());
@@ -659,7 +986,15 @@ TEST (votes, add_one)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -752,7 +1087,15 @@ TEST (votes, add_old)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -763,9 +1106,16 @@ TEST (votes, add_old)
 	auto channel (std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	node1.vote_processor.vote_blocking (vote1, channel);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key2.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	auto send2 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key2.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send2);
-	auto vote2 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ send2->hash () }));
+	auto vote2 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ send2->hash () });
 	{
 		nano::lock_guard<nano::mutex> lock (election1->mutex);
 		election1->last_votes[nano::dev::genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
@@ -788,9 +1138,24 @@ TEST (votes, DISABLED_add_old_different_account)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
-	auto send2 (std::make_shared<nano::send_block> (send1->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send2);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
@@ -828,7 +1193,15 @@ TEST (votes, add_cooldown)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -839,7 +1212,14 @@ TEST (votes, add_cooldown)
 	auto channel (std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	node1.vote_processor.vote_blocking (vote1, channel);
 	nano::keypair key2;
-	auto send2 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key2.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	auto send2 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key2.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send2);
 	auto vote2 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 2, 0, std::vector<nano::block_hash>{ send2->hash () }));
 	node1.vote_processor.vote_blocking (vote2, channel);
@@ -856,11 +1236,19 @@ TEST (ledger, successor)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	nano::send_block send1 (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
-	node1.work_generate_blocking (send1);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build ();
+	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send1).code);
-	ASSERT_EQ (send1, *node1.ledger.successor (transaction, nano::qualified_root (nano::root (0), nano::dev::genesis->hash ())));
+	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+	ASSERT_EQ (*send1, *node1.ledger.successor (transaction, nano::qualified_root (nano::root (0), nano::dev::genesis->hash ())));
 	ASSERT_EQ (*nano::dev::genesis, *node1.ledger.successor (transaction, nano::dev::genesis->qualified_root ()));
 	ASSERT_EQ (nullptr, node1.ledger.successor (transaction, nano::qualified_root (0)));
 }
@@ -876,10 +1264,17 @@ TEST (ledger, fail_change_old)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::change_block block (nano::dev::genesis->hash (), key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block));
+	nano::block_builder builder;
+	auto block = builder
+				 .change ()
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto result1 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	auto result2 (ledger.process (transaction, block));
+	auto result2 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::old, result2.code);
 }
 
@@ -894,8 +1289,15 @@ TEST (ledger, fail_change_gap_previous)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::change_block block (1, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::root (1)));
-	auto result1 (ledger.process (transaction, block));
+	nano::block_builder builder;
+	auto block = builder
+				 .change ()
+				 .previous (1)
+				 .representative (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::root (1)))
+				 .build ();
+	auto result1 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
 }
 
@@ -910,8 +1312,15 @@ TEST (ledger, fail_change_bad_signature)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::change_block block (nano::dev::genesis->hash (), key1.pub, nano::keypair ().prv, 0, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block));
+	nano::block_builder builder;
+	auto block = builder
+				 .change ()
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (key1.pub)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto result1 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
 }
 
@@ -926,12 +1335,25 @@ TEST (ledger, fail_change_fork)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::change_block block1 (nano::dev::genesis->hash (), key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .change ()
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (key1.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
 	nano::keypair key2;
-	nano::change_block block2 (nano::dev::genesis->hash (), key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .change ()
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (key2.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::fork, result2.code);
 }
 
@@ -946,10 +1368,18 @@ TEST (ledger, fail_send_old)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block));
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto result1 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	auto result2 (ledger.process (transaction, block));
+	auto result2 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::old, result2.code);
 }
 
@@ -964,8 +1394,16 @@ TEST (ledger, fail_send_gap_previous)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block (1, key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::root (1)));
-	auto result1 (ledger.process (transaction, block));
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (1)
+				 .destination (key1.pub)
+				 .balance (1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::root (1)))
+				 .build ();
+	auto result1 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
 }
 
@@ -980,8 +1418,16 @@ TEST (ledger, fail_send_bad_signature)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block (nano::dev::genesis->hash (), key1.pub, 1, nano::keypair ().prv, 0, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block));
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (1)
+				 .sign (nano::keypair ().prv, 0)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto result1 (ledger.process (transaction, *block));
 	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
 }
 
@@ -996,11 +1442,26 @@ TEST (ledger, fail_send_negative_spend)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	nano::keypair key2;
-	nano::send_block block2 (block1.hash (), key2.pub, 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	ASSERT_EQ (nano::process_result::negative_spend, ledger.process (transaction, block2).code);
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key2.pub)
+				  .balance (2)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::negative_spend, ledger.process (transaction, *block2).code);
 }
 
 TEST (ledger, fail_send_fork)
@@ -1014,11 +1475,26 @@ TEST (ledger, fail_send_fork)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	nano::keypair key2;
-	nano::send_block block2 (nano::dev::genesis->hash (), key2.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block2).code);
+	auto block2 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key2.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
 }
 
 TEST (ledger, fail_open_old)
@@ -1032,11 +1508,26 @@ TEST (ledger, fail_open_old)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	nano::open_block block2 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, block2).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	auto block2 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *block2).code);
 }
 
 TEST (ledger, fail_open_gap_source)
@@ -1050,8 +1541,16 @@ TEST (ledger, fail_open_gap_source)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::open_block block2 (1, 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result2 (ledger.process (transaction, block2));
+	nano::block_builder builder;
+	auto block2 = builder
+				  .open ()
+				  .source (1)
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::gap_source, result2.code);
 }
 
@@ -1066,11 +1565,26 @@ TEST (ledger, fail_open_bad_signature)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	nano::open_block block2 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	block2.signature.clear ();
-	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, block2).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	auto block2 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	block2->signature.clear ();
+	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *block2).code);
 }
 
 TEST (ledger, fail_open_fork_previous)
@@ -1084,14 +1598,43 @@ TEST (ledger, fail_open_fork_previous)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
-	nano::open_block block4 (block2.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, block4).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	auto block4 = builder
+				  .open ()
+				  .source (block2->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block4).code);
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 }
 
@@ -1106,11 +1649,26 @@ TEST (ledger, fail_open_account_mismatch)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	nano::keypair badkey;
-	nano::open_block block2 (block1.hash (), 1, badkey.pub, badkey.prv, badkey.pub, *pool.generate (badkey.pub));
-	ASSERT_NE (nano::process_result::progress, ledger.process (transaction, block2).code);
+	auto block2 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (badkey.pub)
+				  .sign (badkey.prv, badkey.pub)
+				  .work (*pool.generate (badkey.pub))
+				  .build ();
+	ASSERT_NE (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 }
 
@@ -1125,15 +1683,43 @@ TEST (ledger, fail_receive_old)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
-	nano::receive_block block4 (block3.hash (), block2.hash (), key1.prv, key1.pub, *pool.generate (block3.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block4).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, block4).code);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	auto block4 = builder
+				  .receive ()
+				  .previous (block3->hash ())
+				  .source (block2->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
+	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *block4).code);
 }
 
 TEST (ledger, fail_receive_gap_source)
@@ -1147,17 +1733,45 @@ TEST (ledger, fail_receive_gap_source)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result3 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::progress, result3.code);
-	nano::receive_block block4 (block3.hash (), 1, key1.prv, key1.pub, *pool.generate (block3.hash ()));
-	auto result4 (ledger.process (transaction, block4));
+	auto block4 = builder
+				  .receive ()
+				  .previous (block3->hash ())
+				  .source (1)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	auto result4 (ledger.process (transaction, *block4));
 	ASSERT_EQ (nano::process_result::gap_source, result4.code);
 }
 
@@ -1172,14 +1786,35 @@ TEST (ledger, fail_receive_overreceive)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::open_block block2 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result3 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result3.code);
-	nano::receive_block block3 (block2.hash (), block1.hash (), key1.prv, key1.pub, *pool.generate (block2.hash ()));
-	auto result4 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .receive ()
+				  .previous (block2->hash ())
+				  .source (block1->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block2->hash ()))
+				  .build ();
+	auto result4 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::unreceivable, result4.code);
 }
 
@@ -1194,17 +1829,45 @@ TEST (ledger, fail_receive_bad_signature)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result3 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::progress, result3.code);
-	nano::receive_block block4 (block3.hash (), block2.hash (), nano::keypair ().prv, 0, *pool.generate (block3.hash ()));
-	auto result4 (ledger.process (transaction, block4));
+	auto block4 = builder
+				  .receive ()
+				  .previous (block3->hash ())
+				  .source (block2->hash ())
+				  .sign (nano::keypair ().prv, 0)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	auto result4 (ledger.process (transaction, *block4));
 	ASSERT_EQ (nano::process_result::bad_signature, result4.code);
 }
 
@@ -1219,17 +1882,45 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result3 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::progress, result3.code);
-	nano::receive_block block4 (1, block2.hash (), key1.prv, key1.pub, *pool.generate (nano::root (1)));
-	auto result4 (ledger.process (transaction, block4));
+	auto block4 = builder
+				  .receive ()
+				  .previous (1)
+				  .source (block2->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (nano::root (1)))
+				  .build ();
+	auto result4 (ledger.process (transaction, *block4));
 	ASSERT_EQ (nano::process_result::gap_previous, result4.code);
 }
 
@@ -1244,14 +1935,35 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::receive_block block3 (1, block2.hash (), key1.prv, key1.pub, *pool.generate (nano::root (1)));
-	auto result3 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .receive ()
+				  .previous (1)
+				  .source (block2->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (nano::root (1)))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::gap_previous, result3.code);
 }
 
@@ -1266,21 +1978,56 @@ TEST (ledger, fail_receive_fork_previous)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result3 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::progress, result3.code);
 	nano::keypair key2;
-	nano::send_block block4 (block3.hash (), key1.pub, 1, key1.prv, key1.pub, *pool.generate (block3.hash ()));
-	auto result4 (ledger.process (transaction, block4));
+	auto block4 = builder
+				  .send ()
+				  .previous (block3->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	auto result4 (ledger.process (transaction, *block4));
 	ASSERT_EQ (nano::process_result::progress, result4.code);
-	nano::receive_block block5 (block3.hash (), block2.hash (), key1.prv, key1.pub, *pool.generate (block3.hash ()));
-	auto result5 (ledger.process (transaction, block5));
+	auto block5 = builder
+				  .receive ()
+				  .previous (block3->hash ())
+				  .source (block2->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	auto result5 (ledger.process (transaction, *block5));
 	ASSERT_EQ (nano::process_result::fork, result5.code);
 }
 
@@ -1295,27 +2042,75 @@ TEST (ledger, fail_receive_received_source)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
-	nano::send_block block1 (nano::dev::genesis->hash (), key1.pub, 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	auto result1 (ledger.process (transaction, block1));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (key1.pub)
+				  .balance (2)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto result1 (ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::process_result::progress, result1.code);
-	nano::send_block block2 (block1.hash (), key1.pub, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
-	auto result2 (ledger.process (transaction, block2));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
+	auto result2 (ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::process_result::progress, result2.code);
-	nano::send_block block6 (block2.hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block2.hash ()));
-	auto result6 (ledger.process (transaction, block6));
+	auto block6 = builder
+				  .send ()
+				  .previous (block2->hash ())
+				  .destination (key1.pub)
+				  .balance (0)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block2->hash ()))
+				  .build ();
+	auto result6 (ledger.process (transaction, *block6));
 	ASSERT_EQ (nano::process_result::progress, result6.code);
-	nano::open_block block3 (block1.hash (), 1, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto result3 (ledger.process (transaction, block3));
+	auto block3 = builder
+				  .open ()
+				  .source (block1->hash ())
+				  .representative (1)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (key1.pub))
+				  .build ();
+	auto result3 (ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::process_result::progress, result3.code);
 	nano::keypair key2;
-	nano::send_block block4 (block3.hash (), key1.pub, 1, key1.prv, key1.pub, *pool.generate (block3.hash ()));
-	auto result4 (ledger.process (transaction, block4));
+	auto block4 = builder
+				  .send ()
+				  .previous (block3->hash ())
+				  .destination (key1.pub)
+				  .balance (1)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	auto result4 (ledger.process (transaction, *block4));
 	ASSERT_EQ (nano::process_result::progress, result4.code);
-	nano::receive_block block5 (block4.hash (), block2.hash (), key1.prv, key1.pub, *pool.generate (block4.hash ()));
-	auto result5 (ledger.process (transaction, block5));
+	auto block5 = builder
+				  .receive ()
+				  .previous (block4->hash ())
+				  .source (block2->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block4->hash ()))
+				  .build ();
+	auto result5 (ledger.process (transaction, *block5));
 	ASSERT_EQ (nano::process_result::progress, result5.code);
-	nano::receive_block block7 (block3.hash (), block2.hash (), key1.prv, key1.pub, *pool.generate (block3.hash ()));
-	auto result7 (ledger.process (transaction, block7));
+	auto block7 = builder
+				  .receive ()
+				  .previous (block3->hash ())
+				  .source (block2->hash ())
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
+	auto result7 (ledger.process (transaction, *block7));
 	ASSERT_EQ (nano::process_result::fork, result7.code);
 }
 
@@ -1345,9 +2140,17 @@ TEST (ledger, latest_root)
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub));
 	auto hash1 (ledger.latest (transaction, nano::dev::genesis_key.pub));
-	nano::send_block send (hash1, 0, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (hash1));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	ASSERT_EQ (send.hash (), ledger.latest_root (transaction, nano::dev::genesis_key.pub));
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (hash1)
+				.destination (0)
+				.balance (1)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (hash1))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (send->hash (), ledger.latest_root (transaction, nano::dev::genesis_key.pub));
 }
 
 TEST (ledger, change_representative_move_representation)
@@ -1362,15 +2165,36 @@ TEST (ledger, change_representative_move_representation)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
-	nano::send_block send (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (key1.pub)
+				.balance (0)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	nano::keypair key2;
-	nano::change_block change (send.hash (), key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
+	auto change = builder
+				  .change ()
+				  .previous (send->hash ())
+				  .representative (key2.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (send->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
 	nano::keypair key3;
-	nano::open_block open (send.hash (), key3.pub, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
+	auto open = builder
+				.open ()
+				.source (send->hash ())
+				.representative (key3.pub)
+				.account (key1.pub)
+				.sign (key1.prv, key1.pub)
+				.work (*pool.generate (key1.pub))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key3.pub));
 }
 
@@ -1387,46 +2211,80 @@ TEST (ledger, send_open_receive_rollback)
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key1;
-	nano::send_block send1 (info1.head, key1.pub, nano::dev::constants.genesis_amount - 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	auto return1 (ledger.process (transaction, send1));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (info1.head)
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 50)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (info1.head))
+				 .build ();
+	auto return1 (ledger.process (transaction, *send1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	nano::send_block send2 (send1.hash (), key1.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	auto return2 (ledger.process (transaction, send2));
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto return2 (ledger.process (transaction, *send2));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
 	nano::keypair key2;
-	nano::open_block open (send2.hash (), key2.pub, key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	auto return4 (ledger.process (transaction, open));
+	auto open = builder
+				.open ()
+				.source (send2->hash ())
+				.representative (key2.pub)
+				.account (key1.pub)
+				.sign (key1.prv, key1.pub)
+				.work (*pool.generate (key1.pub))
+				.build ();
+	auto return4 (ledger.process (transaction, *open));
 	ASSERT_EQ (nano::process_result::progress, return4.code);
-	nano::receive_block receive (open.hash (), send1.hash (), key1.prv, key1.pub, *pool.generate (open.hash ()));
-	auto return5 (ledger.process (transaction, receive));
+	auto receive = builder
+				   .receive ()
+				   .previous (open->hash ())
+				   .source (send1->hash ())
+				   .sign (key1.prv, key1.pub)
+				   .work (*pool.generate (open->hash ()))
+				   .build ();
+	auto return5 (ledger.process (transaction, *receive));
 	ASSERT_EQ (nano::process_result::progress, return5.code);
 	nano::keypair key3;
 	ASSERT_EQ (100, ledger.weight (key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
-	nano::change_block change1 (send2.hash (), key3.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send2.hash ()));
-	auto return6 (ledger.process (transaction, change1));
+	auto change1 = builder
+				   .change ()
+				   .previous (send2->hash ())
+				   .representative (key3.pub)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (send2->hash ()))
+				   .build ();
+	auto return6 (ledger.process (transaction, *change1));
 	ASSERT_EQ (nano::process_result::progress, return6.code);
 	ASSERT_EQ (100, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (key3.pub));
-	ASSERT_FALSE (ledger.rollback (transaction, receive.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, receive->hash ()));
 	ASSERT_EQ (50, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (key3.pub));
-	ASSERT_FALSE (ledger.rollback (transaction, open.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, open->hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (key3.pub));
-	ASSERT_FALSE (ledger.rollback (transaction, change1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, change1->hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (nano::dev::genesis_key.pub));
-	ASSERT_FALSE (ledger.rollback (transaction, send2.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, send2->hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (nano::dev::genesis_key.pub));
-	ASSERT_FALSE (ledger.rollback (transaction, send1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 0, ledger.weight (nano::dev::genesis_key.pub));
@@ -1446,8 +2304,16 @@ TEST (ledger, bootstrap_rep_weight)
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache, ledger.constants);
 		ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (info1.head)
+					.destination (key2.pub)
+					.balance (std::numeric_limits<nano::uint128_t>::max () - 50)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (info1.head))
+					.build ();
+		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	}
 	ASSERT_EQ (2, ledger.cache.block_count);
 	{
@@ -1458,8 +2324,16 @@ TEST (ledger, bootstrap_rep_weight)
 	{
 		auto transaction (store->tx_begin_write ());
 		ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-		nano::send_block send (info1.head, key2.pub, std::numeric_limits<nano::uint128_t>::max () - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (info1.head)
+					.destination (key2.pub)
+					.balance (std::numeric_limits<nano::uint128_t>::max () - 100)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (info1.head))
+					.build ();
+		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	}
 	ASSERT_EQ (3, ledger.cache.block_count);
 	{
@@ -1481,36 +2355,84 @@ TEST (ledger, block_destination_source)
 	nano::keypair dest;
 	nano::uint128_t balance (nano::dev::constants.genesis_amount);
 	balance -= nano::Gxrb_ratio;
-	nano::send_block block1 (nano::dev::genesis->hash (), dest.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (nano::dev::genesis->hash ())
+				  .destination (dest.pub)
+				  .balance (balance)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
 	balance -= nano::Gxrb_ratio;
-	nano::send_block block2 (block1.hash (), nano::dev::genesis->account (), balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block1.hash ()));
+	auto block2 = builder
+				  .send ()
+				  .previous (block1->hash ())
+				  .destination (nano::dev::genesis->account ())
+				  .balance (balance)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block1->hash ()))
+				  .build ();
 	balance += nano::Gxrb_ratio;
-	nano::receive_block block3 (block2.hash (), block2.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block2.hash ()));
+	auto block3 = builder
+				  .receive ()
+				  .previous (block2->hash ())
+				  .source (block2->hash ())
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block2->hash ()))
+				  .build ();
 	balance -= nano::Gxrb_ratio;
-	nano::state_block block4 (nano::dev::genesis->account (), block3.hash (), nano::dev::genesis->account (), balance, dest.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block3.hash ()));
+	auto block4 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (block3->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (balance)
+				  .link (dest.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block3->hash ()))
+				  .build ();
 	balance -= nano::Gxrb_ratio;
-	nano::state_block block5 (nano::dev::genesis->account (), block4.hash (), nano::dev::genesis->account (), balance, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block4.hash ()));
+	auto block5 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (block4->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (balance)
+				  .link (nano::dev::genesis->account ())
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block4->hash ()))
+				  .build ();
 	balance += nano::Gxrb_ratio;
-	nano::state_block block6 (nano::dev::genesis->account (), block5.hash (), nano::dev::genesis->account (), balance, block5.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (block5.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block1).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block2).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block3).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block4).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block5).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, block6).code);
-	ASSERT_EQ (balance, ledger.balance (transaction, block6.hash ()));
-	ASSERT_EQ (dest.pub, ledger.block_destination (transaction, block1));
-	ASSERT_TRUE (ledger.block_source (transaction, block1).is_zero ());
-	ASSERT_EQ (nano::dev::genesis->account (), ledger.block_destination (transaction, block2));
-	ASSERT_TRUE (ledger.block_source (transaction, block2).is_zero ());
-	ASSERT_TRUE (ledger.block_destination (transaction, block3) == nullptr);
-	ASSERT_EQ (block2.hash (), ledger.block_source (transaction, block3));
-	ASSERT_EQ (dest.pub, ledger.block_destination (transaction, block4));
-	ASSERT_TRUE (ledger.block_source (transaction, block4).is_zero ());
-	ASSERT_EQ (nano::dev::genesis->account (), ledger.block_destination (transaction, block5));
-	ASSERT_TRUE (ledger.block_source (transaction, block5).is_zero ());
-	ASSERT_TRUE (ledger.block_destination (transaction, block6) == nullptr);
-	ASSERT_EQ (block5.hash (), ledger.block_source (transaction, block6));
+	auto block6 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (block5->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (balance)
+				  .link (block5->hash ())
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (block5->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block5).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block6).code);
+	ASSERT_EQ (balance, ledger.balance (transaction, block6->hash ()));
+	ASSERT_EQ (dest.pub, ledger.block_destination (transaction, *block1));
+	ASSERT_TRUE (ledger.block_source (transaction, *block1).is_zero ());
+	ASSERT_EQ (nano::dev::genesis->account (), ledger.block_destination (transaction, *block2));
+	ASSERT_TRUE (ledger.block_source (transaction, *block2).is_zero ());
+	ASSERT_TRUE (ledger.block_destination (transaction, *block3) == nullptr);
+	ASSERT_EQ (block2->hash (), ledger.block_source (transaction, *block3));
+	ASSERT_EQ (dest.pub, ledger.block_destination (transaction, *block4));
+	ASSERT_TRUE (ledger.block_source (transaction, *block4).is_zero ());
+	ASSERT_EQ (nano::dev::genesis->account (), ledger.block_destination (transaction, *block5));
+	ASSERT_TRUE (ledger.block_source (transaction, *block5).is_zero ());
+	ASSERT_TRUE (ledger.block_destination (transaction, *block6) == nullptr);
+	ASSERT_EQ (block5->hash (), ledger.block_source (transaction, *block6));
 }
 
 TEST (ledger, state_account)
@@ -1523,9 +2445,19 @@ TEST (ledger, state_account)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send1->hash ()));
 }
 
 TEST (ledger, state_send_receive)
@@ -1538,30 +2470,49 @@ TEST (ledger, state_send_receive)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, send2->sideband ().height);
 	ASSERT_TRUE (send2->sideband ().details.is_send);
 	ASSERT_FALSE (send2->sideband ().details.is_receive);
 	ASSERT_FALSE (send2->sideband ().details.is_epoch);
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_TRUE (store->block.exists (transaction, receive1.hash ()));
-	auto receive2 (store->block.get (transaction, receive1.hash ()));
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_TRUE (store->block.exists (transaction, receive1->hash ()));
+	auto receive2 (store->block.get (transaction, receive1->hash ()));
 	ASSERT_NE (nullptr, receive2);
-	ASSERT_EQ (receive1, *receive2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, receive1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1.hash ()));
+	ASSERT_EQ (*receive1, *receive2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, receive1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 	ASSERT_EQ (3, receive2->sideband ().height);
 	ASSERT_FALSE (receive2->sideband ().details.is_send);
@@ -1579,23 +2530,40 @@ TEST (ledger, state_receive)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_TRUE (store->block.exists (transaction, receive1.hash ()));
-	auto receive2 (store->block.get (transaction, receive1.hash ()));
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_TRUE (store->block.exists (transaction, receive1->hash ()));
+	auto receive2 (store->block.get (transaction, receive1->hash ()));
 	ASSERT_NE (nullptr, receive2);
-	ASSERT_EQ (receive1, *receive2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, receive1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1.hash ()));
+	ASSERT_EQ (*receive1, *receive2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, receive1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (3, receive2->sideband ().height);
 	ASSERT_FALSE (receive2->sideband ().details.is_send);
@@ -1614,14 +2582,24 @@ TEST (ledger, state_rep_change)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
-	nano::state_block change1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
-	ASSERT_TRUE (store->block.exists (transaction, change1.hash ()));
-	auto change2 (store->block.get (transaction, change1.hash ()));
+	nano::block_builder builder;
+	auto change1 = builder
+				   .state ()
+				   .account (nano::dev::genesis->account ())
+				   .previous (nano::dev::genesis->hash ())
+				   .representative (rep.pub)
+				   .balance (nano::dev::constants.genesis_amount)
+				   .link (0)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_TRUE (store->block.exists (transaction, change1->hash ()));
+	auto change2 (store->block.get (transaction, change1->hash ()));
 	ASSERT_NE (nullptr, change2);
-	ASSERT_EQ (change1, *change2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, change1.hash ()));
-	ASSERT_EQ (0, ledger.amount (transaction, change1.hash ()));
+	ASSERT_EQ (*change1, *change2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, change1->hash ()));
+	ASSERT_EQ (0, ledger.amount (transaction, change1->hash ()));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (rep.pub));
 	ASSERT_EQ (2, change2->sideband ().height);
@@ -1641,25 +2619,44 @@ TEST (ledger, state_open)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (destination.pub, send1.hash ())));
-	nano::state_block open1 (destination.pub, 0, nano::dev::genesis->account (), nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (destination.pub, send1.hash ())));
-	ASSERT_TRUE (store->block.exists (transaction, open1.hash ()));
-	auto open2 (store->block.get (transaction, open1.hash ()));
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (destination.pub, send1->hash ())));
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (destination.pub, send1->hash ())));
+	ASSERT_TRUE (store->block.exists (transaction, open1->hash ()));
+	auto open2 (store->block.get (transaction, open1->hash ()));
 	ASSERT_NE (nullptr, open2);
-	ASSERT_EQ (open1, *open2);
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, open1.hash ()));
+	ASSERT_EQ (*open1, *open2);
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, open1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (ledger.cache.account_count, store->account.count (transaction));
 	ASSERT_EQ (1, open2->sideband ().height);
@@ -1679,10 +2676,27 @@ TEST (ledger, send_after_state_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::send_block send2 (send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, send2).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio))
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *send2).code);
 }
 
 // Make sure old block types can't be inserted after a state block.
@@ -1696,10 +2710,26 @@ TEST (ledger, receive_after_state_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::receive_block receive1 (send1.hash (), send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, receive1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto receive1 = builder
+					.receive ()
+					.previous (send1->hash ())
+					.source (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
 }
 
 // Make sure old block types can't be inserted after a state block.
@@ -1713,11 +2743,27 @@ TEST (ledger, change_after_state_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair rep;
-	nano::change_block change1 (send1.hash (), rep.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, change1).code);
+	auto change1 = builder
+				   .change ()
+				   .previous (send1->hash ())
+				   .representative (rep.pub)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (send1->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
 }
 
 TEST (ledger, state_unreceivable_fail)
@@ -1730,17 +2776,34 @@ TEST (ledger, state_unreceivable_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, receive1).code);
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount)
+					.link (1)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, *receive1).code);
 }
 
 TEST (ledger, state_receive_bad_amount_fail)
@@ -1753,17 +2816,34 @@ TEST (ledger, state_receive_bad_amount_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, receive1).code);
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, *receive1).code);
 }
 
 TEST (ledger, state_no_link_amount_fail)
@@ -1776,11 +2856,30 @@ TEST (ledger, state_no_link_amount_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair rep;
-	nano::state_block change1 (nano::dev::genesis->account (), send1.hash (), rep.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, change1).code);
+	auto change1 = builder
+				   .state ()
+				   .account (nano::dev::genesis->account ())
+				   .previous (send1->hash ())
+				   .representative (rep.pub)
+				   .balance (nano::dev::constants.genesis_amount)
+				   .link (0)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (send1->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, *change1).code);
 }
 
 TEST (ledger, state_receive_wrong_account_fail)
@@ -1793,18 +2892,37 @@ TEST (ledger, state_receive_wrong_account_fail)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	nano::keypair key;
-	nano::state_block receive1 (key.pub, 0, nano::dev::genesis->account (), nano::Gxrb_ratio, send1.hash (), key.prv, key.pub, *pool.generate (key.pub));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, receive1).code);
+	auto receive1 = builder
+					.state ()
+					.account (key.pub)
+					.previous (0)
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (key.prv, key.pub)
+					.work (*pool.generate (key.pub))
+					.build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
 }
 
 TEST (ledger, state_open_state_fork)
@@ -1818,13 +2936,39 @@ TEST (ledger, state_open_state_fork)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block open1 (destination.pub, 0, nano::dev::genesis->account (), nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::open_block open2 (send1.hash (), nano::dev::genesis->account (), destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, open2).code);
-	ASSERT_EQ (open1.root (), open2.root ());
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	auto open2 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
+	ASSERT_EQ (open1->root (), open2->root ());
 }
 
 TEST (ledger, state_state_open_fork)
@@ -1838,13 +2982,39 @@ TEST (ledger, state_state_open_fork)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::state_block open2 (destination.pub, 0, nano::dev::genesis->account (), nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, open2).code);
-	ASSERT_EQ (open1.root (), open2.root ());
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	auto open2 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
+	ASSERT_EQ (open1->root (), open2->root ());
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 }
 
@@ -1859,10 +3029,29 @@ TEST (ledger, state_open_previous_fail)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block open1 (destination.pub, 1, nano::dev::genesis->account (), nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (1));
-	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, open1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (1)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (1))
+				 .build ();
+	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, *open1).code);
 }
 
 TEST (ledger, state_open_source_fail)
@@ -1876,10 +3065,29 @@ TEST (ledger, state_open_source_fail)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block open1 (destination.pub, 0, nano::dev::genesis->account (), 0, 0, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, open1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (0)
+				 .link (0)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, *open1).code);
 }
 
 TEST (ledger, state_send_change)
@@ -1893,14 +3101,24 @@ TEST (ledger, state_send_change)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (rep.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (rep.pub));
 	ASSERT_EQ (2, send2->sideband ().height);
@@ -1919,24 +3137,43 @@ TEST (ledger, state_receive_change)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1.hash ()));
+	ASSERT_EQ (*send1, *send2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	nano::keypair rep;
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), rep.pub, nano::dev::constants.genesis_amount, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_TRUE (store->block.exists (transaction, receive1.hash ()));
-	auto receive2 (store->block.get (transaction, receive1.hash ()));
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (rep.pub)
+					.balance (nano::dev::constants.genesis_amount)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_TRUE (store->block.exists (transaction, receive1->hash ()));
+	auto receive2 (store->block.get (transaction, receive1->hash ()));
 	ASSERT_NE (nullptr, receive2);
-	ASSERT_EQ (receive1, *receive2);
-	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, receive1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1.hash ()));
+	ASSERT_EQ (*receive1, *receive2);
+	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.balance (transaction, receive1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1->hash ()));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (rep.pub));
 	ASSERT_EQ (3, receive2->sideband ().height);
@@ -1956,12 +3193,29 @@ TEST (ledger, state_open_old)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, open1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, open1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 }
 
@@ -1976,16 +3230,48 @@ TEST (ledger, state_receive_old)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block send2 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio), destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::receive_block receive1 (open1.hash (), send2.hash (), destination.prv, destination.pub, *pool.generate (open1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_EQ (2 * nano::Gxrb_ratio, ledger.balance (transaction, receive1.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio))
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	auto receive1 = builder
+					.receive ()
+					.previous (open1->hash ())
+					.source (send2->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (2 * nano::Gxrb_ratio, ledger.balance (transaction, receive1->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 }
 
@@ -1999,23 +3285,33 @@ TEST (ledger, state_rollback_send)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send2 (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send2);
-	ASSERT_EQ (send1, *send2);
+	ASSERT_EQ (*send1, *send2);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	nano::pending_info info;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ()), info));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()), info));
 	ASSERT_EQ (nano::dev::genesis->account (), info.source);
 	ASSERT_EQ (nano::Gxrb_ratio, info.amount.number ());
-	ASSERT_FALSE (ledger.rollback (transaction, send1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_TRUE (store->block.successor (transaction, nano::dev::genesis->hash ()).is_zero ());
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 }
@@ -2030,17 +3326,36 @@ TEST (ledger, state_rollback_receive)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1.hash ())));
-	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1->hash ())));
+	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	nano::pending_info info;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ()), info));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()), info));
 	ASSERT_EQ (nano::dev::genesis->account (), info.source);
 	ASSERT_EQ (nano::Gxrb_ratio, info.amount.number ());
-	ASSERT_FALSE (store->block.exists (transaction, receive1.hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
@@ -2057,15 +3372,34 @@ TEST (ledger, state_rollback_received_send)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block receive1 (key.pub, 0, key.pub, nano::Gxrb_ratio, send1.hash (), key.prv, key.pub, *pool.generate (key.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1.hash ())));
-	ASSERT_FALSE (ledger.rollback (transaction, send1.hash ()));
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, receive1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto receive1 = builder
+					.state ()
+					.account (key.pub)
+					.previous (0)
+					.representative (key.pub)
+					.balance (nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (key.prv, key.pub)
+					.work (*pool.generate (key.pub))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1->hash ())));
+	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (0, ledger.account_balance (transaction, key.pub));
@@ -2084,10 +3418,20 @@ TEST (ledger, state_rep_change_rollback)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
-	nano::state_block change1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
-	ASSERT_FALSE (ledger.rollback (transaction, change1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, change1.hash ()));
+	nano::block_builder builder;
+	auto change1 = builder
+				   .state ()
+				   .account (nano::dev::genesis->account ())
+				   .previous (nano::dev::genesis->hash ())
+				   .representative (rep.pub)
+				   .balance (nano::dev::constants.genesis_amount)
+				   .link (0)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_FALSE (ledger.rollback (transaction, change1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, change1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (0, ledger.weight (rep.pub));
@@ -2104,16 +3448,35 @@ TEST (ledger, state_open_rollback)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block open1 (destination.pub, 0, nano::dev::genesis->account (), nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_FALSE (ledger.rollback (transaction, open1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, open1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_FALSE (ledger.rollback (transaction, open1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, open1->hash ()));
 	ASSERT_EQ (0, ledger.account_balance (transaction, destination.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	nano::pending_info info;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (destination.pub, send1.hash ()), info));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (destination.pub, send1->hash ()), info));
 	ASSERT_EQ (nano::dev::genesis->account (), info.source);
 	ASSERT_EQ (nano::Gxrb_ratio, info.amount.number ());
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
@@ -2130,10 +3493,20 @@ TEST (ledger, state_send_change_rollback)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), rep.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_FALSE (ledger.rollback (transaction, send1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (rep.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (0, ledger.weight (rep.pub));
@@ -2150,13 +3523,32 @@ TEST (ledger, state_receive_change_rollback)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair rep;
-	nano::state_block receive1 (nano::dev::genesis->account (), send1.hash (), rep.pub, nano::dev::constants.genesis_amount, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, receive1.hash ()));
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send1->hash ())
+					.representative (rep.pub)
+					.balance (nano::dev::constants.genesis_amount)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.account_balance (transaction, nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (0, ledger.weight (rep.pub));
@@ -2174,63 +3566,137 @@ TEST (ledger, epoch_blocks_v1_general)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	ASSERT_FALSE (epoch1.sideband ().details.is_send);
-	ASSERT_FALSE (epoch1.sideband ().details.is_receive);
-	ASSERT_TRUE (epoch1.sideband ().details.is_epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, epoch1.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch1.sideband ().source_epoch); // Not used for epoch blocks
-	nano::state_block epoch2 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, epoch2).code);
+	nano::block_builder builder;
+	auto epoch1 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_FALSE (epoch1->sideband ().details.is_send);
+	ASSERT_FALSE (epoch1->sideband ().details.is_receive);
+	ASSERT_TRUE (epoch1->sideband ().details.is_epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, epoch1->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch1->sideband ().source_epoch); // Not used for epoch blocks
+	auto epoch2 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (epoch1->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (epoch1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch2).code);
 	nano::account_info genesis_info;
 	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
-	ASSERT_FALSE (ledger.rollback (transaction, epoch1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, epoch1->hash ()));
 	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_0);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
 	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
-	ASSERT_FALSE (epoch1.sideband ().details.is_send);
-	ASSERT_FALSE (epoch1.sideband ().details.is_receive);
-	ASSERT_TRUE (epoch1.sideband ().details.is_epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, epoch1.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch1.sideband ().source_epoch); // Not used for epoch blocks
-	nano::change_block change1 (epoch1.hash (), nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, change1).code);
-	nano::state_block send1 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (send1.sideband ().details.is_send);
-	ASSERT_FALSE (send1.sideband ().details.is_receive);
-	ASSERT_FALSE (send1.sideband ().details.is_epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, send1.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, send1.sideband ().source_epoch); // Not used for send blocks
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open1).code);
-	nano::state_block epoch3 (destination.pub, 0, nano::dev::genesis->account (), 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, epoch3).code);
-	nano::state_block epoch4 (destination.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch4).code);
-	ASSERT_FALSE (epoch4.sideband ().details.is_send);
-	ASSERT_FALSE (epoch4.sideband ().details.is_receive);
-	ASSERT_TRUE (epoch4.sideband ().details.is_epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, epoch4.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch4.sideband ().source_epoch); // Not used for epoch blocks
-	nano::receive_block receive1 (epoch4.hash (), send1.hash (), destination.prv, destination.pub, *pool.generate (epoch4.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, receive1).code);
-	nano::state_block receive2 (destination.pub, epoch4.hash (), destination.pub, nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (epoch4.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive2).code);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().source_epoch);
-	ASSERT_EQ (0, ledger.balance (transaction, epoch4.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, receive2.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive2.hash ()));
+	ASSERT_FALSE (epoch1->sideband ().details.is_send);
+	ASSERT_FALSE (epoch1->sideband ().details.is_receive);
+	ASSERT_TRUE (epoch1->sideband ().details.is_epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, epoch1->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch1->sideband ().source_epoch); // Not used for epoch blocks
+	auto change1 = builder
+				   .change ()
+				   .previous (epoch1->hash ())
+				   .representative (nano::dev::genesis->account ())
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (epoch1->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (epoch1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (epoch1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (send1->sideband ().details.is_send);
+	ASSERT_FALSE (send1->sideband ().details.is_receive);
+	ASSERT_FALSE (send1->sideband ().details.is_epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, send1->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, send1->sideband ().source_epoch); // Not used for send blocks
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open1).code);
+	auto epoch3 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (0)
+				  .representative (nano::dev::genesis->account ())
+				  .balance (0)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (destination.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, *epoch3).code);
+	auto epoch4 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (0)
+				  .representative (0)
+				  .balance (0)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (destination.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
+	ASSERT_FALSE (epoch4->sideband ().details.is_send);
+	ASSERT_FALSE (epoch4->sideband ().details.is_receive);
+	ASSERT_TRUE (epoch4->sideband ().details.is_epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, epoch4->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch4->sideband ().source_epoch); // Not used for epoch blocks
+	auto receive1 = builder
+					.receive ()
+					.previous (epoch4->hash ())
+					.source (send1->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (epoch4->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
+	auto receive2 = builder
+					.state ()
+					.account (destination.pub)
+					.previous (epoch4->hash ())
+					.representative (destination.pub)
+					.balance (nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (epoch4->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
+	ASSERT_EQ (0, ledger.balance (transaction, epoch4->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, receive2->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.weight (destination.pub));
-	ASSERT_FALSE (receive2.sideband ().details.is_send);
-	ASSERT_TRUE (receive2.sideband ().details.is_receive);
-	ASSERT_FALSE (receive2.sideband ().details.is_epoch);
+	ASSERT_FALSE (receive2->sideband ().details.is_send);
+	ASSERT_TRUE (receive2->sideband ().details.is_receive);
+	ASSERT_FALSE (receive2->sideband ().details.is_epoch);
 }
 
 TEST (ledger, epoch_blocks_v2_general)
@@ -2244,56 +3710,157 @@ TEST (ledger, epoch_blocks_v2_general)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
+	nano::block_builder builder;
+	auto epoch1 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
 	// Trying to upgrade from epoch 0 to epoch 2. It is a requirement epoch upgrades are sequential unless the account is unopened
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, epoch1).code);
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch1).code);
 	// Set it to the first epoch and it should now succeed
-	epoch1 = nano::state_block (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, epoch1.work);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	ASSERT_EQ (nano::epoch::epoch_1, epoch1.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch1.sideband ().source_epoch); // Not used for epoch blocks
-	nano::state_block epoch2 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch2).code);
-	ASSERT_EQ (nano::epoch::epoch_2, epoch2.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch2.sideband ().source_epoch); // Not used for epoch blocks
-	nano::state_block epoch3 (nano::dev::genesis->account (), epoch2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch2.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, epoch3).code);
+	epoch1 = builder
+			 .state ()
+			 .account (nano::dev::genesis->account ())
+			 .previous (nano::dev::genesis->hash ())
+			 .representative (nano::dev::genesis->account ())
+			 .balance (nano::dev::constants.genesis_amount)
+			 .link (ledger.epoch_link (nano::epoch::epoch_1))
+			 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+			 .work (epoch1->work)
+			 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::epoch::epoch_1, epoch1->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch1->sideband ().source_epoch); // Not used for epoch blocks
+	auto epoch2 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (epoch1->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (epoch1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch2).code);
+	ASSERT_EQ (nano::epoch::epoch_2, epoch2->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch2->sideband ().source_epoch); // Not used for epoch blocks
+	auto epoch3 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (epoch2->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (epoch2->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch3).code);
 	nano::account_info genesis_info;
 	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_2);
-	ASSERT_FALSE (ledger.rollback (transaction, epoch1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, epoch1->hash ()));
 	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_0);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
 	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
 	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
-	nano::change_block change1 (epoch1.hash (), nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, change1).code);
-	nano::state_block send1 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_EQ (nano::epoch::epoch_1, send1.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, send1.sideband ().source_epoch); // Not used for send blocks
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open1).code);
-	nano::state_block epoch4 (destination.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch4).code);
-	ASSERT_EQ (nano::epoch::epoch_1, epoch4.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch4.sideband ().source_epoch); // Not used for epoch blocks
-	nano::state_block epoch5 (destination.pub, epoch4.hash (), nano::dev::genesis->account (), 0, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch4.hash ()));
-	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, epoch5).code);
-	nano::state_block epoch6 (destination.pub, epoch4.hash (), 0, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch4.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch6).code);
-	ASSERT_EQ (nano::epoch::epoch_2, epoch6.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch6.sideband ().source_epoch); // Not used for epoch blocks
-	nano::receive_block receive1 (epoch6.hash (), send1.hash (), destination.prv, destination.pub, *pool.generate (epoch6.hash ()));
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, receive1).code);
-	nano::state_block receive2 (destination.pub, epoch6.hash (), destination.pub, nano::Gxrb_ratio, send1.hash (), destination.prv, destination.pub, *pool.generate (epoch6.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive2).code);
-	ASSERT_EQ (nano::epoch::epoch_2, receive2.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().source_epoch);
-	ASSERT_EQ (0, ledger.balance (transaction, epoch6.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, receive2.hash ()));
-	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive2.hash ()));
+	auto change1 = builder
+				   .change ()
+				   .previous (epoch1->hash ())
+				   .representative (nano::dev::genesis->account ())
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (epoch1->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (epoch1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (epoch1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::epoch::epoch_1, send1->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, send1->sideband ().source_epoch); // Not used for send blocks
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open1).code);
+	auto epoch4 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (0)
+				  .representative (0)
+				  .balance (0)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (destination.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
+	ASSERT_EQ (nano::epoch::epoch_1, epoch4->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch4->sideband ().source_epoch); // Not used for epoch blocks
+	auto epoch5 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (epoch4->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (0)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (epoch4->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, *epoch5).code);
+	auto epoch6 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (epoch4->hash ())
+				  .representative (0)
+				  .balance (0)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (epoch4->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch6).code);
+	ASSERT_EQ (nano::epoch::epoch_2, epoch6->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch6->sideband ().source_epoch); // Not used for epoch blocks
+	auto receive1 = builder
+					.receive ()
+					.previous (epoch6->hash ())
+					.source (send1->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (epoch6->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
+	auto receive2 = builder
+					.state ()
+					.account (destination.pub)
+					.previous (epoch6->hash ())
+					.representative (destination.pub)
+					.balance (nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (epoch6->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
+	ASSERT_EQ (0, ledger.balance (transaction, epoch6->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, receive2->hash ()));
+	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.weight (destination.pub));
 }
@@ -2309,72 +3876,199 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block epoch1 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	nano::state_block send2 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_EQ (nano::epoch::epoch_1, send2.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, send2.sideband ().source_epoch); // Not used for send blocks
-	nano::open_block open1 (send1.hash (), destination.pub, destination.pub, destination.prv, destination.pub, *pool.generate (destination.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_EQ (nano::epoch::epoch_0, open1.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, open1.sideband ().source_epoch);
-	nano::receive_block receive1 (open1.hash (), send2.hash (), destination.prv, destination.pub, *pool.generate (open1.hash ()));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, receive1).code);
-	nano::state_block receive2 (destination.pub, open1.hash (), destination.pub, nano::Gxrb_ratio * 2, send2.hash (), destination.prv, destination.pub, *pool.generate (open1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive2).code);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().source_epoch);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto epoch1 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (send1->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (send1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (epoch1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (epoch1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::epoch::epoch_1, send2->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, send2->sideband ().source_epoch); // Not used for send blocks
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (destination.pub)
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (destination.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::epoch::epoch_0, open1->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, open1->sideband ().source_epoch);
+	auto receive1 = builder
+					.receive ()
+					.previous (open1->hash ())
+					.source (send2->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
+	auto receive2 = builder
+					.state ()
+					.account (destination.pub)
+					.previous (open1->hash ())
+					.representative (destination.pub)
+					.balance (nano::Gxrb_ratio * 2)
+					.link (send2->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
 	nano::account_info destination_info;
 	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
-	ASSERT_FALSE (ledger.rollback (transaction, receive2.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, receive2->hash ()));
 	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_0);
 	nano::pending_info pending_send2;
-	ASSERT_FALSE (ledger.store.pending.get (transaction, nano::pending_key (destination.pub, send2.hash ()), pending_send2));
+	ASSERT_FALSE (ledger.store.pending.get (transaction, nano::pending_key (destination.pub, send2->hash ()), pending_send2));
 	ASSERT_EQ (nano::dev::genesis_key.pub, pending_send2.source);
 	ASSERT_EQ (nano::Gxrb_ratio, pending_send2.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_1, pending_send2.epoch);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive2).code);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_1, receive2.sideband ().source_epoch);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
 	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
 	nano::keypair destination2;
-	nano::state_block send3 (destination.pub, receive2.hash (), destination.pub, nano::Gxrb_ratio, destination2.pub, destination.prv, destination.pub, *pool.generate (receive2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send3).code);
-	nano::open_block open2 (send3.hash (), destination2.pub, destination2.pub, destination2.prv, destination2.pub, *pool.generate (destination2.pub));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open2).code);
+	auto send3 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (receive2->hash ())
+				 .representative (destination.pub)
+				 .balance (nano::Gxrb_ratio)
+				 .link (destination2.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (*pool.generate (receive2->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	auto open2 = builder
+				 .open ()
+				 .source (send3->hash ())
+				 .representative (destination2.pub)
+				 .account (destination2.pub)
+				 .sign (destination2.prv, destination2.pub)
+				 .work (*pool.generate (destination2.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open2).code);
 	// Upgrade to epoch 2 and send to destination. Try to create an open block from an epoch 2 source block.
 	nano::keypair destination3;
-	nano::state_block epoch2 (nano::dev::genesis->account (), send2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch2).code);
-	nano::state_block send4 (nano::dev::genesis->account (), epoch2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3, destination3.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send4).code);
-	nano::open_block open3 (send4.hash (), destination3.pub, destination3.pub, destination3.prv, destination3.pub, *pool.generate (destination3.pub));
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, open3).code);
+	auto epoch2 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (send2->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (send2->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch2).code);
+	auto send4 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (epoch2->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
+				 .link (destination3.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (epoch2->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send4).code);
+	auto open3 = builder
+				 .open ()
+				 .source (send4->hash ())
+				 .representative (destination3.pub)
+				 .account (destination3.pub)
+				 .sign (destination3.prv, destination3.pub)
+				 .work (*pool.generate (destination3.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open3).code);
 	// Send it to an epoch 1 account
-	nano::state_block send5 (nano::dev::genesis->account (), send4.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send4.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send5).code);
+	auto send5 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send4->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send4->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send5).code);
 	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
-	nano::state_block receive3 (destination.pub, send3.hash (), destination.pub, nano::Gxrb_ratio * 2, send5.hash (), destination.prv, destination.pub, *pool.generate (send3.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive3).code);
-	ASSERT_EQ (nano::epoch::epoch_2, receive3.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_2, receive3.sideband ().source_epoch);
+	auto receive3 = builder
+					.state ()
+					.account (destination.pub)
+					.previous (send3->hash ())
+					.representative (destination.pub)
+					.balance (nano::Gxrb_ratio * 2)
+					.link (send5->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (*pool.generate (send3->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive3).code);
+	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().source_epoch);
 	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
 	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_2);
 	// Upgrade an unopened account straight to epoch 2
 	nano::keypair destination4;
-	nano::state_block send6 (nano::dev::genesis->account (), send5.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5, destination4.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send5.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send6).code);
-	nano::state_block epoch4 (destination4.pub, 0, 0, 0, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (destination4.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch4).code);
-	ASSERT_EQ (nano::epoch::epoch_2, epoch4.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch4.sideband ().source_epoch); // Not used for epoch blocks
+	auto send6 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send5->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5)
+				 .link (destination4.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send5->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send6).code);
+	auto epoch4 = builder
+				  .state ()
+				  .account (destination4.pub)
+				  .previous (0)
+				  .representative (0)
+				  .balance (0)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (destination4.pub))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
+	ASSERT_EQ (nano::epoch::epoch_2, epoch4->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch4->sideband ().source_epoch); // Not used for epoch blocks
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 }
 
@@ -2389,18 +4083,62 @@ TEST (ledger, epoch_blocks_fork)
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
-	nano::send_block send1 (nano::dev::genesis->hash (), nano::account{}, nano::dev::constants.genesis_amount, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, epoch1).code);
-	nano::state_block epoch2 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, epoch2).code);
-	nano::state_block epoch3 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch3).code);
-	ASSERT_EQ (nano::epoch::epoch_1, epoch3.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch3.sideband ().source_epoch); // Not used for epoch state blocks
-	nano::state_block epoch4 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, epoch2).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (nano::account {})
+				 .balance (nano::dev::constants.genesis_amount)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	auto epoch1 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch1).code);
+	auto epoch2 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch2).code);
+	auto epoch3 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (send1->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (send1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch3).code);
+	ASSERT_EQ (nano::epoch::epoch_1, epoch3->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch3->sideband ().source_epoch); // Not used for epoch state blocks
+	auto epoch4 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (send1->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_2))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (send1->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch2).code);
 }
 
 TEST (ledger, successor_epoch)
@@ -2409,22 +4147,64 @@ TEST (ledger, successor_epoch)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send1 (nano::dev::genesis->hash (), key1.pub, nano::dev::constants.genesis_amount - 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	nano::state_block open (key1.pub, 0, key1.pub, 1, send1.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
-	nano::state_block change (key1.pub, open.hash (), key1.pub, 1, 0, key1.prv, key1.pub, *pool.generate (open.hash ()));
-	auto open_hash = open.hash ();
-	nano::send_block send2 (send1.hash (), reinterpret_cast<nano::account const &> (open_hash), nano::dev::constants.genesis_amount - 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	nano::state_block epoch_open (reinterpret_cast<nano::account const &> (open_hash), 0, 0, 0, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (open.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open = builder
+				.state ()
+				.account (key1.pub)
+				.previous (0)
+				.representative (key1.pub)
+				.balance (1)
+				.link (send1->hash ())
+				.sign (key1.prv, key1.pub)
+				.work (*pool.generate (key1.pub))
+				.build ();
+	auto change = builder
+				  .state ()
+				  .account (key1.pub)
+				  .previous (open->hash ())
+				  .representative (key1.pub)
+				  .balance (1)
+				  .link (0)
+				  .sign (key1.prv, key1.pub)
+				  .work (*pool.generate (open->hash ()))
+				  .build ();
+	auto open_hash = open->hash ();
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (reinterpret_cast<nano::account const &> (open_hash))
+				 .balance (nano::dev::constants.genesis_amount - 2)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto epoch_open = builder
+					  .state ()
+					  .account (reinterpret_cast<nano::account const &> (open_hash))
+					  .previous (0)
+					  .representative (0)
+					  .balance (0)
+					  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (open->hash ()))
+					  .build ();
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, open).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, change).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, send2).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, epoch_open).code);
-	ASSERT_EQ (change, *node1.ledger.successor (transaction, change.qualified_root ()));
-	ASSERT_EQ (epoch_open, *node1.ledger.successor (transaction, epoch_open.qualified_root ()));
-	ASSERT_EQ (nano::epoch::epoch_1, epoch_open.sideband ().details.epoch);
-	ASSERT_EQ (nano::epoch::epoch_0, epoch_open.sideband ().source_epoch); // Not used for epoch state blocks
+	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *change).code);
+	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *epoch_open).code);
+	ASSERT_EQ (*change, *node1.ledger.successor (transaction, change->qualified_root ()));
+	ASSERT_EQ (*epoch_open, *node1.ledger.successor (transaction, epoch_open->qualified_root ()));
+	ASSERT_EQ (nano::epoch::epoch_1, epoch_open->sideband ().details.epoch);
+	ASSERT_EQ (nano::epoch::epoch_0, epoch_open->sideband ().source_epoch); // Not used for epoch state blocks
 }
 
 TEST (ledger, epoch_open_pending)
@@ -2571,53 +4351,134 @@ TEST (ledger, could_fit)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	// Test legacy and state change blocks could_fit
-	nano::change_block change1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	nano::state_block change2 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_TRUE (ledger.could_fit (transaction, change1));
-	ASSERT_TRUE (ledger.could_fit (transaction, change2));
+	nano::block_builder builder;
+	auto change1 = builder
+				   .change ()
+				   .previous (nano::dev::genesis->hash ())
+				   .representative (nano::dev::genesis->account ())
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .build ();
+	auto change2 = builder
+				   .state ()
+				   .account (nano::dev::genesis->account ())
+				   .previous (nano::dev::genesis->hash ())
+				   .representative (nano::dev::genesis->account ())
+				   .balance (nano::dev::constants.genesis_amount)
+				   .link (0)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .build ();
+	ASSERT_TRUE (ledger.could_fit (transaction, *change1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *change2));
 	// Test legacy and state send
 	nano::keypair key1;
-	nano::send_block send1 (change1.hash (), key1.pub, nano::dev::constants.genesis_amount - 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change1.hash ()));
-	nano::state_block send2 (nano::dev::genesis->account (), change1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 1, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change1.hash ()));
-	ASSERT_FALSE (ledger.could_fit (transaction, send1));
-	ASSERT_FALSE (ledger.could_fit (transaction, send2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
-	ASSERT_TRUE (ledger.could_fit (transaction, change1));
-	ASSERT_TRUE (ledger.could_fit (transaction, change2));
-	ASSERT_TRUE (ledger.could_fit (transaction, send1));
-	ASSERT_TRUE (ledger.could_fit (transaction, send2));
+	auto send1 = builder
+				 .send ()
+				 .previous (change1->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 1)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (change1->hash ()))
+				 .build ();
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (change1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - 1)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (change1->hash ()))
+				 .build ();
+	ASSERT_FALSE (ledger.could_fit (transaction, *send1));
+	ASSERT_FALSE (ledger.could_fit (transaction, *send2));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_TRUE (ledger.could_fit (transaction, *change1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *change2));
+	ASSERT_TRUE (ledger.could_fit (transaction, *send1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *send2));
 	// Test legacy and state open
-	nano::open_block open1 (send2.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	nano::state_block open2 (key1.pub, 0, nano::dev::genesis->account (), 1, send2.hash (), key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_FALSE (ledger.could_fit (transaction, open1));
-	ASSERT_FALSE (ledger.could_fit (transaction, open2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_TRUE (ledger.could_fit (transaction, send1));
-	ASSERT_TRUE (ledger.could_fit (transaction, send2));
-	ASSERT_TRUE (ledger.could_fit (transaction, open1));
-	ASSERT_TRUE (ledger.could_fit (transaction, open2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_TRUE (ledger.could_fit (transaction, open1));
-	ASSERT_TRUE (ledger.could_fit (transaction, open2));
+	auto open1 = builder
+				 .open ()
+				 .source (send2->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key1.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	auto open2 = builder
+				 .state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis->account ())
+				 .balance (1)
+				 .link (send2->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	ASSERT_FALSE (ledger.could_fit (transaction, *open1));
+	ASSERT_FALSE (ledger.could_fit (transaction, *open2));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_TRUE (ledger.could_fit (transaction, *send1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *send2));
+	ASSERT_TRUE (ledger.could_fit (transaction, *open1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *open2));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_TRUE (ledger.could_fit (transaction, *open1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *open2));
 	// Create another send to receive
-	nano::state_block send3 (nano::dev::genesis->account (), send2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 2, key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send2.hash ()));
+	auto send3 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send2->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - 2)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send2->hash ()))
+				 .build ();
 	// Test legacy and state receive
-	nano::receive_block receive1 (open1.hash (), send3.hash (), key1.prv, key1.pub, *pool.generate (open1.hash ()));
-	nano::state_block receive2 (key1.pub, open1.hash (), nano::dev::genesis->account (), 2, send3.hash (), key1.prv, key1.pub, *pool.generate (open1.hash ()));
-	ASSERT_FALSE (ledger.could_fit (transaction, receive1));
-	ASSERT_FALSE (ledger.could_fit (transaction, receive2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send3).code);
-	ASSERT_TRUE (ledger.could_fit (transaction, receive1));
-	ASSERT_TRUE (ledger.could_fit (transaction, receive2));
+	auto receive1 = builder
+					.receive ()
+					.previous (open1->hash ())
+					.source (send3->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	auto receive2 = builder
+					.state ()
+					.account (key1.pub)
+					.previous (open1->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (2)
+					.link (send3->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	ASSERT_FALSE (ledger.could_fit (transaction, *receive1));
+	ASSERT_FALSE (ledger.could_fit (transaction, *receive2));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	ASSERT_TRUE (ledger.could_fit (transaction, *receive1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *receive2));
 	// Test epoch (state)
-	nano::state_block epoch1 (key1.pub, receive1.hash (), nano::dev::genesis->account (), 2, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (receive1.hash ()));
-	ASSERT_FALSE (ledger.could_fit (transaction, epoch1));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_TRUE (ledger.could_fit (transaction, receive1));
-	ASSERT_TRUE (ledger.could_fit (transaction, receive2));
-	ASSERT_TRUE (ledger.could_fit (transaction, epoch1));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	ASSERT_TRUE (ledger.could_fit (transaction, epoch1));
+	auto epoch1 = builder
+				  .state ()
+				  .account (key1.pub)
+				  .previous (receive1->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (2)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (receive1->hash ()))
+				  .build ();
+	ASSERT_FALSE (ledger.could_fit (transaction, *epoch1));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_TRUE (ledger.could_fit (transaction, *receive1));
+	ASSERT_TRUE (ledger.could_fit (transaction, *receive2));
+	ASSERT_TRUE (ledger.could_fit (transaction, *epoch1));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_TRUE (ledger.could_fit (transaction, *epoch1));
 }
 
 TEST (ledger, unchecked_epoch)
@@ -2625,11 +4486,39 @@ TEST (ledger, unchecked_epoch)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
-	auto open1 (std::make_shared<nano::state_block> (destination.pub, 0, destination.pub, nano::Gxrb_ratio, send1->hash (), destination.prv, destination.pub, 0));
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (destination.pub)
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*open1);
-	auto epoch1 (std::make_shared<nano::state_block> (destination.pub, open1->hash (), destination.pub, nano::Gxrb_ratio, node1.ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	auto epoch1 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (open1->hash ())
+				  .representative (destination.pub)
+				  .balance (nano::Gxrb_ratio)
+				  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (0)
+				  .build_shared ();
 	node1.work_generate_blocking (*epoch1);
 	node1.block_processor.add (epoch1);
 	{
@@ -2658,15 +4547,52 @@ TEST (ledger, unchecked_epoch_invalid)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config));
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
-	auto open1 (std::make_shared<nano::state_block> (destination.pub, 0, destination.pub, nano::Gxrb_ratio, send1->hash (), destination.prv, destination.pub, 0));
+	auto open1 = builder
+				 .state ()
+				 .account (destination.pub)
+				 .previous (0)
+				 .representative (destination.pub)
+				 .balance (nano::Gxrb_ratio)
+				 .link (send1->hash ())
+				 .sign (destination.prv, destination.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*open1);
 	// Epoch block with account own signature
-	auto epoch1 (std::make_shared<nano::state_block> (destination.pub, open1->hash (), destination.pub, nano::Gxrb_ratio, node1.ledger.epoch_link (nano::epoch::epoch_1), destination.prv, destination.pub, 0));
+	auto epoch1 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (open1->hash ())
+				  .representative (destination.pub)
+				  .balance (nano::Gxrb_ratio)
+				  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (destination.prv, destination.pub)
+				  .work (0)
+				  .build_shared ();
 	node1.work_generate_blocking (*epoch1);
 	// Pseudo epoch block (send subtype, destination - epoch link)
-	auto epoch2 (std::make_shared<nano::state_block> (destination.pub, open1->hash (), destination.pub, nano::Gxrb_ratio - 1, node1.ledger.epoch_link (nano::epoch::epoch_1), destination.prv, destination.pub, 0));
+	auto epoch2 = builder
+				  .state ()
+				  .account (destination.pub)
+				  .previous (open1->hash ())
+				  .representative (destination.pub)
+				  .balance (nano::Gxrb_ratio - 1)
+				  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (destination.prv, destination.pub)
+				  .work (0)
+				  .build_shared ();
 	node1.work_generate_blocking (*epoch2);
 	node1.block_processor.add (epoch1);
 	node1.block_processor.add (epoch2);
@@ -2706,12 +4632,36 @@ TEST (ledger, unchecked_open)
 	nano::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair destination;
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
-	auto open1 (std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0));
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (destination.pub)
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*open1);
 	// Invalid signature for open block
-	auto open2 (std::make_shared<nano::open_block> (send1->hash (), nano::dev::genesis_key.pub, destination.pub, destination.prv, destination.pub, 0));
+	auto open2 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*open2);
 	open2->signature.bytes[0] ^= 1;
 	node1.block_processor.add (open1);
@@ -2734,13 +4684,45 @@ TEST (ledger, unchecked_receive)
 	nano::system system{ 1 };
 	auto & node1 = *system.nodes[0];
 	nano::keypair destination{};
-	auto send1 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send1);
-	auto send2 = std::make_shared<nano::state_block> (nano::dev::genesis->account (), send1->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio, destination.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+				 .link (destination.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*send2);
-	auto open1 = std::make_shared<nano::open_block> (send1->hash (), destination.pub, destination.pub, destination.prv, destination.pub, 0);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (destination.pub)
+				 .account (destination.pub)
+				 .sign (destination.prv, destination.pub)
+				 .work (0)
+				 .build_shared ();
 	node1.work_generate_blocking (*open1);
-	auto receive1 = std::make_shared<nano::receive_block> (open1->hash (), send2->hash (), destination.prv, destination.pub, 0);
+	auto receive1 = builder
+					.receive ()
+					.previous (open1->hash ())
+					.source (send2->hash ())
+					.sign (destination.prv, destination.pub)
+					.work (0)
+					.build_shared ();
 	node1.work_generate_blocking (*receive1);
 	node1.block_processor.add (send1);
 	node1.block_processor.add (receive1);
@@ -2783,17 +4765,32 @@ TEST (ledger, confirmation_height_not_updated)
 	nano::account_info account_info;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, account_info));
 	nano::keypair key;
-	nano::send_block send1 (account_info.head, key.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (account_info.head));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (account_info.head)
+				 .destination (key.pub)
+				 .balance (50)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (account_info.head))
+				 .build ();
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_FALSE (store->confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
 	ASSERT_EQ (nano::dev::genesis->hash (), confirmation_height_info.frontier);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_FALSE (store->confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
 	ASSERT_EQ (nano::dev::genesis->hash (), confirmation_height_info.frontier);
-	nano::open_block open1 (send1.hash (), nano::dev::genesis->account (), key.pub, key.prv, key.pub, *pool.generate (key.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key.pub)
+				 .sign (key.prv, key.pub)
+				 .work (*pool.generate (key.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_TRUE (store->confirmation_height.get (transaction, key.pub, confirmation_height_info));
 	ASSERT_EQ (0, confirmation_height_info.height);
 	ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
@@ -3201,46 +5198,74 @@ TEST (ledger, pruning_action)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	auto send1_stored (store->block.get (transaction, send1.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send1_stored (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send1_stored);
-	ASSERT_EQ (send1, *send1_stored);
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
-	nano::state_block send2 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	ASSERT_EQ (*send1, *send1_stored);
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
-	ASSERT_EQ (1, ledger.pruning_action (transaction, send1.hash (), 1));
+	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
 	ASSERT_EQ (0, ledger.pruning_action (transaction, nano::dev::genesis->hash (), 1));
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (ledger.block_or_pruned_exists (transaction, send1.hash ()));
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (ledger.block_or_pruned_exists (transaction, send1->hash ()));
 	// Pruned ledger start without proper flags emulation
 	ledger.pruning = false;
-	ASSERT_TRUE (ledger.block_or_pruned_exists (transaction, send1.hash ()));
+	ASSERT_TRUE (ledger.block_or_pruned_exists (transaction, send1->hash ()));
 	ledger.pruning = true;
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Receiving pruned block
-	nano::state_block receive1 (nano::dev::genesis->account (), send2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_TRUE (store->block.exists (transaction, receive1.hash ()));
-	auto receive1_stored (store->block.get (transaction, receive1.hash ()));
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send2->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send2->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_TRUE (store->block.exists (transaction, receive1->hash ()));
+	auto receive1_stored (store->block.get (transaction, receive1->hash ()));
 	ASSERT_NE (nullptr, receive1_stored);
-	ASSERT_EQ (receive1, *receive1_stored);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	ASSERT_EQ (*receive1, *receive1_stored);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (4, receive1_stored->sideband ().height);
 	ASSERT_FALSE (receive1_stored->sideband ().details.is_send);
 	ASSERT_TRUE (receive1_stored->sideband ().details.is_receive);
 	ASSERT_FALSE (receive1_stored->sideband ().details.is_epoch);
 	// Middle block pruning
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
-	ASSERT_EQ (1, ledger.pruning_action (transaction, send2.hash (), 1));
-	ASSERT_TRUE (store->pruned.exists (transaction, send2.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, send2.hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
+	ASSERT_EQ (1, ledger.pruning_action (transaction, send2->hash (), 1));
+	ASSERT_TRUE (store->pruned.exists (transaction, send2->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, send2->hash ()));
 	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
 	ASSERT_EQ (store->pruned.count (transaction), ledger.cache.pruned_count);
 	ASSERT_EQ (store->block.count (transaction), ledger.cache.block_count - ledger.cache.pruned_count);
@@ -3259,15 +5284,34 @@ TEST (ledger, pruning_large_chain)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	size_t send_receive_pairs (20);
 	auto last_hash (nano::dev::genesis->hash ());
+	nano::block_builder builder;
 	for (auto i (0); i < send_receive_pairs; i++)
 	{
-		nano::state_block send (nano::dev::genesis->account (), last_hash, nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (last_hash));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-		ASSERT_TRUE (store->block.exists (transaction, send.hash ()));
-		nano::state_block receive (nano::dev::genesis->account (), send.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send.hash ()));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-		ASSERT_TRUE (store->block.exists (transaction, receive.hash ()));
-		last_hash = receive.hash ();
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (last_hash)
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (nano::dev::genesis->account ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (last_hash))
+					.build ();
+		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+		ASSERT_TRUE (store->block.exists (transaction, send->hash ()));
+		auto receive = builder
+					   .state ()
+					   .account (nano::dev::genesis->account ())
+					   .previous (send->hash ())
+					   .representative (nano::dev::genesis->account ())
+					   .balance (nano::dev::constants.genesis_amount)
+					   .link (send->hash ())
+					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					   .work (*pool.generate (send->hash ()))
+					   .build ();
+		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+		ASSERT_TRUE (store->block.exists (transaction, receive->hash ()));
+		last_hash = receive->hash ();
 	}
 	ASSERT_EQ (0, store->pruned.count (transaction));
 	ASSERT_EQ (send_receive_pairs * 2 + 1, store->block.count (transaction));
@@ -3293,42 +5337,79 @@ TEST (ledger, pruning_source_rollback)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block epoch1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount, ledger.epoch_link (nano::epoch::epoch_1), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, epoch1).code);
-	nano::state_block send1 (nano::dev::genesis->account (), epoch1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (epoch1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
-	nano::state_block send2 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	nano::block_builder builder;
+	auto epoch1 = builder
+				  .state ()
+				  .account (nano::dev::genesis->account ())
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis->account ())
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (epoch1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (epoch1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
-	ASSERT_EQ (2, ledger.pruning_action (transaction, send1.hash (), 1));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, epoch1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, epoch1.hash ()));
+	ASSERT_EQ (2, ledger.pruning_action (transaction, send1->hash (), 1));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, epoch1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, epoch1->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
 	nano::pending_info info;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ()), info));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()), info));
 	ASSERT_EQ (nano::dev::genesis->account (), info.source);
 	ASSERT_EQ (nano::Gxrb_ratio, info.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_1, info.epoch);
 	// Receiving pruned block
-	nano::state_block receive1 (nano::dev::genesis->account (), send2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis->account ())
+					.previous (send2->hash ())
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send2->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
 	// Rollback receive block
-	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	nano::pending_info info2;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ()), info2));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()), info2));
 	ASSERT_NE (nano::dev::genesis->account (), info2.source); // Tradeoff to not store pruned blocks accounts
 	ASSERT_EQ (nano::Gxrb_ratio, info2.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_1, info2.epoch);
 	// Process receive block again
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
 }
@@ -3344,69 +5425,104 @@ TEST (ledger, pruning_source_rollback_legacy)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	nano::keypair key1;
-	nano::send_block send2 (send1.hash (), key1.pub, nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2.hash ())));
-	nano::send_block send3 (send2.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send2.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send3).code);
-	ASSERT_TRUE (store->block.exists (transaction, send3.hash ()));
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send3.hash ())));
+	auto send2 = builder
+				 .send ()
+				 .previous (send1->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
+	auto send3 = builder
+				 .send ()
+				 .previous (send2->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send2->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	ASSERT_TRUE (store->block.exists (transaction, send3->hash ()));
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send3->hash ())));
 	// Pruning action
-	ASSERT_EQ (2, ledger.pruning_action (transaction, send2.hash (), 1));
-	ASSERT_FALSE (store->block.exists (transaction, send2.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, send2.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
+	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 1));
+	ASSERT_FALSE (store->block.exists (transaction, send2->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send2->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
 	nano::pending_info info1;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ()), info1));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()), info1));
 	ASSERT_EQ (nano::dev::genesis->account (), info1.source);
 	ASSERT_EQ (nano::Gxrb_ratio, info1.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_0, info1.epoch);
 	nano::pending_info info2;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (key1.pub, send2.hash ()), info2));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (key1.pub, send2->hash ()), info2));
 	ASSERT_EQ (nano::dev::genesis->account (), info2.source);
 	ASSERT_EQ (nano::Gxrb_ratio, info2.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_0, info2.epoch);
 	// Receiving pruned block
-	nano::receive_block receive1 (send3.hash (), send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send3.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	auto receive1 = builder
+					.receive ()
+					.previous (send3->hash ())
+					.source (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send3->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
 	// Rollback receive block
-	ASSERT_FALSE (ledger.rollback (transaction, receive1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	nano::pending_info info3;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ()), info3));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()), info3));
 	ASSERT_NE (nano::dev::genesis->account (), info3.source); // Tradeoff to not store pruned blocks accounts
 	ASSERT_EQ (nano::Gxrb_ratio, info3.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_0, info3.epoch);
 	// Process receive block again
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
 	// Receiving pruned block (open)
-	nano::open_block open1 (send2.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2.hash ())));
+	auto open1 = builder
+				 .open ()
+				 .source (send2->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key1.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (6, ledger.cache.block_count);
 	// Rollback open block
-	ASSERT_FALSE (ledger.rollback (transaction, open1.hash ()));
+	ASSERT_FALSE (ledger.rollback (transaction, open1->hash ()));
 	nano::pending_info info4;
-	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (key1.pub, send2.hash ()), info4));
+	ASSERT_FALSE (store->pending.get (transaction, nano::pending_key (key1.pub, send2->hash ()), info4));
 	ASSERT_NE (nano::dev::genesis->account (), info4.source); // Tradeoff to not store pruned blocks accounts
 	ASSERT_EQ (nano::Gxrb_ratio, info4.amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_0, info4.epoch);
 	// Process open block again
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2.hash ())));
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (6, ledger.cache.block_count);
 }
@@ -3422,19 +5538,38 @@ TEST (ledger, pruning_process_error)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_EQ (0, ledger.cache.pruned_count);
 	ASSERT_EQ (2, ledger.cache.block_count);
 	// Pruning action for latest block (not valid action)
-	ASSERT_EQ (1, ledger.pruning_action (transaction, send1.hash (), 1));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
+	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	// Attempt to process pruned block again
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, send1).code);
+	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *send1).code);
 	// Attept to process new block after pruned
-	nano::state_block send2 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, send2).code);
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, *send2).code);
 	ASSERT_EQ (1, ledger.cache.pruned_count);
 	ASSERT_EQ (2, ledger.cache.block_count);
 }
@@ -3451,33 +5586,74 @@ TEST (ledger, pruning_legacy_blocks)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send1 (nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1.hash ())));
-	nano::receive_block receive1 (send1.hash (), send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive1).code);
-	nano::change_block change1 (receive1.hash (), key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (receive1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change1).code);
-	nano::send_block send2 (change1.hash (), key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (change1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	nano::open_block open1 (send2.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *pool.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open1).code);
-	nano::send_block send3 (open1.hash (), nano::dev::genesis->account (), 0, key1.prv, key1.pub, *pool.generate (open1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send3).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
+	auto receive1 = builder
+					.receive ()
+					.previous (send1->hash ())
+					.source (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (send1->hash ()))
+					.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	auto change1 = builder
+				   .change ()
+				   .previous (receive1->hash ())
+				   .representative (key1.pub)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (receive1->hash ()))
+				   .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	auto send2 = builder
+				 .send ()
+				 .previous (change1->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (change1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	auto open1 = builder
+				 .open ()
+				 .source (send2->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .account (key1.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	auto send3 = builder
+				 .send ()
+				 .previous (open1->hash ())
+				 .destination (nano::dev::genesis->account ())
+				 .balance (0)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (open1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
 	// Pruning action
-	ASSERT_EQ (3, ledger.pruning_action (transaction, change1.hash (), 2));
-	ASSERT_EQ (1, ledger.pruning_action (transaction, open1.hash (), 1));
+	ASSERT_EQ (3, ledger.pruning_action (transaction, change1->hash (), 2));
+	ASSERT_EQ (1, ledger.pruning_action (transaction, open1->hash (), 1));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, receive1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, receive1.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, change1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, change1.hash ()));
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
-	ASSERT_FALSE (store->block.exists (transaction, open1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, open1.hash ()));
-	ASSERT_TRUE (store->block.exists (transaction, send3.hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, receive1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, receive1->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, change1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, change1->hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
+	ASSERT_FALSE (store->block.exists (transaction, open1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, open1->hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, send3->hash ()));
 	ASSERT_EQ (4, ledger.cache.pruned_count);
 	ASSERT_EQ (7, ledger.cache.block_count);
 	ASSERT_EQ (store->pruned.count (transaction), ledger.cache.pruned_count);
@@ -3495,34 +5671,53 @@ TEST (ledger, pruning_safe_functions)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	nano::state_block send2 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
-	ASSERT_EQ (1, ledger.pruning_action (transaction, send1.hash (), 1));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (ledger.block_or_pruned_exists (transaction, send1.hash ())); // true for pruned
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
+	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (ledger.block_or_pruned_exists (transaction, send1->hash ())); // true for pruned
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Safe ledger actions
 	bool error (false);
-	ASSERT_EQ (0, ledger.balance_safe (transaction, send1.hash (), error));
+	ASSERT_EQ (0, ledger.balance_safe (transaction, send1->hash (), error));
 	ASSERT_TRUE (error);
 	error = false;
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, ledger.balance_safe (transaction, send2.hash (), error));
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, ledger.balance_safe (transaction, send2->hash (), error));
 	ASSERT_FALSE (error);
 	error = false;
-	ASSERT_EQ (0, ledger.amount_safe (transaction, send2.hash (), error));
+	ASSERT_EQ (0, ledger.amount_safe (transaction, send2->hash (), error));
 	ASSERT_TRUE (error);
 	error = false;
-	ASSERT_TRUE (ledger.account_safe (transaction, send1.hash (), error).is_zero ());
+	ASSERT_TRUE (ledger.account_safe (transaction, send1->hash (), error).is_zero ());
 	ASSERT_TRUE (error);
 	error = false;
-	ASSERT_EQ (nano::dev::genesis->account (), ledger.account_safe (transaction, send2.hash (), error));
+	ASSERT_EQ (nano::dev::genesis->account (), ledger.account_safe (transaction, send2->hash (), error));
 	ASSERT_FALSE (error);
 }
 
@@ -3537,18 +5732,37 @@ TEST (ledger, hash_root_random)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::state_block send1 (nano::dev::genesis->account (), nano::dev::genesis->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
-	ASSERT_TRUE (store->block.exists (transaction, send1.hash ()));
-	nano::state_block send2 (nano::dev::genesis->account (), send1.hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, nano::dev::genesis->account (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
+				 .link (nano::dev::genesis->account ())
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
-	ASSERT_EQ (1, ledger.pruning_action (transaction, send1.hash (), 1));
-	ASSERT_FALSE (store->block.exists (transaction, send1.hash ()));
-	ASSERT_TRUE (store->pruned.exists (transaction, send1.hash ()));
+	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
+	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
+	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
-	ASSERT_TRUE (store->block.exists (transaction, send2.hash ()));
+	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Test random block including pruned
 	bool done (false);
 	auto iteration (0);
@@ -3556,7 +5770,7 @@ TEST (ledger, hash_root_random)
 	{
 		++iteration;
 		auto root_hash (ledger.hash_root_random (transaction));
-		done = (root_hash.first == send1.hash ()) && (root_hash.second.is_zero ());
+		done = (root_hash.first == send1->hash ()) && (root_hash.second.is_zero ());
 		ASSERT_LE (iteration, 1000);
 	}
 	done = false;
@@ -3564,7 +5778,7 @@ TEST (ledger, hash_root_random)
 	{
 		++iteration;
 		auto root_hash (ledger.hash_root_random (transaction));
-		done = (root_hash.first == send2.hash ()) && (root_hash.second == send2.root ().as_block_hash ());
+		done = (root_hash.first == send2->hash ()) && (root_hash.second == send2->root ().as_block_hash ());
 		ASSERT_LE (iteration, 1000);
 	}
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4087,7 +4087,7 @@ TEST (ledger, epoch_blocks_fork)
 	auto send1 = builder
 				 .send ()
 				 .previous (nano::dev::genesis->hash ())
-				 .destination (nano::account {})
+				 .destination (nano::account{})
 				 .balance (nano::dev::constants.genesis_amount)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -68,7 +68,15 @@ TEST (message_parser, exact_confirm_ack_size)
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
-	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (1)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (*system.work.generate (nano::root (1)))
+				 .build_shared ();
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, 0, std::vector<nano::block_hash>{ block->hash () }));
 	nano::confirm_ack message{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> bytes;
@@ -102,7 +110,15 @@ TEST (message_parser, exact_confirm_req_size)
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
-	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (1)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (*system.work.generate (nano::root (1)))
+				 .build_shared ();
 	nano::confirm_req message{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{
@@ -135,8 +151,16 @@ TEST (message_parser, exact_confirm_req_hash_size)
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
-	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
-	nano::confirm_req message{ nano::dev::network_params.network, block.hash (), block.root () };
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (1)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (*system.work.generate (nano::root (1)))
+				 .build ();
+	nano::confirm_req message{ nano::dev::network_params.network, block->hash (), block->root () };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -168,7 +192,15 @@ TEST (message_parser, exact_publish_size)
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
 	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, nano::dev::network_params.network);
-	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (1)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (*system.work.generate (nano::root (1)))
+				 .build_shared ();
 	nano::publish message{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{

--- a/nano/core_test/prioritization.cpp
+++ b/nano/core_test/prioritization.cpp
@@ -32,27 +32,77 @@ nano::keypair & key3 ()
 }
 std::shared_ptr<nano::state_block> & blockzero ()
 {
-	static std::shared_ptr<nano::state_block> result = std::make_shared<nano::state_block> (keyzero ().pub, 0, keyzero ().pub, 0, 0, keyzero ().prv, keyzero ().pub, 0);
+	nano::block_builder builder;
+	static auto result = builder
+						 .state ()
+						 .account (keyzero ().pub)
+						 .previous (0)
+						 .representative (keyzero ().pub)
+						 .balance (0)
+						 .link (0)
+						 .sign (keyzero ().prv, keyzero ().pub)
+						 .work (0)
+						 .build_shared ();
 	return result;
 }
 std::shared_ptr<nano::state_block> & block0 ()
 {
-	static std::shared_ptr<nano::state_block> result = std::make_shared<nano::state_block> (key0 ().pub, 0, key0 ().pub, nano::Gxrb_ratio, 0, key0 ().prv, key0 ().pub, 0);
+	nano::block_builder builder;
+	static auto result = builder
+						 .state ()
+						 .account (key0 ().pub)
+						 .previous (0)
+						 .representative (key0 ().pub)
+						 .balance (nano::Gxrb_ratio)
+						 .link (0)
+						 .sign (key0 ().prv, key0 ().pub)
+						 .work (0)
+						 .build_shared ();
 	return result;
 }
 std::shared_ptr<nano::state_block> & block1 ()
 {
-	static std::shared_ptr<nano::state_block> result = std::make_shared<nano::state_block> (key1 ().pub, 0, key1 ().pub, nano::Mxrb_ratio, 0, key1 ().prv, key1 ().pub, 0);
+	nano::block_builder builder;
+	static auto result = builder
+						 .state ()
+						 .account (key1 ().pub)
+						 .previous (0)
+						 .representative (key1 ().pub)
+						 .balance (nano::Mxrb_ratio)
+						 .link (0)
+						 .sign (key1 ().prv, key1 ().pub)
+						 .work (0)
+						 .build_shared ();
 	return result;
 }
 std::shared_ptr<nano::state_block> & block2 ()
 {
-	static std::shared_ptr<nano::state_block> result = std::make_shared<nano::state_block> (key2 ().pub, 0, key2 ().pub, nano::Gxrb_ratio, 0, key2 ().prv, key2 ().pub, 0);
+	nano::block_builder builder;
+	static auto result = builder
+						 .state ()
+						 .account (key2 ().pub)
+						 .previous (0)
+						 .representative (key2 ().pub)
+						 .balance (nano::Gxrb_ratio)
+						 .link (0)
+						 .sign (key2 ().prv, key2 ().pub)
+						 .work (0)
+						 .build_shared ();
 	return result;
 }
 std::shared_ptr<nano::state_block> & block3 ()
 {
-	static std::shared_ptr<nano::state_block> result = std::make_shared<nano::state_block> (key3 ().pub, 0, key3 ().pub, nano::Mxrb_ratio, 0, key3 ().prv, key3 ().pub, 0);
+	nano::block_builder builder;
+	static auto result = builder
+						 .state ()
+						 .account (key3 ().pub)
+						 .previous (0)
+						 .representative (key3 ().pub)
+						 .balance (nano::Mxrb_ratio)
+						 .link (0)
+						 .sign (key3 ().prv, key3 ().pub)
+						 .work (0)
+						 .build_shared ();
 	return result;
 }
 

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -20,9 +20,17 @@ TEST (processor_service, bad_send_signature)
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
 	nano::keypair key2;
-	nano::send_block send (info1.head, nano::dev::genesis_key.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	send.signature.bytes[32] ^= 0x1;
-	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, send).code);
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (info1.head)
+				.destination (nano::dev::genesis_key.pub)
+				.balance (50)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (info1.head))
+				.build ();
+	send->signature.bytes[32] ^= 0x1;
+	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *send).code);
 }
 
 TEST (processor_service, bad_receive_signature)
@@ -37,12 +45,26 @@ TEST (processor_service, bad_receive_signature)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::account_info info1;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info1));
-	nano::send_block send (info1.head, nano::dev::genesis_key.pub, 50, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (info1.head));
-	nano::block_hash hash1 (send.hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (info1.head)
+				.destination (nano::dev::genesis_key.pub)
+				.balance (50)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (info1.head))
+				.build ();
+	nano::block_hash hash1 (send->hash ());
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	nano::account_info info2;
 	ASSERT_FALSE (store->account.get (transaction, nano::dev::genesis_key.pub, info2));
-	nano::receive_block receive (hash1, hash1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (hash1));
-	receive.signature.bytes[32] ^= 0x1;
-	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, receive).code);
+	auto receive = builder
+				   .receive ()
+				   .previous (hash1)
+				   .source (hash1)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (hash1))
+				   .build ();
+	receive->signature.bytes[32] ^= 0x1;
+	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *receive).code);
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -14,7 +14,17 @@ TEST (request_aggregator, one)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node.work_generate_blocking (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
@@ -190,7 +200,17 @@ TEST (request_aggregator, two_endpoints)
 	node_config.peering_port = nano::get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 1, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node1.work_generate_blocking (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 1)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node1.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
@@ -274,7 +294,17 @@ TEST (request_aggregator, channel_lifetime)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node.work_generate_blocking (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -294,7 +324,17 @@ TEST (request_aggregator, channel_update)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node.work_generate_blocking (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -322,7 +362,17 @@ TEST (request_aggregator, channel_max_queue)
 	node_config.max_queued_requests = 1;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node.work_generate_blocking (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
@@ -339,7 +389,17 @@ TEST (request_aggregator, unique)
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto send1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio, nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *node.work_generate_blocking (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -52,7 +52,15 @@ TEST (system, DISABLED_generate_send_existing)
 	// Have stake_preserver receive funds after generate_send_existing so it isn't chosen as the destination
 	{
 		auto transaction (node1.store.tx_begin_write ());
-		auto open_block (std::make_shared<nano::open_block> (send_block->hash (), nano::dev::genesis->account (), stake_preserver.pub, stake_preserver.prv, stake_preserver.pub, 0));
+		nano::block_builder builder;
+		auto open_block = builder
+						  .open ()
+						  .source (send_block->hash ())
+						  .representative (nano::dev::genesis->account ())
+						  .account (stake_preserver.pub)
+						  .sign (stake_preserver.prv, stake_preserver.pub)
+						  .work (0)
+						  .build_shared ();
 		node1.work_generate_blocking (*open_block);
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *open_block).code);
 	}
@@ -97,7 +105,15 @@ TEST (system, DISABLED_generate_send_new)
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis->account (), stake_preserver.pub, nano::dev::constants.genesis_amount / 3 * 2, true));
 	{
 		auto transaction (node1.store.tx_begin_write ());
-		auto open_block (std::make_shared<nano::open_block> (send_block->hash (), nano::dev::genesis->account (), stake_preserver.pub, stake_preserver.prv, stake_preserver.pub, 0));
+		nano::block_builder builder;
+		auto open_block = builder
+						  .open ()
+						  .source (send_block->hash ())
+						  .representative (nano::dev::genesis->account ())
+						  .account (stake_preserver.pub)
+						  .sign (stake_preserver.prv, stake_preserver.pub)
+						  .work (0)
+						  .build_shared ();
 		node1.work_generate_blocking (*open_block);
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *open_block).code);
 	}

--- a/nano/core_test/unchecked_map.cpp
+++ b/nano/core_test/unchecked_map.cpp
@@ -60,7 +60,15 @@ TEST (block_store, one_bootstrap)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
 	ASSERT_TRUE (!store->init_error ());
-	auto block1 = std::make_shared<nano::send_block> (0, 1, 2, nano::keypair ().prv, 4, 5);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (0)
+				  .destination (1)
+				  .balance (2)
+				  .sign (nano::keypair ().prv, 4)
+				  .work (5)
+				  .build_shared ();
 	unchecked.put (block1->hash (), nano::unchecked_info{ block1 });
 	auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 		return unchecked.get (transaction_a, block_hash_a).size () > 0;

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1112,8 +1112,16 @@ TEST (wallet, epoch_2_receive_unopened)
 		auto send1 = wallet.send_action (nano::dev::genesis_key.pub, key.pub, amount, 1);
 
 		// Upgrade unopened account to epoch_2
-		auto epoch2_unopened = nano::state_block (key.pub, 0, 0, 0, node.network_params.ledger.epochs.link (nano::epoch::epoch_2), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (key.pub, node.network_params.work.epoch_2));
-		ASSERT_EQ (nano::process_result::progress, node.process (epoch2_unopened).code);
+		auto epoch2_unopened = builder
+							   .account (key.pub)
+							   .previous (0)
+							   .representative (0)
+							   .balance (0)
+							   .link (node.network_params.ledger.epochs.link (nano::epoch::epoch_2))
+							   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+							   .work (*system.work.generate (key.pub, node.network_params.work.epoch_2))
+							   .build ();
+		ASSERT_EQ (nano::process_result::progress, node.process (*epoch2_unopened).code);
 
 		wallet.insert_adhoc (key.prv, false);
 

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -97,15 +97,52 @@ TEST (wallets, vote_minimum)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::keypair key2;
-	nano::state_block send1 (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - node1.config.vote_minimum.number (), key1.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, node1.process (send1).code);
-	nano::state_block open1 (key1.pub, 0, key1.pub, node1.config.vote_minimum.number (), send1.hash (), key1.prv, key1.pub, *system.work.generate (key1.pub));
-	ASSERT_EQ (nano::process_result::progress, node1.process (open1).code);
+	nano::block_builder builder;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (std::numeric_limits<nano::uint128_t>::max () - node1.config.vote_minimum.number ())
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
+	auto open1 = builder
+				 .state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (key1.pub)
+				 .balance (node1.config.vote_minimum.number ())
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*system.work.generate (key1.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, node1.process (*open1).code);
 	// send2 with amount vote_minimum - 1 (not voting representative)
-	nano::state_block send2 (nano::dev::genesis_key.pub, send1.hash (), nano::dev::genesis_key.pub, std::numeric_limits<nano::uint128_t>::max () - 2 * node1.config.vote_minimum.number () + 1, key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
-	ASSERT_EQ (nano::process_result::progress, node1.process (send2).code);
-	nano::state_block open2 (key2.pub, 0, key2.pub, node1.config.vote_minimum.number () - 1, send2.hash (), key2.prv, key2.pub, *system.work.generate (key2.pub));
-	ASSERT_EQ (nano::process_result::progress, node1.process (open2).code);
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (std::numeric_limits<nano::uint128_t>::max () - 2 * node1.config.vote_minimum.number () + 1)
+				 .link (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
+	auto open2 = builder
+				 .state ()
+				 .account (key2.pub)
+				 .previous (0)
+				 .representative (key2.pub)
+				 .balance (node1.config.vote_minimum.number () - 1)
+				 .link (send2->hash ())
+				 .sign (key2.prv, key2.pub)
+				 .work (*system.work.generate (key2.pub))
+				 .build ();
+	ASSERT_EQ (nano::process_result::progress, node1.process (*open2).code);
 	auto wallet (node1.wallets.items.begin ()->second);
 	nano::unique_lock<nano::mutex> representatives_lk (wallet->representatives_mutex);
 	ASSERT_EQ (0, wallet->representatives.size ());

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -89,7 +89,15 @@ TEST (websocket, confirmation)
 	{
 		nano::block_hash previous (node1->latest (nano::dev::genesis_key.pub));
 		balance -= send_amount;
-		auto send (std::make_shared<nano::send_block> (previous, key.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (previous)));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (previous)
+					.destination (key.pub)
+					.balance (balance)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (previous))
+					.build_shared ();
 		node1->process_active (send);
 	}
 
@@ -140,7 +148,15 @@ TEST (websocket, stopped_election)
 
 	// Create election, then erase it, causing a websocket message to be emitted
 	nano::keypair key1;
-	auto send1 (std::make_shared<nano::send_block> (nano::dev::genesis->hash (), key1.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ())));
+	nano::block_builder builder;
+	auto send1 = builder
+				 .send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build_shared ();
 	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 (node1->network.udp_channels.create (node1->network.endpoint ()));
 	node1->network.inbound (publish1, channel1);
@@ -287,7 +303,15 @@ TEST (websocket, confirmation_options)
 	// When filtering options are enabled, legacy blocks are always filtered
 	{
 		balance -= send_amount;
-		auto send (std::make_shared<nano::send_block> (previous, key.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (previous)));
+		nano::block_builder builder;
+		auto send = builder
+					.send ()
+					.previous (previous)
+					.destination (key.pub)
+					.balance (balance)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (previous))
+					.build_shared ();
 		node1->process_active (send);
 		previous = send->hash ();
 	}

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -16,9 +16,16 @@
 TEST (work, one)
 {
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::change_block block (1, 1, nano::keypair ().prv, 3, 4);
-	block.block_work_set (*pool.generate (block.root ()));
-	ASSERT_LT (nano::dev::network_params.work.threshold_base (block.work_version ()), nano::dev::network_params.work.difficulty (block));
+	nano::block_builder builder;
+	auto block = builder
+				 .change ()
+				 .previous (1)
+				 .representative (1)
+				 .sign (nano::keypair ().prv, 3)
+				 .work (4)
+				 .build ();
+	block->block_work_set (*pool.generate (block->root ()));
+	ASSERT_LT (nano::dev::network_params.work.threshold_base (block->work_version ()), nano::dev::network_params.work.difficulty (*block));
 }
 
 TEST (work, disabled)
@@ -31,10 +38,18 @@ TEST (work, disabled)
 TEST (work, validate)
 {
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::send_block send_block (1, 1, 2, nano::keypair ().prv, 4, 6);
-	ASSERT_LT (nano::dev::network_params.work.difficulty (send_block), nano::dev::network_params.work.threshold_base (send_block.work_version ()));
-	send_block.block_work_set (*pool.generate (send_block.root ()));
-	ASSERT_LT (nano::dev::network_params.work.threshold_base (send_block.work_version ()), nano::dev::network_params.work.difficulty (send_block));
+	nano::block_builder builder;
+	auto send_block = builder
+					  .send ()
+					  .previous (1)
+					  .destination (1)
+					  .balance (2)
+					  .sign (nano::keypair ().prv, 4)
+					  .work (6)
+					  .build ();
+	ASSERT_LT (nano::dev::network_params.work.difficulty (*send_block), nano::dev::network_params.work.threshold_base (send_block->work_version ()));
+	send_block->block_work_set (*pool.generate (send_block->root ()));
+	ASSERT_LT (nano::dev::network_params.work.threshold_base (send_block->work_version ()), nano::dev::network_params.work.difficulty (*send_block));
 }
 
 TEST (work, cancel)

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -890,12 +890,20 @@ int main (int argc, char * const * argv)
 			while (true)
 			{
 				nano::keypair key;
+				nano::block_builder builder;
 				nano::block_hash latest (0);
 				auto begin1 (std::chrono::high_resolution_clock::now ());
 				for (uint64_t balance (0); balance < 1000; ++balance)
 				{
-					nano::send_block send (latest, key.pub, balance, key.prv, key.pub, 0);
-					latest = send.hash ();
+					auto send = builder
+								.send ()
+								.previous (latest)
+								.destination (key.pub)
+								.balance (balance)
+								.sign (key.prv, key.pub)
+								.work (0)
+								.build ();
+					latest = send->hash ();
 				}
 				auto end1 (std::chrono::high_resolution_clock::now ());
 				std::cerr << boost::str (boost::format ("%|1$ 12d|\n") % std::chrono::duration_cast<std::chrono::microseconds> (end1 - begin1).count ());

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -124,21 +124,49 @@ TEST (ledger, deep_account_compute)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
 	auto balance (nano::dev::constants.genesis_amount - 1);
-	nano::send_block send (nano::dev::genesis->hash (), key.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (nano::dev::genesis->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-	nano::open_block open (send.hash (), nano::dev::genesis_key.pub, key.pub, key.prv, key.pub, *pool.generate (key.pub));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
-	auto sprevious (send.hash ());
-	auto rprevious (open.hash ());
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (key.pub)
+				.balance (balance)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	auto open = builder
+				.open ()
+				.source (send->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.account (key.pub)
+				.sign (key.prv, key.pub)
+				.work (*pool.generate (key.pub))
+				.build ();
+	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	auto sprevious (send->hash ());
+	auto rprevious (open->hash ());
 	for (auto i (0), n (100000); i != n; ++i)
 	{
 		balance -= 1;
-		nano::send_block send (sprevious, key.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (sprevious));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-		sprevious = send.hash ();
-		nano::receive_block receive (rprevious, send.hash (), key.prv, key.pub, *pool.generate (rprevious));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
-		rprevious = receive.hash ();
+		auto send = builder
+					.send ()
+					.previous (sprevious)
+					.destination (key.pub)
+					.balance (balance)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*pool.generate (sprevious))
+					.build ();
+		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+		sprevious = send->hash ();
+		auto receive = builder
+					   .receive ()
+					   .previous (rprevious)
+					   .source (send->hash ())
+					   .sign (key.prv, key.pub)
+					   .work (*pool.generate (rprevious))
+					   .build ();
+		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+		rprevious = receive->hash ();
 		if (i % 100 == 0)
 		{
 			std::cerr << i << ' ';
@@ -227,19 +255,34 @@ TEST (node, fork_storm)
 	auto previous (system.nodes[0]->latest (nano::dev::genesis_key.pub));
 	auto balance (system.nodes[0]->balance (nano::dev::genesis_key.pub));
 	ASSERT_FALSE (previous.is_zero ());
+	nano::block_builder builder;
 	for (auto node_j : system.nodes)
 	{
 		balance -= 1;
 		nano::keypair key;
-		nano::send_block send (previous, key.pub, balance, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
-		node_j->work_generate_blocking (send);
-		previous = send.hash ();
+		auto send = builder
+					.send ()
+					.previous (previous)
+					.destination (key.pub)
+					.balance (balance)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (0)
+					.build ();
+		node_j->work_generate_blocking (*send);
+		previous = send->hash ();
 		for (auto node_i : system.nodes)
 		{
-			auto send_result (node_i->process (send));
+			auto send_result (node_i->process (*send));
 			ASSERT_EQ (nano::process_result::progress, send_result.code);
 			nano::keypair rep;
-			auto open (std::make_shared<nano::open_block> (previous, rep.pub, key.pub, key.prv, key.pub, 0));
+			auto open = builder
+						.open ()
+						.source (previous)
+						.representative (rep.pub)
+						.account (key.pub)
+						.sign (key.prv, key.pub)
+						.work (0)
+						.build_shared ();
 			node_i->work_generate_blocking (*open);
 			auto open_result (node_i->process (*open));
 			ASSERT_EQ (nano::process_result::progress, open_result.code);
@@ -450,7 +493,15 @@ TEST (store, unchecked_load)
 {
 	nano::system system{ 1 };
 	auto & node = *system.nodes[0];
-	std::shared_ptr<nano::block> block = std::make_shared<nano::send_block> (0, 0, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, 0);
+	nano::block_builder builder;
+	std::shared_ptr<nano::block> block = builder
+										 .send ()
+										 .previous (0)
+										 .destination (0)
+										 .balance (0)
+										 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+										 .work (0)
+										 .build_shared ();
 	constexpr auto num_unchecked = 1'000'000;
 	for (auto i (0); i < num_unchecked; ++i)
 	{
@@ -549,9 +600,19 @@ TEST (node, mass_vote_by_hash)
 	nano::block_hash previous (nano::dev::genesis->hash ());
 	nano::keypair key;
 	std::vector<std::shared_ptr<nano::state_block>> blocks;
+	nano::block_builder builder;
 	for (auto i (0); i < 10000; ++i)
 	{
-		auto block (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, previous, nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - (i + 1) * nano::Gxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (previous)));
+		auto block = builder
+					 .state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (previous)
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - (i + 1) * nano::Gxrb_ratio)
+					 .link (key.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (previous))
+					 .build_shared ();
 		previous = block->hash ();
 		blocks.push_back (block);
 	}
@@ -576,6 +637,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 	nano::keypair last_keypair = nano::dev::genesis_key;
+	nano::block_builder builder;
 	auto last_open_hash = node->latest (nano::dev::genesis_key.pub);
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -584,11 +646,25 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 			nano::keypair key;
 			system.wallet (0)->insert_adhoc (key.prv);
 
-			nano::send_block send (last_open_hash, key.pub, node->online_reps.delta (), last_keypair.prv, last_keypair.pub, *system.work.generate (last_open_hash));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			nano::open_block open (send.hash (), last_keypair.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
-			last_open_hash = open.hash ();
+			auto send = builder
+						.send ()
+						.previous (last_open_hash)
+						.destination (key.pub)
+						.balance (node->online_reps.delta ())
+						.sign (last_keypair.prv, last_keypair.pub)
+						.work (*system.work.generate (last_open_hash))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			auto open = builder
+						.open ()
+						.source (send->hash ())
+						.representative (last_keypair.pub)
+						.account (key.pub)
+						.sign (key.prv, key.pub)
+						.work (*system.work.generate (key.pub))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			last_open_hash = open->hash ();
 			last_keypair = key;
 		}
 	}
@@ -645,6 +721,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_accounts = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 	auto latest_genesis = node->latest (nano::dev::genesis_key.pub);
+	nano::block_builder builder;
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -653,12 +730,26 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 			nano::keypair key;
 			system.wallet (0)->insert_adhoc (key.prv);
 
-			nano::send_block send (latest_genesis, key.pub, node->online_reps.delta (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest_genesis));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			auto open = std::make_shared<nano::open_block> (send.hash (), nano::dev::genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
+			auto send = builder
+						.send ()
+						.previous (latest_genesis)
+						.destination (key.pub)
+						.balance (node->online_reps.delta ())
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (latest_genesis))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			auto open = builder
+						.open ()
+						.source (send->hash ())
+						.representative (nano::dev::genesis_key.pub)
+						.account (key.pub)
+						.sign (key.prv, key.pub)
+						.work (*system.work.generate (key.pub))
+						.build_shared ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 			open_blocks.push_back (std::move (open));
-			latest_genesis = send.hash ();
+			latest_genesis = send->hash ();
 		}
 	}
 
@@ -709,45 +800,98 @@ TEST (confirmation_height, long_chains)
 	node->confirmation_height_processor.batch_write_size = 500;
 	auto const num_blocks = nano::confirmation_height::unbounded_cutoff * 2 + 50;
 
+	nano::block_builder builder;
 	// First open the other account
-	nano::send_block send (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio + num_blocks + 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-	nano::open_block open (send.hash (), nano::dev::genesis->account (), key1.pub, key1.prv, key1.pub, *system.work.generate (key1.pub));
+	auto send = builder
+				.send ()
+				.previous (latest)
+				.destination (key1.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio + num_blocks + 1)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (latest))
+				.build ();
+	auto open = builder
+				.open ()
+				.source (send->hash ())
+				.representative (nano::dev::genesis->account ())
+				.account (key1.pub)
+				.sign (key1.prv, key1.pub)
+				.work (*system.work.generate (key1.pub))
+				.build ();
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 	}
 
 	// Bulk send from genesis account to destination account
-	auto previous_genesis_chain_hash = send.hash ();
-	auto previous_destination_chain_hash = open.hash ();
+	auto previous_genesis_chain_hash = send->hash ();
+	auto previous_destination_chain_hash = open->hash ();
 	{
 		auto transaction = node->store.tx_begin_write ();
 		for (auto i = num_blocks - 1; i > 0; --i)
 		{
-			nano::send_block send (previous_genesis_chain_hash, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio + i + 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (previous_genesis_chain_hash));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			nano::receive_block receive (previous_destination_chain_hash, send.hash (), key1.prv, key1.pub, *system.work.generate (previous_destination_chain_hash));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive).code);
+			auto send = builder
+						.send ()
+						.previous (previous_genesis_chain_hash)
+						.destination (key1.pub)
+						.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio + i + 1)
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (previous_genesis_chain_hash))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			auto receive = builder
+						   .receive ()
+						   .previous (previous_destination_chain_hash)
+						   .source (send->hash ())
+						   .sign (key1.prv, key1.pub)
+						   .work (*system.work.generate (previous_destination_chain_hash))
+						   .build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive).code);
 
-			previous_genesis_chain_hash = send.hash ();
-			previous_destination_chain_hash = receive.hash ();
+			previous_genesis_chain_hash = send->hash ();
+			previous_destination_chain_hash = receive->hash ();
 		}
 	}
 
 	// Send one from destination to genesis and pocket it
-	nano::send_block send1 (previous_destination_chain_hash, nano::dev::genesis_key.pub, nano::Gxrb_ratio - 2, key1.prv, key1.pub, *system.work.generate (previous_destination_chain_hash));
-	auto receive1 (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, previous_genesis_chain_hash, nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio + 1, send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (previous_genesis_chain_hash)));
+	auto send1 = builder
+				 .send ()
+				 .previous (previous_destination_chain_hash)
+				 .destination (nano::dev::genesis_key.pub)
+				 .balance (nano::Gxrb_ratio - 2)
+				 .sign (key1.prv, key1.pub)
+				 .work (*system.work.generate (previous_destination_chain_hash))
+				 .build ();
+	auto receive1 = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (previous_genesis_chain_hash)
+					.representative (nano::dev::genesis->account ())
+					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio + 1)
+					.link (send1->hash ())
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (previous_genesis_chain_hash))
+					.build_shared ();
 
 	// Unpocketed. Send to a non-existing account to prevent auto receives from the wallet adjusting expected confirmation height
 	nano::keypair key2;
-	nano::state_block send2 (nano::dev::genesis->account (), receive1->hash (), nano::dev::genesis->account (), nano::dev::constants.genesis_amount - nano::Gxrb_ratio, key2.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive1->hash ()));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis->account ())
+				 .previous (receive1->hash ())
+				 .representative (nano::dev::genesis->account ())
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (receive1->hash ()))
+				 .build ();
 
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send2).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
 	}
 
 	// Call block confirm on the existing receive block on the genesis account which will confirm everything underneath on both accounts
@@ -799,9 +943,19 @@ TEST (confirmation_height, dynamic_algorithm)
 	auto const num_blocks = nano::confirmation_height::unbounded_cutoff;
 	auto latest_genesis = nano::dev::genesis;
 	std::vector<std::shared_ptr<nano::state_block>> state_blocks;
+	nano::block_builder builder;
 	for (auto i = 0; i < num_blocks; ++i)
 	{
-		auto send (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, latest_genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - i - 1, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest_genesis->hash ())));
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (latest_genesis->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (nano::dev::constants.genesis_amount - i - 1)
+					.link (key.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest_genesis->hash ()))
+					.build_shared ();
 		latest_genesis = send;
 		state_blocks.push_back (send);
 	}
@@ -857,7 +1011,17 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 
 		auto add_block_to_genesis_chain = [&] (nano::write_transaction & transaction) {
 			static int num = 0;
-			auto send (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, latest_genesis, nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - num - 1, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest_genesis)));
+			nano::block_builder builder;
+			auto send = builder
+						.state ()
+						.account (nano::dev::genesis_key.pub)
+						.previous (latest_genesis)
+						.representative (nano::dev::genesis_key.pub)
+						.balance (nano::dev::constants.genesis_amount - num - 1)
+						.link (key.pub)
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (latest_genesis))
+						.build_shared ();
 			latest_genesis = send->hash ();
 			state_blocks.push_back (send);
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
@@ -928,6 +1092,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 
 	auto latest_genesis = node->latest (nano::dev::genesis_key.pub);
 	std::vector<nano::keypair> keys;
+	nano::block_builder builder;
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 	{
 		auto transaction = node->store.tx_begin_write ();
@@ -936,12 +1101,26 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 			nano::keypair key;
 			keys.emplace_back (key);
 
-			nano::send_block send (latest_genesis, key.pub, nano::dev::constants.genesis_amount - 1 - i, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest_genesis));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			auto open = std::make_shared<nano::open_block> (send.hash (), nano::dev::genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
+			auto send = builder
+						.send ()
+						.previous (latest_genesis)
+						.destination (key.pub)
+						.balance (nano::dev::constants.genesis_amount - 1 - i)
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*system.work.generate (latest_genesis))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			auto open = builder
+						.open ()
+						.source (send->hash ())
+						.representative (nano::dev::genesis_key.pub)
+						.account (key.pub)
+						.sign (key.prv, key.pub)
+						.work (*system.work.generate (key.pub))
+						.build_shared ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 			open_blocks.push_back (std::move (open));
-			latest_genesis = send.hash ();
+			latest_genesis = send->hash ();
 		}
 	}
 
@@ -968,8 +1147,21 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	{
 		auto open_block = open_blocks[i];
 		auto & keypair = keys[i];
-		send_blocks.emplace_back (std::make_shared<nano::send_block> (open_block->hash (), keypair.pub, 1, keypair.prv, keypair.pub, *system.work.generate (open_block->hash ())));
-		receive_blocks.emplace_back (std::make_shared<nano::receive_block> (send_blocks.back ()->hash (), send_blocks.back ()->hash (), keypair.prv, keypair.pub, *system.work.generate (send_blocks.back ()->hash ())));
+		send_blocks.emplace_back (builder
+								  .send ()
+								  .previous (open_block->hash ())
+								  .destination (keypair.pub)
+								  .balance (1)
+								  .sign (keypair.prv, keypair.pub)
+								  .work (*system.work.generate (open_block->hash ()))
+								  .build_shared ());
+		receive_blocks.emplace_back (builder
+									 .receive ()
+									 .previous (send_blocks.back ()->hash ())
+									 .source (send_blocks.back ()->hash ())
+									 .sign (keypair.prv, keypair.pub)
+									 .work (*system.work.generate (send_blocks.back ()->hash ()))
+									 .build_shared ());
 	}
 
 	// Now send and receive to self
@@ -1045,6 +1237,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	std::vector<nano::keypair> keys;
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 
+	nano::block_builder builder;
 	nano::system system;
 
 	{
@@ -1056,12 +1249,26 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 		{
 			nano::keypair key;
 			keys.emplace_back (key);
-			nano::send_block send (latest_genesis, key.pub, nano::dev::constants.genesis_amount - 1 - i, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *pool.generate (latest_genesis));
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
-			auto open = std::make_shared<nano::open_block> (send.hash (), nano::dev::genesis_key.pub, key.pub, key.prv, key.pub, *pool.generate (key.pub));
+			auto send = builder
+						.send ()
+						.previous (latest_genesis)
+						.destination (key.pub)
+						.balance (nano::dev::constants.genesis_amount - 1 - i)
+						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						.work (*pool.generate (latest_genesis))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+			auto open = builder
+						.open ()
+						.source (send->hash ())
+						.representative (nano::dev::genesis_key.pub)
+						.account (key.pub)
+						.sign (key.prv, key.pub)
+						.work (*pool.generate (key.pub))
+						.build_shared ();
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 			open_blocks.push_back (std::move (open));
-			latest_genesis = send.hash ();
+			latest_genesis = send->hash ();
 		}
 	}
 
@@ -1087,8 +1294,21 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 		{
 			auto open_block = open_blocks[i];
 			auto & keypair = keys[i];
-			send_blocks.emplace_back (std::make_shared<nano::send_block> (open_block->hash (), keypair.pub, 1, keypair.prv, keypair.pub, *system.work.generate (open_block->hash ())));
-			receive_blocks.emplace_back (std::make_shared<nano::receive_block> (send_blocks.back ()->hash (), send_blocks.back ()->hash (), keypair.prv, keypair.pub, *system.work.generate (send_blocks.back ()->hash ())));
+			send_blocks.emplace_back (builder
+									  .send ()
+									  .previous (open_block->hash ())
+									  .destination (keypair.pub)
+									  .balance (1)
+									  .sign (keypair.prv, keypair.pub)
+									  .work (*system.work.generate (open_block->hash ()))
+									  .build_shared ());
+			receive_blocks.emplace_back (builder
+										 .receive ()
+										 .previous (send_blocks.back ()->hash ())
+										 .source (send_blocks.back ()->hash ())
+										 .sign (keypair.prv, keypair.pub)
+										 .work (*system.work.generate (send_blocks.back ()->hash ()))
+										 .build_shared ());
 
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send_blocks.back ()).code);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive_blocks.back ()).code);
@@ -1150,6 +1370,7 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 		node->store.confirmation_height.clear (transaction);
 	}
 
+	nano::block_builder builder;
 	{
 		auto transaction = node->store.tx_begin_write ();
 		for (auto i = num_accounts - 1; i > 0; --i)
@@ -1157,11 +1378,25 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 			nano::keypair key;
 			system.wallet (0)->insert_adhoc (key.prv);
 
-			nano::send_block send (last_open_hash, key.pub, nano::Gxrb_ratio - 1, last_keypair.prv, last_keypair.pub, *system.work.generate (last_open_hash));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-			nano::open_block open (send.hash (), last_keypair.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
-			last_open_hash = open.hash ();
+			auto send = builder
+						.send ()
+						.previous (last_open_hash)
+						.destination (key.pub)
+						.balance (nano::Gxrb_ratio - 1)
+						.sign (last_keypair.prv, last_keypair.pub)
+						.work (*system.work.generate (last_open_hash))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			auto open = builder
+						.open ()
+						.source (send->hash ())
+						.representative (last_keypair.pub)
+						.account (key.pub)
+						.sign (key.prv, key.pub)
+						.work (*system.work.generate (key.pub))
+						.build ();
+			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			last_open_hash = open->hash ();
 			last_keypair = key;
 		}
 	}
@@ -1182,12 +1417,26 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	// Add a new frontier with 1 block, it should not be added to the frontier container because it is not higher than any already in the maxed out container
 	nano::keypair key;
 	auto latest_genesis = node->latest (nano::dev::genesis_key.pub);
-	nano::send_block send (latest_genesis, key.pub, nano::Gxrb_ratio - 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest_genesis));
-	nano::open_block open (send.hash (), nano::dev::genesis_key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
+	auto send = builder
+				.send ()
+				.previous (latest_genesis)
+				.destination (key.pub)
+				.balance (nano::Gxrb_ratio - 1)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (latest_genesis))
+				.build ();
+	auto open = builder
+				.open ()
+				.source (send->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.account (key.pub)
+				.sign (key.prv, key.pub)
+				.work (*system.work.generate (key.pub))
+				.build ();
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, open).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
 	}
 	transaction.refresh ();
 	node->active.prioritize_frontiers_for_confirmation (transaction, std::chrono::seconds (60), std::chrono::seconds (60));
@@ -1195,12 +1444,25 @@ TEST (confirmation_height, prioritize_frontiers_overwrite)
 	ASSERT_EQ (node->active.priority_wallet_cementable_frontiers_size (), num_accounts / 2);
 
 	// The account now has an extra block (2 in total) so has 1 more uncemented block than the next smallest frontier in the collection.
-	nano::send_block send1 (send.hash (), key.pub, nano::Gxrb_ratio - 2, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send.hash ()));
-	nano::receive_block receive (open.hash (), send1.hash (), key.prv, key.pub, *system.work.generate (open.hash ()));
+	auto send1 = builder
+				 .send ()
+				 .previous (send->hash ())
+				 .destination (key.pub)
+				 .balance (nano::Gxrb_ratio - 2)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send->hash ()))
+				 .build ();
+	auto receive = builder
+				   .receive ()
+				   .previous (open->hash ())
+				   .source (send1->hash ())
+				   .sign (key.prv, key.pub)
+				   .work (*system.work.generate (open->hash ()))
+				   .build ();
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send1).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, receive).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive).code);
 	}
 
 	// Confirm that it gets replaced
@@ -1373,18 +1635,47 @@ TEST (telemetry, under_load)
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto latest_genesis = node->latest (nano::dev::genesis_key.pub);
 	auto num_blocks = 150000;
-	auto send (std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, latest_genesis, nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - num_blocks, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest_genesis)));
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (latest_genesis)
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - num_blocks)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (latest_genesis))
+				.build_shared ();
 	node->process_active (send);
 	latest_genesis = send->hash ();
-	auto open (std::make_shared<nano::state_block> (key.pub, 0, key.pub, num_blocks, send->hash (), key.prv, key.pub, *system.work.generate (key.pub)));
+	auto open = builder
+				.state ()
+				.account (key.pub)
+				.previous (0)
+				.representative (key.pub)
+				.balance (num_blocks)
+				.link (send->hash ())
+				.sign (key.prv, key.pub)
+				.work (*system.work.generate (key.pub))
+				.build_shared ();
 	node->process_active (open);
 	auto latest_key = open->hash ();
 
 	auto thread_func = [key1, &system, node, num_blocks] (nano::keypair const & keypair, nano::block_hash const & latest, nano::uint128_t const initial_amount) {
 		auto latest_l = latest;
+		nano::block_builder builder;
 		for (int i = 0; i < num_blocks; ++i)
 		{
-			auto send (std::make_shared<nano::state_block> (keypair.pub, latest_l, keypair.pub, initial_amount - i - 1, key1.pub, keypair.prv, keypair.pub, *system.work.generate (latest_l)));
+			auto send = builder
+						.state ()
+						.account (keypair.pub)
+						.previous (latest_l)
+						.representative (keypair.pub)
+						.balance (initial_amount - i - 1)
+						.link (key1.pub)
+						.sign (keypair.prv, keypair.pub)
+						.work (*system.work.generate (latest_l))
+						.build_shared ();
 			latest_l = send->hash ();
 			node->process_active (send);
 		}
@@ -1519,11 +1810,21 @@ TEST (telemetry, many_nodes)
 
 	// Give all nodes a non-default number of blocks
 	nano::keypair key;
-	nano::state_block send (nano::dev::genesis_key.pub, nano::dev::genesis->hash (), nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - nano::Mxrb_ratio, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (nano::dev::genesis->hash ()));
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Mxrb_ratio)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
 	for (auto node : system.nodes)
 	{
 		auto transaction (node->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
+		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 	}
 
 	// This is the node which will request metrics from all other nodes
@@ -1596,6 +1897,7 @@ TEST (signature_checker, mass_boundary_checks)
 		add_boundary (nano::signature_checker::batch_size * i);
 	}
 
+	nano::block_builder builder;
 	for (auto num_threads = 0; num_threads < 5; ++num_threads)
 	{
 		nano::signature_checker checker (num_threads);
@@ -1611,7 +1913,16 @@ TEST (signature_checker, mass_boundary_checks)
 		std::vector<unsigned char const *> signatures;
 		signatures.reserve (max_size);
 		nano::keypair key;
-		nano::state_block block (key.pub, 0, key.pub, 0, 0, key.prv, key.pub, 0);
+		auto block = builder
+					 .state ()
+					 .account (key.pub)
+					 .previous (0)
+					 .representative (key.pub)
+					 .balance (0)
+					 .link (0)
+					 .sign (key.prv, key.pub)
+					 .work (0)
+					 .build ();
 
 		size_t last_size = 0;
 		for (auto size : sizes)
@@ -1623,11 +1934,11 @@ TEST (signature_checker, mass_boundary_checks)
 			verifications.resize (size);
 			for (auto i (0); i < extra_size; ++i)
 			{
-				hashes.push_back (block.hash ());
+				hashes.push_back (block->hash ());
 				messages.push_back (hashes.back ().bytes.data ());
 				lengths.push_back (sizeof (decltype (hashes)::value_type));
-				pub_keys.push_back (block.hashables.account.bytes.data ());
-				signatures.push_back (block.signature.bytes.data ());
+				pub_keys.push_back (block->hashables.account.bytes.data ());
+				signatures.push_back (block->signature.bytes.data ());
 			}
 			nano::signature_check_set check = { size, messages.data (), lengths.data (), pub_keys.data (), signatures.data (), verifications.data () };
 			checker.verify (check);
@@ -1892,6 +2203,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 	for (int i = 0; i < 5; ++i)
 	{
 		nano::system system;
+		nano::block_builder builder;
 		nano::node_config node_config (nano::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config);
@@ -1904,9 +2216,16 @@ TEST (node, wallet_create_block_confirm_conflicts)
 			auto transaction = node->store.tx_begin_write ();
 			for (auto i = num_blocks - 1; i > 0; --i)
 			{
-				nano::send_block send (latest, key1.pub, nano::dev::constants.genesis_amount - nano::Gxrb_ratio + i + 1, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, send).code);
-				latest = send.hash ();
+				auto send = builder
+							.send ()
+							.previous (latest)
+							.destination (key1.pub)
+							.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio + i + 1)
+							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+							.work (*system.work.generate (latest))
+							.build ();
+				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+				latest = send->hash ();
 			}
 		}
 


### PR DESCRIPTION
Related to issue: https://github.com/nanocurrency/nano-node/issues/3817
Done mostly by regex replace.