### PR TITLE
Remove UDP support from bootstrap tests

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1,6 +1,7 @@
 #include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>
+#include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -737,7 +738,7 @@ TEST (bootstrap_processor, lazy_hash)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -811,7 +812,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, true, "123456");
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -949,7 +950,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (3, node1->ledger.cache.pruned_count);
 	// Start lazy bootstrap with last block in chain known
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->ledger.cache.block_count == 9);
@@ -1052,7 +1053,7 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	node0->block_processor.flush ();
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->block (change3->hash ()));
@@ -1121,7 +1122,7 @@ TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (receive->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
@@ -1180,7 +1181,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (15s, !node2->bootstrap_initiator.in_progress ());
@@ -1249,7 +1250,7 @@ TEST (bootstrap_processor, DISABLED_lazy_destinations)
 
 	// Start lazy bootstrap with last block in sender chain
 	auto node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
@@ -1334,7 +1335,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	// Start lazy bootstrap with last block in sender chain
 	config.peering_port = nano::test::get_available_port ();
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
-	node2->network.udp_channels.insert (node1->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	auto lazy_attempt (node2->bootstrap_initiator.current_lazy_attempt ());
@@ -1389,7 +1390,7 @@ TEST (bootstrap_processor, lazy_cancel)
 
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (send1->hash (), true); // Start "confirmed" block bootstrap
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
@@ -1464,7 +1465,7 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -1531,7 +1532,7 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	node0->block_processor.flush ();
 	// Start wallet lazy bootstrap
 	auto node1 = system.add_node ();
-	node1->network.udp_channels.insert (node0->network.endpoint (), node1->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (key2.prv);
@@ -1604,7 +1605,7 @@ TEST (bootstrap_processor, multiple_attempts)
 	nano::node_config node_config (nano::test::get_available_port (), system.logging);
 	node_config.bootstrap_initiator_threads = 3;
 	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work));
-	node2->network.udp_channels.insert (node1->network.endpoint (), node2->network_params.network.protocol_version);
+	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	node2->bootstrap_initiator.bootstrap ();
 	auto lazy_attempt (node2->bootstrap_initiator.current_lazy_attempt ());


### PR DESCRIPTION
Migrate bootstrap tests that use UDP to TCP.

Fixes issue: https://github.com/nanocurrency/nano-node/issues/3846