### PR TITLE
Add stats to blockprocessor

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -548,6 +548,9 @@ std::string nano::stat::type_to_string (stat::type type)
 		case nano::stat::type::hinting:
 			res = "hinting";
 			break;
+		case nano::stat::type::blockprocessor:
+			res = "blockprocessor";
+			break;
 	}
 	return res;
 }
@@ -628,6 +631,33 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 			break;
 		case nano::stat::detail::rollback_failed:
 			res = "rollback_failed";
+			break;
+		case nano::stat::detail::progress:
+			res = "progress";
+			break;
+		case nano::stat::detail::bad_signature:
+			res = "bad_signature";
+			break;
+		case nano::stat::detail::negative_spend:
+			res = "negative_spend";
+			break;
+		case nano::stat::detail::unreceivable:
+			res = "unreceivable";
+			break;
+		case nano::stat::detail::gap_epoch_open_pending:
+			res = "gap_epoch_open_pending";
+			break;
+		case nano::stat::detail::opened_burn_account:
+			res = "opened_burn_account";
+			break;
+		case nano::stat::detail::balance_mismatch:
+			res = "balance_mismatch";
+			break;
+		case nano::stat::detail::representative_mismatch:
+			res = "representative_mismatch";
+			break;
+		case nano::stat::detail::block_position:
+			res = "block_position";
 			break;
 		case nano::stat::detail::frontier_confirmation_failed:
 			res = "frontier_confirmation_failed";

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -245,7 +245,8 @@ public:
 		telemetry,
 		vote_generator,
 		vote_cache,
-		hinting
+		hinting,
+		blockprocessor,
 	};
 
 	/** Optional detail type */
@@ -277,6 +278,15 @@ public:
 		gap_previous,
 		gap_source,
 		rollback_failed,
+		progress,
+		bad_signature,
+		negative_spend,
+		unreceivable,
+		gap_epoch_open_pending,
+		opened_burn_account,
+		balance_mismatch,
+		representative_mismatch,
+		block_position,
 
 		// message specific
 		not_a_type,

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -505,6 +505,9 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 			break;
 		}
 	}
+
+	node.stats.inc (nano::stat::type::blockprocessor, nano::to_stat_detail (result.code));
+
 	return result;
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -756,3 +756,54 @@ void nano::generate_cache::enable_all ()
 	unchecked_count = true;
 	account_count = true;
 }
+
+nano::stat::detail nano::to_stat_detail (nano::process_result process_result)
+{
+	nano::stat::detail result;
+	switch (process_result)
+	{
+		case process_result::progress:
+			return nano::stat::detail::progress;
+			break;
+		case process_result::bad_signature:
+			return nano::stat::detail::bad_signature;
+			break;
+		case process_result::old:
+			return nano::stat::detail::old;
+			break;
+		case process_result::negative_spend:
+			return nano::stat::detail::negative_spend;
+			break;
+		case process_result::fork:
+			return nano::stat::detail::fork;
+			break;
+		case process_result::unreceivable:
+			return nano::stat::detail::unreceivable;
+			break;
+		case process_result::gap_previous:
+			return nano::stat::detail::gap_previous;
+			break;
+		case process_result::gap_source:
+			return nano::stat::detail::gap_source;
+			break;
+		case process_result::gap_epoch_open_pending:
+			return nano::stat::detail::gap_epoch_open_pending;
+			break;
+		case process_result::opened_burn_account:
+			return nano::stat::detail::opened_burn_account;
+			break;
+		case process_result::balance_mismatch:
+			return nano::stat::detail::balance_mismatch;
+			break;
+		case process_result::representative_mismatch:
+			return nano::stat::detail::representative_mismatch;
+			break;
+		case process_result::block_position:
+			return nano::stat::detail::block_position;
+			break;
+		case process_result::insufficient_work:
+			return nano::stat::detail::insufficient_work;
+			break;
+	}
+	return result;
+}

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -7,6 +7,7 @@
 #include <nano/lib/epoch.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/rep_weights.hpp>
+#include <nano/lib/stats.hpp>
 #include <nano/lib/utility.hpp>
 
 #include <boost/iterator/transform_iterator.hpp>
@@ -150,19 +151,19 @@ public:
 	endpoint_key () = default;
 
 	/*
-     * @param address_a This should be in network byte order
-     * @param port_a This should be in host byte order
-     */
+	 * @param address_a This should be in network byte order
+	 * @param port_a This should be in host byte order
+	 */
 	endpoint_key (std::array<uint8_t, 16> const & address_a, uint16_t port_a);
 
 	/*
-     * @return The ipv6 address in network byte order
-     */
+	 * @return The ipv6 address in network byte order
+	 */
 	std::array<uint8_t, 16> const & address_bytes () const;
 
 	/*
-     * @return The port in host byte order
-     */
+	 * @return The port in host byte order
+	 */
 	uint16_t port () const;
 
 private:
@@ -370,6 +371,8 @@ enum class tally_result
 	confirm
 };
 
+nano::stat::detail to_stat_detail (process_result);
+
 class network_params;
 
 /** Genesis keys and ledger constants for network variants */
@@ -496,7 +499,7 @@ enum class confirmation_height_mode
 };
 
 /* Holds flags for various cacheable data. For most CLI operations caching is unnecessary
-     * (e.g getting the cemented block count) so it can be disabled for performance reasons. */
+ * (e.g getting the cemented block count) so it can be disabled for performance reasons. */
 class generate_cache
 {
 public:


### PR DESCRIPTION
Small PR to that add stat tracking for blockprocessor results. Useful for testing ascending bootstrapper. 