### PR TITLE
Fix `vote_processor.producer_consumer` test

### DIFF
--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -57,63 +57,6 @@ TEST (vote_processor, flush)
 	ASSERT_TRUE (node.vote_processor.empty ());
 }
 
-// Tests the normal behavior is more votes getting into the vote_processor than getting processed,
-// so the producer always wins. Also exercises the flush operation, so it must never deadlock.
-TEST (vote_processor, producer_consumer)
-{
-	nano::system system (1);
-	auto & node (*system.nodes[0]);
-	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
-
-	unsigned number_of_votes{ 25'000 };
-	unsigned consumer_wins{ 0 };
-	unsigned producer_wins{ 0 };
-
-	auto producer = [&node, &channel, &number_of_votes] () -> void {
-		for (unsigned i = 0; i < number_of_votes; ++i)
-		{
-			auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * (1 + i), 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-			node.vote_processor.vote (vote, channel);
-		}
-	};
-
-	auto consumer = [&node, &number_of_votes] () -> void {
-		while (node.vote_processor.total_processed.load () < number_of_votes)
-		{
-			if (node.vote_processor.size () >= number_of_votes / 100)
-			{
-				node.vote_processor.flush ();
-			}
-		}
-	};
-
-	auto monitor = [&node, &number_of_votes, &producer_wins, &consumer_wins] () -> void {
-		while (node.vote_processor.total_processed.load () < number_of_votes)
-		{
-			std::this_thread::sleep_for (std::chrono::milliseconds (50));
-			if (node.vote_processor.empty ())
-			{
-				++consumer_wins;
-			}
-			else
-			{
-				++producer_wins;
-			}
-		}
-	};
-
-	std::thread producer_thread{ producer };
-	std::thread consumer_thread{ consumer };
-	std::thread monitor_thread{ monitor };
-
-	ASSERT_TIMELY (10s, node.vote_processor.total_processed.load () >= number_of_votes);
-	producer_thread.join ();
-	consumer_thread.join ();
-	monitor_thread.join ();
-
-	ASSERT_TRUE (producer_wins > consumer_wins);
-}
-
 TEST (vote_processor, invalid_signature)
 {
 	nano::system system{ 1 };

--- a/nano/slow_test/CMakeLists.txt
+++ b/nano/slow_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(slow_test entry.cpp node.cpp)
+add_executable(slow_test entry.cpp node.cpp vote_processor.cpp)
 
 target_link_libraries(
   slow_test

--- a/nano/slow_test/vote_processor.cpp
+++ b/nano/slow_test/vote_processor.cpp
@@ -1,0 +1,67 @@
+#include <nano/node/transport/inproc.hpp>
+#include <nano/node/vote_processor.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+using namespace std::chrono_literals;
+
+// Tests the normal behavior is more votes getting into the vote_processor than getting processed,
+// so the producer always wins. Also exercises the flush operation, so it must never deadlock.
+TEST (vote_processor, producer_consumer)
+{
+	nano::system system (1);
+	auto & node (*system.nodes[0]);
+	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
+
+	unsigned number_of_votes{ 25'000 };
+	unsigned consumer_wins{ 0 };
+	unsigned producer_wins{ 0 };
+
+	auto producer = [&node, &channel, &number_of_votes] () -> void {
+		for (unsigned i = 0; i < number_of_votes; ++i)
+		{
+			auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * (1 + i), 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
+			node.vote_processor.vote (vote, channel);
+		}
+	};
+
+	auto consumer = [&node, &number_of_votes] () -> void {
+		while (node.vote_processor.total_processed.load () < number_of_votes)
+		{
+			if (node.vote_processor.size () >= number_of_votes / 100)
+			{
+				node.vote_processor.flush ();
+			}
+		}
+	};
+
+	auto monitor = [&node, &number_of_votes, &producer_wins, &consumer_wins] () -> void {
+		while (node.vote_processor.total_processed.load () < number_of_votes)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds (50));
+			if (node.vote_processor.empty ())
+			{
+				++consumer_wins;
+			}
+			else
+			{
+				++producer_wins;
+			}
+		}
+	};
+
+	std::thread producer_thread{ producer };
+	std::thread consumer_thread{ consumer };
+	std::thread monitor_thread{ monitor };
+
+	ASSERT_TIMELY (10s, node.vote_processor.total_processed.load () >= number_of_votes);
+	producer_thread.join ();
+	consumer_thread.join ();
+	monitor_thread.join ();
+
+	ASSERT_TRUE (producer_wins > consumer_wins);
+}


### PR DESCRIPTION
The `producer_consumer` test was failing intermittently both on my local machine and on GitHub runners (https://github.com/nanocurrency/nano-node/runs/7696698834?check_suite_focus=true#step:5:1648). Properly testing that behavior requires generating a lot of votes for which the GitHub runners are too slow. My fix is to move it to slow_tests suite and parallelizing producer vote generation part.