### PR TITLE
Move UDP tests to TCP or loopback

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1,6 +1,7 @@
 #include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -737,7 +738,7 @@ TEST (bootstrap_processor, lazy_hash)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -811,7 +812,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, true, "123456");
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -949,7 +950,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (3, node1->ledger.cache.pruned_count);
 	// Start lazy bootstrap with last block in chain known
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->ledger.cache.block_count == 9);
@@ -1052,7 +1053,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->block (change3->hash ()));
@@ -1121,7 +1122,7 @@ TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (receive->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
@@ -1180,7 +1181,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (15s, !node2->bootstrap_initiator.in_progress ());
@@ -1249,7 +1250,7 @@ TEST (bootstrap_processor, DISABLED_lazy_destinations)
 
 	// Start lazy bootstrap with last block in sender chain
 	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
@@ -1334,7 +1335,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	// Start lazy bootstrap with last block in sender chain
 	config.peering_port = nano::test::get_available_port ();
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	auto lazy_attempt (node2->bootstrap_initiator.current_lazy_attempt ());
@@ -1389,7 +1390,7 @@ TEST (bootstrap_processor, lazy_cancel)
 
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (send1->hash (), true); // Start "confirmed" block bootstrap
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -1464,7 +1465,7 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -1531,7 +1532,7 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 = system.add_node ();
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -1604,7 +1605,7 @@ TEST (bootstrap_processor, multiple_attempts)
 	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.bootstrap_initiator_threads = 3;
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work));
-	node2->network.udp_channels.insert (node1->network.endpoint (), node2->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	node2->bootstrap_initiator.bootstrap ();
 	auto lazy_attempt (node2->bootstrap_initiator.current_lazy_attempt ());

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -17,7 +17,7 @@ TEST (confirmation_solicitor, batches)
 	auto & node1 = *system.add_node (node_flags);
 	node_flags.disable_request_loop = true;
 	auto & node2 = *system.add_node (node_flags);
-	auto channel1 = nano::establish_tcp (system, node2, node1.network.endpoint ());
+	auto channel1 = nano::test::establish_tcp (system, node2, node1.network.endpoint ());
 	// Solicitor will only solicit from this representative
 	nano::representative representative (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, channel1);
 	std::vector<nano::representative> representatives{ representative };
@@ -67,7 +67,7 @@ TEST (confirmation_solicitor, different_hash)
 	node_flags.disable_rep_crawler = true;
 	auto & node1 = *system.add_node (node_flags);
 	auto & node2 = *system.add_node (node_flags);
-	auto channel1 = nano::establish_tcp (system, node2, node1.network.endpoint ());
+	auto channel1 = nano::test::establish_tcp (system, node2, node1.network.endpoint ());
 	// Solicitor will only solicit from this representative
 	nano::representative representative (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, channel1);
 	std::vector<nano::representative> representatives{ representative };

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
+#include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -100,7 +101,6 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 }
 
-// TODO: fix failing test
 TEST (confirmation_solicitor, bypass_max_requests_cap)
 {
 	nano::test::system system;
@@ -115,9 +115,8 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	representatives.reserve (max_representatives + 1);
 	for (auto i (0); i < max_representatives + 1; ++i)
 	{
-		auto client = std::make_shared<nano::client_socket> (node2);
-		std::shared_ptr<nano::transport::channel> channel = std::make_shared<nano::transport::channel_tcp> (node1, client);
-		//		auto channel (node2.network.udp_channels.create (node1.network.endpoint ()));
+		// Make a temporary channel associated with node2
+		auto channel = std::make_shared<nano::transport::inproc::channel> (node2, node2);
 		nano::representative representative (nano::account (i), i, channel);
 		representatives.push_back (representative);
 	}

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,6 +1,5 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/inproc.hpp>
-#include <nano/node/transport/udp.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -13,45 +12,95 @@
 
 using namespace std::chrono_literals;
 
+// Only tests a simple connection works using system.io_ctx.
 TEST (network, tcp_connection)
 {
-	boost::asio::io_context io_ctx;
-	boost::asio::ip::tcp::acceptor acceptor (io_ctx);
-	auto port = nano::test::get_available_port ();
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), port);
-	acceptor.open (endpoint.protocol ());
-	acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
-	acceptor.bind (endpoint);
-	acceptor.listen ();
-	boost::asio::ip::tcp::socket incoming (io_ctx);
-	std::atomic<bool> done1 (false);
-	std::string message1;
-	acceptor.async_accept (incoming,
-	[&done1, &message1] (boost::system::error_code const & ec_a) {
-		   if (ec_a)
-		   {
-			   message1 = ec_a.message ();
-			   std::cerr << message1;
-		   }
-		   done1 = true; });
-	boost::asio::ip::tcp::socket connector (io_ctx);
-	std::atomic<bool> done2 (false);
-	std::string message2;
-	connector.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), acceptor.local_endpoint ().port ()),
-	[&done2, &message2] (boost::system::error_code const & ec_a) {
-		if (ec_a)
-		{
-			message2 = ec_a.message ();
-			std::cerr << message2;
-		}
-		done2 = true;
-	});
-	while (!done1 || !done2)
+	// Organizes the code used for a connection into distinguished classes (base class/client/server)
+	struct simple_socket : public boost::enable_shared_from_this<simple_socket>
 	{
-		io_ctx.poll ();
-	}
-	ASSERT_EQ (0, message1.size ());
-	ASSERT_EQ (0, message2.size ());
+		std::atomic<bool> connected;
+		uint16_t port;
+		boost::asio::ip::tcp::endpoint endpoint;
+		boost::asio::ip::tcp::socket socket;
+		std::string error_message;
+
+		explicit simple_socket (boost::asio::io_context & io_ctx_a, boost::asio::ip::address ip_address_a, uint16_t port_a) :
+			connected{ false },
+			port{ port_a },
+			endpoint{ ip_address_a, port_a },
+			socket{ io_ctx_a }
+		{
+		}
+
+		virtual void async_write (std::string message)
+		{
+		}
+		virtual void async_read ()
+		{
+		}
+	};
+
+	struct simple_server_socket final : public simple_socket
+	{
+		boost::asio::ip::tcp::acceptor acceptor;
+
+		explicit simple_server_socket (boost::asio::io_context & io_ctx_a, boost::asio::ip::address ip_address_a, uint16_t port_a) :
+			simple_socket{ io_ctx_a, ip_address_a, port_a },
+			acceptor{ io_ctx_a }
+		{
+			accept ();
+		}
+
+		void accept ()
+		{
+			acceptor.open (endpoint.protocol ());
+			acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
+			acceptor.bind (endpoint);
+			acceptor.listen ();
+			acceptor.async_accept (socket,
+			[this] (boost::system::error_code const & ec_a) {
+				if (ec_a)
+				{
+					this->error_message = ec_a.message ();
+					std::cerr << this->error_message;
+				}
+				else
+				{
+					this->connected = true;
+					this->async_read ();
+				}
+			});
+		}
+	};
+
+	struct simple_client_socket final : public simple_socket
+	{
+		explicit simple_client_socket (boost::asio::io_context & io_ctx_a, boost::asio::ip::address ip_address_a, uint16_t port_a) :
+			simple_socket{ io_ctx_a, ip_address_a, port_a }
+		{
+			socket.async_connect (boost::asio::ip::tcp::endpoint (ip_address_a, port_a),
+			[this] (boost::system::error_code const & ec_a) {
+				if (ec_a)
+				{
+					this->error_message = ec_a.message ();
+					std::cerr << error_message;
+				}
+				else
+				{
+					this->connected = true;
+				}
+			});
+		}
+	};
+
+	nano::test::system system;
+	auto port = nano::test::get_available_port ();
+	simple_server_socket server (system.io_ctx, boost::asio::ip::address_v4::any (), port);
+	simple_client_socket client (system.io_ctx, boost::asio::ip::address_v4::loopback (), port);
+
+	ASSERT_TIMELY (5s, server.connected && client.connected);
+	ASSERT_EQ (0, client.error_message.size ());
+	ASSERT_EQ (0, server.error_message.size ());
 }
 
 TEST (network, construction_with_specified_port)
@@ -72,48 +121,6 @@ TEST (network, construction_without_specified_port)
 	EXPECT_NE (0, port);
 	EXPECT_EQ (port, node->network.endpoint ().port ());
 	EXPECT_EQ (port, node->bootstrap.endpoint ().port ());
-}
-
-TEST (network, self_discard)
-{
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	nano::test::system system (1, nano::transport::transport_type::tcp, node_flags);
-	nano::message_buffer data;
-	data.endpoint = system.nodes[0]->network.endpoint ();
-	ASSERT_EQ (0, system.nodes[0]->stats.count (nano::stat::type::error, nano::stat::detail::bad_sender));
-	system.nodes[0]->network.udp_channels.receive_action (&data);
-	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::error, nano::stat::detail::bad_sender));
-}
-
-// Test disabled because it's failing intermittently.
-// PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3611
-// Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3612
-TEST (network, DISABLED_send_node_id_handshake)
-{
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	nano::test::system system;
-	auto node0 = system.add_node (node_flags);
-	ASSERT_EQ (0, node0->network.size ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
-	node1->start ();
-	system.nodes.push_back (node1);
-	auto initial (node0->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in));
-	auto initial_node1 (node1->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in));
-	auto channel (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node1->network_params.network.protocol_version));
-	node0->network.send_keepalive (channel);
-	ASSERT_EQ (0, node0->network.size ());
-	ASSERT_EQ (0, node1->network.size ());
-	ASSERT_TIMELY (10s, node1->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in) != initial_node1);
-	ASSERT_TIMELY (10s, node0->network.size () == 0 || node1->network.size () == 1);
-	ASSERT_TIMELY (10s, node0->stats.count (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in) == initial + 2);
-	ASSERT_TIMELY (10s, node0->network.size () == 1 || node1->network.size () == 1);
-	auto list1 (node0->network.list (1));
-	ASSERT_EQ (node1->network.endpoint (), list1[0]->get_endpoint ());
-	auto list2 (node1->network.list (1));
-	ASSERT_EQ (node0->network.endpoint (), list2[0]->get_endpoint ());
-	node1->stop ();
 }
 
 TEST (network, send_node_id_handshake_tcp)
@@ -269,103 +276,61 @@ TEST (network, send_invalid_publish)
 
 TEST (network, send_valid_confirm_ack)
 {
-	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
-	for (auto & type : types)
-	{
-		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::udp)
-		{
-			node_flags.disable_tcp_realtime = true;
-			node_flags.disable_bootstrap_listener = true;
-			node_flags.disable_udp = false;
-		}
-		nano::test::system system (2, type, node_flags);
-		auto & node1 (*system.nodes[0]);
-		auto & node2 (*system.nodes[1]);
-		nano::keypair key2;
-		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-		system.wallet (1)->insert_adhoc (key2.prv);
-		nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
-		nano::block_builder builder;
-		auto block2 = builder
-					  .send ()
-					  .previous (latest1)
-					  .destination (key2.pub)
-					  .balance (50)
-					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					  .work (*system.work.generate (latest1))
-					  .build ();
-		nano::block_hash latest2 (node2.latest (nano::dev::genesis_key.pub));
-		node1.process_active (std::make_shared<nano::send_block> (*block2));
-		// Keep polling until latest block changes
-		ASSERT_TIMELY (10s, node2.latest (nano::dev::genesis_key.pub) != latest2);
-		// Make sure the balance has decreased after processing the block.
-		ASSERT_EQ (50, node2.balance (nano::dev::genesis_key.pub));
-	}
+	auto type = nano::transport::transport_type::tcp;
+	nano::node_flags node_flags;
+	nano::test::system system (2, type, node_flags);
+	auto & node1 (*system.nodes[0]);
+	auto & node2 (*system.nodes[1]);
+	nano::keypair key2;
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	system.wallet (1)->insert_adhoc (key2.prv);
+	nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
+	nano::block_builder builder;
+	auto block2 = builder
+				  .send ()
+				  .previous (latest1)
+				  .destination (key2.pub)
+				  .balance (50)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*system.work.generate (latest1))
+				  .build ();
+	nano::block_hash latest2 (node2.latest (nano::dev::genesis_key.pub));
+	node1.process_active (std::make_shared<nano::send_block> (*block2));
+	// Keep polling until latest block changes
+	ASSERT_TIMELY (10s, node2.latest (nano::dev::genesis_key.pub) != latest2);
+	// Make sure the balance has decreased after processing the block.
+	ASSERT_EQ (50, node2.balance (nano::dev::genesis_key.pub));
 }
 
 TEST (network, send_valid_publish)
 {
-	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
-	for (auto & type : types)
-	{
-		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::udp)
-		{
-			node_flags.disable_tcp_realtime = true;
-			node_flags.disable_bootstrap_listener = true;
-			node_flags.disable_udp = false;
-		}
-		nano::test::system system (2, type, node_flags);
-		auto & node1 (*system.nodes[0]);
-		auto & node2 (*system.nodes[1]);
-		node1.bootstrap_initiator.stop ();
-		node2.bootstrap_initiator.stop ();
-		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-		nano::keypair key2;
-		system.wallet (1)->insert_adhoc (key2.prv);
-		nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
-		nano::block_builder builder;
-		auto block2 = builder
-					  .send ()
-					  .previous (latest1)
-					  .destination (key2.pub)
-					  .balance (50)
-					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					  .work (*system.work.generate (latest1))
-					  .build ();
-		auto hash2 (block2->hash ());
-		nano::block_hash latest2 (node2.latest (nano::dev::genesis_key.pub));
-		node2.process_active (std::make_shared<nano::send_block> (*block2));
-		ASSERT_TIMELY (10s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
-		ASSERT_NE (hash2, latest2);
-		ASSERT_TIMELY (10s, node2.latest (nano::dev::genesis_key.pub) != latest2);
-		ASSERT_EQ (50, node2.balance (nano::dev::genesis_key.pub));
-	}
-}
-
-TEST (network, send_insufficient_work_udp)
-{
-	nano::test::system system;
+	auto type = nano::transport::transport_type::tcp;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto & node1 = *system.add_node (node_flags);
-	auto & node2 = *system.add_node (node_flags);
+	nano::test::system system (2, type, node_flags);
+	auto & node1 (*system.nodes[0]);
+	auto & node2 (*system.nodes[1]);
+	node1.bootstrap_initiator.stop ();
+	node2.bootstrap_initiator.stop ();
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair key2;
+	system.wallet (1)->insert_adhoc (key2.prv);
+	nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
-	auto block = builder
-				 .send ()
-				 .previous (0)
-				 .destination (1)
-				 .balance (20)
-				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (0)
-				 .build_shared ();
-	nano::publish publish{ nano::dev::network_params.network, block };
-	nano::transport::channel_udp channel (node1.network.udp_channels, node2.network.endpoint (), node1.network_params.network.protocol_version);
-	channel.send (publish, [] (boost::system::error_code const & ec, size_t size) {});
-	ASSERT_EQ (0, node1.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
-	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work) != 0);
-	ASSERT_EQ (1, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
+	auto block2 = builder
+				  .send ()
+				  .previous (latest1)
+				  .destination (key2.pub)
+				  .balance (50)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*system.work.generate (latest1))
+				  .build ();
+	auto hash2 (block2->hash ());
+	nano::block_hash latest2 (node2.latest (nano::dev::genesis_key.pub));
+	node2.process_active (std::make_shared<nano::send_block> (*block2));
+	ASSERT_TIMELY (10s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
+	ASSERT_NE (hash2, latest2);
+	ASSERT_TIMELY (10s, node2.latest (nano::dev::genesis_key.pub) != latest2);
+	ASSERT_EQ (50, node2.balance (nano::dev::genesis_key.pub));
 }
 
 TEST (network, send_insufficient_work)
