### PR TITLE
Unchecked map sequenced index

### DIFF
--- a/nano/node/unchecked_map.hpp
+++ b/nano/node/unchecked_map.hpp
@@ -92,7 +92,7 @@ private: // In memory store
 
 	using ordered_unchecked = boost::multi_index_container<entry,
 		mi::indexed_by<
-			mi::random_access<mi::tag<tag_sequenced>>,
+			mi::sequenced<mi::tag<tag_sequenced>>,
 			mi::ordered_unique<mi::tag<tag_root>,
 				mi::member<entry, nano::unchecked_key, &entry::key>>>>;
 	// clang-format on


### PR DESCRIPTION
When changing from random_access to sequenced, the tag name was changed but the actual boost index type was not.

Related to https://github.com/nanocurrency/nano-node/pull/3956