### PR TITLE
Improved `inactive_vote_cache`

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
   uint256_union.cpp
   unchecked_map.cpp
   utility.cpp
+  vote_cache.cpp
   vote_processor.cpp
   voting.cpp
   wallet.cpp

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -221,7 +221,7 @@ TEST (active_transactions, inactive_votes_cache)
 				.build_shared ();
 	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash> (1, send->hash ())));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 1);
+	ASSERT_TIMELY (5s, node.inactive_vote_cache.cache_size () == 1);
 	node.process_active (send);
 	node.block_processor.flush ();
 	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send->hash ()));
@@ -243,7 +243,7 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 				.build_shared ();
 	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash> (1, send->hash ()))); // Non-final vote
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 1);
+	ASSERT_TIMELY (5s, node.inactive_vote_cache.cache_size () == 1);
 	node.process_active (send);
 	node.block_processor.flush ();
 	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached) == 1);
@@ -280,7 +280,7 @@ TEST (active_transactions, inactive_votes_cache_fork)
 
 	auto const vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash> (1, send1->hash ()));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 1);
+	ASSERT_TIMELY (5s, node.inactive_vote_cache.cache_size () == 1);
 
 	node.process_active (send2);
 
@@ -335,12 +335,11 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	ASSERT_EQ (nano::vote::timestamp_min * 1, last_vote1.timestamp);
 	// Attempt to change vote with inactive_votes_cache
 	nano::unique_lock<nano::mutex> active_lock (node.active.mutex);
-	node.active.add_inactive_votes_cache (active_lock, send->hash (), key.pub, 0);
-	active_lock.unlock ();
-	const auto cache (node.active.find_inactive_votes_cache (send->hash ()));
-	active_lock.lock ();
-	ASSERT_EQ (1, cache.voters.size ());
-	cache.fill (election);
+	node.inactive_vote_cache.vote (send->hash (), vote1);
+	auto cache = node.inactive_vote_cache.find (send->hash ());
+	ASSERT_TRUE (cache);
+	ASSERT_EQ (1, cache->voters.size ());
+	cache->fill (election);
 	// Check that election data is not changed
 	ASSERT_EQ (2, election->votes ().size ());
 	auto last_vote2 (election->votes ()[key.pub]);
@@ -394,8 +393,9 @@ TEST (active_transactions, DISABLED_inactive_votes_cache_multiple_votes)
 	node.vote_processor.vote (vote1, std::make_shared<nano::transport::inproc::channel> (node, node));
 	auto vote2 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash> (1, send1->hash ())));
 	node.vote_processor.vote (vote2, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.active.find_inactive_votes_cache (send1->hash ()).voters.size () == 2);
-	ASSERT_EQ (1, node.active.inactive_votes_cache_size ());
+	ASSERT_TIMELY (5s, node.inactive_vote_cache.find (send1->hash ()));
+	ASSERT_TIMELY (5s, node.inactive_vote_cache.find (send1->hash ())->voters.size () == 2);
+	ASSERT_EQ (1, node.inactive_vote_cache.cache_size ());
 	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	node.scheduler.flush ();
 	auto election = node.active.election (send1->qualified_root ());
@@ -475,7 +475,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	std::vector<nano::block_hash> hashes{ open1->hash (), open2->hash (), send4->hash () };
 	auto vote1 (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, 0, hashes));
 	node.vote_processor.vote (vote1, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.active.inactive_votes_cache_size () == 3);
+	ASSERT_TIMELY (5s, node.inactive_vote_cache.cache_size () == 3);
 	ASSERT_TRUE (node.active.empty ());
 	ASSERT_EQ (1, node.ledger.cache.cemented_count);
 	// 2 votes are required to start election (dev network)
@@ -490,11 +490,9 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	ASSERT_TIMELY (5s, 5 == node.ledger.cache.cemented_count);
 	// A late block arrival also checks the inactive votes cache
 	ASSERT_TRUE (node.active.empty ());
-	auto send4_cache (node.active.find_inactive_votes_cache (send4->hash ()));
-	ASSERT_EQ (3, send4_cache.voters.size ());
-	ASSERT_TRUE (send4_cache.status.bootstrap_started);
-	ASSERT_TRUE (send4_cache.status.confirmed);
-	ASSERT_TRUE (send4_cache.status.election_started); // already marked even though the block does not exist
+	auto send4_cache (node.inactive_vote_cache.find (send4->hash ()));
+	ASSERT_TRUE (send4_cache);
+	ASSERT_EQ (3, send4_cache->voters.size ());
 	node.process_active (send3);
 	node.block_processor.flush ();
 	// An election is started for send6 but does not confirm
@@ -1495,7 +1493,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 		// Inactive vote
 		auto vote1 (std::make_shared<nano::vote> (rep1.pub, rep1.prv, 0, 0, std::vector<nano::block_hash>{ receive0->hash (), receive1->hash () }));
 		node.vote_processor.vote (vote1, std::make_shared<nano::transport::inproc::channel> (node, node));
-		ASSERT_TIMELY (1s, node.active.inactive_votes_cache_size () == 2);
+		ASSERT_TIMELY (1s, node.inactive_vote_cache.cache_size () == 2);
 		ASSERT_TRUE (node.active.empty ());
 		ASSERT_EQ (7, node.ledger.cache.cemented_count);
 
@@ -1519,7 +1517,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 		node.vote_processor.vote (vote4, std::make_shared<nano::transport::inproc::channel> (node, node));
 		ASSERT_TIMELY (1s, node.active.empty ());
 		ASSERT_EQ (8, node.ledger.cache.cemented_count);
