### PR TITLE
Cleanup `bootstrap_server`

### DIFF
--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -45,7 +45,7 @@ namespace bootstrap
 class bootstrap_server final : public std::enable_shared_from_this<nano::bootstrap_server>
 {
 public:
-	bootstrap_server (std::shared_ptr<nano::socket>, std::shared_ptr<nano::node>);
+	bootstrap_server (std::shared_ptr<nano::socket>, std::shared_ptr<nano::node>, bool allow_bootstrap = true);
 	~bootstrap_server ();
 	void start ();
 	void stop ();
@@ -78,6 +78,8 @@ private:
 	bool is_realtime_connection () const;
 
 	std::shared_ptr<nano::bootstrap::message_deserializer> message_deserializer;
+
+	bool allow_bootstrap;
 
 private:
 	class handshake_message_visitor : public nano::message_visitor

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -52,6 +52,8 @@ public:
 
 	void timeout ();
 
+	void send_handshake_response (nano::uint256_union query);
+
 	std::shared_ptr<nano::socket> const socket;
 	std::shared_ptr<nano::node> const node;
 	nano::mutex mutex;


### PR DESCRIPTION
Those are the first 2 commits from https://github.com/nanocurrency/nano-node/pull/3928 which should be relatively easy to merge. It's cleanup + adding a flag that controls whether bootstrap mode is allowed for this particular connection.