### PR TITLE
Replace random_access with sequenced in `vote_cache`

### DIFF
--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -231,11 +231,11 @@ void nano::vote_cache::trim_overflow_locked ()
 	// When cache overflown remove the oldest entry
 	if (cache.size () > max_size)
 	{
-		cache.get<tag_random_access> ().pop_front ();
+		cache.get<tag_sequenced> ().pop_front ();
 	}
 	if (queue.size () > max_size)
 	{
-		queue.get<tag_random_access> ().pop_front ();
+		queue.get<tag_sequenced> ().pop_front ();
 	}
 }
 

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -142,7 +142,7 @@ private:
 	const std::size_t max_size;
 
 	// clang-format off
-	class tag_random_access {};
+	class tag_sequenced {};
 	class tag_tally {};
 	class tag_hash {};
 	// clang-format on
@@ -150,7 +150,7 @@ private:
 	// clang-format off
 	using ordered_cache = boost::multi_index_container<entry,
 	mi::indexed_by<
-		mi::random_access<mi::tag<tag_random_access>>,
+		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::hashed_unique<mi::tag<tag_hash>,
 			mi::member<entry, nano::block_hash, &entry::hash>>>>;
 	// clang-format on
@@ -159,7 +159,7 @@ private:
 	// clang-format off
 	using ordered_queue = boost::multi_index_container<queue_entry,
 	mi::indexed_by<
-		mi::random_access<mi::tag<tag_random_access>>,
+		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::ordered_non_unique<mi::tag<tag_tally>,
 			mi::member<queue_entry, nano::uint128_t, &queue_entry::tally>>,
 		mi::hashed_unique<mi::tag<tag_hash>,


### PR DESCRIPTION
The `random_access` index from `boost::multi_index_container` has deletion complexity of O(n) when deleting entries from the beginning. For our use case `sequenced` is much better fit, it's essentially a linked list with complexity of this operation of O(1). This seems to be the cause of recent beta network problems. 