### PR TITLE
Remove unchecked_info::account and unchecked_info::verified

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3991,7 +3991,6 @@ TEST (ledger, epoch_open_pending)
 					  .build_shared ();
 	auto process_result = node1.ledger.process (node1.store.tx_begin_write (), *epoch_open);
 	ASSERT_EQ (nano::process_result::gap_epoch_open_pending, process_result.code);
-	ASSERT_EQ (nano::signature_verification::valid_epoch, process_result.verified);
 	node1.block_processor.add (epoch_open);
 	// Waits for the block to get saved in the database
 	ASSERT_TIMELY (10s, 1 == node1.unchecked.count (node1.store.tx_begin_read ()));
@@ -4000,7 +3999,6 @@ TEST (ledger, epoch_open_pending)
 	auto blocks = node1.unchecked.get (node1.store.tx_begin_read (), nano::hash_or_account (epoch_open->account ()).hash);
 	ASSERT_EQ (blocks.size (), 1);
 	ASSERT_EQ (blocks[0].block->full_hash (), epoch_open->full_hash ());
-	ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid_epoch);
 	// New block to process epoch open
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -4292,7 +4290,6 @@ TEST (ledger, unchecked_epoch)
 		ASSERT_TIMELY (10s, 1 == node1.unchecked.count (node1.store.tx_begin_read ()));
 		auto blocks = node1.unchecked.get (node1.store.tx_begin_read (), epoch1->previous ());
 		ASSERT_EQ (blocks.size (), 1);
-		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid_epoch);
 	}
 	node1.block_processor.add (send1);
 	node1.block_processor.add (open1);
@@ -4367,8 +4364,6 @@ TEST (ledger, unchecked_epoch_invalid)
 		ASSERT_TIMELY (10s, 2 == node1.unchecked.count (node1.store.tx_begin_read ()));
 		auto blocks = node1.unchecked.get (node1.store.tx_begin_read (), epoch1->previous ());
 		ASSERT_EQ (blocks.size (), 2);
-		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid);
-		ASSERT_EQ (blocks[1].verified, nano::signature_verification::valid);
 	}
 	node1.block_processor.add (send1);
 	node1.block_processor.add (open1);
@@ -4436,7 +4431,6 @@ TEST (ledger, unchecked_open)
 		ASSERT_TIMELY (10s, 1 == node1.unchecked.count (node1.store.tx_begin_read ()));
 		auto blocks = node1.unchecked.get (node1.store.tx_begin_read (), open1->source ());
 		ASSERT_EQ (blocks.size (), 1);
-		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid);
 	}
 	node1.block_processor.add (send1);
 	// Waits for the send1 block to pass through block_processor and unchecked.put queues
@@ -4500,7 +4494,6 @@ TEST (ledger, unchecked_receive)
 		ASSERT_TIMELY (15s, check_block_is_listed (node1.store.tx_begin_read (), receive1->previous ()));
 		auto blocks = node1.unchecked.get (node1.store.tx_begin_read (), receive1->previous ());
 		ASSERT_EQ (blocks.size (), 1);
-		ASSERT_EQ (blocks[0].verified, nano::signature_verification::unknown);
 	}
 	// Waits for the open1 block to pass through block_processor and unchecked.put queues
 	node1.block_processor.add (open1);
@@ -4510,7 +4503,6 @@ TEST (ledger, unchecked_receive)
 		auto transaction = node1.store.tx_begin_read ();
 		auto blocks (node1.unchecked.get (transaction, receive1->source ()));
 		ASSERT_EQ (blocks.size (), 1);
-		ASSERT_EQ (blocks[0].verified, nano::signature_verification::valid);
 	}
 	node1.block_processor.add (send2);
 	ASSERT_TIMELY (10s, node1.store.block.exists (node1.store.tx_begin_read (), receive1->hash ()));

