### PR TITLE
Move test code into namespace nano::test

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -32,7 +32,7 @@ namespace nano
 
 TEST (active_transactions, confirm_election_by_request)
 {
-	nano::system system{};
+	nano::test::system system{};
 	auto & node1 = *system.add_node ();
 
 	nano::node_flags node_flags2{};
@@ -86,7 +86,7 @@ namespace nano
 {
 TEST (active_transactions, confirm_frontier)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	// Voting node
@@ -132,9 +132,9 @@ TEST (active_transactions, confirm_frontier)
 
 TEST (active_transactions, keep_local)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.enable_voting = false;
 	// Bound to 2, won't drop wallet created transactions, but good to test dropping remote
 	node_config.active_elections_size = 2;
@@ -208,7 +208,7 @@ TEST (active_transactions, keep_local)
 
 TEST (active_transactions, inactive_votes_cache)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node = *system.nodes[0];
 	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
 	nano::keypair key;
@@ -230,7 +230,7 @@ TEST (active_transactions, inactive_votes_cache)
 
 TEST (active_transactions, inactive_votes_cache_non_final)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node = *system.nodes[0];
 	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
 	nano::keypair key;
@@ -255,7 +255,7 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 
 TEST (active_transactions, inactive_votes_cache_fork)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
 
 	auto const latest = node.latest (nano::dev::genesis_key.pub);
@@ -295,8 +295,8 @@ TEST (active_transactions, inactive_votes_cache_fork)
 
 TEST (active_transactions, inactive_votes_cache_existing_vote)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
@@ -355,8 +355,8 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3632
 TEST (active_transactions, DISABLED_inactive_votes_cache_multiple_votes)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
@@ -406,8 +406,8 @@ TEST (active_transactions, DISABLED_inactive_votes_cache_multiple_votes)
 
 TEST (active_transactions, inactive_votes_cache_election_start)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
@@ -512,8 +512,8 @@ namespace nano
 {
 TEST (active_transactions, vote_replays)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
@@ -541,7 +541,7 @@ TEST (active_transactions, vote_replays)
 	ASSERT_NE (nullptr, open1);
 	node.process_active (send1);
 	node.process_active (open1);
-	nano::blocks_confirm (node, { send1, open1 });
+	nano::test::blocks_confirm (node, { send1, open1 });
 	ASSERT_EQ (2, node.active.size ());
 	// First vote is not a replay and confirms the election, second vote should be a replay since the election has confirmed but not yet removed
 	auto vote_send1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send1->hash () }));
@@ -570,7 +570,7 @@ TEST (active_transactions, vote_replays)
 				 .build_shared ();
 	ASSERT_NE (nullptr, send2);
 	node.process_active (send2);
-	nano::blocks_confirm (node, { send2 });
+	nano::test::blocks_confirm (node, { send2 });
 	ASSERT_EQ (1, node.active.size ());
 	auto vote1_send2 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send2->hash () }));
 	auto vote2_send2 (std::make_shared<nano::vote> (key.pub, key.prv, 0, 0, std::vector<nano::block_hash>{ send2->hash () }));
@@ -601,7 +601,7 @@ TEST (active_transactions, vote_replays)
 // Tests that blocks are correctly cleared from the duplicate filter for unconfirmed elections
 TEST (active_transactions, dropped_cleanup)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
 	auto & node (*system.add_node (flags));
@@ -659,11 +659,11 @@ TEST (active_transactions, dropped_cleanup)
 
 TEST (active_transactions, republish_winner)
 {
-	nano::system system;
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::test::system system;
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	nano::keypair key;
@@ -726,9 +726,9 @@ TEST (active_transactions, republish_winner)
 
 TEST (active_transactions, fork_filter_cleanup)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node1 = *system.add_node (node_config);
@@ -776,7 +776,7 @@ TEST (active_transactions, fork_filter_cleanup)
 	ASSERT_EQ (1, node1.active.size ());
 
 	// Instantiate a new node
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	// Process the first initial block on node2
@@ -798,8 +798,8 @@ TEST (active_transactions, fork_filter_cleanup)
 
 TEST (active_transactions, fork_replacement_tally)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config));
 
@@ -904,7 +904,7 @@ TEST (active_transactions, fork_replacement_tally)
 	}
 
 	// Process correct block
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto & node2 (*system.add_node (node_config));
 	node2.network.flood_block (send_last);
 	ASSERT_TIMELY (3s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) > 0);
@@ -944,8 +944,8 @@ namespace nano
 // Blocks that won an election must always be seen as confirming or cemented
 TEST (active_transactions, confirmation_consistency)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -974,7 +974,7 @@ TEST (active_transactions, confirmation_consistency)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3634
 TEST (active_transactions, DISABLED_confirm_new)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 = *system.nodes[0];
 	auto send = nano::send_block_builder ()
 				.previous (nano::dev::genesis->hash ())
@@ -999,7 +999,7 @@ TEST (active_transactions, DISABLED_confirm_new)
 // Ensures votes are tallied on election::publish even if no vote is inserted through inactive_votes_cache
 TEST (active_transactions, conflicting_block_vote_existing_election)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto & node = *system.add_node (node_flags);
@@ -1043,9 +1043,9 @@ TEST (active_transactions, conflicting_block_vote_existing_election)
 
 TEST (active_transactions, activate_account_chain)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config, flags);
 
@@ -1143,9 +1143,9 @@ TEST (active_transactions, activate_account_chain)
 
 TEST (active_transactions, activate_inactive)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config, flags);
 
@@ -1202,7 +1202,7 @@ TEST (active_transactions, activate_inactive)
 
 TEST (active_transactions, list_active)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node = *system.nodes[0];
 
 	nano::keypair key;
@@ -1243,7 +1243,7 @@ TEST (active_transactions, list_active)
 
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
 
-	nano::blocks_confirm (node, { send, send2, open });
+	nano::test::blocks_confirm (node, { send, send2, open });
 	ASSERT_EQ (3, node.active.size ());
 	ASSERT_EQ (1, node.active.list_active (1).size ());
 	ASSERT_EQ (2, node.active.list_active (2).size ());
@@ -1257,8 +1257,8 @@ TEST (active_transactions, list_active)
 
 TEST (active_transactions, vacancy)
 {
-	nano::system system;
-	nano::node_config config{ nano::get_available_port (), system.logging };
+	nano::test::system system;
+	nano::node_config config{ nano::test::get_available_port (), system.logging };
 	config.active_elections_size = 1;
 	auto & node = *system.add_node (config);
 	nano::state_block_builder builder;
@@ -1292,9 +1292,9 @@ TEST (active_transactions, vacancy)
 // Ensure transactions in excess of capacity are removed in fifo order
 TEST (active_transactions, fifo)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config config{ nano::get_available_port (), system.logging };
+	nano::node_config config{ nano::test::get_available_port (), system.logging };
 	config.active_elections_size = 1;
 
 	auto & node = *system.add_node (config);
@@ -1374,8 +1374,8 @@ TEST (active_transactions, fifo)
 // Ensures we limit the number of vote hinted elections in AEC
 TEST (active_transactions, limit_vote_hinted_elections)
 {
-	nano::system system;
-	nano::node_config config{ nano::get_available_port (), system.logging };
+	nano::test::system system;
+	nano::node_config config{ nano::test::get_available_port (), system.logging };
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	config.active_elections_size = 10;
 	config.active_elections_hinted_limit_percentage = 10; // Should give us a limit of 1 hinted election
@@ -1426,7 +1426,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 		ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
 		ASSERT_EQ (nano::process_result::progress, node.process (*open1).code);
 		ASSERT_EQ (nano::process_result::progress, node.process (*open2).code);
-		nano::blocks_confirm (node, { send1, send2, open1, open2 }, true);
+		nano::test::blocks_confirm (node, { send1, send2, open1, open2 }, true);
 		ASSERT_TIMELY (1s, node.block_confirmed (send1->hash ()));
 		ASSERT_TIMELY (1s, node.block_confirmed (send2->hash ()));
 		ASSERT_TIMELY (1s, node.block_confirmed (open1->hash ()));
@@ -1452,7 +1452,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 					 .work (*system.work.generate (latest))
 					 .build_shared ();
 		ASSERT_EQ (nano::process_result::progress, node.process (*send0).code);
-		nano::blocks_confirm (node, { send0 }, true);
+		nano::test::blocks_confirm (node, { send0 }, true);
 		ASSERT_TIMELY (1s, node.block_confirmed (send0->hash ()));
 		ASSERT_TIMELY (1s, node.active.empty ());
 		auto send1 = builder.make_block ()
@@ -1465,7 +1465,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 					 .work (*system.work.generate (send0->hash ()))
 					 .build_shared ();
 		ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
-		nano::blocks_confirm (node, { send1 }, true);
+		nano::test::blocks_confirm (node, { send1 }, true);
 		ASSERT_TIMELY (1s, node.block_confirmed (send1->hash ()));
 		ASSERT_TIMELY (1s, node.active.empty ());
 

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -416,7 +416,7 @@ TEST (block_store, genesis)
 // deleting it from the database
 TEST (unchecked, simple)
 {
-	nano::system system{};
+	nano::test::system system{};
 	nano::logger_mt logger{};
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
@@ -456,7 +456,7 @@ TEST (unchecked, simple)
 // This test ensures the unchecked table is able to receive more than one block
 TEST (unchecked, multiple)
 {
-	nano::system system{};
+	nano::test::system system{};
 	if (nano::rocksdb_config::using_rocksdb_in_tests ())
 	{
 		// Don't test this in rocksdb mode
@@ -494,7 +494,7 @@ TEST (unchecked, multiple)
 // This test ensures that a block can't occur twice in the unchecked table.
 TEST (unchecked, double_put)
 {
-	nano::system system{};
+	nano::test::system system{};
 	nano::logger_mt logger{};
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
@@ -528,7 +528,7 @@ TEST (unchecked, double_put)
 // Tests that recurrent get calls return the correct values
 TEST (unchecked, multiple_get)
 {
-	nano::system system{};
+	nano::test::system system{};
 	nano::logger_mt logger{};
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };
@@ -2649,7 +2649,7 @@ TEST (rocksdb_block_store, tombstone_count)
 	{
 		return;
 	}
-	nano::system system{};
+	nano::test::system system{};
 	nano::logger_mt logger;
 	auto store = std::make_unique<nano::rocksdb::store> (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());

--- a/nano/core_test/blockprocessor.cpp
+++ b/nano/core_test/blockprocessor.cpp
@@ -12,11 +12,11 @@ using namespace std::chrono_literals;
 
 TEST (block_processor, broadcast_block_on_arrival)
 {
-	nano::system system;
-	nano::node_config config1{ nano::get_available_port (), system.logging };
+	nano::test::system system;
+	nano::node_config config1{ nano::test::get_available_port (), system.logging };
 	// Deactivates elections on both nodes.
 	config1.active_elections_size = 0;
-	nano::node_config config2{ nano::get_available_port (), system.logging };
+	nano::node_config config2{ nano::test::get_available_port (), system.logging };
 	config2.active_elections_size = 0;
 	nano::node_flags flags;
 	// Disables bootstrap listener to make sure the block won't be shared by this channel.

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -11,7 +11,7 @@ using namespace std::chrono_literals;
 // If the account doesn't exist, current == end so there's no iteration
 TEST (bulk_pull, no_address)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = 1;
@@ -23,7 +23,7 @@ TEST (bulk_pull, no_address)
 
 TEST (bulk_pull, genesis_to_end)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
@@ -36,7 +36,7 @@ TEST (bulk_pull, genesis_to_end)
 // If we can't find the end block, send everything
 TEST (bulk_pull, no_end)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
@@ -48,7 +48,7 @@ TEST (bulk_pull, no_end)
 
 TEST (bulk_pull, end_not_owned)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, 100));
@@ -79,7 +79,7 @@ TEST (bulk_pull, end_not_owned)
 
 TEST (bulk_pull, none)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
@@ -91,7 +91,7 @@ TEST (bulk_pull, none)
 
 TEST (bulk_pull, get_next_on_open)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub;
@@ -108,7 +108,7 @@ TEST (bulk_pull, get_next_on_open)
  */
 TEST (bulk_pull, ascending_one_hash)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
 	nano::state_block_builder builder;
 	auto block1 = builder
@@ -140,7 +140,7 @@ TEST (bulk_pull, ascending_one_hash)
  */
 TEST (bulk_pull, ascending_two_account)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
 	nano::state_block_builder builder;
 	auto block1 = builder
@@ -175,7 +175,7 @@ TEST (bulk_pull, ascending_two_account)
  */
 TEST (bulk_pull, ascending_end)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
 	nano::state_block_builder builder;
 	auto block1 = builder
@@ -204,7 +204,7 @@ TEST (bulk_pull, ascending_end)
 
 TEST (bulk_pull, by_block)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis->hash ();
@@ -220,7 +220,7 @@ TEST (bulk_pull, by_block)
 
 TEST (bulk_pull, by_block_single)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis->hash ();
@@ -236,7 +236,7 @@ TEST (bulk_pull, by_block_single)
 
 TEST (bulk_pull, count_limit)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node0 (system.nodes[0]);
 
 	nano::block_builder builder;
@@ -281,8 +281,8 @@ TEST (bulk_pull, count_limit)
 
 TEST (bootstrap_processor, DISABLED_process_none)
 {
-	nano::system system (1);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	nano::test::system system (1);
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	auto done (false);
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint (), false);
@@ -296,8 +296,8 @@ TEST (bootstrap_processor, DISABLED_process_none)
 // Bootstrap can pull one basic block
 TEST (bootstrap_processor, process_one)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.enable_voting = false;
 	nano::node_flags node_flags;
@@ -307,7 +307,7 @@ TEST (bootstrap_processor, process_one)
 	auto send (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 100));
 	ASSERT_NE (nullptr, send);
 
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	node_flags.disable_rep_crawler = true;
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work, node_flags));
 	nano::block_hash hash1 (node0->latest (nano::dev::genesis_key.pub));
@@ -322,8 +322,8 @@ TEST (bootstrap_processor, process_one)
 
 TEST (bootstrap_processor, process_two)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -338,7 +338,7 @@ TEST (bootstrap_processor, process_two)
 	ASSERT_NE (hash1, hash3);
 	ASSERT_NE (hash2, hash3);
 
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
@@ -349,8 +349,8 @@ TEST (bootstrap_processor, process_two)
 // Bootstrap can pull universal blocks
 TEST (bootstrap_processor, process_state)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -383,7 +383,7 @@ TEST (bootstrap_processor, process_state)
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block1).code);
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block2).code);
 
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_EQ (node0->latest (nano::dev::genesis_key.pub), block2->hash ());
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), block2->hash ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
@@ -395,13 +395,13 @@ TEST (bootstrap_processor, process_state)
 
 TEST (bootstrap_processor, process_new)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node1 (system.add_node (config, node_flags));
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
@@ -415,7 +415,7 @@ TEST (bootstrap_processor, process_new)
 	nano::uint128_t balance2 (node1->balance (key2.pub));
 	ASSERT_TIMELY (10s, node1->block_confirmed (send->hash ()) && node1->block_confirmed (receive->hash ()) && node1->active.empty () && node2->active.empty ()); // All blocks should be propagated & confirmed
 
-	auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node3->init_error ());
 	node3->bootstrap_initiator.bootstrap (node1->network.endpoint (), false);
 	ASSERT_TIMELY (10s, node3->balance (key2.pub) == balance2);
@@ -425,8 +425,8 @@ TEST (bootstrap_processor, process_new)
 
 TEST (bootstrap_processor, pull_diamond)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -468,7 +468,7 @@ TEST (bootstrap_processor, pull_diamond)
 				   .work (*system.work.generate (send1->hash ()))
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive).code);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
 	ASSERT_TIMELY (10s, node1->balance (nano::dev::genesis_key.pub) == 100);
@@ -479,13 +479,13 @@ TEST (bootstrap_processor, pull_diamond)
 TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 {
 	// Bootstrap attempt stopped before requeue & then cannot be found in attempts list
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node1 (system.add_node (config, node_flags));
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 	nano::keypair key1;
 
@@ -524,12 +524,12 @@ TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 // CI run in which it failed: https://github.com/nanocurrency/nano-node/runs/4280675502?check_suite_focus=true#step:6:398
 TEST (bootstrap_processor, DISABLED_push_diamond)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system.add_node (config));
 	nano::keypair key;
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	auto wallet1 (node1->wallets.create (100));
 	wallet1->insert_adhoc (nano::dev::genesis_key.prv);
@@ -582,12 +582,12 @@ TEST (bootstrap_processor, DISABLED_push_diamond)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3517
 TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system.add_node (config));
 	nano::keypair key;
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -657,12 +657,12 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 
 TEST (bootstrap_processor, push_one)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system.add_node (config));
 	nano::keypair key1;
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
@@ -677,8 +677,8 @@ TEST (bootstrap_processor, push_one)
 
 TEST (bootstrap_processor, lazy_hash)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -736,7 +736,7 @@ TEST (bootstrap_processor, lazy_hash)
 	node0->block_processor.add (receive2);
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	{
@@ -751,8 +751,8 @@ TEST (bootstrap_processor, lazy_hash)
 
 TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -810,7 +810,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	node0->block_processor.add (receive2);
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, true, "123456");
 	{
@@ -825,8 +825,8 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 
 TEST (bootstrap_processor, lazy_hash_pruning)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
@@ -931,14 +931,14 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	node0->block_processor.flush ();
 	ASSERT_EQ (9, node0->ledger.cache.block_count);
 	// Processing chain to prune for node1
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
 	node1->process_active (send1);
 	node1->process_active (receive1);
 	node1->process_active (change1);
 	node1->process_active (change2);
 	// Confirm last block to prune previous
-	nano::blocks_confirm (*node1, { send1, receive1, change1, change2 }, true);
+	nano::test::blocks_confirm (*node1, { send1, receive1, change1, change2 }, true);
 	ASSERT_TIMELY (10s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()) && node1->block_confirmed (change1->hash ()) && node1->block_confirmed (change2->hash ()) && node1->active.empty ());
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
@@ -960,8 +960,8 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 
 TEST (bootstrap_processor, lazy_max_pull_count)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1051,7 +1051,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	node0->block_processor.add (change3);
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
@@ -1065,8 +1065,8 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3640
 TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1120,7 +1120,7 @@ TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	// Start lazy bootstrap with last block in chain known
-	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
 	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (receive->hash ());
 	// Check processed blocks
@@ -1134,8 +1134,8 @@ TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 
 TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1179,7 +1179,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 
 	// Start lazy bootstrap with last block in chain known
-	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
 	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
@@ -1192,8 +1192,8 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 
 TEST (bootstrap_processor, DISABLED_lazy_destinations)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1248,7 +1248,7 @@ TEST (bootstrap_processor, DISABLED_lazy_destinations)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*state_open).code);
 
 	// Start lazy bootstrap with last block in sender chain
-	auto node2 = system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
 	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
@@ -1261,8 +1261,8 @@ TEST (bootstrap_processor, DISABLED_lazy_destinations)
 
 TEST (bootstrap_processor, lazy_pruning_missing_block)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
@@ -1319,7 +1319,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 
 	node1->process_active (state_open);
 	// Confirm last block to prune previous
-	nano::blocks_confirm (*node1, { send1, send2, open, state_open }, true);
+	nano::test::blocks_confirm (*node1, { send1, send2, open, state_open }, true);
 	ASSERT_TIMELY (10s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (send2->hash ()) && node1->block_confirmed (open->hash ()) && node1->block_confirmed (state_open->hash ()) && node1->active.empty ());
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
@@ -1332,7 +1332,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	ASSERT_TRUE (node1->ledger.block_or_pruned_exists (open->hash ()));
 	ASSERT_TRUE (node1->ledger.block_or_pruned_exists (state_open->hash ()));
 	// Start lazy bootstrap with last block in sender chain
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
 	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
@@ -1366,8 +1366,8 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 
 TEST (bootstrap_processor, lazy_cancel)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1388,7 +1388,7 @@ TEST (bootstrap_processor, lazy_cancel)
 				 .build_shared ();
 
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	node1->bootstrap_initiator.bootstrap_lazy (send1->hash (), true); // Start "confirmed" block bootstrap
 	{
@@ -1403,8 +1403,8 @@ TEST (bootstrap_processor, lazy_cancel)
 
 TEST (bootstrap_processor, wallet_lazy_frontier)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1463,7 +1463,7 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	node0->block_processor.add (receive2);
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
@@ -1481,8 +1481,8 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 
 TEST (bootstrap_processor, wallet_lazy_pending)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1542,8 +1542,8 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 
 TEST (bootstrap_processor, multiple_attempts)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -1601,7 +1601,7 @@ TEST (bootstrap_processor, multiple_attempts)
 	node1->block_processor.add (receive2);
 	node1->block_processor.flush ();
 	// Start 2 concurrent bootstrap attempts
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.bootstrap_initiator_threads = 3;
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work));
 	node2->network.udp_channels.insert (node1->network.endpoint (), node2->network_params.network.protocol_version);
