### PR TITLE
Continuous vote generation for active elections

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -628,7 +628,7 @@ TEST (active_transactions, dropped_cleanup)
 
 	// Not yet removed
 	ASSERT_TRUE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
-	ASSERT_TRUE (node.active.active(nano::dev::genesis->hash ()));
+	ASSERT_TRUE (node.active.active (nano::dev::genesis->hash ()));
 
 	// Now simulate dropping the election
 	ASSERT_FALSE (election->confirmed ());

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -628,7 +628,7 @@ TEST (active_transactions, dropped_cleanup)
 
 	// Not yet removed
 	ASSERT_TRUE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
-	ASSERT_EQ (1, node.active.blocks.count (nano::dev::genesis->hash ()));
+	ASSERT_TRUE (node.active.active(nano::dev::genesis->hash ()));
 
 	// Now simulate dropping the election
 	ASSERT_FALSE (election->confirmed ());
@@ -641,7 +641,7 @@ TEST (active_transactions, dropped_cleanup)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_all));
 
 	// Block cleared from active
-	ASSERT_EQ (0, node.active.blocks.count (nano::dev::genesis->hash ()));
+	ASSERT_FALSE (node.active.active (nano::dev::genesis->hash ()));
 
 	// Repeat test for a confirmed election
 	ASSERT_TRUE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
@@ -660,7 +660,7 @@ TEST (active_transactions, dropped_cleanup)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_all));
 
 	// Block cleared from active
-	ASSERT_EQ (0, node.active.blocks.count (nano::dev::genesis->hash ()));
+	ASSERT_FALSE (node.active.active (nano::dev::genesis->hash ()));
 }
 
 TEST (active_transactions, republish_winner)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -933,6 +933,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	// Processing chain to prune for node1
 	config.peering_port = nano::test::get_available_port ();
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
+	node1->start ();
 	node1->process_active (send1);
 	node1->process_active (receive1);
 	node1->process_active (change1);

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1561,10 +1561,7 @@ TEST (confirmation_height, callback_confirmed_history)
 			election->force_confirm ();
 			ASSERT_TIMELY (10s, node->active.size () == 0);
 			ASSERT_EQ (0, node->active.recently_cemented.list ().size ());
-			{
-				nano::lock_guard<nano::mutex> guard (node->active.mutex);
-				ASSERT_EQ (0, node->active.blocks.size ());
-			}
+			ASSERT_TRUE (node->active.empty ());
 
 			auto transaction = node->store.tx_begin_read ();
 			ASSERT_FALSE (node->ledger.block_confirmed (transaction, send->hash ()));
@@ -1584,7 +1581,7 @@ TEST (confirmation_height, callback_confirmed_history)
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out) == 1);
 
 		ASSERT_EQ (1, node->active.recently_cemented.list ().size ());
-		ASSERT_EQ (0, node->active.blocks.size ());
+		ASSERT_TRUE (node->active.empty ());
 
 		// Confirm the callback is not called under this circumstance
 		ASSERT_EQ (2, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -455,11 +455,8 @@ TEST (node, search_receivable_confirmed)
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
 	{
-		nano::lock_guard<nano::mutex> guard (node->active.mutex);
-		auto existing1 (node->active.blocks.find (send1->hash ()));
-		ASSERT_EQ (node->active.blocks.end (), existing1);
-		auto existing2 (node->active.blocks.find (send2->hash ()));
-		ASSERT_EQ (node->active.blocks.end (), existing2);
+		ASSERT_FALSE (node->active.active (send1->hash ()));
+		ASSERT_FALSE (node->active.active (send2->hash ()));
 	}
 	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
 }
