### PR TITLE
Increase the macOS version for GitHub hosted runners

### DIFF
--- a/.github/workflows/beta_artifacts.yml
+++ b/.github/workflows/beta_artifacts.yml
@@ -51,7 +51,7 @@ jobs:
   osx_job:
     if: ${{ github.event.inputs.ref == '' && needs.build_auto_setup_job.result == 'success' && always() || github.event.inputs.ref != '' && always() }}
     needs: build_auto_setup_job
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     timeout-minutes: 90
     env:
       BOOST_ROOT: /tmp/boost

--- a/.github/workflows/live_artifacts.yml
+++ b/.github/workflows/live_artifacts.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   osx_job:
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     timeout-minutes: 90
     env:
       BOOST_ROOT: /tmp/boost

--- a/.github/workflows/test_network_artifacts.yml
+++ b/.github/workflows/test_network_artifacts.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   osx_job:
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     timeout-minutes: 90
     env:
       BOOST_ROOT: /tmp/boost

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       BOOST_ROOT: /tmp/boost
       TEST_USE_ROCKSDB: ${{ matrix.TEST_USE_ROCKSDB }}
       RELEASE: ${{ matrix.RELEASE }}
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
macOS 10.15 is considered deprecated by GitHub to be used as its hosted runners. This increases its version to macOS 11.