### PR TITLE
Fix `confirm_election_by_request` test

### DIFF
--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -150,10 +150,8 @@ nano::test::system::system (uint16_t count_a, nano::transport::transport_type ty
 
 nano::test::system::~system ()
 {
-	for (auto & i : nodes)
-	{
-		i->stop ();
-	}
+	// Only stop system in destructor to avoid confusing and random bugs when debugging assertions that hit deadline expired condition
+	stop ();
 
 #ifndef _WIN32
 	// Windows cannot remove the log and data files while they are still owned by this process.
@@ -314,7 +312,6 @@ std::error_code nano::test::system::poll (std::chrono::nanoseconds const & wait_
 	if (std::chrono::steady_clock::now () > deadline)
 	{
 		ec = nano::error_system::deadline_expired;
-		stop ();
 	}
 	return ec;
 }

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -42,6 +42,16 @@
 		ASSERT_NO_ERROR (system.poll ()); \
 	}
 
+/*
+ * Waits specified number of time while keeping system running.
+ * Useful for asserting conditions that should still hold after some delay of time
+ */
+#define WAIT(time)              \
+	system.deadline_set (time); \
+	while (!system.poll ())     \
+	{                           \
+	}
+
 /* Convenience globals for gtest projects */
 namespace nano
 {


### PR DESCRIPTION
When testing election confirmations by requesting votes we don't want the other node to have the same election active, as in that case votes would be eagerly generated. Previously the election would get confirmed anyway, even if we didn't request any votes.