### PR TITLE
Hinted election scheduler

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -507,7 +507,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	// An election is started for send6 but does not confirm
 	ASSERT_TIMELY (5s, 1 == node.active.size ());
 	node.vote_processor.flush ();
-	ASSERT_FALSE (node.block_confirmed_or_being_confirmed (node.store.tx_begin_read (), send3->hash ()));
+	ASSERT_FALSE (node.block_confirmed_or_being_confirmed (send3->hash ()));
 	// send7 cannot be voted on but an election should be started from inactive votes
 	ASSERT_FALSE (node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send4));
 	node.process_active (send4);
@@ -1230,7 +1230,7 @@ TEST (active_transactions, activate_inactive)
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_conf_height, nano::stat::dir::out));
 
 	// The first block was not active so no activation takes place
-	ASSERT_FALSE (node.active.active (open->qualified_root ()) || node.block_confirmed_or_being_confirmed (node.store.tx_begin_read (), open->hash ()));
+	ASSERT_FALSE (node.active.active (open->qualified_root ()) || node.block_confirmed_or_being_confirmed (open->hash ()));
 }
 
 TEST (active_transactions, list_active)

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -545,6 +545,9 @@ std::string nano::stat::type_to_string (stat::type type)
 		case nano::stat::type::vote_cache:
 			res = "vote_cache";
 			break;
+		case nano::stat::type::hinting:
+			res = "hinting";
+			break;
 	}
 	return res;
 }
@@ -936,6 +939,15 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 			break;
 		case nano::stat::detail::invalid_network:
 			res = "invalid_network";
+			break;
+		case nano::stat::detail::hinted:
+			res = "hinted";
+			break;
+		case nano::stat::detail::insert_failed:
+			res = "insert_failed";
+			break;
+		case nano::stat::detail::missing_block:
+			res = "missing_block";
 			break;
 	}
 	return res;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -244,7 +244,8 @@ public:
 		filter,
 		telemetry,
 		vote_generator,
-		vote_cache
+		vote_cache,
+		hinting
 	};
 
 	/** Optional detail type */
@@ -413,7 +414,12 @@ public:
 		generator_broadcasts,
 		generator_replies,
 		generator_replies_discarded,
-		generator_spacing
+		generator_spacing,
+
+		// hinting
+		hinted,
+		insert_failed,
+		missing_block,
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -96,6 +96,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::backlog_population:
 			thread_role_name_string = "Backlog";
 			break;
+		case nano::thread_role::name::election_hinting:
+			thread_role_name_string = "Hinting";
+			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -43,7 +43,8 @@ namespace thread_role
 		db_parallel_traversal,
 		election_scheduler,
 		unchecked,
