### PR TITLE
Lookup channels by node id instead of endpoints in test code

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -240,7 +240,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	auto const vote1 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send1->hash () });
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1));
 
-	auto channel = node1.network.find_channel (node2.network.endpoint ());
+	auto channel = node1.network.find_node_id (node2.get_node_id ());
 	ASSERT_NE (channel, nullptr);
 
 	auto const vote2 = std::make_shared<nano::vote> (key1.pub, key1.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send1->hash () });

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -139,10 +139,10 @@ TEST (network, send_node_id_handshake_tcp)
 	ASSERT_EQ (1, node1->network.size ());
 	auto list1 (node0->network.list (1));
 	ASSERT_EQ (nano::transport::transport_type::tcp, list1[0]->get_type ());
-	ASSERT_EQ (node1->network.endpoint (), list1[0]->get_endpoint ());
+	ASSERT_EQ (node1->get_node_id (), list1[0]->get_node_id ());
 	auto list2 (node1->network.list (1));
 	ASSERT_EQ (nano::transport::transport_type::tcp, list2[0]->get_type ());
-	ASSERT_EQ (node0->network.endpoint (), list2[0]->get_endpoint ());
+	ASSERT_EQ (node0->get_node_id (), list2[0]->get_node_id ());
 	node1->stop ();
 }
 
@@ -384,7 +384,8 @@ TEST (network, send_insufficient_work)
 				  .work (0)
 				  .build_shared ();
 	nano::publish publish1{ nano::dev::network_params.network, block1 };
-	auto tcp_channel (node1.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node2.network.endpoint ())));
+	auto tcp_channel (node1.network.tcp_channels.find_node_id (node2.get_node_id ()));
+	ASSERT_NE (nullptr, tcp_channel);
 	tcp_channel->send (publish1, [] (boost::system::error_code const & ec, size_t size) {});
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work));
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::error, nano::stat::detail::insufficient_work) != 0);
@@ -1073,7 +1074,8 @@ TEST (network, duplicate_detection)
 	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 1);
 
 	// Publish duplicate detection through TCP
-	auto tcp_channel (node0.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node1.network.endpoint ())));
+	auto tcp_channel (node0.network.tcp_channels.find_node_id (node1.get_node_id ()));
+	ASSERT_NE (nullptr, tcp_channel);
 	ASSERT_EQ (1, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish));
 	tcp_channel->send (publish);
 	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 2);
@@ -1221,8 +1223,7 @@ TEST (network, tcp_no_connect_excluded_peers)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
-	auto endpoint1 (node1->network.endpoint ());
-	auto endpoint1_tcp (nano::transport::map_endpoint_to_tcp (endpoint1));
+	auto endpoint1_tcp (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ()));
 	while (!node0->network.excluded_peers.check (endpoint1_tcp))
 	{
 		node0->network.excluded_peers.add (endpoint1_tcp, 1);
@@ -1230,10 +1231,10 @@ TEST (network, tcp_no_connect_excluded_peers)
 	ASSERT_EQ (0, node0->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_excluded));
 	node1->network.merge_peer (node0->network.endpoint ());
 	ASSERT_TIMELY (5s, node0->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_excluded) >= 1);
-	ASSERT_EQ (nullptr, node0->network.find_channel (endpoint1));
+	ASSERT_EQ (nullptr, node0->network.find_node_id (node1->get_node_id ()));
 
 	// Should not actively reachout to excluded peers
-	ASSERT_TRUE (node0->network.reachout (endpoint1, true));
+	ASSERT_TRUE (node0->network.reachout (node1->network.endpoint (), true));
 
 	// Erasing from excluded peers should allow a connection
 	node0->network.excluded_peers.remove (endpoint1_tcp);
@@ -1374,7 +1375,7 @@ TEST (network, filter_invalid_network_bytes)
 	auto & node2 = *system.nodes[1];
 
 	// find the comms channel that goes from node2 to node1
-	auto channel = node2.network.find_channel (node1.network.endpoint ());
+	auto channel = node2.network.find_node_id (node1.get_node_id ());
 	ASSERT_NE (nullptr, channel);
 
 	// send a keepalive, from node2 to node1, with the wrong network bytes
@@ -1393,7 +1394,7 @@ TEST (network, filter_invalid_version_using)
 	auto & node2 = *system.nodes[1];
 
 	// find the comms channel that goes from node2 to node1
