### PR TITLE
Assert no error code when calling `system::poll_until_true`

### DIFF
--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -71,40 +71,52 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 				(*j)->network.send_keepalive (channel);
 			}
 
-			poll_until_true (3s, [&node1, &node2, starting_size_1, starting_size_2] () {
-				auto size_1 = node1->network.size ();
-				auto size_2 = node2->network.size ();
-				return size_1 > starting_size_1 && size_2 > starting_size_2;
-			});
+			{
+				auto ec = poll_until_true (3s, [&node1, &node2, starting_size_1, starting_size_2] () {
+					auto size_1 = node1->network.size ();
+					auto size_2 = node2->network.size ();
+					return size_1 > starting_size_1 && size_2 > starting_size_2;
+				});
+				debug_assert (!ec);
+			}
 
 			if (type_a == nano::transport::transport_type::tcp && node_config_a.tcp_incoming_connections_max != 0 && !node_flags_a.disable_tcp_realtime)
 			{
-				// Wait for initial connection finish
-				poll_until_true (3s, [&node1, &node2, starting_realtime_1, starting_realtime_2] () {
-					auto realtime_1 = node1->bootstrap.realtime_count.load ();
-					auto realtime_2 = node2->bootstrap.realtime_count.load ();
-					return realtime_1 > starting_realtime_1 && realtime_2 > starting_realtime_2;
-				});
-
-				// Wait for keepalive message exchange
-				poll_until_true (3s, [&node1, &node2, starting_keepalives_1, starting_keepalives_2] () {
-					auto keepalives_1 = node1->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
-					auto keepalives_2 = node2->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
-					return keepalives_1 > starting_keepalives_1 && keepalives_2 > starting_keepalives_2;
-				});
+				{
+					// Wait for initial connection finish
+					auto ec = poll_until_true (3s, [&node1, &node2, starting_realtime_1, starting_realtime_2] () {
+						auto realtime_1 = node1->bootstrap.realtime_count.load ();
+						auto realtime_2 = node2->bootstrap.realtime_count.load ();
+						return realtime_1 > starting_realtime_1 && realtime_2 > starting_realtime_2;
+					});
+					debug_assert (!ec);
+				}
+				{
+					// Wait for keepalive message exchange
+					auto ec = poll_until_true (3s, [&node1, &node2, starting_keepalives_1, starting_keepalives_2] () {
+						auto keepalives_1 = node1->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
+						auto keepalives_2 = node2->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
+						return keepalives_1 > starting_keepalives_1 && keepalives_2 > starting_keepalives_2;
+					});
+					debug_assert (!ec);
+				}
 			}
 		}
 
-		// Ensure no bootstrap initiators are in progress
-		poll_until_true (3s, [this, &begin] () {
-			return std::all_of (begin, nodes.end (), [] (std::shared_ptr<nano::node> const & node_a) { return !node_a->bootstrap_initiator.in_progress (); });
-		});
+		{
+			// Ensure no bootstrap initiators are in progress
+			auto ec = poll_until_true (3s, [this, &begin] () {
+				return std::all_of (begin, nodes.end (), [] (std::shared_ptr<nano::node> const & node_a) { return !node_a->bootstrap_initiator.in_progress (); });
+			});
+			debug_assert (!ec);
+		}
 	}
 	else
 	{
-		poll_until_true (3s, [&node] () {
+		auto ec = poll_until_true (3s, [&node] () {
 			return !node->bootstrap_initiator.in_progress ();
 		});
+		debug_assert (!ec);
 	}
 
 	return node;


### PR DESCRIPTION
`system::poll_until_true` returns error code when error happens so we need to check that, otherwise errors go unnoticed leading to confusing behavior