### PR TITLE
Move `block_arrival` class to its own file

### DIFF
--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
   active_transactions.cpp
   backlog_population.hpp
   backlog_population.cpp
+  block_arrival.hpp
+  block_arrival.cpp
   blockprocessor.hpp
   blockprocessor.cpp
   bootstrap/block_deserializer.hpp

--- a/nano/node/block_arrival.cpp
+++ b/nano/node/block_arrival.cpp
@@ -1,0 +1,35 @@
+#include <nano/node/block_arrival.hpp>
+
+bool nano::block_arrival::add (nano::block_hash const & hash_a)
+{
+	nano::lock_guard<nano::mutex> lock (mutex);
+	auto now (std::chrono::steady_clock::now ());
+	auto inserted (arrival.get<tag_sequence> ().emplace_back (nano::block_arrival_info{ now, hash_a }));
+	auto result (!inserted.second);
+	return result;
+}
+
+bool nano::block_arrival::recent (nano::block_hash const & hash_a)
+{
+	nano::lock_guard<nano::mutex> lock (mutex);
+	auto now (std::chrono::steady_clock::now ());
+	while (arrival.size () > arrival_size_min && arrival.get<tag_sequence> ().front ().arrival + arrival_time_min < now)
+	{
+		arrival.get<tag_sequence> ().pop_front ();
+	}
+	return arrival.get<tag_hash> ().find (hash_a) != arrival.get<tag_hash> ().end ();
+}
+
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_arrival & block_arrival, std::string const & name)
+{
+	std::size_t count = 0;
+	{
+		nano::lock_guard<nano::mutex> guard (block_arrival.mutex);
+		count = block_arrival.arrival.size ();
+	}
+
+	auto sizeof_element = sizeof (decltype (block_arrival.arrival)::value_type);
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "arrival", count, sizeof_element }));
+	return composite;
+}

--- a/nano/node/block_arrival.hpp
+++ b/nano/node/block_arrival.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <nano/lib/threading.hpp>
+#include <nano/secure/common.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <chrono>
+
+namespace nano
+{
+class block_arrival_info final
+{
+public:
+	std::chrono::steady_clock::time_point arrival;
+	nano::block_hash hash;
+};
+
+// This class tracks blocks that are probably live because they arrived in a UDP packet
+// This gives a fairly reliable way to differentiate between blocks being inserted via bootstrap or new, live blocks.
+class block_arrival final
+{
+public:
+	// Return `true' to indicated an error if the block has already been inserted
+	bool add (nano::block_hash const &);
+	bool recent (nano::block_hash const &);
+
+	// clang-format off
+	class tag_sequence {};
+	class tag_hash {};
+
+	boost::multi_index_container<nano::block_arrival_info,
+		boost::multi_index::indexed_by<
+			boost::multi_index::sequenced<boost::multi_index::tag<tag_sequence>>,
+			boost::multi_index::hashed_unique<boost::multi_index::tag<tag_hash>,
+				boost::multi_index::member<nano::block_arrival_info, nano::block_hash, &nano::block_arrival_info::hash>>>>
+	arrival;
+	// clang-format on
+
+	nano::mutex mutex{ mutex_identifier (mutexes::block_arrival) };
+
+	static std::size_t constexpr arrival_size_min = 8 * 1024;
+	static std::chrono::seconds constexpr arrival_time_min = std::chrono::seconds (300);
+};
+
+std::unique_ptr<container_info_component> collect_container_info (block_arrival & block_arrival, std::string const & name);
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -22,8 +22,6 @@
 
 double constexpr nano::node::price_max;
 double constexpr nano::node::free_cutoff;
-std::size_t constexpr nano::block_arrival::arrival_size_min;
-std::chrono::seconds constexpr nano::block_arrival::arrival_time_min;
 
 namespace nano
 {
@@ -1422,40 +1420,6 @@ void nano::node::process_confirmed (nano::election_status const & status_a, uint
 		// Do some cleanup due to this block never being processed by confirmation height processor
 		active.remove_election_winner_details (hash);
 	}
-}
-
-bool nano::block_arrival::add (nano::block_hash const & hash_a)
-{
-	nano::lock_guard<nano::mutex> lock (mutex);
-	auto now (std::chrono::steady_clock::now ());
-	auto inserted (arrival.get<tag_sequence> ().emplace_back (nano::block_arrival_info{ now, hash_a }));
-	auto result (!inserted.second);
-	return result;
-}
-
-bool nano::block_arrival::recent (nano::block_hash const & hash_a)
-{
-	nano::lock_guard<nano::mutex> lock (mutex);
-	auto now (std::chrono::steady_clock::now ());
-	while (arrival.size () > arrival_size_min && arrival.get<tag_sequence> ().front ().arrival + arrival_time_min < now)
-	{
-		arrival.get<tag_sequence> ().pop_front ();
-	}
-	return arrival.get<tag_hash> ().find (hash_a) != arrival.get<tag_hash> ().end ();
-}
-
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_arrival & block_arrival, std::string const & name)
-{
-	std::size_t count = 0;
-	{
-		nano::lock_guard<nano::mutex> guard (block_arrival.mutex);
-		count = block_arrival.arrival.size ();
-	}
-
-	auto sizeof_element = sizeof (decltype (block_arrival.arrival)::value_type);
-	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "arrival", count, sizeof_element }));
-	return composite;
 }
 
 std::shared_ptr<nano::node> nano::node::shared ()

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -5,6 +5,7 @@
 #include <nano/lib/work.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/node/backlog_population.hpp>
+#include <nano/node/block_arrival.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
@@ -30,11 +31,6 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/utility.hpp>
 
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
-#include <boost/multi_index_container.hpp>
 #include <boost/program_options.hpp>
 #include <boost/thread/latch.hpp>
 
@@ -54,36 +50,7 @@ namespace websocket
 class node;
 class telemetry;
 class work_pool;
-class block_arrival_info final
-{
-public:
-	std::chrono::steady_clock::time_point arrival;
-	nano::block_hash hash;
-};
-// This class tracks blocks that are probably live because they arrived in a UDP packet
-// This gives a fairly reliable way to differentiate between blocks being inserted via bootstrap or new, live blocks.
-class block_arrival final
-{
-public:
-	// Return `true' to indicated an error if the block has already been inserted
-	bool add (nano::block_hash const &);
-	bool recent (nano::block_hash const &);
-	// clang-format off
-	class tag_sequence {};
-	class tag_hash {};
-	boost::multi_index_container<nano::block_arrival_info,
-		boost::multi_index::indexed_by<
-			boost::multi_index::sequenced<boost::multi_index::tag<tag_sequence>>,
-			boost::multi_index::hashed_unique<boost::multi_index::tag<tag_hash>,
-				boost::multi_index::member<nano::block_arrival_info, nano::block_hash, &nano::block_arrival_info::hash>>>>
-	arrival;
-	// clang-format on
-	nano::mutex mutex{ mutex_identifier (mutexes::block_arrival) };
-	static std::size_t constexpr arrival_size_min = 8 * 1024;
-	static std::chrono::seconds constexpr arrival_time_min = std::chrono::seconds (300);
-};
 
-std::unique_ptr<container_info_component> collect_container_info (block_arrival & block_arrival, std::string const & name);
 std::unique_ptr<container_info_component> collect_container_info (rep_crawler & rep_crawler, std::string const & name);
 
 // Configs


### PR DESCRIPTION
Small cleanup I did, there is no need for `block_arrival` to be inside node files that are already quite crowded.