--- a/nano/core_test/unchecked_map.cpp
+++ b/nano/core_test/unchecked_map.cpp
@@ -49,7 +49,7 @@ TEST (unchecked_map, construction)
 TEST (unchecked_map, put_one)
 {
 	context context;
-	nano::unchecked_info info{ block (), nano::dev::genesis_key.pub };
+	nano::unchecked_info info{ block () };
 	context.unchecked.put (info.block->previous (), info);
 }
 

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1832,7 +1832,7 @@ int main (int argc, char * const * argv)
 							{
 								std::cout << boost::str (boost::format ("%1% blocks retrieved") % count) << std::endl;
 							}
-							nano::unchecked_info unchecked_info (block, account, nano::signature_verification::unknown);
+							nano::unchecked_info unchecked_info (block, account);
 							node.node->block_processor.add (unchecked_info);
 							if (block->type () == nano::block_type::state && block->previous ().is_zero () && source_node->ledger.is_epoch_link (block->link ()))
 							{

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1832,7 +1832,7 @@ int main (int argc, char * const * argv)
 							{
 								std::cout << boost::str (boost::format ("%1% blocks retrieved") % count) << std::endl;
 							}
-							nano::unchecked_info unchecked_info (block, account);
+							nano::unchecked_info unchecked_info (block);
 							node.node->block_processor.add (unchecked_info);
 							if (block->type () == nano::block_type::state && block->previous ().is_zero () && source_node->ledger.is_epoch_link (block->link ()))
 							{

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -111,7 +111,7 @@ void nano::block_processor::add (nano::unchecked_info const & info_a)
 	debug_assert (!node.network_params.work.validate_entry (*block));
 	if (verified == nano::signature_verification::unknown && (block->type () == nano::block_type::state || block->type () == nano::block_type::open || !account.is_zero ()))
 	{
-		state_block_signature_verification.add ({ block, account, verified });
+		state_block_signature_verification.add ({ block, account });
 	}
 	else
 	{
@@ -127,7 +127,7 @@ void nano::block_processor::add_local (nano::unchecked_info const & info_a)
 {
 	release_assert (info_a.verified == nano::signature_verification::unknown && (info_a.block->type () == nano::block_type::state || !info_a.account.is_zero ()));
 	debug_assert (!node.network_params.work.validate_entry (*info_a.block));
-	state_block_signature_verification.add ({ info_a.block, info_a.account, info_a.verified });
+	state_block_signature_verification.add ({ info_a.block, info_a.account });
 }
 
 void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
@@ -198,31 +198,31 @@ void nano::block_processor::process_verified_state_blocks (std::deque<nano::stat
 		{
 			debug_assert (verifications[i] == 1 || verifications[i] == 0);
 			auto & item = items.front ();
-			auto & [block, account, verified] = item;
+			auto & [block, account] = item;
 			if (!block->link ().is_zero () && node.ledger.is_epoch_link (block->link ()))
 			{
 				// Epoch blocks
 				if (verifications[i] == 1)
 				{
-					verified = nano::signature_verification::valid_epoch;
+					auto verified = nano::signature_verification::valid_epoch;
 					blocks.emplace_back (block, account, verified);
 				}
 				else
 				{
 					// Possible regular state blocks with epoch link (send subtype)
-					verified = nano::signature_verification::unknown;
+					auto verified = nano::signature_verification::unknown;
 					blocks.emplace_back (block, account, verified);
 				}
 			}
 			else if (verifications[i] == 1)
 			{
 				// Non epoch blocks
-				verified = nano::signature_verification::valid;
+				auto verified = nano::signature_verification::valid;
 				blocks.emplace_back (block, account, verified);
 			}
 			else
 			{
-				requeue_invalid (hashes[i], { block, account, verified });
+				requeue_invalid (hashes[i], { block, account });
 			}
 			items.pop_front ();
 		}

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -119,7 +119,7 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	}
 	else
 	{
-		nano::unchecked_info info (block_a, known_account_a, nano::signature_verification::unknown);
+		nano::unchecked_info info (block_a, known_account_a);
 		node->block_processor.add (info);
 	}
 	return stop_pull;

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -119,7 +119,7 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	}
 	else
 	{
-		nano::unchecked_info info (block_a, known_account_a);
+		nano::unchecked_info info (block_a);
 		node->block_processor.add (info);
 	}
 	return stop_pull;

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -267,7 +267,7 @@ bool nano::bootstrap_attempt_lazy::process_block_lazy (std::shared_ptr<nano::blo
 		}
 		lazy_block_state_backlog_check (block_a, hash);
 		lock.unlock ();
-		nano::unchecked_info info (block_a, known_account_a, nano::signature_verification::unknown);
+		nano::unchecked_info info (block_a, known_account_a);
 		node->block_processor.add (info);
 	}
 	// Force drop lazy bootstrap connection for long bulk_pull

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -267,7 +267,7 @@ bool nano::bootstrap_attempt_lazy::process_block_lazy (std::shared_ptr<nano::blo
 		}
 		lazy_block_state_backlog_check (block_a, hash);
 		lock.unlock ();
-		nano::unchecked_info info (block_a, known_account_a);
+		nano::unchecked_info info (block_a);
 		node->block_processor.add (info);
 	}
 	// Force drop lazy bootstrap connection for long bulk_pull

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -679,14 +679,12 @@ nano::process_return nano::node::process_local (std::shared_ptr<nano::block> con
 {
 	// Add block hash as recently arrived to trigger automatic rebroadcast and election
 	block_arrival.add (block_a->hash ());
-	// Set current time to trigger automatic rebroadcast and election
-	nano::unchecked_info info (block_a, block_a->account ());
 	// Notify block processor to release write lock
 	block_processor.wait_write ();
 	// Process block
 	block_post_events post_events ([&store = store] { return store.tx_begin_read (); });
 	auto const transaction (store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending }));
