### PR TITLE
Change election scheduler to consider previous balance

### DIFF
--- a/nano/core_test/prioritization.cpp
+++ b/nano/core_test/prioritization.cpp
@@ -129,7 +129,7 @@ TEST (prioritization, index_max)
 TEST (prioritization, insert_Gxrb)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
@@ -137,25 +137,17 @@ TEST (prioritization, insert_Gxrb)
 TEST (prioritization, insert_Mxrb)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block1 (), 0);
+	prioritization.push (1000, block1 (), nano::Mxrb_ratio);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (1, prioritization.bucket_size (13));
-}
-
-TEST (prioritization, insert_prev_balance)
-{
-	nano::prioritization prioritization;
-	prioritization.push (1000, block1 (), nano::Gxrb_ratio);
-	ASSERT_EQ (1, prioritization.size ());
-	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
 
 // Test two blocks with the same priority
 TEST (prioritization, insert_same_priority)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1000, block2 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1000, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (2, prioritization.size ());
 	ASSERT_EQ (2, prioritization.bucket_size (48));
 }
@@ -164,8 +156,8 @@ TEST (prioritization, insert_same_priority)
 TEST (prioritization, insert_duplicate)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
@@ -173,8 +165,8 @@ TEST (prioritization, insert_duplicate)
 TEST (prioritization, insert_older)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1100, block2 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1100, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (block0 (), prioritization.top ());
 	prioritization.pop ();
 	ASSERT_EQ (block2 (), prioritization.top ());
@@ -185,7 +177,7 @@ TEST (prioritization, pop)
 {
 	nano::prioritization prioritization;
 	ASSERT_TRUE (prioritization.empty ());
-	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_FALSE (prioritization.empty ());
 	prioritization.pop ();
 	ASSERT_TRUE (prioritization.empty ());
@@ -194,15 +186,15 @@ TEST (prioritization, pop)
 TEST (prioritization, top_one)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (block0 (), prioritization.top ());
 }
 
 TEST (prioritization, top_two)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1, block1 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1, block1 (), nano::Mxrb_ratio);
 	ASSERT_EQ (block0 (), prioritization.top ());
 	prioritization.pop ();
 	ASSERT_EQ (block1 (), prioritization.top ());
@@ -215,9 +207,9 @@ TEST (prioritization, top_round_robin)
 	nano::prioritization prioritization;
 	prioritization.push (1000, blockzero (), 0);
 	ASSERT_EQ (blockzero (), prioritization.top ());
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1000, block1 (), 0);
-	prioritization.push (1100, block3 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1000, block1 (), nano::Mxrb_ratio);
+	prioritization.push (1100, block3 (), nano::Mxrb_ratio);
 	prioritization.pop (); // blockzero
 	EXPECT_EQ (block1 (), prioritization.top ());
 	prioritization.pop ();
@@ -231,8 +223,8 @@ TEST (prioritization, top_round_robin)
 TEST (prioritization, trim_normal)
 {
 	nano::prioritization prioritization{ 1 };
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1100, block2 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1100, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
 }
@@ -240,8 +232,8 @@ TEST (prioritization, trim_normal)
 TEST (prioritization, trim_reverse)
 {
 	nano::prioritization prioritization{ 1 };
-	prioritization.push (1100, block2 (), 0);
-	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1100, block2 (), nano::Gxrb_ratio);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
 }
@@ -249,11 +241,11 @@ TEST (prioritization, trim_reverse)
 TEST (prioritization, trim_even)
 {
 	nano::prioritization prioritization{ 2 };
-	prioritization.push (1000, block0 (), 0);
-	prioritization.push (1100, block2 (), 0);
+	prioritization.push (1000, block0 (), nano::Gxrb_ratio);
+	prioritization.push (1100, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
-	prioritization.push (1000, block1 (), 0);
+	prioritization.push (1000, block1 (), nano::Mxrb_ratio);
 	ASSERT_EQ (2, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
 	prioritization.pop ();

--- a/nano/core_test/prioritization.cpp
+++ b/nano/core_test/prioritization.cpp
@@ -129,7 +129,7 @@ TEST (prioritization, index_max)
 TEST (prioritization, insert_Gxrb)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 ());
+	prioritization.push (1000, block0 (), 0);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
@@ -137,17 +137,25 @@ TEST (prioritization, insert_Gxrb)
 TEST (prioritization, insert_Mxrb)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block1 ());
+	prioritization.push (1000, block1 (), 0);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (1, prioritization.bucket_size (13));
+}
+
+TEST (prioritization, insert_prev_balance)
+{
+	nano::prioritization prioritization;
+	prioritization.push (1000, block1 (), nano::Gxrb_ratio);
+	ASSERT_EQ (1, prioritization.size ());
+	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
 
 // Test two blocks with the same priority
 TEST (prioritization, insert_same_priority)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 ());
