### PR TITLE
Skip empty batches in `processing_queue`

### DIFF
--- a/nano/lib/processing_queue.hpp
+++ b/nano/lib/processing_queue.hpp
@@ -145,10 +145,13 @@ private:
 		while (!stopped)
 		{
 			auto batch = next_batch (lock);
-			lock.unlock ();
-			stats.inc (stat_type, nano::stat::detail::batch);
-			process_batch (batch);
-			lock.lock ();
+			if (!batch.empty ())
+			{
+				lock.unlock ();
+				stats.inc (stat_type, nano::stat::detail::batch);
+				process_batch (batch);
+				lock.lock ();
+			}
 		}
 	}
 


### PR DESCRIPTION
The `process_batch` callback was called with an empty batch when node was stopping, causing use after free errors when running core tests.