-	return block_processor.process_one (transaction, post_events, info, false, nano::block_origin::local);
+	return block_processor.process_one (transaction, post_events, block_a, false, nano::block_origin::local);
 }
 
 void nano::node::process_local_async (std::shared_ptr<nano::block> const & block_a)
@@ -694,8 +692,7 @@ void nano::node::process_local_async (std::shared_ptr<nano::block> const & block
 	// Add block hash as recently arrived to trigger automatic rebroadcast and election
 	block_arrival.add (block_a->hash ());
 	// Set current time to trigger automatic rebroadcast and election
-	nano::unchecked_info info (block_a, block_a->account ());
-	block_processor.add_local (info);
+	block_processor.add_local (block_a);
 }
 
 void nano::node::start ()

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -680,7 +680,7 @@ nano::process_return nano::node::process_local (std::shared_ptr<nano::block> con
 	// Add block hash as recently arrived to trigger automatic rebroadcast and election
 	block_arrival.add (block_a->hash ());
 	// Set current time to trigger automatic rebroadcast and election
-	nano::unchecked_info info (block_a, block_a->account (), nano::signature_verification::unknown);
+	nano::unchecked_info info (block_a, block_a->account ());
 	// Notify block processor to release write lock
 	block_processor.wait_write ();
 	// Process block
@@ -694,7 +694,7 @@ void nano::node::process_local_async (std::shared_ptr<nano::block> const & block
 	// Add block hash as recently arrived to trigger automatic rebroadcast and election
 	block_arrival.add (block_a->hash ());
 	// Set current time to trigger automatic rebroadcast and election
-	nano::unchecked_info info (block_a, block_a->account (), nano::signature_verification::unknown);
+	nano::unchecked_info info (block_a, block_a->account ());
 	block_processor.add_local (info);
 }
 

--- a/nano/node/state_block_signature_verification.cpp
+++ b/nano/node/state_block_signature_verification.cpp
@@ -131,7 +131,7 @@ void nano::state_block_signature_verification::verify_state_blocks (std::deque<v
 		signatures.reserve (size);
 		std::vector<int> verifications;
 		verifications.resize (size, 0);
-		for (auto const & [block, account, unused] : items)
+		for (auto const & [block, account] : items)
 		{
 			hashes.push_back (block->hash ());
 			messages.push_back (hashes.back ().bytes.data ());

--- a/nano/node/state_block_signature_verification.cpp
+++ b/nano/node/state_block_signature_verification.cpp
@@ -131,7 +131,7 @@ void nano::state_block_signature_verification::verify_state_blocks (std::deque<v
 		signatures.reserve (size);
 		std::vector<int> verifications;
 		verifications.resize (size, 0);
-		for (auto const & [block, account] : items)
+		for (auto const & [block] : items)
 		{
 			hashes.push_back (block->hash ());
 			messages.push_back (hashes.back ().bytes.data ());
@@ -140,10 +140,6 @@ void nano::state_block_signature_verification::verify_state_blocks (std::deque<v
 			if (!block->link ().is_zero () && epochs.is_epoch_link (block->link ()))
 			{
 				account_l = epochs.signer (epochs.epoch (block->link ()));
-			}
-			else if (!account.is_zero ())
-			{
-				account_l = account;
 			}
 			accounts.push_back (account_l);
 			pub_keys.push_back (accounts.back ().bytes.data ());

--- a/nano/node/state_block_signature_verification.hpp
+++ b/nano/node/state_block_signature_verification.hpp
@@ -17,7 +17,7 @@ class signature_checker;
 class state_block_signature_verification
 {
 public:
-	using value_type = std::tuple<std::shared_ptr<nano::block>, nano::account, nano::signature_verification>;
+	using value_type = std::tuple<std::shared_ptr<nano::block>, nano::account>;
 
 	state_block_signature_verification (nano::signature_checker &, nano::epochs &, nano::node_config &, nano::logger_mt &, uint64_t);
 	~state_block_signature_verification ();

--- a/nano/node/state_block_signature_verification.hpp
+++ b/nano/node/state_block_signature_verification.hpp
@@ -17,7 +17,7 @@ class signature_checker;
 class state_block_signature_verification
 {
 public:
-	using value_type = std::tuple<std::shared_ptr<nano::block>, nano::account>;
+	using value_type = std::tuple<std::shared_ptr<nano::block>>;
 
 	state_block_signature_verification (nano::signature_checker &, nano::epochs &, nano::node_config &, nano::logger_mt &, uint64_t);
 	~state_block_signature_verification ();

--- a/nano/node/unchecked_map.cpp
+++ b/nano/node/unchecked_map.cpp
@@ -223,7 +223,7 @@ void nano::unchecked_map::insert_impl (nano::write_transaction const & transacti
 	}
 	if (entries == nullptr)
 	{
-		store.unchecked.put (transaction, dependency, { info.block, info.account, info.verified });
+		store.unchecked.put (transaction, dependency, { info.block, info.account });
 	}
 	else
 	{

--- a/nano/node/unchecked_map.cpp
+++ b/nano/node/unchecked_map.cpp
@@ -223,7 +223,7 @@ void nano::unchecked_map::insert_impl (nano::write_transaction const & transacti
 	}
 	if (entries == nullptr)
 	{
-		store.unchecked.put (transaction, dependency, { info.block, info.account });
+		store.unchecked.put (transaction, dependency, { info.block });
 	}
 	else
 	{

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -347,16 +347,15 @@ nano::account const & nano::pending_key::key () const
 	return account;
 }
 
-nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, nano::signature_verification verified_a) :
+nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a) :
 	block (block_a),
 	account (account_a),
-	modified_m (nano::seconds_since_epoch ()),
-	verified (verified_a)
+	modified_m (nano::seconds_since_epoch ())
 {
 }
 
 nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block) :
-	unchecked_info{ block, block->account (), nano::signature_verification::unknown }
+	unchecked_info{ block, block->account () }
 {
 }
 
@@ -366,7 +365,6 @@ void nano::unchecked_info::serialize (nano::stream & stream_a) const
 	nano::serialize_block (stream_a, *block);
 	nano::write (stream_a, account.bytes);
 	nano::write (stream_a, modified_m);
-	nano::write (stream_a, verified);
 }
 
 bool nano::unchecked_info::deserialize (nano::stream & stream_a)
@@ -379,7 +377,6 @@ bool nano::unchecked_info::deserialize (nano::stream & stream_a)
 		{
 			nano::read (stream_a, account.bytes);
 			nano::read (stream_a, modified_m);
-			nano::read (stream_a, verified);
 		}
 		catch (std::runtime_error const &)
 		{

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -347,15 +347,9 @@ nano::account const & nano::pending_key::key () const
 	return account;
 }
 
-nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a) :
+nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block_a) :
 	block (block_a),
-	account (account_a),
 	modified_m (nano::seconds_since_epoch ())
-{
-}
-
-nano::unchecked_info::unchecked_info (std::shared_ptr<nano::block> const & block) :
-	unchecked_info{ block, block->account () }
 {
 }
 
@@ -363,7 +357,6 @@ void nano::unchecked_info::serialize (nano::stream & stream_a) const
 {
 	debug_assert (block != nullptr);
 	nano::serialize_block (stream_a, *block);
-	nano::write (stream_a, account.bytes);
 	nano::write (stream_a, modified_m);
 }
 
@@ -375,7 +368,6 @@ bool nano::unchecked_info::deserialize (nano::stream & stream_a)
 	{
 		try
 		{
-			nano::read (stream_a, account.bytes);
 			nano::read (stream_a, modified_m);
 		}
 		catch (std::runtime_error const &)

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -199,13 +199,11 @@ class unchecked_info final
 {
 public:
 	unchecked_info () = default;
-	unchecked_info (std::shared_ptr<nano::block> const &, nano::account const &);
 	unchecked_info (std::shared_ptr<nano::block> const &);
 	void serialize (nano::stream &) const;
 	bool deserialize (nano::stream &);
 	uint64_t modified () const;
 	std::shared_ptr<nano::block> block;
-	nano::account account{};
 
 private:
 	/** Seconds since posix epoch */

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -193,24 +193,13 @@ public:
 };
 
 /**
- * Tag for block signature verification result
- */
-enum class signature_verification : uint8_t
-{
-	unknown = 0,
-	invalid = 1,
-	valid = 2,
-	valid_epoch = 3 // Valid for epoch blocks
-};
-
-/**
  * Information on an unchecked block
  */
 class unchecked_info final
 {
 public:
 	unchecked_info () = default;
-	unchecked_info (std::shared_ptr<nano::block> const &, nano::account const &, nano::signature_verification = nano::signature_verification::unknown);
+	unchecked_info (std::shared_ptr<nano::block> const &, nano::account const &);
 	unchecked_info (std::shared_ptr<nano::block> const &);
 	void serialize (nano::stream &) const;
 	bool deserialize (nano::stream &);
@@ -221,9 +210,6 @@ public:
 private:
 	/** Seconds since posix epoch */
 	uint64_t modified_m{ 0 };
-
-public:
-	nano::signature_verification verified{ nano::signature_verification::unknown };
 };
 
 class block_info final
@@ -361,7 +347,6 @@ class process_return final
 {
 public:
 	nano::process_result code;
-	nano::signature_verification verified;
 	nano::amount previous_balance;
 };
 enum class tally_result

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -183,7 +183,7 @@ public:
 class ledger_processor : public nano::mutable_block_visitor
 {
 public:
-	ledger_processor (nano::ledger &, nano::write_transaction const &, nano::signature_verification = nano::signature_verification::unknown);
+	ledger_processor (nano::ledger &, nano::write_transaction const &);
 	virtual ~ledger_processor () = default;
 	void send_block (nano::send_block &) override;
 	void receive_block (nano::receive_block &) override;
@@ -194,7 +194,6 @@ public:
 	void epoch_block_impl (nano::state_block &);
 	nano::ledger & ledger;
 	nano::write_transaction const & transaction;
-	nano::signature_verification verification;
 	nano::process_return result;
 
 private:
@@ -213,7 +212,7 @@ bool ledger_processor::validate_epoch_block (nano::state_block const & block_a)
 		{
 			prev_balance = ledger.balance (transaction, block_a.hashables.previous);
 		}
-		else if (result.verified == nano::signature_verification::unknown)
+		else
 		{
 			// Check for possible regular state blocks with epoch link (send subtype)
 			if (validate_message (block_a.hashables.account, block_a.hash (), block_a.signature))
@@ -221,17 +220,8 @@ bool ledger_processor::validate_epoch_block (nano::state_block const & block_a)
 				// Is epoch block signed correctly
 				if (validate_message (ledger.epoch_signer (block_a.link ()), block_a.hash (), block_a.signature))
 				{
-					result.verified = nano::signature_verification::invalid;
 					result.code = nano::process_result::bad_signature;
 				}
-				else
-				{
-					result.verified = nano::signature_verification::valid_epoch;
-				}
-			}
-			else
-			{
-				result.verified = nano::signature_verification::valid;
 			}
 		}
 	}
@@ -268,15 +258,10 @@ void ledger_processor::state_block_impl (nano::state_block & block_a)
 	result.code = existing ? nano::process_result::old : nano::process_result::progress; // Have we seen this block before? (Unambiguous)
 	if (result.code == nano::process_result::progress)
 	{
-		// Validate block if not verified outside of ledger
-		if (result.verified != nano::signature_verification::valid)
-		{
-			result.code = validate_message (block_a.hashables.account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Unambiguous)
-		}
+		result.code = validate_message (block_a.hashables.account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Unambiguous)
 		if (result.code == nano::process_result::progress)
 		{
 			debug_assert (!validate_message (block_a.hashables.account, hash, block_a.signature));
-			result.verified = nano::signature_verification::valid;
 			result.code = block_a.hashables.account.is_zero () ? nano::process_result::opened_burn_account : nano::process_result::progress; // Is this for the burn account? (Unambiguous)
 			if (result.code == nano::process_result::progress)
 			{
@@ -395,15 +380,10 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 	result.code = existing ? nano::process_result::old : nano::process_result::progress; // Have we seen this block before? (Unambiguous)
 	if (result.code == nano::process_result::progress)
 	{
-		// Validate block if not verified outside of ledger
-		if (result.verified != nano::signature_verification::valid_epoch)
-		{
-			result.code = validate_message (ledger.epoch_signer (block_a.hashables.link), hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Unambiguous)
-		}
+		result.code = validate_message (ledger.epoch_signer (block_a.hashables.link), hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Unambiguous)
 		if (result.code == nano::process_result::progress)
 		{
 			debug_assert (!validate_message (ledger.epoch_signer (block_a.hashables.link), hash, block_a.signature));
-			result.verified = nano::signature_verification::valid_epoch;
 			result.code = block_a.hashables.account.is_zero () ? nano::process_result::opened_burn_account : nano::process_result::progress; // Is this for the burn account? (Unambiguous)
 			if (result.code == nano::process_result::progress)
 			{
@@ -490,11 +470,7 @@ void ledger_processor::change_block (nano::change_block & block_a)
 					(void)latest_error;
 					debug_assert (!latest_error);
 					debug_assert (info.head == block_a.hashables.previous);
-					// Validate block if not verified outside of ledger
-					if (result.verified != nano::signature_verification::valid)
-					{
-						result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Malformed)
-					}
+					result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
@@ -502,7 +478,6 @@ void ledger_processor::change_block (nano::change_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
-							result.verified = nano::signature_verification::valid;
 							block_a.sideband_set (nano::block_sideband (account, 0, info.balance, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 							ledger.store.block.put (transaction, hash, block_a);
 							auto balance (ledger.balance (transaction, block_a.hashables.previous));
@@ -539,11 +514,7 @@ void ledger_processor::send_block (nano::send_block & block_a)
 				result.code = account.is_zero () ? nano::process_result::fork : nano::process_result::progress;
 				if (result.code == nano::process_result::progress)
 				{
-					// Validate block if not verified outside of ledger
-					if (result.verified != nano::signature_verification::valid)
-					{
-						result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Malformed)
-					}
+					result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
 						nano::block_details block_details (nano::epoch::epoch_0, false /* unused */, false /* unused */, false /* unused */);
@@ -551,7 +522,6 @@ void ledger_processor::send_block (nano::send_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
-							result.verified = nano::signature_verification::valid;
 							nano::account_info info;
 							auto latest_error (ledger.store.account.get (transaction, account, info));
 							(void)latest_error;
@@ -598,15 +568,10 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 				result.code = account.is_zero () ? nano::process_result::gap_previous : nano::process_result::progress; // Have we seen the previous block? No entries for account at all (Harmless)
 				if (result.code == nano::process_result::progress)
 				{
-					// Validate block if not verified outside of ledger
-					if (result.verified != nano::signature_verification::valid)
-					{
-						result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is the signature valid (Malformed)
-					}
+					result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is the signature valid (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
 						debug_assert (!validate_message (account, hash, block_a.signature));
-						result.verified = nano::signature_verification::valid;
 						result.code = ledger.block_or_pruned_exists (transaction, block_a.hashables.source) ? nano::process_result::progress : nano::process_result::gap_source; // Have we seen the source block already? (Harmless)
 						if (result.code == nano::process_result::progress)
 						{
@@ -669,15 +634,10 @@ void ledger_processor::open_block (nano::open_block & block_a)
 	result.code = existing ? nano::process_result::old : nano::process_result::progress; // Have we seen this block already? (Harmless)
 	if (result.code == nano::process_result::progress)
 	{
-		// Validate block if not verified outside of ledger
-		if (result.verified != nano::signature_verification::valid)
-		{
-			result.code = validate_message (block_a.hashables.account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is the signature valid (Malformed)
-		}
+		result.code = validate_message (block_a.hashables.account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is the signature valid (Malformed)
 		if (result.code == nano::process_result::progress)
 		{
 			debug_assert (!validate_message (block_a.hashables.account, hash, block_a.signature));
-			result.verified = nano::signature_verification::valid;
 			result.code = ledger.block_or_pruned_exists (transaction, block_a.hashables.source) ? nano::process_result::progress : nano::process_result::gap_source; // Have we seen the source block? (Harmless)
 			if (result.code == nano::process_result::progress)
 			{
@@ -727,12 +687,10 @@ void ledger_processor::open_block (nano::open_block & block_a)
 	}
 }
 
-ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::write_transaction const & transaction_a, nano::signature_verification verification_a) :
+ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::write_transaction const & transaction_a) :
 	ledger (ledger_a),
-	transaction (transaction_a),
-	verification (verification_a)
+	transaction (transaction_a)
 {
-	result.verified = verification;
 }
 } // namespace
 
@@ -861,10 +819,10 @@ nano::uint128_t nano::ledger::account_receivable (nano::transaction const & tran
 	return result;
 }
 
-nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a, nano::signature_verification verification)
+nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a)
 {
 	debug_assert (!constants.work.validate_entry (block_a) || constants.genesis == nano::dev::genesis);
-	ledger_processor processor (*this, transaction_a, verification);
+	ledger_processor processor (*this, transaction_a);
 	block_a.visit (processor);
 	if (processor.result.code == nano::process_result::progress)
 	{

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -66,7 +66,7 @@ public:
 	nano::account const & block_destination (nano::transaction const &, nano::block const &);
 	nano::block_hash block_source (nano::transaction const &, nano::block const &);
 	std::pair<nano::block_hash, nano::block_hash> hash_root_random (nano::transaction const &) const;
-	nano::process_return process (nano::write_transaction const &, nano::block &, nano::signature_verification = nano::signature_verification::unknown);
+	nano::process_return process (nano::write_transaction const &, nano::block &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);
 	void update_account (nano::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);


### PR DESCRIPTION
This PR removes two fields in unchecked_info related to an optimisation that will not be relevant when the ascending bootstrap client is used and with the block processor pipeline improvements.

This reduces complexity around signature checking code and reduces the amount of data tracked for unchecked entries.