@@ -434,96 +399,44 @@ TEST (network, send_insufficient_work)
 	ASSERT_EQ (2, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
 }
 
-TEST (receivable_processor, confirm_insufficient_pos)
-{
-	nano::test::system system (1);
-	auto & node1 (*system.nodes[0]);
-	nano::block_builder builder;
-	auto block1 = builder
-				  .send ()
-				  .previous (nano::dev::genesis->hash ())
-				  .destination (0)
-				  .balance (0)
-				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (0)
-				  .build_shared ();
-	node1.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
-	nano::keypair key1;
-	auto vote (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, 0, std::vector<nano::block_hash>{ block1->hash () }));
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
-	node1.network.inbound (con1, node1.network.udp_channels.create (node1.network.endpoint ()));
-}
-
-TEST (receivable_processor, confirm_sufficient_pos)
-{
-	nano::test::system system (1);
-	auto & node1 (*system.nodes[0]);
-	nano::block_builder builder;
-	auto block1 = builder
-				  .send ()
-				  .previous (nano::dev::genesis->hash ())
-				  .destination (0)
-				  .balance (0)
-				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (0)
-				  .build_shared ();
-	node1.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
-	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ block1->hash () }));
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
-	node1.network.inbound (con1, node1.network.udp_channels.create (node1.network.endpoint ()));
-}
-
 TEST (receivable_processor, send_with_receive)
 {
-	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
-	for (auto & type : types)
-	{
-		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::udp)
-		{
-			node_flags.disable_tcp_realtime = true;
-			node_flags.disable_bootstrap_listener = true;
-			node_flags.disable_udp = false;
-		}
-		nano::test::system system (2, type, node_flags);
-		auto & node1 (*system.nodes[0]);
-		auto & node2 (*system.nodes[1]);
-		auto amount (std::numeric_limits<nano::uint128_t>::max ());
-		nano::keypair key2;
-		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-		nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
-		system.wallet (1)->insert_adhoc (key2.prv);
-		nano::block_builder builder;
-		auto block1 = builder
-					  .send ()
-					  .previous (latest1)
-					  .destination (key2.pub)
-					  .balance (amount - node1.config.receive_minimum.number ())
-					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					  .work (*system.work.generate (latest1))
-					  .build_shared ();
-		ASSERT_EQ (amount, node1.balance (nano::dev::genesis_key.pub));
-		ASSERT_EQ (0, node1.balance (key2.pub));
-		ASSERT_EQ (amount, node2.balance (nano::dev::genesis_key.pub));
-		ASSERT_EQ (0, node2.balance (key2.pub));
-		node1.process_active (block1);
-		node1.block_processor.flush ();
-		node2.process_active (block1);
-		node2.block_processor.flush ();
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev::genesis_key.pub));
-		ASSERT_EQ (0, node1.balance (key2.pub));
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev::genesis_key.pub));
-		ASSERT_EQ (0, node2.balance (key2.pub));
-		ASSERT_TIMELY (10s, node1.balance (key2.pub) == node1.config.receive_minimum.number () && node2.balance (key2.pub) == node1.config.receive_minimum.number ());
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev::genesis_key.pub));
-		ASSERT_EQ (node1.config.receive_minimum.number (), node1.balance (key2.pub));
-		ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev::genesis_key.pub));
-		ASSERT_EQ (node1.config.receive_minimum.number (), node2.balance (key2.pub));
-	}
+	auto type = nano::transport::transport_type::tcp;
+	nano::node_flags node_flags;
+	nano::test::system system (2, type, node_flags);
+	auto & node1 (*system.nodes[0]);
+	auto & node2 (*system.nodes[1]);
+	auto amount (std::numeric_limits<nano::uint128_t>::max ());
+	nano::keypair key2;
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
+	system.wallet (1)->insert_adhoc (key2.prv);
+	nano::block_builder builder;
+	auto block1 = builder
+				  .send ()
+				  .previous (latest1)
+				  .destination (key2.pub)
+				  .balance (amount - node1.config.receive_minimum.number ())
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*system.work.generate (latest1))
+				  .build_shared ();
+	ASSERT_EQ (amount, node1.balance (nano::dev::genesis_key.pub));
+	ASSERT_EQ (0, node1.balance (key2.pub));
+	ASSERT_EQ (amount, node2.balance (nano::dev::genesis_key.pub));
+	ASSERT_EQ (0, node2.balance (key2.pub));
+	node1.process_active (block1);
+	node1.block_processor.flush ();
+	node2.process_active (block1);
+	node2.block_processor.flush ();
+	ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev::genesis_key.pub));
+	ASSERT_EQ (0, node1.balance (key2.pub));
+	ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev::genesis_key.pub));
+	ASSERT_EQ (0, node2.balance (key2.pub));
+	ASSERT_TIMELY (10s, node1.balance (key2.pub) == node1.config.receive_minimum.number () && node2.balance (key2.pub) == node1.config.receive_minimum.number ());
+	ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev::genesis_key.pub));
+	ASSERT_EQ (node1.config.receive_minimum.number (), node1.balance (key2.pub));
+	ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev::genesis_key.pub));
+	ASSERT_EQ (node1.config.receive_minimum.number (), node2.balance (key2.pub));
 }
 
 TEST (network, receive_weight_change)
@@ -878,16 +791,6 @@ TEST (message_buffer_manager, many_buffers_multithreaded)
 	}
 }
 
-TEST (message_buffer_manager, stats)
-{
-	nano::stat stats;
-	nano::message_buffer_manager buffer (stats, 512, 1);
-	auto buffer1 (buffer.allocate ());
-	buffer.enqueue (buffer1);
-	buffer.allocate ();
-	ASSERT_EQ (1, stats.count (nano::stat::type::udp, nano::stat::detail::overflow));
-}
-
 TEST (tcp_listener, tcp_node_id_handshake)
 {
 	nano::test::system system (1);
@@ -977,35 +880,6 @@ TEST (tcp_listener, tcp_listener_timeout_node_id_handshake)
 	}
 }
 
-TEST (network, replace_port)
-{
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	node_flags.disable_ongoing_telemetry_requests = true;
-	node_flags.disable_initial_telemetry_requests = true;
-	nano::node_config node0_config (nano::test::get_available_port (), system.logging);
-	node0_config.io_threads = 8;
-	auto node0 = system.add_node (node0_config, node_flags);
-	ASSERT_EQ (0, node0->network.size ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
-	node1->start ();
-	system.nodes.push_back (node1);
-	auto wrong_endpoint = nano::endpoint (node1->network.endpoint ().address (), nano::test_node_port ());
-	auto channel0 (node0->network.udp_channels.insert (wrong_endpoint, node1->network_params.network.protocol_version));
-	ASSERT_NE (nullptr, channel0);
-	node0->network.udp_channels.modify (channel0, [&node1] (std::shared_ptr<nano::transport::channel> const & channel_a) {
-		channel_a->set_node_id (node1->node_id.pub);
-	});
-	auto peers_list (node0->network.list (std::numeric_limits<size_t>::max ()));
-	ASSERT_EQ (peers_list[0]->get_node_id (), node1->node_id.pub);
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node1->network_params.network.protocol_version));
-	ASSERT_EQ (node0->network.udp_channels.size (), 1);
-	node0->network.send_keepalive (channel1);
-	// On handshake, the channel is replaced
-	ASSERT_TIMELY (5s, !node0->network.udp_channels.channel (wrong_endpoint) && node0->network.udp_channels.channel (node1->network.endpoint ()));
-}
-
 // Test disabled because it's failing repeatedly for Windows + LMDB.
 // PR in which it got disabled: https://github.com/nanocurrency/nano-node/pull/3622
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3621
@@ -1056,27 +930,23 @@ namespace transport
 }
 }
 
+// Send two publish messages and asserts that the duplication is detected.
 TEST (network, duplicate_detection)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
 	auto & node0 (*system.add_node (node_flags));
 	auto & node1 (*system.add_node (node_flags));
-	auto udp_channel (std::make_shared<nano::transport::channel_udp> (node0.network.udp_channels, node1.network.endpoint (), node1.network_params.network.protocol_version));
 	nano::publish publish{ nano::dev::network_params.network, nano::dev::genesis };
 
-	// Publish duplicate detection through UDP
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish));
-	udp_channel->send (publish);
-	udp_channel->send (publish);
-	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 1);
 
 	// Publish duplicate detection through TCP
 	auto tcp_channel (node0.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node1.network.endpoint ())));
-	ASSERT_EQ (1, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish));
 	tcp_channel->send (publish);
-	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 2);
+	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 0);
+	tcp_channel->send (publish);
+	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 1);
 }
 
 TEST (network, duplicate_revert_publish)
@@ -1122,39 +992,45 @@ TEST (network, bandwidth_limiter)
 	node_config.bandwidth_limit = message_limit * message_size;
 	node_config.bandwidth_limit_burst_ratio = 1.0;
 	auto & node = *system.add_node (node_config);
