### PR TITLE
Fix the tag numbering by using the correct sorting format

### DIFF
--- a/ci/actions/dev-build-tag-gen.sh
+++ b/ci/actions/dev-build-tag-gen.sh
@@ -60,7 +60,7 @@ fi
 
 pushd "$source_dir"
 last_tag=""
-version_tags=$(git tag | sort -r | grep -E "^(V(${current_version_major}).(${current_version_minor})(DB[0-9]+))$")
+version_tags=$(git tag | sort -V -r | grep -E "^(V(${current_version_major}).(${current_version_minor})(DB[0-9]+))$")
 for tag in $version_tags; do
     if [[ -n "$tag" ]]; then
         last_tag=$tag


### PR DESCRIPTION
This fixes the beta DB workflow tag numbering that was broken due to using the Unix sort command with an incorrect format. The proper way to sort it is with the -V option.