@@ -1626,7 +1626,7 @@ TEST (frontier_req_response, DISABLED_destruction)
 	{
 		std::shared_ptr<nano::frontier_req_server> hold; // Destructing tcp acceptor on non-existent io_context
 		{
-			nano::system system (1);
+			nano::test::system system (1);
 			auto connection (std::make_shared<nano::bootstrap_server> (nullptr, system.nodes[0]));
 			auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 			req->start.clear ();
@@ -1640,7 +1640,7 @@ TEST (frontier_req_response, DISABLED_destruction)
 
 TEST (frontier_req, begin)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
@@ -1653,7 +1653,7 @@ TEST (frontier_req, begin)
 
 TEST (frontier_req, end)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start = nano::dev::genesis_key.pub.number () + 1;
@@ -1665,7 +1665,7 @@ TEST (frontier_req, end)
 
 TEST (frontier_req, count)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 = system.nodes[0];
 	// Public key FB93... after genesis in accounts table
 	nano::keypair key1 ("ED5AE0A6505B14B67435C29FD9FEEBC26F597D147BC92F6D795FFAD7AFD3D967");
@@ -1707,7 +1707,7 @@ TEST (frontier_req, count)
 
 TEST (frontier_req, time_bound)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
@@ -1728,7 +1728,7 @@ TEST (frontier_req, time_bound)
 
 TEST (frontier_req, time_cutoff)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto connection (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*system.nodes[0], nano::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
 	req->start.clear ();
@@ -1750,7 +1750,7 @@ TEST (frontier_req, time_cutoff)
 
 TEST (frontier_req, confirmed_frontier)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 = system.nodes[0];
 	nano::keypair key_before_genesis;
 	// Public key before genesis in accounts table
@@ -1876,7 +1876,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (receive2->hash (), request5->frontier);
 
 	// Confirm account before genesis (confirmed only)
-	nano::blocks_confirm (*node1, { send1, receive1 }, true);
+	nano::test::blocks_confirm (*node1, { send1, receive1 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()));
 	auto connection6 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req6 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
@@ -1891,7 +1891,7 @@ TEST (frontier_req, confirmed_frontier)
 	ASSERT_EQ (receive1->hash (), request6->frontier);
 
 	// Confirm account after genesis (confirmed only)
-	nano::blocks_confirm (*node1, { send2, receive2 }, true);
+	nano::test::blocks_confirm (*node1, { send2, receive2 }, true);
 	ASSERT_TIMELY (5s, node1->block_confirmed (send2->hash ()) && node1->block_confirmed (receive2->hash ()));
 	auto connection7 (std::make_shared<nano::bootstrap_server> (std::make_shared<nano::socket> (*node1, nano::socket::endpoint_type_t::server), node1));
 	auto req7 = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
@@ -1908,15 +1908,15 @@ TEST (frontier_req, confirmed_frontier)
 
 TEST (bulk, genesis)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node2->init_error ());
 	nano::block_hash latest1 (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_hash latest2 (node2->latest (nano::dev::genesis_key.pub));
@@ -1935,15 +1935,15 @@ TEST (bulk, genesis)
 
 TEST (bulk, offline_send)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node2->init_error ());
 	node2->start ();
 	system.nodes.push_back (node2);
@@ -1978,8 +1978,8 @@ TEST (bulk, offline_send)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3613
 TEST (bulk, DISABLED_genesis_pruning)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
@@ -1990,7 +1990,7 @@ TEST (bulk, DISABLED_genesis_pruning)
 	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	node_flags.enable_pruning = false;
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node2->init_error ());
 	nano::block_hash latest1 (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_hash latest2 (node2->latest (nano::dev::genesis_key.pub));
@@ -2061,7 +2061,7 @@ TEST (bulk, DISABLED_genesis_pruning)
 
 TEST (bulk_pull_account, basics)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.nodes[0]->config.receive_minimum = 20;
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/core_test/cli.cpp
+++ b/nano/core_test/cli.cpp
@@ -74,7 +74,7 @@ namespace
 std::string call_cli_command (boost::program_options::variables_map const & vm)
 {
 	std::stringstream ss;
-	nano::cout_redirect redirect (ss.rdbuf ());
+	nano::test::cout_redirect redirect (ss.rdbuf ());
 
 	// Execute CLI command. This populates the stringstream with a string like: "Private: 123\n Public: 456\n Account: nano_123"
 	auto ec = nano::handle_node_options (vm);

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -33,7 +33,7 @@ TEST (confirmation_height, single)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		auto amount (std::numeric_limits<nano::uint128_t>::max ());
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
 		auto node = system.add_node (node_flags);
@@ -91,10 +91,10 @@ TEST (confirmation_height, single)
 TEST (confirmation_height, multiple_accounts)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::keypair key1;
@@ -311,7 +311,7 @@ TEST (confirmation_height, multiple_accounts)
 TEST (confirmation_height, gap_bootstrap)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system{};
+		nano::test::system system{};
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
 		auto & node1 = *system.add_node (node_flags);
@@ -436,13 +436,13 @@ TEST (confirmation_height, gap_bootstrap)
 TEST (confirmation_height, gap_live)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system{};
+		nano::test::system system{};
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config{ nano::get_available_port (), system.logging };
+		nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
-		node_config.peering_port = nano::get_available_port ();
+		node_config.peering_port = nano::test::get_available_port ();
 		node_config.receive_minimum = nano::dev::constants.genesis_amount; // Prevent auto-receive & open1/receive1/receive2 blocks conflicts
 		system.add_node (node_config, node_flags);
 		nano::keypair destination;
@@ -570,10 +570,10 @@ TEST (confirmation_height, gap_live)
 TEST (confirmation_height, send_receive_between_2_accounts)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::keypair key1;
@@ -726,10 +726,10 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 TEST (confirmation_height, send_receive_self)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
@@ -835,10 +835,10 @@ TEST (confirmation_height, send_receive_self)
 TEST (confirmation_height, all_block_types)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
@@ -1102,7 +1102,7 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		nano::state_block_builder builder{};
 		auto const genesis_hash = nano::dev::genesis->hash ();
 
-		nano::system system{};
+		nano::test::system system{};
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
 
@@ -1246,7 +1246,7 @@ TEST (confirmation_height, observers)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
 		auto amount (std::numeric_limits<nano::uint128_t>::max ());
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
 		auto node1 = system.add_node (node_flags);
@@ -1452,10 +1452,10 @@ namespace nano
 TEST (confirmation_height, pending_observer_callbacks)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1509,11 +1509,11 @@ TEST (confirmation_height, pending_observer_callbacks)
 TEST (confirmation_height, callback_confirmed_history)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.force_use_write_database_queue = true;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1605,11 +1605,11 @@ namespace nano
 TEST (confirmation_height, dependent_election)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
 		node_flags.force_use_write_database_queue = true;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1678,10 +1678,10 @@ TEST (confirmation_height, dependent_election)
 TEST (confirmation_height, cemented_gap_below_receive)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1839,10 +1839,10 @@ TEST (confirmation_height, cemented_gap_below_receive)
 TEST (confirmation_height, cemented_gap_below_no_cache)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1998,12 +1998,12 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 TEST (confirmation_height, election_winner_details_clearing)
 {
 	auto test_mode = [] (nano::confirmation_height_mode mode_a) {
-		nano::system system{};
+		nano::test::system system{};
 
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
 
-		nano::node_config node_config{ nano::get_available_port (), system.logging };
+		nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 		auto node = system.add_node (node_config, node_flags);
@@ -2065,7 +2065,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 TEST (confirmation_height, election_winner_details_clearing_node_process_confirmed)
 {
 	// Make sure election_winner_details is also cleared if the block never enters the confirmation height processor from node::process_confirmed
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node = system.nodes.front ();
 
 	nano::block_builder builder;

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -9,7 +9,7 @@ using namespace std::chrono_literals;
 
 TEST (confirmation_solicitor, batches)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_rep_crawler = true;
@@ -61,7 +61,7 @@ namespace nano
 {
 TEST (confirmation_solicitor, different_hash)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_rep_crawler = true;
@@ -103,7 +103,7 @@ TEST (confirmation_solicitor, different_hash)
 
 TEST (confirmation_solicitor, bypass_max_requests_cap)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_rep_crawler = true;

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -10,7 +10,7 @@ using namespace std::chrono_literals;
 
 TEST (conflicts, start_stop)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -35,7 +35,7 @@ TEST (conflicts, start_stop)
 
 TEST (conflicts, add_existing)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node1 = *system.nodes[0];
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -67,7 +67,7 @@ TEST (conflicts, add_existing)
 
 TEST (conflicts, add_two)
 {
-	nano::system system{};
+	nano::test::system system{};
 	auto const & node = system.add_node ();
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/core_test/core_test_main.cc
+++ b/nano/core_test/core_test_main.cc
@@ -8,7 +8,10 @@
 
 namespace nano
 {
-void cleanup_dev_directories_on_exit ();
+namespace test
+{
+	void cleanup_dev_directories_on_exit ();
+}
 void force_nano_dev_network ();
 }
 
@@ -22,6 +25,6 @@ GTEST_API_ int main (int argc, char ** argv)
 	logging.init (nano::unique_path ());
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_dev_directories_on_exit ();
+	nano::test::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -8,14 +8,14 @@ using namespace std::chrono_literals;
 
 TEST (distributed_work, stopped)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.nodes[0]->distributed_work.stop ();
 	ASSERT_TRUE (system.nodes[0]->distributed_work.make (nano::work_version::work_1, nano::block_hash (), {}, nano::dev::network_params.work.base, {}));
 }
 
 TEST (distributed_work, no_peers)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::block_hash hash{ 1 };
 	boost::optional<uint64_t> work;
@@ -39,8 +39,8 @@ TEST (distributed_work, no_peers)
 
 TEST (distributed_work, no_peers_disabled)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto & node = *system.add_node (node_config);
 	ASSERT_TRUE (node.distributed_work.make (nano::work_version::work_1, nano::block_hash (), node.config.work_peers, nano::dev::network_params.work.base, {}));
@@ -48,8 +48,8 @@ TEST (distributed_work, no_peers_disabled)
 
 TEST (distributed_work, no_peers_cancel)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.max_work_generate_multiplier = 1e6;
 	auto & node = *system.add_node (node_config);
 	nano::block_hash hash{ 1 };
@@ -78,7 +78,7 @@ TEST (distributed_work, no_peers_cancel)
 
 TEST (distributed_work, no_peers_multi)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::block_hash hash{ 1 };
 	unsigned total{ 10 };
@@ -117,9 +117,9 @@ TEST (distributed_work, no_peers_multi)
 
 TEST (distributed_work, peer)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_config node_config;
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	// Disable local work generation
 	node_config.work_threads = 0;
 	auto node (system.add_node (node_config));
@@ -132,7 +132,7 @@ TEST (distributed_work, peer)
 		work = work_a;
 		done = true;
 	};
-	auto work_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::good));
+	auto work_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::good));
 	work_peer->start ();
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("::ffff:127.0.0.1", work_peer->port ());
@@ -147,7 +147,7 @@ TEST (distributed_work, peer)
 
 TEST (distributed_work, peer_malicious)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	ASSERT_TRUE (node->local_work_generation_enabled ());
 	nano::block_hash hash{ 1 };
@@ -158,7 +158,7 @@ TEST (distributed_work, peer_malicious)
 		work = work_a;
 		done = true;
 	};
-	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::malicious));
+	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::malicious));
 	malicious_peer->start ();
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("::ffff:127.0.0.1", malicious_peer->port ());
@@ -176,7 +176,7 @@ TEST (distributed_work, peer_malicious)
 	// Test again with no local work generation enabled to make sure the malicious peer is sent more than one request
 	node->config.work_threads = 0;
 	ASSERT_FALSE (node->local_work_generation_enabled ());
-	auto malicious_peer2 (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::malicious));
+	auto malicious_peer2 (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::malicious));
 	malicious_peer2->start ();
 	peers[0].second = malicious_peer2->port ();
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, {}, nano::account ()));
@@ -190,7 +190,7 @@ TEST (distributed_work, peer_malicious)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3630
 TEST (distributed_work, DISABLED_peer_multi)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	ASSERT_TRUE (node->local_work_generation_enabled ());
 	nano::block_hash hash{ 1 };
@@ -201,9 +201,9 @@ TEST (distributed_work, DISABLED_peer_multi)
 		work = work_a;
 		done = true;
 	};
-	auto good_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::good));
-	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::malicious));
-	auto slow_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::get_available_port (), work_peer_type::slow));
+	auto good_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::good));
+	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::malicious));
+	auto slow_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::slow));
 	good_peer->start ();
 	malicious_peer->start ();
 	slow_peer->start ();
@@ -230,7 +230,7 @@ TEST (distributed_work, DISABLED_peer_multi)
 
 TEST (distributed_work, fail_resolve)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::block_hash hash{ 1 };
 	boost::optional<uint64_t> work;

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -8,7 +8,7 @@ using namespace std::chrono_literals;
 
 TEST (election, construction)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node = *system.nodes[0];
 	node.block_confirm (nano::dev::genesis);
 	node.scheduler.flush ();
@@ -18,9 +18,9 @@ TEST (election, construction)
 
 TEST (election, quorum_minimum_flip_success)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
@@ -69,9 +69,9 @@ TEST (election, quorum_minimum_flip_success)
 
 TEST (election, quorum_minimum_flip_fail)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
@@ -122,8 +122,8 @@ TEST (election, quorum_minimum_flip_fail)
 
 TEST (election, quorum_minimum_confirm_success)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
@@ -155,8 +155,8 @@ TEST (election, quorum_minimum_confirm_success)
 
 TEST (election, quorum_minimum_confirm_fail)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
@@ -190,9 +190,9 @@ namespace nano
 {
 TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node1 = *system.add_node (node_config);
@@ -226,7 +226,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
 	ASSERT_TIMELY (5s, node1.ledger.cache.block_count == 4);
 
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	system.wallet (1)->insert_adhoc (key1.prv);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -10,12 +10,12 @@ using namespace std::chrono_literals;
 
 TEST (election_scheduler, construction)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 }
 
 TEST (election_scheduler, activate_one_timely)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -33,7 +33,7 @@ TEST (election_scheduler, activate_one_timely)
 
 TEST (election_scheduler, activate_one_flush)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -67,9 +67,9 @@ TEST (election_scheduler, activate_one_flush)
  */
 TEST (election_scheduler, no_vacancy)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config config{ nano::get_available_port (), system.logging };
+	nano::node_config config{ nano::test::get_available_port (), system.logging };
 	config.active_elections_size = 1;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
@@ -144,8 +144,8 @@ TEST (election_scheduler, no_vacancy)
 // Ensure that election_scheduler::flush terminates even if no elections can currently be queued e.g. shutdown or no active_transactions vacancy
 TEST (election_scheduler, flush_vacancy)
 {
-	nano::system system;
-	nano::node_config config{ nano::get_available_port (), system.logging };
+	nano::test::system system;
+	nano::node_config config{ nano::test::get_available_port (), system.logging };
 	// No elections can be activated
 	config.active_elections_size = 0;
 	auto & node = *system.add_node (config);

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -13,8 +13,8 @@ TEST (frontiers_confirmation, mode)
 	nano::node_flags node_flags;
 	// Always mode
 	{
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 		auto node = system.add_node (node_config, node_flags);
 		auto send = builder
@@ -35,8 +35,8 @@ TEST (frontiers_confirmation, mode)
 	}
 	// Auto mode
 	{
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::automatic;
 		auto node = system.add_node (node_config, node_flags);
 		auto send = builder
@@ -57,8 +57,8 @@ TEST (frontiers_confirmation, mode)
 	}
 	// Disabled mode
 	{
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		auto send = builder

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -7,7 +7,7 @@ using namespace std::chrono_literals;
 
 TEST (gap_cache, add_new)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::gap_cache cache (*system.nodes[0]);
 	nano::block_builder builder;
 	auto block1 = builder
@@ -23,7 +23,7 @@ TEST (gap_cache, add_new)
 
 TEST (gap_cache, add_existing)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::gap_cache cache (*system.nodes[0]);
 	nano::block_builder builder;
 	auto block1 = builder
@@ -51,7 +51,7 @@ TEST (gap_cache, add_existing)
 
 TEST (gap_cache, comparison)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::gap_cache cache (*system.nodes[0]);
 	nano::block_builder builder;
 	auto block1 = builder
@@ -92,7 +92,7 @@ TEST (gap_cache, gap_bootstrap)
 	nano::node_flags node_flags;
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_request_loop = true; // to avoid fallback behavior of broadcasting blocks
-	nano::system system (2, nano::transport::transport_type::tcp, node_flags);
+	nano::test::system system (2, nano::transport::transport_type::tcp, node_flags);
 
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
@@ -127,7 +127,7 @@ TEST (gap_cache, gap_bootstrap)
 
 TEST (gap_cache, two_dependencies)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key;
 	nano::block_builder builder;

--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -19,7 +19,7 @@ using namespace std::chrono_literals;
 
 TEST (ipc, asynchronous)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.nodes[0]->config.ipc_config.transport_tcp.enabled = true;
 	system.nodes[0]->config.ipc_config.transport_tcp.port = 24077;
 	nano::node_rpc_config node_rpc_config;
@@ -59,7 +59,7 @@ TEST (ipc, asynchronous)
 
 TEST (ipc, synchronous)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.nodes[0]->config.ipc_config.transport_tcp.enabled = true;
 	system.nodes[0]->config.ipc_config.transport_tcp.port = 24077;
 	nano::node_rpc_config node_rpc_config;
@@ -192,7 +192,7 @@ TEST (ipc, permissions_default_user_order)
 
 TEST (ipc, invalid_endpoint)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.nodes[0]->config.ipc_config.transport_tcp.enabled = true;
 	system.nodes[0]->config.ipc_config.transport_tcp.port = 24077;
 	nano::node_rpc_config node_rpc_config;

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -895,8 +895,8 @@ TEST (ledger, double_receive)
 
 TEST (votes, check_signature)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
 	auto & node1 = *system.add_node (node_config);
 	nano::keypair key1;
@@ -928,7 +928,7 @@ TEST (votes, check_signature)
 
 TEST (votes, add_one)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -967,8 +967,8 @@ namespace nano
 // Higher timestamps change the vote
 TEST (votes, add_existing)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
@@ -1029,7 +1029,7 @@ TEST (votes, add_existing)
 // Lower timestamps are ignored
 TEST (votes, add_old)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1080,7 +1080,7 @@ TEST (votes, add_old)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3631
 TEST (votes, DISABLED_add_old_different_account)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1104,7 +1104,7 @@ TEST (votes, DISABLED_add_old_different_account)
 	node1.work_generate_blocking (*send2);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
-	nano::blocks_confirm (node1, { send1, send2 });
+	nano::test::blocks_confirm (node1, { send1, send2 });
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election1);
 	auto election2 = node1.active.election (send2->qualified_root ());
@@ -1135,7 +1135,7 @@ TEST (votes, DISABLED_add_old_different_account)
 // The voting cooldown is respected
 TEST (votes, add_cooldown)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1178,7 +1178,7 @@ TEST (votes, add_cooldown)
 // Query for block successor
 TEST (ledger, successor)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -3909,7 +3909,7 @@ TEST (ledger, epoch_blocks_fork)
 
 TEST (ledger, successor_epoch)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -3976,7 +3976,7 @@ TEST (ledger, successor_epoch)
 TEST (ledger, epoch_open_pending)
 {
 	nano::block_builder builder{};
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node1 = *system.nodes[0];
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1{};
@@ -4018,7 +4018,7 @@ TEST (ledger, epoch_open_pending)
 TEST (ledger, block_hash_account_conflict)
 {
 	nano::block_builder builder;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::keypair key2;
@@ -4086,7 +4086,7 @@ TEST (ledger, block_hash_account_conflict)
 	ASSERT_EQ (nano::process_result::progress, node1.process (*receive1).code);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*open_epoch1).code);
-	nano::blocks_confirm (node1, { send1, receive1, send2, open_epoch1 });
+	nano::test::blocks_confirm (node1, { send1, receive1, send2, open_epoch1 });
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election1);
 	auto election2 = node1.active.election (receive1->qualified_root ());
@@ -4249,7 +4249,7 @@ TEST (ledger, could_fit)
 
 TEST (ledger, unchecked_epoch)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -4308,8 +4308,8 @@ TEST (ledger, unchecked_epoch)
 
 TEST (ledger, unchecked_epoch_invalid)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config));
 	nano::keypair destination;
@@ -4395,7 +4395,7 @@ TEST (ledger, unchecked_epoch_invalid)
 
 TEST (ledger, unchecked_open)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -4447,7 +4447,7 @@ TEST (ledger, unchecked_open)
 
 TEST (ledger, unchecked_receive)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node1 = *system.nodes[0];
 	nano::keypair destination{};
 	nano::block_builder builder;
