### PR TITLE
Fix test `node.rep_remove`

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1850,12 +1850,12 @@ TEST (node, rep_remove)
 		ASSERT_EQ (nano::process_result::progress, searching_node.ledger.process (transaction, *receive_rep2).code);
 	}
 
-	// Create inactive TCP channel for Rep1
-	std::shared_ptr<nano::transport::channel> channel_rep1 (std::make_shared<nano::transport::channel_tcp> (searching_node, std::weak_ptr<nano::socket> ()));
+	// Create channel for Rep1
+	auto channel_rep1 (std::make_shared<nano::transport::fake::channel> (searching_node));
 
 	// Ensure Rep1 is found by the rep_crawler after receiving a vote from it
 	auto vote_rep1 = std::make_shared<nano::vote> (keys_rep1.pub, keys_rep1.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep1, vote_rep1));
+	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep1, vote_rep1, true));
 	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 1);
 	auto reps (searching_node.rep_crawler.representatives (1));
 	ASSERT_EQ (1, reps.size ());
@@ -1863,9 +1863,9 @@ TEST (node, rep_remove)
 	ASSERT_EQ (keys_rep1.pub, reps[0].account);
 	ASSERT_EQ (*channel_rep1, reps[0].channel_ref ());
 
-	// channel_rep1 is not reachable and should time out
-	ASSERT_EQ (1, searching_node.rep_crawler.representative_count ());
-	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 0);
+	// When rep1 disconnects then rep1 should not be found anymore
+	channel_rep1->disconnect ();
+	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 0);
 
 	// Add working node for genesis representative
 	auto node_genesis_rep = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
@@ -1875,7 +1875,7 @@ TEST (node, rep_remove)
 
 	// genesis_rep should be found as principal representative after receiving a vote from it
 	auto vote_genesis_rep = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-	searching_node.rep_crawler.response (channel_genesis_rep, vote_genesis_rep);
+	searching_node.rep_crawler.response (channel_genesis_rep, vote_genesis_rep, true);
 	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
 
 	// Start a node for Rep2 and wait until it is connected
@@ -1887,7 +1887,7 @@ TEST (node, rep_remove)
 
 	// Rep2 should be found as a principal representative after receiving a vote from it
 	auto vote_rep2 = std::make_shared<nano::vote> (keys_rep2.pub, keys_rep2.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
-	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep2, vote_rep2));
+	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep2, vote_rep2, true));
 	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 2);
 
 	// When Rep2 is stopped, it should not be found as principal representative anymore

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -324,6 +324,10 @@ void nano::rep_crawler::cleanup_reps ()
 				equal = true;
 			}
 		}
+		else if (i->get_type () == nano::transport::transport_type::fake)
+		{
+			equal = true;
+		}
 		if (!equal)
 		{
 			nano::lock_guard<nano::mutex> lock (probable_reps_mutex);

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -30,6 +30,11 @@ namespace transport
 			bool operator== (nano::transport::channel const &) const override;
 			bool operator== (nano::transport::fake::channel const & other_a) const;
 
+			void set_endpoint (nano::endpoint const & endpoint_a)
+			{
+				endpoint = endpoint_a;
+			}
+
 			nano::endpoint get_endpoint () const override
 			{
 				return endpoint;
@@ -45,8 +50,13 @@ namespace transport
 				return nano::transport::transport_type::fake;
 			}
 
+			void disconnect ()
+			{
+				endpoint = nano::endpoint (boost::asio::ip::address_v6::any (), 0);
+			}
+
 		private:
-			nano::endpoint const endpoint;
+			nano::endpoint endpoint;
 		};
 	} // namespace fake
 } // namespace transport


### PR DESCRIPTION
The test `node.rep_remove` could fail, because the temporary `channel_tcp` was not present
in `searching_node.network.tcp_channels` and that could lead to a race
condition where `rep_crawler::cleanup_reps()` would remove `rep1` immediatly
after it was added.

This commit adds the `channel_tcp` to `network.tcp_channels`.