### PR TITLE
Add missing include file for std::atomic (required by slow_test)

### DIFF
--- a/nano/test_common/rate_observer.hpp
+++ b/nano/test_common/rate_observer.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/stats.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <string>
 #include <thread>


### PR DESCRIPTION
The `slow_test` may not build without the include header for std::atomic.
It is required for rate_observer class because it constructs an atomic object on 'std::atomic<bool> stopped{ false };'

Got an error for this when building on Ubuntu 22.04 with clang-14.