### PR TITLE
Remove UDP support from confirmation_solicitor tests

### DIFF
--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,5 +1,7 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
+#include <nano/node/transport/inproc.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -13,11 +15,10 @@ TEST (confirmation_solicitor, batches)
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_rep_crawler = true;
-	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
 	node_flags.disable_request_loop = true;
 	auto & node2 = *system.add_node (node_flags);
-	auto channel1 (node2.network.udp_channels.create (node1.network.endpoint ()));
+	auto channel1 = nano::test::establish_tcp (system, node2, node1.network.endpoint ());
 	// Solicitor will only solicit from this representative
 	nano::representative representative (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, channel1);
 	std::vector<nano::representative> representatives{ representative };
@@ -65,10 +66,9 @@ TEST (confirmation_solicitor, different_hash)
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_rep_crawler = true;
-	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
 	auto & node2 = *system.add_node (node_flags);
-	auto channel1 (node2.network.udp_channels.create (node1.network.endpoint ()));
+	auto channel1 = nano::test::establish_tcp (system, node2, node1.network.endpoint ());
 	// Solicitor will only solicit from this representative
 	nano::representative representative (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, channel1);
 	std::vector<nano::representative> representatives{ representative };
@@ -107,7 +107,6 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	node_flags.disable_rep_crawler = true;
-	node_flags.disable_udp = false;
 	auto & node1 = *system.add_node (node_flags);
 	auto & node2 = *system.add_node (node_flags);
 	nano::confirmation_solicitor solicitor (node2.network, node2.config);
@@ -116,7 +115,8 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	representatives.reserve (max_representatives + 1);
 	for (auto i (0); i < max_representatives + 1; ++i)
 	{
-		auto channel (node2.network.udp_channels.create (node1.network.endpoint ()));
+		// Make a temporary channel associated with node2
+		auto channel = std::make_shared<nano::transport::inproc::channel> (node2, node2);
 		nano::representative representative (nano::account (i), i, channel);
 		representatives.push_back (representative);
 	}
@@ -144,7 +144,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	ASSERT_FALSE (solicitor.broadcast (*election));
 	solicitor.flush ();
 	// All requests went through, the last one would normally not go through due to the cap but a vote for a different hash does not count towards the cap
-	ASSERT_EQ (max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
+	ASSERT_TIMELY (6s, max_representatives + 1 == node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 
 	solicitor.prepare (representatives);
 	auto election2 (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::normal));


### PR DESCRIPTION
Migrate confirmation_solicitor tests that use UDP to TCP or inproc.

Fixes issue: https://github.com/nanocurrency/nano-node/issues/3846