### PR TITLE
Adding comments to test local_votes_cache_fork and documenting a race

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2538,8 +2538,8 @@ TEST (node, vote_republish)
 	// the real node will do a confirm request if it needs to find a lost vote
 
 	// check that send2 won on both nodes
-	ASSERT_TIMELY (5s, node1.block_confirmed(send2->hash ()));
-	ASSERT_TIMELY (5s, node2.block_confirmed(send2->hash ()));
+	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
+	ASSERT_TIMELY (5s, node2.block_confirmed (send2->hash ()));
 
 	// check that send1 is deleted from the ledger on nodes
 	ASSERT_FALSE (node1.block (send1->hash ()));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2530,7 +2530,7 @@ TEST (node, vote_republish)
 
 	// the vote causes the election to reach quorum and for the vote (and block?) to be published from node1 to node2
 	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ send2->hash () }));
-	node1.vote_processor.vote (vote, std::make_shared<nano::transport::fake::channel> (node1, node1));
+	node1.vote_processor.vote (vote, std::make_shared<nano::transport::fake::channel> (node1));
 
 	// FIXME: there is a race condition here, if the vote arrives before the block then the vote is wasted and the test fails
 	// we could resend the vote but then there is a race condition between the vote resending and the election reaching quorum on node1


### PR DESCRIPTION
There is a race condition. If the vote arrives before the block then
the vote is wasted and the test fails. We could resend the vote but then
there is a race condition between the vote resending and the election
reaching quorum on node1. The proper fix would be to observe on node2
that both the block and the vote arrived in whatever order.
The real node will do a confirm request if it needs to find a lost vote.