### PR TITLE
Removing "confirmed" from function signatures in lazy bootstrap.

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -812,7 +812,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	// Start lazy bootstrap with last block in chain known
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
-	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, true, "123456");
+	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, "123456");
 	{
 		auto lazy_attempt (node1->bootstrap_initiator.current_lazy_attempt ());
 		ASSERT_NE (nullptr, lazy_attempt);

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -79,7 +79,7 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 	condition.notify_all ();
 }
 
-bool nano::bootstrap_initiator::bootstrap_lazy (nano::hash_or_account const & hash_or_account_a, bool force, bool confirmed, std::string id_a)
+bool nano::bootstrap_initiator::bootstrap_lazy (nano::hash_or_account const & hash_or_account_a, bool force, std::string id_a)
 {
 	bool key_inserted (false);
 	auto lazy_attempt (current_lazy_attempt ());
@@ -96,12 +96,12 @@ bool nano::bootstrap_initiator::bootstrap_lazy (nano::hash_or_account const & ha
 			lazy_attempt = std::make_shared<nano::bootstrap_attempt_lazy> (node.shared (), attempts.incremental++, id_a.empty () ? hash_or_account_a.to_string () : id_a);
 			attempts_list.push_back (lazy_attempt);
 			attempts.add (lazy_attempt);
-			key_inserted = lazy_attempt->lazy_start (hash_or_account_a, confirmed);
+			key_inserted = lazy_attempt->lazy_start (hash_or_account_a);
 		}
 	}
 	else
 	{
-		key_inserted = lazy_attempt->lazy_start (hash_or_account_a, confirmed);
+		key_inserted = lazy_attempt->lazy_start (hash_or_account_a);
 	}
 	condition.notify_all ();
 	return key_inserted;

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -93,7 +93,7 @@ public:
 	~bootstrap_initiator ();
 	void bootstrap (nano::endpoint const &, bool add_to_peers = true, std::string id_a = "");
 	void bootstrap (bool force = false, std::string id_a = "", uint32_t const frontiers_age_a = std::numeric_limits<uint32_t>::max (), nano::account const & start_account_a = nano::account{});
-	bool bootstrap_lazy (nano::hash_or_account const &, bool force = false, bool confirmed = true, std::string id_a = "");
+	bool bootstrap_lazy (nano::hash_or_account const &, bool force = false, std::string id_a = "");
 	void bootstrap_wallet (std::deque<nano::account> &);
 	void run_bootstrap ();
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &);

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -276,7 +276,7 @@ void nano::bulk_pull_account_client::receive_pending ()
 							{
 								if (!this_l->connection->node->ledger.block_or_pruned_exists (pending))
 								{
-									this_l->connection->node->bootstrap_initiator.bootstrap_lazy (pending, false, false);
+									this_l->connection->node->bootstrap_initiator.bootstrap_lazy (pending, false);
 								}
 							}
 						}

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -25,7 +25,7 @@ nano::bootstrap_attempt_lazy::~bootstrap_attempt_lazy ()
 	node->bootstrap_initiator.notify_listeners (false);
 }
 
-bool nano::bootstrap_attempt_lazy::lazy_start (nano::hash_or_account const & hash_or_account_a, bool confirmed)
+bool nano::bootstrap_attempt_lazy::lazy_start (nano::hash_or_account const & hash_or_account_a)
 {
 	nano::unique_lock<nano::mutex> lock (mutex);
 	bool inserted (false);
@@ -34,7 +34,7 @@ bool nano::bootstrap_attempt_lazy::lazy_start (nano::hash_or_account const & has
 	if (lazy_keys.size () < max_keys && lazy_keys.find (hash_or_account_a.as_block_hash ()) == lazy_keys.end () && !lazy_blocks_processed (hash_or_account_a.as_block_hash ()))
 	{
 		lazy_keys.insert (hash_or_account_a.as_block_hash ());
-		lazy_pulls.emplace_back (hash_or_account_a, confirmed ? lazy_retry_limit_confirmed () : node->network_params.bootstrap.lazy_retry_limit);
+		lazy_pulls.emplace_back (hash_or_account_a, node->network_params.bootstrap.lazy_retry_limit);
 		lock.unlock ();
 		condition.notify_all ();
 		inserted = true;
@@ -438,18 +438,6 @@ bool nano::bootstrap_attempt_lazy::lazy_processed_or_exists (nano::block_hash co
 		}
 	}
 	return result;
-}
-
-unsigned nano::bootstrap_attempt_lazy::lazy_retry_limit_confirmed ()
-{
-	debug_assert (!mutex.try_lock ());
-	if (total_blocks % 1024 == 512 || peer_count == 0)
-	{
-		// Prevent too frequent network locks
-		peer_count = node->network.size ();
-	}
-	auto multiplier (node->flags.disable_legacy_bootstrap ? 2 : 1.25);
-	return multiplier * std::max (node->network_params.bootstrap.lazy_retry_limit, 2 * nano::narrow_cast<unsigned> (peer_count));
 }
 
 void nano::bootstrap_attempt_lazy::get_information (boost::property_tree::ptree & tree_a)

--- a/nano/node/bootstrap/bootstrap_lazy.hpp
+++ b/nano/node/bootstrap/bootstrap_lazy.hpp
@@ -35,7 +35,7 @@ public:
 	~bootstrap_attempt_lazy ();
 	bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned) override;
 	void run () override;
-	bool lazy_start (nano::hash_or_account const &, bool confirmed = true);
+	bool lazy_start (nano::hash_or_account const &);
 	void lazy_add (nano::hash_or_account const &, unsigned);
 	void lazy_add (nano::pull_info const &);
 	void lazy_requeue (nano::block_hash const &, nano::block_hash const &);
@@ -51,7 +51,6 @@ public:
 	void lazy_blocks_erase (nano::block_hash const &);
 	bool lazy_blocks_processed (nano::block_hash const &);
 	bool lazy_processed_or_exists (nano::block_hash const &);
-	unsigned lazy_retry_limit_confirmed ();
 	void get_information (boost::property_tree::ptree &) override;
 	std::unordered_set<std::size_t> lazy_blocks;
 	std::unordered_map<nano::block_hash, nano::lazy_state_backlog_item> lazy_state_backlog;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -264,7 +264,7 @@ nano::account_info nano::json_handler::account_info_impl (nano::transaction cons
 		if (node.store.account.get (transaction_a, account_a, result))
 		{
 			ec = nano::error_common::account_not_found;
-			node.bootstrap_initiator.bootstrap_lazy (account_a, false, false, account_a.to_account ());
+			node.bootstrap_initiator.bootstrap_lazy (account_a, false, account_a.to_account ());
 		}
 	}
 	return result;
@@ -1855,7 +1855,7 @@ void nano::json_handler::bootstrap_lazy ()
 		{
 			auto existed (node.bootstrap_initiator.current_lazy_attempt () != nullptr);
 			std::string bootstrap_id (request.get<std::string> ("id", ""));
-			auto key_inserted (node.bootstrap_initiator.bootstrap_lazy (hash, force, true, bootstrap_id));
+			auto key_inserted (node.bootstrap_initiator.bootstrap_lazy (hash, force, bootstrap_id));
 			bool started = !existed && key_inserted;
 			response_l.put ("started", started ? "1" : "0");
 			response_l.put ("key_inserted", key_inserted ? "1" : "0");


### PR DESCRIPTION
This variable seems to only affect the retry delay of lazy bootstrapping. The actual delay computed isn't documented or obvious. No tests fail so removing this entirely.