-	prioritization.push (1000, block2 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block2 (), 0);
 	ASSERT_EQ (2, prioritization.size ());
 	ASSERT_EQ (2, prioritization.bucket_size (48));
 }
@@ -156,8 +164,8 @@ TEST (prioritization, insert_same_priority)
 TEST (prioritization, insert_duplicate)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 ());
-	prioritization.push (1000, block0 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block0 (), 0);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (1, prioritization.bucket_size (48));
 }
@@ -165,8 +173,8 @@ TEST (prioritization, insert_duplicate)
 TEST (prioritization, insert_older)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 ());
-	prioritization.push (1100, block2 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1100, block2 (), 0);
 	ASSERT_EQ (block0 (), prioritization.top ());
 	prioritization.pop ();
 	ASSERT_EQ (block2 (), prioritization.top ());
@@ -177,7 +185,7 @@ TEST (prioritization, pop)
 {
 	nano::prioritization prioritization;
 	ASSERT_TRUE (prioritization.empty ());
-	prioritization.push (1000, block0 ());
+	prioritization.push (1000, block0 (), 0);
 	ASSERT_FALSE (prioritization.empty ());
 	prioritization.pop ();
 	ASSERT_TRUE (prioritization.empty ());
@@ -186,15 +194,15 @@ TEST (prioritization, pop)
 TEST (prioritization, top_one)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 ());
+	prioritization.push (1000, block0 (), 0);
 	ASSERT_EQ (block0 (), prioritization.top ());
 }
 
 TEST (prioritization, top_two)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, block0 ());
-	prioritization.push (1, block1 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1, block1 (), 0);
 	ASSERT_EQ (block0 (), prioritization.top ());
 	prioritization.pop ();
 	ASSERT_EQ (block1 (), prioritization.top ());
