### PR TITLE
Extract `recently_confirmed` container out of `active_transactions`

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4280,7 +4280,7 @@ TEST (rep_crawler, recently_confirmed)
 	auto & node1 (*system.nodes[0]);
 	ASSERT_EQ (1, node1.ledger.cache.block_count);
 	auto const block = nano::dev::genesis;
-	node1.active.add_recently_confirmed (block->qualified_root (), block->hash ());
+	node1.active.recently_confirmed.put (block->qualified_root (), block->hash ());
 	auto & node2 (*system.add_node ());
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto channel = node1.network.find_channel (node2.network.endpoint ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -20,6 +20,7 @@ nano::active_transactions::active_transactions (nano::node & node_a, nano::confi
 	node{ node_a },
 	generator{ node_a.config, node_a.ledger, node_a.wallets, node_a.vote_processor, node_a.history, node_a.network, node_a.stats, false },
 	final_generator{ node_a.config, node_a.ledger, node_a.wallets, node_a.vote_processor, node_a.history, node_a.network, node_a.stats, true },
+	recently_confirmed{ 65536 },
 	election_time_to_live{ node_a.network_params.network.is_dev_network () ? 0s : 2s },
 	thread ([this] () {
 		nano::thread_role::set (nano::thread_role::name::request_loop);
@@ -372,7 +373,7 @@ nano::election_insertion_result nano::active_transactions::insert_impl (nano::un
 		auto existing (roots.get<tag_root> ().find (root));
 		if (existing == roots.get<tag_root> ().end ())
 		{
-			if (recently_confirmed.get<tag_root> ().find (root) == recently_confirmed.get<tag_root> ().end ())
+			if (!recently_confirmed.exists (root))
 			{
 				result.inserted = true;
 				auto hash (block_a->hash ());
@@ -447,13 +448,12 @@ nano::vote_code nano::active_transactions::vote (std::shared_ptr<nano::vote> con
 		nano::unique_lock<nano::mutex> lock (mutex);
 		for (auto const & hash : vote_a->hashes)
 		{
-			auto & recently_confirmed_by_hash (recently_confirmed.get<tag_hash> ());
 			auto existing (blocks.find (hash));
 			if (existing != blocks.end ())
 			{
 				process.emplace_back (existing->second, hash);
 			}
-			else if (recently_confirmed_by_hash.count (hash) == 0)
+			else if (!recently_confirmed.exists (hash))
 			{
 				add_inactive_votes_cache (lock, hash, vote_a->account, vote_a->timestamp ());
 			}
@@ -545,22 +545,6 @@ void nano::active_transactions::add_recently_cemented (nano::election_status con
 	{
 		recently_cemented.pop_front ();
 	}
-}
-
-void nano::active_transactions::add_recently_confirmed (nano::qualified_root const & root_a, nano::block_hash const & hash_a)
-{
-	nano::lock_guard<nano::mutex> guard (mutex);
-	recently_confirmed.get<tag_sequence> ().emplace_back (root_a, hash_a);
-	if (recently_confirmed.size () > recently_confirmed_size)
-	{
-		recently_confirmed.get<tag_sequence> ().pop_front ();
-	}
-}
-
-void nano::active_transactions::erase_recently_confirmed (nano::block_hash const & hash_a)
-{
-	nano::lock_guard<nano::mutex> guard (mutex);
-	recently_confirmed.get<tag_hash> ().erase (hash_a);
 }
 
 void nano::active_transactions::erase (nano::block const & block_a)
@@ -888,9 +872,64 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (ac
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "roots", roots_count, sizeof (decltype (active_transactions.roots)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", blocks_count, sizeof (decltype (active_transactions.blocks)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "election_winner_details", active_transactions.election_winner_details_size (), sizeof (decltype (active_transactions.election_winner_details)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "recently_confirmed", recently_confirmed_count, sizeof (decltype (active_transactions.recently_confirmed)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "recently_confirmed", recently_confirmed_count, sizeof (decltype (active_transactions.recently_confirmed.confirmed)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "recently_cemented", recently_cemented_count, sizeof (decltype (active_transactions.recently_cemented)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "inactive_votes_cache", active_transactions.inactive_votes_cache_size (), sizeof (nano::gap_information) }));
 	composite->add_component (collect_container_info (active_transactions.generator, "generator"));
 	return composite;
+}
+
+/*
+ * class recently_confirmed
+ */
+
+nano::recently_confirmed::recently_confirmed (std::size_t max_size_a) :
+	max_size{ max_size_a }
+{
+}
+
+void nano::recently_confirmed::put (const nano::qualified_root & root, const nano::block_hash & hash)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	confirmed.get<tag_sequence> ().emplace_back (root, hash);
+	if (confirmed.size () > max_size)
+	{
+		confirmed.get<tag_sequence> ().pop_front ();
+	}
+}
+
+void nano::recently_confirmed::erase (const nano::block_hash & hash)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	confirmed.get<tag_hash> ().erase (hash);
+}
+
+void nano::recently_confirmed::clear ()
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	confirmed.clear ();
+}
+
+bool nano::recently_confirmed::exists (const nano::block_hash & hash) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return confirmed.get<tag_hash> ().find (hash) != confirmed.get<tag_hash> ().end ();
+}
+
+bool nano::recently_confirmed::exists (const nano::qualified_root & root) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return confirmed.get<tag_root> ().find (root) != confirmed.get<tag_root> ().end ();
+}
+
+std::size_t nano::recently_confirmed::size () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return confirmed.size ();
+}
+
+nano::recently_confirmed::entry_t nano::recently_confirmed::back () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return confirmed.back ();
 }

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -869,11 +869,6 @@ std::size_t nano::active_transactions::election_winner_details_size ()
 	return election_winner_details.size ();
 }
 
-nano::cementable_account::cementable_account (nano::account const & account_a, std::size_t blocks_uncemented_a) :
-	account (account_a), blocks_uncemented (blocks_uncemented_a)
-{
-}
-
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (active_transactions & active_transactions, std::string const & name)
 {
 	std::size_t roots_count;

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -883,12 +883,12 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (ac
  * class recently_confirmed
  */
 
-nano::recently_confirmed::recently_confirmed (std::size_t max_size_a) :
+nano::recently_confirmed_cache::recently_confirmed_cache (std::size_t max_size_a) :
 	max_size{ max_size_a }
 {
 }
 
-void nano::recently_confirmed::put (const nano::qualified_root & root, const nano::block_hash & hash)
+void nano::recently_confirmed_cache::put (const nano::qualified_root & root, const nano::block_hash & hash)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	confirmed.get<tag_sequence> ().emplace_back (root, hash);
@@ -898,37 +898,37 @@ void nano::recently_confirmed::put (const nano::qualified_root & root, const nan
 	}
 }
 
-void nano::recently_confirmed::erase (const nano::block_hash & hash)
+void nano::recently_confirmed_cache::erase (const nano::block_hash & hash)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	confirmed.get<tag_hash> ().erase (hash);
 }
 
-void nano::recently_confirmed::clear ()
+void nano::recently_confirmed_cache::clear ()
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	confirmed.clear ();
 }
 
-bool nano::recently_confirmed::exists (const nano::block_hash & hash) const
+bool nano::recently_confirmed_cache::exists (const nano::block_hash & hash) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return confirmed.get<tag_hash> ().find (hash) != confirmed.get<tag_hash> ().end ();
 }
 
