### PR TITLE
Fix `server_socket` close method override

### DIFF
--- a/nano/node/socket.hpp
+++ b/nano/node/socket.hpp
@@ -64,7 +64,7 @@ public:
 	void async_read (std::shared_ptr<std::vector<uint8_t>> const &, std::size_t, std::function<void (boost::system::error_code const &, std::size_t)>);
 	void async_write (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> = {});
 
-	void close ();
+	virtual void close ();
 	boost::asio::ip::tcp::endpoint remote_endpoint () const;
 	boost::asio::ip::tcp::endpoint local_endpoint () const;
 	/** Returns true if the socket has timed out */
@@ -193,7 +193,7 @@ public:
 	/**Start accepting new connections */
 	void start (boost::system::error_code &);
 	/** Stop accepting new connections */
-	void close ();
+	void close () override;
 	/** Register callback for new connections. The callback must return true to keep accepting new connections. */
 	void on_connection (std::function<bool (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const &)>);
 	uint16_t listening_port ()


### PR DESCRIPTION
This is a fix for a subtle bug I found. The `close` method of `socket` was not virtual so an override in `server_socket` had no effect.