-		ASSERT_TIMELY (1s, node.active.inactive_votes_cache_size () == 1);
+		ASSERT_TIMELY (1s, node.inactive_vote_cache.cache_size () == 1);
 
 		// Now it should be possible to vote hint second block
 		auto vote5 = (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ receive1->hash () }));
@@ -1527,7 +1525,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 		ASSERT_TIMELY (1s, node.stats.count (nano::stat::type::election, nano::stat::detail::election_hinted_overflow) == 1);
 		ASSERT_TIMELY (1s, 1 == node.active.size ());
 		ASSERT_EQ (8, node.ledger.cache.cemented_count);
-		ASSERT_TIMELY (1s, node.active.inactive_votes_cache_size () == 1);
+		ASSERT_TIMELY (1s, node.inactive_vote_cache.cache_size () == 1);
 
 		// Ensure there was no overflow
 		ASSERT_EQ (0, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_overflow));

--- a/nano/core_test/memory_pool.cpp
+++ b/nano/core_test/memory_pool.cpp
@@ -86,15 +86,4 @@ TEST (memory_pool, validate_cleanup)
 	ASSERT_EQ (nano::determine_shared_ptr_pool_size<nano::change_block> (), get_allocated_size<nano::change_block> () - sizeof (size_t));
 	ASSERT_EQ (nano::determine_shared_ptr_pool_size<nano::state_block> (), get_allocated_size<nano::state_block> () - sizeof (size_t));
 	ASSERT_EQ (nano::determine_shared_ptr_pool_size<nano::vote> (), get_allocated_size<nano::vote> () - sizeof (size_t));
