### PR TITLE
Update qt.cpp to match block_count RPC & fix bug with pruned display

### DIFF
--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -957,7 +957,7 @@ std::string nano_qt::status::text ()
 	}
 
 	result += ", Blocks: ";
-	count_string += ", Queued: " + std::to_string (unchecked);
+	count_string += ", Unchecked: " + std::to_string (unchecked);
 	count_string += ", Cemented: " + std::to_string (cemented);
 
 	if (wallet.node.flags.enable_pruning)

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -957,15 +957,8 @@ std::string nano_qt::status::text ()
 	}
 
 	result += ", Blocks: ";
-	if (unchecked != 0 && wallet.node.bootstrap_initiator.in_progress ())
-	{
-		count_string += ", Queued: " + std::to_string (unchecked);
-	}
-	
-	if (cemented != 0)
-	{
-		count_string += ", Cemented: " + std::to_string (cemented);
-	}
+	count_string += ", Queued: " + std::to_string (unchecked);
+	count_string += ", Cemented: " + std::to_string (cemented);
 
 	if (wallet.node.flags.enable_pruning)
 	{

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -961,11 +961,16 @@ std::string nano_qt::status::text ()
 	{
 		count_string += ", Queued: " + std::to_string (unchecked);
 	}
+	
+	if (cemented != 0)
+	{
+		count_string += ", Cemented: " + std::to_string (cemented);
+	}
 
 	if (wallet.node.flags.enable_pruning)
 	{
-		count_string += "Full: " + std::to_string (wallet.wallet_m->wallets.node.ledger.cache.block_count - wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
-		count_string += ", Pruned: ", std::to_string (wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
+		count_string += ", Full: " + std::to_string (wallet.wallet_m->wallets.node.ledger.cache.block_count - wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
+		count_string += ", Pruned: " + std::to_string (wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
 	}
 
 	result += count_string.c_str ();

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -272,7 +272,7 @@ TEST (wallet, enter_password)
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
-	ASSERT_EQ ("Status: Wallet password empty, Blocks: 1", wallet->status->text ().toStdString ());
+	ASSERT_NE (wallet->status->text ().toStdString ().rfind("Status: Wallet password empty", 0), std::string::npos);
 	{
 		auto transaction (system.nodes[0]->wallets.tx_begin_write ());
 		ASSERT_FALSE (system.wallet (0)->store.rekey (transaction, "abc"));
@@ -280,12 +280,12 @@ TEST (wallet, enter_password)
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
-	ASSERT_EQ ("Status: Wallet locked, Blocks: 1", wallet->status->text ().toStdString ());
+	ASSERT_NE (wallet->status->text ().toStdString ().rfind("Status: Wallet locked", 0), std::string::npos);
 	wallet->settings.new_password->setText ("");
 	QTest::keyClicks (wallet->settings.password, "abc");
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
-	ASSERT_EQ ("Status: Running, Blocks: 1", wallet->status->text ().toStdString ());
+	ASSERT_NE (wallet->status->text ().toStdString ().rfind("Status: Running", 0), std::string::npos);
 	ASSERT_EQ ("", wallet->settings.password->text ());
 }
 

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -272,7 +272,7 @@ TEST (wallet, enter_password)
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
-	ASSERT_NE (wallet->status->text ().toStdString ().rfind("Status: Wallet password empty", 0), std::string::npos);
+	ASSERT_NE (wallet->status->text ().toStdString ().rfind ("Status: Wallet password empty", 0), std::string::npos);
 	{
 		auto transaction (system.nodes[0]->wallets.tx_begin_write ());
 		ASSERT_FALSE (system.wallet (0)->store.rekey (transaction, "abc"));
@@ -280,12 +280,12 @@ TEST (wallet, enter_password)
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
-	ASSERT_NE (wallet->status->text ().toStdString ().rfind("Status: Wallet locked", 0), std::string::npos);
+	ASSERT_NE (wallet->status->text ().toStdString ().rfind ("Status: Wallet locked", 0), std::string::npos);
 	wallet->settings.new_password->setText ("");
 	QTest::keyClicks (wallet->settings.password, "abc");
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
-	ASSERT_NE (wallet->status->text ().toStdString ().rfind("Status: Running", 0), std::string::npos);
+	ASSERT_NE (wallet->status->text ().toStdString ().rfind ("Status: Running", 0), std::string::npos);
 	ASSERT_EQ ("", wallet->settings.password->text ());
 }
 


### PR DESCRIPTION
Currently the QT wallet 1) does not show cemented count, 2) has "Full" directly appended to the unchecked count (no comma or space), and 3) the "Pruned" count is always empty (due to a minor concatenation bug). This change fixes that.

Here is a screenshot of the current situation, where "Cemented" is missing and the "Pruned" count does not display correctly:

![image](https://user-images.githubusercontent.com/3682613/202211085-9a1eab6f-dfce-4315-b22a-0d483dac9658.png)
