### PR TITLE
observer_set: do not call the observer callbacks holding the lock

### DIFF
--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -158,8 +158,11 @@ public:
 	}
 	void notify (T... args)
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
-		for (auto & i : observers)
+		nano::unique_lock<nano::mutex> lock (mutex);
+		auto observers_copy = observers;
+		lock.unlock();
+
+		for (auto & i : observers_copy)
 		{
 			i (args...);
 		}

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -160,7 +160,7 @@ public:
 	{
 		nano::unique_lock<nano::mutex> lock (mutex);
 		auto observers_copy = observers;
-		lock.unlock();
+		lock.unlock ();
 
 		for (auto & i : observers_copy)
 		{


### PR DESCRIPTION
It unnecessarily leaves the door open for deadlocks.