### PR TITLE
Immediately remove confirmed elections from AEC

### DIFF
--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -201,7 +201,7 @@ public:
 		default_rpc_port (45000),
 		default_ipc_port (46000),
 		default_websocket_port (47000),
-		request_interval_ms (500),
+		request_interval_ms (300), // Update AEC ~3 times per second
 		cleanup_period (default_cleanup_period),
 		keepalive_period (std::chrono::seconds (15)),
 		idle_timeout (default_cleanup_period * 2),

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -201,7 +201,7 @@ public:
 		default_rpc_port (45000),
 		default_ipc_port (46000),
 		default_websocket_port (47000),
-		request_interval_ms (300), // Update AEC ~3 times per second
+		aec_loop_interval_ms (300), // Update AEC ~3 times per second
 		cleanup_period (default_cleanup_period),
 		keepalive_period (std::chrono::seconds (15)),
 		idle_timeout (default_cleanup_period * 2),
@@ -236,7 +236,7 @@ public:
 		}
 		else if (is_dev_network ())
 		{
-			request_interval_ms = 20;
+			aec_loop_interval_ms = 20;
 			cleanup_period = std::chrono::seconds (1);
 			keepalive_period = std::chrono::seconds (1);
 			idle_timeout = cleanup_period * 15;
@@ -258,7 +258,7 @@ public:
 	uint16_t default_rpc_port;
 	uint16_t default_ipc_port;
 	uint16_t default_websocket_port;
-	unsigned request_interval_ms;
+	unsigned aec_loop_interval_ms;
 
 	std::chrono::seconds cleanup_period;
 	std::chrono::milliseconds cleanup_period_half () const

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -343,8 +343,8 @@ void nano::active_transactions::request_loop ()
 
 		if (!stopped)
 		{
-			auto const min_sleep_l = std::chrono::milliseconds (node.network_params.network.request_interval_ms / 2);
-			auto const wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.request_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
+			auto const min_sleep_l = std::chrono::milliseconds (node.network_params.network.aec_loop_interval_ms / 2);
+			auto const wakeup_l = std::max (stamp_l + std::chrono::milliseconds (node.network_params.network.aec_loop_interval_ms), std::chrono::steady_clock::now () + min_sleep_l);
 			condition.wait_until (lock, wakeup_l, [&wakeup_l, &stopped = stopped] { return stopped || std::chrono::steady_clock::now () >= wakeup_l; });
 		}
 	}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -184,11 +184,8 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			send_confirm_req (solicitor_a);
 			break;
 		case nano::election::state_t::confirmed:
-			if (base_latency () * confirmed_duration_factor < std::chrono::steady_clock::now ().time_since_epoch () - state_start.load ())
-			{
-				result = true;
-				state_change (nano::election::state_t::confirmed, nano::election::state_t::expired_confirmed);
-			}
+			result = true; // Return true to indicate this election should be cleaned up
+			state_change (nano::election::state_t::confirmed, nano::election::state_t::expired_confirmed);
 			break;
 		case nano::election::state_t::expired_unconfirmed:
 		case nano::election::state_t::expired_confirmed:
@@ -203,7 +200,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 		// state_change returning true would indicate it
 		if (!state_change (state_m.load (), nano::election::state_t::expired_unconfirmed))
 		{
-			result = true;
+			result = true; // Return true to indicate this election should be cleaned up
 			if (node.config.logging.election_expiration_tally_logging ())
 			{
 				log_votes (tally_impl (), "Election expired: ");

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -77,7 +77,6 @@ private: // State management
 	};
 	static unsigned constexpr passive_duration_factor = 5;
 	static unsigned constexpr active_request_count_min = 2;
-	static unsigned constexpr confirmed_duration_factor = 5;
 	std::atomic<nano::election::state_t> state_m = { state_t::passive };
 
 	static_assert (std::is_trivial<std::chrono::steady_clock::duration> ());


### PR DESCRIPTION
This is a small, but important PR that showed great improvements in CPS during testing. Full credit for discovering and finding the underlying problem goes to @gr0vity-dev Huge thanks for constantly trying to break the node in a myriad of ways!

The problem we had before was that when an election was confirmed, there was still a 5 second timeout before it got evicted from active election container. This effectively limited our CPS to 1/5 of the AEC size, even when the underlying resources allowed for much more than that.

Initially it was probably meant for easier analysis (polling) of votes going into elections, however we already have websocket topics better suited for that purpose.