-	auto channel = node2.network.find_channel (node1.network.endpoint ());
+	auto channel = node2.network.find_node_id (node1.get_node_id ());
 	ASSERT_NE (nullptr, channel);
 
 	// send a keepalive, from node2 to node1, with the wrong version_using

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1857,7 +1857,7 @@ TEST (node, rep_remove)
 	// Add working node for genesis representative
 	auto node_genesis_rep = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto channel_genesis_rep (searching_node.network.find_channel (node_genesis_rep->network.endpoint ()));
+	auto channel_genesis_rep (searching_node.network.find_node_id (node_genesis_rep->get_node_id ()));
 	ASSERT_NE (nullptr, channel_genesis_rep);
 
 	// genesis_rep should be found as principal representative after receiving a vote from it
@@ -1870,7 +1870,7 @@ TEST (node, rep_remove)
 	node_rep2->start ();
 	searching_node.network.tcp_channels.start_tcp (node_rep2->network.endpoint ());
 	std::shared_ptr<nano::transport::channel> channel_rep2;
-	ASSERT_TIMELY (10s, (channel_rep2 = searching_node.network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_rep2->network.endpoint ()))) != nullptr);
+	ASSERT_TIMELY (10s, (channel_rep2 = searching_node.network.tcp_channels.find_node_id (node_rep2->get_node_id ())) != nullptr);
 
 	// Rep2 should be found as a principal representative after receiving a vote from it
 	auto vote_rep2 = std::make_shared<nano::vote> (keys_rep2.pub, keys_rep2.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
@@ -3196,11 +3196,11 @@ TEST (node, peers)
 	// Confirm that the peers match with the endpoints we are expecting
 	ASSERT_EQ (1, node1->network.size ());
 	auto list1 (node1->network.list (2));
-	ASSERT_EQ (node2->network.endpoint (), list1[0]->get_endpoint ());
+	ASSERT_EQ (node2->get_node_id (), list1[0]->get_node_id ());
 	ASSERT_EQ (nano::transport::transport_type::tcp, list1[0]->get_type ());
 	ASSERT_EQ (1, node2->network.size ());
 	auto list2 (node2->network.list (2));
-	ASSERT_EQ (node1->network.endpoint (), list2[0]->get_endpoint ());
+	ASSERT_EQ (node1->get_node_id (), list2[0]->get_node_id ());
 	ASSERT_EQ (nano::transport::transport_type::tcp, list2[0]->get_type ());
 	// Stop the peer node and check that it is removed from the store
 	node1->stop ();
@@ -4244,7 +4244,7 @@ TEST (rep_crawler, recently_confirmed)
 	node1.active.recently_confirmed.put (block->qualified_root (), block->hash ());
 	auto & node2 (*system.add_node ());
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto channel = node1.network.find_channel (node2.network.endpoint ());
+	auto channel = node1.network.find_node_id (node2.get_node_id ());
 	ASSERT_NE (nullptr, channel);
 	node1.rep_crawler.query (channel);
 	ASSERT_TIMELY (3s, node1.rep_crawler.representative_count () == 1);

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -292,17 +292,18 @@ TEST (telemetry, basic)
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;
 	auto server_endpoint = node_server->network.endpoint ();
-	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 	{
 		std::atomic<bool> done{ false };
 		node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &server_endpoint, &telemetry_data] (nano::telemetry_data_response const & response_a) {
 			ASSERT_FALSE (response_a.error);
-			ASSERT_EQ (server_endpoint, response_a.endpoint);
 			telemetry_data = response_a.telemetry_data;
 			done = true;
 		});
 
 		ASSERT_TIMELY (10s, done);
+		ASSERT_EQ (node_server->get_node_id (), telemetry_data.node_id);
 	}
 
 	// Check the metrics are correct
@@ -357,7 +358,8 @@ TEST (telemetry, over_tcp)
 	nano::test::wait_peer_connections (system);
 
 	std::atomic<bool> done{ false };