@@ -4561,7 +4561,7 @@ TEST (ledger, confirmation_height_not_updated)
 
 TEST (ledger, zero_rep)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::block_builder builder;
 	auto block1 = builder.state ()

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -13,7 +13,7 @@ using namespace std::chrono_literals;
 
 TEST (ledger_walker, genesis_block)
 {
-	nano::system system{};
+	nano::test::system system{};
 	auto const node = system.add_node ();
 
 	nano::ledger_walker ledger_walker{ node->ledger };
@@ -41,8 +41,8 @@ namespace nano
 {
 TEST (ledger_walker, genesis_account_longer)
 {
-	nano::system system{};
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system{};
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
@@ -90,8 +90,8 @@ TEST (ledger_walker, genesis_account_longer)
 
 TEST (ledger_walker, cross_account)
 {
-	nano::system system{};
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system{};
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
@@ -140,9 +140,9 @@ TEST (ledger_walker, cross_account)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3603
 TEST (ledger_walker, DISABLED_ladder_geometry)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 

--- a/nano/core_test/locks.cpp
+++ b/nano/core_test/locks.cpp
@@ -29,7 +29,7 @@ unsigned num_matches (std::string const & str)
 TEST (locks, no_conflicts)
 {
 	std::stringstream ss;
-	nano::cout_redirect (ss.rdbuf ());
+	nano::test::cout_redirect (ss.rdbuf ());
 
 	nano::mutex guard_mutex;
 	nano::lock_guard<nano::mutex> guard (guard_mutex);
@@ -47,7 +47,7 @@ TEST (locks, lock_guard)
 	ASSERT_LE (NANO_TIMED_LOCKS, 10000);
 
 	std::stringstream ss;
-	nano::cout_redirect redirect (ss.rdbuf ());
+	nano::test::cout_redirect redirect (ss.rdbuf ());
 
 	nano::mutex mutex{ xstr (NANO_TIMED_LOCKS_FILTER) };
 
@@ -81,7 +81,7 @@ TEST (locks, unique_lock)
 	ASSERT_LE (NANO_TIMED_LOCKS, 10000);
 
 	std::stringstream ss;
-	nano::cout_redirect redirect (ss.rdbuf ());
+	nano::test::cout_redirect redirect (ss.rdbuf ());
 
 	nano::mutex mutex{ xstr (NANO_TIMED_LOCKS_FILTER) };
 
@@ -119,7 +119,7 @@ TEST (locks, condition_variable_wait)
 	ASSERT_LE (NANO_TIMED_LOCKS, 10000);
 
 	std::stringstream ss;
-	nano::cout_redirect redirect (ss.rdbuf ());
+	nano::test::cout_redirect redirect (ss.rdbuf ());
 
 	nano::condition_variable cv;
 	nano::mutex mutex;
@@ -152,7 +152,7 @@ TEST (locks, condition_variable_wait_until)
 	ASSERT_LE (NANO_TIMED_LOCKS, 10000);
 
 	std::stringstream ss;
-	nano::cout_redirect redirect (ss.rdbuf ());
+	nano::test::cout_redirect redirect (ss.rdbuf ());
 
 	nano::condition_variable cv;
 	nano::mutex mutex;

--- a/nano/core_test/logger.cpp
+++ b/nano/core_test/logger.cpp
@@ -29,7 +29,7 @@ TEST (logger, try_log)
 {
 	auto path1 (nano::unique_path ());
 	std::stringstream ss;
-	nano::boost_log_cerr_redirect redirect_cerr (ss.rdbuf ());
+	nano::test::boost_log_cerr_redirect redirect_cerr (ss.rdbuf ());
 	nano::logger_mt my_logger (100ms);
 	auto output1 = "logger.try_log1";
 	auto error (my_logger.try_log (output1));
@@ -54,7 +54,7 @@ TEST (logger, always_log)
 {
 	auto path1 (nano::unique_path ());
 	std::stringstream ss;
-	nano::boost_log_cerr_redirect redirect_cerr (ss.rdbuf ());
+	nano::test::boost_log_cerr_redirect redirect_cerr (ss.rdbuf ());
 	nano::logger_mt my_logger (20s); // Make time interval effectively unreachable
 	auto output1 = "logger.always_log1";
 	auto error (my_logger.try_log (output1));

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -62,7 +62,7 @@ public:
 
 TEST (message_parser, exact_confirm_ack_size)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
@@ -104,7 +104,7 @@ TEST (message_parser, exact_confirm_ack_size)
 
 TEST (message_parser, exact_confirm_req_size)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
@@ -145,7 +145,7 @@ TEST (message_parser, exact_confirm_req_size)
 
 TEST (message_parser, exact_confirm_req_hash_size)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
@@ -186,7 +186,7 @@ TEST (message_parser, exact_confirm_req_hash_size)
 
 TEST (message_parser, exact_publish_size)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
@@ -227,7 +227,7 @@ TEST (message_parser, exact_publish_size)
 
 TEST (message_parser, exact_keepalive_size)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	dev_visitor visitor;
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -159,7 +159,7 @@ TEST (network, last_contacted)
 	node1->start ();
 	system.nodes.push_back (node1);
 
-	auto channel1 = nano::establish_tcp (system, *node1, node0->network.endpoint ());
+	auto channel1 = nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	ASSERT_NE (nullptr, channel1);
 	ASSERT_TIMELY (3s, node0->network.size () == 1);
 
@@ -1101,7 +1101,7 @@ TEST (network, duplicate_revert_publish)
 	auto other_node (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
 	other_node->start ();
 	system.nodes.push_back (other_node);
-	auto channel = nano::establish_tcp (system, *other_node, node.network.endpoint ());
+	auto channel = nano::test::establish_tcp (system, *other_node, node.network.endpoint ());
 	ASSERT_NE (nullptr, channel);
 	ASSERT_EQ (0, publish.digest);
 	node.network.inbound (publish, channel);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -29,7 +29,7 @@ TEST (node, null_account)
 
 TEST (node, stop)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	ASSERT_NE (system.nodes[0]->wallets.items.end (), system.nodes[0]->wallets.items.begin ());
 	system.nodes[0]->stop ();
 	system.io_ctx.run ();
@@ -38,7 +38,7 @@ TEST (node, stop)
 
 TEST (node, work_generate)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::block_hash root{ 1 };
 	nano::work_version version{ nano::work_version::work_1 };
@@ -68,7 +68,7 @@ TEST (node, block_store_path_failure)
 	nano::logging logging;
 	logging.init (path);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	auto node (std::make_shared<nano::node> (*service, nano::get_available_port (), path, logging, pool));
+	auto node (std::make_shared<nano::node> (*service, nano::test::get_available_port (), path, logging, pool));
 	ASSERT_TRUE (node->wallets.items.empty ());
 	node->stop ();
 }
@@ -96,7 +96,7 @@ TEST (node, password_fanout)
 	boost::asio::io_context io_ctx;
 	auto path (nano::unique_path ());
 	nano::node_config config;
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	config.logging.init (path);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	config.password_fanout = 10;
@@ -108,7 +108,7 @@ TEST (node, password_fanout)
 
 TEST (node, balance)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto transaction (system.nodes[0]->store.tx_begin_write ());
 	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max (), system.nodes[0]->ledger.account_balance (transaction, nano::dev::genesis_key.pub));
@@ -116,7 +116,7 @@ TEST (node, balance)
 
 TEST (node, representative)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto block1 (system.nodes[0]->rep_block (nano::dev::genesis_key.pub));
 	{
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
@@ -128,7 +128,7 @@ TEST (node, representative)
 
 TEST (node, send_unkeyed)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->store.password.value_set (nano::keypair ().prv);
@@ -137,7 +137,7 @@ TEST (node, send_unkeyed)
 
 TEST (node, send_self)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
@@ -148,7 +148,7 @@ TEST (node, send_self)
 
 TEST (node, send_single)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key2.prv);
@@ -160,7 +160,7 @@ TEST (node, send_single)
 
 TEST (node, send_single_observing_peer)
 {
-	nano::system system (3);
+	nano::test::system system (3);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key2.prv);
@@ -172,7 +172,7 @@ TEST (node, send_single_observing_peer)
 
 TEST (node, send_single_many_peers)
 {
-	nano::system system (10);
+	nano::test::system system (10);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (1)->insert_adhoc (key2.prv);
@@ -189,7 +189,7 @@ TEST (node, send_single_many_peers)
 
 TEST (node, send_out_of_order)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key2;
 	nano::send_block_builder builder;
@@ -222,7 +222,7 @@ TEST (node, send_out_of_order)
 
 TEST (node, quick_confirm)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key;
 	nano::block_hash previous (node1.latest (nano::dev::genesis_key.pub));
@@ -244,7 +244,7 @@ TEST (node, quick_confirm)
 
 TEST (node, node_receive_quorum)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 = *system.nodes[0];
 	nano::keypair key;
 	nano::block_hash previous (node1.latest (nano::dev::genesis_key.pub));
@@ -264,7 +264,7 @@ TEST (node, node_receive_quorum)
 	ASSERT_FALSE (election->confirmed ());
 	ASSERT_EQ (1, election->votes ().size ());
 
-	nano::system system2;
+	nano::test::system system2;
 	system2.add_node ();
 
 	system2.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -279,8 +279,8 @@ TEST (node, node_receive_quorum)
 
 TEST (node, auto_bootstrap)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -292,7 +292,7 @@ TEST (node, auto_bootstrap)
 	auto send1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send1);
 	ASSERT_TIMELY (10s, node0->balance (key2.pub) == node0->config.receive_minimum.number ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
@@ -311,8 +311,8 @@ TEST (node, auto_bootstrap)
 
 TEST (node, auto_bootstrap_reverse)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -321,7 +321,7 @@ TEST (node, auto_bootstrap_reverse)
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	node1->start ();
@@ -332,15 +332,15 @@ TEST (node, auto_bootstrap_reverse)
 
 TEST (node, auto_bootstrap_age)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.bootstrap_interval = 1;
 	auto node0 = system.add_node (config, node_flags);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
@@ -356,7 +356,7 @@ TEST (node, auto_bootstrap_age)
 
 TEST (node, receive_gap)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	ASSERT_EQ (0, node1.gap_cache.size ());
 	auto block = nano::send_block_builder ()
@@ -375,17 +375,17 @@ TEST (node, receive_gap)
 
 TEST (node, merge_peers)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	std::array<nano::endpoint, 8> endpoints;
-	endpoints.fill (nano::endpoint (boost::asio::ip::address_v6::loopback (), nano::get_available_port ()));
-	endpoints[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	endpoints.fill (nano::endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ()));
+	endpoints[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
 	system.nodes[0]->network.merge_peers (endpoints);
 	ASSERT_EQ (0, system.nodes[0]->network.size ());
 }
 
 TEST (node, search_receivable)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -397,7 +397,7 @@ TEST (node, search_receivable)
 
 TEST (node, search_receivable_same)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -410,7 +410,7 @@ TEST (node, search_receivable_same)
 
 TEST (node, search_receivable_multiple)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
 	nano::keypair key3;
@@ -427,8 +427,8 @@ TEST (node, search_receivable_multiple)
 
 TEST (node, search_receivable_confirmed)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key2;
@@ -464,13 +464,13 @@ TEST (node, search_receivable_confirmed)
 
 TEST (node, search_receivable_pruned)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node1 = system.add_node (node_config);
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.enable_voting = false; // Remove after allowing pruned voting
 	auto node2 = system.add_node (config, node_flags);
 	nano::keypair key2;
@@ -502,7 +502,7 @@ TEST (node, search_receivable_pruned)
 
 TEST (node, unlock_search)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	nano::keypair key2;
 	nano::uint128_t balance (node->balance (nano::dev::genesis_key.pub));
@@ -528,11 +528,11 @@ TEST (node, unlock_search)
 
 TEST (node, connect_after_junk)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	auto node0 = system.add_node (node_flags);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	std::vector<uint8_t> junk_buffer;
 	junk_buffer.push_back (0);
 	auto channel1 (std::make_shared<nano::transport::channel_udp> (node1->network.udp_channels, node0->network.endpoint (), node1->network_params.network.protocol_version));
@@ -554,7 +554,7 @@ TEST (node, working)
 
 TEST (node, price)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto price1 (system.nodes[0]->price (nano::Gxrb_ratio, 1));
 	ASSERT_EQ (nano::node::price_max * 100.0, price1);
 	auto price2 (system.nodes[0]->price (nano::Gxrb_ratio * int (nano::node::free_cutoff + 1), 1));
@@ -567,7 +567,7 @@ TEST (node, price)
 
 TEST (node, confirm_locked)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	system.wallet (0)->enter_password (transaction, "1");
@@ -593,7 +593,7 @@ TEST (node_config, random_rep)
 
 TEST (node_flags, disable_tcp_realtime)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	auto node1 = system.add_node (node_flags);
@@ -611,7 +611,7 @@ TEST (node_flags, disable_tcp_realtime)
 
 TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	auto node1 = system.add_node (node_flags);
@@ -633,11 +633,11 @@ TEST (node_flags, disable_tcp_realtime_and_bootstrap_listener)
 // UDP is disabled by default
 TEST (node_flags, disable_udp)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	auto node1 = system.add_node (node_flags);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::get_available_port (), system.logging), system.work));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::test::get_available_port (), system.logging), system.work));
 	system.nodes.push_back (node2);
 	node2->start ();
 	ASSERT_EQ (nano::endpoint (boost::asio::ip::address_v6::loopback (), 0), node2->network.udp_channels.get_local_endpoint ());
@@ -667,7 +667,7 @@ TEST (node, fork_publish)
 {
 	std::weak_ptr<nano::node> node0;
 	{
-		nano::system system (1);
+		nano::test::system system (1);
 		node0 = system.nodes[0];
 		auto & node1 (*system.nodes[0]);
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -716,7 +716,7 @@ TEST (node, fork_publish)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3614
 TEST (node, DISABLED_fork_publish_inactive)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::send_block_builder builder;
@@ -749,7 +749,7 @@ TEST (node, DISABLED_fork_publish_inactive)
 
 TEST (node, fork_keep)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	ASSERT_EQ (1, node1.network.size ());
@@ -803,7 +803,7 @@ TEST (node, fork_keep)
 
 TEST (node, fork_flip)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	ASSERT_EQ (1, node1.network.size ());
@@ -860,7 +860,7 @@ TEST (node, fork_multi_flip)
 	std::vector<nano::transport::transport_type> types{ nano::transport::transport_type::tcp, nano::transport::transport_type::udp };
 	for (auto & type : types)
 	{
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		if (type == nano::transport::transport_type::udp)
 		{
@@ -868,10 +868,10 @@ TEST (node, fork_multi_flip)
 			node_flags.disable_bootstrap_listener = true;
 			node_flags.disable_udp = false;
 		}
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto & node1 (*system.add_node (node_config, node_flags, type));
-		node_config.peering_port = nano::get_available_port ();
+		node_config.peering_port = nano::test::get_available_port ();
 		auto & node2 (*system.add_node (node_config, node_flags, type));
 		ASSERT_EQ (1, node1.network.size ());
 		nano::keypair key1;
@@ -937,15 +937,15 @@ TEST (node, fork_multi_flip)
 // This could happen if a fork wasn't resolved before the process previously shut down
 TEST (node, fork_bootstrap_flip)
 {
-	nano::system system0;
-	nano::system system1;
-	nano::node_config config0{ nano::get_available_port (), system0.logging };
+	nano::test::system system0;
+	nano::test::system system1;
+	nano::node_config config0{ nano::test::get_available_port (), system0.logging };
 	config0.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto & node1 = *system0.add_node (config0, node_flags);
-	nano::node_config config1 (nano::get_available_port (), system1.logging);
+	nano::node_config config1 (nano::test::get_available_port (), system1.logging);
 	auto & node2 = *system1.add_node (config1, node_flags);
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_hash latest = node1.latest (nano::dev::genesis_key.pub);
@@ -984,7 +984,7 @@ TEST (node, fork_bootstrap_flip)
 
 TEST (node, fork_open)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	auto send1 = nano::send_block_builder ()
@@ -1038,7 +1038,7 @@ TEST (node, fork_open)
 
 TEST (node, fork_open_flip)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	ASSERT_EQ (1, node1.network.size ());
@@ -1110,7 +1110,7 @@ TEST (node, fork_open_flip)
 
 TEST (node, coherent_observer)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	node1.observers.blocks.add ([&node1] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::uint128_t const &, bool, bool) {
 		auto transaction (node1.store.tx_begin_read ());
@@ -1123,7 +1123,7 @@ TEST (node, coherent_observer)
 
 TEST (node, fork_no_vote_quorum)
 {
-	nano::system system (3);
+	nano::test::system system (3);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	auto & node3 (*system.nodes[2]);
@@ -1185,7 +1185,7 @@ TEST (node, fork_no_vote_quorum)
 // Disabled because it sometimes takes way too long (but still eventually finishes)
 TEST (node, DISABLED_fork_pre_confirm)
 {
-	nano::system system (3);
+	nano::test::system system (3);
 	auto & node0 (*system.nodes[0]);
 	auto & node1 (*system.nodes[1]);
 	auto & node2 (*system.nodes[2]);
@@ -1248,9 +1248,9 @@ TEST (node, DISABLED_fork_pre_confirm)
 // Sometimes hangs on the bootstrap_initiator.bootstrap call
 TEST (node, DISABLED_fork_stale)
 {
-	nano::system system1 (1);
+	nano::test::system system1 (1);
 	system1.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::system system2 (1);
+	nano::test::system system2 (1);
 	auto & node1 (*system1.nodes[0]);
 	auto & node2 (*system2.nodes[0]);
 	node2.bootstrap_initiator.bootstrap (node1.network.endpoint (), false);
@@ -1330,13 +1330,13 @@ TEST (node, DISABLED_broadcast_elected)
 			node_flags.disable_bootstrap_listener = true;
 			node_flags.disable_udp = false;
 		}
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node0 = system.add_node (node_config, node_flags, type);
-		node_config.peering_port = nano::get_available_port ();
+		node_config.peering_port = nano::test::get_available_port ();
 		auto node1 = system.add_node (node_config, node_flags, type);
-		node_config.peering_port = nano::get_available_port ();
+		node_config.peering_port = nano::test::get_available_port ();
 		auto node2 = system.add_node (node_config, node_flags, type);
 		nano::keypair rep_big;
 		nano::keypair rep_small;
@@ -1457,8 +1457,8 @@ TEST (node, DISABLED_broadcast_elected)
 
 TEST (node, rep_self_vote)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (node_config);
@@ -1513,8 +1513,8 @@ TEST (node, rep_self_vote)
 // Bootstrapping shouldn't republish the blocks to the network.
 TEST (node, DISABLED_bootstrap_no_publish)
 {
-	nano::system system0 (1);
-	nano::system system1 (1);
+	nano::test::system system0 (1);
+	nano::test::system system1 (1);
 	auto node0 (system0.nodes[0]);
 	auto node1 (system1.nodes[0]);
 	nano::keypair key0;
@@ -1553,12 +1553,12 @@ TEST (node, DISABLED_bootstrap_no_publish)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3515
 TEST (node, DISABLED_bootstrap_bulk_push)
 {
-	nano::system system0;
-	nano::system system1;
-	nano::node_config config0 (nano::get_available_port (), system0.logging);
+	nano::test::system system0;
+	nano::test::system system1;
+	nano::node_config config0 (nano::test::get_available_port (), system0.logging);
 	config0.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system0.add_node (config0));
-	nano::node_config config1 (nano::get_available_port (), system1.logging);
+	nano::node_config config1 (nano::test::get_available_port (), system1.logging);
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node1 (system1.add_node (config1));
 	nano::keypair key0;
@@ -1594,10 +1594,10 @@ TEST (node, DISABLED_bootstrap_bulk_push)
 // Bootstrapping a forked open block should succeed.
 TEST (node, bootstrap_fork_open)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	auto node0 = system.add_node (node_config);
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto node1 = system.add_node (node_config);
 	nano::keypair key0;
 	nano::block_builder builder;
@@ -1651,8 +1651,8 @@ TEST (node, bootstrap_fork_open)
 TEST (node, bootstrap_confirm_frontiers)
 {
 	// create 2 separate systems, the 2 system do not interact with each other automatically
-	nano::system system0 (1);
-	nano::system system1 (1);
+	nano::test::system system0 (1);
+	nano::test::system system1 (1);
 	auto node0 = system0.nodes[0];
 	auto node1 = system1.nodes[0];
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -1691,7 +1691,7 @@ TEST (node, bootstrap_confirm_frontiers)
 // Test that if we create a block that isn't confirmed, the bootstrapping processes sync the missing block.
 TEST (node, unconfirmed_send)
 {
-	nano::system system{};
+	nano::test::system system{};
 
 	auto & node1 = *system.add_node ();
 	auto wallet1 = system.wallet (0);
@@ -1738,7 +1738,7 @@ TEST (node, unconfirmed_send)
 // Test that nodes can track nodes that have rep weight for priority broadcasting
 TEST (node, rep_list)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[1]);
 	auto wallet0 (system.wallet (0));
 	auto wallet1 (system.wallet (1));
@@ -1766,9 +1766,9 @@ TEST (node, rep_list)
 
 TEST (node, rep_weight)
 {
-	nano::system system;
+	nano::test::system system;
 	auto add_node = [&system] {
-		auto node = std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work);
+		auto node = std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work);
 		node->start ();
 		system.nodes.push_back (node);
 		return node;
@@ -1856,7 +1856,7 @@ TEST (node, rep_weight)
 
 TEST (node, rep_remove)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	auto & node = *system.add_node (node_flags);
@@ -1932,14 +1932,14 @@ TEST (node, rep_remove)
 	ASSERT_EQ (1, node.rep_crawler.representative_count ());
 	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 0);
 	// Add working representative
-	auto node1 = system.add_node (nano::node_config (nano::get_available_port (), system.logging));
+	auto node1 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto channel1 (node.network.find_channel (node1->network.endpoint ()));
 	ASSERT_NE (nullptr, channel1);
 	auto vote2 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
 	node.rep_crawler.response (channel1, vote2);
 	ASSERT_TIMELY (10s, node.rep_crawler.representative_count () == 1);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::get_available_port (), system.logging), system.work));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::test::get_available_port (), system.logging), system.work));
 	node2->start ();
 	std::weak_ptr<nano::node> node_w (node.shared ());
 	auto vote3 = std::make_shared<nano::vote> (keypair2.pub, keypair2.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
@@ -1959,7 +1959,7 @@ TEST (node, rep_remove)
 
 TEST (node, rep_connection_close)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	// Add working representative (node 2)
@@ -1973,9 +1973,9 @@ TEST (node, rep_connection_close)
 // Test that nodes can disable representative voting
 TEST (node, no_voting)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node0 (*system.nodes[0]);
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	system.add_node (node_config);
 
@@ -1993,7 +1993,7 @@ TEST (node, no_voting)
 
 TEST (node, send_callback)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node0 (*system.nodes[0]);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2008,7 +2008,7 @@ TEST (node, send_callback)
 
 TEST (node, balance_observer)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	std::atomic<int> balances (0);
 	nano::keypair key;
@@ -2036,7 +2036,7 @@ TEST (node, balance_observer)
 
 TEST (node, bootstrap_connection_scaling)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	ASSERT_EQ (34, node1.bootstrap_initiator.connections->target_connections (5000, 1));
 	ASSERT_EQ (4, node1.bootstrap_initiator.connections->target_connections (0, 1));
@@ -2068,7 +2068,7 @@ TEST (node, bootstrap_connection_scaling)
 // Test stat counting at both type and detail levels
 TEST (node, stat_counting)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	node1.stats.add (nano::stat::type::ledger, nano::stat::dir::in, 1);
 	node1.stats.add (nano::stat::type::ledger, nano::stat::dir::in, 5);
@@ -2085,7 +2085,7 @@ TEST (node, stat_counting)
 
 TEST (node, stat_histogram)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 
 	// Specific bins
@@ -2117,7 +2117,7 @@ TEST (node, stat_histogram)
 
 TEST (node, online_reps)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	// 1 sample of minimum weight
 	ASSERT_EQ (node1.config.online_weight_minimum, node1.online_reps.trended ());
@@ -2139,7 +2139,7 @@ namespace nano
 {
 TEST (node, online_reps_rep_crawler)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_rep_crawler = true;
 	auto & node1 = *system.add_node (flags);
@@ -2160,7 +2160,7 @@ TEST (node, online_reps_rep_crawler)
 
 TEST (node, online_reps_election)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_rep_crawler = true;
 	auto & node1 = *system.add_node (flags);
@@ -2199,7 +2199,7 @@ TEST (node, block_confirm)
 			node_flags.disable_bootstrap_listener = true;
 			node_flags.disable_udp = false;
 		}
-		nano::system system (2, type, node_flags);
+		nano::test::system system (2, type, node_flags);
 		auto & node1 (*system.nodes[0]);
 		auto & node2 (*system.nodes[1]);
 		nano::keypair key;
@@ -2233,7 +2233,7 @@ TEST (node, block_confirm)
 
 TEST (node, block_arrival)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	ASSERT_EQ (0, node.block_arrival.arrival.size ());
 	nano::block_hash hash1 (1);
@@ -2248,7 +2248,7 @@ TEST (node, block_arrival)
 
 TEST (node, block_arrival_size)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto time (std::chrono::steady_clock::now () - nano::block_arrival::arrival_time_min - std::chrono::seconds (5));
 	nano::block_hash hash (0);
@@ -2264,7 +2264,7 @@ TEST (node, block_arrival_size)
 
 TEST (node, block_arrival_time)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto time (std::chrono::steady_clock::now ());
 	nano::block_hash hash (0);
@@ -2280,7 +2280,7 @@ TEST (node, block_arrival_time)
 
 TEST (node, confirm_quorum)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 = *system.nodes[0];
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Put greater than node.delta () in pending so quorum can't be reached
@@ -2306,8 +2306,8 @@ TEST (node, confirm_quorum)
 
 TEST (node, local_votes_cache)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.receive_minimum = nano::dev::constants.genesis_amount;
 	auto & node (*system.add_node (node_config));
@@ -2394,8 +2394,8 @@ TEST (node, local_votes_cache)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3481
 TEST (node, DISABLED_local_votes_cache_batch)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	ASSERT_GE (node.network_params.voting.max_cache, 2);
@@ -2463,8 +2463,8 @@ TEST (node, DISABLED_local_votes_cache_batch)
 
 TEST (node, local_votes_cache_generate_new_vote)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2505,7 +2505,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 
 TEST (node, local_votes_cache_fork)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_bootstrap_bulk_pull_server = true;
@@ -2513,7 +2513,7 @@ TEST (node, local_votes_cache_fork)
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_wallet_bootstrap = true;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2544,7 +2544,7 @@ TEST (node, local_votes_cache_fork)
 	ASSERT_EQ (1, votes2.size ());
 	ASSERT_EQ (1, votes2[0]->hashes.size ());
 	// Start election for forked block
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	node2.process_active (send1_fork);
 	node2.block_processor.flush ();
@@ -2553,7 +2553,7 @@ TEST (node, local_votes_cache_fork)
 
 TEST (node, vote_republish)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	nano::keypair key2;
@@ -2593,7 +2593,7 @@ TEST (node, vote_by_hash_bundle)
 {
 	// Keep max_hashes above system to ensure it is kept in scope as votes can be added during system destruction
 	std::atomic<size_t> max_hashes{ 0 };
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node = *system.nodes[0];
 	nano::state_block_builder builder;
 	std::vector<std::shared_ptr<nano::state_block>> blocks;
@@ -2647,7 +2647,7 @@ TEST (node, vote_by_hash_bundle)
 
 TEST (node, vote_by_hash_republish)
 {
-	nano::system system{ 2 };
+	nano::test::system system{ 2 };
 	auto & node1 = *system.nodes[0];
 	auto & node2 = *system.nodes[1];
 	nano::keypair key2;
@@ -2689,7 +2689,7 @@ TEST (node, vote_by_hash_republish)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3638
 TEST (node, DISABLED_vote_by_hash_epoch_block_republish)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	nano::keypair key2;
@@ -2727,11 +2727,11 @@ TEST (node, DISABLED_vote_by_hash_epoch_block_republish)
 
 TEST (node, epoch_conflict_confirm)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (node_config);
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto node1 = system.add_node (node_config);
 	nano::keypair key;
 	nano::keypair epoch_signer (nano::dev::genesis_key);
@@ -2797,10 +2797,10 @@ TEST (node, epoch_conflict_confirm)
 	node0->process_active (epoch_open);
 	ASSERT_TIMELY (10s, node0->block (change->hash ()) && node0->block (epoch_open->hash ()) && node1->block (change->hash ()) && node1->block (epoch_open->hash ()));
 	// Confirm blocks in node1 to allow generating votes
-	nano::blocks_confirm (*node1, { change, epoch_open }, true /* forced */);
+	nano::test::blocks_confirm (*node1, { change, epoch_open }, true /* forced */);
 	ASSERT_TIMELY (3s, node1->block_confirmed (change->hash ()) && node1->block_confirmed (epoch_open->hash ()));
 	// Start elections for node0
-	nano::blocks_confirm (*node0, { change, epoch_open });
+	nano::test::blocks_confirm (*node0, { change, epoch_open });
 	ASSERT_EQ (2, node0->active.size ());
 	{
 		nano::lock_guard<nano::mutex> lock (node0->active.mutex);
@@ -2822,7 +2822,7 @@ TEST (node, epoch_conflict_confirm)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3527
 TEST (node, DISABLED_fork_invalid_block_signature)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	// Disabling republishing + waiting for a rollback before sending the correct vote below fixes an intermittent failure in this test
 	// If these are taken out, one of two things may cause the test two fail often:
@@ -2868,7 +2868,7 @@ TEST (node, DISABLED_fork_invalid_block_signature)
 
 TEST (node, fork_election_invalid_block_signature)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::block_builder builder;
 	auto send1 = builder.state ()
@@ -2912,7 +2912,7 @@ TEST (node, fork_election_invalid_block_signature)
 
 TEST (node, block_processor_signatures)
 {
-	nano::system system0 (1);
+	nano::test::system system0 (1);
 	auto & node1 (*system0.nodes[0]);
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_hash latest (system0.nodes[0]->latest (nano::dev::genesis_key.pub));
@@ -3031,7 +3031,7 @@ TEST (node, block_processor_signatures)
  */
 TEST (node, block_processor_reject_state)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
@@ -3066,11 +3066,11 @@ TEST (node, block_processor_reject_state)
 
 TEST (node, block_processor_full)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.force_use_write_database_queue = true;
 	node_flags.block_processor_full_size = 3;
-	auto & node = *system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto & node = *system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -3112,11 +3112,11 @@ TEST (node, block_processor_full)
 
 TEST (node, block_processor_half_full)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.block_processor_full_size = 6;
 	node_flags.force_use_write_database_queue = true;
-	auto & node = *system.add_node (nano::node_config (nano::get_available_port (), system.logging), node_flags);
+	auto & node = *system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -3159,7 +3159,7 @@ TEST (node, block_processor_half_full)
 
 TEST (node, confirm_back)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key;
 	auto & node (*system.nodes[0]);
 	auto genesis_start_balance (node.balance (nano::dev::genesis_key.pub));
@@ -3192,7 +3192,7 @@ TEST (node, confirm_back)
 	node.process_active (send1);
 	node.process_active (open);
 	node.process_active (send2);
-	nano::blocks_confirm (node, { send1, open, send2 });
+	nano::test::blocks_confirm (node, { send1, open, send2 });
 	ASSERT_EQ (3, node.active.size ());
 	std::vector<nano::block_hash> vote_blocks;
 	vote_blocks.push_back (send2->hash ());
@@ -3203,11 +3203,11 @@ TEST (node, confirm_back)
 
 TEST (node, peers)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 (system.nodes[0]);
 	ASSERT_TRUE (node1->network.empty ());
 
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	system.nodes.push_back (node2);
 
 	auto endpoint = node1->network.endpoint ();
@@ -3252,14 +3252,14 @@ TEST (node, peers)
 
 TEST (node, peer_cache_restart)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 (system.nodes[0]);
 	ASSERT_TRUE (node1->network.empty ());
 	auto endpoint = node1->network.endpoint ();
 	nano::endpoint_key endpoint_key{ endpoint.address ().to_v6 ().to_bytes (), endpoint.port () };
 	auto path (nano::unique_path ());
 	{
-		auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), path, system.logging, system.work));
+		auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), path, system.logging, system.work));
 		system.nodes.push_back (node2);
 		auto & store = node2->store;
 		{
@@ -3279,7 +3279,7 @@ TEST (node, peer_cache_restart)
 	{
 		nano::node_flags node_flags;
 		node_flags.read_only = true;
-		auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), path, system.logging, system.work, node_flags));
+		auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), path, system.logging, system.work, node_flags));
 		system.nodes.push_back (node3);
 		// Check cached peers after restart
 		node3->network.start ();
