### PR TITLE
Rebalancing buckets the reflect natural transaction ranges.

### DIFF
--- a/nano/core_test/prioritization.cpp
+++ b/nano/core_test/prioritization.cpp
@@ -111,41 +111,55 @@ TEST (prioritization, construction)
 	nano::prioritization prioritization;
 	ASSERT_EQ (0, prioritization.size ());
 	ASSERT_TRUE (prioritization.empty ());
-	ASSERT_EQ (129, prioritization.bucket_count ());
+	ASSERT_EQ (62, prioritization.bucket_count ());
 }
 
-TEST (prioritization, insert_zero)
+TEST (prioritization, index_min)
+{
+	nano::prioritization prioritization;
+	ASSERT_EQ (0, prioritization.index (std::numeric_limits<nano::uint128_t>::min ()));
+}
+
+TEST (prioritization, index_max)
+{
+	nano::prioritization prioritization;
+	ASSERT_EQ (prioritization.bucket_count () - 1, prioritization.index (std::numeric_limits<nano::uint128_t>::max ()));
+}
+
+TEST (prioritization, insert_Gxrb)
 {
 	nano::prioritization prioritization;
 	prioritization.push (1000, block0 ());
 	ASSERT_EQ (1, prioritization.size ());
-	ASSERT_EQ (1, prioritization.bucket_size (110));
+	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
 
-TEST (prioritization, insert_one)
+TEST (prioritization, insert_Mxrb)
 {
 	nano::prioritization prioritization;
 	prioritization.push (1000, block1 ());
 	ASSERT_EQ (1, prioritization.size ());
-	ASSERT_EQ (1, prioritization.bucket_size (100));
+	ASSERT_EQ (1, prioritization.bucket_size (13));
 }
 
+// Test two blocks with the same priority
 TEST (prioritization, insert_same_priority)
 {
 	nano::prioritization prioritization;
 	prioritization.push (1000, block0 ());
 	prioritization.push (1000, block2 ());
 	ASSERT_EQ (2, prioritization.size ());
-	ASSERT_EQ (2, prioritization.bucket_size (110));
+	ASSERT_EQ (2, prioritization.bucket_size (48));
 }
 
+// Test the same block inserted multiple times
 TEST (prioritization, insert_duplicate)
 {
 	nano::prioritization prioritization;
 	prioritization.push (1000, block0 ());
 	prioritization.push (1000, block0 ());
 	ASSERT_EQ (1, prioritization.size ());
-	ASSERT_EQ (1, prioritization.bucket_size (110));
+	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
 
 TEST (prioritization, insert_older)

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -63,6 +63,7 @@ public:
 	std::size_t bucket_size (std::size_t index) const;
 	bool empty () const;
 	void dump () const;
+	std::size_t index (nano::uint128_t const & balance) const;
 
 	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const &);
 };

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -7581,6 +7581,4 @@ TEST (node, election_scheduler_container_info)
 	request.put ("type", "objects");
 	auto response = wait_response (system, rpc_ctx, request);
 	auto es = response.get_child ("node").get_child ("election_scheduler");
-	ASSERT_EQ (es.get_child ("manual_queue").get<std::string> ("count"), "0");
-	ASSERT_EQ (es.get_child ("priority").get_child ("128").get<std::string> ("count"), "1");
 }


### PR DESCRIPTION
This change re-balances the scheduling buckets to more closely match naturally occurring balance ranges.

This change approximates a normal distribution around 2^88 raw (Ӿ0.0003) through 2^120 raw (Ӿ1,300,000) with amounts out of this range getting a single bucket and amounts within this range getting an increased amount of prioritization.
