### PR TITLE
New bootstrap: track priority weights rather than backoff weights to reduce memory consumption.

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1547,7 +1547,7 @@ TEST (node, bootstrap_fork_open)
 
 	// the ascending bootstrap has no way to know about the account that was opened
 	// because the send0 block was force added to the ledger without going through te block processor
-	node1->ascendboot.prioritize (send0.destination (), 0.0f);
+	node1->ascendboot.priority_up (send0.destination ());
 
 	ASSERT_TIMELY (5s, !node1->ledger.block_or_pruned_exists (open1.hash ()) && node1->ledger.block_or_pruned_exists (open0.hash ()));
 }

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -1042,9 +1042,6 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 		case nano::stat::detail::prioritize:
 			res = "prioritize";
 			break;
-		case nano::stat::detail::prioritize_failed:
-			res = "prioritize_failed";
-			break;
 		case nano::stat::detail::block:
 			res = "block";
 			break;
@@ -1056,9 +1053,6 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 			break;
 		case nano::stat::detail::next_forwarding:
 			res = "next_forwarding";
-			break;
-		case nano::stat::detail::next_random:
-			res = "next_random";
 			break;
 	}
 	return res;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -459,12 +459,10 @@ public:
 
 		// bootstrap ascending accounts
 		prioritize,
-		prioritize_failed,
 		block,
 		unblock,
 		unblock_failed,
 		next_forwarding,
-		next_random,
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/nano/node/bootstrap/bootstrap_ascending.cpp
+++ b/nano/node/bootstrap/bootstrap_ascending.cpp
@@ -574,7 +574,7 @@ void nano::bootstrap::bootstrap_ascending::dump_stats ()
 bool nano::bootstrap::bootstrap_ascending::thread::wait_available_request ()
 {
 	nano::unique_lock<nano::mutex> lock{ bootstrap.mutex };
-	bootstrap.condition.wait (lock, [this] () { return bootstrap.stopped || requests < requests_max; });
+	bootstrap.condition.wait (lock, [this] () { return bootstrap.stopped || (requests < requests_max && !bootstrap.node.block_processor.half_full ()); });
 	bootstrap.debug_log (boost::str (boost::format ("wait_available_request stopped=%1% request=%2%") % bootstrap.stopped % requests));
 	return bootstrap.stopped;
 }

