### PR TITLE
Fix for test election.quorum_minimum_update_weight_before_quorum_checks

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -243,6 +243,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_NE (channel, nullptr);
 
 	auto const vote2 = std::make_shared<nano::vote> (key1.pub, key1.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send1->hash () });
+	node1.rep_crawler.add_to_active (send1->hash ());
 	ASSERT_TIMELY (10s, !node1.rep_crawler.response (channel, vote2));
 
 	ASSERT_FALSE (election->confirmed ());

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -188,6 +188,7 @@ TEST (election, quorum_minimum_confirm_fail)
 
 namespace nano
 {
+// FIXME: this test fails on rare occasions. It needs a review.
 TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 {
 	nano::test::system system{};
@@ -243,8 +244,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_NE (channel, nullptr);
 
 	auto const vote2 = std::make_shared<nano::vote> (key1.pub, key1.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send1->hash () });
-	node1.rep_crawler.add_to_active (send1->hash ());
-	ASSERT_TIMELY (10s, !node1.rep_crawler.response (channel, vote2));
+	ASSERT_FALSE (node1.rep_crawler.response (channel, vote2, true));
 
 	ASSERT_FALSE (election->confirmed ());
 	{

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -246,6 +246,13 @@ bool nano::rep_crawler::response (std::shared_ptr<nano::transport::channel> cons
 	return error;
 }
 
+bool nano::rep_crawler::add_to_active (const nano::block_hash & hash_a)
+{
+	nano::lock_guard<nano::mutex> lock (active_mutex);
+	auto result = active.insert (hash_a);
+	return result.second;
+}
+
 nano::uint128_t nano::rep_crawler::total_weight () const
 {
 	nano::lock_guard<nano::mutex> lock (probable_reps_mutex);

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -230,13 +230,13 @@ bool nano::rep_crawler::is_pr (nano::transport::channel const & channel_a) const
 	return result;
 }
 
-bool nano::rep_crawler::response (std::shared_ptr<nano::transport::channel> const & channel_a, std::shared_ptr<nano::vote> const & vote_a)
+bool nano::rep_crawler::response (std::shared_ptr<nano::transport::channel> const & channel_a, std::shared_ptr<nano::vote> const & vote_a, bool force)
 {
 	bool error = true;
 	nano::lock_guard<nano::mutex> lock (active_mutex);
 	for (auto i = vote_a->hashes.begin (), n = vote_a->hashes.end (); i != n; ++i)
 	{
-		if (active.count (*i) != 0)
+		if (force || active.count (*i) != 0)
 		{
 			responses.emplace_back (channel_a, vote_a);
 			error = false;
@@ -244,13 +244,6 @@ bool nano::rep_crawler::response (std::shared_ptr<nano::transport::channel> cons
 		}
 	}
 	return error;
-}
-
-bool nano::rep_crawler::add_to_active (const nano::block_hash & hash_a)
-{
-	nano::lock_guard<nano::mutex> lock (active_mutex);
-	auto result = active.insert (hash_a);
-	return result.second;
 }
 
 nano::uint128_t nano::rep_crawler::total_weight () const

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -102,6 +102,9 @@ public:
 	 */
 	bool response (std::shared_ptr<nano::transport::channel> const &, std::shared_ptr<nano::vote> const &);
 
+	/** add block hash to the active list of hashes, this should be used only for testing purposes for injecting responses into rep crawler */
+	bool add_to_active (const nano::block_hash &);
+
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;
 

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -98,12 +98,10 @@ public:
 	/**
 	 * Called when a non-replay vote on a block previously sent by query() is received. This indicates
 	 * with high probability that the endpoint is a representative node.
-	 * @return false if the vote corresponded to any active hash.
+	 * The force flag can be set to skip the active check in unit testing when we want to force a vote in the rep crawler.
+	 * @return false if any vote passed the checks and was added to the response queue of the rep crawler
 	 */
-	bool response (std::shared_ptr<nano::transport::channel> const &, std::shared_ptr<nano::vote> const &);
-
-	/** add block hash to the active list of hashes, this should be used only for testing purposes for injecting responses into rep crawler */
-	bool add_to_active (const nano::block_hash &);
+	bool response (std::shared_ptr<nano::transport::channel> const &, std::shared_ptr<nano::vote> const &, bool force = false);
 
 	/** Get total available weight from representatives */
 	nano::uint128_t total_weight () const;


### PR DESCRIPTION
The problem was that there was a race condition between the rep crawler
background thread and rep_crawler::response(). For the response to be
processed as valid, a request must be marked in rep_crawler::active
container.