-
-	{
-		nano::active_transactions::ordered_cache inactive_votes_cache;
-		nano::account representative{ 1 };
-		nano::block_hash hash{ 1 };
-		uint64_t timestamp{ 1 };
-		nano::inactive_cache_status default_status{};
-		inactive_votes_cache.emplace (std::chrono::steady_clock::now (), hash, representative, timestamp, default_status);
-	}
-
-	ASSERT_TRUE (nano::purge_singleton_inactive_votes_cache_pool_memory ());
 }

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -1,0 +1,270 @@
+#include <nano/node/election.hpp>
+#include <nano/node/vote_cache.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+namespace
+{
+std::map<nano::account, nano::uint128_t> & rep_to_weight_map ()
+{
+	static std::map<nano::account, nano::uint128_t> map;
+	return map;
+}
+
+std::function<nano::uint128_t (nano::account const & rep)> rep_weight_query ()
+{
+	return [] (nano::account const & rep) { return rep_to_weight_map ()[rep]; };
+}
+
+void register_rep (nano::account & rep, nano::uint128_t weight)
+{
+	auto & map = rep_to_weight_map ();
+	map[rep] = weight;
+}
+
+nano::keypair create_rep (nano::uint128_t weight)
+{
+	nano::keypair key;
+	register_rep (key.pub, weight);
+	return key;
+}
+
+std::shared_ptr<nano::vote> create_vote (nano::keypair & key, uint64_t timestamp, uint8_t duration, std::vector<nano::block_hash> hashes)
+{
+	return std::make_shared<nano::vote> (key.pub, key.prv, timestamp, duration, hashes);
+}
+
+nano::block_hash random_hash ()
+{
+	nano::block_hash random_hash;
+	nano::random_pool::generate_block (random_hash.bytes.data (), random_hash.bytes.size ());
+	return random_hash;
+}
+
+constexpr int default_size = 1024;
+}
+
+TEST (vote_cache, construction)
+{
+	nano::vote_cache vote_cache{ default_size };
+	ASSERT_EQ (0, vote_cache.cache_size ());
+	ASSERT_TRUE (vote_cache.cache_empty ());
+	auto hash1 = random_hash ();
+	ASSERT_FALSE (vote_cache.find (hash1));
+}
+
+TEST (vote_cache, insert_one_hash)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto rep1 = create_rep (7);
+	auto hash1 = random_hash ();
+	auto vote1 = create_vote (rep1, 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	ASSERT_EQ (1, vote_cache.cache_size ());
+	ASSERT_TRUE (vote_cache.find (hash1));
+	auto peek1 = vote_cache.peek ();
+	ASSERT_TRUE (peek1);
+	ASSERT_EQ (peek1->hash, hash1);
+	ASSERT_EQ (peek1->voters.size (), 1);
+	ASSERT_EQ (peek1->voters.front ().first, rep1.pub); // account
+	ASSERT_EQ (peek1->voters.front ().second, 1024 * 1024); // timestamp
+	ASSERT_EQ (peek1->tally, 7);
+}
+
+TEST (vote_cache, insert_one_hash_many_votes)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto hash1 = random_hash ();
+	auto rep1 = create_rep (7);
+	auto rep2 = create_rep (9);
+	auto rep3 = create_rep (11);
+	auto vote1 = create_vote (rep1, 1 * 1024 * 1024, 0, { hash1 });
+	auto vote2 = create_vote (rep2, 2 * 1024 * 1024, 0, { hash1 });
+	auto vote3 = create_vote (rep3, 3 * 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote2->hashes.front (), vote2);
+	vote_cache.vote (vote3->hashes.front (), vote3);
+	ASSERT_EQ (1, vote_cache.cache_size ());
+	auto peek1 = vote_cache.peek ();
+	ASSERT_TRUE (peek1);
+	ASSERT_EQ (peek1->voters.size (), 3);
+	ASSERT_EQ (peek1->tally, 7 + 9 + 11);
+}
+
+TEST (vote_cache, insert_many_hashes_many_votes)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto hash1 = random_hash ();
+	auto hash2 = random_hash ();
+	auto hash3 = random_hash ();
+	auto rep1 = create_rep (7);
+	auto rep2 = create_rep (9);
+	auto rep3 = create_rep (11);
+	auto rep4 = create_rep (13);
+	auto vote1 = create_vote (rep1, 1024 * 1024, 0, { hash1 });
+	auto vote2 = create_vote (rep2, 1024 * 1024, 0, { hash2 });
+	auto vote3 = create_vote (rep3, 1024 * 1024, 0, { hash3 });
+	auto vote4 = create_vote (rep4, 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote2->hashes.front (), vote2);
+	vote_cache.vote (vote3->hashes.front (), vote3);
+	ASSERT_EQ (3, vote_cache.cache_size ());
+	ASSERT_TRUE (vote_cache.find (hash1));
+	ASSERT_TRUE (vote_cache.find (hash2));
+	ASSERT_TRUE (vote_cache.find (hash3));
+
+	auto peek1 = vote_cache.peek ();
+	ASSERT_TRUE (peek1);
+	ASSERT_EQ (peek1->voters.size (), 1);
+	ASSERT_EQ (peek1->tally, 11);
+	ASSERT_EQ (peek1->hash, hash3);
+
+	vote_cache.vote (vote4->hashes.front (), vote4);
+
+	auto pop1 = vote_cache.pop ();
+	ASSERT_TRUE (pop1);
+	ASSERT_EQ ((*pop1).voters.size (), 2);
+	ASSERT_EQ ((*pop1).tally, 7 + 13);
+	ASSERT_EQ ((*pop1).hash, hash1);
+	ASSERT_TRUE (vote_cache.find (hash1)); // Only pop from queue, votes should still be stored in cache
+
+	auto pop2 = vote_cache.pop ();
+	ASSERT_EQ ((*pop2).voters.size (), 1);
+	ASSERT_EQ ((*pop2).tally, 11);
+	ASSERT_EQ ((*pop2).hash, hash3);
+	ASSERT_TRUE (vote_cache.find (hash3));
+
+	auto pop3 = vote_cache.pop ();
+	ASSERT_EQ ((*pop3).voters.size (), 1);
+	ASSERT_EQ ((*pop3).tally, 9);
+	ASSERT_EQ ((*pop3).hash, hash2);
+	ASSERT_TRUE (vote_cache.find (hash2));
+
+	ASSERT_TRUE (vote_cache.queue_empty ());
+}
+
+TEST (vote_cache, insert_duplicate)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto hash1 = random_hash ();
+	auto rep1 = create_rep (9);
+	auto vote1 = create_vote (rep1, 1 * 1024 * 1024, 0, { hash1 });
+	auto vote2 = create_vote (rep1, 1 * 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote2->hashes.front (), vote2);
+	ASSERT_EQ (1, vote_cache.cache_size ());
+}
+
+TEST (vote_cache, insert_newer)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto hash1 = random_hash ();
+	auto rep1 = create_rep (9);
+	auto vote1 = create_vote (rep1, 1 * 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	auto peek1 = vote_cache.peek ();
+	ASSERT_TRUE (peek1);
+	auto vote2 = create_vote (rep1, nano::vote::timestamp_max, nano::vote::duration_max, { hash1 });
+	vote_cache.vote (vote2->hashes.front (), vote2);
+	auto peek2 = vote_cache.peek ();
+	ASSERT_TRUE (peek2);
+	ASSERT_EQ (1, vote_cache.cache_size ());
+	ASSERT_EQ (1, peek2->voters.size ());
+	ASSERT_GT (peek2->voters.front ().second, peek1->voters.front ().second); // timestamp2 > timestamp1
+	ASSERT_EQ (peek2->voters.front ().second, std::numeric_limits<uint64_t>::max ()); // final timestamp
+}
+
+TEST (vote_cache, insert_older)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto hash1 = random_hash ();
+	auto rep1 = create_rep (9);
+	auto vote1 = create_vote (rep1, 2 * 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	auto peek1 = vote_cache.peek ();
+	ASSERT_TRUE (peek1);
+	auto vote2 = create_vote (rep1, 1 * 1024 * 1024, 0, { hash1 });
+	vote_cache.vote (vote2->hashes.front (), vote2);
+	auto peek2 = vote_cache.peek ();
+	ASSERT_TRUE (peek2);
+	ASSERT_EQ (1, vote_cache.cache_size ());
+	ASSERT_EQ (1, peek2->voters.size ());
+	ASSERT_EQ (peek2->voters.front ().second, peek1->voters.front ().second); // timestamp2 == timestamp1
+}
+
+TEST (vote_cache, erase)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	auto hash1 = random_hash ();
+	auto hash2 = random_hash ();
+	auto hash3 = random_hash ();
+	auto rep1 = create_rep (7);
+	auto rep2 = create_rep (9);
+	auto rep3 = create_rep (11);
+	auto rep4 = create_rep (13);
+	auto vote1 = create_vote (rep1, 1024 * 1024, 0, { hash1 });
+	auto vote2 = create_vote (rep2, 1024 * 1024, 0, { hash2 });
+	auto vote3 = create_vote (rep3, 1024 * 1024, 0, { hash3 });
+	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote2->hashes.front (), vote2);
+	vote_cache.vote (vote3->hashes.front (), vote3);
+	ASSERT_EQ (3, vote_cache.cache_size ());
+	ASSERT_TRUE (vote_cache.find (hash1));
+	ASSERT_TRUE (vote_cache.find (hash2));
+	ASSERT_TRUE (vote_cache.find (hash3));
+	vote_cache.erase (hash2);
+	ASSERT_EQ (2, vote_cache.cache_size ());
+	ASSERT_TRUE (vote_cache.find (hash1));
+	ASSERT_FALSE (vote_cache.find (hash2));
+	ASSERT_TRUE (vote_cache.find (hash3));
+	vote_cache.erase (hash1);
+	vote_cache.erase (hash3);
+	ASSERT_FALSE (vote_cache.find (hash1));
+	ASSERT_FALSE (vote_cache.find (hash2));
+	ASSERT_FALSE (vote_cache.find (hash3));
+	ASSERT_TRUE (vote_cache.cache_empty ());
+}
+
+TEST (vote_cache, overfill)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	const int count = 16 * default_size;
+	for (int n = 0; n < count; ++n)
+	{
+		auto rep1 = create_rep (count - n);
+		auto hash1 = random_hash ();
+		auto vote1 = create_vote (rep1, 1024 * 1024, 0, { hash1 });
+		vote_cache.vote (vote1->hashes.front (), vote1);
+	}
+	ASSERT_LT (vote_cache.cache_size (), count);
+	auto peek1 = vote_cache.peek ();
+	ASSERT_TRUE (peek1);
+	ASSERT_EQ (peek1->tally, default_size); // Check that oldest are dropped first
+}
+
+TEST (vote_cache, overfill_entry)
+{
+	nano::vote_cache vote_cache{ default_size };
+	vote_cache.rep_weight_query = rep_weight_query ();
+	const int count = 1024;
+	auto hash1 = random_hash ();
+	for (int n = 0; n < count; ++n)
+	{
+		auto rep1 = create_rep (9);
+		auto vote1 = create_vote (rep1, 1024 * 1024, 0, { hash1 });
+		vote_cache.vote (vote1->hashes.front (), vote1);
+	}
+	ASSERT_EQ (1, vote_cache.cache_size ());
+}

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -45,12 +45,17 @@ nano::block_hash random_hash ()
 	return random_hash;
 }
 
