### PR TITLE
Adding to_string method on keepalive

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -276,3 +276,29 @@ TEST (message, bulk_pull_serialization)
 	ASSERT_FALSE (error);
 	ASSERT_TRUE (header.bulk_pull_ascending ());
 }
+
+TEST (message, keepalive_to_string)
+{
+	nano::keepalive keepalive = nano::keepalive (nano::dev::network_params.network);
+
+	std::string expectedString = "NetID: 5241(dev), VerMaxUsingMin: 19/19/18, MsgType: 2(keepalive), Extensions: 0000";
+
+	for (auto peer = keepalive.peers.begin (), peers_end = keepalive.peers.end (); peer != peers_end; ++peer)
+	{
+		int index = std::distance (keepalive.peers.begin (), peer);
+
+		std::string test_ip = "::ffff:1.2.3.4";
+		int port = 7072;
+		std::array<char, 64> external_address_1 = {};
+
+		int ip_length = test_ip.length ();
+
+		for (int i = 0; i < ip_length; i++)
+			external_address_1[i] = test_ip[i];
+
+		keepalive.peers[index] = nano::endpoint (boost::asio::ip::make_address_v6 (test_ip), port);
+		expectedString.append ("\n" + test_ip + ":" + std::to_string (port));
+	}
+
+	ASSERT_EQ (keepalive.to_string (), expectedString);
+}

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -144,7 +144,7 @@ nano::stat::detail nano::to_stat_detail (nano::message_type message_type)
 	return {};
 }
 
-std::string nano::message_header::to_string ()
+std::string nano::message_header::to_string () const
 {
 	// Cast to uint16_t to get integer value since uint8_t is treated as an unsigned char in string formatting.
 	uint16_t type_l = static_cast<uint16_t> (type);
@@ -710,6 +710,21 @@ bool nano::keepalive::deserialize (nano::stream & stream_a)
 bool nano::keepalive::operator== (nano::keepalive const & other_a) const
 {
 	return peers == other_a.peers;
+}
+
+std::string nano::keepalive::to_string () const
+{
+	std::stringstream stream;
+
+	stream << header.to_string ();
+
+	for (auto peer = peers.begin (); peer != peers.end (); ++peer)
+	{
+		stream << "\n"
+			   << peer->address ().to_string () + ":" + std::to_string (peer->port ());
+	}
+
+	return stream.str ();
 }
 
 /*

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -64,7 +64,7 @@ public:
 	uint8_t version_max;
 	uint8_t version_using;
 	uint8_t version_min;
-	std::string to_string ();
+	std::string to_string () const;
 
 public:
 	nano::message_type type;
@@ -160,6 +160,7 @@ public:
 	bool operator== (nano::keepalive const &) const;
 	std::array<nano::endpoint, 8> peers;
 	static std::size_t constexpr size = 8 * (16 + 2);
+	std::string to_string () const;
 };
 
 class publish final : public message


### PR DESCRIPTION
Adding "to_string" method to nano::keepalive

Re: #3960 