### PR TITLE
Remove `confirmation_solicitor & election` circular dependency

### DIFF
--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -32,7 +32,7 @@ public:
 	bool add (std::shared_ptr<nano::block> const & winner, std::unordered_map<nano::account, nano::vote_info> const & last_votes);
 	/** Dispatch bundled requests to each channel*/
 	void flush ();
-	
+
 	/** Global maximum amount of block broadcasts */
 	std::size_t const max_block_broadcasts;
 	/** Maximum amount of requests to be sent per election, bypassed if an existing vote is for a different hash*/

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -10,19 +10,29 @@ namespace nano
 class election;
 class node;
 class node_config;
+class vote_info;
+
 /** This class accepts elections that need further votes before they can be confirmed and bundles them in to single confirm_req packets */
 class confirmation_solicitor final
 {
 public:
 	confirmation_solicitor (nano::network &, nano::node_config const &);
-	/** Prepare object for batching election confirmation requests*/
+
+	/*
+	 * Prepare object for batching election confirmation requests
+	 */
 	void prepare (std::vector<nano::representative> const &);
-	/** Broadcast the winner of an election if the broadcast limit has not been reached. Returns false if the broadcast was performed */
-	bool broadcast (nano::election const &);
-	/** Add an election that needs to be confirmed. Returns false if successfully added */
-	bool add (nano::election const &);
+	/*
+	 * Broadcast the winner of an election if the broadcast limit has not been reached. Returns false if the broadcast was performed
+	 */
+	bool broadcast (std::shared_ptr<nano::block> const & winner, std::unordered_map<nano::account, nano::vote_info> const & last_votes);
+	/*
+	 * Add an election that needs to be confirmed. Returns false if successfully added
+	 */
+	bool add (std::shared_ptr<nano::block> const & winner, std::unordered_map<nano::account, nano::vote_info> const & last_votes);
 	/** Dispatch bundled requests to each channel*/
 	void flush ();
+	
 	/** Global maximum amount of block broadcasts */
 	std::size_t const max_block_broadcasts;
 	/** Maximum amount of requests to be sent per election, bypassed if an existing vote is for a different hash*/

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -138,11 +138,24 @@ private:
 	void remove_votes (nano::block_hash const &);
 	void remove_block (nano::block_hash const &);
 	bool replace_by_weight (nano::unique_lock<nano::mutex> & lock_a, nano::block_hash const &);
+	/*
+	 * Return amount of time after which this election should expire.
+	 */
 	std::chrono::milliseconds time_to_live () const;
 	/*
 	 * Calculates minimum time delay between subsequent votes when processing non-final votes
 	 */
 	std::chrono::seconds cooldown_time (nano::uint128_t weight) const;
+	/*
+	 * Call `confirmation_solicitor::add` with data from this election
+	 * @returns true if successful, false otherwise
+	 */
+	bool solicitor_add (nano::confirmation_solicitor &) const;
+	/*
+	 * Call `confirmation_solicitor::broadcast` with data from this election
+	 * @returns true if successful, false otherwise
+	 */
+	bool solicitor_broadcast (nano::confirmation_solicitor &) const;
 
 private:
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> last_blocks;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -180,6 +180,7 @@ public: // Only used in tests
 	std::unordered_map<nano::account, nano::vote_info> votes () const;
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks () const;
 
+	friend class confirmation_solicitor_batches_Test;
 	friend class confirmation_solicitor_different_hash_Test;
 	friend class confirmation_solicitor_bypass_max_requests_cap_Test;
 	friend class votes_add_existing_Test;


### PR DESCRIPTION
`confirmation_solicitor` was accessing `election` variables under implicit mutex because it was called from inside one of the `election` methods. It was a bit hard to reason about, and prevented better encapsulation of election class. This PR cleans this part up.