### PR TITLE
Fix MacOS compilation, add libsecure to target link libs for nano_lib

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries(
   ed25519
   crypto_lib
   blake2
+  secure
   ipc_flatbuffers_lib
   ${CRYPTOPP_LIBRARY}
   ${CMAKE_DL_LIBS}


### PR DESCRIPTION
The problem appears to be that nano_lib uses libsecure but it is not listing it as a dependency. The ipc_flatbuffers_test_client does not list libsecure and the compilation was failing.

The problem was only happening in MacOs Debug builds only. I assume that it was happening in Debug builds only because of an assert that used libsecure code.

However, I do not understand why this problem was not appearing on linux.