### PR TITLE
Add GitHub workflow for Google Code Sanitizers

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -1,0 +1,74 @@
+name: Code Sanitizers
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  RELEASE: 0
+  artifact: 0
+
+jobs:  
+  google_sanitizers_linux:
+    name: ${{ matrix.SANITIZER }} / ROCKSDB=${{ matrix.TEST_USE_ROCKSDB }} / ${{ matrix.COMPILER }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        TEST_USE_ROCKSDB: [0, 1]
+        COMPILER: [clang]
+        SANITIZER: [ASAN, ASAN_INT, TSAN]
+    runs-on: ubuntu-20.04
+    outputs:
+      issue_reported: ${{ steps.show_report.outputs.issue_reported }}
+    env:
+      COMPILER: ${{ matrix.COMPILER }}
+      TEST_USE_ROCKSDB: ${{ matrix.TEST_USE_ROCKSDB }}
+      XSAN: ${{ endsWith(matrix.sanitizer, 'ASAN_INT') && 'ASAN' || matrix.SANITIZER }}
+      XSAN_SUPPRESSIONS: ${{ endsWith(matrix.SANITIZER, 'TSAN') && 'suppressions=../tsan_suppressions:' || '' }}
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
+        with:
+          submodules: "true"
+      - name: Git Submodule Update
+        run: git submodule update --init --recursive
+      - name: XSan variable values
+        run: |
+          (
+            echo "XSAN: '${XSAN}'"
+            echo "XSAN_SUPPRESSIONS: '${XSAN_SUPPRESSIONS}'"
+          )
+      - name: Install Dependencies
+        run: ci/actions/linux/install_deps.sh
+      - name: Build Tests
+        id: build_tests
+        run: docker run -e TEST_USE_ROCKSDB -v ${PWD}:/workspace nanocurrency/nano-env:${{ matrix.COMPILER }} /bin/bash -c \
+          "cd /workspace && ${{ matrix.SANITIZER }}=1 ./ci/build-ci.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 'core_test rpc_test'"
+      - name: Run core_test
+        id: core_test
+        continue-on-error: true
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:${{ matrix.COMPILER }} /bin/bash -c \
+          "cd /workspace/build && ${XSAN}_OPTIONS=${XSAN_SUPPRESSIONS}log_exe_name=1:log_path=sanitizer_report ./core_test"
+      - name: Run rpc_test
+        id: rpc_test
+        continue-on-error: true
+        run: docker run -v ${PWD}:/workspace nanocurrency/nano-env:${{ matrix.COMPILER }} /bin/bash -c \
+          "cd /workspace/build && ${XSAN}_OPTIONS=${XSAN_SUPPRESSIONS}log_exe_name=1:log_path=sanitizer_report ./rpc_test"
+      - name: Test Reports
+        id: show_report
+        run: |
+          (
+            issue_reported=false
+            reports=$(ls build/sanitizer_report*)
+            if [[ -n "${reports}" ]]; then
+              echo "Report Output:"
+              for report in ${reports}; do
+                echo "File: $report"
+                docker run -v ${PWD}:/workspace nanocurrency/nano-env:${{ matrix.COMPILER }} /bin/bash -c "cat /workspace/${report}"
+                echo
+              done
+              issue_reported=true
+            else
+              echo "No report has been generated."
+            fi
+            echo "issue_reported=${issue_reported}" >> $GITHUB_OUTPUT
+          ) || exit 0

--- a/ci/build-ci.sh
+++ b/ci/build-ci.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 qt_dir=${1}
+build_target=${2:-all}
 
 set -o errexit
 set -o nounset
@@ -61,10 +62,10 @@ if [[ "$OS" == 'Linux' ]]; then
     if [[ ${LCOV:-0} == 1 ]]; then
         cmake --build ${PWD} --target generate_coverage -- -j2
     else
-        cmake --build ${PWD} --target all -k -- -j2
+        cmake --build ${PWD} --target ${build_target} -k -- -j2
     fi
 else
-    sudo cmake --build ${PWD} --target all -- -j2
+    sudo cmake --build ${PWD} --target ${build_target} -- -j2
 fi
 
 popd


### PR DESCRIPTION
The code sanitizers ASAN, ASAN_INT and TSAN were configured to run in a matrix with clang compiler and both DB types (LDMB and RocksDB), composing six combinations.

The code set to be exercised are the binaries `core_test` and `rpc_test`. The workflow doesn't stop if any of these tests doesn't complete. The final result as success means that all steps have ran, regardless errors happening on the test steps.