### PR TITLE
Disambiguity of all the implemented locks

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -507,7 +507,7 @@ TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 	ASSERT_TIMELY (2s, attempt->frontiers_received);
 	// Add non-existing pull & stop remote peer
 	{
-		nano::unique_lock<nano::mutex> lock (node1->bootstrap_initiator.connections->mutex);
+		nano::unique_lock<nano::mutex> lock{ node1->bootstrap_initiator.connections->mutex };
 		ASSERT_FALSE (attempt->stopped);
 		++attempt->pulling;
 		node1->bootstrap_initiator.connections->pulls.emplace_back (nano::dev::genesis_key.pub, send1->hash (), nano::dev::genesis->hash (), attempt->incremental_id);

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -35,7 +35,7 @@ TEST (gap_cache, add_existing)
 				  .work (5)
 				  .build_shared ();
 	cache.add (block1->hash ());
-	nano::unique_lock<nano::mutex> lock (cache.mutex);
+	nano::unique_lock<nano::mutex> lock{ cache.mutex };
 	auto existing1 (cache.blocks.get<1> ().find (block1->hash ()));
 	ASSERT_NE (cache.blocks.get<1> ().end (), existing1);
 	auto arrival (existing1->arrival);
@@ -63,7 +63,7 @@ TEST (gap_cache, comparison)
 				  .work (5)
 				  .build_shared ();
 	cache.add (block1->hash ());
-	nano::unique_lock<nano::mutex> lock (cache.mutex);
+	nano::unique_lock<nano::mutex> lock{ cache.mutex };
 	auto existing1 (cache.blocks.get<1> ().find (block1->hash ()));
 	ASSERT_NE (cache.blocks.get<1> ().end (), existing1);
 	auto arrival (existing1->arrival);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -956,7 +956,7 @@ TEST (votes, add_one)
 	auto existing1 (votes1.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (votes1.end (), existing1);
 	ASSERT_EQ (send1->hash (), existing1->second.hash);
-	nano::lock_guard<nano::mutex> guard (node1.active.mutex);
+	nano::lock_guard<nano::mutex> guard{ node1.active.mutex };
 	auto winner (*election1->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, winner.first);
@@ -1008,7 +1008,7 @@ TEST (votes, add_existing)
 	ASSERT_TIMELY (5s, node1.active.active (*send2));
 	auto vote2 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 2, 0, std::vector<nano::block_hash>{ send2->hash () }));
 	// Pretend we've waited the timeout
-	nano::unique_lock<nano::mutex> lock (election1->mutex);
+	nano::unique_lock<nano::mutex> lock{ election1->mutex };
 	election1->last_votes[nano::dev::genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	lock.unlock ();
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2));
@@ -1062,7 +1062,7 @@ TEST (votes, add_old)
 	node1.work_generate_blocking (*send2);
 	auto vote2 = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ send2->hash () });
 	{
-		nano::lock_guard<nano::mutex> lock (election1->mutex);
+		nano::lock_guard<nano::mutex> lock{ election1->mutex };
 		election1->last_votes[nano::dev::genesis_key.pub].time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	}
 	node1.vote_processor.vote_blocking (vote2, channel);

--- a/nano/core_test/locks.cpp
+++ b/nano/core_test/locks.cpp
@@ -32,10 +32,10 @@ TEST (locks, no_conflicts)
 	nano::test::cout_redirect (ss.rdbuf ());
 
 	nano::mutex guard_mutex;
-	nano::lock_guard<nano::mutex> guard (guard_mutex);
+	nano::lock_guard<nano::mutex> guard{ guard_mutex };
 
 	nano::mutex lk_mutex;
-	nano::unique_lock<nano::mutex> lk (lk_mutex);
+	nano::unique_lock<nano::mutex> lk{ lk_mutex };
 
 	// This could fail if NANO_TIMED_LOCKS is such a low value that the above mutexes are held longer than that before reaching this statement
 	ASSERT_EQ (ss.str (), "");