-	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 	node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &node_server] (nano::telemetry_data_response const & response_a) {
 		ASSERT_FALSE (response_a.error);
 		nano::test::compare_default_telemetry_response_data (response_a.telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
@@ -423,7 +425,9 @@ TEST (telemetry, blocking_request)
 	node_client->workers.push_task (call_system_poll);
 
 	// Now try single request metric
-	auto telemetry_data_response = node_client->telemetry->get_metrics_single_peer (node_client->network.find_channel (node_server->network.endpoint ()));
+	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
+	auto telemetry_data_response = node_client->telemetry->get_metrics_single_peer (channel);
 	ASSERT_FALSE (telemetry_data_response.error);
 	nano::test::compare_default_telemetry_response_data (telemetry_data_response.telemetry_data, node_server->network_params, node_server->config.bandwidth_limit, node_server->default_difficulty (nano::work_version::work_1), node_server->node_id);
 
@@ -442,7 +446,8 @@ TEST (telemetry, disconnects)
 	nano::test::wait_peer_connections (system);
 
 	// Try and request metrics from a node which is turned off but a channel is not closed yet
-	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 	node_server->stop ();
 	ASSERT_TRUE (channel);
 
@@ -468,7 +473,8 @@ TEST (telemetry, dos_tcp)
 	nano::test::wait_peer_connections (system);
 
 	nano::telemetry_req message{ nano::dev::network_params.network };
-	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
+	auto channel = node_client->network.tcp_channels.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
 		ASSERT_FALSE (ec);
 	});
@@ -508,8 +514,8 @@ TEST (telemetry, disable_metrics)
 	nano::test::wait_peer_connections (system);
 
 	// Try and request metrics from a node which is turned off but a channel is not closed yet
-	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
-	ASSERT_TRUE (channel);
+	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 
 	std::atomic<bool> done{ false };
 	node_client->telemetry->get_metrics_single_peer_async (channel, [&done] (nano::telemetry_data_response const & response_a) {
@@ -521,7 +527,8 @@ TEST (telemetry, disable_metrics)
 
 	// It should still be able to receive metrics though
 	done = false;
-	auto channel1 = node_server->network.find_channel (node_client->network.endpoint ());
+	auto channel1 = node_server->network.find_node_id (node_client->get_node_id ());
+	ASSERT_NE (nullptr, channel1);
 	node_server->telemetry->get_metrics_single_peer_async (channel1, [&done, node_client] (nano::telemetry_data_response const & response_a) {
 		ASSERT_FALSE (response_a.error);
 		nano::test::compare_default_telemetry_response_data (response_a.telemetry_data, node_client->network_params, node_client->config.bandwidth_limit, node_client->default_difficulty (nano::work_version::work_1), node_client->node_id);
@@ -546,7 +553,8 @@ TEST (telemetry, max_possible_size)
 	nano::telemetry_ack message{ nano::dev::network_params.network, data };
 	nano::test::wait_peer_connections (system);
 
-	auto channel = node_client->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node_server->network.endpoint ()));
+	auto channel = node_client->network.tcp_channels.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 	channel->send (message, [] (boost::system::error_code const & ec, size_t size_a) {
 		ASSERT_FALSE (ec);
 	});
@@ -629,17 +637,18 @@ TEST (telemetry, maker_pruning)
 	// Request telemetry metrics
 	nano::telemetry_data telemetry_data;
 	auto server_endpoint = node_server->network.endpoint ();
-	auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
+	ASSERT_NE (nullptr, channel);
 	{
 		std::atomic<bool> done{ false };
 		node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &server_endpoint, &telemetry_data] (nano::telemetry_data_response const & response_a) {
 			ASSERT_FALSE (response_a.error);
-			ASSERT_EQ (server_endpoint, response_a.endpoint);
 			telemetry_data = response_a.telemetry_data;
 			done = true;
 		});
 
 		ASSERT_TIMELY (10s, done);
+		ASSERT_EQ (node_server->get_node_id (), telemetry_data.node_id);
 	}
 
 	ASSERT_EQ (nano::telemetry_maker::nf_pruned_node, static_cast<nano::telemetry_maker> (telemetry_data.maker));

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1002,7 +1002,7 @@ TEST (websocket, telemetry)
 
 	ASSERT_TIMELY (10s, done);
 
