### PR TITLE
Removing WIN32_LEAN_AND_MEAN define from global project settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,8 +214,8 @@ find_package(Threads)
 
 if(WIN32)
   find_library(PSAPI Psapi)
-  add_definitions(-D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -DWIN32_LEAN_AND_MEAN
-                  -DMINIUPNP_STATICLIB -D_CRT_SECURE_NO_WARNINGS /EHsc)
+  add_definitions(-D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -DMINIUPNP_STATICLIB
+                  -D_CRT_SECURE_NO_WARNINGS /EHsc)
 
   if(${USING_TSAN}
      OR ${USING_ASAN}


### PR DESCRIPTION
This fixes a number of duplicate definition warnings with 3rd party libraries and nano files have no need for it.