### PR TITLE
Helper function to create a node out of the network

### DIFF
--- a/nano/test_common/network.cpp
+++ b/nano/test_common/network.cpp
@@ -23,3 +23,11 @@ std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::t
 	});
 	return result;
 }
+
+std::shared_ptr<nano::node> nano::test::add_outer_node (nano::test::system & system_a, uint16_t port_a)
+{
+	auto outer_node = std::make_shared<nano::node> (system_a.io_ctx, port_a, nano::unique_path (), system_a.logging, system_a.work);
+	outer_node->start ();
+	system_a.nodes.push_back (outer_node);
+	return outer_node;
+}

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/node/common.hpp>
+#include <nano/test_common/system.hpp>
 
 namespace nano
 {
@@ -17,5 +18,7 @@ namespace test
 	class system;
 	/** Waits until a TCP connection is established and returns the TCP channel on success*/
 	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
+	/** Adds a node to the system without establishing connections */
+	std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, uint16_t port_a = nano::test::get_available_port ());
 }
 }


### PR DESCRIPTION
Just adds a function to be used by the tests.

Related to issue: https://github.com/nanocurrency/nano-node/issues/3846