-constexpr int default_size = 1024;
+nano::vote_cache::config make_config (std::size_t max_size = 1024)
+{
+	nano::vote_cache::config cfg;
+	cfg.max_size = max_size;
+	return cfg;
+}
 }
 
 TEST (vote_cache, construction)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	ASSERT_EQ (0, vote_cache.cache_size ());
 	ASSERT_TRUE (vote_cache.cache_empty ());
 	auto hash1 = random_hash ();
@@ -59,7 +64,7 @@ TEST (vote_cache, construction)
 
 TEST (vote_cache, insert_one_hash)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto rep1 = create_rep (7);
 	auto hash1 = random_hash ();
@@ -78,7 +83,7 @@ TEST (vote_cache, insert_one_hash)
 
 TEST (vote_cache, insert_one_hash_many_votes)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = random_hash ();
 	auto rep1 = create_rep (7);
@@ -99,7 +104,7 @@ TEST (vote_cache, insert_one_hash_many_votes)
 
 TEST (vote_cache, insert_many_hashes_many_votes)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = random_hash ();
 	auto hash2 = random_hash ();
@@ -152,7 +157,7 @@ TEST (vote_cache, insert_many_hashes_many_votes)
 
 TEST (vote_cache, insert_duplicate)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = random_hash ();
 	auto rep1 = create_rep (9);
@@ -165,7 +170,7 @@ TEST (vote_cache, insert_duplicate)
 
 TEST (vote_cache, insert_newer)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = random_hash ();
 	auto rep1 = create_rep (9);
@@ -185,7 +190,7 @@ TEST (vote_cache, insert_newer)
 
 TEST (vote_cache, insert_older)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = random_hash ();
 	auto rep1 = create_rep (9);
@@ -204,7 +209,7 @@ TEST (vote_cache, insert_older)
 
 TEST (vote_cache, erase)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = random_hash ();
 	auto hash2 = random_hash ();
@@ -238,9 +243,9 @@ TEST (vote_cache, erase)
 
 TEST (vote_cache, overfill)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config (1024) };
 	vote_cache.rep_weight_query = rep_weight_query ();
