### PR TITLE
Improve `vote_cache` slow_tests

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -640,11 +640,15 @@ void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 	block_processor.add (incoming);
 }
 
-nano::process_return nano::node::process (nano::block & block_a)
+[[nodiscard]] nano::process_return nano::node::process (nano::write_transaction const & transaction, nano::block & block)
 {
-	auto const transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
-	auto result (ledger.process (transaction, block_a));
-	return result;
+	return ledger.process (transaction, block);
+}
+
+nano::process_return nano::node::process (nano::block & block)
+{
+	auto const transaction = store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending });
+	return process (transaction, block);
 }
 
 nano::process_return nano::node::process_local (std::shared_ptr<nano::block> const & block_a)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -200,6 +200,7 @@ public: // Testing convenience functions
 		Transaction is comitted before function return
 	 */
 	[[nodiscard]] nano::process_return process (nano::block & block);
+	[[nodiscard]] nano::process_return process (nano::write_transaction const &, nano::block & block);
 	nano::block_hash latest (nano::account const &);
 	nano::uint128_t balance (nano::account const &);
 

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -96,13 +96,18 @@ std::vector<std::shared_ptr<nano::block>> setup_blocks (nano::test::system & sys
 
 		sends.push_back (send);
 		receives.push_back (open);
-
-		EXPECT_TRUE (nano::test::process (node, { send, open }));
 	}
+
+	std::cout << "setup_blocks confirming" << std::endl;
+
+	EXPECT_TRUE (nano::test::process (node, sends));
+	EXPECT_TRUE (nano::test::process (node, receives));
 
 	// Confirm whole genesis chain at once
 	EXPECT_TRUE (nano::test::confirm (node, { sends.back () }));
 	EXPECT_TIMELY (5s, nano::test::confirmed (node, { sends }));
+
+	std::cout << "setup_blocks done" << std::endl;
 
 	return receives;
 }
@@ -127,13 +132,12 @@ TEST (vote_cache, perf_singlethreaded)
 {
 	nano::test::system system;
 	nano::node_flags flags;
-	flags.inactive_votes_cache_size = 5000; // Keep it below block count size so it is forced to constantly evict stale entries
 	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config, flags);
 
 	const int rep_count = 50;
-	const int block_count = 20000;
+	const int block_count = 1024 * 128 * 2; // 2x the inactive vote cache size
 	const int vote_count = 100000;
 	const int single_vote_size = 7;
 	const int single_vote_reps = 7;
@@ -187,14 +191,13 @@ TEST (vote_cache, perf_multithreaded)
 {
 	nano::test::system system;
 	nano::node_flags flags;
-	flags.inactive_votes_cache_size = 5000; // Keep it below block count size so it is forced to constantly evict stale entries
 	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config, flags);
 
 	const int thread_count = 12;
 	const int rep_count = 50;
-	const int block_count = 20000;
+	const int block_count = 1024 * 128 * 2; // 2x the inactive vote cache size
 	const int vote_count = 200000 / thread_count;
 	const int single_vote_size = 7;
 	const int single_vote_reps = 7;

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -40,9 +40,10 @@ void nano::test::wait_peer_connections (nano::test::system & system_a)
 
 bool nano::test::process (nano::node & node, std::vector<std::shared_ptr<nano::block>> blocks)
 {
+	auto const transaction = node.store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending });
 	for (auto & block : blocks)
 	{
-		auto result = node.process (*block);
+		auto result = node.process (transaction, *block);
 		if (result.code != nano::process_result::progress)
 		{
 			return false;


### PR DESCRIPTION
Vote cache performance test were not running with full sized inactive vote cache.