-	auto channel1 (node.network.udp_channels.create (node.network.endpoint ()));
-	auto channel2 (node.network.udp_channels.create (node.network.endpoint ()));
+
+	// Another node instance just for the inproc channels.
+	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	other_node->start ();
+	system.nodes.push_back (other_node);
+
+	nano::transport::inproc::channel channel1{ node, *other_node };
+	nano::transport::inproc::channel channel2{ node, *other_node };
 	// Send droppable messages
 	for (auto i = 0; i < message_limit; i += 2) // number of channels
 	{
-		channel1->send (message);
-		channel2->send (message);
+		channel1.send (message);
+		channel2.send (message);
 	}
 	// Only sent messages below limit, so we don't expect any drops
 	ASSERT_TIMELY (1s, 0 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// Send droppable message; drop stats should increase by one now
-	channel1->send (message);
+	channel1.send (message);
 	ASSERT_TIMELY (1s, 1 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// Send non-droppable message, i.e. drop stats should not increase
-	channel2->send (message, nullptr, nano::buffer_drop_policy::no_limiter_drop);
+	channel2.send (message, nullptr, nano::buffer_drop_policy::no_limiter_drop);
 	ASSERT_TIMELY (1s, 1 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// change the bandwidth settings, 2 packets will be dropped
 	node.network.set_bandwidth_params (1.1, message_size * 2);
-	channel1->send (message);
-	channel2->send (message);
-	channel1->send (message);
-	channel2->send (message);
+	channel1.send (message);
+	channel2.send (message);
+	channel1.send (message);
+	channel2.send (message);
 	ASSERT_TIMELY (1s, 3 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// change the bandwidth settings, no packet will be dropped
 	node.network.set_bandwidth_params (4, message_size);
-	channel1->send (message);
-	channel2->send (message);
-	channel1->send (message);
-	channel2->send (message);
+	channel1.send (message);
+	channel2.send (message);
+	channel1.send (message);
+	channel2.send (message);
 	ASSERT_TIMELY (1s, 3 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	node.stop ();
@@ -1327,11 +1203,6 @@ TEST (network, cleanup_purge)
 	ASSERT_EQ (0, node1.network.size ());
 	node1.network.cleanup (test_start);
 	ASSERT_EQ (0, node1.network.size ());
-
-	node1.network.udp_channels.insert (node2->network.endpoint (), node1.network_params.network.protocol_version);
-	ASSERT_EQ (1, node1.network.size ());
-	node1.network.cleanup (test_start);
-	ASSERT_EQ (1, node1.network.size ());
 
 	node1.network.cleanup (std::chrono::steady_clock::now ());
 	ASSERT_EQ (0, node1.network.size ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -533,27 +533,6 @@ TEST (node, unlock_search)
 	ASSERT_TIMELY (10s, !node->balance (key2.pub).is_zero ());
 }
 
-// TODO: This test isn't applicable to the TCP channels, should be removed with UDP support.
-TEST (node, connect_after_junk)
-{
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto node0 = system.add_node (node_flags);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
-	std::vector<uint8_t> junk_buffer;
-	junk_buffer.push_back (0);
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.network.protocol_version));
-	channel1->send_buffer (nano::shared_const_buffer (std::move (junk_buffer)), [] (boost::system::error_code const &, size_t) {});
-	ASSERT_TIMELY (10s, node0->stats.count (nano::stat::type::error) != 0);
-	node1->start ();
-	system.nodes.push_back (node1);
-	auto channel2 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.network.protocol_version));
-	node1->network.send_keepalive (channel2);
-	ASSERT_TIMELY (10s, !node1->network.empty ());
-	node1->stop ();
-}
-
 TEST (node, working)
 {
 	auto path (nano::working_path ());
@@ -597,81 +576,6 @@ TEST (node_config, random_rep)
 	nano::node_config config1 (100, logging1);
 	auto rep (config1.random_representative ());
 	ASSERT_NE (config1.preconfigured_representatives.end (), std::find (config1.preconfigured_representatives.begin (), config1.preconfigured_representatives.end (), rep));
-}
-
-// TODO: Remove this test with UDP support, it tests UDP works when the TCP is disabled
-TEST (node_flags, disable_tcp_realtime)
-{
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto node1 = system.add_node (node_flags);
-	node_flags.disable_tcp_realtime = true;
-	auto node2 = system.add_node (node_flags);
-	ASSERT_EQ (1, node1->network.size ());
-	auto list1 (node1->network.list (2));
-	ASSERT_EQ (node2->network.endpoint (), list1[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::udp, list1[0]->get_type ());
-	ASSERT_EQ (1, node2->network.size ());
-	auto list2 (node2->network.list (2));
-	ASSERT_EQ (node1->network.endpoint (), list2[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::udp, list2[0]->get_type ());
-}
-
-// TODO: Remove this test with UDP support, it tests UDP works when the TCP is disabled
-TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
-{
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto node1 = system.add_node (node_flags);
-	node_flags.disable_tcp_realtime = true;
-	node_flags.disable_bootstrap_listener = true;
-	auto node2 = system.add_node (node_flags);
-	ASSERT_EQ (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->bootstrap.endpoint ());
-	ASSERT_NE (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.endpoint ());
-	ASSERT_EQ (1, node1->network.size ());
-	auto list1 (node1->network.list (2));
-	ASSERT_EQ (node2->network.endpoint (), list1[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::udp, list1[0]->get_type ());
-	ASSERT_EQ (1, node2->network.size ());
-	auto list2 (node2->network.list (2));
-	ASSERT_EQ (node1->network.endpoint (), list2[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::udp, list2[0]->get_type ());
-}
-
-// UDP is disabled by default
-// TODO: Remove this test with UDP support, it tests UDP works when the TCP is disabled
-TEST (node_flags, disable_udp)
-{
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto node1 = system.add_node (node_flags);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::test::get_available_port (), system.logging), system.work));
-	system.nodes.push_back (node2);
-	node2->start ();
-	ASSERT_EQ (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.udp_channels.get_local_endpoint ());
-	ASSERT_NE (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.endpoint ());
-	// Send UDP message
-	auto channel (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node2->network.endpoint (), node2->network_params.network.protocol_version));
-	node1->network.send_keepalive (channel);
-	std::this_thread::sleep_for (std::chrono::milliseconds (500));
-	// Check empty network
-	ASSERT_EQ (0, node1->network.size ());
-	ASSERT_EQ (0, node2->network.size ());
-	// Send TCP handshake
-	node1->network.merge_peer (node2->network.endpoint ());
-	ASSERT_TIMELY (5s, node1->bootstrap.realtime_count == 1 && node2->bootstrap.realtime_count == 1);
-	ASSERT_EQ (1, node1->network.size ());
-	auto list1 (node1->network.list (2));
-	ASSERT_EQ (node2->network.endpoint (), list1[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::tcp, list1[0]->get_type ());
-	ASSERT_EQ (1, node2->network.size ());
-	auto list2 (node2->network.list (2));
-	ASSERT_EQ (node1->network.endpoint (), list2[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::tcp, list2[0]->get_type ());
-	node2->stop ();
 }
 
 TEST (node, fork_publish)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/variant.hpp>
+#include <boost/optional.hpp>
 
 #include <fstream>
 #include <numeric>
@@ -368,7 +368,14 @@ TEST (node, receive_gap)
 				 .build_shared ();
 	node1.work_generate_blocking (*block);
 	nano::publish message{ nano::dev::network_params.network, block };
-	node1.network.inbound (message, node1.network.udp_channels.create (node1.network.endpoint ()));
+
+	// Another node instance just to be a tcp client for channel1.
+	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	other_node->start ();
+	system.nodes.push_back (other_node);
+
+	auto channel1 = nano::test::establish_tcp (system, *other_node, node1.network.endpoint ());
+	node1.network.inbound (message, channel1);
 	node1.block_processor.flush ();
 	ASSERT_EQ (1, node1.gap_cache.size ());
 }
@@ -526,6 +533,7 @@ TEST (node, unlock_search)
 	ASSERT_TIMELY (10s, !node->balance (key2.pub).is_zero ());
 }
 
+// TODO: This test isn't applicable to the TCP channels, should be removed with UDP support.
 TEST (node, connect_after_junk)
 {
 	nano::test::system system;
@@ -591,6 +599,7 @@ TEST (node_config, random_rep)
 	ASSERT_NE (config1.preconfigured_representatives.end (), std::find (config1.preconfigured_representatives.begin (), config1.preconfigured_representatives.end (), rep));
 }
 
+// TODO: Remove this test with UDP support, it tests UDP works when the TCP is disabled
 TEST (node_flags, disable_tcp_realtime)
 {
 	nano::test::system system;
@@ -609,6 +618,7 @@ TEST (node_flags, disable_tcp_realtime)
 	ASSERT_EQ (nano::transport::transport_type::udp, list2[0]->get_type ());
 }
 
+// TODO: Remove this test with UDP support, it tests UDP works when the TCP is disabled
 TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 {
 	nano::test::system system;
@@ -631,6 +641,7 @@ TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 }
 
 // UDP is disabled by default
+// TODO: Remove this test with UDP support, it tests UDP works when the TCP is disabled
 TEST (node_flags, disable_udp)
 {
 	nano::test::system system;
@@ -801,6 +812,7 @@ TEST (node, fork_keep)
 	ASSERT_TRUE (node2.store.block.exists (transaction1, send1->hash ()));
 }
 
+// TODO: Fix failing test
 TEST (node, fork_flip)
 {
 	nano::test::system system (2);
@@ -826,11 +838,23 @@ TEST (node, fork_flip)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	nano::publish publish2{ nano::dev::network_params.network, send2 };
-	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
+
+	// Dangling node instance just to be a tcp client for channel1.
+	auto outer_node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node1->start ();
+	system.nodes.push_back (outer_node1);
+
+	auto channel1 = nano::test::establish_tcp (system, *outer_node1, node1.network.endpoint ());
 	node1.network.inbound (publish1, channel1);
 	node1.block_processor.flush ();
 	node1.scheduler.flush ();
-	auto channel2 (node2.network.udp_channels.create (node1.network.endpoint ()));
+
+	// Dangling node instance just to be a tcp client for channel2.
+	auto outer_node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node2->start ();
+	system.nodes.push_back (outer_node2);
+
+	auto channel2 = nano::test::establish_tcp (system, *outer_node2, node1.network.endpoint ());
 	node2.network.inbound (publish2, channel2);
 	node2.block_processor.flush ();
 	node2.scheduler.flush ();
@@ -857,80 +881,82 @@ TEST (node, fork_flip)
 
 TEST (node, fork_multi_flip)
 {
-	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
-	for (auto & type : types)
-	{
-		nano::test::system system;
-		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::udp)
-		{
-			node_flags.disable_tcp_realtime = true;
-			node_flags.disable_bootstrap_listener = true;
-			node_flags.disable_udp = false;
-		}
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
-		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-		auto & node1 (*system.add_node (node_config, node_flags, type));
-		node_config.peering_port = nano::test::get_available_port ();
-		auto & node2 (*system.add_node (node_config, node_flags, type));
-		ASSERT_EQ (1, node1.network.size ());
-		nano::keypair key1;
-		nano::send_block_builder builder;
-		auto send1 = builder.make_block ()
-					 .previous (nano::dev::genesis->hash ())
-					 .destination (key1.pub)
-					 .balance (nano::dev::constants.genesis_amount - 100)
-					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					 .work (*system.work.generate (nano::dev::genesis->hash ()))
-					 .build_shared ();
-		nano::publish publish1{ nano::dev::network_params.network, send1 };
-		nano::keypair key2;
-		auto send2 = builder.make_block ()
-					 .previous (nano::dev::genesis->hash ())
-					 .destination (key2.pub)
-					 .balance (nano::dev::constants.genesis_amount - 100)
-					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					 .work (*system.work.generate (nano::dev::genesis->hash ()))
-					 .build_shared ();
-		nano::publish publish2{ nano::dev::network_params.network, send2 };
-		auto send3 = builder.make_block ()
-					 .previous (publish2.block->hash ())
-					 .destination (key2.pub)
-					 .balance (nano::dev::constants.genesis_amount - 100)
-					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					 .work (*system.work.generate (publish2.block->hash ()))
-					 .build_shared ();
-		nano::publish publish3{ nano::dev::network_params.network, send3 };
-		node1.network.inbound (publish1, node1.network.udp_channels.create (node1.network.endpoint ()));
-		node2.network.inbound (publish2, node2.network.udp_channels.create (node2.network.endpoint ()));
-		node2.network.inbound (publish3, node2.network.udp_channels.create (node2.network.endpoint ()));
-		node1.block_processor.flush ();
-		node1.scheduler.flush ();
-		node2.block_processor.flush ();
-		node2.scheduler.flush ();
-		ASSERT_EQ (1, node1.active.size ());
-		ASSERT_EQ (1, node2.active.size ());
-		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-		node1.network.inbound (publish2, node1.network.udp_channels.create (node1.network.endpoint ()));
-		node1.network.inbound (publish3, node1.network.udp_channels.create (node1.network.endpoint ()));
-		node1.block_processor.flush ();
-		node2.network.inbound (publish1, node2.network.udp_channels.create (node2.network.endpoint ()));
-		node2.block_processor.flush ();
-		auto election1 (node2.active.election (nano::qualified_root (nano::dev::genesis->hash (), nano::dev::genesis->hash ())));
-		ASSERT_NE (nullptr, election1);
-		ASSERT_EQ (1, election1->votes ().size ());
-		ASSERT_TRUE (node1.ledger.block_or_pruned_exists (publish1.block->hash ()));
-		ASSERT_TRUE (node2.ledger.block_or_pruned_exists (publish2.block->hash ()));
-		ASSERT_TRUE (node2.ledger.block_or_pruned_exists (publish3.block->hash ()));
-		ASSERT_TIMELY (10s, node2.ledger.block_or_pruned_exists (publish1.block->hash ()));
-		auto winner (*election1->tally ().begin ());
-		ASSERT_EQ (*publish1.block, *winner.second);
-		ASSERT_EQ (nano::dev::constants.genesis_amount - 100, winner.first);
-		ASSERT_TRUE (node1.ledger.block_or_pruned_exists (publish1.block->hash ()));
-		ASSERT_TRUE (node2.ledger.block_or_pruned_exists (publish1.block->hash ()));
-		ASSERT_FALSE (node2.ledger.block_or_pruned_exists (publish2.block->hash ()));
-		ASSERT_FALSE (node2.ledger.block_or_pruned_exists (publish3.block->hash ()));
-	}
+	auto type = nano::transport::transport_type::tcp;
+	nano::test::system system;
+	nano::node_flags node_flags;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto & node1 (*system.add_node (node_config, node_flags, type));
+	node_config.peering_port = nano::test::get_available_port ();
+	auto & node2 (*system.add_node (node_config, node_flags, type));
+	ASSERT_EQ (1, node1.network.size ());
+	nano::keypair key1;
+	nano::send_block_builder builder;
+	auto send1 = builder.make_block ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build_shared ();
+	nano::publish publish1{ nano::dev::network_params.network, send1 };
+	nano::keypair key2;
+	auto send2 = builder.make_block ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key2.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build_shared ();
+	nano::publish publish2{ nano::dev::network_params.network, send2 };
+	auto send3 = builder.make_block ()
+				 .previous (publish2.block->hash ())
+				 .destination (key2.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (publish2.block->hash ()))
+				 .build_shared ();
+	nano::publish publish3{ nano::dev::network_params.network, send3 };
+
+	auto outer_node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto outer_node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node1->start ();
+	outer_node2->start ();
+	system.nodes.push_back (outer_node1);
+	system.nodes.push_back (outer_node2);
+
+	auto channel1 = nano::test::establish_tcp (system, *outer_node1, node1.network.endpoint ());
+	auto channel2 = nano::test::establish_tcp (system, *outer_node2, node1.network.endpoint ());
+	node1.network.inbound (publish1, channel1);
+	node2.network.inbound (publish2, channel2);
+	node2.network.inbound (publish3, channel2);
+	node1.block_processor.flush ();
+	node1.scheduler.flush ();
+	node2.block_processor.flush ();
+	node2.scheduler.flush ();
+	ASSERT_EQ (1, node1.active.size ());
+	ASSERT_EQ (1, node2.active.size ());
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	node1.network.inbound (publish2, channel1);
+	node1.network.inbound (publish3, channel1);
+	node1.block_processor.flush ();
+	node2.network.inbound (publish1, channel2);
+	node2.block_processor.flush ();
+	auto election1 (node2.active.election (nano::qualified_root (nano::dev::genesis->hash (), nano::dev::genesis->hash ())));
+	ASSERT_NE (nullptr, election1);
+	ASSERT_EQ (1, election1->votes ().size ());
+	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (publish1.block->hash ()));
+	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (publish2.block->hash ()));
+	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (publish3.block->hash ()));
+	ASSERT_TIMELY (10s, node2.ledger.block_or_pruned_exists (publish1.block->hash ()));
+	auto winner (*election1->tally ().begin ());
+	ASSERT_EQ (*publish1.block, *winner.second);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, winner.first);
+	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (publish1.block->hash ()));
+	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (publish1.block->hash ()));
+	ASSERT_FALSE (node2.ledger.block_or_pruned_exists (publish2.block->hash ()));
+	ASSERT_FALSE (node2.ledger.block_or_pruned_exists (publish3.block->hash ()));
 }
 
 // Blocks that are no longer actively being voted on should be able to be evicted through bootstrapping.