-	const int count = 16 * default_size;
+	const int count = 16 * 1024;
 	for (int n = 0; n < count; ++n)
 	{
 		auto rep1 = create_rep (count - n);
@@ -251,12 +256,12 @@ TEST (vote_cache, overfill)
 	ASSERT_LT (vote_cache.cache_size (), count);
 	auto peek1 = vote_cache.peek ();
 	ASSERT_TRUE (peek1);
-	ASSERT_EQ (peek1->tally, default_size); // Check that oldest are dropped first
+	ASSERT_EQ (peek1->tally, 1024); // Check that oldest votes are dropped first
 }
 
 TEST (vote_cache, overfill_entry)
 {
-	nano::vote_cache vote_cache{ default_size };
+	nano::vote_cache vote_cache{ make_config () };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	const int count = 1024;
 	auto hash1 = random_hash ();

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -156,6 +156,7 @@ TEST (vote_spacing, vote_generator)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	config.active_elections_hinted_limit_percentage = 0; // Disable election hinting
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;
@@ -199,6 +200,7 @@ TEST (vote_spacing, rapid)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+	config.active_elections_hinted_limit_percentage = 0; // Disable election hinting
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -196,6 +196,8 @@ add_library(
   transport/udp.cpp
   unchecked_map.cpp
   unchecked_map.hpp
+  vote_cache.hpp
+  vote_cache.cpp
   vote_processor.hpp
   vote_processor.cpp
   voting.hpp

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -690,6 +690,10 @@ void nano::active_transactions::check_inactive_vote_cache (nano::block_hash cons
 	}
 }
 
+/*
+ * This is called when a new block is received from live network
+ * We check if maybe we already have enough inactive votes stored for it to start an election
+ */
 void nano::active_transactions::trigger_inactive_votes_cache_election (std::shared_ptr<nano::block> const & block_a)
 {
 	check_inactive_vote_cache (block_a->hash ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -729,8 +729,6 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (ac
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "election_winner_details", active_transactions.election_winner_details_size (), sizeof (decltype (active_transactions.election_winner_details)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "recently_confirmed", recently_confirmed_count, sizeof (decltype (active_transactions.recently_confirmed.confirmed)::value_type) }));
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "recently_cemented", recently_cemented_count, sizeof (decltype (active_transactions.recently_cemented.cemented)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "inactive_votes_cache", active_transactions.node.inactive_vote_cache.cache_size (), sizeof (vote_cache::ordered_cache::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "inactive_votes_queue", active_transactions.node.inactive_vote_cache.queue_size (), sizeof (vote_cache::ordered_queue::value_type) }));
 	composite->add_component (collect_container_info (active_transactions.generator, "generator"));
 	return composite;
 }

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1654,6 +1654,6 @@ std::chrono::seconds nano::telemetry_cache_cutoffs::network_to_time (network_con
 }
 
 nano::node_singleton_memory_pool_purge_guard::node_singleton_memory_pool_purge_guard () :
-	cleanup_guard ({ nano::block_memory_pool_purge, nano::purge_shared_ptr_singleton_pool_memory<nano::vote>, nano::purge_shared_ptr_singleton_pool_memory<nano::election>, nano::purge_singleton_inactive_votes_cache_pool_memory })
+	cleanup_guard ({ nano::block_memory_pool_purge, nano::purge_shared_ptr_singleton_pool_memory<nano::vote>, nano::purge_shared_ptr_singleton_pool_memory<nano::election> })
 {
 }

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -549,8 +549,8 @@ bool nano::election::replace_by_weight (nano::unique_lock<nano::mutex> & lock_a,
 	// Sort in ascending order
 	std::sort (sorted.begin (), sorted.end (), [] (auto const & left, auto const & right) { return left.second < right.second; });
 	// Replace if lowest tally is below inactive cache new block weight
-	auto inactive_existing (node.active.find_inactive_votes_cache (hash_a));
-	auto inactive_tally (inactive_existing.status.tally);
+	auto inactive_existing = node.inactive_vote_cache.find (hash_a);
+	auto inactive_tally = inactive_existing ? inactive_existing->tally : 0;
 	if (inactive_tally > 0 && sorted.size () < max_blocks)
 	{
 		// If count of tally items is less than 10, remove any block without tally

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -39,6 +39,13 @@ nano::backlog_population::config nano::nodeconfig_to_backlog_population_config (
 	return cfg;
 }
 
+nano::vote_cache::config nano::nodeconfig_to_vote_cache_config (node_config const & config, node_flags const & flags)
+{
+	vote_cache::config cfg;
+	cfg.max_size = flags.inactive_votes_cache_size;
+	return cfg;
+}
+
 void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
 {
 	auto node_l (shared_from_this ());
@@ -158,7 +165,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	history{ config.network_params.voting },
 	vote_uniquer (block_uniquer),
 	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
-	inactive_vote_cache{ flags.inactive_votes_cache_size },
+	inactive_vote_cache{ nodeconfig_to_vote_cache_config (config, flags) },
 	active (*this, confirmation_height_processor),
 	scheduler{ *this },
 	aggregator (config, stats, active.generator, active.final_generator, history, ledger, wallets, active),

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -618,6 +618,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.distributed_work, "distributed_work"));
 	composite->add_component (collect_container_info (node.aggregator, "request_aggregator"));
 	composite->add_component (node.scheduler.collect_container_info ("election_scheduler"));
+	composite->add_component (node.inactive_vote_cache.collect_container_info ("inactive_vote_cache"));
 	return composite;
 }
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -25,6 +25,7 @@
 #include <nano/node/signatures.hpp>
 #include <nano/node/telemetry.hpp>
 #include <nano/node/unchecked_map.hpp>
+#include <nano/node/vote_cache.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/node/write_database_queue.hpp>
@@ -163,6 +164,7 @@ public:
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
 	nano::confirmation_height_processor confirmation_height_processor;
+	nano::vote_cache inactive_vote_cache;
 	nano::active_transactions active;
 	nano::election_scheduler scheduler;
 	nano::request_aggregator aggregator;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -55,7 +55,8 @@ class work_pool;
 std::unique_ptr<container_info_component> collect_container_info (rep_crawler & rep_crawler, std::string const & name);
 
 // Configs
-backlog_population::config nodeconfig_to_backlog_population_config (const node_config & config);
+backlog_population::config nodeconfig_to_backlog_population_config (node_config const & config);
+vote_cache::config nodeconfig_to_vote_cache_config (node_config const &, node_flags const &);
 
 class node final : public std::enable_shared_from_this<nano::node>
 {

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -49,8 +49,8 @@ std::size_t nano::vote_cache::entry::fill (std::shared_ptr<nano::election> elect
 	return inserted;
 }
 
-nano::vote_cache::vote_cache (std::size_t max_size) :
-	max_size{ max_size }
+nano::vote_cache::vote_cache (const config config_a) :
+	max_size{ config_a.max_size }
 {
 }
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -233,3 +233,11 @@ void nano::vote_cache::trim_overflow_locked ()
 		queue.get<tag_random_access> ().pop_front ();
 	}
 }
