### PR TITLE
Add `EXPECT_TIMELY` test macro

### DIFF
--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -39,11 +39,7 @@ nano::keypair setup_rep (nano::test::system & system, nano::node & node, nano::u
 
 	EXPECT_TRUE (nano::test::process (node, { send, open }));
 	EXPECT_TRUE (nano::test::confirm (node, { send, open }));
-	// TODO: Create `EXPECT_TIMELY` macro to remove this boilerplate
-	system.poll_until_true (3s, [&node, &send, &open] () {
-		return nano::test::confirmed (node, { send, open });
-	});
-	EXPECT_TRUE (nano::test::confirmed (node, { send, open }));
+	EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
 
 	return key;
 }
@@ -106,12 +102,7 @@ std::vector<std::shared_ptr<nano::block>> setup_blocks (nano::test::system & sys
 
 	// Confirm whole genesis chain at once
 	EXPECT_TRUE (nano::test::confirm (node, { sends.back () }));
-
-	// TODO: Create `EXPECT_TIMELY` macro to remove this boilerplate
-	system.poll_until_true (60s, [&node, &sends] () {
-		return nano::test::confirmed (node, { sends });
-	});
-	EXPECT_TRUE (nano::test::confirmed (node, { sends }));
+	EXPECT_TIMELY (5s, nano::test::confirmed (node, { sends }));
 
 	return receives;
 }

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -37,13 +37,13 @@
 	GTEST_NONFATAL_FAILURE_)
 
 /** Extends gtest with a std::error_code assert that expects an error */
-#define ASSERT_IS_ERROR(condition)                                                            \
-	GTEST_TEST_ERROR_CODE ((condition.value () > 0), #condition, "An error was expected", "", \
+#define ASSERT_IS_ERROR(condition)                                                             \
+	GTEST_TEST_ERROR_CODE ((condition.value () != 0), #condition, "An error was expected", "", \
 	GTEST_FATAL_FAILURE_)
 
 /** Extends gtest with a std::error_code assert that expects an error */
-#define EXPECT_IS_ERROR(condition)                                                            \
-	GTEST_TEST_ERROR_CODE ((condition.value () > 0), #condition, "An error was expected", "", \
+#define EXPECT_IS_ERROR(condition)                                                             \
+	GTEST_TEST_ERROR_CODE ((condition.value () != 0), #condition, "An error was expected", "", \
 	GTEST_NONFATAL_FAILURE_)
 
 /** Asserts that the condition becomes true within the deadline */

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -4,6 +4,8 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/timer.hpp>
 
+#include <gtest/gtest.h>
+
 #include <boost/iostreams/concepts.hpp>
 #include <boost/log/sinks/text_ostream_backend.hpp>
 #include <boost/log/utility/setup/console.hpp>
@@ -29,10 +31,20 @@
 	GTEST_TEST_ERROR_CODE (!(condition), #condition, condition.message ().c_str (), "", \
 	GTEST_FATAL_FAILURE_)
 
+/** Extends gtest with a std::error_code assert that prints the error code message when non-zero */
+#define EXPECT_NO_ERROR(condition)                                                      \
+	GTEST_TEST_ERROR_CODE (!(condition), #condition, condition.message ().c_str (), "", \
+	GTEST_NONFATAL_FAILURE_)
+
 /** Extends gtest with a std::error_code assert that expects an error */
 #define ASSERT_IS_ERROR(condition)                                                            \
 	GTEST_TEST_ERROR_CODE ((condition.value () > 0), #condition, "An error was expected", "", \
 	GTEST_FATAL_FAILURE_)
+
+/** Extends gtest with a std::error_code assert that expects an error */
+#define EXPECT_IS_ERROR(condition)                                                            \
+	GTEST_TEST_ERROR_CODE ((condition.value () > 0), #condition, "An error was expected", "", \
+	GTEST_NONFATAL_FAILURE_)
 
 /** Asserts that the condition becomes true within the deadline */
 #define ASSERT_TIMELY(time, condition)    \
@@ -41,6 +53,15 @@
 	{                                     \
 		ASSERT_NO_ERROR (system.poll ()); \
 	}
+
+/** Expects that the condition becomes true within the deadline */
+#define EXPECT_TIMELY(time, condition)             \
+	system.deadline_set (time);                    \
+	std::error_code ec;                            \
+	while (!(condition) && !(ec = system.poll ())) \
+	{                                              \
+	}                                              \
+	EXPECT_NO_ERROR (ec);
 
 /*
  * Waits specified number of time while keeping system running.


### PR DESCRIPTION
It is not always possible to call ASSERT_TIMELY, for example from helper functions or lambdas.