@@ -999,7 +1025,10 @@ TEST (node, fork_open)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	nano::publish publish1{ nano::dev::network_params.network, send1 };
-	auto channel1 = node.network.udp_channels.create (node.network.endpoint ());
+	auto outer_node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node1->start ();
+	system.nodes.push_back (outer_node1);
+	auto channel1 = nano::test::establish_tcp (system, *outer_node1, node.network.endpoint ());
 	node.network.inbound (publish1, channel1);
 	ASSERT_TIMELY (5s, (election = node.active.election (publish1.block->qualified_root ())) != nullptr);
 	election->force_confirm ();
@@ -1265,7 +1294,8 @@ TEST (node, DISABLED_fork_stale)
 	auto & node1 (*system1.nodes[0]);
 	auto & node2 (*system2.nodes[0]);
 	node2.bootstrap_initiator.bootstrap (node1.network.endpoint (), false);
-	std::shared_ptr<nano::transport::channel> channel (std::make_shared<nano::transport::channel_udp> (node2.network.udp_channels, node1.network.endpoint (), node2.network_params.network.protocol_version));
+
+	auto channel = nano::test::establish_tcp (system1, node2, node1.network.endpoint ());
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash> ());
 	node2.rep_crawler.response (channel, vote);
 	nano::keypair key1;
@@ -1331,139 +1361,130 @@ TEST (node, DISABLED_fork_stale)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3516
 TEST (node, DISABLED_broadcast_elected)
 {
-	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
-	for (auto & type : types)
+	auto type = nano::transport::transport_type::tcp;
+	nano::node_flags node_flags;
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	auto node0 = system.add_node (node_config, node_flags, type);
+	node_config.peering_port = nano::test::get_available_port ();
+	auto node1 = system.add_node (node_config, node_flags, type);
+	node_config.peering_port = nano::test::get_available_port ();
+	auto node2 = system.add_node (node_config, node_flags, type);
+	nano::keypair rep_big;
+	nano::keypair rep_small;
+	nano::keypair rep_other;
+	nano::block_builder builder;
 	{
-		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::udp)
-		{
-			node_flags.disable_tcp_realtime = true;
-			node_flags.disable_bootstrap_listener = true;
-			node_flags.disable_udp = false;
-		}
-		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
-		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-		auto node0 = system.add_node (node_config, node_flags, type);
-		node_config.peering_port = nano::test::get_available_port ();
-		auto node1 = system.add_node (node_config, node_flags, type);
-		node_config.peering_port = nano::test::get_available_port ();
-		auto node2 = system.add_node (node_config, node_flags, type);
-		nano::keypair rep_big;
-		nano::keypair rep_small;
-		nano::keypair rep_other;
-		nano::block_builder builder;
-		{
-			auto transaction0 (node0->store.tx_begin_write ());
-			auto transaction1 (node1->store.tx_begin_write ());
-			auto transaction2 (node2->store.tx_begin_write ());
-			auto fund_big = *builder.send ()
-							 .previous (nano::dev::genesis->hash ())
-							 .destination (rep_big.pub)
-							 .balance (nano::Gxrb_ratio * 5)
-							 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							 .work (*system.work.generate (nano::dev::genesis->hash ()))
-							 .build ();
-			auto open_big = *builder.open ()
-							 .source (fund_big.hash ())
-							 .representative (rep_big.pub)
-							 .account (rep_big.pub)
-							 .sign (rep_big.prv, rep_big.pub)
-							 .work (*system.work.generate (rep_big.pub))
-							 .build ();
-			auto fund_small = *builder.send ()
-							   .previous (fund_big.hash ())
-							   .destination (rep_small.pub)
-							   .balance (nano::Gxrb_ratio * 2)
-							   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							   .work (*system.work.generate (fund_big.hash ()))
-							   .build ();
-			auto open_small = *builder.open ()
-							   .source (fund_small.hash ())
-							   .representative (rep_small.pub)
-							   .account (rep_small.pub)
-							   .sign (rep_small.prv, rep_small.pub)
-							   .work (*system.work.generate (rep_small.pub))
-							   .build ();
-			auto fund_other = *builder.send ()
-							   .previous (fund_small.hash ())
-							   .destination (rep_other.pub)
-							   .balance (nano::Gxrb_ratio)
-							   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-							   .work (*system.work.generate (fund_small.hash ()))
-							   .build ();
-			auto open_other = *builder.open ()
-							   .source (fund_other.hash ())
-							   .representative (rep_other.pub)
-							   .account (rep_other.pub)
-							   .sign (rep_other.prv, rep_other.pub)
-							   .work (*system.work.generate (rep_other.pub))
-							   .build ();
-			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_big).code);
-			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_big).code);
-			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_big).code);
-			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, open_big).code);
-			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, open_big).code);
-			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, open_big).code);
-			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_small).code);
-			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_small).code);
-			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_small).code);
-			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, open_small).code);
-			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, open_small).code);
-			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, open_small).code);
-			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_other).code);
-			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_other).code);
-			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_other).code);
-			ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, open_other).code);
-			ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, open_other).code);
-			ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, open_other).code);
-		}
-		// Confirm blocks to allow voting
-		for (auto & node : system.nodes)
-		{
-			auto block (node->block (node->latest (nano::dev::genesis_key.pub)));
-			ASSERT_NE (nullptr, block);
-			node->block_confirm (block);
-			auto election (node->active.election (block->qualified_root ()));
-			ASSERT_NE (nullptr, election);
-			election->force_confirm ();
-			ASSERT_TIMELY (5s, 4 == node->ledger.cache.cemented_count)
-		}
-
-		system.wallet (0)->insert_adhoc (rep_big.prv);
-		system.wallet (1)->insert_adhoc (rep_small.prv);
-		system.wallet (2)->insert_adhoc (rep_other.prv);
-		auto fork0 = builder.send ()
-					 .previous (node2->latest (nano::dev::genesis_key.pub))
-					 .destination (rep_small.pub)
-					 .balance (0)
-					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					 .work (*node0->work_generate_blocking (node2->latest (nano::dev::genesis_key.pub)))
-					 .build_shared ();
-		// A copy is necessary to avoid data races during ledger processing, which sets the sideband
-		auto fork0_copy (std::make_shared<nano::send_block> (*fork0));
-		node0->process_active (fork0);
-		node1->process_active (fork0_copy);
-		auto fork1 = builder.send ()
-					 .previous (node2->latest (nano::dev::genesis_key.pub))
-					 .destination (rep_big.pub)
-					 .balance (0)
-					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					 .work (*node0->work_generate_blocking (node2->latest (nano::dev::genesis_key.pub)))
-					 .build_shared ();
-		system.wallet (2)->insert_adhoc (rep_small.prv);
-		node2->process_active (fork1);
-		ASSERT_TIMELY (10s, node0->ledger.block_or_pruned_exists (fork0->hash ()) && node1->ledger.block_or_pruned_exists (fork0->hash ()));
-		system.deadline_set (50s);
-		while (!node2->ledger.block_or_pruned_exists (fork0->hash ()))
-		{
-			auto ec = system.poll ();
-			ASSERT_TRUE (node0->ledger.block_or_pruned_exists (fork0->hash ()));
-			ASSERT_TRUE (node1->ledger.block_or_pruned_exists (fork0->hash ()));
-			ASSERT_NO_ERROR (ec);
-		}
-		ASSERT_TIMELY (5s, node1->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out) != 0);
+		auto transaction0 (node0->store.tx_begin_write ());
+		auto transaction1 (node1->store.tx_begin_write ());
+		auto transaction2 (node2->store.tx_begin_write ());
+		auto fund_big = *builder.send ()
+						 .previous (nano::dev::genesis->hash ())
+						 .destination (rep_big.pub)
+						 .balance (nano::Gxrb_ratio * 5)
+						 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						 .work (*system.work.generate (nano::dev::genesis->hash ()))
+						 .build ();
+		auto open_big = *builder.open ()
+						 .source (fund_big.hash ())
+						 .representative (rep_big.pub)
+						 .account (rep_big.pub)
+						 .sign (rep_big.prv, rep_big.pub)
+						 .work (*system.work.generate (rep_big.pub))
+						 .build ();
+		auto fund_small = *builder.send ()
+						   .previous (fund_big.hash ())
+						   .destination (rep_small.pub)
+						   .balance (nano::Gxrb_ratio * 2)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*system.work.generate (fund_big.hash ()))
+						   .build ();
+		auto open_small = *builder.open ()
+						   .source (fund_small.hash ())
+						   .representative (rep_small.pub)
+						   .account (rep_small.pub)
+						   .sign (rep_small.prv, rep_small.pub)
+						   .work (*system.work.generate (rep_small.pub))
+						   .build ();
+		auto fund_other = *builder.send ()
+						   .previous (fund_small.hash ())
+						   .destination (rep_other.pub)
+						   .balance (nano::Gxrb_ratio)
+						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+						   .work (*system.work.generate (fund_small.hash ()))
+						   .build ();
+		auto open_other = *builder.open ()
+						   .source (fund_other.hash ())
+						   .representative (rep_other.pub)
+						   .account (rep_other.pub)
+						   .sign (rep_other.prv, rep_other.pub)
+						   .work (*system.work.generate (rep_other.pub))
+						   .build ();
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_big).code);
+		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_big).code);
+		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_big).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, open_big).code);
+		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, open_big).code);
+		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, open_big).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_small).code);
+		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_small).code);
+		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_small).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, open_small).code);
+		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, open_small).code);
+		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, open_small).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, fund_other).code);
+		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, fund_other).code);
+		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, fund_other).code);
+		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction0, open_other).code);
+		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction1, open_other).code);
+		ASSERT_EQ (nano::process_result::progress, node2->ledger.process (transaction2, open_other).code);
 	}
+	// Confirm blocks to allow voting
+	for (auto & node : system.nodes)
+	{
+		auto block (node->block (node->latest (nano::dev::genesis_key.pub)));
+		ASSERT_NE (nullptr, block);
+		node->block_confirm (block);
+		auto election (node->active.election (block->qualified_root ()));
+		ASSERT_NE (nullptr, election);
+		election->force_confirm ();
+		ASSERT_TIMELY (5s, 4 == node->ledger.cache.cemented_count)
+	}
+
+	system.wallet (0)->insert_adhoc (rep_big.prv);
+	system.wallet (1)->insert_adhoc (rep_small.prv);
+	system.wallet (2)->insert_adhoc (rep_other.prv);
+	auto fork0 = builder.send ()
+				 .previous (node2->latest (nano::dev::genesis_key.pub))
+				 .destination (rep_small.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node0->work_generate_blocking (node2->latest (nano::dev::genesis_key.pub)))
+				 .build_shared ();
+	// A copy is necessary to avoid data races during ledger processing, which sets the sideband
+	auto fork0_copy (std::make_shared<nano::send_block> (*fork0));
+	node0->process_active (fork0);
+	node1->process_active (fork0_copy);
+	auto fork1 = builder.send ()
+				 .previous (node2->latest (nano::dev::genesis_key.pub))
+				 .destination (rep_big.pub)
+				 .balance (0)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node0->work_generate_blocking (node2->latest (nano::dev::genesis_key.pub)))
+				 .build_shared ();
+	system.wallet (2)->insert_adhoc (rep_small.prv);
+	node2->process_active (fork1);
+	ASSERT_TIMELY (10s, node0->ledger.block_or_pruned_exists (fork0->hash ()) && node1->ledger.block_or_pruned_exists (fork0->hash ()));
+	system.deadline_set (50s);
+	while (!node2->ledger.block_or_pruned_exists (fork0->hash ()))
+	{
+		auto ec = system.poll ();
+		ASSERT_TRUE (node0->ledger.block_or_pruned_exists (fork0->hash ()));
+		ASSERT_TRUE (node1->ledger.block_or_pruned_exists (fork0->hash ()));
+		ASSERT_NO_ERROR (ec);
+	}
+	ASSERT_TIMELY (5s, node1->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out) != 0);
 }
 
 TEST (node, rep_self_vote)
@@ -1865,6 +1886,7 @@ TEST (node, rep_weight)
 	ASSERT_TRUE (node.rep_crawler.is_pr (*channel3));
 }
 