-	node1->telemetry->get_metrics_single_peer_async (node1->network.find_channel (node2->network.endpoint ()), [] (auto const & response_a) {
+	node1->telemetry->get_metrics_single_peer_async (node1->network.find_node_id (node2->get_node_id ()), [] (auto const & response_a) {
 		ASSERT_FALSE (response_a.error);
 	});
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1807,6 +1807,11 @@ uint64_t nano::node::get_confirmation_height (nano::transaction const & transact
 	nano::confirmation_height_info info;
 	store.confirmation_height.get (transaction_a, account_a, info);
 	return info.height;
+}
+
+nano::account nano::node::get_node_id () const
+{
+	return node_id.pub;
 };
 
 nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -132,6 +132,7 @@ public:
 	 * Attempts to bootstrap block. This is the best effort, there is no guarantee that the block will be bootstrapped.
 	 */
 	void bootstrap_block (nano::block_hash const &);
+	nano::account get_node_id () const;
 	nano::write_database_queue write_database_queue;
 	boost::asio::io_context & io_ctx;
 	boost::latch node_initialized_latch;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1900,11 +1900,11 @@ TEST (rpc, keepalive)
 	auto port (boost::str (boost::format ("%1%") % node1->network.endpoint ().port ()));
 	request.put ("address", address);
 	request.put ("port", port);
-	ASSERT_EQ (nullptr, node0->network.tcp_channels.find_channel (nano::transport::map_endpoint_to_tcp (node1->network.endpoint ())));
+	ASSERT_EQ (nullptr, node0->network.tcp_channels.find_node_id (node1->get_node_id ()));
 	ASSERT_EQ (0, node0->network.size ());
 	auto response (wait_response (system, rpc_ctx, request));
 	system.deadline_set (10s);
-	while (node0->network.find_channel (node1->network.endpoint ()) == nullptr)
+	while (node0->network.find_node_id (node1->get_node_id ()) == nullptr)
 	{
 		ASSERT_EQ (0, node0->network.size ());
 		ASSERT_NO_ERROR (system.poll ());
@@ -7374,7 +7374,7 @@ TEST (rpc, telemetry_all)
 	// First need to set up the cached data
 	std::atomic<bool> done{ false };
 	auto node = system.nodes.front ();
-	node1->telemetry->get_metrics_single_peer_async (node1->network.find_channel (node->network.endpoint ()), [&done] (nano::telemetry_data_response const & telemetry_data_response_a) {
+	node1->telemetry->get_metrics_single_peer_async (node1->network.find_node_id (node->get_node_id ()), [&done] (nano::telemetry_data_response const & telemetry_data_response_a) {
 		ASSERT_FALSE (telemetry_data_response_a.error);
 		done = true;
 	});

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -989,7 +989,7 @@ TEST (confirmation_height, dynamic_algorithm)
  *    of blocks uncemented is > unbounded_cutoff so that it hits the bounded processor), the main `run` loop on the conf height processor is iterated.
  *
  * This cause unbounded pending entries not to be written, and then the bounded processor would write them, causing some inconsistencies.
-*/
+ */
 TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 {
 	// Repeat in case of intermittent issues not replicating the issue talked about above.
@@ -1595,7 +1595,7 @@ TEST (telemetry, cache_read_and_timeout)
 	nano::telemetry_data telemetry_data;
 	{
 		std::atomic<bool> done{ false };
-		auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+		auto channel = node_client->network.find_node_id (node_server->get_node_id ());
 		node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &telemetry_data] (nano::telemetry_data_response const & response_a) {
 			telemetry_data = response_a.telemetry_data;
 			done = true;
@@ -1625,7 +1625,7 @@ TEST (telemetry, cache_read_and_timeout)
 	// Request telemetry metrics again
 	{
 		std::atomic<bool> done{ false };
-		auto channel = node_client->network.find_channel (node_server->network.endpoint ());
+		auto channel = node_client->network.find_node_id (node_server->get_node_id ());
 		node_client->telemetry->get_metrics_single_peer_async (channel, [&done, &telemetry_data] (nano::telemetry_data_response const & response_a) {
 			telemetry_data = response_a.telemetry_data;
 			done = true;
@@ -1845,7 +1845,7 @@ TEST (node, mass_epoch_upgrader)
 		nano::test::system system;
 		nano::node_config node_config (nano::test::get_available_port (), system.logging);
 		node_config.work_threads = 4;
-		//node_config.work_peers = { { "192.168.1.101", 7000 } };
+		// node_config.work_peers = { { "192.168.1.101", 7000 } };
 		auto & node = *system.add_node (node_config);
 
 		auto balance = node.balance (nano::dev::genesis_key.pub);


### PR DESCRIPTION
Right now we assume we can lookup channels by their associated endpoint, however this is only because we always establish two channels per peer, one inbound and one outbound. This PR is preparation for future changes introducing bidirectional channels where one endpoint uses a random ephemeral port.

There are also a few smaller fixes that I noticed when going through code that didn't seem worthwhile to have their own PR.

TODO: It is probably a good idea to replace looking up channels by node id everywhere, but a lot of those usages are left in legacy UDP code, so this needs to wait after that part is removed.