### PR TITLE
Extract `recently_cemented` container out of `active_transactions`

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1560,7 +1560,7 @@ TEST (confirmation_height, callback_confirmed_history)
 			ASSERT_NE (nullptr, election);
 			election->force_confirm ();
 			ASSERT_TIMELY (10s, node->active.size () == 0);
-			ASSERT_EQ (0, node->active.list_recently_cemented ().size ());
+			ASSERT_EQ (0, node->active.recently_cemented.list ().size ());
 			{
 				nano::lock_guard<nano::mutex> guard (node->active.mutex);
 				ASSERT_EQ (0, node->active.blocks.size ());
@@ -1583,7 +1583,7 @@ TEST (confirmation_height, callback_confirmed_history)
 		ASSERT_TIMELY (10s, node->active.size () == 0);
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out) == 1);
 
-		ASSERT_EQ (1, node->active.list_recently_cemented ().size ());
+		ASSERT_EQ (1, node->active.recently_cemented.list ().size ());
 		ASSERT_EQ (0, node->active.blocks.size ());
 
 		// Confirm the callback is not called under this circumstance

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2227,7 +2227,7 @@ TEST (node, block_confirm)
 		node2.block_confirm (send1_copy);
 		auto election = node2.active.election (send1_copy->qualified_root ());
 		ASSERT_NE (nullptr, election);
-		ASSERT_TIMELY (10s, node1.active.list_recently_cemented ().size () == 1);
+		ASSERT_TIMELY (10s, node1.active.recently_cemented.list ().size () == 1);
 	}
 }
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1187,7 +1187,7 @@ void nano::json_handler::block_confirm ()
 			{
 				// Add record in confirmation history for confirmed block
 				nano::election_status status{ block_l, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::active_confirmation_height };
-				node.active.add_recently_cemented (status);
+				node.active.recently_cemented.put (status);
 				// Trigger callback for confirmed block
 				node.block_arrival.add (hash);
 				auto account (node.ledger.account (transaction, hash));
@@ -2006,7 +2006,7 @@ void nano::json_handler::confirmation_history ()
 	}
 	if (!ec)
 	{
-		for (auto const & status : node.active.list_recently_cemented ())
+		for (auto const & status : node.active.recently_cemented.list ())
 		{
 			if (hash.is_zero () || status.winner->hash () == hash)
 			{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5875,9 +5875,9 @@ TEST (rpc, confirmation_history)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_TRUE (node->active.list_recently_cemented ().empty ());
+	ASSERT_TRUE (node->active.recently_cemented.list ().empty ());
 	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
-	ASSERT_TIMELY (10s, !node->active.list_recently_cemented ().empty ());
+	ASSERT_TIMELY (10s, !node->active.recently_cemented.list ().empty ());
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_history");
@@ -5906,11 +5906,11 @@ TEST (rpc, confirmation_history_hash)
 	auto node = add_ipc_enabled_node (system);
 	nano::keypair key;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_TRUE (node->active.list_recently_cemented ().empty ());
+	ASSERT_TRUE (node->active.recently_cemented.list ().empty ());
 	auto send1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	auto send2 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	auto send3 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
-	ASSERT_TIMELY (10s, node->active.list_recently_cemented ().size () == 3);
+	ASSERT_TIMELY (10s, node->active.recently_cemented.list ().size () == 3);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_history");
@@ -5995,7 +5995,7 @@ TEST (rpc, block_confirm_confirmed)
 	auto response (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("1", response.get<std::string> ("started"));
 	// Check confirmation history
-	auto confirmed (node->active.list_recently_cemented ());
+	auto confirmed (node->active.recently_cemented.list ());
 	ASSERT_EQ (1, confirmed.size ());
 	ASSERT_EQ (nano::dev::genesis->hash (), confirmed.begin ()->winner->hash ());
 	// Check callback


### PR DESCRIPTION
`active_transactions` class internally manages a few helper containers, this PR extracts one responsible for remembering recently cemented elections (used currently by some RPCs and tests)