### PR TITLE
Store and forward the original peering port in keepalive messages

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -418,12 +418,16 @@ public:
 		}
 		node.stats.inc (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in);
 		node.network.merge_peers (message_a.peers);
+
 		// Check for special node port data
 		auto peer0 (message_a.peers[0]);
 		if (peer0.address () == boost::asio::ip::address_v6{} && peer0.port () != 0)
 		{
 			nano::endpoint new_endpoint (channel->get_tcp_endpoint ().address (), peer0.port ());
 			node.network.merge_peer (new_endpoint);
+
+			// Remember this for future forwarding to other peers
+			channel->set_peering_endpoint (new_endpoint);
 		}
 	}
 	void publish (nano::publish const & message_a) override
@@ -652,9 +656,9 @@ void nano::network::random_fill (std::array<nano::endpoint, 8> & target_a) const
 	auto j (target_a.begin ());
 	for (auto i (peers.begin ()), n (peers.end ()); i != n; ++i, ++j)
 	{
-		debug_assert ((*i)->get_endpoint ().address ().is_v6 ());
+		debug_assert ((*i)->get_peering_endpoint ().address ().is_v6 ());
 		debug_assert (j < target_a.end ());
-		*j = (*i)->get_endpoint ();
+		*j = (*i)->get_peering_endpoint ();
 	}
 }
 

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -257,7 +257,7 @@ nano::tcp_endpoint nano::transport::tcp_channels::bootstrap_peer (uint8_t connec
 	{
 		if (i->channel->get_network_version () >= connection_protocol_version_min)
 		{
-			result = i->endpoint ();
+			result = nano::transport::map_endpoint_to_tcp (i->channel->get_peering_endpoint ());
 			channels.get<last_bootstrap_attempt_tag> ().modify (i, [] (channel_tcp_wrapper & wrapper_a) {
 				wrapper_a.channel->set_last_bootstrap_attempt (std::chrono::steady_clock::now ());
 			});

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -134,6 +134,23 @@ void nano::transport::channel::send (nano::message & message_a, std::function<vo
 	}
 }
 
+void nano::transport::channel::set_peering_endpoint (nano::endpoint endpoint)
+{
+	peering_endpoint = endpoint;
+}
+
+nano::endpoint nano::transport::channel::get_peering_endpoint () const
+{
+	if (peering_endpoint)
+	{
+		return *peering_endpoint;
+	}
+	else
+	{
+		return get_endpoint ();
+	}
+}
+
 boost::asio::ip::address_v6 nano::transport::mapped_from_v4_bytes (unsigned long address_a)
 {
 	return boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (address_a));

--- a/nano/node/transport/transport.hpp
+++ b/nano/node/transport/transport.hpp
@@ -134,6 +134,9 @@ namespace transport
 			network_version = network_version_a;
 		}
 
+		nano::endpoint get_peering_endpoint () const;
+		void set_peering_endpoint (nano::endpoint endpoint);
+
 		mutable nano::mutex channel_mutex;
 
 	private:
@@ -142,6 +145,7 @@ namespace transport
 		std::chrono::steady_clock::time_point last_packet_sent{ std::chrono::steady_clock::now () };
 		boost::optional<nano::account> node_id{ boost::none };
 		std::atomic<uint8_t> network_version{ 0 };
+		std::optional<nano::endpoint> peering_endpoint{};
 
 	protected:
 		nano::node & node;


### PR DESCRIPTION
When sending keepalive messages, the node sends endpoints of peers connected to us. Right now it will send the endpoint to which the socket is connected, but that could be a random ephemeral port. (It works now because we always establish two connections per peer). This PR changes this behaviour to instead forward the peering port that was originally announced to us.