-bool nano::recently_confirmed::exists (const nano::qualified_root & root) const
+bool nano::recently_confirmed_cache::exists (const nano::qualified_root & root) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return confirmed.get<tag_root> ().find (root) != confirmed.get<tag_root> ().end ();
 }
 
-std::size_t nano::recently_confirmed::size () const
+std::size_t nano::recently_confirmed_cache::size () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return confirmed.size ();
 }
 
-nano::recently_confirmed::entry_t nano::recently_confirmed::back () const
+nano::recently_confirmed_cache::entry_t nano::recently_confirmed_cache::back () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return confirmed.back ();

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -39,12 +39,12 @@ class transaction;
 class confirmation_height_processor;
 class stat;
 
-class recently_confirmed final
+class recently_confirmed_cache final
 {
 public:
 	using entry_t = std::pair<nano::qualified_root, nano::block_hash>;
 
-	explicit recently_confirmed (std::size_t max_size);
+	explicit recently_confirmed_cache (std::size_t max_size);
 
 	void put (nano::qualified_root const &, nano::block_hash const &);
 	void erase (nano::block_hash const &);
@@ -168,7 +168,7 @@ public:
 	nano::vote_generator generator;
 	nano::vote_generator final_generator;
 
-	recently_confirmed recently_confirmed;
+	recently_confirmed_cache recently_confirmed;
 
 #ifdef MEMORY_POOL_DISABLED
 	using allocator = std::allocator<nano::inactive_cache_information>;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -38,14 +38,6 @@ class transaction;
 class confirmation_height_processor;
 class stat;
 
-class cementable_account final
-{
-public:
-	cementable_account (nano::account const & account_a, std::size_t blocks_uncemented_a);
-	nano::account account;
-	uint64_t blocks_uncemented{ 0 };
-};
-
 class election_insertion_result final
 {
 public:

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1401,7 +1401,7 @@ void nano::node::process_confirmed (nano::election_status const & status_a, uint
 	auto const num_iters = (config.block_processor_batch_max_time / network_params.node.process_confirmed_interval) * 4;
 	if (auto block_l = ledger.store.block.get (ledger.store.tx_begin_read (), hash))
 	{
-		active.add_recently_confirmed (block_l->qualified_root (), hash);
+		active.recently_confirmed.put (block_l->qualified_root (), hash);
 		confirmation_height_processor.add (block_l);
 	}
 	else if (iteration_a < num_iters)

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -172,7 +172,8 @@ void nano::rep_crawler::query (std::vector<std::shared_ptr<nano::transport::chan
 	}
 	if (!channels_a.empty ())
 	{
-		node.active.erase_recently_confirmed (hash_root.first);
+		// In case our random block is a recently confirmed one, we remove an entry otherwise votes will be marked as replay and not forwarded to repcrawler
+		node.active.recently_confirmed.erase (hash_root.first);
 	}
 	for (auto i (channels_a.begin ()), n (channels_a.end ()); i != n; ++i)
 	{


### PR DESCRIPTION
`active_transactions` class internally manages a few helper containers, this PR extracts one of those.