### PR TITLE
Fix unit test active_transactions.fork_replacement_tally

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -904,7 +904,7 @@ TEST (active_transactions, fork_replacement_tally)
 
 	// function to count the number of rep votes (non genesis) found in election
 	// it also checks that there are 10 votes in the election
-	auto count_rep_votes_in_election = [&election, &keys] () {
+	auto count_rep_votes_in_election = [&max_blocks, &reps_count, &election, &keys] () {
 		// Check that only max weight blocks remains (and start winner)
 		auto votes_l = election->votes ();
 		if (max_blocks != votes_l.size ())


### PR DESCRIPTION
The test had at least the following problems:
1. Issued blocks and not allowed the node time to process
   the blocks and start elections
2. It expected blocks to be processed in the order that they were created
3. Doing flood blood without clearing the publish filter
4. Not allowing time for blocks and votes to be processed in the background
5. Not allowing for the vote to the final winning block to arrive before the block 