-		backlog_population
+		backlog_population,
+		election_hinting
 	};
 
 	/*

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -68,6 +68,8 @@ add_library(
   election_scheduler.cpp
   gap_cache.hpp
   gap_cache.cpp
+  hinted_scheduler.hpp
+  hinted_scheduler.cpp
   inactive_cache_information.hpp
   inactive_cache_information.cpp
   inactive_cache_status.hpp

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -166,18 +166,28 @@ void nano::active_transactions::block_already_cemented_callback (nano::block_has
 	remove_election_winner_details (hash_a);
 }
 
+int64_t nano::active_transactions::limit () const
+{
+	return static_cast<int64_t> (node.config.active_elections_size);
+}
+
+int64_t nano::active_transactions::hinted_limit () const
+{
+	const uint64_t limit = node.config.active_elections_hinted_limit_percentage * node.config.active_elections_size / 100;
+	return static_cast<int64_t> (limit);
+}
+
 int64_t nano::active_transactions::vacancy () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
-	auto result = static_cast<int64_t> (node.config.active_elections_size) - static_cast<int64_t> (roots.size ());
+	auto result = limit () - static_cast<int64_t> (roots.size ());
 	return result;
 }
 
 int64_t nano::active_transactions::vacancy_hinted () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
-	const uint64_t limit = node.config.active_elections_hinted_limit_percentage * node.config.active_elections_size / 100;
-	auto result = static_cast<int64_t> (limit) - active_hinted_elections_count;
+	auto result = hinted_limit () - active_hinted_elections_count;
 	return result;
 }
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -686,11 +686,7 @@ void nano::active_transactions::check_inactive_vote_cache (nano::block_hash cons
 			else
 			{
 				// We don't have the block yet, try to bootstrap it
-				// TODO: Details of bootstraping a block are not `active_transactions` concern, encapsulate somewhere
-				if (!node.ledger.pruning || !node.store.pruned.exists (transaction, hash))
-				{
-					node.gap_cache.bootstrap_start (hash);
-				}
+				node.bootstrap_block (hash);
 			}
 		}
 	}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -678,7 +678,7 @@ void nano::active_transactions::check_inactive_vote_cache (nano::block_hash cons
 			if (block)
 			{
 				// We have the block, check that it's not yet confirmed
-				if (!node.block_confirmed_or_being_confirmed (transaction, hash))
+				if (!node.block_confirmed_or_being_confirmed (hash))
 				{
 					insert_hinted (block);
 				}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -76,7 +76,8 @@ private:
 
 	mutable nano::mutex mutex;
 
-	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, std::string const &);
+public: // Container info
+	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 };
 
 /*
@@ -99,7 +100,8 @@ private:
 
 	mutable nano::mutex mutex;
 
-	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, std::string const &);
+public: // Container info
+	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 };
 
 class election_insertion_result final

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -146,6 +146,12 @@ public:
 
 	explicit active_transactions (nano::node &, nano::confirmation_height_processor &);
 	~active_transactions ();
+
+	/*
+	 * Starts new election with hinted behavior type
+	 * Hinted elections have shorter timespan and only can take up limited space inside active elections container
+	 */
+	nano::election_insertion_result insert_hinted (std::shared_ptr<nano::block> const & block_a);
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
 	nano::vote_code vote (std::shared_ptr<nano::vote> const &);
 	// Is the root of this block in the roots container
@@ -171,12 +177,15 @@ public:
 	void block_already_cemented_callback (nano::block_hash const &);
 
 	int64_t vacancy () const;
+	/*
+	 * How many election slots are available for hinted elections.
+	 * The limit of AEC taken up by hinted elections is controlled by `node_config::active_elections_hinted_limit_percentage`
+	 */
+	int64_t vacancy_hinted () const;
 	std::function<void ()> vacancy_update{ [] () {} };
 
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
 
-	// Inserts an election if conditions are met
-	void trigger_inactive_votes_cache_election (std::shared_ptr<nano::block> const &);
 	nano::election_scheduler & scheduler;
 	nano::confirmation_height_processor & confirmation_height_processor;
 	nano::node & node;
@@ -197,10 +206,7 @@ private:
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> election_winner_details;
 
 	// Call action with confirmed block, may be different than what we started with
-	// clang-format off
-	nano::election_insertion_result insert_impl (nano::unique_lock<nano::mutex> &, std::shared_ptr<nano::block> const&, nano::election_behavior = nano::election_behavior::normal, std::function<void(std::shared_ptr<nano::block>const&)> const & = nullptr);
-	// clang-format on
-	nano::election_insertion_result insert_hinted (std::shared_ptr<nano::block> const & block_a);
+	nano::election_insertion_result insert_impl (nano::unique_lock<nano::mutex> &, std::shared_ptr<nano::block> const &, nano::election_behavior = nano::election_behavior::normal, std::function<void (std::shared_ptr<nano::block> const &)> const & = nullptr);
 	void request_loop ();
 	void request_confirm (nano::unique_lock<nano::mutex> &);
 	void erase (nano::qualified_root const &);
@@ -209,8 +215,11 @@ private:
 	// Returns a list of elections sorted by difficulty, mutex must be locked
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
 
+	/*
+	 * Checks if vote passes minimum representative weight threshold and adds it to inactive vote cache
+	 * TODO: Should be moved to `vote_cache` class
+	 */
 	void add_inactive_vote_cache (nano::block_hash const & hash, std::shared_ptr<nano::vote> const vote);