@@ -205,11 +213,11 @@ TEST (prioritization, top_two)
 TEST (prioritization, top_round_robin)
 {
 	nano::prioritization prioritization;
-	prioritization.push (1000, blockzero ());
+	prioritization.push (1000, blockzero (), 0);
 	ASSERT_EQ (blockzero (), prioritization.top ());
-	prioritization.push (1000, block0 ());
-	prioritization.push (1000, block1 ());
-	prioritization.push (1100, block3 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1000, block1 (), 0);
+	prioritization.push (1100, block3 (), 0);
 	prioritization.pop (); // blockzero
 	EXPECT_EQ (block1 (), prioritization.top ());
 	prioritization.pop ();
@@ -223,8 +231,8 @@ TEST (prioritization, top_round_robin)
 TEST (prioritization, trim_normal)
 {
 	nano::prioritization prioritization{ 1 };
-	prioritization.push (1000, block0 ());
-	prioritization.push (1100, block2 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1100, block2 (), 0);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
 }
@@ -232,8 +240,8 @@ TEST (prioritization, trim_normal)
 TEST (prioritization, trim_reverse)
 {
 	nano::prioritization prioritization{ 1 };
-	prioritization.push (1100, block2 ());
-	prioritization.push (1000, block0 ());
+	prioritization.push (1100, block2 (), 0);
+	prioritization.push (1000, block0 (), 0);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
 }
@@ -241,11 +249,11 @@ TEST (prioritization, trim_reverse)
 TEST (prioritization, trim_even)
 {
 	nano::prioritization prioritization{ 2 };
-	prioritization.push (1000, block0 ());
-	prioritization.push (1100, block2 ());
+	prioritization.push (1000, block0 (), 0);
+	prioritization.push (1100, block2 (), 0);
 	ASSERT_EQ (1, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
-	prioritization.push (1000, block1 ());
+	prioritization.push (1000, block1 (), 0);
 	ASSERT_EQ (2, prioritization.size ());
 	ASSERT_EQ (block0 (), prioritization.top ());
 	prioritization.pop ();

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -37,8 +37,9 @@ void nano::election_scheduler::activate (nano::account const & account_a, nano::
 			debug_assert (block != nullptr);
 			if (node.ledger.dependents_confirmed (transaction, *block))
 			{
+				auto previous_balance = node.ledger.balance (transaction, conf_info.frontier);
 				nano::lock_guard<nano::mutex> lock{ mutex };
-				priority.push (account_info.modified, block);
+				priority.push (account_info.modified, block, previous_balance);
 				notify ();
 			}
 		}

--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -37,9 +37,10 @@ void nano::election_scheduler::activate (nano::account const & account_a, nano::
 			debug_assert (block != nullptr);
 			if (node.ledger.dependents_confirmed (transaction, *block))
 			{
+				auto balance = node.ledger.balance (transaction, hash);
 				auto previous_balance = node.ledger.balance (transaction, conf_info.frontier);
 				nano::lock_guard<nano::mutex> lock{ mutex };
-				priority.push (account_info.modified, block, previous_balance);
+				priority.push (account_info.modified, block, std::max (balance, previous_balance));
 				notify ();
 			}
 		}

--- a/nano/node/prioritization.cpp
+++ b/nano/node/prioritization.cpp
@@ -82,12 +82,13 @@ std::size_t nano::prioritization::index (nano::uint128_t const & balance) const
  * Push a block and its associated time into the prioritization container.
  * The time is given here because sideband might not exist in the case of state blocks.
  */
-void nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> block)
+void nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & previous_balance)
 {
 	auto was_empty = empty ();
 	auto block_has_balance = block->type () == nano::block_type::state || block->type () == nano::block_type::send;
 	debug_assert (block_has_balance || block->has_sideband ());
 	auto balance = block_has_balance ? block->balance () : block->sideband ().balance;
+	balance = std::max (balance, previous_balance);
 	auto & bucket = buckets[index (balance.number ())];
 	bucket.emplace (value_type{ time, block });
 	if (bucket.size () > std::max (decltype (maximum){ 1 }, maximum / buckets.size ()))

--- a/nano/node/prioritization.cpp
+++ b/nano/node/prioritization.cpp
@@ -82,14 +82,10 @@ std::size_t nano::prioritization::index (nano::uint128_t const & balance) const
  * Push a block and its associated time into the prioritization container.
  * The time is given here because sideband might not exist in the case of state blocks.
  */
-void nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & previous_balance)
+void nano::prioritization::push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & priority)
 {
 	auto was_empty = empty ();
-	auto block_has_balance = block->type () == nano::block_type::state || block->type () == nano::block_type::send;
-	debug_assert (block_has_balance || block->has_sideband ());
-	auto balance = block_has_balance ? block->balance () : block->sideband ().balance;
-	balance = std::max (balance, previous_balance);
-	auto & bucket = buckets[index (balance.number ())];
+	auto & bucket = buckets[index (priority.number ())];
 	bucket.emplace (value_type{ time, block });
 	if (bucket.size () > std::max (decltype (maximum){ 1 }, maximum / buckets.size ()))
 	{

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -55,7 +55,7 @@ class prioritization final
 
 public:
 	prioritization (uint64_t maximum = 250000u);
-	void push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & previous_balance);
+	void push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & priority);
 	std::shared_ptr<nano::block> top () const;
 	void pop ();
 	std::size_t size () const;

--- a/nano/node/prioritization.hpp
+++ b/nano/node/prioritization.hpp
@@ -55,7 +55,7 @@ class prioritization final
 
 public:
 	prioritization (uint64_t maximum = 250000u);
-	void push (uint64_t time, std::shared_ptr<nano::block> block);
+	void push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & previous_balance);
 	std::shared_ptr<nano::block> top () const;
 	void pop ();
 	std::size_t size () const;


### PR DESCRIPTION
This change teaches the election scheduler to consider both the previous and new balance when scheduling a block. With this change if an account sends its entire balance, the transaction will not be placed in the lowest priority bucket.