### PR TITLE
Replace random_access with sequenced in `active_transactions`

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -313,7 +313,7 @@ std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_act
 	std::vector<std::shared_ptr<nano::election>> result_l;
 	result_l.reserve (std::min (max_a, roots.size ()));
 	{
-		auto & sorted_roots_l (roots.get<tag_random_access> ());
+		auto & sorted_roots_l (roots.get<tag_sequenced> ());
 		std::size_t count_l{ 0 };
 		for (auto i = sorted_roots_l.begin (), n = sorted_roots_l.end (); i != n && count_l < max_a; ++i, ++count_l)
 		{
@@ -590,7 +590,7 @@ void nano::active_transactions::erase_oldest ()
 	if (!roots.empty ())
 	{
 		node.stats.inc (nano::stat::type::election, nano::stat::detail::election_drop_overflow);
-		auto item = roots.get<tag_random_access> ().front ();
+		auto item = roots.get<tag_sequenced> ().front ();
 		cleanup_election (lock, item.election);
 	}
 }

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -126,9 +126,8 @@ class active_transactions final
 
 	// clang-format off
 	class tag_account {};
-	class tag_random_access {};
 	class tag_root {};
-	class tag_sequence {};
+	class tag_sequenced {};
 	class tag_uncemented {};
 	class tag_arrival {};
 	class tag_hash {};
@@ -138,13 +137,12 @@ public:
 	// clang-format off
 	using ordered_roots = boost::multi_index_container<conflict_info,
 	mi::indexed_by<
-		mi::random_access<mi::tag<tag_random_access>>,
+		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::hashed_unique<mi::tag<tag_root>,
 			mi::member<conflict_info, nano::qualified_root, &conflict_info::root>>
 	>>;
 	// clang-format on
 	ordered_roots roots;
-	using roots_iterator = active_transactions::ordered_roots::index_iterator<tag_root>::type;
 
 	explicit active_transactions (nano::node &, nano::confirmation_height_processor &);
 	~active_transactions ();


### PR DESCRIPTION
The `random_access` index from `boost::multi_index_container` has deletion complexity of O(n) when deleting entries from the beginning. For our use case `sequenced` is much better fit, it's essentially a linked list with complexity of this operation of O(1)