-	void check_inactive_vote_cache (nano::block_hash const & hash);
 
 	nano::condition_variable condition;
 	bool started{ false };

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -176,6 +176,15 @@ public:
 	void block_cemented_callback (std::shared_ptr<nano::block> const &);
 	void block_already_cemented_callback (nano::block_hash const &);
 
+	/*
+	 * Maximum number of all elections that should be present in this container.
+	 * This is only a soft limit, it is possible for this container to exceed this count.
+	 */
+	int64_t limit () const;
+	/*
+	 * Maximum number of hinted elections that should be present in this container.
+	 */
+	int64_t hinted_limit () const;
 	int64_t vacancy () const;
 	/*
 	 * How many election slots are available for hinted elections.

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -320,10 +320,9 @@ void nano::block_processor::process_live (nano::transaction const & transaction_
 		auto account = block_a->account ().is_zero () ? block_a->sideband ().account : block_a->account ();
 		node.scheduler.activate (account, transaction_a);
 	}
-	else
-	{
-		node.active.trigger_inactive_votes_cache_election (block_a);
-	}
+
+	// Notify inactive vote cache about a new live block
+	node.inactive_vote_cache.trigger (block_a->hash ());
 
 	// Announce block contents to the network
 	if (origin_a == nano::block_origin::local)

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -99,7 +99,12 @@ bool nano::election_scheduler::manual_queue_predicate () const
 
 bool nano::election_scheduler::overfill_predicate () const
 {
-	return node.active.vacancy () < 0;
+	/*
+	 * Both normal and hinted election schedulers are well-behaved, meaning they first check for AEC vacancy before inserting new elections.
+	 * However, it is possible that AEC will be temporarily overfilled in case it's running at full capacity and election hinting or manual queue kicks in.
+	 * That case will lead to unwanted churning of elections, so this allows for AEC to be overfilled to 125% until erasing of elections happens.
+	 */
+	return node.active.vacancy () < -(node.active.limit () / 4);
 }
 
 void nano::election_scheduler::run ()