+
+std::unique_ptr<nano::container_info_component> nano::vote_cache::collect_container_info (const std::string & name)
+{
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cache", cache_size (), sizeof (ordered_cache::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "queue", queue_size (), sizeof (ordered_queue::value_type) }));
+	return composite;
+}

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -1,0 +1,235 @@
+#include <nano/node/node.hpp>
+#include <nano/node/vote_cache.hpp>
+
+nano::vote_cache::entry::entry (const nano::block_hash & hash) :
+	hash{ hash }
+{
+}
+
+bool nano::vote_cache::entry::vote (const nano::account & representative, const uint64_t & timestamp, const nano::uint128_t & rep_weight)
+{
+	auto existing = std::find_if (voters.begin (), voters.end (), [&representative] (auto const & item) { return item.first == representative; });
+	if (existing != voters.end ())
+	{
+		// We already have a vote from this rep
+		// Update timestamp if newer but tally remains unchanged as we already counted this rep weight
+		if (timestamp > existing->second)
+		{
+			existing->second = timestamp;
+		}
+		return false;
+	}
+	else
+	{
+		// Vote from an unseen representative, add to list and update tally
+		if (voters.size () < max_voters)
+		{
+			voters.emplace_back (representative, timestamp);
+			tally += rep_weight;
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+}
+
+std::size_t nano::vote_cache::entry::fill (std::shared_ptr<nano::election> election) const
+{
+	std::size_t inserted = 0;
+	for (const auto & [rep, timestamp] : voters)
+	{
+		auto [is_replay, processed] = election->vote (rep, timestamp, hash, nano::election::vote_source::cache);
+		if (processed)
+		{
+			inserted++;
+		}
+	}
+	return inserted;
+}
+
+nano::vote_cache::vote_cache (std::size_t max_size) :
+	max_size{ max_size }
+{
+}
+
+void nano::vote_cache::vote (const nano::block_hash & hash, const std::shared_ptr<nano::vote> vote)
+{
+	auto weight = rep_weight_query (vote->account);
+	vote_impl (hash, vote->account, vote->timestamp (), weight);
+}
+
+void nano::vote_cache::vote_impl (const nano::block_hash & hash, const nano::account & representative, uint64_t const & timestamp, const nano::uint128_t & rep_weight)
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+
+	/**
+	 * If there is no cache entry for the block hash, create a new entry for both cache and queue.
+	 * Otherwise update existing cache entry and, if queue contains entry for the block hash, update the queue entry
+	 */
+	auto & cache_by_hash = cache.get<tag_hash> ();
+	if (auto existing = cache_by_hash.find (hash); existing != cache_by_hash.end ())
+	{
+		bool success = cache_by_hash.modify (existing, [&representative, &timestamp, &rep_weight] (entry & ent) {
+			ent.vote (representative, timestamp, rep_weight);
+		});
+		if (success) // Should never fail, but a check ensures the iterator `existing` is valid
+		{
+			auto & queue_by_hash = queue.get<tag_hash> ();
+			if (auto queue_existing = queue_by_hash.find (hash); queue_existing != queue_by_hash.end ())
+			{
+				queue_by_hash.modify (queue_existing, [&existing] (queue_entry & ent) {
+					ent.tally = existing->tally;
+				});
+			}
+		}
+	}
+	else
+	{
+		entry cache_entry{ hash };
+		cache_entry.vote (representative, timestamp, rep_weight);
+
+		cache.get<tag_hash> ().insert (cache_entry);
+
+		// If a stale entry for the same hash already exists in queue, replace it by a new entry with fresh tally
+		auto & queue_by_hash = queue.get<tag_hash> ();
+		if (auto queue_existing = queue_by_hash.find (hash); queue_existing != queue_by_hash.end ())
+		{
+			queue_by_hash.erase (queue_existing);
+		}
+		queue_by_hash.insert ({ hash, cache_entry.tally });
+
+		trim_overflow_locked ();
+	}
+}
+
+bool nano::vote_cache::cache_empty () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return cache.empty ();
+}
+
+bool nano::vote_cache::queue_empty () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return queue.empty ();
+}
+
+std::size_t nano::vote_cache::cache_size () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return cache.size ();
+}
+
+std::size_t nano::vote_cache::queue_size () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return queue.size ();
+}
+
+std::optional<nano::vote_cache::entry> nano::vote_cache::find (const nano::block_hash & hash) const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return find_locked (hash);
+}
+
+bool nano::vote_cache::erase (const nano::block_hash & hash)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	bool result = false;
+	auto & cache_by_hash = cache.get<tag_hash> ();
+	if (auto existing = cache_by_hash.find (hash); existing != cache_by_hash.end ())
+	{
+		cache_by_hash.erase (existing);
+		result = true;
+	}
+	auto & queue_by_hash = queue.get<tag_hash> ();
+	if (auto existing = queue_by_hash.find (hash); existing != queue_by_hash.end ())
+	{
+		queue_by_hash.erase (existing);
+	}
+	return result;
+}
+
+std::optional<nano::vote_cache::entry> nano::vote_cache::pop (nano::uint128_t const & min_tally)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	if (!queue.empty ())
+	{
+		auto & queue_by_tally = queue.get<tag_tally> ();
+		auto top = std::prev (queue_by_tally.end ()); // Iterator to element with the highest tally
+		if (auto maybe_cache_entry = find_locked (top->hash); maybe_cache_entry)
+		{
+			// Here we check whether our best candidate passes the minimum vote tally threshold
+			// If yes, erase it from the queue (but still keep the votes in cache)
+			if (maybe_cache_entry->tally >= min_tally)
+			{
+				queue_by_tally.erase (top);
+				return maybe_cache_entry.value ();
+			}
+		}
+	}
+	return {};
+}
+
+std::optional<nano::vote_cache::entry> nano::vote_cache::peek (nano::uint128_t const & min_tally) const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	if (!queue.empty ())
+	{
+		auto & queue_by_tally = queue.get<tag_tally> ();
+		auto top = std::prev (queue_by_tally.end ()); // Iterator to element with the highest tally
+		if (auto maybe_cache_entry = find_locked (top->hash); maybe_cache_entry)
+		{
+			if (maybe_cache_entry->tally >= min_tally)
+			{
+				return maybe_cache_entry.value ();
+			}
+		}
+	}
+	return {};
+}
+
+void nano::vote_cache::trigger (const nano::block_hash & hash)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	auto & queue_by_hash = queue.get<tag_hash> ();
+	// Only reinsert to queue if it is not already in queue and there are votes in passive cache
+	if (auto existing_queue = queue_by_hash.find (hash); existing_queue == queue_by_hash.end ())
+	{
+		if (auto maybe_cache_entry = find_locked (hash); maybe_cache_entry)
+		{
+			queue_by_hash.insert ({ hash, maybe_cache_entry->tally });
+
+			trim_overflow_locked ();
+		}
+	}
+}
+
+std::optional<nano::vote_cache::entry> nano::vote_cache::find_locked (const nano::block_hash & hash) const
+{
+	debug_assert (!mutex.try_lock ());
+
+	auto & cache_by_hash = cache.get<tag_hash> ();
+	if (auto existing = cache_by_hash.find (hash); existing != cache_by_hash.end ())
+	{
+		return *existing;
+	}
+	return {};
+}
+
+void nano::vote_cache::trim_overflow_locked ()
+{
+	debug_assert (!mutex.try_lock ());
+
+	// When cache overflown remove the oldest entry
+	if (cache.size () > max_size)
+	{
+		cache.get<tag_random_access> ().pop_front ();
+	}
+	if (queue.size () > max_size)
+	{
+		queue.get<tag_random_access> ().pop_front ();
+	}
+}

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -101,14 +101,18 @@ public:
 	bool erase (nano::block_hash const & hash);
 	/**
 	 * Returns an entry with the highest tally.
+	 * @param min_tally minimum tally threshold, entries below with their voting weight below this will be ignored
 	 */
 	std::optional<entry> peek (nano::uint128_t const & min_tally = 0) const;
 	/**
 	 * Returns an entry with the highest tally and removes it from container.
+	 * @param min_tally minimum tally threshold, entries below with their voting weight below this will be ignored
 	 */
 	std::optional<entry> pop (nano::uint128_t const & min_tally = 0);
 	/**
 	 * Reinserts a block into the queue.
+	 * It is possible that we dequeue a hash that doesn't have a received block yet (for eg. if publish message was lost).
+	 * We need a way to reinsert that hash into the queue when we finally receive the block
 	 */
 	void trigger (const nano::block_hash & hash);
 