+// TODO: test written for UDP, should be rewritten or deleted if unuseful
 TEST (node, rep_remove)
 {
 	nano::test::system system;
@@ -2200,46 +2222,37 @@ TEST (node, online_reps_election)
 
 TEST (node, block_confirm)
 {
-	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
-	for (auto & type : types)
-	{
-		nano::node_flags node_flags;
-		if (type == nano::transport::transport_type::udp)
-		{
-			node_flags.disable_tcp_realtime = true;
-			node_flags.disable_bootstrap_listener = true;
-			node_flags.disable_udp = false;
-		}
-		nano::test::system system (2, type, node_flags);
-		auto & node1 (*system.nodes[0]);
-		auto & node2 (*system.nodes[1]);
-		nano::keypair key;
-		nano::state_block_builder builder;
-		system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
-		auto send1 = builder.make_block ()
-					 .account (nano::dev::genesis_key.pub)
-					 .previous (nano::dev::genesis->hash ())
-					 .representative (nano::dev::genesis_key.pub)
-					 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
-					 .link (key.pub)
-					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					 .work (*node1.work_generate_blocking (nano::dev::genesis->hash ()))
-					 .build_shared ();
-		// A copy is necessary to avoid data races during ledger processing, which sets the sideband
-		auto send1_copy = builder.make_block ()
-						  .from (*send1)
-						  .build_shared ();
-		node1.block_processor.add (send1);
-		node2.block_processor.add (send1_copy);
-		ASSERT_TIMELY (5s, node1.ledger.block_or_pruned_exists (send1->hash ()) && node2.ledger.block_or_pruned_exists (send1_copy->hash ()));
-		ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ()));
-		ASSERT_TRUE (node2.ledger.block_or_pruned_exists (send1_copy->hash ()));
-		// Confirm send1 on node2 so it can vote for send2
-		node2.block_confirm (send1_copy);
-		auto election = node2.active.election (send1_copy->qualified_root ());
-		ASSERT_NE (nullptr, election);
-		ASSERT_TIMELY (10s, node1.active.recently_cemented.list ().size () == 1);
-	}
+	auto type = nano::transport::transport_type::tcp;
+	nano::node_flags node_flags;
+	nano::test::system system (2, type, node_flags);
+	auto & node1 (*system.nodes[0]);
+	auto & node2 (*system.nodes[1]);
+	nano::keypair key;
+	nano::state_block_builder builder;
+	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
+	auto send1 = builder.make_block ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*node1.work_generate_blocking (nano::dev::genesis->hash ()))
+				 .build_shared ();
+	// A copy is necessary to avoid data races during ledger processing, which sets the sideband
+	auto send1_copy = builder.make_block ()
+					  .from (*send1)
+					  .build_shared ();
+	node1.block_processor.add (send1);
+	node2.block_processor.add (send1_copy);
+	ASSERT_TIMELY (5s, node1.ledger.block_or_pruned_exists (send1->hash ()) && node2.ledger.block_or_pruned_exists (send1_copy->hash ()));
+	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ()));
+	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (send1_copy->hash ()));
+	// Confirm send1 on node2 so it can vote for send2
+	node2.block_confirm (send1_copy);
+	auto election = node2.active.election (send1_copy->qualified_root ());
+	ASSERT_NE (nullptr, election);
+	ASSERT_TIMELY (10s, node1.active.recently_cemented.list ().size () == 1);
 }
 
 TEST (node, block_arrival)
@@ -2364,7 +2377,12 @@ TEST (node, local_votes_cache)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::confirm_req message1{ nano::dev::network_params.network, send1 };
 	nano::confirm_req message2{ nano::dev::network_params.network, send2 };
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
+
+	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	other_node->start ();
+	system.nodes.push_back (other_node);
+
+	auto channel = nano::test::establish_tcp (system, *other_node, node.network.endpoint ());
 	node.network.inbound (message1, channel);
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 1);
 	node.network.inbound (message2, channel);
@@ -2395,9 +2413,9 @@ TEST (node, local_votes_cache)
 		ASSERT_NO_ERROR (system.poll (node.aggregator.max_delay));
 	}
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 3);
-	ASSERT_FALSE (node.history.votes (send1->root (), send1->hash ()).empty ());
-	ASSERT_FALSE (node.history.votes (send2->root (), send2->hash ()).empty ());
-	ASSERT_FALSE (node.history.votes (send3->root (), send3->hash ()).empty ());
+	ASSERT_TIMELY (3s, !node.history.votes (send1->root (), send1->hash ()).empty ());
+	ASSERT_TIMELY (3s, !node.history.votes (send2->root (), send2->hash ()).empty ());
+	ASSERT_TIMELY (3s, !node.history.votes (send3->root (), send3->hash ()).empty ());
 }
 
 // Test disabled because it's failing intermittently.
@@ -2446,7 +2464,10 @@ TEST (node, DISABLED_local_votes_cache_batch)
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *receive1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> batch{ { send2->hash (), send2->root () }, { receive1->hash (), receive1->root () } };
 	nano::confirm_req message{ nano::dev::network_params.network, batch };
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
+	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	other_node->start ();
+	system.nodes.push_back (other_node);
+	auto channel = nano::test::establish_tcp (system, *other_node, node.network.endpoint ());
 	// Generates and sends one vote for both hashes which is then cached
 	node.network.inbound (message, channel);
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 1);
@@ -2481,7 +2502,10 @@ TEST (node, local_votes_cache_generate_new_vote)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Repsond with cached vote
 	nano::confirm_req message1{ nano::dev::network_params.network, nano::dev::genesis };
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
+	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	other_node->start ();
+	system.nodes.push_back (other_node);
+	auto channel = nano::test::establish_tcp (system, *other_node, node.network.endpoint ());
 	node.network.inbound (message1, channel);
 	ASSERT_TIMELY (3s, !node.history.votes (nano::dev::genesis->root (), nano::dev::genesis->hash ()).empty ());
 	auto votes1 (node.history.votes (nano::dev::genesis->root (), nano::dev::genesis->hash ()));
@@ -2909,7 +2933,12 @@ TEST (node, fork_election_invalid_block_signature)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .sign (nano::dev::genesis_key.prv, 0) // Invalid signature
 				 .build_shared ();
-	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
+
+	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	other_node->start ();
+	system.nodes.push_back (other_node);
+
+	auto channel1 = nano::test::establish_tcp (system, *other_node, node1.network.endpoint ());
 	node1.network.inbound (nano::publish{ nano::dev::network_params.network, send1 }, channel1);
 	ASSERT_TIMELY (5s, node1.active.active (send1->qualified_root ()));
 	auto election (node1.active.election (send1->qualified_root ()));
@@ -3673,7 +3702,10 @@ TEST (node, rollback_vote_self)
 		ASSERT_TRUE (node.history.votes (send2->root (), send2->hash ()).empty ());
 		ASSERT_TRUE (node.history.votes (fork->root (), fork->hash ()).empty ());
 		auto & node2 = *system.add_node ();
-		auto channel (node.network.udp_channels.create (node2.network.endpoint ()));
+		auto outer_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+		outer_node->start ();
+		system.nodes.push_back (outer_node);
+		auto channel = nano::test::establish_tcp (system, *outer_node, node2.network.endpoint ());
 		node.aggregator.add (channel, { { send2->hash (), send2->root () } });
 		ASSERT_TIMELY (5s, !node.history.votes (fork->root (), fork->hash ()).empty ());
 		ASSERT_TRUE (node.history.votes (send2->root (), send2->hash ()).empty ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1875,108 +1875,122 @@ TEST (node, rep_weight)
 	ASSERT_TRUE (node.rep_crawler.is_pr (*channel3));
 }
 
-// TODO: test written for UDP, should be rewritten or deleted if unuseful
+// Test that rep_crawler removes unreachable reps from its search results.
+// This test creates three principal representatives (rep1, rep2, genesis_rep) and
+// one node for searching them (searching_node).
 TEST (node, rep_remove)
 {
 	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	auto & node = *system.add_node (node_flags);
-	nano::keypair keypair1;
-	nano::keypair keypair2;
+	auto & searching_node = *system.add_node (); // will be used to find principal representatives
+	nano::keypair keys_rep1; // Principal representative 1
+	nano::keypair keys_rep2; // Principal representative 2
 	nano::block_builder builder;
-	std::shared_ptr<nano::block> block1 = builder
-										  .state ()
-										  .account (nano::dev::genesis_key.pub)
-										  .previous (nano::dev::genesis->hash ())
-										  .representative (nano::dev::genesis_key.pub)
-										  .balance (nano::dev::constants.genesis_amount - node.minimum_principal_weight () * 2)
-										  .link (keypair1.pub)
-										  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-										  .work (*system.work.generate (nano::dev::genesis->hash ()))
-										  .build ();
-	std::shared_ptr<nano::block> block2 = builder
-										  .state ()
-										  .account (keypair1.pub)
-										  .previous (0)
-										  .representative (keypair1.pub)
-										  .balance (node.minimum_principal_weight () * 2)
-										  .link (block1->hash ())
-										  .sign (keypair1.prv, keypair1.pub)
-										  .work (*system.work.generate (keypair1.pub))
-										  .build ();
-	std::shared_ptr<nano::block> block3 = builder
-										  .state ()
-										  .account (nano::dev::genesis_key.pub)
-										  .previous (block1->hash ())
-										  .representative (nano::dev::genesis_key.pub)
-										  .balance (nano::dev::constants.genesis_amount - node.minimum_principal_weight () * 4)
-										  .link (keypair2.pub)
-										  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-										  .work (*system.work.generate (block1->hash ()))
-										  .build ();
-	std::shared_ptr<nano::block> block4 = builder
-										  .state ()
-										  .account (keypair2.pub)
-										  .previous (0)
-										  .representative (keypair2.pub)
-										  .balance (node.minimum_principal_weight () * 2)
-										  .link (block3->hash ())
-										  .sign (keypair2.prv, keypair2.pub)
-										  .work (*system.work.generate (keypair2.pub))
-										  .build ();
+
+	// Send enough nanos to Rep1 to make it a principal representative
+	std::shared_ptr<nano::block> send_to_rep1 = builder
+												.state ()
+												.account (nano::dev::genesis_key.pub)
+												.previous (nano::dev::genesis->hash ())
+												.representative (nano::dev::genesis_key.pub)
+												.balance (nano::dev::constants.genesis_amount - searching_node.minimum_principal_weight () * 2)
+												.link (keys_rep1.pub)
+												.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+												.work (*system.work.generate (nano::dev::genesis->hash ()))
+												.build ();
+
+	// Receive by Rep1
+	std::shared_ptr<nano::block> receive_rep1 = builder
+												.state ()
+												.account (keys_rep1.pub)
+												.previous (0)
+												.representative (keys_rep1.pub)
+												.balance (searching_node.minimum_principal_weight () * 2)
+												.link (send_to_rep1->hash ())
+												.sign (keys_rep1.prv, keys_rep1.pub)
+												.work (*system.work.generate (keys_rep1.pub))
+												.build ();
+
+	// Send enough nanos to Rep2 to make it a principal representative
+	std::shared_ptr<nano::block> send_to_rep2 = builder
+												.state ()
+												.account (nano::dev::genesis_key.pub)
+												.previous (send_to_rep1->hash ())
+												.representative (nano::dev::genesis_key.pub)
+												.balance (nano::dev::constants.genesis_amount - searching_node.minimum_principal_weight () * 4)
+												.link (keys_rep2.pub)
+												.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+												.work (*system.work.generate (send_to_rep1->hash ()))
+												.build ();
+
+	// Receive by Rep2
+	std::shared_ptr<nano::block> receive_rep2 = builder
+												.state ()
+												.account (keys_rep2.pub)
+												.previous (0)
+												.representative (keys_rep2.pub)
+												.balance (searching_node.minimum_principal_weight () * 2)
+												.link (send_to_rep2->hash ())
+												.sign (keys_rep2.prv, keys_rep2.pub)
+												.work (*system.work.generate (keys_rep2.pub))
+												.build ();
 	{
-		auto transaction = node.store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block1).code);
-		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block2).code);
-		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block3).code);
-		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block4).code);
+		auto transaction = searching_node.store.tx_begin_write ();
+		ASSERT_EQ (nano::process_result::progress, searching_node.ledger.process (transaction, *send_to_rep1).code);
+		ASSERT_EQ (nano::process_result::progress, searching_node.ledger.process (transaction, *receive_rep1).code);
+		ASSERT_EQ (nano::process_result::progress, searching_node.ledger.process (transaction, *send_to_rep2).code);
+		ASSERT_EQ (nano::process_result::progress, searching_node.ledger.process (transaction, *receive_rep2).code);
 	}
-	// Add inactive UDP representative channel
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
-	std::shared_ptr<nano::transport::channel> channel0 (std::make_shared<nano::transport::channel_udp> (node.network.udp_channels, endpoint0, node.network_params.network.protocol_version));
-	auto channel_udp = node.network.udp_channels.insert (endpoint0, node.network_params.network.protocol_version);
-	ASSERT_NE (channel_udp, nullptr);
-	auto vote1 = std::make_shared<nano::vote> (keypair1.pub, keypair1.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-	ASSERT_FALSE (node.rep_crawler.response (channel0, vote1));
-	ASSERT_TIMELY (5s, node.rep_crawler.representative_count () == 1);
-	auto reps (node.rep_crawler.representatives (1));
+
+	// Create inactive TCP channel for Rep1
+	std::shared_ptr<nano::transport::channel> channel_rep1 (std::make_shared<nano::transport::channel_tcp> (searching_node, std::weak_ptr<nano::socket> ()));
+
+	// Ensure Rep1 is found by the rep_crawler after receiving a vote from it
+	auto vote_rep1 = std::make_shared<nano::vote> (keys_rep1.pub, keys_rep1.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
+	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep1, vote_rep1));
+	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 1);
+	auto reps (searching_node.rep_crawler.representatives (1));
 	ASSERT_EQ (1, reps.size ());
