### PR TITLE
Disable systest set_bandwidth_params

### DIFF
--- a/systest/set_bandwidth_params.sh.disabled
+++ b/systest/set_bandwidth_params.sh.disabled
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# This test is disabled because it fails fairly frequently
+# with error "Address already in use" and I do not know what
+# the cause is. It is not a priority and it is not an important test,
+# therefore I am disabling it so we can start getting clean runs
+# through CI and so that CI problems do not go unnoticed.
+
 set -e
 
 DATADIR=data.systest


### PR DESCRIPTION
It fails fairly frequently with error "Address already in use" and I do
not what the cause is. It is not a priority and it is not important test,
so I am disabling it so we can start getting clean runs through CI and
problems do not go unnoticed.