@@ -160,7 +164,5 @@ private:
 	ordered_queue queue;
 
 	mutable nano::mutex mutex;
-
-	friend std::unique_ptr<nano::container_info_component> collect_container_info (active_transactions &, std::string const &);
 };
 }

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -43,6 +43,13 @@ class vote;
 class vote_cache final
 {
 public:
+	class config final
+	{
+	public:
+		std::size_t max_size;
+	};
+
+public:
 	/**
 	 * Class that stores votes associated with a single block hash
 	 */
@@ -77,7 +84,7 @@ private:
 	};
 
 public:
-	explicit vote_cache (std::size_t max_size);
+	explicit vote_cache (const config);
 
 	/**
 	 * Adds a new vote to cache
@@ -121,7 +128,7 @@ private:
 	std::optional<entry> find_locked (nano::block_hash const & hash) const;
 	void trim_overflow_locked ();
 
-	const std::size_t max_size = 1024 * 128;
+	const std::size_t max_size;
 
 	// clang-format off
 	class tag_random_access {};

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -117,6 +117,9 @@ public:
 	bool cache_empty () const;
 	bool queue_empty () const;
 
+public: // Container info
+	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name);
+
 public:
 	/**
 	 * Function used to query rep weight for tally calculation

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/timer.hpp>
+#include <nano/lib/utility.hpp>
+#include <nano/secure/common.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <condition_variable>
+#include <memory>
+#include <optional>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace mi = boost::multi_index;
+
+namespace nano
+{
+class node;
+class active_transactions;
+class election;
+class vote;
+
+/**
+ *	A container holding votes that do not match any active or recently finished elections.
+ *	It keeps track of votes in two internal structures: cache and queue
+ *
+ *	Cache: Stores votes associated with a particular block hash with a bounded maximum number of votes per hash.
+ *			When cache size exceeds `max_size` oldest entries are evicted first.
+ *
+ *	Queue: Keeps track of block hashes ordered by total cached vote tally.
+ *			When inserting a new vote into cache, the queue is atomically updated.
+ *			When queue size exceeds `max_size` oldest entries are evicted first.
+ */
+class vote_cache final
+{
+public:
+	/**
+	 * Class that stores votes associated with a single block hash
+	 */
+	class entry final
+	{
+	public:
+		constexpr static int max_voters = 40;
+
+		explicit entry (nano::block_hash const & hash);
+
+		nano::block_hash hash;
+		std::vector<std::pair<nano::account, uint64_t>> voters; // <rep, timestamp> pair
+		nano::uint128_t tally{ 0 };
+
+		/**
+		 * Adds a vote into a list, checks for duplicates and updates timestamp if new one is greater
+		 * @return true if current tally changed, false otherwise
+		 */
+		bool vote (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight);
+		/**
+		 * Inserts votes stored in this entry into an election
+		 */
+		std::size_t fill (std::shared_ptr<nano::election> election) const;
+	};
+
+private:
+	class queue_entry final
+	{
+	public:
+		nano::block_hash hash{ 0 };
+		nano::uint128_t tally{ 0 };
+	};
+
+public:
+	explicit vote_cache (std::size_t max_size);
+
+	/**
+	 * Adds a new vote to cache
+	 */
+	void vote (nano::block_hash const & hash, std::shared_ptr<nano::vote> vote);
+	/**
+	 * Tries to find an entry associated with block hash
+	 */
+	std::optional<entry> find (nano::block_hash const & hash) const;
+	/**
+	 * Removes an entry associated with block hash, does nothing if entry does not exist
+	 * @return true if hash existed and was erased, false otherwise
+	 */
+	bool erase (nano::block_hash const & hash);
+	/**
+	 * Returns an entry with the highest tally.
+	 */
+	std::optional<entry> peek (nano::uint128_t const & min_tally = 0) const;
+	/**
+	 * Returns an entry with the highest tally and removes it from container.
+	 */
+	std::optional<entry> pop (nano::uint128_t const & min_tally = 0);
+	/**
+	 * Reinserts a block into the queue.
+	 */
+	void trigger (const nano::block_hash & hash);
+
+	std::size_t cache_size () const;
+	std::size_t queue_size () const;
+	bool cache_empty () const;
+	bool queue_empty () const;
+
+public:
+	/**
+	 * Function used to query rep weight for tally calculation
+	 */
+	std::function<nano::uint128_t (nano::account const &)> rep_weight_query{ [] (nano::account const & rep) { return 0; } };
+
+private:
+	void vote_impl (nano::block_hash const & hash, nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight);
+	std::optional<entry> find_locked (nano::block_hash const & hash) const;
+	void trim_overflow_locked ();
+
+	const std::size_t max_size = 1024 * 128;
+
+	// clang-format off
+	class tag_random_access {};
+	class tag_tally {};
+	class tag_hash {};
+	// clang-format on
+
+	// clang-format off
+	using ordered_cache = boost::multi_index_container<entry,
+	mi::indexed_by<
+		mi::random_access<mi::tag<tag_random_access>>,
+		mi::hashed_unique<mi::tag<tag_hash>,
+			mi::member<entry, nano::block_hash, &entry::hash>>>>;
+	// clang-format on
+	ordered_cache cache;
+
+	// clang-format off
+	using ordered_queue = boost::multi_index_container<queue_entry,
+	mi::indexed_by<
+		mi::random_access<mi::tag<tag_random_access>>,
+		mi::ordered_non_unique<mi::tag<tag_tally>,
+			mi::member<queue_entry, nano::uint128_t, &queue_entry::tally>>,
+		mi::hashed_unique<mi::tag<tag_hash>,
+			mi::member<queue_entry, nano::block_hash, &queue_entry::hash>>>>;
+	// clang-format on
+	ordered_queue queue;
+
+	mutable nano::mutex mutex;
+};
+}

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -150,5 +150,7 @@ private:
 	ordered_queue queue;
 
 	mutable nano::mutex mutex;