-	ASSERT_EQ (node.minimum_principal_weight () * 2, reps[0].weight.number ());
-	ASSERT_EQ (keypair1.pub, reps[0].account);
-	ASSERT_EQ (*channel0, reps[0].channel_ref ());
-	// Modify last_packet_received so the channel is removed faster
-	std::chrono::steady_clock::time_point fake_timepoint{};
-	node.network.udp_channels.modify (channel_udp, [fake_timepoint] (std::shared_ptr<nano::transport::channel_udp> const & channel_a) {
-		channel_a->set_last_packet_received (fake_timepoint);
-	});
-	// This UDP channel is not reachable and should timeout
-	ASSERT_EQ (1, node.rep_crawler.representative_count ());
-	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 0);
-	// Add working representative
-	auto node1 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
+	ASSERT_EQ (searching_node.minimum_principal_weight () * 2, reps[0].weight.number ());
+	ASSERT_EQ (keys_rep1.pub, reps[0].account);
+	ASSERT_EQ (*channel_rep1, reps[0].channel_ref ());
+
+	// channel_rep1 is not reachable and should time out
+	ASSERT_EQ (1, searching_node.rep_crawler.representative_count ());
+	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 0);
+
+	// Add working node for genesis representative
+	auto node_genesis_rep = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto channel1 (node.network.find_channel (node1->network.endpoint ()));
-	ASSERT_NE (nullptr, channel1);
-	auto vote2 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-	node.rep_crawler.response (channel1, vote2);
-	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 1);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::test::get_available_port (), system.logging), system.work));
-	node2->start ();
-	std::weak_ptr<nano::node> node_w (node.shared ());
-	auto vote3 = std::make_shared<nano::vote> (keypair2.pub, keypair2.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-	node.network.tcp_channels.start_tcp (node2->network.endpoint ());
-	std::shared_ptr<nano::transport::channel> channel2;
-	ASSERT_TIMELY (10s, (channel2 = node.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node2->network.endpoint ()))) != nullptr);
-	ASSERT_FALSE (node.rep_crawler.response (channel2, vote3));
-	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 2);
-	node2->stop ();
-	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 1);
-	reps = node.rep_crawler.representatives (1);
+	auto channel_genesis_rep (searching_node.network.find_channel (node_genesis_rep->network.endpoint ()));
+	ASSERT_NE (nullptr, channel_genesis_rep);
+
+	// genesis_rep should be found as principal representative after receiving a vote from it
+	auto vote_genesis_rep = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
+	searching_node.rep_crawler.response (channel_genesis_rep, vote_genesis_rep);
+	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
+
+	// Start a node for Rep2 and wait until it is connected
+	auto node_rep2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::test::get_available_port (), system.logging), system.work));
+	node_rep2->start ();
+	searching_node.network.tcp_channels.start_tcp (node_rep2->network.endpoint ());
+	std::shared_ptr<nano::transport::channel> channel_rep2;
+	ASSERT_TIMELY (10s, (channel_rep2 = searching_node.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_rep2->network.endpoint ()))) != nullptr);
+
+	// Rep2 should be found as a principal representative after receiving a vote from it
+	auto vote_rep2 = std::make_shared<nano::vote> (keys_rep2.pub, keys_rep2.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
+	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep2, vote_rep2));
+	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 2);
+
+	// When Rep2 is stopped, it should not be found as principal representative anymore
+	node_rep2->stop ();
+	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
+
+	// Now only genesisRep should be found:
+	reps = searching_node.rep_crawler.representatives (1);
 	ASSERT_EQ (nano::dev::genesis_key.pub, reps[0].account);
-	ASSERT_EQ (1, node.network.size ());
-	auto list (node.network.list (1));
-	ASSERT_EQ (node1->network.endpoint (), list[0]->get_endpoint ());
+	ASSERT_EQ (1, searching_node.network.size ());
+	auto list (searching_node.network.list (1));
+	ASSERT_EQ (node_genesis_rep->network.endpoint (), list[0]->get_endpoint ());
 }
 
 TEST (node, rep_connection_close)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -838,32 +838,21 @@ TEST (node, fork_flip)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	nano::publish publish2{ nano::dev::network_params.network, send2 };
+	auto ignored_channel{ std::make_shared<nano::transport::channel_tcp> (node1, std::weak_ptr<nano::socket> ()) };
 
-	// Dangling node instance just to be a tcp client for channel1.
-	auto outer_node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	outer_node1->start ();
-	system.nodes.push_back (outer_node1);
-
-	auto channel1 = nano::test::establish_tcp (system, *outer_node1, node1.network.endpoint ());
-	node1.network.inbound (publish1, channel1);
+	node1.network.inbound (publish1, ignored_channel);
 	node1.block_processor.flush ();
 	node1.scheduler.flush ();
 
-	// Dangling node instance just to be a tcp client for channel2.
-	auto outer_node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	outer_node2->start ();
-	system.nodes.push_back (outer_node2);
-
-	auto channel2 = nano::test::establish_tcp (system, *outer_node2, node1.network.endpoint ());
-	node2.network.inbound (publish2, channel2);
+	node2.network.inbound (publish2, ignored_channel);
 	node2.block_processor.flush ();
 	node2.scheduler.flush ();
 	ASSERT_EQ (1, node1.active.size ());
 	ASSERT_EQ (1, node2.active.size ());
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node1.network.inbound (publish2, channel1);
+	node1.network.inbound (publish2, ignored_channel);
 	node1.block_processor.flush ();
-	node2.network.inbound (publish1, channel2);
+	node2.network.inbound (publish1, ignored_channel);
 	node2.block_processor.flush ();
 	auto election1 (node2.active.election (nano::qualified_root (nano::dev::genesis->hash (), nano::dev::genesis->hash ())));
 	ASSERT_NE (nullptr, election1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,6 +1,5 @@
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
-#include <nano/node/transport/udp.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -1,7 +1,14 @@
+#include <nano/node/socket.hpp>
+#include <nano/node/transport/tcp.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace std::chrono_literals;
 
 TEST (peer_container, empty_peers)
 {
@@ -13,69 +20,90 @@ TEST (peer_container, empty_peers)
 
 TEST (peer_container, no_recontact)
 {
-	nano::test::system system (1);
-	auto & node1 (*system.nodes[0]);
-	nano::network & network (node1.network);
-	auto observed_peer (0);
-	auto observed_disconnect (false);
-	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), 10000);
+	nano::test::system system{ 1 };
+	auto & node1 = *system.nodes[0];
+	nano::network & network{ node1.network };
+	unsigned observed_peer{ 0 };
+	auto observed_disconnect{ false };
 	ASSERT_EQ (0, network.size ());
 	network.channel_observer = [&observed_peer] (std::shared_ptr<nano::transport::channel> const &) { ++observed_peer; };
 	node1.network.disconnect_observer = [&observed_disconnect] () { observed_disconnect = true; };
-	auto channel (network.udp_channels.insert (endpoint1, node1.network_params.network.protocol_version));
+	auto outer_node = nano::test::add_outer_node (system);
+	auto channel = nano::test::establish_tcp (system, node1, outer_node->network.endpoint ());
+	ASSERT_NE (nullptr, channel);
 	ASSERT_EQ (1, network.size ());
-	ASSERT_EQ (channel, network.udp_channels.insert (endpoint1, node1.network_params.network.protocol_version));
 	node1.network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (5));
 	ASSERT_TRUE (network.empty ());
 	ASSERT_EQ (1, observed_peer);
 	ASSERT_TRUE (observed_disconnect);
 }
 
+// Test a node cannot connect to its own endpoint.
 TEST (peer_container, no_self_incoming)
 {
-	nano::test::system system (1);
-	ASSERT_EQ (nullptr, system.nodes[0]->network.udp_channels.insert (system.nodes[0]->network.endpoint (), 0));
+	nano::test::system system{ 1 };
+	auto & node = *system.nodes[0];
+	node.network.tcp_channels.start_tcp (node.network.endpoint ());
+	auto error = system.poll_until_true (2s, [&node] {
+		auto result = node.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node.network.endpoint ()));
+		return result != nullptr;
+	});
+	ASSERT_TRUE (error);
 	ASSERT_TRUE (system.nodes[0]->network.empty ());
 }
 
+// Tests the function nano::transport::tcp_channels.insert () doesn't accept peers from the reserved addresses list
 TEST (peer_container, reserved_peers_no_contact)
 {
-	nano::test::system system (1);
-	auto & channels (system.nodes[0]->network.udp_channels);
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x00000001)), 10000), 0));
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xc0000201)), 10000), 0));
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xc6336401)), 10000), 0));
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xcb007101)), 10000), 0));
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xe9fc0001)), 10000), 0));
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xf0000001)), 10000), 0));
-	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xffffffff)), 10000), 0));
+	nano::test::system system{ 1 };
+	auto & channels = system.nodes[0]->network.tcp_channels;
+	auto insert_channel = [&node = *system.nodes[0], &channels] (nano::endpoint endpoint_a) -> bool {
+		// Create dummy socket and channel only for passing the IP address
+		auto ignored_socket = std::make_shared<nano::server_socket> (node, nano::transport::map_endpoint_to_tcp (endpoint_a), 10);
+		auto ignored_channel = std::make_shared<nano::transport::channel_tcp> (node, ignored_socket->weak_from_this ());
+		return channels.insert (ignored_channel, std::shared_ptr<nano::socket> (), std::shared_ptr<nano::bootstrap_server> ());
+	};
+
+	// The return value as true means an error.
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x00000001)), 10000)));
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xc0000201)), 10000)));
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xc6336401)), 10000)));
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xcb007101)), 10000)));
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xe9fc0001)), 10000)));
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xf0000001)), 10000)));
+	ASSERT_TRUE (insert_channel (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xffffffff)), 10000)));
 	ASSERT_EQ (0, system.nodes[0]->network.size ());
 }
 
+// TODO: Fix the failing test
 TEST (peer_container, split)
 {
-	nano::test::system system (1);
-	auto & node1 (*system.nodes[0]);
-	auto now (std::chrono::steady_clock::now ());
-	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), 100);
-	nano::endpoint endpoint2 (boost::asio::ip::address_v6::loopback (), 101);
-	auto channel1 (node1.network.udp_channels.insert (endpoint1, 0));
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	node_config.network_params.network.cleanup_period = std::chrono::minutes (10);
+	nano::node_flags node_flags;
+	node_flags.disable_connection_cleanup = true;
+	auto & node1 = *system.add_node (node_config, node_flags);
+	auto outer_node1 = nano::test::add_outer_node (system);
+	auto outer_node2 = nano::test::add_outer_node (system);
+	auto now = std::chrono::steady_clock::now ();
+	auto channel1 = nano::test::establish_tcp (system, node1, outer_node1->network.endpoint ());
 	ASSERT_NE (nullptr, channel1);
-	node1.network.udp_channels.modify (channel1, [&now] (auto channel) {
-		channel->set_last_packet_received (now - std::chrono::seconds (1));
+	node1.network.tcp_channels.modify (channel1, [&now] (auto channel) {
+		channel->set_last_packet_sent (now - std::chrono::seconds (5));
 	});
-	auto channel2 (node1.network.udp_channels.insert (endpoint2, 0));
+	auto channel2 = nano::test::establish_tcp (system, node1, outer_node2->network.endpoint ());
 	ASSERT_NE (nullptr, channel2);
-	node1.network.udp_channels.modify (channel2, [&now] (auto channel) {
-		channel->set_last_packet_received (now + std::chrono::seconds (1));
+	node1.network.tcp_channels.modify (channel2, [&now] (auto channel) {
+		channel->set_last_packet_sent (now + std::chrono::seconds (1));
 	});
 	ASSERT_EQ (2, node1.network.size ());
-	ASSERT_EQ (2, node1.network.udp_channels.size ());
+	ASSERT_EQ (2, node1.network.tcp_channels.size ());
 	node1.network.cleanup (now);
 	ASSERT_EQ (1, node1.network.size ());
-	ASSERT_EQ (1, node1.network.udp_channels.size ());
-	auto list (node1.network.list (1));
-	ASSERT_EQ (endpoint2, list[0]->get_endpoint ());
+	ASSERT_EQ (1, node1.network.tcp_channels.size ());
+	auto list = node1.network.list (1);
+	ASSERT_EQ (outer_node2->network.endpoint (), list[0]->get_endpoint ());
 }
 
 TEST (channels, fill_random_clear)
@@ -87,28 +115,35 @@ TEST (channels, fill_random_clear)
 	ASSERT_TRUE (std::all_of (target.begin (), target.end (), [] (nano::endpoint const & endpoint_a) { return endpoint_a == nano::endpoint (boost::asio::ip::address_v6::any (), 0); }));
 }
 
+// Test all targets get replaced
 TEST (channels, fill_random_full)
 {
-	nano::test::system system (1);
-	for (uint16_t i (0u); i < 100u; ++i)
+	nano::test::system system{ 1 };
+	unsigned network_size{ 20 };
+	for (uint16_t i (0u); i < network_size; ++i)
 	{
-		system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), i), 0);
+		auto outer_node = nano::test::add_outer_node (system);
+		ASSERT_NE (nullptr, nano::test::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ()));
 	}
+	ASSERT_EQ (network_size, system.nodes[0]->network.tcp_channels.size ());
 	std::array<nano::endpoint, 8> target;
 	std::fill (target.begin (), target.end (), nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000));
 	system.nodes[0]->network.random_fill (target);
 	ASSERT_TRUE (std::none_of (target.begin (), target.end (), [] (nano::endpoint const & endpoint_a) { return endpoint_a == nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000); }));
 }
 