@@ -3907,11 +3904,10 @@ TEST (node, dependency_graph)
 	ASSERT_NO_ERROR (system.poll_until_true (15s, [&] {
 		// Not many blocks should be active simultaneously
 		EXPECT_LT (node.active.size (), 6);
-		nano::lock_guard<nano::mutex> guard (node.active.mutex);
 
 		// Ensure that active blocks have their ancestors confirmed
 		auto error = std::any_of (dependency_graph.cbegin (), dependency_graph.cend (), [&] (auto entry) {
-			if (node.active.blocks.count (entry.first))
+			if (node.active.active (entry.first))
 			{
 				for (auto ancestor : entry.second)
 				{

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -103,22 +103,6 @@ TEST (vote_generator, multiple_representatives)
 	}
 }
 
-TEST (vote_generator, session)
-{
-	nano::test::system system (1);
-	auto node (system.nodes[0]);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::vote_generator_session generator_session (node->generator);
-	boost::thread thread ([node, &generator_session] () {
-		nano::thread_role::set (nano::thread_role::name::request_loop);
-		generator_session.add (nano::dev::genesis->account (), nano::dev::genesis->hash ());
-		ASSERT_EQ (0, node->stats.count (nano::stat::type::vote, nano::stat::detail::vote_indeterminate));
-		generator_session.flush ();
-	});
-	thread.join ();
-	ASSERT_TIMELY (2s, 1 == node->stats.count (nano::stat::type::vote, nano::stat::detail::vote_indeterminate));
-}
-
 TEST (vote_spacing, basic)
 {
 	nano::vote_spacing spacing{ std::chrono::milliseconds{ 100 } };

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -211,7 +211,8 @@ public:
 		max_peers_per_ip (default_max_peers_per_ip),
 		max_peers_per_subnetwork (default_max_peers_per_ip * 4),
 		ipv6_subnetwork_prefix_for_limiting (64), // Equivalent to network prefix /64.
-		peer_dump_interval (std::chrono::seconds (5 * 60))
+		peer_dump_interval (std::chrono::seconds (5 * 60)),
+		vote_broadcast_interval (1000)
 	{
 		if (is_live_network ())
 		{
@@ -243,6 +244,7 @@ public:
 			max_peers_per_ip = 20;
 			max_peers_per_subnetwork = max_peers_per_ip * 4;
 			peer_dump_interval = std::chrono::seconds (1);
+			vote_broadcast_interval = 100;
 		}
 	}
 
@@ -282,6 +284,10 @@ public:
 	size_t max_peers_per_subnetwork;
 	size_t ipv6_subnetwork_prefix_for_limiting;
 	std::chrono::seconds peer_dump_interval;
+	/** Time to wait before vote rebroadcasts for active elections, this is doubled for each broadcast, up to `max_vote_broadcast_interval` (milliseconds) */
+	uint64_t vote_broadcast_interval;
+	/** Maximum interval for vote broadcasts for active elections (milliseconds) */
+	static uint64_t constexpr max_vote_broadcast_interval{ 16 * 1000 };
 
 	/** Returns the network this object contains values for */
 	nano::networks network () const

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -554,11 +554,8 @@ std::string nano::stat::type_to_string (stat::type type)
 		case nano::stat::type::bootstrap_server:
 			res = "bootstrap_server";
 			break;
-		case nano::stat::type::bootstrap_server_requests:
-			res = "bootstrap_server_requests";
-			break;
-		case nano::stat::type::bootstrap_server_responses:
-			res = "bootstrap_server_responses";
+		case nano::stat::type::active:
+			res = "active";
 			break;
 	}
 	return res;
@@ -571,6 +568,9 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 	{
 		case nano::stat::detail::all:
 			res = "all";
+			break;
+		case nano::stat::detail::loop:
+			res = "loop";
 			break;
 		case nano::stat::detail::queue:
 			res = "queue";
@@ -822,6 +822,15 @@ std::string nano::stat::detail_to_string (stat::detail detail)
 			break;
 		case nano::stat::detail::election_hinted_drop:
 			res = "election_hinted_drop";
+			break;
+		case nano::stat::detail::generate_vote:
+			res = "generate_vote";
+			break;
+		case nano::stat::detail::generate_vote_normal:
+			res = "generate_vote_normal";
+			break;
+		case nano::stat::detail::generate_vote_final:
+			res = "generate_vote_final";
 			break;
 		case nano::stat::detail::blocking:
 			res = "blocking";

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -248,14 +248,16 @@ public:
 		hinting,
 		blockprocessor,
 		bootstrap_server,
-		bootstrap_server_requests,
-		bootstrap_server_responses,
+		active,
 	};
 
 	/** Optional detail type */
 	enum class detail : uint8_t
 	{
 		all = 0,
+
+		// common
+		loop,
 
 		// processing queue
 		queue,
@@ -358,6 +360,9 @@ public:
 		election_hinted_started,
 		election_hinted_confirmed,
 		election_hinted_drop,
+		generate_vote,
+		generate_vote_normal,
+		generate_vote_final,
 
 		// udp
 		blocking,

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -215,8 +215,6 @@ void nano::active_transactions::request_confirm (nano::unique_lock<nano::mutex> 
 
 	nano::confirmation_solicitor solicitor (node.network, node.config);
 	solicitor.prepare (node.rep_crawler.principal_representatives (std::numeric_limits<std::size_t>::max ()));
-	nano::vote_generator_session generator_session (node.generator);
-	nano::vote_generator_session final_generator_session (node.final_generator);
 
 	std::size_t unconfirmed_count_l (0);
 	nano::timer<std::chrono::milliseconds> elapsed (nano::timer_state::started);
@@ -245,8 +243,6 @@ void nano::active_transactions::request_confirm (nano::unique_lock<nano::mutex> 
 	}
 
 	solicitor.flush ();
-	generator_session.flush ();
-	final_generator_session.flush ();
 	lock_a.lock ();
 
 	if (node.config.logging.timing_logging ())

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -339,6 +339,8 @@ void nano::active_transactions::request_loop ()
 	{
 		auto const stamp_l = std::chrono::steady_clock::now ();
 
+		node.stats.inc (nano::stat::type::active, nano::stat::detail::loop);
+
 		request_confirm (lock);
 		debug_assert (lock.owns_lock ());
 
@@ -402,7 +404,7 @@ nano::election_insertion_result nano::active_transactions::insert_impl (nano::un
 		// Votes are generated for inserted or ongoing elections
 		if (result.election)
 		{
-			result.election->generate_votes ();
+			result.election->broadcast_vote ();
 		}
 	}
 	return result;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -111,10 +111,13 @@ public:
 	bool inserted{ false };
 };
 
-// Core class for determining consensus
-// Holds all active blocks i.e. recently added blocks that need confirmation
+/**
+ * Core class for determining consensus
+ * Holds all active blocks i.e. recently added blocks that need confirmation
+ */
 class active_transactions final
 {
+private: // Elections
 	class conflict_info final
 	{
 	public:
@@ -131,10 +134,7 @@ class active_transactions final
 	class tag_uncemented {};
 	class tag_arrival {};
 	class tag_hash {};
-	// clang-format on
 
-public:
-	// clang-format off
 	using ordered_roots = boost::multi_index_container<conflict_info,
 	mi::indexed_by<
 		mi::sequenced<mi::tag<tag_sequenced>>,
@@ -143,11 +143,16 @@ public:
 	>>;
 	// clang-format on
 	ordered_roots roots;
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
 
+public:
 	explicit active_transactions (nano::node &, nano::confirmation_height_processor &);
 	~active_transactions ();
 
-	/*
+	void start ();
+	void stop ();
+
+	/**
 	 * Starts new election with hinted behavior type
 	 * Hinted elections have shorter timespan and only can take up limited space inside active elections container
 	 */
@@ -155,12 +160,12 @@ public:
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
 	nano::vote_code vote (std::shared_ptr<nano::vote> const &);
 	// Is the root of this block in the roots container
-	bool active (nano::block const &);
-	bool active (nano::qualified_root const &);
-	/*
+	bool active (nano::block const &) const;
+	bool active (nano::qualified_root const &) const;
+	/**
 	 * Is the block hash present in any active election
 	 */
-	bool active (nano::block_hash const &);
+	bool active (nano::block_hash const &) const;
 	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
 	std::shared_ptr<nano::block> winner (nano::block_hash const &) const;
 	// Returns a list of elections sorted by difficulty
@@ -168,49 +173,35 @@ public:
 	void erase (nano::block const &);
 	void erase_hash (nano::block_hash const &);
 	void erase_oldest ();
-	bool empty ();
-	std::size_t size ();
-	void stop ();
+	bool empty () const;
+	std::size_t size () const;
 	bool publish (std::shared_ptr<nano::block> const &);
 	boost::optional<nano::election_status_type> confirm_block (nano::transaction const &, std::shared_ptr<nano::block> const &);
 	void block_cemented_callback (std::shared_ptr<nano::block> const &);
 	void block_already_cemented_callback (nano::block_hash const &);
 
-	/*
+	/**
 	 * Maximum number of all elections that should be present in this container.
 	 * This is only a soft limit, it is possible for this container to exceed this count.
 	 */
 	int64_t limit () const;
-	/*
+	/**
 	 * Maximum number of hinted elections that should be present in this container.
 	 */
 	int64_t hinted_limit () const;
 	int64_t vacancy () const;
-	/*
+	/**
 	 * How many election slots are available for hinted elections.
 	 * The limit of AEC taken up by hinted elections is controlled by `node_config::active_elections_hinted_limit_percentage`
 	 */
 	int64_t vacancy_hinted () const;
 	std::function<void ()> vacancy_update{ [] () {} };
 
-	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
-
-	nano::election_scheduler & scheduler;
-	nano::confirmation_height_processor & confirmation_height_processor;
-	nano::node & node;
-	mutable nano::mutex mutex{ mutex_identifier (mutexes::active) };
 	std::size_t election_winner_details_size ();
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
 	void remove_election_winner_details (nano::block_hash const &);
 
-	recently_confirmed_cache recently_confirmed;
-	recently_cemented_cache recently_cemented;
-
 private:
-	nano::mutex election_winner_details_mutex{ mutex_identifier (mutexes::election_winner_details) };
-
-	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> election_winner_details;
-
 	// Call action with confirmed block, may be different than what we started with
 	nano::election_insertion_result insert_impl (nano::unique_lock<nano::mutex> &, std::shared_ptr<nano::block> const &, nano::election_behavior = nano::election_behavior::normal, std::function<void (std::shared_ptr<nano::block> const &)> const & = nullptr);
 	void request_loop ();
@@ -220,23 +211,37 @@ private:
 	void cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
 	// Returns a list of elections sorted by difficulty, mutex must be locked
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
-
-	/*
+	/**
 	 * Checks if vote passes minimum representative weight threshold and adds it to inactive vote cache
 	 * TODO: Should be moved to `vote_cache` class
 	 */
-	void add_inactive_vote_cache (nano::block_hash const & hash, std::shared_ptr<nano::vote> const vote);
+	void add_inactive_vote_cache (nano::block_hash const & hash, std::shared_ptr<nano::vote> vote);
 
-	nano::condition_variable condition;
-	bool started{ false };
-	std::atomic<bool> stopped{ false };
+private: // Dependencies
+	nano::election_scheduler & scheduler;
+	nano::confirmation_height_processor & confirmation_height_processor;
+	nano::node & node;
+
+public:
+	recently_confirmed_cache recently_confirmed;
+	recently_cemented_cache recently_cemented;
+
+	// TODO: This mutex is currently public because many tests access it
+	// TODO: This is bad. Remove the need to explicitly lock this from any code outside of this class
+	mutable nano::mutex mutex{ mutex_identifier (mutexes::active) };
+
+private:
+	nano::mutex election_winner_details_mutex{ mutex_identifier (mutexes::election_winner_details) };
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> election_winner_details;
 
 	// Maximum time an election can be kept active if it is extending the container
 	std::chrono::seconds const election_time_to_live;
 
 	int active_hinted_elections_count{ 0 };
 
-	boost::thread thread;
+	nano::condition_variable condition;
+	std::atomic<bool> stopped{ false };
+	std::thread thread;
 
 	friend class election;
 	friend class election_scheduler;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -21,8 +21,8 @@ nano::election_vote_result::election_vote_result (bool replay_a, bool processed_
 nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> const & block_a, std::function<void (std::shared_ptr<nano::block> const &)> const & confirmation_action_a, std::function<void (nano::account const &)> const & live_vote_action_a, nano::election_behavior election_behavior_a) :
 	confirmation_action (confirmation_action_a),
 	live_vote_action (live_vote_action_a),
-	behavior (election_behavior_a),
 	node (node_a),
+	behavior (election_behavior_a),
 	status ({ block_a, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
 	height (block_a->sideband ().height),
 	root (block_a->root ()),

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -167,10 +167,11 @@ void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a
 void nano::election::broadcast_vote ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	if (last_vote + std::chrono::seconds (vote_generation_interval) < std::chrono::steady_clock::now ())
+	if (last_vote + std::chrono::milliseconds (vote_broadcast_interval) < std::chrono::steady_clock::now ())
 	{
 		broadcast_vote_impl ();
 		last_vote = std::chrono::steady_clock::now ();
+		vote_broadcast_interval = std::min (vote_broadcast_interval * 2, max_vote_broadcast_interval);
 	}
 }
 

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -166,12 +166,16 @@ private:
 	nano::election_behavior const behavior{ nano::election_behavior::normal };
 	std::chrono::steady_clock::time_point const election_start = { std::chrono::steady_clock::now () };
 
+	/** Time to wait before next vote broadcast for current winner, starts at 1s and doubles for each broadcast, up to `max_vote_broadcast_interval` */
+	uint64_t vote_broadcast_interval{ 1000 };
+
 	nano::node & node;
 	mutable nano::mutex mutex;
 
+private: // Constants
 	static std::size_t constexpr max_blocks{ 10 };
-	/** How often to generate and broadcasts votes for active elections (seconds) */
-	static std::size_t constexpr vote_generation_interval{ 15 };
+	/** Maximum interval for vote broadcast (milliseconds) */
+	static uint64_t constexpr max_vote_broadcast_interval{ 16 * 1000 };
 
 	friend class active_transactions;
 	friend class confirmation_solicitor;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -169,15 +169,13 @@ private:
 	nano::election_behavior const behavior{ nano::election_behavior::normal };
 	std::chrono::steady_clock::time_point const election_start = { std::chrono::steady_clock::now () };
 
-	/** Time to wait before next vote broadcast for current winner, starts at 1s and doubles for each broadcast, up to `max_vote_broadcast_interval` */
-	uint64_t vote_broadcast_interval{ 1000 };
+	/** Time to wait before next vote broadcast for current winner, doubles for each broadcast, up to `max_vote_broadcast_interval` */
+	uint64_t vote_broadcast_interval;
 
 	mutable nano::mutex mutex;
 
 private: // Constants
 	static std::size_t constexpr max_blocks{ 10 };
-	/** Maximum interval for vote broadcast (milliseconds) */
-	static uint64_t constexpr max_vote_broadcast_interval{ 16 * 1000 };
 
 	friend class active_transactions;
 	friend class confirmation_solicitor;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -23,6 +23,7 @@ public:
 	uint64_t timestamp;
 	nano::block_hash hash;
 };
+
 class vote_with_weight_info final
 {
 public:
@@ -32,6 +33,7 @@ public:
 	nano::block_hash hash;
 	nano::uint128_t weight;
 };
+
 class election_vote_result final
 {
 public:
@@ -40,17 +42,20 @@ public:
 	bool replay{ false };
 	bool processed{ false };
 };
+
 enum class election_behavior
 {
 	normal,
 	hinted
 };
+
 struct election_extended_status final
 {
 	nano::election_status status;
 	std::unordered_map<nano::account, nano::vote_info> votes;
 	nano::tally_t tally;
 };
+
 class election final : public std::enable_shared_from_this<nano::election>
 {
 public:

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -130,6 +130,9 @@ public: // Interface
 	 */
 	void broadcast_vote ();
 
+private: // Dependencies
+	nano::node & node;
+
 public: // Information
 	uint64_t const height;
 	nano::root const root;
@@ -169,7 +172,6 @@ private:
 	/** Time to wait before next vote broadcast for current winner, starts at 1s and doubles for each broadcast, up to `max_vote_broadcast_interval` */
 	uint64_t vote_broadcast_interval{ 1000 };
 
-	nano::node & node;
 	mutable nano::mutex mutex;
 
 private: // Constants

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -15,7 +15,7 @@ class channel;
 class confirmation_solicitor;
 class inactive_cache_information;
 class node;
-class vote_generator_session;
+
 class vote_info final
 {
 public:

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -765,6 +765,7 @@ void nano::node::start ()
 		port_mapping.start ();
 	}
 	wallets.start ();
+	active.start();
 	generator.start ();
 	final_generator.start ();
 	backlog.start ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -765,7 +765,7 @@ void nano::node::start ()
 		port_mapping.start ();
 	}
 	wallets.start ();
-	active.start();
+	active.start ();
 	generator.start ();
 	final_generator.start ();
 	backlog.start ();

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -444,26 +444,6 @@ void nano::vote_generator::run ()
 	}
 }
 
-nano::vote_generator_session::vote_generator_session (nano::vote_generator & vote_generator_a) :
-	generator (vote_generator_a)
-{
-}
-
-void nano::vote_generator_session::add (nano::root const & root_a, nano::block_hash const & hash_a)
-{
-	debug_assert (nano::thread_role::get () == nano::thread_role::name::request_loop);
-	items.emplace_back (root_a, hash_a);
-}
-
-void nano::vote_generator_session::flush ()
-{
-	debug_assert (nano::thread_role::get () == nano::thread_role::name::request_loop);
-	for (auto const & [root, hash] : items)
-	{
-		generator.add (root, hash);
-	}
-}
-
 std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::vote_generator & vote_generator, std::string const & name)
 {
 	std::size_t candidates_count = 0;

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -177,16 +177,4 @@ private:
 };
 
 std::unique_ptr<container_info_component> collect_container_info (vote_generator & generator, std::string const & name);
-
-class vote_generator_session final
-{
-public:
-	explicit vote_generator_session (vote_generator & vote_generator_a);
-	void add (nano::root const &, nano::block_hash const &);
-	void flush ();
-
-private:
-	nano::vote_generator & generator;
-	std::vector<std::pair<nano::root, nano::block_hash>> items;
-};
 }


### PR DESCRIPTION
There was a regression introduced in https://github.com/nanocurrency/nano-node/pull/3280 that removed the use of generator session inside AEC request loop. That meant elections only generated votes either when they started or when they reached quorum and broadcasted final vote. If the election was stuck inside AEC for longer without reaching quorum, it never generated more votes.

This PR fixes that by making active elections broadcast votes in exponentially increasing intervals, first vote appears immediately after election becomes active (like before), next one is generated with 1 second delay, and subsequent broadcasts double the delay, for the maximum delay of 16 seconds. During testing that showed much better results than using a fixed interval.

I decided to remove the generator sessions altogether, because buffering is already provided by vote generators themselves thanks to an earlier PR (https://github.com/nanocurrency/nano-node/pull/3963), plus the implementation of generator session wasn't doing the buffering properly in the first place.

As usual, @gr0vity-dev was instrumental in testing this and providing valuable feedback