--- a/nano/node/hinted_scheduler.cpp
+++ b/nano/node/hinted_scheduler.cpp
@@ -1,0 +1,121 @@
+#include <nano/node/hinted_scheduler.hpp>
+#include <nano/node/node.hpp>
+
+nano::hinted_scheduler::hinted_scheduler (nano::node & node_a, nano::vote_cache & inactive_vote_cache_a, nano::active_transactions & active_a, nano::online_reps & online_reps_a) :
+	node{ node_a },
+	inactive_vote_cache{ inactive_vote_cache_a },
+	active{ active_a },
+	online_reps{ online_reps_a },
+	stopped{ false }
+{
+}
+
+nano::hinted_scheduler::~hinted_scheduler ()
+{
+	stop ();
+	if (thread.joinable ()) // Ensure thread was started
+	{
+		thread.join ();
+	}
+}
+
+void nano::hinted_scheduler::start ()
+{
+	debug_assert (!thread.joinable ());
+	thread = std::thread{
+		[this] () { run (); }
+	};
+}
+
+void nano::hinted_scheduler::stop ()
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	stopped = true;
+	notify ();
+}
+
+void nano::hinted_scheduler::notify ()
+{
+	condition.notify_all ();
+}
+
+bool nano::hinted_scheduler::predicate (nano::uint128_t const & minimum_tally) const
+{
+	// Check if there is space inside AEC for a new hinted election
+	if (active.vacancy_hinted () > 0)
+	{
+		// Check if there is any vote cache entry surpassing our minimum vote tally threshold
+		if (inactive_vote_cache.peek (minimum_tally))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool nano::hinted_scheduler::run_one (nano::uint128_t const & minimum_tally)
+{
+	if (auto top = inactive_vote_cache.pop (minimum_tally); top)
+	{
+		const auto hash = top->hash; // Hash of block we want to hint
+
+		// Check if block exists
+		auto block = node.block (hash);
+		if (block != nullptr)
+		{
+			// Ensure block is not already confirmed
+			if (!node.block_confirmed_or_being_confirmed (hash))
+			{
+				// Try to insert it into AEC as hinted election
+				// We check for AEC vacancy inside our predicate
+				auto result = node.active.insert_hinted (block);
+				return result.inserted; // Return whether block was inserted
+			}
+		}
+		else
+		{
+			// Missing block in ledger to start an election
+			node.bootstrap_block (hash);
+		}
+	}
+	return false;
+}
+
+void nano::hinted_scheduler::run ()
+{
+	nano::thread_role::set (nano::thread_role::name::election_hinting);
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		// It is possible that if we are waiting long enough this tally becomes outdated due to changes in trended online weight
+		// However this is only used here for hinting, election does independent tally calculation, so there is no need to ensure it's always up-to-date
+		const auto minimum_tally = tally_threshold ();
+
+		// Periodically wakeup for condition checking
+		// We are not notified every time new vote arrives in inactive vote cache as that happens too often
+		condition.wait_for (lock, std::chrono::seconds (1), [this, minimum_tally] () {
+			return stopped || predicate (minimum_tally);
+		});
+
+		debug_assert ((std::this_thread::yield (), true)); // Introduce some random delay in debug builds
+
+		if (!stopped)
+		{
+			// We don't need the lock when running main loop
+			lock.unlock ();
+
+			if (predicate (minimum_tally))
+			{
+				run_one (minimum_tally);
+			}
+
+			lock.lock ();
+		}
+	}
+}
+
+nano::uint128_t nano::hinted_scheduler::tally_threshold () const
+{
+	const auto min_tally = (online_reps.trended () / 100) * node.config.election_hint_weight_percent;
+	return min_tally;
+}

--- a/nano/node/hinted_scheduler.cpp
+++ b/nano/node/hinted_scheduler.cpp
@@ -1,7 +1,8 @@
 #include <nano/node/hinted_scheduler.hpp>
 #include <nano/node/node.hpp>
 
-nano::hinted_scheduler::hinted_scheduler (nano::node & node_a, nano::vote_cache & inactive_vote_cache_a, nano::active_transactions & active_a, nano::online_reps & online_reps_a) :
+nano::hinted_scheduler::hinted_scheduler (config const & config_a, nano::node & node_a, nano::vote_cache & inactive_vote_cache_a, nano::active_transactions & active_a, nano::online_reps & online_reps_a) :
+	config_m{ config_a },
 	node{ node_a },
 	inactive_vote_cache{ inactive_vote_cache_a },
 	active{ active_a },
@@ -93,7 +94,7 @@ void nano::hinted_scheduler::run ()
 
 		// Periodically wakeup for condition checking
 		// We are not notified every time new vote arrives in inactive vote cache as that happens too often
-		condition.wait_for (lock, std::chrono::seconds (1), [this, minimum_tally] () {
+		condition.wait_for (lock, std::chrono::milliseconds (config_m.vote_cache_check_interval_ms), [this, minimum_tally] () {
 			return stopped || predicate (minimum_tally);
 		});
 

--- a/nano/node/hinted_scheduler.hpp
+++ b/nano/node/hinted_scheduler.hpp
@@ -21,8 +21,15 @@ class online_reps;
 
 class hinted_scheduler final
 {
+public: // Config
+	struct config final
+	{
+		// Interval of wakeup to check inactive vote cache when idle
+		uint64_t vote_cache_check_interval_ms;
+	};
+
 public:
-	explicit hinted_scheduler (nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &);
+	explicit hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &);
 	~hinted_scheduler ();
 
 	void start ();
@@ -43,6 +50,8 @@ private: // Dependencies
 	nano::online_reps & online_reps;
 
 private:
+	config const config_m;
+
 	bool stopped;
 	nano::condition_variable condition;
 	mutable nano::mutex mutex;

--- a/nano/node/hinted_scheduler.hpp
+++ b/nano/node/hinted_scheduler.hpp
@@ -19,6 +19,9 @@ class active_transactions;
 class vote_cache;
 class online_reps;
 
+/*
+ * Monitors inactive vote cache and schedules elections with the highest observed vote tally.
+ */
 class hinted_scheduler final
 {
 public: // Config
@@ -34,6 +37,9 @@ public:
 
 	void start ();
 	void stop ();
+	/*
+	 * Notify about changes in AEC vacancy
+	 */
 	void notify ();
 
 private:

--- a/nano/node/hinted_scheduler.hpp
+++ b/nano/node/hinted_scheduler.hpp
@@ -32,7 +32,7 @@ public: // Config
 	};
 
 public:
-	explicit hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &);
+	explicit hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stat &);
 	~hinted_scheduler ();
 
 	void start ();
@@ -54,6 +54,7 @@ private: // Dependencies
 	nano::vote_cache & inactive_vote_cache;
 	nano::active_transactions & active;
 	nano::online_reps & online_reps;
+	nano::stat & stats;
 
 private:
 	config const config_m;

--- a/nano/node/hinted_scheduler.hpp
+++ b/nano/node/hinted_scheduler.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/timer.hpp>
+#include <nano/lib/utility.hpp>
+#include <nano/secure/common.hpp>
+
+#include <condition_variable>
+#include <memory>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace nano
+{
+class node;
+class active_transactions;
+class vote_cache;
+class online_reps;
+
+class hinted_scheduler final
+{
+public:
+	explicit hinted_scheduler (nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &);
+	~hinted_scheduler ();
+
+	void start ();
+	void stop ();
+	void notify ();
+
+private:
+	bool predicate (nano::uint128_t const & minimum_tally) const;
+	void run ();
+	bool run_one (nano::uint128_t const & minimum_tally);
+
+	nano::uint128_t tally_threshold () const;
+
+private: // Dependencies
+	nano::node & node;
+	nano::vote_cache & inactive_vote_cache;
+	nano::active_transactions & active;
+	nano::online_reps & online_reps;
+
+private:
+	bool stopped;
+	nano::condition_variable condition;
+	mutable nano::mutex mutex;
+	std::thread thread;
+};
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -175,7 +175,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	inactive_vote_cache{ nano::nodeconfig_to_vote_cache_config (config, flags) },
 	active (*this, confirmation_height_processor),
 	scheduler{ *this },
-	hinting{ nano::nodeconfig_to_hinted_scheduler_config (config), *this, inactive_vote_cache, active, online_reps },
+	hinting{ nano::nodeconfig_to_hinted_scheduler_config (config), *this, inactive_vote_cache, active, online_reps, stats },
 	aggregator (config, stats, active.generator, active.final_generator, history, ledger, wallets, active),
 	wallets (wallets_store.init_error (), *this),
 	backlog{ nano::nodeconfig_to_backlog_population_config (config), store, scheduler },

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1303,9 +1303,9 @@ bool nano::node::block_confirmed (nano::block_hash const & hash_a)
 	return ledger.block_confirmed (transaction, hash_a);
 }
 
-bool nano::node::block_confirmed_or_being_confirmed (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
+bool nano::node::block_confirmed_or_being_confirmed (nano::block_hash const & hash_a)
 {
-	return confirmation_height_processor.is_processing_block (hash_a) || ledger.block_confirmed (transaction_a, hash_a);
+	return confirmation_height_processor.is_processing_block (hash_a) || ledger.block_confirmed (store.tx_begin_read (), hash_a);
 }
 
 void nano::node::ongoing_online_weight_calculation_queue ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1765,6 +1765,16 @@ std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> nano::node::get_
 	return { max_blocks, weights };
 }
 
+void nano::node::bootstrap_block (const nano::block_hash & hash)
+{
+	// If we are running pruning node check if block was not already pruned
+	if (!ledger.pruning || !store.pruned.exists (store.tx_begin_read (), hash))
+	{
+		// We don't have the block, try to bootstrap it
+		gap_cache.bootstrap_start (hash);
+	}
+}
+
 /** Convenience function to easily return the confirmation height of an account. */
 uint64_t nano::node::get_confirmation_height (nano::transaction const & transaction_a, nano::account & account_a)
 {

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -46,6 +46,13 @@ nano::vote_cache::config nano::nodeconfig_to_vote_cache_config (node_config cons
 	return cfg;
 }
 
+nano::hinted_scheduler::config nano::nodeconfig_to_hinted_scheduler_config (const nano::node_config & config)
+{
+	hinted_scheduler::config cfg;
+	cfg.vote_cache_check_interval_ms = config.network_params.network.is_dev_network () ? 100u : 1000u;
+	return cfg;
+}
+
 void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
 {
 	auto node_l (shared_from_this ());
@@ -165,10 +172,10 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	history{ config.network_params.voting },
 	vote_uniquer (block_uniquer),
 	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
-	inactive_vote_cache{ nodeconfig_to_vote_cache_config (config, flags) },
+	inactive_vote_cache{ nano::nodeconfig_to_vote_cache_config (config, flags) },
 	active (*this, confirmation_height_processor),
 	scheduler{ *this },
-	hinting{ *this, inactive_vote_cache, active, online_reps },
+	hinting{ nano::nodeconfig_to_hinted_scheduler_config (config), *this, inactive_vote_cache, active, online_reps },
 	aggregator (config, stats, active.generator, active.final_generator, history, ledger, wallets, active),
 	wallets (wallets_store.init_error (), *this),
 	backlog{ nano::nodeconfig_to_backlog_population_config (config), store, scheduler },

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -56,8 +56,9 @@ class work_pool;
 std::unique_ptr<container_info_component> collect_container_info (rep_crawler & rep_crawler, std::string const & name);
 
 // Configs
-backlog_population::config nodeconfig_to_backlog_population_config (node_config const & config);
+backlog_population::config nodeconfig_to_backlog_population_config (node_config const &);
 vote_cache::config nodeconfig_to_vote_cache_config (node_config const &, node_flags const &);
+hinted_scheduler::config nodeconfig_to_hinted_scheduler_config (node_config const &);
 
 class node final : public std::enable_shared_from_this<nano::node>
 {

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -15,6 +15,7 @@
 #include <nano/node/election.hpp>
 #include <nano/node/election_scheduler.hpp>
 #include <nano/node/gap_cache.hpp>
+#include <nano/node/hinted_scheduler.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/nodeconfig.hpp>
@@ -172,6 +173,7 @@ public:
 	nano::vote_cache inactive_vote_cache;
 	nano::active_transactions active;
 	nano::election_scheduler scheduler;
+	nano::hinted_scheduler hinting;
 	nano::request_aggregator aggregator;
 	nano::wallets wallets;
 	nano::backlog_population backlog;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -126,6 +126,10 @@ public:
 	void set_bandwidth_params (std::size_t limit, double ratio);
 	std::pair<uint64_t, decltype (nano::ledger::bootstrap_weights)> get_bootstrap_weights () const;
 	uint64_t get_confirmation_height (nano::transaction const &, nano::account &);
+	/*
+	 * Attempts to bootstrap block. This is the best effort, there is no guarantee that the block will be bootstrapped.
+	 */
+	void bootstrap_block (nano::block_hash const &);
 	nano::write_database_queue write_database_queue;
 	boost::asio::io_context & io_ctx;
 	boost::latch node_initialized_latch;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -116,7 +116,7 @@ public:
 	 */
 	std::shared_ptr<nano::election> block_confirm (std::shared_ptr<nano::block> const &);
 	bool block_confirmed (nano::block_hash const &);
-	bool block_confirmed_or_being_confirmed (nano::transaction const &, nano::block_hash const &);
+	bool block_confirmed_or_being_confirmed (nano::block_hash const &);
 	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
 	void ongoing_online_weight_calculation ();
 	void ongoing_online_weight_calculation_queue ();

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/node/transport/fake.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -174,9 +175,24 @@ std::shared_ptr<nano::vote> nano::test::make_vote (nano::keypair key, std::vecto
 	return make_vote (key, hashes, timestamp, duration);
 }
 
+std::shared_ptr<nano::vote> nano::test::make_final_vote (nano::keypair key, std::vector<nano::block_hash> hashes)
+{
+	return make_vote (key, hashes, nano::vote::timestamp_max, nano::vote::duration_max);
+}
+
+std::shared_ptr<nano::vote> nano::test::make_final_vote (nano::keypair key, std::vector<std::shared_ptr<nano::block>> blocks)
+{
+	return make_vote (key, blocks, nano::vote::timestamp_max, nano::vote::duration_max);
+}
+
 std::vector<nano::block_hash> nano::test::blocks_to_hashes (std::vector<std::shared_ptr<nano::block>> blocks)
 {
 	std::vector<nano::block_hash> hashes;
 	std::transform (blocks.begin (), blocks.end (), std::back_inserter (hashes), [] (auto & block) { return block->hash (); });
 	return hashes;
+}
+
+std::shared_ptr<nano::transport::channel> nano::test::fake_channel (nano::node & node)
+{
+	return std::make_shared<nano::transport::fake::channel> (node);
 }

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -63,6 +63,14 @@
 	}                                              \
 	EXPECT_NO_ERROR (ec);
 
+/** Asserts that the condition becomes true within the deadline */
+#define ASSERT_TIMELY_EQ(time, val1, val2)         \
+	system.deadline_set (time);                    \
+	while (!((val1) == (val2)) && !system.poll ()) \
+	{                                              \
+	}                                              \
+	ASSERT_EQ (val1, val2);
+
 /*
  * Waits specified number of time while keeping system running.
  * Useful for asserting conditions that should still hold after some delay of time
@@ -71,6 +79,26 @@
 	system.deadline_set (time); \
 	while (!system.poll ())     \
 	{                           \
+	}
+
+/*
+ * Asserts that condition is always true during the specified amount of time
+ */
+#define ASSERT_ALWAYS(time, condition) \
+	system.deadline_set (time);        \
+	while (!system.poll ())            \
+	{                                  \
+		ASSERT_TRUE (condition);       \
+	}
+
+/*
+ * Asserts that condition is never true during the specified amount of time
+ */
+#define ASSERT_NEVER(time, condition) \
+	system.deadline_set (time);       \
+	while (!system.poll ())           \
+	{                                 \
+		ASSERT_FALSE (condition);     \
 	}
 
 /* Convenience globals for gtest projects */

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -64,7 +64,10 @@
 	}                                              \
 	EXPECT_NO_ERROR (ec);
 
-/** Asserts that the condition becomes true within the deadline */
+/*
+ * Asserts that the `val1 == val2` condition becomes true within the deadline
+ * Checked expressions should not modify any state
+ */
 #define ASSERT_TIMELY_EQ(time, val1, val2)         \
 	system.deadline_set (time);                    \
 	while (!((val1) == (val2)) && !system.poll ()) \

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -66,7 +66,7 @@
 
 /*
  * Asserts that the `val1 == val2` condition becomes true within the deadline
- * Checked expressions should not modify any state
+ * Condition must hold for at least 2 consecutive reads
  */
 #define ASSERT_TIMELY_EQ(time, val1, val2)         \
 	system.deadline_set (time);                    \

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/timer.hpp>
+#include <nano/node/transport/transport.hpp>
 
 #include <gtest/gtest.h>
 
@@ -340,8 +341,20 @@ namespace test
 	 */
 	std::shared_ptr<nano::vote> make_vote (nano::keypair key, std::vector<nano::block_hash> hashes, uint64_t timestamp = 0, uint8_t duration = 0);
 	/*
+	 * Convenience function to create a new final vote from list of blocks
+	 */
+	std::shared_ptr<nano::vote> make_final_vote (nano::keypair key, std::vector<std::shared_ptr<nano::block>> blocks);
+	/*
+	 * Convenience function to create a new final vote from list of block hashes
+	 */
+	std::shared_ptr<nano::vote> make_final_vote (nano::keypair key, std::vector<nano::block_hash> hashes);
+	/*
 	 * Converts list of blocks to list of hashes
 	 */
 	std::vector<nano::block_hash> blocks_to_hashes (std::vector<std::shared_ptr<nano::block>> blocks);
+	/*
+	 * Creates a new fake channel associated with `node`
+	 */
+	std::shared_ptr<nano::transport::channel> fake_channel (nano::node & node);
 }
 }


### PR DESCRIPTION
This PR adds an additional election scheduler that prioritises elections by cached tally weight, so elections with the most voting weight already cached (thus under normal conditions more likely to be quickly confirmed) are started first. During testing this demonstrated a significant speedup when backlog is present and nodes are desynchronised.