+// Test only the known channels are filled
 TEST (channels, fill_random_part)
 {
-	nano::test::system system (1);
+	nano::test::system system{ 1 };
 	std::array<nano::endpoint, 8> target;
-	auto half (target.size () / 2);
-	for (auto i (0); i < half; ++i)
+	unsigned half{ target.size () / 2 };
+	for (unsigned i = 0; i < half; ++i)
 	{
-		system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), i + 1), 0);
+		auto outer_node = nano::test::add_outer_node (system);
+		ASSERT_NE (nullptr, nano::test::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ()));
 	}
+	ASSERT_EQ (half, system.nodes[0]->network.tcp_channels.size ());
 	std::fill (target.begin (), target.end (), nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000));
 	system.nodes[0]->network.random_fill (target);
 	ASSERT_TRUE (std::none_of (target.begin (), target.begin () + half, [] (nano::endpoint const & endpoint_a) { return endpoint_a == nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000); }));
@@ -116,39 +151,44 @@ TEST (channels, fill_random_part)
 	ASSERT_TRUE (std::all_of (target.begin () + half, target.end (), [] (nano::endpoint const & endpoint_a) { return endpoint_a == nano::endpoint (boost::asio::ip::address_v6::any (), 0); }));
 }
 
+// TODO: remove node instantiation requirement for testing with bigger network size
 TEST (peer_container, list_fanout)
 {
-	nano::test::system system (1);
-	auto & node (*system.nodes[0]);
-	ASSERT_EQ (0, node.network.size ());
-	ASSERT_EQ (0.0, node.network.size_sqrt ());
-	ASSERT_EQ (0, node.network.fanout ());
-	auto list1 (node.network.list (node.network.fanout ()));
+	nano::test::system system{ 1 };
+	auto node = system.nodes[0];
+	ASSERT_EQ (0, node->network.size ());
+	ASSERT_EQ (0.0, node->network.size_sqrt ());
+	ASSERT_EQ (0, node->network.fanout ());
+	auto list1 = node->network.list (node->network.fanout ());
 	ASSERT_TRUE (list1.empty ());
-	auto add_peer = [&node] (uint16_t const port_a) {
-		ASSERT_NE (nullptr, node.network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), port_a), node.network_params.network.protocol_version));
+	auto add_peer = [&node, &system] (uint16_t const port_a) {
+		auto outer_node = nano::test::add_outer_node (system);
+		auto channel = nano::test::establish_tcp (system, *node, outer_node->network.endpoint ());
 	};
 	add_peer (9998);
-	ASSERT_EQ (1, node.network.size ());
-	ASSERT_EQ (1.f, node.network.size_sqrt ());
-	ASSERT_EQ (1, node.network.fanout ());
-	auto list2 (node.network.list (node.network.fanout ()));
+	ASSERT_EQ (1, node->network.size ());
+	ASSERT_EQ (1.f, node->network.size_sqrt ());
+	ASSERT_EQ (1, node->network.fanout ());
+	auto list2 = node->network.list (node->network.fanout ());
 	ASSERT_EQ (1, list2.size ());
 	add_peer (9999);
-	ASSERT_EQ (2, node.network.size ());
-	ASSERT_EQ (std::sqrt (2.f), node.network.size_sqrt ());
-	ASSERT_EQ (2, node.network.fanout ());
-	auto list3 (node.network.list (node.network.fanout ()));
+	ASSERT_EQ (2, node->network.size ());
+	ASSERT_EQ (std::sqrt (2.f), node->network.size_sqrt ());
+	ASSERT_EQ (2, node->network.fanout ());
+	auto list3 = node->network.list (node->network.fanout ());
 	ASSERT_EQ (2, list3.size ());
-	for (auto i (0); i < 1000; ++i)
+	// The previous version of this test used 1000 peers. Reduced to 10 due to the use of node instances
+	unsigned number_of_peers{ 20 };
+	for (auto i = 0; i < number_of_peers; ++i)
 	{
 		add_peer (10000 + i);
 	}
-	ASSERT_EQ (1002, node.network.size ());
-	ASSERT_EQ (std::sqrt (1002.f), node.network.size_sqrt ());
-	auto expected_size (static_cast<size_t> (std::ceil (std::sqrt (1002.f))));
-	ASSERT_EQ (expected_size, node.network.fanout ());
-	auto list4 (node.network.list (node.network.fanout ()));
+	number_of_peers += 2;
+	ASSERT_EQ (number_of_peers, node->network.size ());
+	ASSERT_EQ (std::sqrt (float (number_of_peers)), node->network.size_sqrt ());
+	auto expected_size (static_cast<size_t> (std::ceil (std::sqrt (float (number_of_peers)))));
+	ASSERT_EQ (expected_size, node->network.fanout ());
+	auto list4 = node->network.list (node->network.fanout ());
 	ASSERT_EQ (expected_size, list4.size ());
 }
 
@@ -157,32 +197,37 @@ TEST (peer_container, reachout)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
+	auto outer_node1 = nano::test::add_outer_node (system);
+	ASSERT_NE (nullptr, nano::test::establish_tcp (system, node1, outer_node1->network.endpoint ()));
 	// Make sure having been contacted by them already indicates we shouldn't reach out
-	node1.network.udp_channels.insert (endpoint0, node1.network_params.network.protocol_version);
-	ASSERT_TRUE (node1.network.reachout (endpoint0));
-	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
-	ASSERT_FALSE (node1.network.reachout (endpoint1));
+	ASSERT_TRUE (node1.network.reachout (outer_node1->network.endpoint ()));
+	auto outer_node2 = nano::test::add_outer_node (system);
+	ASSERT_FALSE (node1.network.reachout (outer_node2->network.endpoint ()));
+	ASSERT_NE (nullptr, nano::test::establish_tcp (system, node1, outer_node2->network.endpoint ()));
 	// Reaching out to them once should signal we shouldn't reach out again.
-	ASSERT_TRUE (node1.network.reachout (endpoint1));
+	ASSERT_TRUE (node1.network.reachout (outer_node2->network.endpoint ()));
 	// Make sure we don't purge new items
 	node1.network.cleanup (std::chrono::steady_clock::now () - std::chrono::seconds (10));
-	ASSERT_TRUE (node1.network.reachout (endpoint1));
+	ASSERT_TRUE (node1.network.reachout (outer_node2->network.endpoint ()));
 	// Make sure we purge old items
 	node1.network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (10));
-	ASSERT_FALSE (node1.network.reachout (endpoint1));
+	ASSERT_FALSE (node1.network.reachout (outer_node2->network.endpoint ()));
 }
 
