### PR TITLE
Fix the compiler name set for docker build on install_deps.sh

### DIFF
--- a/ci/actions/linux/install_deps.sh
+++ b/ci/actions/linux/install_deps.sh
@@ -9,7 +9,7 @@ sudo mkdir -p /etc/docker && echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64
 
 ci/build-docker-image.sh docker/ci/Dockerfile-base nanocurrency/nano-env:base
 if [[ "${COMPILER:-}" != "" ]]; then
-    ci/build-docker-image.sh docker/ci/Dockerfile-gcc nanocurrency/nano-env:${COMPILER}
+    ci/build-docker-image.sh docker/ci/Dockerfile-${COMPILER} nanocurrency/nano-env:${COMPILER}
 else
     ci/build-docker-image.sh docker/ci/Dockerfile-gcc nanocurrency/nano-env:gcc
     ci/build-docker-image.sh docker/ci/Dockerfile-clang nanocurrency/nano-env:clang


### PR DESCRIPTION
The old script version could have a misbehavior when called from GitHub workflows where the `matrix.COMPILER` can also select clang. The `Dockerfile-gcc` was read to build `nanocurrency/nano-env:clang-6` docker container. This was affecting only the Unit Tests workflow, but now this change will be required also by the Code Sanitizers workflow.