### PR TITLE
Adds a ledger_context class

### DIFF
--- a/nano/test_common/CMakeLists.txt
+++ b/nano/test_common/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(
   test_common
+  ledger.hpp
+  ledger.cpp
   network.hpp
   network.cpp
   system.hpp

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -1,0 +1,30 @@
+#include <nano/node/node.hpp>
+#include <nano/test_common/ledger.hpp>
+
+nano::test::context::ledger_context::ledger_context () :
+	store_m{ nano::make_store (logger, nano::unique_path (), nano::dev::constants) },
+	ledger_m{ *store_m, stats_m, nano::dev::constants }
+{
+	debug_assert (!store_m->init_error ());
+	store_m->initialize (store_m->tx_begin_write (), ledger_m.cache, ledger_m.constants);
+}
+
+nano::ledger & nano::test::context::ledger_context::ledger ()
+{
+	return ledger_m;
+}
+
+nano::store & nano::test::context::ledger_context::store ()
+{
+	return *store_m;
+}
+
+nano::stat & nano::test::context::ledger_context::stats ()
+{
+	return stats_m;
+}
+
+auto nano::test::context::ledger_empty () -> ledger_context
+{
+	return ledger_context{};
+}

--- a/nano/test_common/ledger.hpp
+++ b/nano/test_common/ledger.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <nano/lib/logger_mt.hpp>
+#include <nano/lib/stats.hpp>
+#include <nano/node/common.hpp>
+#include <nano/secure/ledger.hpp>
+
+namespace nano
+{
+class store;
+namespace test
+{
+	namespace context
+	{
+		class ledger_context
+		{
+		public:
+			ledger_context ();
+			nano::ledger & ledger ();
+			nano::store & store ();
+			nano::stat & stats ();
+
+		private:
+			nano::logger_mt logger;
+			std::unique_ptr<nano::store> store_m;
+			nano::stat stats_m;
+			nano::ledger ledger_m;
+		};
+
+		ledger_context ledger_empty ();
+	}
+}
+}


### PR DESCRIPTION
Adds a ledger_context class and ledger_empty function which can be us…ed by unit tests to easily create an empty ledger. This removes a lot of boilerplate code in associated tests.