### PR TITLE
Fix nano::active_transactions::clear (should call vacancy_update)

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -681,9 +681,11 @@ std::size_t nano::active_transactions::election_winner_details_size ()
 
 void nano::active_transactions::clear ()
 {
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	blocks.clear ();
-	roots.clear ();
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		blocks.clear ();
+		roots.clear ();
+	}
 	vacancy_update ();
 }
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -684,6 +684,7 @@ void nano::active_transactions::clear ()
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	blocks.clear ();
 	roots.clear ();
+	vacancy_update ();
 }
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (active_transactions & active_transactions, std::string const & name)


### PR DESCRIPTION
When the AEc is cleared it can create vacancies, so it should call the vacancy update function.

This is likely not affecting the real node, that funciton is mostly used in test code.