### PR TITLE
Run `node::process_confirmed` from worker thread

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1221,9 +1221,9 @@ TEST (active_transactions, activate_inactive)
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 
-	ASSERT_TIMELY (3s, !node.confirmation_height_processor.is_processing_added_block (send2->hash ()));
-	ASSERT_TRUE (node.block_confirmed (send2->hash ()));
-	ASSERT_TRUE (node.block_confirmed (send->hash ()));
+	ASSERT_TIMELY (5s, !node.confirmation_height_processor.is_processing_added_block (send2->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (send2->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (send->hash ()));
 
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out));

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -53,8 +53,10 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock_a, nano
 		status.type = type_a;
 		auto const status_l = status;
 		lock_a.unlock ();
-		node.process_confirmed (status_l);
+
 		node.background ([node_l = node.shared (), status_l, confirmation_action_l = confirmation_action] () {
+			node_l->process_confirmed (status_l);
+
 			if (confirmation_action_l)
 			{
 				confirmation_action_l (status_l.winner);


### PR DESCRIPTION
The `node::process_confirmed (..)` does database lookup and is called from vote processor thread which is already very congested. This PR moves starting this operation to background worker.