### PR TITLE
Fix rocksdb_block_store.tombstone_count

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -2645,34 +2645,36 @@ namespace nano
 // logic bound to the way RocksDB is used by the node.
 TEST (rocksdb_block_store, tombstone_count)
 {
-	if (nano::rocksdb_config::using_rocksdb_in_tests ())
+	if (!nano::rocksdb_config::using_rocksdb_in_tests ())
 	{
-		nano::system system{};
-		nano::logger_mt logger{};
-		auto store = std::make_unique<nano::rocksdb::store> (logger, nano::unique_path (), nano::dev::constants);
-		nano::unchecked_map unchecked{ *store, false };
-		ASSERT_TRUE (!store->init_error ());
-		nano::block_builder builder;
-		auto block = builder
-					 .send ()
-					 .previous (0)
-					 .destination (1)
-					 .balance (2)
-					 .sign (nano::keypair ().prv, 4)
-					 .work (5)
-					 .build_shared ();
-		// Enqueues a block to be saved in the database
-		unchecked.put (block->previous (), nano::unchecked_info (block));
-		auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
-			return unchecked.get (transaction_a, block_hash_a).size () > 0;
-		};
-		// Waits for the block to get saved
-		ASSERT_TIMELY (5s, check_block_is_listed (store->tx_begin_read (), block->previous ()));
-		ASSERT_EQ (store->tombstone_map.at (nano::tables::unchecked).num_since_last_flush.load (), 0);
-		// Perorms a delete and checks for the tombstone counter
-		unchecked.del (store->tx_begin_write (), nano::unchecked_key (block->previous (), block->hash ()));
-		ASSERT_EQ (store->tombstone_map.at (nano::tables::unchecked).num_since_last_flush.load (), 1);
+		return;
 	}
+	nano::system system{};
+	nano::logger_mt logger;
+	auto store = std::make_unique<nano::rocksdb::store> (logger, nano::unique_path (), nano::dev::constants);
+	ASSERT_TRUE (!store->init_error ());
+	nano::block_builder builder;
+	auto block = builder
+				 .send ()
+				 .previous (0)
+				 .destination (1)
+				 .balance (2)
+				 .sign (nano::keypair ().prv, 4)
+				 .work (5)
+				 .build_shared ();
+	// Enqueues a block to be saved in the database
+	auto previous = block->previous ();
+	store->unchecked.put (store->tx_begin_write (), previous, nano::unchecked_info (block));
+	nano::unchecked_key key{ previous, block->hash () };
+	auto check_block_is_listed = [&] (nano::transaction const & transaction_a) {
+		return store->unchecked.exists (transaction_a, key);
+	};
+	// Waits for the block to get saved
+	ASSERT_TIMELY (5s, check_block_is_listed (store->tx_begin_read ()));
+	ASSERT_EQ (store->tombstone_map.at (nano::tables::unchecked).num_since_last_flush.load (), 0);
+	// Perorms a delete and checks for the tombstone counter
+	store->unchecked.del (store->tx_begin_write (), nano::unchecked_key (previous, block->hash ()));
+	ASSERT_TIMELY (5s, store->tombstone_map.at (nano::tables::unchecked).num_since_last_flush.load () == 1);
 }
 }
 

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -826,6 +826,8 @@ class unchecked_map;
  */
 class store
 {
+	friend class rocksdb_block_store_tombstone_count_Test;
+
 public:
 	// clang-format off
 	explicit store (


### PR DESCRIPTION
With the addition of storing unchecked entries in memory, the unchecked_map class doesn't give guarantees that entries are written to disk which causes the rocksdb-specific tombstone checking to fail.

This rewrites the test directly in terms of the unchecked_store rather than unchecked_map.