@@ -54,7 +54,7 @@ TEST (locks, lock_guard)
 	// Depending on timing the mutex could be reached first in
 	std::promise<void> promise;
 	std::thread t ([&mutex, &promise] {
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		promise.set_value ();
 		// Tries to make sure that the other guard to held for a minimum of NANO_TIMED_LOCKS, may need to increase this for low NANO_TIMED_LOCKS values
 		std::this_thread::sleep_for (std::chrono::milliseconds (NANO_TIMED_LOCKS * 2));
@@ -63,7 +63,7 @@ TEST (locks, lock_guard)
 	// Wait until the lock_guard has been reached in the other thread
 	promise.get_future ().wait ();
 	{
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		t.join ();
 	}
 
@@ -88,7 +88,7 @@ TEST (locks, unique_lock)
 	// Depending on timing the mutex could be reached first in
 	std::promise<void> promise;
 	std::thread t ([&mutex, &promise] {
-		nano::unique_lock<nano::mutex> lk (mutex);
+		nano::unique_lock<nano::mutex> lk{ mutex };
 		std::this_thread::sleep_for (std::chrono::milliseconds (NANO_TIMED_LOCKS));
 		lk.unlock ();
 		lk.lock ();
@@ -101,7 +101,7 @@ TEST (locks, unique_lock)
 	// Wait until the lock_guard has been reached in the other thread
 	promise.get_future ().wait ();
 	{
-		nano::unique_lock<nano::mutex> lk (mutex);
+		nano::unique_lock<nano::mutex> lk{ mutex };
 		t.join ();
 	}
 
@@ -134,7 +134,7 @@ TEST (locks, condition_variable_wait)
 		}
 	});
 
-	nano::unique_lock<nano::mutex> lk (mutex);
+	nano::unique_lock<nano::mutex> lk{ mutex };
 	std::this_thread::sleep_for (std::chrono::milliseconds (NANO_TIMED_LOCKS));
 	cv.wait (lk, [&notified] {
 		return notified.load ();
@@ -159,7 +159,7 @@ TEST (locks, condition_variable_wait_until)
 	auto impl = [&] (auto time_to_sleep) {
 		std::atomic<bool> notified{ false };
 		std::atomic<bool> finished{ false };
-		nano::unique_lock<nano::mutex> lk (mutex);
+		nano::unique_lock<nano::mutex> lk{ mutex };
 		std::this_thread::sleep_for (std::chrono::milliseconds (time_to_sleep));
 		std::thread t ([&] {
 			while (!finished)
@@ -188,7 +188,7 @@ TEST (locks, condition_variable_wait_until)
 TEST (locks, defer_lock)
 {
 	nano::mutex mutex;
-	nano::unique_lock<nano::mutex> lock (mutex, std::defer_lock);
+	nano::unique_lock<nano::mutex> lock{ mutex, std::defer_lock };
 	ASSERT_FALSE (lock.owns_lock ());
 	ASSERT_TRUE (lock.try_lock ());
 	ASSERT_TRUE (lock.owns_lock ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -515,7 +515,7 @@ TEST (node, unlock_search)
 	ASSERT_TIMELY (10s, node->active.empty ());
 	system.wallet (0)->insert_adhoc (key2.prv);
 	{
-		nano::lock_guard<std::recursive_mutex> lock (system.wallet (0)->store.mutex);
+		nano::lock_guard<std::recursive_mutex> lock{ system.wallet (0)->store.mutex };
 		system.wallet (0)->store.password.value_set (nano::keypair ().prv);
 	}
 	{
@@ -2079,7 +2079,7 @@ TEST (node, online_reps_rep_crawler)
 	ASSERT_EQ (0, node1.online_reps.online ());
 	// After inserting to rep crawler
 	{
-		nano::lock_guard<nano::mutex> guard (node1.rep_crawler.probable_reps_mutex);
+		nano::lock_guard<nano::mutex> guard{ node1.rep_crawler.probable_reps_mutex };
 		node1.rep_crawler.active.insert (nano::dev::genesis->hash ());
 	}
 	node1.vote_processor.vote_blocking (vote, std::make_shared<nano::transport::fake::channel> (node1));
@@ -4255,7 +4255,7 @@ TEST (rep_crawler, local)
 	auto loopback = std::make_shared<nano::transport::inproc::channel> (node, node);
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector{ nano::dev::genesis->hash () });
 	{
-		nano::lock_guard<nano::mutex> guard (node.rep_crawler.probable_reps_mutex);
+		nano::lock_guard<nano::mutex> guard{ node.rep_crawler.probable_reps_mutex };
 		node.rep_crawler.active.insert (nano::dev::genesis->hash ());
 		node.rep_crawler.responses.emplace_back (loopback, vote);
 	}

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -159,7 +159,7 @@ TEST (thread_pool_alarm, one)
 	nano::condition_variable condition;
 	workers.add_timed_task (std::chrono::steady_clock::now (), [&] () {
 		{
-			nano::lock_guard<nano::mutex> lock (mutex);
+			nano::lock_guard<nano::mutex> lock{ mutex };
 			done = true;
 		}
 		condition.notify_one ();
@@ -178,7 +178,7 @@ TEST (thread_pool_alarm, many)
 	{
 		workers.add_timed_task (std::chrono::steady_clock::now (), [&] () {
 			{
-				nano::lock_guard<nano::mutex> lock (mutex);
+				nano::lock_guard<nano::mutex> lock{ mutex };
 				count += 1;
 			}
 			condition.notify_one ();
@@ -196,17 +196,17 @@ TEST (thread_pool_alarm, top_execution)
 	nano::mutex mutex;
 	std::promise<bool> promise;
 	workers.add_timed_task (std::chrono::steady_clock::now (), [&] () {
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		value1 = 1;
 		value2 = 1;
 	});
 	workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::milliseconds (1), [&] () {
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		value2 = 2;
 		promise.set_value (false);
 	});
 	promise.get_future ().get ();
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	ASSERT_EQ (1, value1);
 	ASSERT_EQ (2, value2);
 }

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1877,7 +1877,7 @@ std::shared_ptr<nano::block> nano::block_uniquer::unique (std::shared_ptr<nano::
 	if (result != nullptr)
 	{
 		nano::uint256_union key (block_a->full_hash ());
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		auto & existing (blocks[key]);
 		if (auto block_l = existing.lock ())
 		{
@@ -1914,7 +1914,7 @@ std::shared_ptr<nano::block> nano::block_uniquer::unique (std::shared_ptr<nano::
 
 size_t nano::block_uniquer::size ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return blocks.size ();
 }
 

--- a/nano/lib/observer_set.hpp
+++ b/nano/lib/observer_set.hpp
@@ -14,13 +14,13 @@ class observer_set final
 public:
 	void add (std::function<void (T...)> const & observer_a)
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		observers.push_back (observer_a);
 	}
 
 	void notify (T... args) const
 	{
-		nano::unique_lock<nano::mutex> lock (mutex);
+		nano::unique_lock<nano::mutex> lock{ mutex };
 		auto observers_copy = observers;
 		lock.unlock ();
 
@@ -32,13 +32,13 @@ public:
 
 	bool empty () const
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return observers.empty ();
 	}
 
 	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const
 	{
-		nano::unique_lock<nano::mutex> lock (mutex);
+		nano::unique_lock<nano::mutex> lock{ mutex };
 		auto count = observers.size ();
 		lock.unlock ();
 		auto sizeof_element = sizeof (typename decltype (observers)::value_type);

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -215,7 +215,7 @@ nano::stat_histogram::stat_histogram (std::initializer_list<uint64_t> intervals_
 
 void nano::stat_histogram::add (uint64_t index_a, uint64_t addend_a)
 {
-	nano::lock_guard<nano::mutex> lk (histogram_mutex);
+	nano::lock_guard<nano::mutex> lk{ histogram_mutex };
 	debug_assert (!bins.empty ());
 
 	// The search for a bin is linear, but we're searching just a few
@@ -248,7 +248,7 @@ void nano::stat_histogram::add (uint64_t index_a, uint64_t addend_a)
 
 std::vector<nano::stat_histogram::bin> nano::stat_histogram::get_bins () const
 {
-	nano::lock_guard<nano::mutex> lk (histogram_mutex);
+	nano::lock_guard<nano::mutex> lk{ histogram_mutex };
 	return bins;
 }
 
@@ -264,7 +264,7 @@ std::shared_ptr<nano::stat_entry> nano::stat::get_entry (uint32_t key)
 
 std::shared_ptr<nano::stat_entry> nano::stat::get_entry (uint32_t key, size_t interval, size_t capacity)
 {
-	nano::unique_lock<nano::mutex> lock (stat_mutex);
+	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	return get_entry_impl (key, interval, capacity);
 }
 
@@ -291,7 +291,7 @@ std::unique_ptr<nano::stat_log_sink> nano::stat::log_sink_json () const
 
 void nano::stat::log_counters (stat_log_sink & sink)
 {
-	nano::unique_lock<nano::mutex> lock (stat_mutex);
+	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	log_counters_impl (sink);
 }
 
@@ -326,7 +326,7 @@ void nano::stat::log_counters_impl (stat_log_sink & sink)
 
 void nano::stat::log_samples (stat_log_sink & sink)
 {
-	nano::unique_lock<nano::mutex> lock (stat_mutex);
+	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	log_samples_impl (sink);
 }
 
@@ -389,7 +389,7 @@ void nano::stat::update (uint32_t key_a, uint64_t value)
 
 	auto now (std::chrono::steady_clock::now ());
 
-	nano::unique_lock<nano::mutex> lock (stat_mutex);
+	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	if (!stopped)
 	{
 		auto entry (get_entry_impl (key_a, config.interval, config.capacity));
@@ -441,20 +441,20 @@ void nano::stat::update (uint32_t key_a, uint64_t value)
 
 std::chrono::seconds nano::stat::last_reset ()
 {
-	nano::unique_lock<nano::mutex> lock (stat_mutex);
+	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	auto now (std::chrono::steady_clock::now ());
 	return std::chrono::duration_cast<std::chrono::seconds> (now - timestamp);
 }
 
 void nano::stat::stop ()
 {
-	nano::lock_guard<nano::mutex> guard (stat_mutex);
+	nano::lock_guard<nano::mutex> guard{ stat_mutex };
 	stopped = true;
 }
 
 void nano::stat::clear ()
 {
-	nano::unique_lock<nano::mutex> lock (stat_mutex);
+	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	entries.clear ();
 	timestamp = std::chrono::steady_clock::now ();
 }
@@ -1078,14 +1078,14 @@ std::string nano::stat::dir_to_string (dir dir)
 
 nano::stat_datapoint::stat_datapoint (stat_datapoint const & other_a)
 {
-	nano::lock_guard<nano::mutex> lock (other_a.datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ other_a.datapoint_mutex };
 	value = other_a.value;
 	timestamp = other_a.timestamp;
 }
 
 nano::stat_datapoint & nano::stat_datapoint::operator= (stat_datapoint const & other_a)
 {
-	nano::lock_guard<nano::mutex> lock (other_a.datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ other_a.datapoint_mutex };
 	value = other_a.value;
 	timestamp = other_a.timestamp;
 	return *this;
@@ -1093,32 +1093,32 @@ nano::stat_datapoint & nano::stat_datapoint::operator= (stat_datapoint const & o
 
 uint64_t nano::stat_datapoint::get_value () const
 {
-	nano::lock_guard<nano::mutex> lock (datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ datapoint_mutex };
 	return value;
 }
 
 void nano::stat_datapoint::set_value (uint64_t value_a)
 {
-	nano::lock_guard<nano::mutex> lock (datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ datapoint_mutex };
 	value = value_a;
 }
 
 std::chrono::system_clock::time_point nano::stat_datapoint::get_timestamp () const
 {
-	nano::lock_guard<nano::mutex> lock (datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ datapoint_mutex };
 	return timestamp;
 }
 
 void nano::stat_datapoint::set_timestamp (std::chrono::system_clock::time_point timestamp_a)
 {
-	nano::lock_guard<nano::mutex> lock (datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ datapoint_mutex };
 	timestamp = timestamp_a;
 }
 
 /** Add \addend to the current value and optionally update the timestamp */
 void nano::stat_datapoint::add (uint64_t addend, bool update_timestamp)
 {
-	nano::lock_guard<nano::mutex> lock (datapoint_mutex);
+	nano::lock_guard<nano::mutex> lock{ datapoint_mutex };
 	value += addend;
 	if (update_timestamp)
 	{

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -66,7 +66,7 @@ void nano::work_pool::loop (uint64_t thread)
 	uint64_t output;
 	blake2b_state hash;
 	blake2b_init (&hash, sizeof (output));
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto pow_sleep = pow_rate_limiter;
 	while (!done)
 	{
@@ -146,7 +146,7 @@ void nano::work_pool::loop (uint64_t thread)
 
 void nano::work_pool::cancel (nano::root const & root_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	if (!done)
 	{
 		if (!pending.empty ())
@@ -174,7 +174,7 @@ void nano::work_pool::cancel (nano::root const & root_a)
 void nano::work_pool::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		done = true;
 		++ticket;
 	}
@@ -187,7 +187,7 @@ void nano::work_pool::generate (nano::work_version const version_a, nano::root c
 	if (!threads.empty ())
 	{
 		{
-			nano::lock_guard<nano::mutex> lock (mutex);
+			nano::lock_guard<nano::mutex> lock{ mutex };
 			pending.emplace_back (version_a, root_a, difficulty_a, callback_a);
 		}
 		producer_condition.notify_all ();
@@ -227,7 +227,7 @@ boost::optional<uint64_t> nano::work_pool::generate (nano::work_version const ve
 
 size_t nano::work_pool::size ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return pending.size ();
 }
 
@@ -235,7 +235,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (wo
 {
 	size_t count;
 	{
-		nano::lock_guard<nano::mutex> guard (work_pool.mutex);
+		nano::lock_guard<nano::mutex> guard{ work_pool.mutex };
 		count = work_pool.pending.size ();
 	}
 	auto sizeof_element = sizeof (decltype (work_pool.pending)::value_type);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1388,7 +1388,7 @@ int main (int argc, char * const * argv)
 				if (!silent)
 				{
 					static nano::mutex cerr_mutex;
-					nano::lock_guard<nano::mutex> lock (cerr_mutex);
+					nano::lock_guard<nano::mutex> lock{ cerr_mutex };
 					std::cerr << error_message_a;
 				}
 				++errors;
@@ -1399,7 +1399,7 @@ int main (int argc, char * const * argv)
 				{
 					threads.emplace_back ([&function_a, node, &mutex, &condition, &finished, &deque_a] () {
 						auto transaction (node->store.tx_begin_read ());
-						nano::unique_lock<nano::mutex> lock (mutex);
+						nano::unique_lock<nano::mutex> lock{ mutex };
 						while (!deque_a.empty () || !finished)
 						{
 							while (deque_a.empty () && !finished)
@@ -1651,7 +1651,7 @@ int main (int argc, char * const * argv)
 			for (auto i (node->store.account.begin (transaction)), n (node->store.account.end ()); i != n; ++i)
 			{
 				{
-					nano::unique_lock<nano::mutex> lock (mutex);
+					nano::unique_lock<nano::mutex> lock{ mutex };
 					if (accounts.size () > accounts_deque_overflow)
 					{
 						auto wait_ms (250 * accounts.size () / accounts_deque_overflow);
@@ -1663,7 +1663,7 @@ int main (int argc, char * const * argv)
 				condition.notify_all ();
 			}
 			{
-				nano::lock_guard<nano::mutex> lock (mutex);
+				nano::lock_guard<nano::mutex> lock{ mutex };
 				finished = true;
 			}
 			condition.notify_all ();
@@ -1762,7 +1762,7 @@ int main (int argc, char * const * argv)
 			for (auto i (node->store.pending.begin (transaction)), n (node->store.pending.end ()); i != n; ++i)
 			{
 				{
-					nano::unique_lock<nano::mutex> lock (mutex);
+					nano::unique_lock<nano::mutex> lock{ mutex };
 					if (pending.size () > pending_deque_overflow)
 					{
 						auto wait_ms (50 * pending.size () / pending_deque_overflow);
@@ -1774,7 +1774,7 @@ int main (int argc, char * const * argv)
 				condition.notify_all ();
 			}
 			{
-				nano::lock_guard<nano::mutex> lock (mutex);
+				nano::lock_guard<nano::mutex> lock{ mutex };
 				finished = true;
 			}
 			condition.notify_all ();

--- a/nano/node/block_arrival.cpp
+++ b/nano/node/block_arrival.cpp
@@ -2,7 +2,7 @@
 
 bool nano::block_arrival::add (nano::block_hash const & hash_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto now (std::chrono::steady_clock::now ());
 	auto inserted (arrival.get<tag_sequence> ().emplace_back (nano::block_arrival_info{ now, hash_a }));
 	auto result (!inserted.second);
@@ -11,7 +11,7 @@ bool nano::block_arrival::add (nano::block_hash const & hash_a)
 
 bool nano::block_arrival::recent (nano::block_hash const & hash_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto now (std::chrono::steady_clock::now ());
 	while (arrival.size () > arrival_size_min && arrival.get<tag_sequence> ().front ().arrival + arrival_time_min < now)
 	{
@@ -24,7 +24,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (bl
 {
 	std::size_t count = 0;
 	{
-		nano::lock_guard<nano::mutex> guard (block_arrival.mutex);
+		nano::lock_guard<nano::mutex> guard{ block_arrival.mutex };
 		count = block_arrival.arrival.size ();
 	}
 

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -39,7 +39,7 @@ nano::block_processor::block_processor (nano::node & node_a, nano::write_databas
 		{
 			{
 				// Prevent a race with condition.wait in block_processor::flush
-				nano::lock_guard<nano::mutex> guard (this->mutex);
+				nano::lock_guard<nano::mutex> guard{ this->mutex };
 			}
 			this->condition.notify_all ();
 		}
@@ -62,7 +62,7 @@ nano::block_processor::~block_processor ()
 void nano::block_processor::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		stopped = true;
 	}
 	condition.notify_all ();
@@ -73,7 +73,7 @@ void nano::block_processor::flush ()
 {
 	node.checker.flush ();
 	flushing = true;
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped && (have_blocks () || active || state_block_signature_verification.is_active ()))
 	{
 		condition.wait (lock);
@@ -83,7 +83,7 @@ void nano::block_processor::flush ()
 
 std::size_t nano::block_processor::size ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	return (blocks.size () + state_block_signature_verification.size () + forced.size ());
 }
 
@@ -114,7 +114,7 @@ void nano::block_processor::add (nano::unchecked_info const & info_a)
 	else
 	{
 		{
-			nano::lock_guard<nano::mutex> guard (mutex);
+			nano::lock_guard<nano::mutex> guard{ mutex };
 			blocks.emplace_back (info_a);
 		}
 		condition.notify_all ();
@@ -130,7 +130,7 @@ void nano::block_processor::add_local (nano::unchecked_info const & info_a)
 void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		forced.push_back (block_a);
 	}
 	condition.notify_all ();
@@ -138,13 +138,13 @@ void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
 
 void nano::block_processor::wait_write ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	awaiting_write = true;
 }
 
 void nano::block_processor::process_blocks ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
 		if (have_blocks_ready ())
@@ -190,7 +190,7 @@ bool nano::block_processor::have_blocks ()
 void nano::block_processor::process_verified_state_blocks (std::deque<nano::state_block_signature_verification::value_type> & items, std::vector<int> const & verifications, std::vector<nano::block_hash> const & hashes, std::vector<nano::signature> const & blocks_signatures)
 {
 	{
-		nano::unique_lock<nano::mutex> lk (mutex);
+		nano::unique_lock<nano::mutex> lk{ mutex };
 		for (auto i (0); i < verifications.size (); ++i)
 		{
 			debug_assert (verifications[i] == 1 || verifications[i] == 0);
@@ -525,7 +525,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (bl
 	std::size_t forced_count;
 
 	{
-		nano::lock_guard<nano::mutex> guard (block_processor.mutex);
+		nano::lock_guard<nano::mutex> guard{ block_processor.mutex };
 		blocks_count = block_processor.blocks.size ();
 		forced_count = block_processor.forced.size ();
 	}

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -38,7 +38,7 @@ void nano::bootstrap_initiator::bootstrap (bool force, std::string id_a, uint32_
 	{
 		stop_attempts ();
 	}
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	if (!stopped && find_attempt (nano::bootstrap_mode::legacy) == nullptr)
 	{
 		node.stats.inc (nano::stat::type::bootstrap, frontiers_age_a == std::numeric_limits<uint32_t>::max () ? nano::stat::detail::initiate : nano::stat::detail::initiate_legacy_age, nano::stat::dir::out);
@@ -67,7 +67,7 @@ void nano::bootstrap_initiator::bootstrap (nano::endpoint const & endpoint_a, bo
 	{
 		stop_attempts ();
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate, nano::stat::dir::out);
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		auto legacy_attempt (std::make_shared<nano::bootstrap_attempt_legacy> (node.shared (), attempts.incremental++, id_a, std::numeric_limits<uint32_t>::max (), 0));
 		attempts_list.push_back (legacy_attempt);
 		attempts.add (legacy_attempt);
@@ -90,7 +90,7 @@ bool nano::bootstrap_initiator::bootstrap_lazy (nano::hash_or_account const & ha
 			stop_attempts ();
 		}
 		node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate_lazy, nano::stat::dir::out);
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		if (!stopped && find_attempt (nano::bootstrap_mode::lazy) == nullptr)
 		{
 			lazy_attempt = std::make_shared<nano::bootstrap_attempt_lazy> (node.shared (), attempts.incremental++, id_a.empty () ? hash_or_account_a.to_string () : id_a);
@@ -114,7 +114,7 @@ void nano::bootstrap_initiator::bootstrap_wallet (std::deque<nano::account> & ac
 	node.stats.inc (nano::stat::type::bootstrap, nano::stat::detail::initiate_wallet_lazy, nano::stat::dir::out);
 	if (wallet_attempt == nullptr)
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		std::string id (!accounts_a.empty () ? accounts_a[0].to_account () : "");
 		wallet_attempt = std::make_shared<nano::bootstrap_attempt_wallet> (node.shared (), attempts.incremental++, id);
 		attempts_list.push_back (wallet_attempt);
@@ -130,7 +130,7 @@ void nano::bootstrap_initiator::bootstrap_wallet (std::deque<nano::account> & ac
 
 void nano::bootstrap_initiator::run_bootstrap ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
 		if (has_new_attempts ())
@@ -162,19 +162,19 @@ void nano::bootstrap_initiator::lazy_requeue (nano::block_hash const & hash_a, n
 
 void nano::bootstrap_initiator::add_observer (std::function<void (bool)> const & observer_a)
 {
-	nano::lock_guard<nano::mutex> lock (observers_mutex);
+	nano::lock_guard<nano::mutex> lock{ observers_mutex };
 	observers.push_back (observer_a);
 }
 
 bool nano::bootstrap_initiator::in_progress ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return !attempts_list.empty ();
 }
 
 void nano::bootstrap_initiator::block_processed (nano::transaction const & tx, nano::process_return const & result, nano::block const & block)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	for (auto & i : attempts_list)
 	{
 		i->block_processed (tx, result, block);
@@ -195,7 +195,7 @@ std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::find_attempt
 
 void nano::bootstrap_initiator::remove_attempt (std::shared_ptr<nano::bootstrap_attempt> attempt_a)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto attempt (std::find (attempts_list.begin (), attempts_list.end (), attempt_a));
 	if (attempt != attempts_list.end ())
 	{
@@ -239,25 +239,25 @@ bool nano::bootstrap_initiator::has_new_attempts ()
 
 std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_initiator::current_attempt ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return find_attempt (nano::bootstrap_mode::legacy);
 }
 
 std::shared_ptr<nano::bootstrap_attempt_lazy> nano::bootstrap_initiator::current_lazy_attempt ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return std::dynamic_pointer_cast<nano::bootstrap_attempt_lazy> (find_attempt (nano::bootstrap_mode::lazy));
 }
 
 std::shared_ptr<nano::bootstrap_attempt_wallet> nano::bootstrap_initiator::current_wallet_attempt ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return std::dynamic_pointer_cast<nano::bootstrap_attempt_wallet> (find_attempt (nano::bootstrap_mode::wallet_lazy));
 }
 
 void nano::bootstrap_initiator::stop_attempts ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	std::vector<std::shared_ptr<nano::bootstrap_attempt>> copy_attempts;
 	copy_attempts.swap (attempts_list);
 	attempts.clear ();
@@ -288,7 +288,7 @@ void nano::bootstrap_initiator::stop ()
 
 void nano::bootstrap_initiator::notify_listeners (bool in_progress_a)
 {
-	nano::lock_guard<nano::mutex> lock (observers_mutex);
+	nano::lock_guard<nano::mutex> lock{ observers_mutex };
 	for (auto & i : observers)
 	{
 		i (in_progress_a);
@@ -300,11 +300,11 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (bo
 	std::size_t count;
 	std::size_t cache_count;
 	{
-		nano::lock_guard<nano::mutex> guard (bootstrap_initiator.observers_mutex);
+		nano::lock_guard<nano::mutex> guard{ bootstrap_initiator.observers_mutex };
 		count = bootstrap_initiator.observers.size ();
 	}
 	{
-		nano::lock_guard<nano::mutex> guard (bootstrap_initiator.cache.pulls_cache_mutex);
+		nano::lock_guard<nano::mutex> guard{ bootstrap_initiator.cache.pulls_cache_mutex };
 		cache_count = bootstrap_initiator.cache.cache.size ();
 	}
 
@@ -320,7 +320,7 @@ void nano::pulls_cache::add (nano::pull_info const & pull_a)
 {
 	if (pull_a.processed > 500)
 	{
-		nano::lock_guard<nano::mutex> guard (pulls_cache_mutex);
+		nano::lock_guard<nano::mutex> guard{ pulls_cache_mutex };
 		// Clean old pull
 		if (cache.size () > cache_size_max)
 		{
@@ -349,7 +349,7 @@ void nano::pulls_cache::add (nano::pull_info const & pull_a)
 
 void nano::pulls_cache::update_pull (nano::pull_info & pull_a)
 {
-	nano::lock_guard<nano::mutex> guard (pulls_cache_mutex);
+	nano::lock_guard<nano::mutex> guard{ pulls_cache_mutex };
 	nano::uint512_union head_512 (pull_a.account_or_head, pull_a.head_original);
 	auto existing (cache.get<account_head_tag> ().find (head_512));
 	if (existing != cache.get<account_head_tag> ().end ())
@@ -360,32 +360,32 @@ void nano::pulls_cache::update_pull (nano::pull_info & pull_a)
 
 void nano::pulls_cache::remove (nano::pull_info const & pull_a)
 {
-	nano::lock_guard<nano::mutex> guard (pulls_cache_mutex);
+	nano::lock_guard<nano::mutex> guard{ pulls_cache_mutex };
 	nano::uint512_union head_512 (pull_a.account_or_head, pull_a.head_original);
 	cache.get<account_head_tag> ().erase (head_512);
 }
 
 void nano::bootstrap_attempts::add (std::shared_ptr<nano::bootstrap_attempt> attempt_a)
 {
-	nano::lock_guard<nano::mutex> lock (bootstrap_attempts_mutex);
+	nano::lock_guard<nano::mutex> lock{ bootstrap_attempts_mutex };
 	attempts.emplace (attempt_a->incremental_id, attempt_a);
 }
 
 void nano::bootstrap_attempts::remove (uint64_t incremental_id_a)
 {
-	nano::lock_guard<nano::mutex> lock (bootstrap_attempts_mutex);
+	nano::lock_guard<nano::mutex> lock{ bootstrap_attempts_mutex };
 	attempts.erase (incremental_id_a);
 }
 
 void nano::bootstrap_attempts::clear ()
 {
-	nano::lock_guard<nano::mutex> lock (bootstrap_attempts_mutex);
+	nano::lock_guard<nano::mutex> lock{ bootstrap_attempts_mutex };
 	attempts.clear ();
 }
 
 std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_attempts::find (uint64_t incremental_id_a)
 {
-	nano::lock_guard<nano::mutex> lock (bootstrap_attempts_mutex);
+	nano::lock_guard<nano::mutex> lock{ bootstrap_attempts_mutex };
 	auto find_attempt (attempts.find (incremental_id_a));
 	if (find_attempt != attempts.end ())
 	{
@@ -399,6 +399,6 @@ std::shared_ptr<nano::bootstrap_attempt> nano::bootstrap_attempts::find (uint64_
 
 std::size_t nano::bootstrap_attempts::size ()
 {
-	nano::lock_guard<nano::mutex> lock (bootstrap_attempts_mutex);
+	nano::lock_guard<nano::mutex> lock{ bootstrap_attempts_mutex };
 	return attempts.size ();
 }

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -48,7 +48,7 @@ nano::bootstrap_attempt::~bootstrap_attempt ()
 
 bool nano::bootstrap_attempt::should_log ()
 {
-	nano::lock_guard<nano::mutex> guard (next_log_mutex);
+	nano::lock_guard<nano::mutex> guard{ next_log_mutex };
 	auto result (false);
 	auto now (std::chrono::steady_clock::now ());
 	if (next_log < now)
@@ -70,7 +70,7 @@ bool nano::bootstrap_attempt::still_pulling ()
 void nano::bootstrap_attempt::pull_started ()
 {
 	{
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		++pulling;
 	}
 	condition.notify_all ();
@@ -79,7 +79,7 @@ void nano::bootstrap_attempt::pull_started ()
 void nano::bootstrap_attempt::pull_finished ()
 {
 	{
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		--pulling;
 	}
 	condition.notify_all ();
@@ -88,7 +88,7 @@ void nano::bootstrap_attempt::pull_finished ()
 void nano::bootstrap_attempt::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		stopped = true;
 	}
 	condition.notify_all ();

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -43,13 +43,13 @@ double nano::bootstrap_client::sample_block_rate ()
 
 void nano::bootstrap_client::set_start_time (std::chrono::steady_clock::time_point start_time_a)
 {
-	nano::lock_guard<nano::mutex> guard (start_time_mutex);
+	nano::lock_guard<nano::mutex> guard{ start_time_mutex };
 	start_time_m = start_time_a;
 }
 
 double nano::bootstrap_client::elapsed_seconds () const
 {
-	nano::lock_guard<nano::mutex> guard (start_time_mutex);
+	nano::lock_guard<nano::mutex> guard{ start_time_mutex };
 	return std::chrono::duration_cast<std::chrono::duration<double>> (std::chrono::steady_clock::now () - start_time_m).count ();
 }
 
@@ -69,7 +69,7 @@ nano::bootstrap_connections::bootstrap_connections (nano::node & node_a) :
 
 std::shared_ptr<nano::bootstrap_client> nano::bootstrap_connections::connection (std::shared_ptr<nano::bootstrap_attempt> const & attempt_a, bool use_front_connection)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	condition.wait (lock, [&stopped = stopped, &idle = idle, &new_connections_empty = new_connections_empty] { return stopped || !idle.empty () || new_connections_empty; });
 	std::shared_ptr<nano::bootstrap_client> result;
 	if (!stopped && !idle.empty ())
@@ -96,7 +96,7 @@ std::shared_ptr<nano::bootstrap_client> nano::bootstrap_connections::connection 
 
 void nano::bootstrap_connections::pool_connection (std::shared_ptr<nano::bootstrap_client> const & client_a, bool new_client, bool push_front)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto const & socket_l = client_a->socket;
 	if (!stopped && !client_a->pending_stop && !node.network.excluded_peers.check (client_a->channel->get_tcp_endpoint ()))
 	{
@@ -130,7 +130,7 @@ void nano::bootstrap_connections::add_connection (nano::endpoint const & endpoin
 
 std::shared_ptr<nano::bootstrap_client> nano::bootstrap_connections::find_connection (nano::tcp_endpoint const & endpoint_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	std::shared_ptr<nano::bootstrap_client> result;
 	for (auto i (idle.begin ()), end (idle.end ()); i != end && !stopped; ++i)
 	{
@@ -212,7 +212,7 @@ void nano::bootstrap_connections::populate_connections (bool repeat)
 	std::priority_queue<std::shared_ptr<nano::bootstrap_client>, std::vector<std::shared_ptr<nano::bootstrap_client>>, block_rate_cmp> sorted_connections;
 	std::unordered_set<nano::tcp_endpoint> endpoints;
 	{
-		nano::unique_lock<nano::mutex> lock (mutex);
+		nano::unique_lock<nano::mutex> lock{ mutex };
 		num_pulls = pulls.size ();
 		std::deque<std::weak_ptr<nano::bootstrap_client>> new_clients;
 		for (auto & c : clients)
@@ -291,13 +291,13 @@ void nano::bootstrap_connections::populate_connections (bool repeat)
 			{
 				connect_client (endpoint);
 				endpoints.insert (endpoint);
-				nano::lock_guard<nano::mutex> lock (mutex);
+				nano::lock_guard<nano::mutex> lock{ mutex };
 				new_connections_empty = false;
 			}
 			else if (connections_count == 0)
 			{
 				{
-					nano::lock_guard<nano::mutex> lock (mutex);
+					nano::lock_guard<nano::mutex> lock{ mutex };
 					new_connections_empty = true;
 				}
 				condition.notify_all ();
@@ -329,7 +329,7 @@ void nano::bootstrap_connections::add_pull (nano::pull_info const & pull_a)
 	nano::pull_info pull (pull_a);
 	node.bootstrap_initiator.cache.update_pull (pull);
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		pulls.push_back (pull);
 	}
 	condition.notify_all ();
@@ -398,7 +398,7 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 		if (attempt_l->mode == nano::bootstrap_mode::legacy && (pull.attempts < pull.retry_limit + (pull.processed / nano::bootstrap_limits::requeued_pulls_processed_blocks_factor)))
 		{
 			{
-				nano::lock_guard<nano::mutex> lock (mutex);
+				nano::lock_guard<nano::mutex> lock{ mutex };
 				pulls.push_front (pull);
 			}
 			attempt_l->pull_started ();
@@ -410,7 +410,7 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 			if (!lazy->lazy_processed_or_exists (pull.account_or_head.as_block_hash ()))
 			{
 				{
-					nano::lock_guard<nano::mutex> lock (mutex);
+					nano::lock_guard<nano::mutex> lock{ mutex };
 					pulls.push_back (pull);
 				}
 				attempt_l->pull_started ();
@@ -440,7 +440,7 @@ void nano::bootstrap_connections::requeue_pull (nano::pull_info const & pull_a, 
 void nano::bootstrap_connections::clear_pulls (uint64_t bootstrap_id_a)
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		auto i (pulls.begin ());
 		while (i != pulls.end ())
 		{
@@ -460,7 +460,7 @@ void nano::bootstrap_connections::clear_pulls (uint64_t bootstrap_id_a)
 void nano::bootstrap_connections::run ()
 {
 	start_populate_connections ();
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
 		if (!pulls.empty ())
@@ -479,7 +479,7 @@ void nano::bootstrap_connections::run ()
 
 void nano::bootstrap_connections::stop ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	stopped = true;
 	lock.unlock ();
 	condition.notify_all ();

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -27,7 +27,7 @@ nano::bootstrap_attempt_lazy::~bootstrap_attempt_lazy ()
 
 bool nano::bootstrap_attempt_lazy::lazy_start (nano::hash_or_account const & hash_or_account_a)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	bool inserted (false);
 	// Add start blocks, limit 1024 (4k with disabled legacy bootstrap)
 	std::size_t max_keys (node->flags.disable_legacy_bootstrap ? 4 * 1024 : 1024);
@@ -55,13 +55,13 @@ void nano::bootstrap_attempt_lazy::lazy_add (nano::hash_or_account const & hash_
 void nano::bootstrap_attempt_lazy::lazy_add (nano::pull_info const & pull_a)
 {
 	debug_assert (pull_a.account_or_head == pull_a.head);
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	lazy_add (pull_a.account_or_head, pull_a.retry_limit);
 }
 
 void nano::bootstrap_attempt_lazy::lazy_requeue (nano::block_hash const & hash_a, nano::block_hash const & previous_a)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	// Add only known blocks
 	if (lazy_blocks_processed (hash_a))
 	{
@@ -184,7 +184,7 @@ void nano::bootstrap_attempt_lazy::run ()
 	debug_assert (!node->flags.disable_lazy_bootstrap);
 	node->bootstrap_initiator.connections->populate_connections (false);
 	lazy_start_time = std::chrono::steady_clock::now ();
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while ((still_pulling () || !lazy_finished ()) && !lazy_has_expired ())
 	{
 		unsigned iterations (0);
@@ -241,7 +241,7 @@ bool nano::bootstrap_attempt_lazy::process_block_lazy (std::shared_ptr<nano::blo
 {
 	bool stop_pull (false);
 	auto hash (block_a->hash ());
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	// Processing new blocks
 	if (!lazy_blocks_processed (hash))
 	{
@@ -424,7 +424,7 @@ bool nano::bootstrap_attempt_lazy::lazy_blocks_processed (nano::block_hash const
 bool nano::bootstrap_attempt_lazy::lazy_processed_or_exists (nano::block_hash const & hash_a)
 {
 	bool result (false);
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	if (lazy_blocks_processed (hash_a))
 	{
 		result = true;
@@ -442,7 +442,7 @@ bool nano::bootstrap_attempt_lazy::lazy_processed_or_exists (nano::block_hash co
 
 void nano::bootstrap_attempt_lazy::get_information (boost::property_tree::ptree & tree_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	tree_a.put ("lazy_blocks", std::to_string (lazy_blocks.size ()));
 	tree_a.put ("lazy_state_backlog", std::to_string (lazy_state_backlog.size ()));
 	tree_a.put ("lazy_balances", std::to_string (lazy_balances.size ()));
@@ -490,7 +490,7 @@ void nano::bootstrap_attempt_wallet::requeue_pending (nano::account const & acco
 {
 	auto account (account_a);
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		wallet_accounts.push_front (account);
 	}
 	condition.notify_all ();
@@ -499,7 +499,7 @@ void nano::bootstrap_attempt_wallet::requeue_pending (nano::account const & acco
 void nano::bootstrap_attempt_wallet::wallet_start (std::deque<nano::account> & accounts_a)
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		wallet_accounts.swap (accounts_a);
 	}
 	condition.notify_all ();
@@ -521,7 +521,7 @@ void nano::bootstrap_attempt_wallet::run ()
 	node->bootstrap_initiator.connections->populate_connections (false);
 	auto start_time (std::chrono::steady_clock::now ());
 	auto max_time (std::chrono::minutes (10));
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (wallet_finished () && std::chrono::steady_clock::now () - start_time < max_time)
 	{
 		if (!wallet_accounts.empty ())
@@ -544,12 +544,12 @@ void nano::bootstrap_attempt_wallet::run ()
 
 std::size_t nano::bootstrap_attempt_wallet::wallet_size ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return wallet_accounts.size ();
 }
 
 void nano::bootstrap_attempt_wallet::get_information (boost::property_tree::ptree & tree_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	tree_a.put ("wallet_accounts", std::to_string (wallet_accounts.size ()));
 }

--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -29,7 +29,7 @@ bool nano::bootstrap_attempt_legacy::consume_future (std::future<bool> & future_
 
 void nano::bootstrap_attempt_legacy::stop ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	stopped = true;
 	lock.unlock ();
 	condition.notify_all ();
@@ -93,20 +93,20 @@ void nano::bootstrap_attempt_legacy::add_frontier (nano::pull_info const & pull_
 	// Prevent incorrect or malicious pulls with frontier 0 insertion
 	if (!pull_a.head.is_zero ())
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		frontier_pulls.push_back (pull_a);
 	}
 }
 
 void nano::bootstrap_attempt_legacy::add_bulk_push_target (nano::block_hash const & head, nano::block_hash const & end)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	bulk_push_targets.emplace_back (head, end);
 }
 
 bool nano::bootstrap_attempt_legacy::request_bulk_push_target (std::pair<nano::block_hash, nano::block_hash> & current_target_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto empty (bulk_push_targets.empty ());
 	if (!empty)
 	{
@@ -119,7 +119,7 @@ bool nano::bootstrap_attempt_legacy::request_bulk_push_target (std::pair<nano::b
 void nano::bootstrap_attempt_legacy::set_start_account (nano::account const & start_account_a)
 {
 	// Add last account fron frontier request
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	start_account = start_account_a;
 }
 
@@ -204,7 +204,7 @@ void nano::bootstrap_attempt_legacy::run ()
 	debug_assert (started);
 	debug_assert (!node->flags.disable_legacy_bootstrap);
 	node->bootstrap_initiator.connections->populate_connections (false);
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	run_start (lock);
 	while (still_pulling ())
 	{
@@ -248,7 +248,7 @@ void nano::bootstrap_attempt_legacy::run ()
 
 void nano::bootstrap_attempt_legacy::get_information (boost::property_tree::ptree & tree_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	tree_a.put ("frontier_pulls", std::to_string (frontier_pulls.size ()));
 	tree_a.put ("frontiers_received", static_cast<bool> (frontiers_received));
 	tree_a.put ("frontiers_age", std::to_string (frontiers_age));

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1119,7 +1119,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 							{
 								bool error (true);
 								{
-									nano::lock_guard<nano::mutex> lock (node->wallets.mutex);
+									nano::lock_guard<nano::mutex> lock{ node->wallets.mutex };
 									auto transaction (node->wallets.tx_begin_write ());
 									nano::wallet wallet (error, transaction, node->wallets, wallet_id.to_string (), contents.str ());
 								}
@@ -1131,7 +1131,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 								else
 								{
 									node->wallets.reload ();
-									nano::lock_guard<nano::mutex> lock (node->wallets.mutex);
+									nano::lock_guard<nano::mutex> lock{ node->wallets.mutex };
 									release_assert (node->wallets.items.find (wallet_id) != node->wallets.items.end ());
 									std::cout << "Import completed\n";
 								}

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -129,7 +129,7 @@ void nano::distributed_work::do_request (nano::tcp_endpoint const & endpoint_a)
 	auto this_l (shared_from_this ());
 	auto connection (std::make_shared<peer_request> (node.io_ctx, endpoint_a));
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		connections.emplace_back (connection);
 	}
 	connection->socket.async_connect (connection->endpoint,
@@ -271,7 +271,7 @@ void nano::distributed_work::stop_once (bool const local_stop_a)
 {
 	if (!stopped.exchange (true))
 	{
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		if (local_stop_a && node.local_work_generation_enabled ())
 		{
 			node.work.cancel (request.root);
@@ -389,6 +389,6 @@ void nano::distributed_work::handle_failure ()
 
 void nano::distributed_work::add_bad_peer (nano::tcp_endpoint const & endpoint_a)
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	bad_peers.emplace_back (boost::str (boost::format ("%1%:%2%") % endpoint_a.address () % endpoint_a.port ()));
 }

--- a/nano/node/gap_cache.cpp
+++ b/nano/node/gap_cache.cpp
@@ -11,7 +11,7 @@ nano::gap_cache::gap_cache (nano::node & node_a) :
 
 void nano::gap_cache::add (nano::block_hash const & hash_a, std::chrono::steady_clock::time_point time_point_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto existing (blocks.get<tag_hash> ().find (hash_a));
 	if (existing != blocks.get<tag_hash> ().end ())
 	{
@@ -31,13 +31,13 @@ void nano::gap_cache::add (nano::block_hash const & hash_a, std::chrono::steady_
 
 void nano::gap_cache::erase (nano::block_hash const & hash_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	blocks.get<tag_hash> ().erase (hash_a);
 }
 
 void nano::gap_cache::vote (std::shared_ptr<nano::vote> const & vote_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	for (auto const & hash : vote_a->hashes)
 	{
 		auto & gap_blocks_by_hash (blocks.get<tag_hash> ());
@@ -123,7 +123,7 @@ nano::uint128_t nano::gap_cache::bootstrap_threshold ()
 
 std::size_t nano::gap_cache::size ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return blocks.size ();
 }
 

--- a/nano/node/ipc/ipc_access_config.cpp
+++ b/nano/node/ipc/ipc_access_config.cpp
@@ -92,7 +92,7 @@ void nano::ipc::access::clear ()
 
 nano::error nano::ipc::access::deserialize_toml (nano::tomlconfig & toml)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	clear ();
 
 	nano::error error;
@@ -208,7 +208,7 @@ nano::error nano::ipc::access::deserialize_toml (nano::tomlconfig & toml)
 
 bool nano::ipc::access::has_access (std::string const & credentials_a, nano::ipc::access_permission permssion_a) const
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	bool permitted = false;
 	auto user = users.find (credentials_a);
 	if (user != users.end ())
@@ -224,7 +224,7 @@ bool nano::ipc::access::has_access (std::string const & credentials_a, nano::ipc
 
 bool nano::ipc::access::has_access_to_all (std::string const & credentials_a, std::initializer_list<nano::ipc::access_permission> permissions_a) const
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	bool permitted = false;
 	auto user = users.find (credentials_a);
 	if (user != users.end ())
@@ -243,7 +243,7 @@ bool nano::ipc::access::has_access_to_all (std::string const & credentials_a, st
 
 bool nano::ipc::access::has_access_to_oneof (std::string const & credentials_a, std::initializer_list<nano::ipc::access_permission> permissions_a) const
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	bool permitted = false;
 	auto user = users.find (credentials_a);
 	if (user != users.end ())

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -129,7 +129,7 @@ public:
 		};
 
 		static nano::mutex subscriber_mutex;
-		nano::unique_lock<nano::mutex> lock (subscriber_mutex);
+		nano::unique_lock<nano::mutex> lock{ subscriber_mutex };
 
 		if (!subscriber)
 		{

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -852,7 +852,7 @@ nano::message_buffer_manager::message_buffer_manager (nano::stat & stats_a, std:
 
 nano::message_buffer * nano::message_buffer_manager::allocate ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	if (!stopped && free.empty () && full.empty ())
 	{
 		stats.inc (nano::stat::type::udp, nano::stat::detail::blocking, nano::stat::dir::in);
@@ -878,7 +878,7 @@ void nano::message_buffer_manager::enqueue (nano::message_buffer * data_a)
 {
 	debug_assert (data_a != nullptr);
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		full.push_back (data_a);
 	}
 	condition.notify_all ();
@@ -886,7 +886,7 @@ void nano::message_buffer_manager::enqueue (nano::message_buffer * data_a)
 
 nano::message_buffer * nano::message_buffer_manager::dequeue ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped && full.empty ())
 	{
 		condition.wait (lock);
@@ -904,7 +904,7 @@ void nano::message_buffer_manager::release (nano::message_buffer * data_a)
 {
 	debug_assert (data_a != nullptr);
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		free.push_back (data_a);
 	}
 	condition.notify_all ();
@@ -913,7 +913,7 @@ void nano::message_buffer_manager::release (nano::message_buffer * data_a)
 void nano::message_buffer_manager::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		stopped = true;
 	}
 	condition.notify_all ();
@@ -928,7 +928,7 @@ nano::tcp_message_manager::tcp_message_manager (unsigned incoming_connections_ma
 void nano::tcp_message_manager::put_message (nano::tcp_message_item const & item_a)
 {
 	{
-		nano::unique_lock<nano::mutex> lock (mutex);
+		nano::unique_lock<nano::mutex> lock{ mutex };
 		while (entries.size () >= max_entries && !stopped)
 		{
 			producer_condition.wait (lock);
@@ -941,7 +941,7 @@ void nano::tcp_message_manager::put_message (nano::tcp_message_item const & item
 nano::tcp_message_item nano::tcp_message_manager::get_message ()
 {
 	nano::tcp_message_item result;
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (entries.empty () && !stopped)
 	{
 		consumer_condition.wait (lock);
@@ -963,7 +963,7 @@ nano::tcp_message_item nano::tcp_message_manager::get_message ()
 void nano::tcp_message_manager::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		stopped = true;
 	}
 	consumer_condition.notify_all ();
@@ -979,7 +979,7 @@ boost::optional<nano::uint256_union> nano::syn_cookies::assign (nano::endpoint c
 {
 	auto ip_addr (endpoint_a.address ());
 	debug_assert (ip_addr.is_v6 ());
-	nano::lock_guard<nano::mutex> lock (syn_cookie_mutex);
+	nano::lock_guard<nano::mutex> lock{ syn_cookie_mutex };
 	unsigned & ip_cookies = cookies_per_ip[ip_addr];
 	boost::optional<nano::uint256_union> result;
 	if (ip_cookies < max_cookies_per_ip)
@@ -1001,7 +1001,7 @@ bool nano::syn_cookies::validate (nano::endpoint const & endpoint_a, nano::accou
 {
 	auto ip_addr (endpoint_a.address ());
 	debug_assert (ip_addr.is_v6 ());
-	nano::lock_guard<nano::mutex> lock (syn_cookie_mutex);
+	nano::lock_guard<nano::mutex> lock{ syn_cookie_mutex };
 	auto result (true);
 	auto cookie_it (cookies.find (endpoint_a));
 	if (cookie_it != cookies.end () && !nano::validate_message (node_id, cookie_it->second.cookie, sig))
@@ -1023,7 +1023,7 @@ bool nano::syn_cookies::validate (nano::endpoint const & endpoint_a, nano::accou
 
 void nano::syn_cookies::purge (std::chrono::steady_clock::time_point const & cutoff_a)
 {
-	nano::lock_guard<nano::mutex> lock (syn_cookie_mutex);
+	nano::lock_guard<nano::mutex> lock{ syn_cookie_mutex };
 	auto it (cookies.begin ());
 	while (it != cookies.end ())
 	{
@@ -1050,7 +1050,7 @@ void nano::syn_cookies::purge (std::chrono::steady_clock::time_point const & cut
 
 std::size_t nano::syn_cookies::cookies_size ()
 {
-	nano::lock_guard<nano::mutex> lock (syn_cookie_mutex);
+	nano::lock_guard<nano::mutex> lock{ syn_cookie_mutex };
 	return cookies.size ();
 }
 
@@ -1069,7 +1069,7 @@ std::unique_ptr<nano::container_info_component> nano::syn_cookies::collect_conta
 	std::size_t syn_cookies_count;
 	std::size_t syn_cookies_per_ip_count;
 	{
-		nano::lock_guard<nano::mutex> syn_cookie_guard (syn_cookie_mutex);
+		nano::lock_guard<nano::mutex> syn_cookie_guard{ syn_cookie_mutex };
 		syn_cookies_count = cookies.size ();
 		syn_cookies_per_ip_count = cookies_per_ip.size ();
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (re
 {
 	std::size_t count;
 	{
-		nano::lock_guard<nano::mutex> guard (rep_crawler.active_mutex);
+		nano::lock_guard<nano::mutex> guard{ rep_crawler.active_mutex };
 		count = rep_crawler.active.size ();
 	}
 
@@ -1011,12 +1011,12 @@ void nano::node::bootstrap_wallet ()
 {
 	std::deque<nano::account> accounts;
 	{
-		nano::lock_guard<nano::mutex> lock (wallets.mutex);
+		nano::lock_guard<nano::mutex> lock{ wallets.mutex };
 		auto const transaction (wallets.tx_begin_read ());
 		for (auto i (wallets.items.begin ()), n (wallets.items.end ()); i != n && accounts.size () < 128; ++i)
 		{
 			auto & wallet (*i->second);
-			nano::lock_guard<std::recursive_mutex> wallet_lock (wallet.store.mutex);
+			nano::lock_guard<std::recursive_mutex> wallet_lock{ wallet.store.mutex };
 			for (auto j (wallet.store.begin (transaction)), m (wallet.store.end ()); j != m && accounts.size () < 128; ++j)
 			{
 				nano::account account (j->first);
@@ -1379,7 +1379,7 @@ void nano::node::ongoing_online_weight_calculation ()
 
 void nano::node::receive_confirmed (nano::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a)
 {
-	nano::unique_lock<nano::mutex> lk (wallets.mutex);
+	nano::unique_lock<nano::mutex> lk{ wallets.mutex };
 	auto wallets_l = wallets.get_wallets ();
 	auto wallet_transaction = wallets.tx_begin_read ();
 	lk.unlock ();
@@ -1631,7 +1631,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 					if (threads != 0)
 					{
 						{
-							nano::unique_lock<nano::mutex> lock (upgrader_mutex);
+							nano::unique_lock<nano::mutex> lock{ upgrader_mutex };
 							++workers;
 							while (workers > threads)
 							{
@@ -1641,7 +1641,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 						this->workers.push_task ([node_l = shared_from_this (), &upgrader_process, &upgrader_mutex, &upgrader_condition, &upgraded_accounts, &workers, epoch, difficulty, signer, root, account] () {
 							upgrader_process (*node_l, upgraded_accounts, epoch, difficulty, signer, root, account);
 							{
-								nano::lock_guard<nano::mutex> lock (upgrader_mutex);
+								nano::lock_guard<nano::mutex> lock{ upgrader_mutex };
 								--workers;
 							}
 							upgrader_condition.notify_all ();
@@ -1654,7 +1654,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 				}
 			}
 			{
-				nano::unique_lock<nano::mutex> lock (upgrader_mutex);
+				nano::unique_lock<nano::mutex> lock{ upgrader_mutex };
 				while (workers > 0)
 				{
 					upgrader_condition.wait (lock);
@@ -1710,7 +1710,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 						if (threads != 0)
 						{
 							{
-								nano::unique_lock<nano::mutex> lock (upgrader_mutex);
+								nano::unique_lock<nano::mutex> lock{ upgrader_mutex };
 								++workers;
 								while (workers > threads)
 								{
@@ -1720,7 +1720,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 							this->workers.push_task ([node_l = shared_from_this (), &upgrader_process, &upgrader_mutex, &upgrader_condition, &upgraded_pending, &workers, epoch, difficulty, signer, root, account] () {
 								upgrader_process (*node_l, upgraded_pending, epoch, difficulty, signer, root, account);
 								{
-									nano::lock_guard<nano::mutex> lock (upgrader_mutex);
+									nano::lock_guard<nano::mutex> lock{ upgrader_mutex };
 									--workers;
 								}
 								upgrader_condition.notify_all ();
@@ -1755,7 +1755,7 @@ void nano::node::epoch_upgrader_impl (nano::raw_key const & prv_a, nano::epoch e
 				}
 			}
 			{
-				nano::unique_lock<nano::mutex> lock (upgrader_mutex);
+				nano::unique_lock<nano::mutex> lock{ upgrader_mutex };
 				while (workers > 0)
 				{
 					upgrader_condition.wait (lock);

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -18,7 +18,7 @@ void nano::online_reps::observe (nano::account const & rep_a)
 {
 	if (ledger.weight (rep_a) > 0)
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		auto now = std::chrono::steady_clock::now ();
 		auto new_insert = reps.get<tag_account> ().erase (rep_a) == 0;
 		reps.insert ({ now, rep_a });
@@ -34,7 +34,7 @@ void nano::online_reps::observe (nano::account const & rep_a)
 
 void nano::online_reps::sample ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	nano::uint128_t online_l = online_m;
 	lock.unlock ();
 	nano::uint128_t trend_l;
@@ -83,19 +83,19 @@ nano::uint128_t nano::online_reps::calculate_trend (nano::transaction & transact
 
 nano::uint128_t nano::online_reps::trended () const
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return trended_m;
 }
 
 nano::uint128_t nano::online_reps::online () const
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return online_m;
 }
 
 nano::uint128_t nano::online_reps::delta () const
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	// Using a larger container to ensure maximum precision
 	auto weight = static_cast<nano::uint256_t> (std::max ({ online_m, trended_m, config.online_weight_minimum.number () }));
 	return ((weight * online_weight_quorum) / 100).convert_to<nano::uint128_t> ();
@@ -104,14 +104,14 @@ nano::uint128_t nano::online_reps::delta () const
 std::vector<nano::account> nano::online_reps::list ()
 {
 	std::vector<nano::account> result;
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	std::for_each (reps.begin (), reps.end (), [&result] (rep_info const & info_a) { result.push_back (info_a.account); });
 	return result;
 }
 
 void nano::online_reps::clear ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	reps.clear ();
 	online_m = 0;
 }
@@ -120,7 +120,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (on
 {
 	std::size_t count;
 	{
-		nano::lock_guard<nano::mutex> guard (online_reps.mutex);
+		nano::lock_guard<nano::mutex> guard{ online_reps.mutex };
 		count = online_reps.reps.size ();
 	}
 

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -450,7 +450,7 @@ boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version c
 
 boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version const version_a, nano::root const & root_a, uint64_t const difficulty_a, std::atomic<int> & ticket_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	bool error (false);
 	int ticket_l (ticket_a);
 	uint64_t result (0);

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -31,7 +31,7 @@ nano::request_aggregator::request_aggregator (nano::node_config const & config_a
 	final_generator.set_reply_action ([this] (std::shared_ptr<nano::vote> const & vote_a, std::shared_ptr<nano::transport::channel> const & channel_a) {
 		this->reply_action (vote_a, channel_a);
 	});
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	condition.wait (lock, [&started = started] { return started; });
 }
 
@@ -40,7 +40,7 @@ void nano::request_aggregator::add (std::shared_ptr<nano::transport::channel> co
 	debug_assert (wallets.reps ().voting > 0);
 	bool error = true;
 	auto const endpoint (nano::transport::map_endpoint_to_v6 (channel_a->get_endpoint ()));
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	// Protecting from ever-increasing memory usage when request are consumed slower than generated
 	// Reject request if the oldest request has not yet been processed after its deadline + a modest margin
 	if (requests.empty () || (requests.get<tag_deadline> ().begin ()->deadline + 2 * this->max_delay > std::chrono::steady_clock::now ()))
@@ -74,7 +74,7 @@ void nano::request_aggregator::add (std::shared_ptr<nano::transport::channel> co
 void nano::request_aggregator::run ()
 {
 	nano::thread_role::set (nano::thread_role::name::request_aggregator);
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	started = true;
 	lock.unlock ();
 	condition.notify_all ();
@@ -128,7 +128,7 @@ void nano::request_aggregator::run ()
 void nano::request_aggregator::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		stopped = true;
 	}
 	condition.notify_all ();
@@ -140,7 +140,7 @@ void nano::request_aggregator::stop ()
 
 std::size_t nano::request_aggregator::size ()
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	return requests.size ();
 }
 

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -16,7 +16,7 @@ nano::transport::channel_tcp::channel_tcp (nano::node & node_a, std::weak_ptr<na
 
 nano::transport::channel_tcp::~channel_tcp ()
 {
-	nano::lock_guard<nano::mutex> lk (channel_mutex);
+	nano::lock_guard<nano::mutex> lk{ channel_mutex };
 	// Close socket. Exception: socket is used by tcp_server
 	if (auto socket_l = socket.lock ())
 	{
@@ -100,7 +100,7 @@ std::string nano::transport::channel_tcp::to_string () const
 
 void nano::transport::channel_tcp::set_endpoint ()
 {
-	nano::lock_guard<nano::mutex> lk (channel_mutex);
+	nano::lock_guard<nano::mutex> lk{ channel_mutex };
 	debug_assert (endpoint == nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0)); // Not initialized endpoint value
 	// Calculate TCP socket endpoint
 	if (auto socket_l = socket.lock ())
@@ -127,7 +127,7 @@ bool nano::transport::tcp_channels::insert (std::shared_ptr<nano::transport::cha
 	bool error (true);
 	if (!node.network.not_a_peer (udp_endpoint, node.config.allow_local_peers) && !stopped)
 	{
-		nano::unique_lock<nano::mutex> lock (mutex);
+		nano::unique_lock<nano::mutex> lock{ mutex };
 		auto existing (channels.get<endpoint_tag> ().find (endpoint));
 		if (existing == channels.get<endpoint_tag> ().end ())
 		{
@@ -152,19 +152,19 @@ bool nano::transport::tcp_channels::insert (std::shared_ptr<nano::transport::cha
 
 void nano::transport::tcp_channels::erase (nano::tcp_endpoint const & endpoint_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	channels.get<endpoint_tag> ().erase (endpoint_a);
 }
 
 std::size_t nano::transport::tcp_channels::size () const
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return channels.size ();
 }
 
 std::shared_ptr<nano::transport::channel_tcp> nano::transport::tcp_channels::find_channel (nano::tcp_endpoint const & endpoint_a) const
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	std::shared_ptr<nano::transport::channel_tcp> result;
 	auto existing (channels.get<endpoint_tag> ().find (endpoint_a));
 	if (existing != channels.get<endpoint_tag> ().end ())
@@ -178,7 +178,7 @@ std::unordered_set<std::shared_ptr<nano::transport::channel>> nano::transport::t
 {
 	std::unordered_set<std::shared_ptr<nano::transport::channel>> result;
 	result.reserve (count_a);
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	// Stop trying to fill result with random samples after this many attempts
 	auto random_cutoff (count_a * 2);
 	auto peers_size (channels.size ());
@@ -222,7 +222,7 @@ bool nano::transport::tcp_channels::store_all (bool clear_peers)
 	// we collect endpoints to be saved and then relase the lock.
 	std::vector<nano::endpoint> endpoints;
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		endpoints.reserve (channels.size ());
 		std::transform (channels.begin (), channels.end (),
 		std::back_inserter (endpoints), [] (auto const & channel) { return nano::transport::map_tcp_to_endpoint (channel.endpoint ()); });
@@ -248,7 +248,7 @@ bool nano::transport::tcp_channels::store_all (bool clear_peers)
 std::shared_ptr<nano::transport::channel_tcp> nano::transport::tcp_channels::find_node_id (nano::account const & node_id_a)
 {
 	std::shared_ptr<nano::transport::channel_tcp> result;
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto existing (channels.get<node_id_tag> ().find (node_id_a));
 	if (existing != channels.get<node_id_tag> ().end ())
 	{
@@ -260,7 +260,7 @@ std::shared_ptr<nano::transport::channel_tcp> nano::transport::tcp_channels::fin
 nano::tcp_endpoint nano::transport::tcp_channels::bootstrap_peer (uint8_t connection_protocol_version_min)
 {
 	nano::tcp_endpoint result (boost::asio::ip::address_v6::any (), 0);
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	for (auto i (channels.get<last_bootstrap_attempt_tag> ().begin ()), n (channels.get<last_bootstrap_attempt_tag> ().end ()); i != n;)
 	{
 		if (i->channel->get_network_version () >= connection_protocol_version_min)
@@ -350,7 +350,7 @@ void nano::transport::tcp_channels::start ()
 void nano::transport::tcp_channels::stop ()
 {
 	stopped = true;
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	// Close all TCP sockets
 	for (auto const & channel : channels)
 	{
@@ -375,7 +375,7 @@ bool nano::transport::tcp_channels::max_ip_connections (nano::tcp_endpoint const
 	}
 	bool result{ false };
 	auto const address (nano::transport::ipv4_address_or_ipv6_subnet (endpoint_a.address ()));
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	result = channels.get<ip_address_tag> ().count (address) >= node.network_params.network.max_peers_per_ip;
 	if (!result)
 	{
@@ -396,7 +396,7 @@ bool nano::transport::tcp_channels::max_subnetwork_connections (nano::tcp_endpoi
 	}
 	bool result{ false };
 	auto const subnet (nano::transport::map_address_to_subnetwork (endpoint_a.address ()));
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	result = channels.get<subnetwork_tag> ().count (subnet) >= node.network_params.network.max_peers_per_subnetwork;
 	if (!result)
 	{
@@ -423,7 +423,7 @@ bool nano::transport::tcp_channels::reachout (nano::endpoint const & endpoint_a)
 	{
 		// Don't keepalive to nodes that already sent us something
 		error |= find_channel (tcp_endpoint) != nullptr;
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		auto inserted (attempts.emplace (tcp_endpoint));
 		error |= !inserted.second;
 	}
@@ -436,7 +436,7 @@ std::unique_ptr<nano::container_info_component> nano::transport::tcp_channels::c
 	std::size_t attemps_count;
 	std::size_t node_id_handshake_sockets_count;
 	{
-		nano::lock_guard<nano::mutex> guard (mutex);
+		nano::lock_guard<nano::mutex> guard{ mutex };
 		channels_count = channels.size ();
 		attemps_count = attempts.size ();
 	}
@@ -450,7 +450,7 @@ std::unique_ptr<nano::container_info_component> nano::transport::tcp_channels::c
 
 void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point const & cutoff_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 
 	// Remove channels with dead underlying sockets
 	for (auto it = channels.begin (); it != channels.end (); ++it)
@@ -477,7 +477,7 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 {
 	nano::keepalive message{ node.network_params.network };
 	node.network.random_fill (message.peers);
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	// Wake up channels
 	std::vector<std::shared_ptr<nano::transport::channel_tcp>> send_list;
 	auto keepalive_sent_cutoff (channels.get<last_packet_sent_tag> ().lower_bound (std::chrono::steady_clock::now () - node.network_params.network.keepalive_period));
@@ -518,7 +518,7 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 
 void nano::transport::tcp_channels::list (std::deque<std::shared_ptr<nano::transport::channel>> & deque_a, uint8_t minimum_version_a, bool include_temporary_channels_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	// clang-format off
 	nano::transform_if (channels.get<random_access_tag> ().begin (), channels.get<random_access_tag> ().end (), std::back_inserter (deque_a),
 		[include_temporary_channels_a, minimum_version_a](auto & channel_a) { return channel_a.channel->get_network_version () >= minimum_version_a && (include_temporary_channels_a || !channel_a.channel->temporary); },
@@ -528,7 +528,7 @@ void nano::transport::tcp_channels::list (std::deque<std::shared_ptr<nano::trans
 
 void nano::transport::tcp_channels::modify (std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::function<void (std::shared_ptr<nano::transport::channel_tcp> const &)> modify_callback_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto existing (channels.get<endpoint_tag> ().find (channel_a->get_tcp_endpoint ()));
 	if (existing != channels.get<endpoint_tag> ().end ())
 	{
@@ -540,7 +540,7 @@ void nano::transport::tcp_channels::modify (std::shared_ptr<nano::transport::cha
 
 void nano::transport::tcp_channels::update (nano::tcp_endpoint const & endpoint_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto existing (channels.get<endpoint_tag> ().find (endpoint_a));
 	if (existing != channels.get<endpoint_tag> ().end ())
 	{
@@ -673,7 +673,7 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 			cleanup_node_id_handshake_socket (endpoint_a);
 			// Cleanup attempt
 			{
-				nano::lock_guard<nano::mutex> lock (node_l->network.tcp_channels.mutex);
+				nano::lock_guard<nano::mutex> lock{ node_l->network.tcp_channels.mutex };
 				node_l->network.tcp_channels.attempts.get<endpoint_tag> ().erase (nano::transport::map_endpoint_to_tcp (endpoint_a));
 			}
 			return;

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -17,7 +17,7 @@ nano::transport::tcp_listener::tcp_listener (uint16_t port_a, nano::node & node_
 
 void nano::transport::tcp_listener::start ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	on = true;
 	listening_socket = std::make_shared<nano::server_socket> (node, boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::any (), port), node.config.tcp_incoming_connections_max);
 	boost::system::error_code ec;
@@ -77,13 +77,13 @@ void nano::transport::tcp_listener::stop ()
 {
 	decltype (connections) connections_l;
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		on = false;
 		connections_l.swap (connections);
 	}
 	if (listening_socket)
 	{
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		listening_socket->close ();
 		listening_socket = nullptr;
 	}
@@ -91,7 +91,7 @@ void nano::transport::tcp_listener::stop ()
 
 std::size_t nano::transport::tcp_listener::connection_count ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return connections.size ();
 }
 
@@ -100,7 +100,7 @@ void nano::transport::tcp_listener::accept_action (boost::system::error_code con
 	if (!node.network.excluded_peers.check (socket_a->remote_endpoint ()))
 	{
 		auto server = std::make_shared<nano::transport::tcp_server> (socket_a, node.shared (), true);
-		nano::lock_guard<nano::mutex> lock (mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		connections[server.get ()] = server;
 		server->start ();
 	}
@@ -116,7 +116,7 @@ void nano::transport::tcp_listener::accept_action (boost::system::error_code con
 
 boost::asio::ip::tcp::endpoint nano::transport::tcp_listener::endpoint ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	if (on && listening_socket)
 	{
 		return boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), port);
@@ -170,7 +170,7 @@ nano::transport::tcp_server::~tcp_server ()
 
 	stop ();
 
-	nano::lock_guard<nano::mutex> lock (node->tcp_listener.mutex);
+	nano::lock_guard<nano::mutex> lock{ node->tcp_listener.mutex };
 	node->tcp_listener.connections.erase (this);
 }
 
@@ -564,7 +564,7 @@ void nano::transport::tcp_server::timeout ()
 			node->logger.try_log ("Closing incoming tcp / bootstrap server by timeout");
 		}
 		{
-			nano::lock_guard<nano::mutex> lock (node->tcp_listener.mutex);
+			nano::lock_guard<nano::mutex> lock{ node->tcp_listener.mutex };
 			node->tcp_listener.connections.erase (this);
 		}
 		socket->close ();

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -68,7 +68,7 @@ bool nano::local_vote_history::consistency_check (nano::root const & root_a) con
 
 void nano::local_vote_history::add (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a)
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	clean ();
 	auto add_vote (true);
 	auto & history_by_root (history.get<tag_root> ());
@@ -102,7 +102,7 @@ void nano::local_vote_history::add (nano::root const & root_a, nano::block_hash 
 
 void nano::local_vote_history::erase (nano::root const & root_a)
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	auto & history_by_root (history.get<tag_root> ());
 	auto range (history_by_root.equal_range (root_a));
 	history_by_root.erase (range.first, range.second);
@@ -110,7 +110,7 @@ void nano::local_vote_history::erase (nano::root const & root_a)
 
 std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::root const & root_a) const
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	std::vector<std::shared_ptr<nano::vote>> result;
 	auto range (history.get<tag_root> ().equal_range (root_a));
 	std::transform (range.first, range.second, std::back_inserter (result), [] (auto const & entry) { return entry.vote; });
@@ -119,7 +119,7 @@ std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::
 
 std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::root const & root_a, nano::block_hash const & hash_a, bool const is_final_a) const
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	std::vector<std::shared_ptr<nano::vote>> result;
 	auto range (history.get<tag_root> ().equal_range (root_a));
 	// clang-format off
@@ -132,7 +132,7 @@ std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::
 
 bool nano::local_vote_history::exists (nano::root const & root_a) const
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	return history.get<tag_root> ().find (root_a) != history.get<tag_root> ().end ();
 }
 
@@ -148,7 +148,7 @@ void nano::local_vote_history::clean ()
 
 std::size_t nano::local_vote_history::size () const
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	return history.size ();
 }
 
@@ -200,7 +200,7 @@ void nano::vote_generator::process (nano::write_transaction const & transaction,
 	}
 	if (should_vote)
 	{
-		nano::unique_lock<nano::mutex> lock (mutex);
+		nano::unique_lock<nano::mutex> lock{ mutex };
 		candidates.emplace_back (root_a, hash_a);
 		if (candidates.size () >= nano::network::confirm_ack_hashes_max)
 		{
@@ -222,7 +222,7 @@ void nano::vote_generator::stop ()
 {
 	vote_generation_queue.stop ();
 
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	stopped = true;
 
 	lock.unlock ();
@@ -263,7 +263,7 @@ std::size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::bl
 		nano::transform_if (blocks_a.begin (), blocks_a.end (), std::back_inserter (req_candidates), dependents_confirmed, as_candidate);
 	}
 	auto const result = req_candidates.size ();
-	nano::lock_guard<nano::mutex> guard (mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	requests.emplace_back (std::move (req_candidates), channel_a);
 	while (requests.size () > max_requests)
 	{
@@ -386,7 +386,7 @@ void nano::vote_generator::broadcast_action (std::shared_ptr<nano::vote> const &
 void nano::vote_generator::run ()
 {
 	nano::thread_role::set (nano::thread_role::name::voting);
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
 		if (candidates.size () >= nano::network::confirm_ack_hashes_max)
@@ -419,7 +419,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (na
 	std::size_t candidates_count = 0;
 	std::size_t requests_count = 0;
 	{
-		nano::lock_guard<nano::mutex> guard (vote_generator.mutex);
+		nano::lock_guard<nano::mutex> guard{ vote_generator.mutex };
 		candidates_count = vote_generator.candidates.size ();
 		requests_count = vote_generator.requests.size ();
 	}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -29,7 +29,7 @@ nano::uint256_union nano::wallet_store::salt (nano::transaction const & transact
 
 void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::transaction const & transaction_a)
 {
-	nano::lock_guard<std::recursive_mutex> lock (mutex);
+	nano::lock_guard<std::recursive_mutex> lock{ mutex };
 	nano::raw_key wallet_l;
 	wallet_key_mem.value (wallet_l);
 	nano::raw_key password_l;
@@ -147,7 +147,7 @@ bool nano::wallet_store::attempt_password (nano::transaction const & transaction
 {
 	bool result = false;
 	{
-		nano::lock_guard<std::recursive_mutex> lock (mutex);
+		nano::lock_guard<std::recursive_mutex> lock{ mutex };
 		nano::raw_key password_l;
 		derive_key (password_l, transaction_a, password_a);
 		password.value_set (password_l);
@@ -168,7 +168,7 @@ bool nano::wallet_store::attempt_password (nano::transaction const & transaction
 
 bool nano::wallet_store::rekey (nano::transaction const & transaction_a, std::string const & password_a)
 {
-	nano::lock_guard<std::recursive_mutex> lock (mutex);
+	nano::lock_guard<std::recursive_mutex> lock{ mutex };
 	bool result (false);
 	if (valid_password (transaction_a))
 	{
@@ -214,7 +214,7 @@ nano::fan::fan (nano::raw_key const & key, std::size_t count_a)
 
 void nano::fan::value (nano::raw_key & prv_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	value_get (prv_a);
 }
 
@@ -230,7 +230,7 @@ void nano::fan::value_get (nano::raw_key & prv_a)
 
 void nano::fan::value_set (nano::raw_key const & value_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	nano::raw_key value_l;
 	value_get (value_l);
 	*(values[0]) ^= value_l;
@@ -651,7 +651,7 @@ void nano::wallet_store::version_put (nano::transaction const & transaction_a, u
 
 void nano::kdf::phs (nano::raw_key & result_a, std::string const & password_a, nano::uint256_union const & salt_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto success (argon2_hash (1, kdf_work, 1, password_a.data (), password_a.size (), salt_a.bytes.data (), salt_a.bytes.size (), result_a.bytes.data (), result_a.bytes.size (), NULL, 0, Argon2_d, 0x10));
 	debug_assert (success == 0);
 	(void)success;
@@ -675,7 +675,7 @@ void nano::wallet::enter_initial_password ()
 {
 	nano::raw_key password_l;
 	{
-		nano::lock_guard<std::recursive_mutex> lock (store.mutex);
+		nano::lock_guard<std::recursive_mutex> lock{ store.mutex };
 		store.password.value (password_l);
 	}
 	if (password_l.is_zero ())
@@ -725,7 +725,7 @@ nano::public_key nano::wallet::deterministic_insert (nano::transaction const & t
 		auto half_principal_weight (wallets.node.minimum_principal_weight () / 2);
 		if (wallets.check_rep (key, half_principal_weight))
 		{
-			nano::lock_guard<nano::mutex> lock (representatives_mutex);
+			nano::lock_guard<nano::mutex> lock{ representatives_mutex };
 			representatives.insert (key);
 		}
 	}
@@ -772,7 +772,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 		transaction.commit ();
 		if (wallets.check_rep (key, half_principal_weight))
 		{
-			nano::lock_guard<nano::mutex> lock (representatives_mutex);
+			nano::lock_guard<nano::mutex> lock{ representatives_mutex };
 			representatives.insert (key);
 		}
 	}
@@ -1308,7 +1308,7 @@ void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::r
 
 void nano::wallets::do_wallet_actions ()
 {
-	nano::unique_lock<nano::mutex> action_lock (action_mutex);
+	nano::unique_lock<nano::mutex> action_lock{ action_mutex };
 	while (!stopped)
 	{
 		if (!actions.empty ())
@@ -1341,7 +1341,7 @@ nano::wallets::wallets (bool error_a, nano::node & node_a) :
 	env (boost::polymorphic_downcast<nano::mdb_wallets_store *> (node_a.wallets_store_impl.get ())->environment),
 	stopped (false)
 {
-	nano::unique_lock<nano::mutex> lock (mutex);
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	if (!error_a)
 	{
 		auto transaction (tx_begin_write ());
@@ -1410,7 +1410,7 @@ nano::wallets::~wallets ()
 
 std::shared_ptr<nano::wallet> nano::wallets::open (nano::wallet_id const & id_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	std::shared_ptr<nano::wallet> result;
 	auto existing (items.find (id_a));
 	if (existing != items.end ())
@@ -1422,7 +1422,7 @@ std::shared_ptr<nano::wallet> nano::wallets::open (nano::wallet_id const & id_a)
 
 std::shared_ptr<nano::wallet> nano::wallets::create (nano::wallet_id const & id_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	debug_assert (items.find (id_a) == items.end ());
 	std::shared_ptr<nano::wallet> result;
 	bool error;
@@ -1450,7 +1450,7 @@ bool nano::wallets::search_receivable (nano::wallet_id const & wallet_a)
 
 void nano::wallets::search_receivable_all ()
 {
-	nano::unique_lock<nano::mutex> lk (mutex);
+	nano::unique_lock<nano::mutex> lk{ mutex };
 	auto wallets_l = get_wallets ();
 	auto wallet_transaction (tx_begin_read ());
 	lk.unlock ();
@@ -1462,10 +1462,10 @@ void nano::wallets::search_receivable_all ()
 
 void nano::wallets::destroy (nano::wallet_id const & id_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto transaction (tx_begin_write ());
 	// action_mutex should be after transactions to prevent deadlocks in deterministic_insert () & insert_adhoc ()
-	nano::lock_guard<nano::mutex> action_lock (action_mutex);
+	nano::lock_guard<nano::mutex> action_lock{ action_mutex };
 	auto existing (items.find (id_a));
 	debug_assert (existing != items.end ());
 	auto wallet (existing->second);
@@ -1475,7 +1475,7 @@ void nano::wallets::destroy (nano::wallet_id const & id_a)
 
 void nano::wallets::reload ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto transaction (tx_begin_write ());
 	std::unordered_set<nano::uint256_union> stored_items;
 	std::string beginning (nano::uint256_union (0).to_string ());
@@ -1519,7 +1519,7 @@ void nano::wallets::reload ()
 void nano::wallets::queue_wallet_action (nano::uint128_t const & amount_a, std::shared_ptr<nano::wallet> const & wallet_a, std::function<void (nano::wallet &)> action_a)
 {
 	{
-		nano::lock_guard<nano::mutex> action_lock (action_mutex);
+		nano::lock_guard<nano::mutex> action_lock{ action_mutex };
 		actions.emplace (amount_a, std::make_pair (wallet_a, action_a));
 	}
 	condition.notify_all ();
@@ -1532,14 +1532,14 @@ void nano::wallets::foreach_representative (std::function<void (nano::public_key
 		std::vector<std::pair<nano::public_key const, nano::raw_key const>> action_accounts_l;
 		{
 			auto transaction_l (tx_begin_read ());
-			nano::lock_guard<nano::mutex> lock (mutex);
+			nano::lock_guard<nano::mutex> lock{ mutex };
 			for (auto i (items.begin ()), n (items.end ()); i != n; ++i)
 			{
 				auto & wallet (*i->second);
-				nano::lock_guard<std::recursive_mutex> store_lock (wallet.store.mutex);
+				nano::lock_guard<std::recursive_mutex> store_lock{ wallet.store.mutex };
 				decltype (wallet.representatives) representatives_l;
 				{
-					nano::lock_guard<nano::mutex> representatives_lock (wallet.representatives_mutex);
+					nano::lock_guard<nano::mutex> representatives_lock{ wallet.representatives_mutex };
 					representatives_l = wallet.representatives;
 				}
 				for (auto const & account : representatives_l)
@@ -1579,7 +1579,7 @@ void nano::wallets::foreach_representative (std::function<void (nano::public_key
 
 bool nano::wallets::exists (nano::transaction const & transaction_a, nano::account const & account_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto result (false);
 	for (auto i (items.begin ()), n (items.end ()); !result && i != n; ++i)
 	{
@@ -1591,7 +1591,7 @@ bool nano::wallets::exists (nano::transaction const & transaction_a, nano::accou
 void nano::wallets::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> action_lock (action_mutex);
+		nano::lock_guard<nano::mutex> action_lock{ action_mutex };
 		stopped = true;
 		actions.clear ();
 	}
@@ -1629,7 +1629,7 @@ void nano::wallets::clear_send_ids (nano::transaction const & transaction_a)
 
 nano::wallet_representatives nano::wallets::reps () const
 {
-	nano::lock_guard<nano::mutex> counts_guard (reps_cache_mutex);
+	nano::lock_guard<nano::mutex> counts_guard{ reps_cache_mutex };
 	return representatives;
 }
 
@@ -1645,7 +1645,7 @@ bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t 
 	nano::unique_lock<nano::mutex> lock;
 	if (acquire_lock_a)
 	{
-		lock = nano::unique_lock<nano::mutex> (reps_cache_mutex);
+		lock = nano::unique_lock<nano::mutex>{ reps_cache_mutex };
 	}
 
 	if (weight >= half_principal_weight_a)
@@ -1666,8 +1666,8 @@ bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t 
 
 void nano::wallets::compute_reps ()
 {
-	nano::lock_guard<nano::mutex> guard (mutex);
-	nano::lock_guard<nano::mutex> counts_guard (reps_cache_mutex);
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	nano::lock_guard<nano::mutex> counts_guard{ reps_cache_mutex };
 	representatives.clear ();
 	auto half_principal_weight (node.minimum_principal_weight () / 2);
 	auto transaction (tx_begin_read ());
@@ -1683,7 +1683,7 @@ void nano::wallets::compute_reps ()
 				representatives_l.insert (account);
 			}
 		}
-		nano::lock_guard<nano::mutex> representatives_guard (wallet.representatives_mutex);
+		nano::lock_guard<nano::mutex> representatives_guard{ wallet.representatives_mutex };
 		wallet.representatives.swap (representatives_l);
 	}
 }
@@ -1840,7 +1840,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (wa
 	std::size_t items_count;
 	std::size_t actions_count;
 	{
-		nano::lock_guard<nano::mutex> guard (wallets.mutex);
+		nano::lock_guard<nano::mutex> guard{ wallets.mutex };
 		items_count = wallets.items.size ();
 		actions_count = wallets.actions.size ();
 	}

--- a/nano/rpc/rpc_request_processor.cpp
+++ b/nano/rpc/rpc_request_processor.cpp
@@ -13,7 +13,7 @@ nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io
 		this->run ();
 	})
 {
-	nano::lock_guard<nano::mutex> lk (this->request_mutex);
+	nano::lock_guard<nano::mutex> lk{ this->request_mutex };
 	this->connections.reserve (rpc_config.rpc_process.num_ipc_connections);
 	for (auto i = 0u; i < rpc_config.rpc_process.num_ipc_connections; ++i)
 	{
@@ -21,7 +21,7 @@ nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io
 		auto connection = this->connections.back ();
 		connection->client.async_connect (ipc_address, ipc_port, [connection, &connections_mutex = this->connections_mutex] (nano::error err) {
 			// Even if there is an error this needs to be set so that another attempt can be made to connect with the ipc connection
-			nano::lock_guard<nano::mutex> lk (connections_mutex);
+			nano::lock_guard<nano::mutex> lk{ connections_mutex };
 			connection->is_available = true;
 		});
 	}
@@ -40,7 +40,7 @@ nano::rpc_request_processor::~rpc_request_processor ()
 void nano::rpc_request_processor::stop ()
 {
 	{
-		nano::lock_guard<nano::mutex> lock (request_mutex);
+		nano::lock_guard<nano::mutex> lock{ request_mutex };
 		stopped = true;
 	}
 	condition.notify_one ();
@@ -53,7 +53,7 @@ void nano::rpc_request_processor::stop ()
 void nano::rpc_request_processor::add (std::shared_ptr<rpc_request> const & request)
 {
 	{
-		nano::lock_guard<nano::mutex> lk (request_mutex);
+		nano::lock_guard<nano::mutex> lk{ request_mutex };
 		requests.push_back (request);
 	}
 	condition.notify_one ();
@@ -85,7 +85,7 @@ void nano::rpc_request_processor::read_payload (std::shared_ptr<nano::ipc_connec
 
 void nano::rpc_request_processor::make_available (nano::ipc_connection & connection)
 {
-	nano::lock_guard<nano::mutex> lk (connections_mutex);
+	nano::lock_guard<nano::mutex> lk{ connections_mutex };
 	connection.is_available = true; // Allow people to use it now
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -661,7 +661,7 @@ std::shared_ptr<nano::vote> nano::vote_uniquer::unique (std::shared_ptr<nano::vo
 
 size_t nano::vote_uniquer::size ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return votes.size ();
 }
 

--- a/nano/secure/network_filter.cpp
+++ b/nano/secure/network_filter.cpp
@@ -15,7 +15,7 @@ bool nano::network_filter::apply (uint8_t const * bytes_a, size_t count_a, nano:
 	// Get hash before locking
 	auto digest (hash (bytes_a, count_a));
 
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto & element (get_element (digest));
 	bool existed (element == digest);
 	if (!existed)
@@ -32,7 +32,7 @@ bool nano::network_filter::apply (uint8_t const * bytes_a, size_t count_a, nano:
 
 void nano::network_filter::clear (nano::uint128_t const & digest_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto & element (get_element (digest_a));
 	if (element == digest_a)
 	{
@@ -42,7 +42,7 @@ void nano::network_filter::clear (nano::uint128_t const & digest_a)
 
 void nano::network_filter::clear (std::vector<nano::uint128_t> const & digests_a)
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	for (auto const & digest : digests_a)
 	{
 		auto & element (get_element (digest));
@@ -66,7 +66,7 @@ void nano::network_filter::clear (OBJECT const & object_a)
 
 void nano::network_filter::clear ()
 {
-	nano::lock_guard<nano::mutex> lock (mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	items.assign (items.size (), nano::uint128_t{ 0 });
 }
 

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -311,7 +311,7 @@ TEST (node, fork_storm)
 			}
 			else
 			{
-				nano::unique_lock<nano::mutex> lock (node_a->active.mutex);
+				nano::unique_lock<nano::mutex> lock{ node_a->active.mutex };
 				auto election = node_a->active.roots.begin ()->election;
 				lock.unlock ();
 				if (election->votes ().size () == 1)
@@ -1713,13 +1713,13 @@ TEST (telemetry, many_nodes)
 	{
 		node_client->telemetry->get_metrics_single_peer_async (peer, [&telemetry_datas, &mutex] (nano::telemetry_data_response const & response_a) {
 			ASSERT_FALSE (response_a.error);
-			nano::lock_guard<nano::mutex> guard (mutex);
+			nano::lock_guard<nano::mutex> guard{ mutex };
 			telemetry_datas.push_back (response_a.telemetry_data);
 		});
 	}
 
 	system.deadline_set (20s);
-	nano::unique_lock<nano::mutex> lk (mutex);
+	nano::unique_lock<nano::mutex> lk{ mutex };
 	while (telemetry_datas.size () != num_nodes - 1)
 	{
 		lk.unlock ();
@@ -1977,7 +1977,7 @@ TEST (node, mass_block_new)
 		node.block_processor.flush ();
 		// Clear all active
 		{
-			nano::lock_guard<nano::mutex> guard (node.active.mutex);
+			nano::lock_guard<nano::mutex> guard{ node.active.mutex };
 			node.active.roots.clear ();
 			node.active.blocks.clear ();
 		}

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -142,20 +142,20 @@ namespace test
 		stringstream_mt_sink () = default;
 		stringstream_mt_sink (stringstream_mt_sink const & sink)
 		{
-			nano::lock_guard<nano::mutex> guard (mutex);
+			nano::lock_guard<nano::mutex> guard{ mutex };
 			ss << sink.ss.str ();
 		}
 
 		std::streamsize write (char const * string_to_write, std::streamsize size)
 		{
-			nano::lock_guard<nano::mutex> guard (mutex);
+			nano::lock_guard<nano::mutex> guard{ mutex };
 			ss << std::string (string_to_write, size);
 			return size;
 		}
 
 		std::string str ()
 		{
-			nano::lock_guard<nano::mutex> guard (mutex);
+			nano::lock_guard<nano::mutex> guard{ mutex };
 			return ss.str ();
 		}
 
@@ -254,7 +254,7 @@ namespace test
 				error = count < required_count;
 				if (error)
 				{
-					nano::unique_lock<nano::mutex> lock (mutex);
+					nano::unique_lock<nano::mutex> lock{ mutex };
 					cv.wait_for (lock, std::chrono::milliseconds (1));
 				}
 			}


### PR DESCRIPTION
Found a warning when building the node for Windows.
```
...
warning C4930: 'std::unique_lock<nano::mutex> lock(nano::mutex)': prototyped function not called (was a variable definition intended?)
...
```
This is related to an ambiguity described by [the wiki](https://en.wikipedia.org/wiki/Most_vexing_parse), where the C++ compiler tries to declare a function as `lock` instead of creating an object for it.

The best approach is to use the uniform initialization `{}` when there is any argument. The warning was issued only for `vote_processor.cpp`, but decided to change all the mutex lock object creations.