+
+	friend std::unique_ptr<nano::container_info_component> collect_container_info (active_transactions &, std::string const &);
 };
 }

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -189,7 +189,7 @@ TEST (vote_cache, perf_singlethreaded)
 	ASSERT_EQ (node.stats.count (nano::stat::type::vote_cache, nano::stat::detail::vote_processed, nano::stat::dir::in), vote_count * single_vote_size * single_vote_reps);
 
 	// Ensure vote cache size is at max capacity
-	ASSERT_EQ (node.active.inactive_votes_cache_size (), flags.inactive_votes_cache_size);
+	ASSERT_EQ (node.inactive_vote_cache.cache_size (), flags.inactive_votes_cache_size);
 }
 
 TEST (vote_cache, perf_multithreaded)
@@ -253,5 +253,5 @@ TEST (vote_cache, perf_multithreaded)
 	std::cout << "total votes processed: " << node.stats.count (nano::stat::type::vote_cache, nano::stat::detail::vote_processed, nano::stat::dir::in) << std::endl;
 
 	// Ensure vote cache size is at max capacity
-	ASSERT_EQ (node.active.inactive_votes_cache_size (), flags.inactive_votes_cache_size);
+	ASSERT_EQ (node.inactive_vote_cache.cache_size (), flags.inactive_votes_cache_size);
 }


### PR DESCRIPTION
This PR extracts and improves `inactive_vote_cache` which is responsible for storing votes that do not correspond to any currently active election. It contains logic for sorting block hashes according to the amount of tally from stored votes which will enable prioritization of hinted elections in the future.

When running tests there might be some errors, but I already addressed them in separate PRs:
https://github.com/nanocurrency/nano-node/pull/3905
https://github.com/nanocurrency/nano-node/pull/3906