@@ -3302,7 +3302,7 @@ TEST (node, peer_cache_restart)
 
 TEST (node, unchecked_cleanup)
 {
-	nano::system system{};
+	nano::test::system system{};
 	nano::node_flags node_flags{};
 	node_flags.disable_unchecked_cleanup = true;
 	nano::keypair key{};
@@ -3378,16 +3378,16 @@ TEST (node, bidirectional_tcp)
 		return;
 	}
 #endif
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	// Disable bootstrap to start elections for new blocks
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.disable_wallet_bootstrap = true;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node1 = system.add_node (node_config, node_flags);
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	node_config.tcp_incoming_connections_max = 0; // Disable incoming TCP connections for node 2
 	auto node2 = system.add_node (node_config, node_flags);
 	// Check network connections
@@ -3470,7 +3470,7 @@ TEST (node, bidirectional_tcp)
 // Sanitizers or running within valgrind use different timings and number of nodes
 TEST (node, aggressive_flooding)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_block_processor_republishing = true;
@@ -3488,7 +3488,7 @@ TEST (node, aggressive_flooding)
 	nodes_wallets.resize (!sanitizer_or_valgrind ? 5 : 3);
 
 	std::generate (nodes_wallets.begin (), nodes_wallets.end (), [&system, node_flags] () {
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		auto node (system.add_node (node_config, node_flags));
 		return std::make_pair (node, system.wallet (system.nodes.size () - 1));
 	});
@@ -3524,9 +3524,9 @@ TEST (node, aggressive_flooding)
 		ASSERT_EQ (node1.latest (nano::dev::genesis_key.pub), node_wallet.first->latest (nano::dev::genesis_key.pub));
 		ASSERT_EQ (genesis_blocks.back ()->hash (), node_wallet.first->latest (nano::dev::genesis_key.pub));
 		// Confirm blocks for rep crawler & receiving
-		nano::blocks_confirm (*node_wallet.first, { genesis_blocks.back () }, true);
+		nano::test::blocks_confirm (*node_wallet.first, { genesis_blocks.back () }, true);
 	}
-	nano::blocks_confirm (node1, { genesis_blocks.back () }, true);
+	nano::test::blocks_confirm (node1, { genesis_blocks.back () }, true);
 
 	// Wait until all genesis blocks are received
 	auto all_received = [&nodes_wallets] () {
@@ -3580,7 +3580,7 @@ TEST (node, aggressive_flooding)
 
 TEST (node, node_sequence)
 {
-	nano::system system (3);
+	nano::test::system system (3);
 	ASSERT_EQ (0, system.nodes[0]->node_seq);
 	ASSERT_EQ (0, system.nodes[0]->node_seq);
 	ASSERT_EQ (1, system.nodes[1]->node_seq);
@@ -3589,7 +3589,7 @@ TEST (node, node_sequence)
 
 TEST (node, rollback_vote_self)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
 	auto & node = *system.add_node (flags);
@@ -3679,8 +3679,8 @@ TEST (node, rollback_vote_self)
 
 TEST (node, rollback_gap_source)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::state_block_builder builder;
@@ -3721,7 +3721,7 @@ TEST (node, rollback_gap_source)
 	// Node has fork & doesn't have source for correct block open (send2)
 	ASSERT_EQ (nullptr, node.block (send2->hash ()));
 	// Start election for fork
-	nano::blocks_confirm (node, { fork });
+	nano::test::blocks_confirm (node, { fork });
 	{
 		auto election = node.active.election (fork->qualified_root ());
 		ASSERT_NE (nullptr, election);
@@ -3749,7 +3749,7 @@ TEST (node, rollback_gap_source)
 	ASSERT_NE (nullptr, node.block (fork->hash ()));
 	// With send2 block in ledger election can start again to remove fork block
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
-	nano::blocks_confirm (node, { fork });
+	nano::test::blocks_confirm (node, { fork });
 	{
 		auto election = node.active.election (fork->qualified_root ());
 		ASSERT_NE (nullptr, election);
@@ -3773,8 +3773,8 @@ TEST (node, rollback_gap_source)
 // Confirm a complex dependency graph starting from the first block
 TEST (node, dependency_graph)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config);
 
@@ -3972,11 +3972,11 @@ TEST (node, dependency_graph)
 // confirm a frontier optimistically then fallback to pessimistic confirmation.
 TEST (node, dependency_graph_frontier)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (config);
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 	auto & node2 = *system.add_node (config);
 
@@ -4139,10 +4139,10 @@ namespace nano
 {
 TEST (node, deferred_dependent_elections)
 {
-	nano::system system;
-	nano::node_config node_config_1{ nano::get_available_port (), system.logging };
+	nano::test::system system;
+	nano::node_config node_config_1{ nano::test::get_available_port (), system.logging };
 	node_config_1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	nano::node_config node_config_2{ nano::get_available_port (), system.logging };
+	nano::node_config node_config_2{ nano::test::get_available_port (), system.logging };
 	node_config_2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
@@ -4277,7 +4277,7 @@ TEST (node, deferred_dependent_elections)
 
 TEST (rep_crawler, recently_confirmed)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	ASSERT_EQ (1, node1.ledger.cache.block_count);
 	auto const block = nano::dev::genesis;
@@ -4294,7 +4294,7 @@ namespace nano
 {
 TEST (rep_crawler, local)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_rep_crawler = true;
 	auto & node = *system.add_node (flags);
@@ -4314,9 +4314,9 @@ TEST (rep_crawler, local)
 // prune old confirmed blocks without explicitly saying `node.ledger_pruning` in the unit test
 TEST (node, pruning_automatic)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	// TODO: remove after allowing pruned voting
 	node_config.enable_voting = false;
 	node_config.max_pruning_age = std::chrono::seconds (1);
@@ -4368,9 +4368,9 @@ TEST (node, pruning_automatic)
 
 TEST (node, pruning_age)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	// TODO: remove after allowing pruned voting
 	node_config.enable_voting = false;
 
@@ -4431,9 +4431,9 @@ TEST (node, pruning_age)
 // prune DEEP-enough confirmed blocks by explicitly saying `node.ledger_pruning` in the unit test
 TEST (node, pruning_depth)
 {
-	nano::system system{};
+	nano::test::system system{};
 
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	// TODO: remove after allowing pruned voting
 	node_config.enable_voting = false;
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -296,7 +296,7 @@ TEST (node, auto_bootstrap)
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
-	ASSERT_NE (nullptr, nano::establish_tcp (system, *node1, node0->network.endpoint ()));
+	ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node1, node0->network.endpoint ()));
 	ASSERT_TIMELY (10s, node1->bootstrap_initiator.in_progress ());
 	ASSERT_TIMELY (10s, node1->balance (key2.pub) == node0->config.receive_minimum.number ());
 	ASSERT_TIMELY (10s, !node1->bootstrap_initiator.in_progress ());
@@ -326,7 +326,7 @@ TEST (node, auto_bootstrap_reverse)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	node1->start ();
 	system.nodes.push_back (node1);
-	ASSERT_NE (nullptr, nano::establish_tcp (system, *node0, node1->network.endpoint ()));
+	ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node0, node1->network.endpoint ()));
 	ASSERT_TIMELY (10s, node1->balance (key2.pub) == node0->config.receive_minimum.number ());
 }
 
@@ -344,7 +344,7 @@ TEST (node, auto_bootstrap_age)
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
-	ASSERT_NE (nullptr, nano::establish_tcp (system, *node1, node0->network.endpoint ()));
+	ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node1, node0->network.endpoint ()));
 	ASSERT_TIMELY (10s, node1->bootstrap_initiator.in_progress ());
 	// 4 bootstraps with frontiers age
 	ASSERT_TIMELY (10s, node0->stats.count (nano::stat::type::bootstrap, nano::stat::detail::initiate_legacy_age, nano::stat::dir::out) >= 3);
@@ -1830,11 +1830,11 @@ TEST (node, rep_weight)
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *block4).code);
 	}
 	ASSERT_TRUE (node.rep_crawler.representatives (1).empty ());
-	std::shared_ptr<nano::transport::channel> channel1 = nano::establish_tcp (system, node, node1.network.endpoint ());
+	std::shared_ptr<nano::transport::channel> channel1 = nano::test::establish_tcp (system, node, node1.network.endpoint ());
 	ASSERT_NE (nullptr, channel1);
-	std::shared_ptr<nano::transport::channel> channel2 = nano::establish_tcp (system, node, node2.network.endpoint ());
+	std::shared_ptr<nano::transport::channel> channel2 = nano::test::establish_tcp (system, node, node2.network.endpoint ());
 	ASSERT_NE (nullptr, channel2);
-	std::shared_ptr<nano::transport::channel> channel3 = nano::establish_tcp (system, node, node3.network.endpoint ());
+	std::shared_ptr<nano::transport::channel> channel3 = nano::test::establish_tcp (system, node, node3.network.endpoint ());
 	ASSERT_NE (nullptr, channel3);
 	auto vote0 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
 	auto vote1 = std::make_shared<nano::vote> (keypair1.pub, keypair1.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -5,7 +5,7 @@
 
 TEST (peer_container, empty_peers)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::network & network (system.nodes[0]->network);
 	system.nodes[0]->network.cleanup (std::chrono::steady_clock::now ());
 	ASSERT_EQ (0, network.size ());
@@ -13,7 +13,7 @@ TEST (peer_container, empty_peers)
 
 TEST (peer_container, no_recontact)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::network & network (node1.network);
 	auto observed_peer (0);
@@ -33,14 +33,14 @@ TEST (peer_container, no_recontact)
 
 TEST (peer_container, no_self_incoming)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	ASSERT_EQ (nullptr, system.nodes[0]->network.udp_channels.insert (system.nodes[0]->network.endpoint (), 0));
 	ASSERT_TRUE (system.nodes[0]->network.empty ());
 }
 
 TEST (peer_container, reserved_peers_no_contact)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & channels (system.nodes[0]->network.udp_channels);
 	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x00000001)), 10000), 0));
 	ASSERT_EQ (nullptr, channels.insert (nano::endpoint (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0xc0000201)), 10000), 0));
@@ -54,7 +54,7 @@ TEST (peer_container, reserved_peers_no_contact)
 
 TEST (peer_container, split)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	auto now (std::chrono::steady_clock::now ());
 	nano::endpoint endpoint1 (boost::asio::ip::address_v6::loopback (), 100);
@@ -80,7 +80,7 @@ TEST (peer_container, split)
 
 TEST (channels, fill_random_clear)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	std::array<nano::endpoint, 8> target;
 	std::fill (target.begin (), target.end (), nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000));
 	system.nodes[0]->network.random_fill (target);
@@ -89,7 +89,7 @@ TEST (channels, fill_random_clear)
 
 TEST (channels, fill_random_full)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	for (uint16_t i (0u); i < 100u; ++i)
 	{
 		system.nodes[0]->network.udp_channels.insert (nano::endpoint (boost::asio::ip::address_v6::loopback (), i), 0);
@@ -102,7 +102,7 @@ TEST (channels, fill_random_full)
 
 TEST (channels, fill_random_part)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	std::array<nano::endpoint, 8> target;
 	auto half (target.size () / 2);
 	for (auto i (0); i < half; ++i)
@@ -118,7 +118,7 @@ TEST (channels, fill_random_part)
 
 TEST (peer_container, list_fanout)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	ASSERT_EQ (0, node.network.size ());
 	ASSERT_EQ (0.0, node.network.size_sqrt ());
@@ -155,11 +155,11 @@ TEST (peer_container, list_fanout)
 // Test to make sure we don't repeatedly send keepalive messages to nodes that aren't responding
 TEST (peer_container, reachout)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
-	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
 	// Make sure having been contacted by them already indicates we shouldn't reach out
 	node1.network.udp_channels.insert (endpoint0, node1.network_params.network.protocol_version);
 	ASSERT_TRUE (node1.network.reachout (endpoint0));
@@ -177,7 +177,7 @@ TEST (peer_container, reachout)
 
 TEST (peer_container, depeer)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::test_node_port ());
 	nano::keepalive message{ nano::dev::network_params.network };
 	const_cast<uint8_t &> (message.header.version_using) = 1;

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -9,8 +9,8 @@ using namespace std::chrono_literals;
 
 TEST (request_aggregator, one)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -54,8 +54,8 @@ TEST (request_aggregator, one)
 
 TEST (request_aggregator, one_update)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -119,8 +119,8 @@ TEST (request_aggregator, one_update)
 
 TEST (request_aggregator, two)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -191,13 +191,13 @@ TEST (request_aggregator, two)
 
 TEST (request_aggregator, two_endpoints)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_rep_crawler = true;
 	auto & node1 (*system.add_node (node_config, node_flags));
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_builder builder;
@@ -236,8 +236,8 @@ TEST (request_aggregator, two_endpoints)
 TEST (request_aggregator, split)
 {
 	constexpr size_t max_vbh = nano::network::confirm_ack_hashes_max;
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -289,8 +289,8 @@ TEST (request_aggregator, split)
 
 TEST (request_aggregator, channel_lifetime)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -319,8 +319,8 @@ TEST (request_aggregator, channel_lifetime)
 
 TEST (request_aggregator, channel_update)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -356,8 +356,8 @@ TEST (request_aggregator, channel_update)
 
 TEST (request_aggregator, channel_max_queue)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.max_queued_requests = 1;
 	auto & node (*system.add_node (node_config));
@@ -384,8 +384,8 @@ TEST (request_aggregator, channel_max_queue)
 
 TEST (request_aggregator, unique)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -416,7 +416,7 @@ namespace nano
 {
 TEST (request_aggregator, cannot_vote)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
 	auto & node (*system.add_node (flags));

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -438,7 +438,7 @@ TEST (socket, drop_policy)
 
 		auto client = std::make_shared<nano::client_socket> (*node);
 		nano::transport::channel_tcp channel{ *node, client };
-		nano::util::counted_completion write_completion (static_cast<unsigned> (total_message_count));
+		nano::test::counted_completion write_completion (static_cast<unsigned> (total_message_count));
 
 		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), server_socket->listening_port ()),
 		[&channel, total_message_count, node, &write_completion, &drop_policy, client] (boost::system::error_code const & ec_a) mutable {
@@ -492,7 +492,7 @@ TEST (socket, concurrent_writes)
 	constexpr size_t total_message_count = client_count * message_count;
 
 	// We're expecting client_count*4 messages
-	nano::util::counted_completion read_count_completion (total_message_count);
+	nano::test::counted_completion read_count_completion (total_message_count);
 	std::function<void (std::shared_ptr<nano::socket> const &)> reader = [&read_count_completion, &total_message_count, &reader] (std::shared_ptr<nano::socket> const & socket_a) {
 		auto buff (std::make_shared<std::vector<uint8_t>> ());
 		buff->resize (1);
@@ -546,7 +546,7 @@ TEST (socket, concurrent_writes)
 		return true;
 	});
 
