### PR TITLE
Constant vote broadcast interval

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -294,5 +294,5 @@ TEST (election, continuous_voting)
 	ASSERT_TIMELY (5s, node1.active.active (*send2));
 
 	// Ensure votes are generated in continuous manner
-	ASSERT_TIMELY_EQ (5s, node1.stats.count (nano::stat::type::election, nano::stat::detail::generate_vote), 5);
+	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::election, nano::stat::detail::generate_vote) >= 5);
 }

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -212,7 +212,7 @@ public:
 		max_peers_per_subnetwork (default_max_peers_per_ip * 4),
 		ipv6_subnetwork_prefix_for_limiting (64), // Equivalent to network prefix /64.
 		peer_dump_interval (std::chrono::seconds (5 * 60)),
-		vote_broadcast_interval (1000)
+		vote_broadcast_interval (15 * 1000)
 	{
 		if (is_live_network ())
 		{
@@ -244,7 +244,7 @@ public:
 			max_peers_per_ip = 20;
 			max_peers_per_subnetwork = max_peers_per_ip * 4;
 			peer_dump_interval = std::chrono::seconds (1);
-			vote_broadcast_interval = 100;
+			vote_broadcast_interval = 500;
 		}
 	}
 
@@ -284,10 +284,8 @@ public:
 	size_t max_peers_per_subnetwork;
 	size_t ipv6_subnetwork_prefix_for_limiting;
 	std::chrono::seconds peer_dump_interval;
-	/** Time to wait before vote rebroadcasts for active elections, this is doubled for each broadcast, up to `max_vote_broadcast_interval` (milliseconds) */
+	/** Time to wait before vote rebroadcasts for active elections (milliseconds) */
 	uint64_t vote_broadcast_interval;
-	/** Maximum interval for vote broadcasts for active elections (milliseconds) */
-	static uint64_t constexpr max_vote_broadcast_interval{ 16 * 1000 };
 
 	/** Returns the network this object contains values for */
 	nano::networks network () const

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -26,8 +26,7 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> cons
 	status ({ block_a, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::ongoing }),
 	height (block_a->sideband ().height),
 	root (block_a->root ()),
-	qualified_root (block_a->qualified_root ()),
-	vote_broadcast_interval{ node.config.network_params.network.vote_broadcast_interval }
+	qualified_root (block_a->qualified_root ())
 {
 	last_votes.emplace (nano::account::null (), nano::vote_info{ std::chrono::steady_clock::now (), 0, block_a->hash () });
 	last_blocks.emplace (block_a->hash (), block_a);
@@ -167,14 +166,11 @@ void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a
 
 void nano::election::broadcast_vote ()
 {
-	debug_assert (vote_broadcast_interval > 0);
-
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	if (last_vote + std::chrono::milliseconds (vote_broadcast_interval) < std::chrono::steady_clock::now ())
+	if (last_vote + std::chrono::milliseconds (node.config.network_params.network.vote_broadcast_interval) < std::chrono::steady_clock::now ())
 	{
 		broadcast_vote_impl ();
 		last_vote = std::chrono::steady_clock::now ();
-		vote_broadcast_interval = std::min (vote_broadcast_interval * 2, node.config.network_params.network.max_vote_broadcast_interval);
 	}
 }
 

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -173,9 +173,6 @@ private:
 	nano::election_behavior const behavior{ nano::election_behavior::normal };
 	std::chrono::steady_clock::time_point const election_start = { std::chrono::steady_clock::now () };
 
-	/** Time to wait before next vote broadcast for current winner, doubles for each broadcast, up to `max_vote_broadcast_interval` */
-	uint64_t vote_broadcast_interval;
-
 	mutable nano::mutex mutex;
 
 private: // Constants


### PR DESCRIPTION
During stress testing with restricted bandwidth (as always, thanks @gr0vity-dev) it became clear that using exponentially increasing vote broadcast interval, and therefore broadcasting votes more often, performs worse than broadcasting votes in fixed, longer intervals. 

This PR modifies vote broadcasting to happen in fixed 15 second intervals.