### PR TITLE
Fix: ledger bootstrap_weights size is reported as 0

### DIFF
--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1605,7 +1605,7 @@ nano::uncemented_info::uncemented_info (nano::block_hash const & cemented_fronti
 
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (ledger & ledger, std::string const & name)
 {
-	auto count = ledger.bootstrap_weights_size.load ();
+	auto count = ledger.bootstrap_weights.size ();
 	auto sizeof_element = sizeof (decltype (ledger.bootstrap_weights)::value_type);
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "bootstrap_weights", count, sizeof_element }));

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -77,7 +77,6 @@ public:
 	nano::ledger_cache cache;
 	nano::stat & stats;
 	std::unordered_map<nano::account, nano::uint128_t> bootstrap_weights;
-	std::atomic<size_t> bootstrap_weights_size{ 0 };
 	uint64_t bootstrap_weight_max_blocks{ 1 };
 	std::atomic<bool> check_bootstrap_weights;
 	bool pruning{ false };


### PR DESCRIPTION
This fixes a small bug where the container info for `bootstrap_weights` always reports a size of zero.