### PR TITLE
IWYU in `signal_manager`

### DIFF
--- a/nano/core_test/signal_manager.cpp
+++ b/nano/core_test/signal_manager.cpp
@@ -19,6 +19,7 @@
 
 #include <csignal>
 #include <iostream>
+#include <thread>
 
 static void handler_print_signal (int signum)
 {


### PR DESCRIPTION
Fixes build error when using GCC 11.2 on Ubuntu 22.04