-	nano::util::counted_completion connection_count_completion (client_count);
+	nano::test::counted_completion connection_count_completion (client_count);
 	std::vector<std::shared_ptr<nano::socket>> clients;
 	for (unsigned i = 0; i < client_count; i++)
 	{

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -18,11 +18,11 @@ using namespace std::chrono_literals;
 
 TEST (socket, max_connections)
 {
-	nano::system system;
+	nano::test::system system;
 
 	auto node = system.add_node ();
 
-	auto server_port = nano::get_available_port ();
+	auto server_port = nano::test::get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -109,12 +109,12 @@ TEST (socket, max_connections)
 
 TEST (socket, max_connections_per_ip)
 {
-	nano::system system;
+	nano::test::system system;
 
 	auto node = system.add_node ();
 	ASSERT_FALSE (node->flags.disable_max_peers_per_ip);
 
-	auto server_port = nano::get_available_port ();
+	auto server_port = nano::test::get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -192,7 +192,7 @@ TEST (socket, last_ipv6_subnet_address)
 
 TEST (socket, count_subnetwork_connections)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = system.add_node ();
 
 	auto address0 = boost::asio::ip::make_address ("a41d:b7b1:ffff:ffff:ffff:ffff:ffff:ffff"); // out of network prefix
@@ -226,7 +226,7 @@ TEST (socket, count_subnetwork_connections)
 
 TEST (socket, max_connections_per_subnetwork)
 {
-	nano::system system;
+	nano::test::system system;
 
 	nano::node_flags node_flags;
 	// disabling IP limit because it will be used the same IP address to check they come from the same subnetwork.
@@ -236,7 +236,7 @@ TEST (socket, max_connections_per_subnetwork)
 	ASSERT_TRUE (node->flags.disable_max_peers_per_ip);
 	ASSERT_FALSE (node->flags.disable_max_peers_per_subnetwork);
 
-	auto server_port = nano::get_available_port ();
+	auto server_port = nano::test::get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -292,14 +292,14 @@ TEST (socket, max_connections_per_subnetwork)
 
 TEST (socket, disabled_max_peers_per_ip)
 {
-	nano::system system;
+	nano::test::system system;
 
 	nano::node_flags node_flags;
 	node_flags.disable_max_peers_per_ip = true;
 	auto node = system.add_node (node_flags);
 	ASSERT_TRUE (node->flags.disable_max_peers_per_ip);
 
-	auto server_port = nano::get_available_port ();
+	auto server_port = nano::test::get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -355,7 +355,7 @@ TEST (socket, disabled_max_peers_per_ip)
 
 TEST (socket, disconnection_of_silent_connections)
 {
-	nano::system system;
+	nano::test::system system;
 
 	nano::node_config config;
 	// Increasing the timer timeout, so we don't let the connection to timeout due to the timer checker.
@@ -366,7 +366,7 @@ TEST (socket, disconnection_of_silent_connections)
 
 	auto node = system.add_node (config);
 
-	auto server_port = nano::get_available_port ();
+	auto server_port = nano::test::get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -422,7 +422,7 @@ TEST (socket, drop_policy)
 	std::vector<std::shared_ptr<nano::socket>> connections;
 
 	auto func = [&] (size_t total_message_count, nano::buffer_drop_policy drop_policy) {
-		auto server_port (nano::get_available_port ());
+		auto server_port (nano::test::get_available_port ());
 		boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::any (), server_port);
 
 		auto server_socket = std::make_shared<nano::server_socket> (*node, endpoint, 1);
@@ -618,14 +618,14 @@ TEST (socket, concurrent_writes)
 TEST (socket_timeout, connect)
 {
 	// create one node and set timeout to 1 second
-	nano::system system (1);
+	nano::test::system system (1);
 	std::shared_ptr<nano::node> node = system.nodes[0];
 	node->config.tcp_io_timeout = std::chrono::seconds (1);
 
 	// try to connect to an IP address that most likely does not exist and will not reply
 	// we want the tcp stack to not receive a negative reply, we want it to see silence and to keep trying
 	// I use the un-routable IP address 10.255.254.253, which is likely to not exist
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::make_address_v6 ("::ffff:10.255.254.253"), nano::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::make_address_v6 ("::ffff:10.255.254.253"), nano::test::get_available_port ());
 
 	// create a client socket and try to connect to the IP address that wil not respond
 	auto socket = std::make_shared<nano::client_socket> (*node);
@@ -651,12 +651,12 @@ TEST (socket_timeout, connect)
 TEST (socket_timeout, read)
 {
 	// create one node and set timeout to 1 second
-	nano::system system (1);
+	nano::test::system system (1);
 	std::shared_ptr<nano::node> node = system.nodes[0];
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);
@@ -696,12 +696,12 @@ TEST (socket_timeout, read)
 TEST (socket_timeout, write)
 {
 	// create one node and set timeout to 1 second
-	nano::system system (1);
+	nano::test::system system (1);
 	std::shared_ptr<nano::node> node = system.nodes[0];
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);
@@ -746,12 +746,12 @@ TEST (socket_timeout, write)
 TEST (socket_timeout, read_overlapped)
 {
 	// create one node and set timeout to 1 second
-	nano::system system (1);
+	nano::test::system system (1);
 	std::shared_ptr<nano::node> node = system.nodes[0];
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);
@@ -802,12 +802,12 @@ TEST (socket_timeout, read_overlapped)
 TEST (socket_timeout, write_overlapped)
 {
 	// create one node and set timeout to 1 second
-	nano::system system (1);
+	nano::test::system system (1);
 	std::shared_ptr<nano::node> node = system.nodes[0];
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -9,7 +9,7 @@ using namespace std::chrono_literals;
 
 TEST (system, work_generate_limited)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::block_hash key (1);
 	auto min = nano::dev::network_params.work.entry;
 	auto max = nano::dev::network_params.work.base;
@@ -25,7 +25,7 @@ TEST (system, work_generate_limited)
 // All nodes in the system should agree on the genesis balance
 TEST (system, system_genesis)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	for (auto & i : system.nodes)
 	{
 		auto transaction (i->store.tx_begin_read ());
@@ -35,7 +35,7 @@ TEST (system, system_genesis)
 
 TEST (system, DISABLED_generate_send_existing)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::thread_runner runner (system.io_ctx, node1.config.io_threads);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -90,7 +90,7 @@ TEST (system, DISABLED_generate_send_existing)
 
 TEST (system, DISABLED_generate_send_new)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::thread_runner runner (system.io_ctx, node1.config.io_threads);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -148,7 +148,7 @@ TEST (system, DISABLED_generate_send_new)
 
 TEST (system, rep_initialize_one)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key;
 	system.ledger_initialization_set ({ key });
 	auto node = system.add_node ();
@@ -157,7 +157,7 @@ TEST (system, rep_initialize_one)
 
 TEST (system, rep_initialize_two)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key0;
 	nano::keypair key1;
 	system.ledger_initialization_set ({ key0, key1 });
@@ -168,7 +168,7 @@ TEST (system, rep_initialize_two)
 
 TEST (system, rep_initialize_one_reserve)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key;
 	system.ledger_initialization_set ({ key }, nano::Gxrb_ratio);
 	auto node = system.add_node ();
@@ -178,7 +178,7 @@ TEST (system, rep_initialize_one_reserve)
 
 TEST (system, rep_initialize_two_reserve)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key0;
 	nano::keypair key1;
 	system.ledger_initialization_set ({ key0, key1 }, nano::Gxrb_ratio);
@@ -189,7 +189,7 @@ TEST (system, rep_initialize_two_reserve)
 
 TEST (system, rep_initialize_many)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key0;
 	nano::keypair key1;
 	system.ledger_initialization_set ({ key0, key1 }, nano::Gxrb_ratio);
@@ -203,10 +203,10 @@ TEST (system, rep_initialize_many)
 
 TEST (system, transport_basic)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node0 = *system.nodes[0];
 	// Start nodes in separate systems so they don't automatically connect with each other.
-	nano::system system1{ 1 };
+	nano::test::system system1{ 1 };
 	auto & node1 = *system1.nodes[0];
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in));
 	nano::transport::inproc::channel channel{ node0, node1 };

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -305,7 +305,7 @@ TEST (telemetry, basic)
 	}
 
 	// Check the metrics are correct
-	nano::compare_default_telemetry_response_data (telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
+	nano::test::compare_default_telemetry_response_data (telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
 
 	// Call again straight away. It should use the cache
 	{
@@ -357,7 +357,7 @@ TEST (telemetry, over_udp)
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
 	node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &node_server] (nano::telemetry_data_response const & response_a) {
 		ASSERT_FALSE (response_a.error);
-		nano::compare_default_telemetry_response_data (response_a.telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
+		nano::test::compare_default_telemetry_response_data (response_a.telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
 		done = true;
 	});
 
@@ -422,7 +422,7 @@ TEST (telemetry, blocking_request)
 	// Now try single request metric
 	auto telemetry_data_response = node_client->telemetry->get_metrics_single_peer (node_client->network.find_channel (node_server->network.endpoint ()));
 	ASSERT_FALSE (telemetry_data_response.error);
-	nano::compare_default_telemetry_response_data (telemetry_data_response.telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
+	nano::test::compare_default_telemetry_response_data (telemetry_data_response.telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
 
 	done = true;
 	promise.get_future ().wait ();
@@ -565,7 +565,7 @@ TEST (telemetry, disable_metrics)
 	auto channel1 = node_server->network.find_channel (node_client->network.endpoint ());
 	node_server->telemetry->get_metrics_single_peer_async (channel1, [&done, node_client] (nano::telemetry_data_response const & response_a) {
 		ASSERT_FALSE (response_a.error);
-		nano::compare_default_telemetry_response_data (response_a.telemetry_data, node_client->network_params, node_client->config.bandwidth_limit, node_client->default_difficulty (nano::work_version::work_1), node_client->node_id);
+		nano::test::compare_default_telemetry_response_data (response_a.telemetry_data, node_client->network_params, node_client->config.bandwidth_limit, node_client->default_difficulty (nano::work_version::work_1), node_client->node_id);
 		done = true;
 	});
 

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -286,7 +286,7 @@ TEST (telemetry, basic)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;
@@ -351,7 +351,7 @@ TEST (telemetry, over_udp)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	std::atomic<bool> done{ false };
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
@@ -397,7 +397,7 @@ TEST (telemetry, blocking_request)
 	auto node_client = system.nodes.front ();
 	auto node_server = system.nodes.back ();
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	std::atomic<bool> done{ false };
@@ -436,7 +436,7 @@ TEST (telemetry, disconnects)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Try and request metrics from a node which is turned off but a channel is not closed yet
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
@@ -462,7 +462,7 @@ TEST (telemetry, dos_tcp)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	nano::telemetry_req message{ nano::dev::network_params.network };
 	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
@@ -505,7 +505,7 @@ TEST (telemetry, dos_udp)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	nano::telemetry_req message{ nano::dev::network_params.network };
 	auto channel (node_client->network.udp_channels.create (node_server->network.endpoint ()));
@@ -546,7 +546,7 @@ TEST (telemetry, disable_metrics)
 	node_flags.disable_providing_telemetry_metrics = true;
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Try and request metrics from a node which is turned off but a channel is not closed yet
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
@@ -585,7 +585,7 @@ TEST (telemetry, max_possible_size)
 	data.unknown_data.resize (nano::message_header::telemetry_size_mask.to_ulong () - nano::telemetry_data::latest_size);
 
 	nano::telemetry_ack message{ nano::dev::network_params.network, data };
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
 	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
@@ -712,7 +712,7 @@ TEST (telemetry, maker_pruning)
 	config.enable_voting = false;
 	auto node_server = system.add_node (config, node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -271,7 +271,7 @@ TEST (telemetry, unknown_data)
 
 TEST (telemetry, no_peers)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 
 	auto responses = system.nodes[0]->telemetry->get_metrics ();
 	ASSERT_TRUE (responses.empty ());
@@ -279,14 +279,14 @@ TEST (telemetry, no_peers)
 
 TEST (telemetry, basic)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;
@@ -334,7 +334,7 @@ TEST (telemetry, basic)
 
 TEST (telemetry, receive_from_non_listening_channel)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = system.add_node ();
 	nano::telemetry_ack message{ nano::dev::network_params.network, nano::telemetry_data{} };
 	node->network.inbound (message, node->network.udp_channels.create (node->network.endpoint ()));
@@ -344,14 +344,14 @@ TEST (telemetry, receive_from_non_listening_channel)
 
 TEST (telemetry, over_udp)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_tcp_realtime = true;
 	node_flags.disable_udp = false;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	std::atomic<bool> done{ false };
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
@@ -376,7 +376,7 @@ TEST (telemetry, over_udp)
 
 TEST (telemetry, invalid_channel)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 
 	auto node_client = system.nodes.front ();
 	auto node_server = system.nodes.back ();
@@ -392,12 +392,12 @@ TEST (telemetry, invalid_channel)
 
 TEST (telemetry, blocking_request)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 
 	auto node_client = system.nodes.front ();
 	auto node_server = system.nodes.back ();
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	std::atomic<bool> done{ false };
@@ -430,13 +430,13 @@ TEST (telemetry, blocking_request)
 
 TEST (telemetry, disconnects)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Try and request metrics from a node which is turned off but a channel is not closed yet
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
@@ -455,14 +455,14 @@ TEST (telemetry, disconnects)
 TEST (telemetry, dos_tcp)
 {
 	// Confirm that telemetry_reqs are not processed
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	nano::telemetry_req message{ nano::dev::network_params.network };
 	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
@@ -496,7 +496,7 @@ TEST (telemetry, dos_tcp)
 TEST (telemetry, dos_udp)
 {
 	// Confirm that telemetry_reqs are not processed
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	node_flags.disable_tcp_realtime = true;
@@ -505,7 +505,7 @@ TEST (telemetry, dos_udp)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	nano::telemetry_req message{ nano::dev::network_params.network };
 	auto channel (node_client->network.udp_channels.create (node_server->network.endpoint ()));
@@ -539,14 +539,14 @@ TEST (telemetry, dos_udp)
 
 TEST (telemetry, disable_metrics)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	node_flags.disable_providing_telemetry_metrics = true;
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Try and request metrics from a node which is turned off but a channel is not closed yet
 	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
@@ -574,7 +574,7 @@ TEST (telemetry, disable_metrics)
 
 TEST (telemetry, max_possible_size)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	node_flags.disable_ongoing_telemetry_requests = true;
@@ -585,7 +585,7 @@ TEST (telemetry, max_possible_size)
 	data.unknown_data.resize (nano::message_header::telemetry_size_mask.to_ulong () - nano::telemetry_data::latest_size);
 
 	nano::telemetry_ack message{ nano::dev::network_params.network, data };
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
 	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
@@ -602,7 +602,7 @@ namespace nano
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3524
 TEST (telemetry, DISABLED_remove_peer_different_genesis)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
 	// Change genesis block to something else in this test (this is the reference telemetry processing uses).
@@ -633,7 +633,7 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 	node_flags.disable_udp = false;
 	node_flags.disable_tcp_realtime = true;
 	node_flags.disable_ongoing_telemetry_requests = true;
-	nano::system system (1, nano::transport::transport_type::udp, node_flags);
+	nano::test::system system (1, nano::transport::transport_type::udp, node_flags);
 	auto node0 (system.nodes[0]);
 	ASSERT_EQ (0, node0->network.size ());
 	nano::network_params network_params{ nano::networks::nano_dev_network };
@@ -674,7 +674,7 @@ TEST (telemetry, remove_peer_different_genesis_udp)
 
 TEST (telemetry, remove_peer_invalid_signature)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_udp = false;
 	node_flags.disable_initial_telemetry_requests = true;
@@ -702,7 +702,7 @@ TEST (telemetry, remove_peer_invalid_signature)
 
 TEST (telemetry, maker_pruning)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	node_flags.disable_initial_telemetry_requests = true;
@@ -712,7 +712,7 @@ TEST (telemetry, maker_pruning)
 	config.enable_voting = false;
 	auto node_server = system.add_node (config, node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;

--- a/nano/core_test/unchecked_map.cpp
+++ b/nano/core_test/unchecked_map.cpp
@@ -55,7 +55,7 @@ TEST (unchecked_map, put_one)
 
 TEST (block_store, one_bootstrap)
 {
-	nano::system system{};
+	nano::test::system system{};
 	nano::logger_mt logger{};
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	nano::unchecked_map unchecked{ *store, false };

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -10,7 +10,7 @@ using namespace std::chrono_literals;
 
 TEST (vote_processor, codes)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::keypair key;
 	auto vote (std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () }));
@@ -45,7 +45,7 @@ TEST (vote_processor, codes)
 
 TEST (vote_processor, flush)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
 	for (unsigned i = 0; i < 2000; ++i)
@@ -59,7 +59,7 @@ TEST (vote_processor, flush)
 
 TEST (vote_processor, invalid_signature)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
 	nano::keypair key;
 	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
@@ -81,7 +81,7 @@ TEST (vote_processor, invalid_signature)
 
 TEST (vote_processor, no_capacity)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.vote_processor_capacity = 0;
 	auto & node (*system.add_node (node_flags));
@@ -93,7 +93,7 @@ TEST (vote_processor, no_capacity)
 
 TEST (vote_processor, overflow)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.vote_processor_capacity = 1;
 	auto & node (*system.add_node (node_flags));
@@ -124,7 +124,7 @@ namespace nano
 {
 TEST (vote_processor, weights)
 {
-	nano::system system (4);
+	nano::test::system system (4);
 	auto & node (*system.nodes[0]);
 
 	// Create representatives of different weight levels
@@ -177,14 +177,14 @@ TEST (vote_processor, weights)
 // Nodes should not relay their own votes
 TEST (vote_processor, no_broadcast_local)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
 	nano::node_config config1, config2;
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (config1, flags));
 	config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config2.peering_port = nano::get_available_port ();
+	config2.peering_port = nano::test::get_available_port ();
 	system.add_node (config2, flags);
 	nano::block_builder builder;
 	std::error_code ec;
@@ -230,14 +230,14 @@ TEST (vote_processor, no_broadcast_local)
 // Done without a representative.
 TEST (vote_processor, local_broadcast_without_a_representative)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
 	nano::node_config config1, config2;
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (config1, flags));
 	config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config2.peering_port = nano::get_available_port ();
+	config2.peering_port = nano::test::get_available_port ();
 	system.add_node (config2, flags);
 	nano::block_builder builder;
 	std::error_code ec;
@@ -278,14 +278,14 @@ TEST (vote_processor, local_broadcast_without_a_representative)
 // Done with a principal representative.
 TEST (vote_processor, no_broadcast_local_with_a_principal_representative)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
 	nano::node_config config1, config2;
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (config1, flags));
 	config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config2.peering_port = nano::get_available_port ();
+	config2.peering_port = nano::test::get_available_port ();
 	system.add_node (config2, flags);
 	nano::block_builder builder;
 	std::error_code ec;
@@ -330,7 +330,7 @@ TEST (vote_processor, no_broadcast_local_with_a_principal_representative)
  */
 TEST (vote, timestamp_and_duration_masking)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key;
 	auto hash = std::vector<nano::block_hash>{ nano::dev::genesis->hash () };
 	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, 0x123f, 0xf, hash);

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -57,7 +57,7 @@ TEST (local_vote_history, basic)
 
 TEST (vote_generator, cache)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto epoch1 = system.upgrade_genesis_epoch (node, nano::epoch::epoch_1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -70,7 +70,7 @@ TEST (vote_generator, cache)
 
 TEST (vote_generator, multiple_representatives)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::keypair key1, key2, key3;
 	auto & wallet (*system.wallet (0));
@@ -105,7 +105,7 @@ TEST (vote_generator, multiple_representatives)
 
 TEST (vote_generator, session)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node (system.nodes[0]);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::vote_generator_session generator_session (node->active.generator);
@@ -156,7 +156,7 @@ TEST (vote_spacing, vote_generator)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;
 	auto & node = *system.add_node (config, node_flags);
@@ -199,7 +199,7 @@ TEST (vote_spacing, rapid)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;
 	auto & node = *system.add_node (config, node_flags);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -164,7 +164,7 @@ TEST (wallet, two_item_iteration)
 
 TEST (wallet, insufficient_spend_one)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 500));
@@ -174,7 +174,7 @@ TEST (wallet, insufficient_spend_one)
 
 TEST (wallet, spend_all_one)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -195,7 +195,7 @@ TEST (wallet, spend_all_one)
 
 TEST (wallet, send_async)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
 	std::thread thread ([&system] () {
@@ -209,7 +209,7 @@ TEST (wallet, send_async)
 
 TEST (wallet, spend)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::block_hash latest1 (node1.latest (nano::dev::genesis_key.pub));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -232,7 +232,7 @@ TEST (wallet, spend)
 
 TEST (wallet, change)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
 	auto block1 (system.nodes[0]->rep_block (nano::dev::genesis_key.pub));
@@ -245,7 +245,7 @@ TEST (wallet, change)
 
 TEST (wallet, partial_spend)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, 500));
@@ -254,7 +254,7 @@ TEST (wallet, partial_spend)
 
 TEST (wallet, spend_no_previous)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	{
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 		auto transaction (system.nodes[0]->store.tx_begin_read ());
@@ -594,7 +594,7 @@ TEST (wallet_store, move)
 
 TEST (wallet_store, import)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto wallet1 (system.wallet (0));
 	auto wallet2 (system.wallet (1));
 	nano::keypair key1;
@@ -609,7 +609,7 @@ TEST (wallet_store, import)
 
 TEST (wallet_store, fail_import_bad_password)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto wallet1 (system.wallet (0));
 	auto wallet2 (system.wallet (1));
 	nano::keypair key1;
@@ -623,7 +623,7 @@ TEST (wallet_store, fail_import_bad_password)
 
 TEST (wallet_store, fail_import_corrupt)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto wallet1 (system.wallet (1));
 	std::string json;
 	auto error (wallet1->import (json, "1"));
@@ -633,7 +633,7 @@ TEST (wallet_store, fail_import_corrupt)
 // Test work is precached when a key is inserted
 TEST (wallet, work)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet (system.wallet (0));
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
@@ -653,7 +653,7 @@ TEST (wallet, work)
 
 TEST (wallet, work_generate)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
 	nano::uint128_t amount1 (node1.balance (nano::dev::genesis_key.pub));
@@ -681,7 +681,7 @@ TEST (wallet, work_generate)
 
 TEST (wallet, work_cache_delayed)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
 	uint64_t work1;
@@ -713,7 +713,7 @@ TEST (wallet, work_cache_delayed)
 
 TEST (wallet, insert_locked)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet (system.wallet (0));
 	{
 		auto transaction (wallet->wallets.tx_begin_write ());
@@ -804,7 +804,7 @@ TEST (wallet, reseed)
 
 TEST (wallet, insert_deterministic_locked)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet (system.wallet (0));
 	auto transaction (wallet->wallets.tx_begin_write ());
 	wallet->store.rekey (transaction, "1");
@@ -816,7 +816,7 @@ TEST (wallet, insert_deterministic_locked)
 
 TEST (wallet, no_work)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv, false);
 	nano::keypair key2;
 	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), false));
@@ -831,7 +831,7 @@ TEST (wallet, no_work)
 
 TEST (wallet, send_race)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
 	for (auto i (1); i < 60; ++i)
@@ -843,7 +843,7 @@ TEST (wallet, send_race)
 
 TEST (wallet, password_race)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	auto wallet = system.wallet (0);
 	std::thread thread ([&wallet] () {
@@ -871,7 +871,7 @@ TEST (wallet, password_race)
 
 TEST (wallet, password_race_corrupt_seed)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
 	auto wallet = system.wallet (0);
 	nano::raw_key seed;
@@ -941,7 +941,7 @@ TEST (wallet, password_race_corrupt_seed)
 
 TEST (wallet, change_seed)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet (system.wallet (0));
 	wallet->enter_initial_password ();
 	nano::raw_key seed1;
@@ -967,7 +967,7 @@ TEST (wallet, change_seed)
 
 TEST (wallet, deterministic_restore)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet (system.wallet (0));
 	wallet->enter_initial_password ();
 	nano::raw_key seed1;
@@ -998,7 +998,7 @@ TEST (wallet, deterministic_restore)
 
 TEST (wallet, epoch_2_validation)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto & wallet (*system.wallet (0));
 
@@ -1043,7 +1043,7 @@ TEST (wallet, epoch_2_receive_propagation)
 	auto const max_tries = 20;
 	while (++tries < max_tries)
 	{
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.disable_request_loop = true;
 		auto & node (*system.add_node (node_flags));
@@ -1093,7 +1093,7 @@ TEST (wallet, epoch_2_receive_unopened)
 	auto const max_tries = 20;
 	while (++tries < max_tries)
 	{
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.disable_request_loop = true;
 		auto & node (*system.add_node (node_flags));
@@ -1143,7 +1143,7 @@ TEST (wallet, epoch_2_receive_unopened)
  */
 TEST (wallet, foreach_representative_deadlock)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	node.wallets.compute_reps ();
@@ -1162,8 +1162,8 @@ TEST (wallet, foreach_representative_deadlock)
 
 TEST (wallet, search_receivable)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.enable_voting = false;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags flags;
@@ -1214,12 +1214,12 @@ TEST (wallet, search_receivable)
 
 TEST (wallet, receive_pruned)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto & node1 = *system.add_node (node_flags);
 	node_flags.enable_pruning = true;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.enable_voting = false; // Remove after allowing pruned voting
 	auto & node2 = *system.add_node (config, node_flags);
 

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -8,7 +8,7 @@ using namespace std::chrono_literals;
 
 TEST (wallets, open_create)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	bool error (false);
 	nano::wallets wallets (error, *system.nodes[0]);
 	ASSERT_FALSE (error);
@@ -22,7 +22,7 @@ TEST (wallets, open_create)
 
 TEST (wallets, open_existing)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto id (nano::random_wallet_id ());
 	{
 		bool error (false);
@@ -52,7 +52,7 @@ TEST (wallets, open_existing)
 
 TEST (wallets, remove)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::wallet_id one (1);
 	{
 		bool error (false);
@@ -75,7 +75,7 @@ TEST (wallets, remove)
 
 TEST (wallets, reload)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::wallet_id one (1);
 	bool error (false);
@@ -93,7 +93,7 @@ TEST (wallets, reload)
 
 TEST (wallets, vote_minimum)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::keypair key2;
@@ -157,7 +157,7 @@ TEST (wallets, vote_minimum)
 
 TEST (wallets, exists)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	nano::keypair key1;
 	nano::keypair key2;
@@ -184,8 +184,8 @@ TEST (wallets, search_receivable)
 {
 	for (auto search_all : { false, true })
 	{
-		nano::system system;
-		nano::node_config config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config config (nano::test::get_available_port (), system.logging);
 		config.enable_voting = false;
 		config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		nano::node_flags flags;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -20,10 +20,10 @@ using namespace std::chrono_literals;
 // Tests clients subscribing multiple times or unsubscribing without a subscription
 TEST (websocket, subscription_edge)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::confirmation));
@@ -51,10 +51,10 @@ TEST (websocket, subscription_edge)
 // Subscribes to block confirmations, confirms a block and then awaits websocket notification
 TEST (websocket, confirmation)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -127,10 +127,10 @@ TEST (websocket, confirmation)
 // Tests getting notification of a started election
 TEST (websocket, started_election)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 = system.add_node (config);
 
 	std::atomic<bool> ack_ready{ false };
@@ -175,10 +175,10 @@ TEST (websocket, started_election)
 // Tests getting notification of an erased election
 TEST (websocket, stopped_election)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -226,10 +226,10 @@ TEST (websocket, stopped_election)
 // Tests the filtering options of block confirmations
 TEST (websocket, confirmation_options)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -369,10 +369,10 @@ TEST (websocket, confirmation_options)
 
 TEST (websocket, confirmation_options_votes)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -456,10 +456,10 @@ TEST (websocket, confirmation_options_votes)
 
 TEST (websocket, confirmation_options_sideband)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -526,10 +526,10 @@ TEST (websocket, confirmation_options_sideband)
 // Tests updating options of block confirmations
 TEST (websocket, confirmation_options_update)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> added{ false };
@@ -601,10 +601,10 @@ TEST (websocket, confirmation_options_update)
 // Subscribes to votes, sends a block and awaits websocket notification of a vote arrival
 TEST (websocket, vote)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -651,10 +651,10 @@ TEST (websocket, vote)
 // Tests vote subscription options - vote type
 TEST (websocket, vote_options_type)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -692,10 +692,10 @@ TEST (websocket, vote_options_type)
 // Tests vote subscription options - list of representatives
 TEST (websocket, vote_options_representatives)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -767,10 +767,10 @@ TEST (websocket, vote_options_representatives)
 // Test client subscribing to notifications for work generation
 TEST (websocket, work)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::work));
@@ -837,10 +837,10 @@ TEST (websocket, work)
 // Test client subscribing to notifications for bootstrap
 TEST (websocket, bootstrap)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::bootstrap));
@@ -887,10 +887,10 @@ TEST (websocket, bootstrap)
 
 TEST (websocket, bootstrap_exited)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	// Start bootstrap, exit after subscription
@@ -952,10 +952,10 @@ TEST (websocket, bootstrap_exited)
 // Tests sending keepalive
 TEST (websocket, ws_keepalive)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	auto task = ([&node1] () {
@@ -971,20 +971,20 @@ TEST (websocket, ws_keepalive)
 // Tests sending telemetry
 TEST (websocket, telemetry)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node1 (system.add_node (config, node_flags));
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	std::atomic<bool> done{ false };
 	auto task = ([config = node1->config, &node1, &done] () {
@@ -1030,10 +1030,10 @@ TEST (websocket, telemetry)
 
 TEST (websocket, new_unconfirmed_block)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::get_available_port ();
+	config.websocket_config.port = nano::test::get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -895,7 +895,7 @@ TEST (websocket, bootstrap_exited)
 
 	// Start bootstrap, exit after subscription
 	std::atomic<bool> bootstrap_started{ false };
-	nano::util::counted_completion subscribed_completion (1);
+	nano::test::counted_completion subscribed_completion (1);
 	std::thread bootstrap_thread ([node1, &system, &bootstrap_started, &subscribed_completion] () {
 		std::shared_ptr<nano::bootstrap_attempt> attempt;
 		while (attempt == nullptr)
@@ -984,7 +984,7 @@ TEST (websocket, telemetry)
 	config.websocket_config.port = nano::test::get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	std::atomic<bool> done{ false };
 	auto task = ([config = node1->config, &node1, &done] () {

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1019,7 +1019,7 @@ TEST (websocket, telemetry)
 	nano::jsonconfig telemetry_contents (contents);
 	nano::telemetry_data telemetry_data;
 	telemetry_data.deserialize_json (telemetry_contents, false);
-	compare_default_telemetry_response_data (telemetry_data, node2->network_params, node2->config.bandwidth_limit, node2->default_difficulty (nano::work_version::work_1), node2->node_id);
+	nano::test::compare_default_telemetry_response_data (telemetry_data, node2->network_params, node2->config.bandwidth_limit, node2->default_difficulty (nano::work_version::work_1), node2->node_id);
 
 	ASSERT_EQ (contents.get<std::string> ("address"), node2->network.endpoint ().address ().to_string ());
 	ASSERT_EQ (contents.get<uint16_t> ("port"), node2->network.endpoint ().port ());

--- a/nano/fuzzer_test/fuzz_buffer.cpp
+++ b/nano/fuzzer_test/fuzz_buffer.cpp
@@ -13,7 +13,7 @@ void force_nano_dev_network ();
 }
 namespace
 {
-std::shared_ptr<nano::system> system0;
+std::shared_ptr<nano::test::system> system0;
 std::shared_ptr<nano::node> node0;
 
 class fuzz_visitor : public nano::message_visitor
@@ -63,7 +63,7 @@ void fuzz_message_parser (uint8_t const * Data, size_t Size)
 	{
 		nano::force_nano_dev_network ();
 		initialized = true;
-		system0 = std::make_shared<nano::system> (1);
+		system0 = std::make_shared<nano::test::system> (1);
 		node0 = system0->nodes[0];
 	}
 

--- a/nano/qt_test/entry.cpp
+++ b/nano/qt_test/entry.cpp
@@ -6,7 +6,10 @@
 QApplication * test_application = nullptr;
 namespace nano
 {
-void cleanup_dev_directories_on_exit ();
+namespace test
+{
+	void cleanup_dev_directories_on_exit ();
+}
 void force_nano_dev_network ();
 }
 

--- a/nano/qt_test/entry.cpp
+++ b/nano/qt_test/entry.cpp
@@ -21,6 +21,6 @@ int main (int argc, char ** argv)
 	test_application = &application;
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_dev_directories_on_exit ();
+	nano::test::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -17,7 +17,7 @@ extern QApplication * test_application;
 TEST (wallet, construction)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	auto key (wallet_l->deterministic_insert ());
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key));
@@ -34,7 +34,7 @@ TEST (wallet, construction)
 TEST (wallet, DISABLED_status)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	nano::keypair key;
 	wallet_l->insert_adhoc (key.prv);
@@ -66,7 +66,7 @@ TEST (wallet, DISABLED_status)
 TEST (wallet, status_with_peer)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (2);
+	nano::test::system system (2);
 	auto wallet_l = system.nodes[0]->wallets.create (nano::random_wallet_id ());
 	nano::keypair key;
 	wallet_l->insert_adhoc (key.prv);
@@ -96,7 +96,7 @@ TEST (wallet, status_with_peer)
 TEST (wallet, startup_balance)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	nano::keypair key;
 	wallet_l->insert_adhoc (key.prv);
@@ -110,7 +110,7 @@ TEST (wallet, startup_balance)
 TEST (wallet, select_account)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	nano::public_key key1 (wallet_l->deterministic_insert ());
 	nano::public_key key2 (wallet_l->deterministic_insert ());
@@ -142,7 +142,7 @@ TEST (wallet, select_account)
 TEST (wallet, main)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	nano::keypair key;
 	wallet_l->insert_adhoc (key.prv);
@@ -173,7 +173,7 @@ TEST (wallet, main)
 TEST (wallet, password_change)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
@@ -209,7 +209,7 @@ TEST (wallet, password_change)
 TEST (client, password_nochange)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
@@ -253,7 +253,7 @@ TEST (client, password_nochange)
 TEST (wallet, enter_password)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (2);
+	nano::test::system system (2);
 	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
 	{
@@ -290,7 +290,7 @@ TEST (wallet, enter_password)
 TEST (wallet, send)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (2);
+	nano::test::system system (2);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::public_key key1 (system.wallet (1)->insert_adhoc (nano::keypair ().prv));
 	auto account (nano::dev::genesis_key.pub);
@@ -323,7 +323,7 @@ TEST (wallet, send)
 TEST (wallet, send_locked)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	{
@@ -351,7 +351,7 @@ TEST (wallet, send_locked)
 TEST (wallet, DISABLED_process_block)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::account account;
 	nano::block_hash latest (system.nodes[0]->latest (nano::dev::genesis->account ()));
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
@@ -396,7 +396,7 @@ TEST (wallet, create_send)
 {
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key.prv);
 	auto account (nano::dev::genesis_key.pub);
@@ -426,7 +426,7 @@ TEST (wallet, create_open_receive)
 {
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 100);
 	nano::block_hash latest1 (system.nodes[0]->latest (nano::dev::genesis_key.pub));
@@ -475,7 +475,7 @@ TEST (wallet, create_change)
 {
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -508,7 +508,7 @@ TEST (history, short_text)
 	}
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
@@ -545,7 +545,7 @@ TEST (history, pruned_source)
 	}
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
@@ -611,7 +611,7 @@ TEST (wallet, startup_work)
 {
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
@@ -643,7 +643,7 @@ TEST (wallet, block_viewer)
 {
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
 	nano::account account;
 	{
@@ -667,7 +667,7 @@ TEST (wallet, block_viewer)
 TEST (wallet, import)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (2);
+	nano::test::system system (2);
 	std::string json;
 	nano::keypair key1;
 	nano::keypair key2;
@@ -701,7 +701,7 @@ TEST (wallet, import)
 TEST (wallet, republish)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (2);
+	nano::test::system system (2);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
 	nano::block_hash hash;
@@ -732,7 +732,7 @@ TEST (wallet, republish)
 TEST (wallet, ignore_empty_adhoc)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (key1.prv);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1.pub));
@@ -759,7 +759,7 @@ TEST (wallet, ignore_empty_adhoc)
 TEST (wallet, change_seed)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto key1 (system.wallet (0)->deterministic_insert ());
 	system.wallet (0)->deterministic_insert ();
 	nano::raw_key seed3;
@@ -812,7 +812,7 @@ TEST (wallet, change_seed)
 TEST (wallet, seed_work_generation)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto key1 (system.wallet (0)->deterministic_insert ());
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1));
 	wallet->start ();
@@ -844,7 +844,7 @@ TEST (wallet, seed_work_generation)
 TEST (wallet, backup_seed)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto key1 (system.wallet (0)->deterministic_insert ());
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1));
 	wallet->start ();
@@ -862,7 +862,7 @@ TEST (wallet, backup_seed)
 TEST (wallet, import_locked)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto key1 (system.wallet (0)->deterministic_insert ());
 	{
 		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
@@ -900,8 +900,8 @@ TEST (wallet, import_locked)
 TEST (wallet, DISABLED_synchronizing)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system0 (1);
-	nano::system system1 (1);
+	nano::test::system system0 (1);
+	nano::test::system system1 (1);
 	auto key1 (system0.wallet (0)->deterministic_insert ());
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system0.nodes[0], system0.wallet (0), key1));
 	wallet->start ();
@@ -932,7 +932,7 @@ TEST (wallet, DISABLED_synchronizing)
 TEST (wallet, epoch_2_validation)
 {
 	nano_qt::eventloop_processor processor;
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node = system.nodes[0];
 
 	// Upgrade the genesis account to epoch 2

--- a/nano/rpc_test/entry.cpp
+++ b/nano/rpc_test/entry.cpp
@@ -4,7 +4,10 @@
 #include <gtest/gtest.h>
 namespace nano
 {
-void cleanup_dev_directories_on_exit ();
+namespace test
+{
+	void cleanup_dev_directories_on_exit ();
+}
 void force_nano_dev_network ();
 }
 
@@ -15,6 +18,6 @@ int main (int argc, char ** argv)
 	nano::node_singleton_memory_pool_purge_guard cleanup_guard;
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_dev_directories_on_exit ();
+	nano::test::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -140,21 +140,21 @@ public:
 	std::unique_ptr<scoped_io_thread_name_change> io_scope;
 };
 
-std::shared_ptr<nano::node> add_ipc_enabled_node (nano::system & system, nano::node_config & node_config, nano::node_flags const & node_flags)
+std::shared_ptr<nano::node> add_ipc_enabled_node (nano::test::system & system, nano::node_config & node_config, nano::node_flags const & node_flags)
 {
 	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = nano::get_available_port ();
+	node_config.ipc_config.transport_tcp.port = nano::test::get_available_port ();
 	return system.add_node (node_config, node_flags);
 }
 
-std::shared_ptr<nano::node> add_ipc_enabled_node (nano::system & system, nano::node_config & node_config)
+std::shared_ptr<nano::node> add_ipc_enabled_node (nano::test::system & system, nano::node_config & node_config)
 {
 	return add_ipc_enabled_node (system, node_config, nano::node_flags ());
 }
 
-std::shared_ptr<nano::node> add_ipc_enabled_node (nano::system & system)
+std::shared_ptr<nano::node> add_ipc_enabled_node (nano::test::system & system)
 {
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	return add_ipc_enabled_node (system, node_config);
 }
 
@@ -168,7 +168,7 @@ void reset_confirmation_height (nano::store & store, nano::account const & accou
 	}
 }
 
-void wait_response_impl (nano::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json)
+void wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json)
 {
 	test_response response (request, rpc_ctx.rpc->listening_port (), system.io_ctx);
 	ASSERT_TIMELY (time, response.status != 0);
@@ -176,14 +176,14 @@ void wait_response_impl (nano::system & system, rpc_context const & rpc_ctx, boo
 	response_json = response.json;
 }
 
-boost::property_tree::ptree wait_response (nano::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time = 5s)
+boost::property_tree::ptree wait_response (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time = 5s)
 {
 	boost::property_tree::ptree response_json;
 	wait_response_impl (system, rpc_ctx, request, time, response_json);
 	return response_json;
 }
 
-void check_block_response_count (nano::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count)
+void check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count)
 {
 	auto response (wait_response (system, rpc_ctx, request));
 	auto & blocks = response.get_child ("blocks");
@@ -197,12 +197,12 @@ void check_block_response_count (nano::system & system, rpc_context const & rpc_
 	}
 }
 
-rpc_context add_rpc (nano::system & system, std::shared_ptr<nano::node> const & node_a)
+rpc_context add_rpc (nano::test::system & system, std::shared_ptr<nano::node> const & node_a)
 {
 	auto scoped_thread_name_io (std::make_unique<scoped_io_thread_name_change> ());
 	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
 	auto ipc_server (std::make_unique<nano::ipc::ipc_server> (*node_a, *node_rpc_config));
-	nano::rpc_config rpc_config (node_a->network_params.network, nano::get_available_port (), true);
+	nano::rpc_config rpc_config (node_a->network_params.network, nano::test::get_available_port (), true);
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
 	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));
@@ -215,7 +215,7 @@ rpc_context add_rpc (nano::system & system, std::shared_ptr<nano::node> const & 
 
 TEST (rpc, wrapped_task)
 {
-	nano::system system;
+	nano::test::system system;
 	auto & node = *add_ipc_enabled_node (system);
 	nano::node_rpc_config node_rpc_config;
 	std::atomic<bool> response (false);
@@ -238,7 +238,7 @@ TEST (rpc, wrapped_task)
 
 TEST (rpc, account_balance)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 
 	// Add a send block (which will add a pending entry too) for the genesis account
@@ -283,7 +283,7 @@ TEST (rpc, account_balance)
 
 TEST (rpc, account_block_count)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -296,7 +296,7 @@ TEST (rpc, account_block_count)
 
 TEST (rpc, account_create)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -322,7 +322,7 @@ TEST (rpc, account_create)
 TEST (rpc, account_weight)
 {
 	nano::keypair key;
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::block_hash latest (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
@@ -345,7 +345,7 @@ TEST (rpc, account_weight)
 
 TEST (rpc, wallet_contains)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -362,7 +362,7 @@ TEST (rpc, wallet_contains)
 
 TEST (rpc, wallet_doesnt_contain)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -378,7 +378,7 @@ TEST (rpc, wallet_doesnt_contain)
 
 TEST (rpc, validate_account_number)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -391,7 +391,7 @@ TEST (rpc, validate_account_number)
 
 TEST (rpc, validate_account_invalid)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	std::string account;
@@ -407,7 +407,7 @@ TEST (rpc, validate_account_invalid)
 
 TEST (rpc, send)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -431,7 +431,7 @@ TEST (rpc, send)
 
 TEST (rpc, send_fail)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -448,7 +448,7 @@ TEST (rpc, send_fail)
 
 TEST (rpc, send_work)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -475,8 +475,8 @@ TEST (rpc, send_work)
 
 TEST (rpc, send_work_disabled)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -495,7 +495,7 @@ TEST (rpc, send_work_disabled)
 
 TEST (rpc, send_idempotent)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -530,7 +530,7 @@ TEST (rpc, send_idempotent)
 // CI run in which it failed: https://github.com/nanocurrency/nano-node/runs/4280938039?check_suite_focus=true#step:5:1895
 TEST (rpc, DISABLED_send_epoch_2)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 
 	// Upgrade the genesis account to epoch 2
@@ -566,7 +566,7 @@ TEST (rpc, DISABLED_send_epoch_2)
 
 TEST (rpc, send_ipc_random_id)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	std::atomic<bool> got_request{ false };
@@ -584,7 +584,7 @@ TEST (rpc, send_ipc_random_id)
 
 TEST (rpc, stop)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -594,7 +594,7 @@ TEST (rpc, stop)
 
 TEST (rpc, wallet_add)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key1;
@@ -614,7 +614,7 @@ TEST (rpc, wallet_add)
 
 TEST (rpc, wallet_password_valid)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -629,7 +629,7 @@ TEST (rpc, wallet_password_valid)
 
 TEST (rpc, wallet_password_change)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -652,7 +652,7 @@ TEST (rpc, wallet_password_change)
 
 TEST (rpc, wallet_password_enter)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::raw_key password_l;
@@ -676,7 +676,7 @@ TEST (rpc, wallet_password_enter)
 
 TEST (rpc, wallet_representative)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -691,7 +691,7 @@ TEST (rpc, wallet_representative)
 
 TEST (rpc, wallet_representative_set)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -708,7 +708,7 @@ TEST (rpc, wallet_representative_set)
 
 TEST (rpc, wallet_representative_set_force)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -740,7 +740,7 @@ TEST (rpc, wallet_representative_set_force)
 
 TEST (rpc, account_list)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -770,7 +770,7 @@ TEST (rpc, account_list)
 
 TEST (rpc, wallet_key_valid)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -786,7 +786,7 @@ TEST (rpc, wallet_key_valid)
 
 TEST (rpc, wallet_create)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -800,7 +800,7 @@ TEST (rpc, wallet_create)
 
 TEST (rpc, wallet_create_seed)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::raw_key seed;
 	nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
@@ -832,7 +832,7 @@ TEST (rpc, wallet_create_seed)
 
 TEST (rpc, wallet_export)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -852,7 +852,7 @@ TEST (rpc, wallet_export)
 
 TEST (rpc, wallet_destroy)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -866,7 +866,7 @@ TEST (rpc, wallet_destroy)
 
 TEST (rpc, account_move)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto wallet_id (node->wallets.items.begin ()->first);
 	auto destination (system.wallet (0));
@@ -895,7 +895,7 @@ TEST (rpc, account_move)
 
 TEST (rpc, block)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -909,7 +909,7 @@ TEST (rpc, block)
 
 TEST (rpc, block_account)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -923,7 +923,7 @@ TEST (rpc, block_account)
 
 TEST (rpc, chain)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
@@ -950,7 +950,7 @@ TEST (rpc, chain)
 
 TEST (rpc, chain_limit)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
@@ -976,7 +976,7 @@ TEST (rpc, chain_limit)
 
 TEST (rpc, chain_offset)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
@@ -1003,7 +1003,7 @@ TEST (rpc, chain_offset)
 
 TEST (rpc, frontier)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	std::unordered_map<nano::account, nano::block_hash> source;
 	{
@@ -1041,7 +1041,7 @@ TEST (rpc, frontier)
 
 TEST (rpc, frontier_limited)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	std::unordered_map<nano::account, nano::block_hash> source;
 	{
@@ -1069,7 +1069,7 @@ TEST (rpc, frontier_limited)
 
 TEST (rpc, frontier_startpoint)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	std::unordered_map<nano::account, nano::block_hash> source;
 	{
@@ -1098,7 +1098,7 @@ TEST (rpc, frontier_startpoint)
 
 TEST (rpc, history)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node0 = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto change (system.wallet (0)->change_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub));
@@ -1182,7 +1182,7 @@ TEST (rpc, history)
 
 TEST (rpc, account_history)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node0 = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto change (system.wallet (0)->change_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub));
@@ -1330,7 +1330,7 @@ TEST (rpc, account_history)
 
 TEST (rpc, history_count)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto change (system.wallet (0)->change_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub));
@@ -1351,8 +1351,8 @@ TEST (rpc, history_count)
 
 TEST (rpc, history_pruning)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -1538,7 +1538,7 @@ TEST (rpc, history_pruning)
 
 TEST (rpc, process_block)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::keypair key;
@@ -1573,7 +1573,7 @@ TEST (rpc, process_block)
 
 TEST (rpc, process_json_block)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::keypair key;
@@ -1608,7 +1608,7 @@ TEST (rpc, process_json_block)
 
 TEST (rpc, process_block_async)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::keypair key;
@@ -1663,7 +1663,7 @@ TEST (rpc, process_block_async)
 
 TEST (rpc, process_block_no_work)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::keypair key;
@@ -1689,7 +1689,7 @@ TEST (rpc, process_block_no_work)
 
 TEST (rpc, process_republish)
 {
-	nano::system system (2);
+	nano::test::system system (2);
 	auto & node1 (*system.nodes[0]);
 	auto & node2 (*system.nodes[1]);
 	auto node3 = add_ipc_enabled_node (system);
@@ -1716,7 +1716,7 @@ TEST (rpc, process_republish)
 
 TEST (rpc, process_subtype_send)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	system.add_node ();
 	auto const rpc_ctx = add_rpc (system, node1);
@@ -1753,7 +1753,7 @@ TEST (rpc, process_subtype_send)
 
 TEST (rpc, process_subtype_open)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	nano::keypair key;
@@ -1803,7 +1803,7 @@ TEST (rpc, process_subtype_open)
 
 TEST (rpc, process_subtype_receive)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	auto latest (node1->latest (nano::dev::genesis_key.pub));
@@ -1853,7 +1853,7 @@ TEST (rpc, process_subtype_receive)
 
 TEST (rpc, process_ledger_insufficient_work)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	ASSERT_LT (node->network_params.work.entry, node->network_params.work.epoch_1);
@@ -1887,9 +1887,9 @@ TEST (rpc, process_ledger_insufficient_work)
 
 TEST (rpc, keepalive)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node0 = add_ipc_enabled_node (system);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto const rpc_ctx = add_rpc (system, node0);
@@ -1913,9 +1913,9 @@ TEST (rpc, keepalive)
 
 TEST (rpc, peers)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto port = nano::get_available_port ();
+	auto port = nano::test::get_available_port ();
 	auto const node2 = system.add_node (nano::node_config (port, system.logging));
 	nano::endpoint endpoint (boost::asio::ip::make_address_v6 ("fc00::1"), 4000);
 	node->network.udp_channels.insert (endpoint, node->network_params.network.protocol_version);
@@ -1934,9 +1934,9 @@ TEST (rpc, peers)
 
 TEST (rpc, peers_node_id)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto port = nano::get_available_port ();
+	auto port = nano::test::get_available_port ();
 	auto const node2 = system.add_node (nano::node_config (port, system.logging));
 	nano::endpoint endpoint (boost::asio::ip::make_address_v6 ("fc00::1"), 4000);
 	node->network.udp_channels.insert (endpoint, node->network_params.network.protocol_version);
@@ -1959,7 +1959,7 @@ TEST (rpc, peers_node_id)
 
 TEST (rpc, pending)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2084,7 +2084,7 @@ TEST (rpc, pending)
  */
 TEST (rpc, receivable_offset_and_sorting)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2238,7 +2238,7 @@ TEST (rpc, receivable_offset_and_sorting)
 
 TEST (rpc, pending_burn)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto block1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::constants.burn_account, 100));
@@ -2261,7 +2261,7 @@ TEST (rpc, pending_burn)
 
 TEST (rpc, search_receivable)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto wallet (node->wallets.items.begin ()->first.to_string ());
@@ -2289,7 +2289,7 @@ TEST (rpc, search_receivable)
 
 TEST (rpc, version)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2327,7 +2327,7 @@ TEST (rpc, version)
 
 TEST (rpc, work_generate)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::block_hash hash (1);
@@ -2355,8 +2355,8 @@ TEST (rpc, work_generate)
 
 TEST (rpc, work_generate_difficulty)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.max_work_generate_multiplier = 1000;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -2402,8 +2402,8 @@ TEST (rpc, work_generate_difficulty)
 
 TEST (rpc, work_generate_multiplier)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.max_work_generate_multiplier = 100;
 	auto node = add_ipc_enabled_node (system, node_config);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -2447,7 +2447,7 @@ TEST (rpc, work_generate_multiplier)
 
 TEST (rpc, work_generate_block_high)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key;
@@ -2480,7 +2480,7 @@ TEST (rpc, work_generate_block_high)
 
 TEST (rpc, work_generate_block_low)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key;
@@ -2525,7 +2525,7 @@ TEST (rpc, work_generate_block_low)
 
 TEST (rpc, work_generate_block_root_mismatch)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key;
@@ -2557,7 +2557,7 @@ TEST (rpc, work_generate_block_root_mismatch)
 
 TEST (rpc, work_generate_block_ledger_epoch_2)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto epoch1 = system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1);
 	ASSERT_NE (nullptr, epoch1);
@@ -2611,7 +2611,7 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 
 TEST (rpc, work_cancel)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::block_hash hash1 (1);
@@ -2635,7 +2635,7 @@ TEST (rpc, work_cancel)
 
 TEST (rpc, work_peer_bad)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	node2.config.work_peers.emplace_back (boost::asio::ip::address_v6::any ().to_string (), 0);
@@ -2654,7 +2654,7 @@ TEST (rpc, work_peer_bad)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3639
 TEST (rpc, DISABLED_work_peer_one)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	auto const rpc_ctx = add_rpc (system, node1);
@@ -2673,10 +2673,10 @@ TEST (rpc, DISABLED_work_peer_one)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3636
 TEST (rpc, DISABLED_work_peer_many)
 {
-	nano::system system1 (1);
-	nano::system system2;
-	nano::system system3 (1);
-	nano::system system4 (1);
+	nano::test::system system1 (1);
+	nano::test::system system2;
+	nano::test::system system3 (1);
+	nano::test::system system4 (1);
 	auto & node1 (*system1.nodes[0]);
 	auto node2 = add_ipc_enabled_node (system2);
 	auto node3 = add_ipc_enabled_node (system3);
@@ -2711,7 +2711,7 @@ TEST (rpc, DISABLED_work_peer_many)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3637
 TEST (rpc, DISABLED_work_version_invalid)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::block_hash hash (1);
@@ -2735,7 +2735,7 @@ TEST (rpc, DISABLED_work_version_invalid)
 TEST (rpc, block_count)
 {
 	{
-		nano::system system;
+		nano::test::system system;
 		auto node1 = add_ipc_enabled_node (system);
 		auto const rpc_ctx = add_rpc (system, node1);
 		boost::property_tree::ptree request1;
@@ -2750,7 +2750,7 @@ TEST (rpc, block_count)
 
 	// Should be able to get all counts even when enable_control is false.
 	{
-		nano::system system;
+		nano::test::system system;
 		auto node1 = add_ipc_enabled_node (system);
 		auto const rpc_ctx = add_rpc (system, node1);
 		boost::property_tree::ptree request1;
@@ -2766,9 +2766,9 @@ TEST (rpc, block_count)
 
 TEST (rpc, block_count_pruning)
 {
-	nano::system system;
+	nano::test::system system;
 	auto & node0 = *system.add_node ();
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -2815,7 +2815,7 @@ TEST (rpc, block_count_pruning)
 
 TEST (rpc, frontier_count)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2826,7 +2826,7 @@ TEST (rpc, frontier_count)
 
 TEST (rpc, account_count)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2837,7 +2837,7 @@ TEST (rpc, account_count)
 
 TEST (rpc, available_supply)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2860,7 +2860,7 @@ TEST (rpc, available_supply)
 
 TEST (rpc, mrai_to_raw)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2872,7 +2872,7 @@ TEST (rpc, mrai_to_raw)
 
 TEST (rpc, mrai_from_raw)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2884,7 +2884,7 @@ TEST (rpc, mrai_from_raw)
 
 TEST (rpc, krai_to_raw)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2896,7 +2896,7 @@ TEST (rpc, krai_to_raw)
 
 TEST (rpc, krai_from_raw)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2908,7 +2908,7 @@ TEST (rpc, krai_from_raw)
 
 TEST (rpc, nano_to_raw)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2920,7 +2920,7 @@ TEST (rpc, nano_to_raw)
 
 TEST (rpc, raw_to_nano)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
@@ -2932,7 +2932,7 @@ TEST (rpc, raw_to_nano)
 
 TEST (rpc, account_representative)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -2945,7 +2945,7 @@ TEST (rpc, account_representative)
 
 TEST (rpc, account_representative_set)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto & wallet = *system.wallet (0);
 	wallet.insert_adhoc (nano::dev::genesis_key.prv);
@@ -2980,8 +2980,8 @@ TEST (rpc, account_representative_set)
 
 TEST (rpc, account_representative_set_work_disabled)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3000,7 +3000,7 @@ TEST (rpc, account_representative_set_work_disabled)
 
 TEST (rpc, account_representative_set_epoch_2_insufficient_work)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv, false);
 
@@ -3041,9 +3041,9 @@ TEST (rpc, account_representative_set_epoch_2_insufficient_work)
 
 TEST (rpc, bootstrap)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
-	nano::system system1 (1);
+	nano::test::system system1 (1);
 	auto node1 = system1.nodes[0];
 	auto latest (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
@@ -3079,7 +3079,7 @@ TEST (rpc, bootstrap)
 
 TEST (rpc, account_remove)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	auto key1 (system0.wallet (0)->deterministic_insert ());
 	ASSERT_TRUE (system0.wallet (0)->exists (key1));
@@ -3094,7 +3094,7 @@ TEST (rpc, account_remove)
 
 TEST (rpc, representatives)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
@@ -3115,7 +3115,7 @@ TEST (rpc, representatives)
 // wallet_seed is only available over IPC's unsafe encoding, and when running on test network
 TEST (rpc, wallet_seed)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::raw_key seed;
@@ -3135,7 +3135,7 @@ TEST (rpc, wallet_seed)
 
 TEST (rpc, wallet_change_seed)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	auto const rpc_ctx = add_rpc (system0, node);
 	nano::raw_key seed;
@@ -3170,7 +3170,7 @@ TEST (rpc, wallet_change_seed)
 
 TEST (rpc, wallet_frontiers)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system0, node);
@@ -3190,7 +3190,7 @@ TEST (rpc, wallet_frontiers)
 
 TEST (rpc, work_validate)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::block_hash hash (1);
@@ -3256,7 +3256,7 @@ TEST (rpc, work_validate)
 
 TEST (rpc, work_validate_epoch_2)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto epoch1 = system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1);
 	ASSERT_NE (nullptr, epoch1);
@@ -3297,7 +3297,7 @@ TEST (rpc, work_validate_epoch_2)
 
 TEST (rpc, successors)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
@@ -3329,9 +3329,9 @@ TEST (rpc, successors)
 
 TEST (rpc, bootstrap_any)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
-	nano::system system1 (1);
+	nano::test::system system1 (1);
 	auto latest (system1.nodes[0]->latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
 	auto send = builder
@@ -3356,7 +3356,7 @@ TEST (rpc, bootstrap_any)
 
 TEST (rpc, republish)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key;
 	auto node1 = add_ipc_enabled_node (system);
 	system.add_node ();
@@ -3424,7 +3424,7 @@ TEST (rpc, republish)
 
 TEST (rpc, deterministic_key)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	nano::raw_key seed;
 	{
@@ -3455,7 +3455,7 @@ TEST (rpc, deterministic_key)
  */
 TEST (rpc, accounts_balances)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3508,7 +3508,7 @@ TEST (rpc, accounts_balances)
 // Tests the  happy path of retrieving an account's representative
 TEST (rpc, accounts_representatives)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3530,7 +3530,7 @@ TEST (rpc, accounts_representatives)
  */
 TEST (rpc, accounts_representatives_per_account_result_with_errors)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3580,7 +3580,7 @@ TEST (rpc, accounts_representatives_per_account_result_with_errors)
 
 TEST (rpc, accounts_frontiers)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -3632,7 +3632,7 @@ TEST (rpc, accounts_frontiers)
 
 TEST (rpc, accounts_pending)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3648,7 +3648,7 @@ TEST (rpc, accounts_pending)
 
 TEST (rpc, accounts_receivable)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3743,7 +3743,7 @@ TEST (rpc, accounts_receivable)
 
 TEST (rpc, blocks)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3765,8 +3765,8 @@ TEST (rpc, blocks)
 
 TEST (rpc, wallet_info)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = true;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3819,7 +3819,7 @@ TEST (rpc, wallet_info)
 
 TEST (rpc, wallet_balances)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system0, node);
@@ -3856,7 +3856,7 @@ TEST (rpc, wallet_balances)
 
 TEST (rpc, pending_exists)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3895,7 +3895,7 @@ TEST (rpc, pending_exists)
 
 TEST (rpc, wallet_pending)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3917,7 +3917,7 @@ TEST (rpc, wallet_pending)
 
 TEST (rpc, wallet_receivable)
 {
-	nano::system system0;
+	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	nano::keypair key1;
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -4007,7 +4007,7 @@ TEST (rpc, wallet_receivable)
 
 TEST (rpc, receive_minimum)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -4019,7 +4019,7 @@ TEST (rpc, receive_minimum)
 
 TEST (rpc, receive_minimum_set)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -4034,7 +4034,7 @@ TEST (rpc, receive_minimum_set)
 
 TEST (rpc, work_get)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->work_cache_blocking (nano::dev::genesis_key.pub, node->latest (nano::dev::genesis_key.pub));
@@ -4053,7 +4053,7 @@ TEST (rpc, work_get)
 
 TEST (rpc, wallet_work_get)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->work_cache_blocking (nano::dev::genesis_key.pub, node->latest (nano::dev::genesis_key.pub));
@@ -4076,7 +4076,7 @@ TEST (rpc, wallet_work_get)
 
 TEST (rpc, work_set)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -4097,7 +4097,7 @@ TEST (rpc, work_set)
 
 TEST (rpc, search_receivable_all)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto latest (node->latest (nano::dev::genesis_key.pub));
@@ -4123,7 +4123,7 @@ TEST (rpc, search_receivable_all)
 
 TEST (rpc, wallet_republish)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	while (key.pub < nano::dev::genesis_key.pub)
@@ -4173,7 +4173,7 @@ TEST (rpc, wallet_republish)
 
 TEST (rpc, delegators)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -4216,7 +4216,7 @@ TEST (rpc, delegators)
 
 TEST (rpc, delegators_parameters)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	auto latest (node1->latest (nano::dev::genesis_key.pub));
@@ -4324,7 +4324,7 @@ TEST (rpc, delegators_parameters)
 
 TEST (rpc, delegators_count)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -4360,7 +4360,7 @@ TEST (rpc, delegators_count)
 
 TEST (rpc, account_info)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::keypair key;
 
 	auto node1 = add_ipc_enabled_node (system);
@@ -4549,7 +4549,7 @@ TEST (rpc, account_info)
 /** Make sure we can use json block literals instead of string as input */
 TEST (rpc, json_block_input)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
@@ -4589,7 +4589,7 @@ TEST (rpc, json_block_input)
 /** Make sure we can receive json block literals instead of string as output */
 TEST (rpc, json_block_output)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	auto latest (node1->latest (nano::dev::genesis_key.pub));
@@ -4618,7 +4618,7 @@ TEST (rpc, json_block_output)
 
 TEST (rpc, blocks_info)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	auto check_blocks = [node] (boost::property_tree::ptree & response) {
@@ -4696,7 +4696,7 @@ TEST (rpc, blocks_info)
  */
 TEST (rpc, blocks_info_receive_hash)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (key1.prv);
@@ -4768,7 +4768,7 @@ TEST (rpc, blocks_info_receive_hash)
 
 TEST (rpc, blocks_info_subtype)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -4811,7 +4811,7 @@ TEST (rpc, blocks_info_subtype)
 
 TEST (rpc, block_info_successor)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	auto latest (node1->latest (nano::dev::genesis_key.pub));
@@ -4842,11 +4842,11 @@ TEST (rpc, block_info_successor)
 
 TEST (rpc, block_info_pruning)
 {
-	nano::system system;
-	nano::node_config node_config0 (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config0 (nano::test::get_available_port (), system.logging);
 	node_config0.receive_minimum = nano::dev::constants.genesis_amount; // Prevent auto-receive & receive1 block conflicts
 	auto & node0 = *system.add_node (node_config0);
-	nano::node_config node_config1 (nano::get_available_port (), system.logging);
+	nano::node_config node_config1 (nano::test::get_available_port (), system.logging);
 	node_config1.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -4909,11 +4909,11 @@ TEST (rpc, block_info_pruning)
 
 TEST (rpc, pruned_exists)
 {
-	nano::system system;
-	nano::node_config node_config0 (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config0 (nano::test::get_available_port (), system.logging);
 	node_config0.receive_minimum = nano::dev::constants.genesis_amount; // Prevent auto-receive & receive1 block conflicts
 	auto & node0 = *system.add_node (node_config0);
-	nano::node_config node_config1 (nano::get_available_port (), system.logging);
+	nano::node_config node_config1 (nano::test::get_available_port (), system.logging);
 	node_config1.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -4963,7 +4963,7 @@ TEST (rpc, pruned_exists)
 
 TEST (rpc, work_peers_all)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
@@ -4996,8 +4996,8 @@ TEST (rpc, work_peers_all)
 
 TEST (rpc, populate_backlog)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	// Disable automatic backlog population
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = add_ipc_enabled_node (system, node_config);
@@ -5032,7 +5032,7 @@ TEST (rpc, populate_backlog)
 
 TEST (rpc, ledger)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	auto latest (node->latest (nano::dev::genesis_key.pub));
@@ -5153,7 +5153,7 @@ TEST (rpc, ledger)
 
 TEST (rpc, accounts_create)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -5174,7 +5174,7 @@ TEST (rpc, accounts_create)
 
 TEST (rpc, block_create)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5299,7 +5299,7 @@ TEST (rpc, block_create)
 
 TEST (rpc, block_create_state)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5331,7 +5331,7 @@ TEST (rpc, block_create_state)
 
 TEST (rpc, block_create_state_open)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5376,7 +5376,7 @@ TEST (rpc, block_create_state_request_work)
 	// case, the account will be used for work generation)
 	std::unique_ptr<nano::state_block> epoch2;
 	{
-		nano::system system (1);
+		nano::test::system system (1);
 		system.upgrade_genesis_epoch (*system.nodes.front (), nano::epoch::epoch_1);
 		epoch2 = system.upgrade_genesis_epoch (*system.nodes.front (), nano::epoch::epoch_2);
 	}
@@ -5384,7 +5384,7 @@ TEST (rpc, block_create_state_request_work)
 	std::vector<std::string> previous_test_input{ epoch2->hash ().to_string (), std::string ("0") };
 	for (auto previous : previous_test_input)
 	{
-		nano::system system;
+		nano::test::system system;
 		auto node = add_ipc_enabled_node (system);
 		nano::keypair key;
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5410,7 +5410,7 @@ TEST (rpc, block_create_state_request_work)
 
 TEST (rpc, block_create_open_epoch_v2)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5451,7 +5451,7 @@ TEST (rpc, block_create_open_epoch_v2)
 
 TEST (rpc, block_create_receive_epoch_v2)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5504,7 +5504,7 @@ TEST (rpc, block_create_receive_epoch_v2)
 
 TEST (rpc, block_create_send_epoch_v2)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5556,7 +5556,7 @@ TEST (rpc, block_create_send_epoch_v2)
 
 TEST (rpc, block_hash)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 	nano::keypair key;
@@ -5582,7 +5582,7 @@ TEST (rpc, block_hash)
 
 TEST (rpc, wallet_lock)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -5603,7 +5603,7 @@ TEST (rpc, wallet_lock)
 
 TEST (rpc, wallet_locked)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -5618,7 +5618,7 @@ TEST (rpc, wallet_locked)
 
 TEST (rpc, wallet_create_fail)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	// lmdb_max_dbs should be removed once the wallet store is refactored to support more wallets.
 	for (int i = 0; i < 127; i++)
@@ -5634,7 +5634,7 @@ TEST (rpc, wallet_create_fail)
 
 TEST (rpc, wallet_ledger)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
@@ -5709,7 +5709,7 @@ TEST (rpc, wallet_ledger)
 
 TEST (rpc, wallet_add_watch)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -5741,7 +5741,7 @@ TEST (rpc, wallet_add_watch)
 
 TEST (rpc, online_reps)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 (system.nodes[0]);
 	auto node2 = add_ipc_enabled_node (system);
 	nano::keypair key;
@@ -5805,10 +5805,10 @@ TEST (rpc, online_reps)
 
 TEST (rpc, confirmation_height_currently_processing)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.force_use_write_database_queue = true;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto node = add_ipc_enabled_node (system, node_config, node_flags);
@@ -5871,7 +5871,7 @@ TEST (rpc, confirmation_height_currently_processing)
 
 TEST (rpc, confirmation_history)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5902,7 +5902,7 @@ TEST (rpc, confirmation_history)
 
 TEST (rpc, confirmation_history_hash)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5933,7 +5933,7 @@ TEST (rpc, confirmation_history_hash)
 
 TEST (rpc, block_confirm)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_builder builder;
@@ -5961,7 +5961,7 @@ TEST (rpc, block_confirm)
 
 TEST (rpc, block_confirm_absent)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -5974,12 +5974,12 @@ TEST (rpc, block_confirm_absent)
 
 TEST (rpc, block_confirm_confirmed)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto path (nano::unique_path ());
 	nano::node_config config;
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	config.callback_address = "localhost";
-	config.callback_port = nano::get_available_port ();
+	config.callback_port = nano::test::get_available_port ();
 	config.callback_target = "/";
 	config.logging.init (path);
 	auto node = add_ipc_enabled_node (system, config);
@@ -6007,7 +6007,7 @@ TEST (rpc, block_confirm_confirmed)
 
 TEST (rpc, node_id)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -6020,7 +6020,7 @@ TEST (rpc, node_id)
 
 TEST (rpc, stats_clear)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key;
@@ -6038,7 +6038,7 @@ TEST (rpc, stats_clear)
 // Tests the RPC command returns the correct data for the unchecked blocks
 TEST (rpc, unchecked)
 {
-	nano::system system{};
+	nano::test::system system{};
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key{};
@@ -6090,7 +6090,7 @@ TEST (rpc, unchecked)
 // Tests the RPC command returns the correct data for the unchecked blocks
 TEST (rpc, unchecked_get)
 {
-	nano::system system{};
+	nano::test::system system{};
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key{};
@@ -6129,7 +6129,7 @@ TEST (rpc, unchecked_get)
 
 TEST (rpc, unchecked_clear)
 {
-	nano::system system{};
+	nano::test::system system{};
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::keypair key{};
@@ -6157,7 +6157,7 @@ TEST (rpc, unchecked_clear)
 
 TEST (rpc, unopened)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::account account1 (1), account2 (account1.number () + 1);
@@ -6220,7 +6220,7 @@ TEST (rpc, unopened)
 
 TEST (rpc, unopened_burn)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto genesis (node->latest (nano::dev::genesis_key.pub));
@@ -6237,7 +6237,7 @@ TEST (rpc, unopened_burn)
 
 TEST (rpc, unopened_no_accounts)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -6249,7 +6249,7 @@ TEST (rpc, unopened_no_accounts)
 
 TEST (rpc, uptime)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -6264,8 +6264,8 @@ TEST (rpc, uptime)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3514
 TEST (rpc, DISABLED_wallet_history)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -6320,7 +6320,7 @@ TEST (rpc, DISABLED_wallet_history)
 
 TEST (rpc, sign_hash)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	nano::block_builder builder;
@@ -6352,7 +6352,7 @@ TEST (rpc, sign_hash)
 
 TEST (rpc, sign_block)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (key.prv);
@@ -6390,7 +6390,7 @@ TEST (rpc, sign_block)
 
 TEST (rpc, memory_stats)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 
@@ -6429,7 +6429,7 @@ TEST (rpc, memory_stats)
 
 TEST (rpc, block_confirmed)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -6513,7 +6513,7 @@ TEST (rpc, database_txn_tracker)
 
 	// First try when database tracking is disabled
 	{
-		nano::system system;
+		nano::test::system system;
 		auto node = add_ipc_enabled_node (system);
 		auto const rpc_ctx = add_rpc (system, node);
 
@@ -6527,8 +6527,8 @@ TEST (rpc, database_txn_tracker)
 	}
 
 	// Now try enabling it but with invalid amounts
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.diagnostics_config.txn_tracking.enable = true;
 	auto node = add_ipc_enabled_node (system, node_config);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -6603,7 +6603,7 @@ TEST (rpc, database_txn_tracker)
 
 TEST (rpc, active_difficulty)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	ASSERT_EQ (node->default_difficulty (nano::work_version::work_1), node->network_params.work.epoch_2);
@@ -6649,13 +6649,13 @@ TEST (rpc, active_difficulty)
 TEST (rpc, simultaneous_calls)
 {
 	// This tests simulatenous calls to the same node in different threads
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::thread_runner runner (system.io_ctx, node->config.io_threads);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
-	nano::rpc_config rpc_config{ nano::dev::network_params.network, nano::get_available_port (), true };
+	nano::rpc_config rpc_config{ nano::dev::network_params.network, nano::test::get_available_port (), true };
 	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
 	ASSERT_TRUE (ipc_tcp_port.has_value ());
 	rpc_config.rpc_process.num_ipc_connections = 8;
@@ -6707,7 +6707,7 @@ TEST (rpc, simultaneous_calls)
 // This tests that the inprocess RPC (i.e without using IPC) works correctly
 TEST (rpc, in_process)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -6722,7 +6722,7 @@ TEST (rpc, in_process)
 
 TEST (rpc, deprecated_account_format)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -6743,7 +6743,7 @@ TEST (rpc, deprecated_account_format)
 
 TEST (rpc, epoch_upgrade)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key1, key2, key3;
 	nano::keypair epoch_signer (nano::dev::genesis_key);
@@ -6906,8 +6906,8 @@ TEST (rpc, epoch_upgrade)
 
 TEST (rpc, epoch_upgrade_multithreaded)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.work_threads = 4;
 	auto node = add_ipc_enabled_node (system, node_config);
 	nano::keypair key1, key2, key3;
@@ -7072,7 +7072,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 
 TEST (rpc, account_lazy_start)
 {
-	nano::system system{};
+	nano::test::system system{};
 	nano::node_flags node_flags{};
 	node_flags.disable_legacy_bootstrap = true;
 	auto node1 = system.add_node (node_flags);
@@ -7101,9 +7101,9 @@ TEST (rpc, account_lazy_start)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
 
 	// Start lazy bootstrap with account
-	nano::node_config node_config{ nano::get_available_port (), system.logging };
+	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
 	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = nano::get_available_port ();
+	node_config.ipc_config.transport_tcp.port = nano::test::get_available_port ();
 	auto node2 = system.add_node (node_config, node_flags);
 	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
 	auto const rpc_ctx = add_rpc (system, node2);
@@ -7125,7 +7125,7 @@ TEST (rpc, account_lazy_start)
 
 TEST (rpc, receive)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto wallet = system.wallet (0);
 	std::string wallet_text;
@@ -7166,7 +7166,7 @@ TEST (rpc, receive)
 
 TEST (rpc, receive_unopened)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto wallet = system.wallet (0);
 	std::string wallet_text;
@@ -7222,10 +7222,10 @@ TEST (rpc, receive_unopened)
 
 TEST (rpc, receive_work_disabled)
 {
-	nano::system system;
-	nano::node_config config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config config (nano::test::get_available_port (), system.logging);
 	auto & worker_node = *system.add_node (config);
-	config.peering_port = nano::get_available_port ();
+	config.peering_port = nano::test::get_available_port ();
 	config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, config);
 	auto wallet = system.wallet (1);
@@ -7254,9 +7254,9 @@ TEST (rpc, receive_work_disabled)
 
 TEST (rpc, receive_pruned)
 {
-	nano::system system;
+	nano::test::system system;
 	auto & node1 = *system.add_node ();
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -7316,7 +7316,7 @@ TEST (rpc, receive_pruned)
 
 TEST (rpc, telemetry_single)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 
@@ -7376,7 +7376,7 @@ TEST (rpc, telemetry_single)
 
 TEST (rpc, telemetry_all)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 
@@ -7428,7 +7428,7 @@ TEST (rpc, telemetry_all)
 // Also tests all forms of ipv4/ipv6
 TEST (rpc, telemetry_self)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 
@@ -7476,10 +7476,10 @@ TEST (rpc, telemetry_self)
 
 TEST (rpc, confirmation_active)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_config node_config;
 	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = nano::get_available_port ();
+	node_config.ipc_config.transport_tcp.port = nano::test::get_available_port ();
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto node1 (system.add_node (node_config, node_flags));
@@ -7504,7 +7504,7 @@ TEST (rpc, confirmation_active)
 				 .build_shared ();
 	node1->process_active (send1);
 	node1->process_active (send2);
-	nano::blocks_confirm (*node1, { send1, send2 });
+	nano::test::blocks_confirm (*node1, { send1, send2 });
 	ASSERT_EQ (2, node1->active.size ());
 	auto election (node1->active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
@@ -7524,7 +7524,7 @@ TEST (rpc, confirmation_active)
 
 TEST (rpc, confirmation_info)
 {
-	nano::system system;
+	nano::test::system system;
 	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 
@@ -7565,7 +7565,7 @@ TEST (rpc, confirmation_info)
  */
 TEST (node, election_scheduler_container_info)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_config node_config;
 	node_config.active_elections_size = 0;
 	nano::node_flags node_flags;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -7370,7 +7370,7 @@ TEST (rpc, telemetry_single)
 		nano::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = false;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (telemetry_data, node->network_params, node->config.bandwidth_limit, node->default_difficulty (nano::work_version::work_1), node->node_id);
+		nano::test::compare_default_telemetry_response_data (telemetry_data, node->network_params, node->config.bandwidth_limit, node->default_difficulty (nano::work_version::work_1), node->node_id);
 	}
 }
 
@@ -7401,7 +7401,7 @@ TEST (rpc, telemetry_all)
 		nano::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = true;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data_excluding_signature (telemetry_data, node->network_params, node->config.bandwidth_limit, node->default_difficulty (nano::work_version::work_1));
+		nano::test::compare_default_telemetry_response_data_excluding_signature (telemetry_data, node->network_params, node->config.bandwidth_limit, node->default_difficulty (nano::work_version::work_1));
 		ASSERT_FALSE (response.get_optional<std::string> ("node_id").is_initialized ());
 		ASSERT_FALSE (response.get_optional<std::string> ("signature").is_initialized ());
 	}
@@ -7418,7 +7418,7 @@ TEST (rpc, telemetry_all)
 	nano::telemetry_data data;
 	auto const should_ignore_identification_metrics = false;
 	ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-	nano::compare_default_telemetry_response_data (data, node->network_params, node->config.bandwidth_limit, node->default_difficulty (nano::work_version::work_1), node->node_id);
+	nano::test::compare_default_telemetry_response_data (data, node->network_params, node->config.bandwidth_limit, node->default_difficulty (nano::work_version::work_1), node->node_id);
 
 	ASSERT_EQ (node->network.endpoint ().address ().to_string (), metrics.get<std::string> ("address"));
 	ASSERT_EQ (node->network.endpoint ().port (), metrics.get<uint16_t> ("port"));
@@ -7445,7 +7445,7 @@ TEST (rpc, telemetry_self)
 		nano::telemetry_data data;
 		nano::jsonconfig config (response);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (data, node1->network_params, node1->config.bandwidth_limit, node1->default_difficulty (nano::work_version::work_1), node1->node_id);
+		nano::test::compare_default_telemetry_response_data (data, node1->network_params, node1->config.bandwidth_limit, node1->default_difficulty (nano::work_version::work_1), node1->node_id);
 	}
 
 	request.put ("address", "[::1]");
@@ -7454,7 +7454,7 @@ TEST (rpc, telemetry_self)
 		nano::telemetry_data data;
 		nano::jsonconfig config (response);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (data, node1->network_params, node1->config.bandwidth_limit, node1->default_difficulty (nano::work_version::work_1), node1->node_id);
+		nano::test::compare_default_telemetry_response_data (data, node1->network_params, node1->config.bandwidth_limit, node1->default_difficulty (nano::work_version::work_1), node1->node_id);
 	}
 
 	request.put ("address", "127.0.0.1");
@@ -7463,7 +7463,7 @@ TEST (rpc, telemetry_self)
 		nano::telemetry_data data;
 		nano::jsonconfig config (response);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
-		nano::compare_default_telemetry_response_data (data, node1->network_params, node1->config.bandwidth_limit, node1->default_difficulty (nano::work_version::work_1), node1->node_id);
+		nano::test::compare_default_telemetry_response_data (data, node1->network_params, node1->config.bandwidth_limit, node1->default_difficulty (nano::work_version::work_1), node1->node_id);
 	}
 
 	// Incorrect port should fail

--- a/nano/slow_test/entry.cpp
+++ b/nano/slow_test/entry.cpp
@@ -3,7 +3,10 @@
 #include <gtest/gtest.h>
 namespace nano
 {
-void cleanup_dev_directories_on_exit ();
+namespace test
+{
+	void cleanup_dev_directories_on_exit ();
+}
 void force_nano_dev_network ();
 }
 
@@ -13,6 +16,6 @@ int main (int argc, char ** argv)
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
 	testing::InitGoogleTest (&argc, argv);
 	auto res = RUN_ALL_TESTS ();
-	nano::cleanup_dev_directories_on_exit ();
+	nano::test::cleanup_dev_directories_on_exit ();
 	return res;
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -36,8 +36,8 @@ size_t manually_count_pruned_blocks (nano::store & store)
 
 TEST (system, generate_mass_activity)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false; // Prevent blocks cementing
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -51,8 +51,8 @@ TEST (system, generate_mass_activity)
 
 TEST (system, generate_mass_activity_long)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.enable_voting = false; // Prevent blocks cementing
 	auto node = system.add_node (node_config);
 	nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
@@ -77,8 +77,8 @@ TEST (system, receive_while_synchronizing)
 {
 	std::vector<boost::thread> threads;
 	{
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.enable_voting = false; // Prevent blocks cementing
 		auto node = system.add_node (node_config);
 		nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
@@ -86,7 +86,7 @@ TEST (system, receive_while_synchronizing)
 		uint32_t count (1000);
 		system.generate_mass_activity (count, *system.nodes[0]);
 		nano::keypair key;
-		auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::get_available_port (), nano::unique_path (), system.logging, system.work));
+		auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 		ASSERT_FALSE (node1->init_error ());
 		auto wallet (node1->wallets.create (1));
 		wallet->insert_adhoc (nano::dev::genesis_key.prv); // For voting
@@ -186,7 +186,7 @@ TEST (wallet, multithreaded_send_async)
 {
 	std::vector<boost::thread> threads;
 	{
-		nano::system system (1);
+		nano::test::system system (1);
 		nano::keypair key;
 		auto wallet_l (system.wallet (0));
 		wallet_l->insert_adhoc (nano::dev::genesis_key.prv);
@@ -215,7 +215,7 @@ TEST (wallet, multithreaded_send_async)
 
 TEST (store, load)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	std::vector<boost::thread> threads;
 	for (auto i (0); i < 100; ++i)
 	{
@@ -250,7 +250,7 @@ TEST (node, fork_storm)
 
 	nano::node_flags flags;
 	flags.disable_max_peers_per_ip = true;
-	nano::system system (node_count, nano::transport::transport_type::tcp, flags);
+	nano::test::system system (node_count, nano::transport::transport_type::tcp, flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto previous (system.nodes[0]->latest (nano::dev::genesis_key.pub));
 	auto balance (system.nodes[0]->balance (nano::dev::genesis_key.pub));
@@ -473,7 +473,7 @@ TEST (broadcast, sqrt_broadcast_simulate)
 
 TEST (peer_container, random_set)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto old (std::chrono::steady_clock::now ());
 	auto current (std::chrono::steady_clock::now ());
 	for (auto i (0); i < 10000; ++i)
@@ -491,7 +491,7 @@ TEST (peer_container, random_set)
 // Can take up to 2 hours
 TEST (store, unchecked_load)
 {
-	nano::system system{ 1 };
+	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
 	nano::block_builder builder;
 	std::shared_ptr<nano::block> block = builder
@@ -513,7 +513,7 @@ TEST (store, unchecked_load)
 
 TEST (store, vote_load)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	for (auto i (0); i < 1000000; ++i)
 	{
@@ -577,7 +577,7 @@ TEST (store, pruned_load)
 
 TEST (wallets, rep_scan)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto wallet (system.wallet (0));
 	{
@@ -595,7 +595,7 @@ TEST (wallets, rep_scan)
 
 TEST (node, mass_vote_by_hash)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_hash previous (nano::dev::genesis->hash ());
 	nano::keypair key;
@@ -626,8 +626,8 @@ namespace nano
 {
 TEST (confirmation_height, many_accounts_single_confirmation)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
@@ -711,8 +711,8 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 
 TEST (confirmation_height, many_accounts_many_confirmations)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
@@ -788,8 +788,8 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 
 TEST (confirmation_height, long_chains)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key1;
@@ -934,8 +934,8 @@ TEST (confirmation_height, long_chains)
 
 TEST (confirmation_height, dynamic_algorithm)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key;
@@ -996,8 +996,8 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 	// Repeat in case of intermittent issues not replicating the issue talked about above.
 	for (auto _ = 0; _ < 3; ++_)
 	{
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		nano::node_flags node_flags;
 		node_flags.force_use_write_database_queue = true;
@@ -1074,8 +1074,8 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 
 TEST (confirmation_height, many_accounts_send_receive_self)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.active_elections_size = 400000;
@@ -1238,7 +1238,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	std::vector<std::shared_ptr<nano::open_block>> open_blocks;
 
 	nano::block_builder builder;
-	nano::system system;
+	nano::test::system system;
 
 	{
 		auto transaction (store->tx_begin_write ());
@@ -1395,13 +1395,13 @@ void callback_process (shared_data & shared_data_a, data & data, T & all_node_da
 
 TEST (telemetry, ongoing_requests)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	ASSERT_EQ (0, node_client->telemetry->telemetry_data_size ());
 	ASSERT_EQ (0, node_server->telemetry->telemetry_data_size ());
@@ -1428,7 +1428,7 @@ namespace transport
 {
 	TEST (telemetry, simultaneous_requests)
 	{
-		nano::system system;
+		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.disable_initial_telemetry_requests = true;
 		auto const num_nodes = 4;
@@ -1437,7 +1437,7 @@ namespace transport
 			system.add_node (node_flags);
 		}
 
-		wait_peer_connections (system);
+		nano::wait_peer_connections (system);
 
 		std::vector<std::thread> threads;
 		auto const num_threads = 4;
@@ -1494,13 +1494,13 @@ namespace transport
 
 TEST (telemetry, under_load)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node = system.add_node (node_config, node_flags);
-	node_config.peering_port = nano::get_available_port ();
+	node_config.peering_port = nano::test::get_available_port ();
 	auto node1 = system.add_node (node_config, node_flags);
 	nano::keypair key;
 	nano::keypair key1;
@@ -1583,14 +1583,14 @@ TEST (telemetry, under_load)
  */
 TEST (telemetry, cache_read_and_timeout)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	node_flags.disable_initial_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;
@@ -1648,7 +1648,7 @@ TEST (telemetry, cache_read_and_timeout)
 
 TEST (telemetry, many_nodes)
 {
-	nano::system system;
+	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_ongoing_telemetry_requests = true;
 	node_flags.disable_initial_telemetry_requests = true;
@@ -1657,7 +1657,7 @@ TEST (telemetry, many_nodes)
 	auto const num_nodes = (is_sanitizer_build || nano::running_within_valgrind ()) ? 4 : 10;
 	for (auto i = 0; i < num_nodes; ++i)
 	{
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		// Make a metric completely different for each node so we can check afterwards that there are no duplicates
 		node_config.bandwidth_limit = 100000 + i;
 
@@ -1679,7 +1679,7 @@ TEST (telemetry, many_nodes)
 		}
 	}
 
-	wait_peer_connections (system);
+	nano::wait_peer_connections (system);
 
 	// Give all nodes a non-default number of blocks
 	nano::keypair key;
@@ -1843,8 +1843,8 @@ TEST (node, mass_epoch_upgrader)
 		std::vector<info> opened (total_accounts / 2);
 		std::vector<info> unopened (total_accounts / 2);
 
-		nano::system system;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::test::system system;
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.work_threads = 4;
 		//node_config.work_peers = { { "192.168.1.101", 7000 } };
 		auto & node = *system.add_node (node_config);
@@ -1945,8 +1945,8 @@ TEST (node, mass_epoch_upgrader)
 
 TEST (node, mass_block_new)
 {
-	nano::system system;
-	nano::node_config node_config (nano::get_available_port (), system.logging);
+	nano::test::system system;
+	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	node.network_params.network.request_interval_ms = 500;
@@ -2075,9 +2075,9 @@ TEST (node, wallet_create_block_confirm_conflicts)
 {
 	for (int i = 0; i < 5; ++i)
 	{
-		nano::system system;
+		nano::test::system system;
 		nano::block_builder builder;
-		nano::node_config node_config (nano::get_available_port (), system.logging);
+		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config);
 		auto const num_blocks = 10000;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1368,7 +1368,7 @@ public:
 class shared_data
 {
 public:
-	nano::util::counted_completion write_completion{ 0 };
+	nano::test::counted_completion write_completion{ 0 };
 	std::atomic<bool> done{ false };
 };
 
@@ -1401,7 +1401,7 @@ TEST (telemetry, ongoing_requests)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	ASSERT_EQ (0, node_client->telemetry->telemetry_data_size ());
 	ASSERT_EQ (0, node_server->telemetry->telemetry_data_size ());
@@ -1437,7 +1437,7 @@ namespace transport
 			system.add_node (node_flags);
 		}
 
-		nano::wait_peer_connections (system);
+		nano::test::wait_peer_connections (system);
 
 		std::vector<std::thread> threads;
 		auto const num_threads = 4;
@@ -1590,7 +1590,7 @@ TEST (telemetry, cache_read_and_timeout)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;
@@ -1679,7 +1679,7 @@ TEST (telemetry, many_nodes)
 		}
 	}
 
-	nano::wait_peer_connections (system);
+	nano::test::wait_peer_connections (system);
 
 	// Give all nodes a non-default number of blocks
 	nano::keypair key;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -93,7 +93,7 @@ TEST (system, receive_while_synchronizing)
 		ASSERT_EQ (key.pub, wallet->insert_adhoc (key.prv));
 		node1->start ();
 		system.nodes.push_back (node1);
-		ASSERT_NE (nullptr, nano::establish_tcp (system, *node1, node->network.endpoint ()));
+		ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node1, node->network.endpoint ()));
 		node1->workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::milliseconds (200), ([&system, &key] () {
 			auto hash (system.wallet (0)->send_sync (nano::dev::genesis_key.pub, key.pub, system.nodes[0]->config.receive_minimum.number ()));
 			auto transaction (system.nodes[0]->store.tx_begin_read ());

--- a/nano/slow_test/vote_processor.cpp
+++ b/nano/slow_test/vote_processor.cpp
@@ -14,7 +14,7 @@ using namespace std::chrono_literals;
 // so the producer always wins. Also exercises the flush operation, so it must never deadlock.
 TEST (vote_processor, producer_consumer)
 {
-	nano::system system (1);
+	nano::test::system system (1);
 	auto & node (*system.nodes[0]);
 	auto channel (std::make_shared<nano::transport::inproc::channel> (node, node));
 

--- a/nano/test_common/network.cpp
+++ b/nano/test_common/network.cpp
@@ -10,7 +10,7 @@
 
 using namespace std::chrono_literals;
 
-std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::system & system, nano::node & node, nano::endpoint const & endpoint)
+std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::test::system & system, nano::node & node, nano::endpoint const & endpoint)
 {
 	debug_assert (node.network.endpoint () != endpoint && "Establishing TCP to self is not allowed");
 

--- a/nano/test_common/network.cpp
+++ b/nano/test_common/network.cpp
@@ -10,7 +10,7 @@
 
 using namespace std::chrono_literals;
 
-std::shared_ptr<nano::transport::channel_tcp> nano::establish_tcp (nano::system & system, nano::node & node, nano::endpoint const & endpoint)
+std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::system & system, nano::node & node, nano::endpoint const & endpoint)
 {
 	debug_assert (node.network.endpoint () != endpoint && "Establishing TCP to self is not allowed");
 

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -5,7 +5,6 @@
 namespace nano
 {
 class node;
-class system;
 
 namespace transport
 {
@@ -15,7 +14,8 @@ namespace transport
 
 namespace test
 {
+	class system;
 	/** Waits until a TCP connection is established and returns the TCP channel on success*/
-	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::system &, nano::node &, nano::endpoint const &);
+	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
 }
 }

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -13,6 +13,9 @@ namespace transport
 	class channel_tcp;
 }
 
-/** Waits until a TCP connection is established and returns the TCP channel on success*/
-std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::system &, nano::node &, nano::endpoint const &);
+namespace test
+{
+	/** Waits until a TCP connection is established and returns the TCP channel on success*/
+	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::system &, nano::node &, nano::endpoint const &);
+}
 }

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -13,53 +13,57 @@ enum class error_system
 	generic = 1,
 	deadline_expired
 };
-class system final
+
+namespace test
 {
-public:
-	system ();
-	system (uint16_t, nano::transport::transport_type = nano::transport::transport_type::tcp, nano::node_flags = nano::node_flags ());
-	~system ();
-	void ledger_initialization_set (std::vector<nano::keypair> const & reps, nano::amount const & reserve = 0);
-	void generate_activity (nano::node &, std::vector<nano::account> &);
-	void generate_mass_activity (uint32_t, nano::node &);
-	void generate_usage_traffic (uint32_t, uint32_t, size_t);
-	void generate_usage_traffic (uint32_t, uint32_t);
-	nano::account get_random_account (std::vector<nano::account> &);
-	nano::uint128_t get_random_amount (nano::transaction const &, nano::node &, nano::account const &);
-	void generate_rollback (nano::node &, std::vector<nano::account> &);
-	void generate_change_known (nano::node &, std::vector<nano::account> &);
-	void generate_change_unknown (nano::node &, std::vector<nano::account> &);
-	void generate_receive (nano::node &);
-	void generate_send_new (nano::node &, std::vector<nano::account> &);
-	void generate_send_existing (nano::node &, std::vector<nano::account> &);
-	std::unique_ptr<nano::state_block> upgrade_genesis_epoch (nano::node &, nano::epoch const);
-	std::shared_ptr<nano::wallet> wallet (size_t);
-	nano::account account (nano::transaction const &, size_t);
-	/** Generate work with difficulty between \p min_difficulty_a (inclusive) and \p max_difficulty_a (exclusive) */
-	uint64_t work_generate_limited (nano::block_hash const & root_a, uint64_t min_difficulty_a, uint64_t max_difficulty_a);
-	/**
+	class system final
+	{
+	public:
+		system ();
+		system (uint16_t, nano::transport::transport_type = nano::transport::transport_type::tcp, nano::node_flags = nano::node_flags ());
+		~system ();
+		void ledger_initialization_set (std::vector<nano::keypair> const & reps, nano::amount const & reserve = 0);
+		void generate_activity (nano::node &, std::vector<nano::account> &);
+		void generate_mass_activity (uint32_t, nano::node &);
+		void generate_usage_traffic (uint32_t, uint32_t, size_t);
+		void generate_usage_traffic (uint32_t, uint32_t);
+		nano::account get_random_account (std::vector<nano::account> &);
+		nano::uint128_t get_random_amount (nano::transaction const &, nano::node &, nano::account const &);
+		void generate_rollback (nano::node &, std::vector<nano::account> &);
+		void generate_change_known (nano::node &, std::vector<nano::account> &);
+		void generate_change_unknown (nano::node &, std::vector<nano::account> &);
+		void generate_receive (nano::node &);
+		void generate_send_new (nano::node &, std::vector<nano::account> &);
+		void generate_send_existing (nano::node &, std::vector<nano::account> &);
+		std::unique_ptr<nano::state_block> upgrade_genesis_epoch (nano::node &, nano::epoch const);
+		std::shared_ptr<nano::wallet> wallet (size_t);
+		nano::account account (nano::transaction const &, size_t);
+		/** Generate work with difficulty between \p min_difficulty_a (inclusive) and \p max_difficulty_a (exclusive) */
+		uint64_t work_generate_limited (nano::block_hash const & root_a, uint64_t min_difficulty_a, uint64_t max_difficulty_a);
+		/**
 	 * Polls, sleep if there's no work to be done (default 50ms), then check the deadline
 	 * @returns 0 or nano::deadline_expired
-	 */
-	std::error_code poll (std::chrono::nanoseconds const & sleep_time = std::chrono::milliseconds (50));
-	std::error_code poll_until_true (std::chrono::nanoseconds deadline, std::function<bool ()>);
-	void delay_ms (std::chrono::milliseconds const & delay);
-	void stop ();
-	void deadline_set (std::chrono::duration<double, std::nano> const & delta);
-	std::shared_ptr<nano::node> add_node (nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
-	std::shared_ptr<nano::node> add_node (nano::node_config const &, nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
-	boost::asio::io_context io_ctx;
-	std::vector<std::shared_ptr<nano::node>> nodes;
-	nano::logging logging;
-	nano::work_pool work{ nano::dev::network_params.network, std::max (std::thread::hardware_concurrency (), 1u) };
-	std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
-	double deadline_scaling_factor{ 1.0 };
-	unsigned node_sequence{ 0 };
-	std::vector<std::shared_ptr<nano::block>> initialization_blocks;
-};
-std::unique_ptr<nano::state_block> upgrade_epoch (nano::work_pool &, nano::ledger &, nano::epoch);
-void blocks_confirm (nano::node &, std::vector<std::shared_ptr<nano::block>> const &, bool const = false);
-uint16_t get_available_port ();
-void cleanup_dev_directories_on_exit ();
+		 */
+		std::error_code poll (std::chrono::nanoseconds const & sleep_time = std::chrono::milliseconds (50));
+		std::error_code poll_until_true (std::chrono::nanoseconds deadline, std::function<bool ()>);
+		void delay_ms (std::chrono::milliseconds const & delay);
+		void stop ();
+		void deadline_set (std::chrono::duration<double, std::nano> const & delta);
+		std::shared_ptr<nano::node> add_node (nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
+		std::shared_ptr<nano::node> add_node (nano::node_config const &, nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
+		boost::asio::io_context io_ctx;
+		std::vector<std::shared_ptr<nano::node>> nodes;
+		nano::logging logging;
+		nano::work_pool work{ nano::dev::network_params.network, std::max (std::thread::hardware_concurrency (), 1u) };
+		std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
+		double deadline_scaling_factor{ 1.0 };
+		unsigned node_sequence{ 0 };
+		std::vector<std::shared_ptr<nano::block>> initialization_blocks;
+	};
+	std::unique_ptr<nano::state_block> upgrade_epoch (nano::work_pool &, nano::ledger &, nano::epoch);
+	void blocks_confirm (nano::node &, std::vector<std::shared_ptr<nano::block>> const &, bool const = false);
+	uint16_t get_available_port ();
+	void cleanup_dev_directories_on_exit ();
+}
 }
 REGISTER_ERROR_CODES (nano, error_system);

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-void nano::compare_default_telemetry_response_data_excluding_signature (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a)
+void nano::test::compare_default_telemetry_response_data_excluding_signature (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a)
 {
 	ASSERT_EQ (telemetry_data_a.block_count, 1);
 	ASSERT_EQ (telemetry_data_a.cemented_count, 1);
@@ -24,7 +24,7 @@ void nano::compare_default_telemetry_response_data_excluding_signature (nano::te
 	ASSERT_EQ (telemetry_data_a.unknown_data, std::vector<uint8_t>{});
 }
 
-void nano::compare_default_telemetry_response_data (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a)
+void nano::test::compare_default_telemetry_response_data (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a)
 {
 	ASSERT_FALSE (telemetry_data_a.validate_signature ());
 	nano::telemetry_data telemetry_data_l = telemetry_data_a;
@@ -32,6 +32,6 @@ void nano::compare_default_telemetry_response_data (nano::telemetry_data const &
 	telemetry_data_l.sign (node_id_a);
 	// Signature should be different because uptime/timestamp will have changed.
 	ASSERT_NE (telemetry_data_a.signature, telemetry_data_l.signature);
-	compare_default_telemetry_response_data_excluding_signature (telemetry_data_a, network_params_a, bandwidth_limit_a, active_difficulty_a);
+	nano::test::compare_default_telemetry_response_data_excluding_signature (telemetry_data_a, network_params_a, bandwidth_limit_a, active_difficulty_a);
 	ASSERT_EQ (telemetry_data_a.node_id, node_id_a.pub);
 }

--- a/nano/test_common/telemetry.hpp
+++ b/nano/test_common/telemetry.hpp
@@ -8,6 +8,9 @@ class keypair;
 class network_params;
 class telemetry_data;
 
-void compare_default_telemetry_response_data_excluding_signature (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a);
-void compare_default_telemetry_response_data (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a);
+namespace test
+{
+	void compare_default_telemetry_response_data_excluding_signature (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a);
+	void compare_default_telemetry_response_data (nano::telemetry_data const & telemetry_data_a, nano::network_params const & network_params_a, uint64_t bandwidth_limit_a, uint64_t active_difficulty_a, nano::keypair const & node_id_a);
+}
 }

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -9,7 +9,7 @@
 
 using namespace std::chrono_literals;
 
-void nano::wait_peer_connections (nano::system & system_a)
+void nano::wait_peer_connections (nano::test::system & system_a)
 {
 	auto wait_peer_count = [&system_a] (bool in_memory) {
 		auto num_nodes = system_a.nodes.size ();

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -9,7 +9,7 @@
 
 using namespace std::chrono_literals;
 
-void nano::wait_peer_connections (nano::test::system & system_a)
+void nano::test::wait_peer_connections (nano::test::system & system_a)
 {
 	auto wait_peer_count = [&system_a] (bool in_memory) {
 		auto num_nodes = system_a.nodes.size ();

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -51,7 +51,11 @@ class public_key;
 class block_hash;
 class telemetry_data;
 class network_params;
-class system;
+
+namespace test
+{
+	class system;
+}
 
 extern nano::uint128_t const & genesis_amount;
 
@@ -204,5 +208,5 @@ namespace util
 	};
 }
 
-void wait_peer_connections (nano::system &);
+void wait_peer_connections (nano::test::system &);
 }


### PR DESCRIPTION
Some of the test code is under namespace nano, some is in nano::test and some is in nano::util.
There seems to be no apparent for this discrepancy, which makes it untidy.
Moving all test code inside the folder test_common into namespace nano::test to make it tidy.