--- a/nano/node/bootstrap/bootstrap_ascending.cpp
+++ b/nano/node/bootstrap/bootstrap_ascending.cpp
@@ -155,7 +155,8 @@ void nano::bootstrap::bootstrap_ascending::account_sets::priority_down (nano::ac
 	auto iter = priorities.find (account);
 	if (iter != priorities.end ())
 	{
-		if (iter->second < 4.0f)
+		auto priority_new = iter->second / 2.0f;
+		if (priority_new < 2.0f)
 		{
 			priorities.erase (iter);
 		}
@@ -257,12 +258,12 @@ nano::account nano::bootstrap::bootstrap_ascending::account_sets::random ()
 			dump += std::to_string (weights[i]);
 			dump += "\n";
 		}
-	}
+	}*/
 	static int count = 0;
 	if (count++ % 10000 == 0)
 	{
 		this->dump ();
-	}*/
+	}
 	/*dump += "============\n";
 	for (auto i: priorities)
 	{

--- a/nano/node/bootstrap/bootstrap_ascending.hpp
+++ b/nano/node/bootstrap/bootstrap_ascending.hpp
@@ -110,7 +110,7 @@ namespace bootstrap
 			// Blocked accounts are assumed priority 0.0f
 			std::map<nano::account, float> priorities;
 
-			static size_t constexpr backoff_exclusion = 4;
+			static size_t constexpr backoff_exclusion = 2;
 			std::default_random_engine rng;
 
 		public:

--- a/nano/node/bootstrap/bootstrap_ascending.hpp
+++ b/nano/node/bootstrap/bootstrap_ascending.hpp
@@ -103,6 +103,7 @@ namespace bootstrap
 
 		public:
 			bool blocked (nano::account const & account) const;
+			size_t blocked_size () const;
 			float priority (nano::account const & account) const;
 			/**
 			 * Selects a random account from either:
@@ -148,7 +149,7 @@ namespace bootstrap
 			boost::multi_index::ordered_non_unique<boost::multi_index::tag<tag_priority>,
 			boost::multi_index::member<priority_t, float, &priority_t::priority>>>>
 			priorities;
-			static size_t const priorities_max = 65536;
+			static size_t const priorities_max = 1024 * 1024;
 
 			std::default_random_engine rng;
 
@@ -217,7 +218,7 @@ namespace bootstrap
 			std::weak_ptr<nano::node> node_weak;
 		};
 
-		bool blocked (nano::account const & account);
+		size_t blocked_size () const;
 		void inspect (nano::transaction const & tx, nano::process_return const & result, nano::block const & block);
 		void dump_stats ();
 
@@ -237,7 +238,6 @@ namespace bootstrap
 		std::atomic<int> requests_total{ 0 };
 		std::atomic<float> weights{ 0 };
 		std::atomic<int> forwarded{ 0 };
-		std::atomic<int> block_total{ 0 };
 	};
 }
 }

--- a/nano/node/bootstrap/bootstrap_ascending.hpp
+++ b/nano/node/bootstrap/bootstrap_ascending.hpp
@@ -104,11 +104,30 @@ namespace bootstrap
 			// An account is unblocked once it has a block successfully inserted.
 			// Maps "blocked account" -> ["blocked hash", "Priority count"]
 			std::map<nano::account, std::pair<nano::block_hash, float>> blocking;
+			class priority_t
+			{
+			public:
+				nano::account account;
+				float priority;
+			};
+			class tag_hash
+			{
+			};
+			class tag_priority
+			{
+			};
 			// Tracks the ongoing account priorities
 			// This only stores account priorities > 1.0f.
 			// Accounts in the ledger but not in this list are assumed priority 1.0f.
 			// Blocked accounts are assumed priority 0.0f
-			std::map<nano::account, float> priorities;
+			boost::multi_index_container<priority_t,
+			boost::multi_index::indexed_by<
+			boost::multi_index::ordered_unique<boost::multi_index::tag<tag_hash>,
+			boost::multi_index::member<priority_t, nano::account, &priority_t::account>>,
+			boost::multi_index::ordered_non_unique<boost::multi_index::tag<tag_priority>,
+			boost::multi_index::member<priority_t, float, &priority_t::priority>>>>
+			priorities;
+			static size_t const priorities_max = 65536;
 
 			static size_t constexpr backoff_exclusion = 2;
 			std::default_random_engine rng;

--- a/nano/node/bootstrap/bootstrap_ascending.hpp
+++ b/nano/node/bootstrap/bootstrap_ascending.hpp
@@ -192,7 +192,7 @@ namespace bootstrap
 		connection_pool pool;
 
 		static std::size_t constexpr parallelism = 1;
-		static std::size_t constexpr request_message_count = 1;
+		static std::size_t constexpr request_message_count = 128;
 
 		std::atomic<int> responses{ 0 };
 		std::atomic<int> requests_total{ 0 };

--- a/nano/node/bootstrap/bootstrap_ascending.hpp
+++ b/nano/node/bootstrap/bootstrap_ascending.hpp
@@ -96,8 +96,6 @@ namespace bootstrap
 		private:
 			nano::account random ();
 
-			// A forwarded account is an account that has recently had a new block inserted or has been a destination reference and therefore is a more likely candidate for furthur block retrieval
-			std::unordered_set<nano::account> forwarding;
 			// A blocked account is an account that has failed to insert a block because the source block is gapped.
 			// An account is unblocked once it has a block successfully inserted.
 			std::map<nano::account, nano::block_hash> blocking;
@@ -115,7 +113,7 @@ namespace bootstrap
 			std::vector<double> probability_transform (std::vector<decltype (backoff)::mapped_type> const & attempts) const;
 
 		public:
-			using backoff_info_t = std::tuple<decltype (forwarding), decltype (blocking), decltype (backoff)>; // <forwarding, blocking, backoff>
+			using backoff_info_t = std::tuple<decltype (blocking), decltype (backoff)>; // <blocking, backoff>
 
 			backoff_info_t backoff_info () const;
 		};

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5261,8 +5261,9 @@ void nano::json_handler::backoff_info ()
 			// blocking
 			{
 				boost::property_tree::ptree response_blocking;
-				for (auto const & [account, dependency] : blocking)
+				for (auto const & [account, data] : blocking)
 				{
+					auto const & [dependency, count] = data;
 					response_blocking.put (account.to_account (), dependency.to_string ());
 				}
 				response_l.add_child ("blocking", response_blocking);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5247,7 +5247,7 @@ void nano::json_handler::backoff_info ()
 		auto ascending = node.bootstrap_initiator.current_ascending_attempt ();
 		if (ascending)
 		{
-			auto [forwarding, blocking, backoffs] = ascending->backoff_info ();
+			auto [blocking, backoffs] = ascending->backoff_info ();
 
 			// backoff
 			{
@@ -5257,17 +5257,6 @@ void nano::json_handler::backoff_info ()
 					response_backoffs.put (account.to_account (), backoff);
 				}
 				response_l.add_child ("backoff", response_backoffs);
-			}
-			// forwarding
-			{
-				boost::property_tree::ptree response_forwarding;
-				for (auto const & account : forwarding)
-				{
-					boost::property_tree::ptree entry;
-					entry.put ("", account.to_account ());
-					response_forwarding.push_back (std::make_pair ("", entry));
-				}
-				response_l.add_child ("forwarding", response_forwarding);
 			}
 			// blocking
 			{

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -60,6 +60,7 @@ TEST (bootstrap_ascending, profile)
 	config_client.disable_wallet_bootstrap = true;
 	config_client.disable_legacy_bootstrap = true;
 	config_client.ipc_config.transport_tcp.enabled = true;
+	config_client.lmdb_config.sync = nano::lmdb_config::sync_strategy::nosync_unsafe;
 	nano::node_flags flags_client;
 	flags_client.disable_add_initial_peers = true;
 	auto client = system.add_node (config_client, flags_client);
@@ -82,6 +83,7 @@ TEST (bootstrap_ascending, profile)
 	nano::test::rate_observer rate;
 	rate.observe ("count", [&] () { return client->ledger.cache.block_count.load (); });
 	rate.observe ("unchecked", [&] () { return client->unchecked.count (); });
+	rate.observe ("block_processor", [&] () { return client->block_processor.size (); });
 	rate.background_print (3s);
 
 	while (true)

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -84,6 +84,8 @@ TEST (bootstrap_ascending, profile)
 	rate.observe ("unchecked", [&] () { return client->unchecked.count (); });
 	rate.background_print (3s);
 
+	while (true)
+		std::this_thread::sleep_for (1s);
 	wait_for_key ();
 
 	server->stop ();


### PR DESCRIPTION
The purpose of this is to fix memory/space consumption of tracked weights. Accounts implicitly have the lowest priority if they're not stored in memory which gives the greatest memory reduction.