+// TODO: fix failing test
+// This test checks if a packet is discarded when its protocol version is outdated
 TEST (peer_container, depeer)
 {
-	nano::test::system system (1);
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
-	nano::keepalive message{ nano::dev::network_params.network };
-	const_cast<uint8_t &> (message.header.version_using) = 1;
-	auto bytes (message.to_bytes ());
-	nano::message_buffer buffer = { bytes->data (), bytes->size (), endpoint0 };
-	system.nodes[0]->network.udp_channels.receive_action (&buffer);
-	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::udp, nano::stat::detail::outdated_version));
+	nano::test::system system{ 1 };
+	auto network_constants = nano::dev::network_params.network;
+	const_cast<uint8_t &> (network_constants.protocol_version) = 1;
+	nano::keepalive message{ network_constants };
+	auto bytes = message.to_bytes ();
+	ASSERT_EQ (1, message.header.version_using);
+	auto outer_node = nano::test::add_outer_node (system);
+	auto channel = nano::test::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ());
+	ASSERT_NE (nullptr, channel);
+	system.nodes[0]->network.tcp_channels.start_tcp_receive_node_id (channel, channel->get_endpoint (), message.to_bytes ());
+	ASSERT_TIMELY (6s, 1 == system.nodes[0]->stats.count (nano::stat::type::message, nano::stat::detail::outdated_version));
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/request_aggregator.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -27,24 +28,25 @@ TEST (request_aggregator, one)
 				 .build_shared ();
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-	node.aggregator.add (channel, request);
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	// Not yet in the ledger
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
-	node.aggregator.add (channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
-	ASSERT_TRUE (node.aggregator.empty ());
-	node.aggregator.add (channel, request);
+	ASSERT_TIMELY (3s, node.aggregator.empty ());
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// Already cached
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
-	ASSERT_EQ (3, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
+	ASSERT_TIMELY (3s, 3 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
+	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
@@ -95,18 +97,19 @@ TEST (request_aggregator, one_update)
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *receive1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-	node.aggregator.add (channel, request);
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	node.aggregator.add (dummy_channel, request);
 	request.clear ();
 	request.emplace_back (receive1->hash (), receive1->root ());
 	// Update the pool of requests with another hash
-	node.aggregator.add (channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes))
 	ASSERT_TRUE (node.aggregator.empty ());
-	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
+	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
+	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
 	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
 	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
 	size_t count = 0;
@@ -161,15 +164,16 @@ TEST (request_aggregator, two)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
 	request.emplace_back (receive1->hash (), receive1->root ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
 	// Process both blocks
-	node.aggregator.add (channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// One vote should be generated for both blocks
 	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_TRUE (node.aggregator.empty ());
 	// The same request should now send the cached vote
-	node.aggregator.add (channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
@@ -189,6 +193,7 @@ TEST (request_aggregator, two)
 	ASSERT_EQ (vote1.front (), vote2.front ());
 }
 
+// TODO: fix this test
 TEST (request_aggregator, two_endpoints)
 {
 	nano::test::system system;
@@ -214,12 +219,53 @@ TEST (request_aggregator, two_endpoints)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
-	auto channel1 (node1.network.udp_channels.create (node1.network.endpoint ()));
-	auto channel2 (node2.network.udp_channels.create (node2.network.endpoint ()));
-	ASSERT_NE (nano::transport::map_endpoint_to_v6 (channel1->get_endpoint ()), nano::transport::map_endpoint_to_v6 (channel2->get_endpoint ()));
+
+	// Simulate connections only for the remote endpoint fields to be valid.
+	boost::asio::ip::tcp::endpoint listen_endpoint1{ boost::asio::ip::address_v6::any (), nano::get_available_port () };
+	boost::asio::ip::tcp::endpoint listen_endpoint2{ boost::asio::ip::address_v6::any (), nano::get_available_port () };
+	auto server_socket1 = std::make_shared<nano::server_socket> (node2, listen_endpoint1, 1);
+	{
+		boost::system::error_code ec;
+		server_socket1->start (ec);
+		ASSERT_FALSE (ec);
+	}
+	auto server_socket2 = std::make_shared<nano::server_socket> (node1, listen_endpoint2, 1);
+	{
+		boost::system::error_code ec;
+		server_socket2->start (ec);
+		ASSERT_FALSE (ec);
+	}
+	std::shared_ptr<nano::socket> server1_sockets;
+	std::shared_ptr<nano::socket> server2_sockets;
+	{
+		server_socket1->on_connection ([&server1_sockets] (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const & ec_a) {
+			server1_sockets = new_connection;
+			return true;
+		});
+		server_socket2->on_connection ([&server2_sockets] (std::shared_ptr<nano::socket> const & new_connection, boost::system::error_code const & ec_a) {
+			server2_sockets = new_connection;
+			return true;
+		});
+	}
+	// client side connection tracking, needed to know the connections are ok
+	std::atomic<size_t> connection_attempts = 0;
+	auto connect_handler = [&connection_attempts] (boost::system::error_code const & ec_a) {
+		ASSERT_EQ (ec_a.value (), 0);
+		++connection_attempts;
+	};
+
+	auto client1 = std::make_shared<nano::client_socket> (node1);
+	client1->async_connect (boost::asio::ip::tcp::endpoint{ boost::asio::ip::address_v6::loopback (), listen_endpoint1.port () }, connect_handler);
+	auto client2 = std::make_shared<nano::client_socket> (node2);
+	client2->async_connect (boost::asio::ip::tcp::endpoint{ boost::asio::ip::address_v6::loopback (), listen_endpoint2.port () }, connect_handler);
+
+	ASSERT_TIMELY (3s, 2 == connection_attempts && server1_sockets != nullptr && server2_sockets != nullptr);
+	auto dummy_channel1 = std::make_shared<nano::transport::channel_tcp> (node1, client1);
+	auto dummy_channel2 = std::make_shared<nano::transport::channel_tcp> (node2, client2);
+	ASSERT_NE (nano::transport::map_endpoint_to_v6 (dummy_channel1->get_endpoint ()), nano::transport::map_endpoint_to_v6 (dummy_channel2->get_endpoint ()));
 	// Use the aggregator from node1 only, making requests from both nodes
-	node1.aggregator.add (channel1, request);
-	node1.aggregator.add (channel2, request);
+	node1.aggregator.add (dummy_channel1, request);
+	node1.aggregator.add (dummy_channel2, request);
 	ASSERT_EQ (2, node1.aggregator.size ());
 	// For the first request it generates the vote, for the second it uses the generated vote
 	ASSERT_TIMELY (3s, node1.aggregator.empty ());
@@ -270,8 +316,9 @@ TEST (request_aggregator, split)
 	election->force_confirm ();
 	ASSERT_TIMELY (5s, max_vbh + 2 == node.ledger.cache.cemented_count);
 	ASSERT_EQ (max_vbh + 1, request.size ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-	node.aggregator.add (channel, request);
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
@@ -310,8 +357,9 @@ TEST (request_aggregator, channel_lifetime)
 	request.emplace_back (send1->hash (), send1->root ());
 	{
 		// The aggregator should extend the lifetime of the channel
-		auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-		node.aggregator.add (channel, request);
+		auto client = std::make_shared<nano::client_socket> (node);
+		std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+		node.aggregator.add (dummy_channel, request);
 	}
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
@@ -340,12 +388,14 @@ TEST (request_aggregator, channel_update)
 	request.emplace_back (send1->hash (), send1->root ());
 	std::weak_ptr<nano::transport::channel> channel1_w;
 	{
-		auto channel1 (node.network.udp_channels.create (node.network.endpoint ()));
-		channel1_w = channel1;
-		node.aggregator.add (channel1, request);
-		auto channel2 (node.network.udp_channels.create (node.network.endpoint ()));
+		auto client1 = std::make_shared<nano::client_socket> (node);
+		std::shared_ptr<nano::transport::channel> dummy_channel1 = std::make_shared<nano::transport::channel_tcp> (node, client1);
+		channel1_w = dummy_channel1;
+		node.aggregator.add (dummy_channel1, request);
+		auto client2 = std::make_shared<nano::client_socket> (node);
+		std::shared_ptr<nano::transport::channel> dummy_channel2 = std::make_shared<nano::transport::channel_tcp> (node, client2);
 		// The aggregator then hold channel2 and drop channel1
-		node.aggregator.add (channel2, request);
+		node.aggregator.add (dummy_channel2, request);
 	}
 	// Both requests were for the same endpoint, so only one pool should exist
 	ASSERT_EQ (1, node.aggregator.size ());
@@ -376,9 +426,10 @@ TEST (request_aggregator, channel_max_queue)
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-	node.aggregator.add (channel, request);
-	node.aggregator.add (channel, request);
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	node.aggregator.add (dummy_channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
 }
 
@@ -403,11 +454,12 @@ TEST (request_aggregator, unique)
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-	node.aggregator.add (channel, request);
-	node.aggregator.add (channel, request);
-	node.aggregator.add (channel, request);
-	node.aggregator.add (channel, request);
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	node.aggregator.add (dummy_channel, request);
+	node.aggregator.add (dummy_channel, request);
+	node.aggregator.add (dummy_channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
 	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 }
@@ -449,8 +501,9 @@ TEST (request_aggregator, cannot_vote)
 	request.emplace_back (send2->hash (), send2->root ());
 	// Incorrect hash, correct root
 	request.emplace_back (1, send2->root ());
-	auto channel (node.network.udp_channels.create (node.network.endpoint ()));
-	node.aggregator.add (channel, request);
+	auto client = std::make_shared<nano::client_socket> (node);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
@@ -463,7 +516,7 @@ TEST (request_aggregator, cannot_vote)
 
 	// With an ongoing election
 	node.block_confirm (send2);
-	node.aggregator.add (channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
@@ -480,7 +533,7 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 	ASSERT_TIMELY (3s, node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send2));
-	node.aggregator.add (channel, request);
+	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -221,8 +221,8 @@ TEST (request_aggregator, two_endpoints)
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
 
 	// Simulate connections only for the remote endpoint fields to be valid.
-	boost::asio::ip::tcp::endpoint listen_endpoint1{ boost::asio::ip::address_v6::any (), nano::get_available_port () };
-	boost::asio::ip::tcp::endpoint listen_endpoint2{ boost::asio::ip::address_v6::any (), nano::get_available_port () };
+	boost::asio::ip::tcp::endpoint listen_endpoint1{ boost::asio::ip::address_v6::any (), nano::test::get_available_port () };
+	boost::asio::ip::tcp::endpoint listen_endpoint2{ boost::asio::ip::address_v6::any (), nano::test::get_available_port () };
 	auto server_socket1 = std::make_shared<nano::server_socket> (node2, listen_endpoint1, 1);
 	{
 		boost::system::error_code ec;

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -1,4 +1,5 @@
 #include <nano/node/telemetry.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/telemetry.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -337,17 +338,21 @@ TEST (telemetry, receive_from_non_listening_channel)
 	nano::test::system system;
 	auto node = system.add_node ();
 	nano::telemetry_ack message{ nano::dev::network_params.network, nano::telemetry_data{} };
-	node->network.inbound (message, node->network.udp_channels.create (node->network.endpoint ()));
+
+	auto outer_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node->start ();
+	system.nodes.push_back (outer_node);
+	auto channel = nano::test::establish_tcp (system, *outer_node, node->network.endpoint ());
+
+	node->network.inbound (message, channel);
 	// We have not sent a telemetry_req message to this endpoint, so shouldn't count telemetry_ack received from it.
 	ASSERT_EQ (node->telemetry->telemetry_data_size (), 0);
 }
 
-TEST (telemetry, over_udp)
+TEST (telemetry, over_tcp)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_tcp_realtime = true;
-	node_flags.disable_udp = false;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
@@ -363,15 +368,15 @@ TEST (telemetry, over_udp)
 
 	ASSERT_TIMELY (10s, done);
 
-	// Check channels are indeed udp
+	// Check channels are indeed tcp
 	ASSERT_EQ (1, node_client->network.size ());
 	auto list1 (node_client->network.list (2));
 	ASSERT_EQ (node_server->network.endpoint (), list1[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::udp, list1[0]->get_type ());
+	ASSERT_EQ (nano::transport::transport_type::tcp, list1[0]->get_type ());
 	ASSERT_EQ (1, node_server->network.size ());
 	auto list2 (node_server->network.list (2));
 	ASSERT_EQ (node_client->network.endpoint (), list2[0]->get_endpoint ());
-	ASSERT_EQ (nano::transport::transport_type::udp, list2[0]->get_type ());
+	ASSERT_EQ (nano::transport::transport_type::tcp, list2[0]->get_type ());
 }
 
 TEST (telemetry, invalid_channel)
@@ -493,50 +498,6 @@ TEST (telemetry, dos_tcp)
 	}
 }
 
-TEST (telemetry, dos_udp)
-{
-	// Confirm that telemetry_reqs are not processed
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	node_flags.disable_tcp_realtime = true;
-	node_flags.disable_initial_telemetry_requests = true;
-	node_flags.disable_ongoing_telemetry_requests = true;
-	auto node_client = system.add_node (node_flags);
-	auto node_server = system.add_node (node_flags);
-
-	nano::test::wait_peer_connections (system);
-
-	nano::telemetry_req message{ nano::dev::network_params.network };
-	auto channel (node_client->network.udp_channels.create (node_server->network.endpoint ()));
-	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
-		ASSERT_FALSE (ec);
-	});
-
-	ASSERT_TIMELY (20s, 1 == node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in));
-
-	auto orig = std::chrono::steady_clock::now ();
-	for (int i = 0; i < 10; ++i)
-	{
-		channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
-			ASSERT_FALSE (ec);
-		});
-	}
-
-	ASSERT_TIMELY (20s, (nano::telemetry_cache_cutoffs::dev + orig) <= std::chrono::steady_clock::now ());
-
-	// Should process no more telemetry_req messages
-	ASSERT_EQ (1, node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in));
-
-	// Now spam messages waiting for it to be processed
-	system.deadline_set (20s);
-	while (node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in) == 1)
-	{
-		channel->send (message);
-		ASSERT_NO_ERROR (system.poll ());
-	}
-}
-
 TEST (telemetry, disable_metrics)
 {
 	nano::test::system system;
@@ -626,62 +587,19 @@ TEST (telemetry, DISABLED_remove_peer_different_genesis)
 	ASSERT_EQ (1, node1->network.excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ().count (node0->network.endpoint ().address ()));
 }
 
-// Peer exclusion is only fully supported for TCP-only nodes; peers can still reconnect through UDP
-TEST (telemetry, remove_peer_different_genesis_udp)
-{
-	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
-	node_flags.disable_tcp_realtime = true;
-	node_flags.disable_ongoing_telemetry_requests = true;
-	nano::test::system system (1, nano::transport::transport_type::udp, node_flags);
-	auto node0 (system.nodes[0]);
-	ASSERT_EQ (0, node0->network.size ());
-	nano::network_params network_params{ nano::networks::nano_dev_network };
-	network_params.ledger.genesis = network_params.ledger.nano_live_genesis;
-	nano::node_config config{ network_params };
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags));
-	node1->start ();
-	system.nodes.push_back (node1);
-	auto channel0 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node0->network_params.network.protocol_version));
-	auto channel1 (std::make_shared<nano::transport::channel_udp> (node0->network.udp_channels, node1->network.endpoint (), node1->network_params.network.protocol_version));
-	node0->network.send_keepalive (channel1);
-	node1->network.send_keepalive (channel0);
-
-	ASSERT_TIMELY (10s, node0->network.udp_channels.size () != 0 && node1->network.udp_channels.size () != 0);
-	ASSERT_EQ (node0->network.tcp_channels.size (), 0);
-	ASSERT_EQ (node1->network.tcp_channels.size (), 0);
-
-	std::atomic<bool> done0{ false };
-	std::atomic<bool> done1{ false };
-
-	node0->telemetry->get_metrics_single_peer_async (channel1, [&done0] (nano::telemetry_data_response const & response_a) {
-		done0 = true;
-	});
-
-	node1->telemetry->get_metrics_single_peer_async (channel0, [&done1] (nano::telemetry_data_response const & response_a) {
-		done1 = true;
-	});
-
-	ASSERT_TIMELY (10s, done0 && done1);
-
-	ASSERT_EQ (node0->network.tcp_channels.size (), 0);
-	ASSERT_EQ (node1->network.tcp_channels.size (), 0);
-
-	nano::lock_guard<nano::mutex> guard (node0->network.excluded_peers.mutex);
-	ASSERT_EQ (1, node0->network.excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ().count (node1->network.endpoint ().address ()));
-	ASSERT_EQ (1, node1->network.excluded_peers.peers.get<nano::peer_exclusion::tag_endpoint> ().count (node0->network.endpoint ().address ()));
-}
-
 TEST (telemetry, remove_peer_invalid_signature)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_udp = false;
 	node_flags.disable_initial_telemetry_requests = true;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node = system.add_node (node_flags);
 
-	auto channel = node->network.udp_channels.create (node->network.endpoint ());
+	auto outer_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node->start ();
+	system.nodes.push_back (outer_node);
+
+	auto channel = nano::test::establish_tcp (system, *outer_node, node->network.endpoint ());
 	channel->set_node_id (node->node_id.pub);
 	// (Implementation detail) So that messages are not just discarded when requests were not sent.
 	node->telemetry->recent_or_initial_request_telemetry_data.emplace (channel->get_endpoint (), nano::telemetry_data (), std::chrono::steady_clock::now (), true);

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -45,10 +45,10 @@ TEST (wallet, DISABLED_status)
 		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
 	};
 	ASSERT_EQ ("Status: Disconnected, Blocks: 1", wallet->status->text ().toStdString ());
-	auto outer_node (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto outer_node (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	outer_node->start ();
 	system.nodes.push_back (outer_node);
-	nano::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ());
+	nano::test::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ());
 	// Because of the wallet "vulnerable" message, this won't be the message displayed.
 	// However, it will still be part of the status set.
 	ASSERT_FALSE (wallet_has (nano_qt::status_types::synchronizing));

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -1,4 +1,5 @@
 #include <nano/qt/qt.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -44,7 +45,10 @@ TEST (wallet, DISABLED_status)
 		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
 	};
 	ASSERT_EQ ("Status: Disconnected, Blocks: 1", wallet->status->text ().toStdString ());
-	system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000), 0);
+	auto outer_node (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	outer_node->start ();
+	system.nodes.push_back (outer_node);
+	nano::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ());
 	// Because of the wallet "vulnerable" message, this won't be the message displayed.
 	// However, it will still be part of the status set.
 	ASSERT_FALSE (wallet_has (nano_qt::status_types::synchronizing));

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -2,7 +2,6 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
-#include <nano/node/transport/udp.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/test_common/network.cpp
+++ b/nano/test_common/network.cpp
@@ -23,3 +23,11 @@ std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::t
 	});
 	return result;
 }
+
+std::shared_ptr<nano::node> nano::test::add_outer_node (nano::test::system & system_a, uint16_t port_a)
+{
+	auto outer_node = std::make_shared<nano::node> (system_a.io_ctx, port_a, nano::unique_path (), system_a.logging, system_a.work);
+	outer_node->start ();
+	system_a.nodes.push_back (outer_node);
+	return outer_node;
+}

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -1,6 +1,14 @@
 #pragma once
 
+#include <nano/boost/asio/read.hpp>
+#include <nano/boost/asio/write.hpp>
 #include <nano/node/common.hpp>
+#include <nano/test_common/system.hpp>
+
+#include <boost/asio/streambuf.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+#include <string>
 
 namespace nano
 {
@@ -14,8 +22,11 @@ namespace transport
 
 namespace test
 {
-	class system;
-	/** Waits until a TCP connection is established and returns the TCP channel on success*/
-	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
+  class system;
+  /** Waits until a TCP connection is established and returns the TCP channel on success*/
+  std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
+
+  /** Adds a node to the system without establishing connections */
+  std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, uint16_t port_a = nano::test::get_available_port ());
 }
 }

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -22,11 +22,11 @@ namespace transport
 
 namespace test
 {
-  class system;
-  /** Waits until a TCP connection is established and returns the TCP channel on success*/
-  std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
+	class system;
+	/** Waits until a TCP connection is established and returns the TCP channel on success*/
+	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
 
-  /** Adds a node to the system without establishing connections */
-  std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, uint16_t port_a = nano::test::get_available_port ());
+	/** Adds a node to the system without establishing connections */
+	std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, uint16_t port_a = nano::test::get_available_port ());
 }
 }


### PR DESCRIPTION
Migrates or marks to remove tests that use UDP.
- Migrated when it is possible to do so.
- Otherwise marked to be analyzed or removed

Fixes issue: https://github.com/nanocurrency/nano-node/issues/3846