### PR TITLE
Specify whether bootstrap pull should start at block hash or account

### DIFF
--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -171,7 +171,7 @@ TEST (bootstrap_server, serve_account_blocks)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = first_account;
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::account;
+	request_payload.start_type = nano::asc_pull_req::hash_type::account;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -218,7 +218,7 @@ TEST (bootstrap_server, serve_hash)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = blocks.front ()->hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
+	request_payload.start_type = nano::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -265,7 +265,7 @@ TEST (bootstrap_server, serve_hash_one)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = blocks.front ()->hash ();
 	request_payload.count = 1;
-	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
+	request_payload.start_type = nano::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -306,7 +306,7 @@ TEST (bootstrap_server, serve_end_of_chain)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = blocks.back ()->hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
+	request_payload.start_type = nano::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -347,7 +347,7 @@ TEST (bootstrap_server, serve_missing)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = nano::test::random_hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
+	request_payload.start_type = nano::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -392,7 +392,7 @@ TEST (bootstrap_server, serve_multiple)
 			nano::asc_pull_req::blocks_payload request_payload;
 			request_payload.start = account;
 			request_payload.count = nano::bootstrap_server::max_blocks;
-			request_payload.start_type = nano::asc_pull_req::blocks_payload::type::account;
+			request_payload.start_type = nano::asc_pull_req::hash_type::account;
 
 			request.payload = request_payload;
 			request.update_header ();
@@ -450,6 +450,7 @@ TEST (bootstrap_server, serve_account_info)
 
 	nano::asc_pull_req::account_info_payload request_payload;
 	request_payload.target = account;
+	request_payload.target_type = nano::asc_pull_req::hash_type::account;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -497,6 +498,7 @@ TEST (bootstrap_server, serve_account_info_missing)
 
 	nano::asc_pull_req::account_info_payload request_payload;
 	request_payload.target = nano::test::random_account ();
+	request_payload.target_type = nano::asc_pull_req::hash_type::account;
 
 	request.payload = request_payload;
 	request.update_header ();

--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -171,6 +171,7 @@ TEST (bootstrap_server, serve_account_blocks)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = first_account;
 	request_payload.count = nano::bootstrap_server::max_blocks;
+	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::account;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -217,6 +218,7 @@ TEST (bootstrap_server, serve_hash)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = blocks.front ()->hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
+	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -263,6 +265,7 @@ TEST (bootstrap_server, serve_hash_one)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = blocks.front ()->hash ();
 	request_payload.count = 1;
+	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -303,6 +306,7 @@ TEST (bootstrap_server, serve_end_of_chain)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = blocks.back ()->hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
+	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -343,6 +347,7 @@ TEST (bootstrap_server, serve_missing)
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = nano::test::random_hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
+	request_payload.start_type = nano::asc_pull_req::blocks_payload::type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -387,6 +392,7 @@ TEST (bootstrap_server, serve_multiple)
 			nano::asc_pull_req::blocks_payload request_payload;
 			request_payload.start = account;
 			request_payload.count = nano::bootstrap_server::max_blocks;
+			request_payload.start_type = nano::asc_pull_req::blocks_payload::type::account;
 
 			request.payload = request_payload;
 			request.update_header ();

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -1764,11 +1764,13 @@ void nano::asc_pull_req::blocks_payload::deserialize (nano::stream & stream)
 void nano::asc_pull_req::account_info_payload::serialize (stream & stream) const
 {
 	nano::write (stream, target);
+	nano::write (stream, target_type);
 }
 
 void nano::asc_pull_req::account_info_payload::deserialize (stream & stream)
 {
 	nano::read (stream, target);
+	nano::read (stream, target_type);
 }
 
 /*

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -1747,12 +1747,14 @@ void nano::asc_pull_req::blocks_payload::serialize (nano::stream & stream) const
 {
 	nano::write (stream, start);
 	nano::write (stream, count);
+	nano::write (stream, start_type);
 }
 
 void nano::asc_pull_req::blocks_payload::deserialize (nano::stream & stream)
 {
 	nano::read (stream, start);
 	nano::read (stream, count);
+	nano::read (stream, start_type);
 }
 
 /*

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -417,12 +417,20 @@ public: // Payload definitions
 	class blocks_payload
 	{
 	public:
+		enum class type : uint8_t
+		{
+			block = 1,
+			account = 2,
+		};
+
+	public:
 		void serialize (nano::stream &) const;
 		void deserialize (nano::stream &);
 
 	public:
 		nano::hash_or_account start{ 0 };
 		uint8_t count{ 0 };
+		type start_type{ 0 };
 	};
 
 	class account_info_payload

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -414,15 +414,14 @@ private: // Debug
 	bool verify_consistency () const;
 
 public: // Payload definitions
+	enum class hash_type : uint8_t
+	{
+		account = 0,
+		block = 1,
+	};
+
 	class blocks_payload
 	{
-	public:
-		enum class type : uint8_t
-		{
-			block = 1,
-			account = 2,
-		};
-
 	public:
 		void serialize (nano::stream &) const;
 		void deserialize (nano::stream &);
@@ -430,7 +429,7 @@ public: // Payload definitions
 	public:
 		nano::hash_or_account start{ 0 };
 		uint8_t count{ 0 };
-		type start_type{ 0 };
+		asc_pull_req::hash_type start_type{ 0 };
 	};
 
 	class account_info_payload
@@ -441,6 +440,7 @@ public: // Payload definitions
 
 	public:
 		nano::hash_or_account target{ 0 };
+		asc_pull_req::hash_type target_type{ 0 };
 	};
 
 public: // Payload


### PR DESCRIPTION
There are accounts with the same hash as another block in our live ledger. That creates ambiguity and makes it impossible to pull those account chains. This PR removes that ambiguity by always specifying whether requested hash is a block or account.