### PR TITLE
Use 'magic_enum' library for static reflection for enums

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "boost"]
 	path = boost
 	url = https://github.com/boostorg/boost.git
+[submodule "magic_enum"]
+	path = magic_enum
+	url = https://github.com/Neargye/magic_enum.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,5 +30,5 @@
 	path = submodules/boost
 	url = https://github.com/boostorg/boost.git
 [submodule "magic_enum"]
-	path = magic_enum
+	path = submodules/magic_enum
 	url = https://github.com/Neargye/magic_enum.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ add_subdirectory(submodules/rocksdb EXCLUDE_FROM_ALL)
 include_directories(cpptoml/include)
 
 # magic_enum
-include_directories(magic_enum/include)
+include_directories(submodules/magic_enum/include)
 
 add_subdirectory(crypto/ed25519-donna)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,10 @@ set(FAIL_ON_WARNINGS
 add_subdirectory(rocksdb EXCLUDE_FROM_ALL)
 
 include_directories(cpptoml/include)
+
+# magic_enum
+include_directories(magic_enum/include)
+
 add_subdirectory(crypto/ed25519-donna)
 
 add_subdirectory(nano/ipc_flatbuffers_lib)

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -346,7 +346,7 @@ TEST (block_store, pending_iterator_comparison)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	auto transaction (store->tx_begin_write ());
 	// Populate pending
 	store->pending.put (transaction, nano::pending_key (nano::account (3), nano::block_hash (1)), nano::pending_info (nano::account (10), nano::amount (1), nano::epoch::epoch_0));
@@ -853,7 +853,7 @@ namespace lmdb
 		nano::logger_mt logger;
 		{
 			nano::lmdb::store store (logger, path, nano::dev::constants);
-			nano::stat stats;
+			nano::stats stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -871,7 +871,7 @@ namespace lmdb
 		// Now try with the minimum version
 		{
 			nano::lmdb::store store (logger, path1, nano::dev::constants);
-			nano::stat stats;
+			nano::stats stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -1271,8 +1271,8 @@ TEST (mdb_block_store, sideband_height)
 	nano::keypair key3;
 	nano::lmdb::store store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
-	nano::stat stat;
-	nano::ledger ledger (store, stat, nano::dev::constants);
+	nano::stats stats;
+	nano::ledger ledger (store, stats, nano::dev::constants);
 	nano::block_builder builder;
 	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -1673,7 +1673,7 @@ namespace lmdb
 		{
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
-			nano::stat stats;
+			nano::stats stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -1806,7 +1806,7 @@ namespace lmdb
 		{
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
-			nano::stat stats;
+			nano::stats stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -1887,7 +1887,7 @@ namespace lmdb
 			{
 				nano::logger_mt logger;
 				nano::lmdb::store store (logger, path, nano::dev::constants);
-				nano::stat stats;
+				nano::stats stats;
 				nano::ledger ledger (store, stats, nano::dev::constants);
 				auto transaction (store.tx_begin_write ());
 				store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -2066,7 +2066,7 @@ namespace lmdb
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
-			nano::stat stats;
+			nano::stats stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
 			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send_zero).code);
@@ -2306,7 +2306,7 @@ namespace lmdb
 		{
 			nano::logger_mt logger;
 			nano::lmdb::store store (logger, path, nano::dev::constants);
-			nano::stat stats;
+			nano::stats stats;
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -2386,7 +2386,7 @@ namespace lmdb
 		}
 		auto path (nano::unique_path ());
 		nano::logger_mt logger;
-		nano::stat stats;
+		nano::stats stats;
 		{
 			nano::lmdb::store store (logger, path, nano::dev::constants);
 			nano::ledger ledger (store, stats, nano::dev::constants);
@@ -2415,7 +2415,7 @@ namespace lmdb
 		}
 		auto path (nano::unique_path ());
 		nano::logger_mt logger;
-		nano::stat stats;
+		nano::stats stats;
 		{
 			nano::lmdb::store store (logger, path, nano::dev::constants);
 			nano::ledger ledger (store, stats, nano::dev::constants);

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1208,7 +1208,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		auto path (nano::unique_path ());
 		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
-		nano::stat stats;
+		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -1300,7 +1300,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		auto path (nano::unique_path ());
 		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
-		nano::stat stats;
+		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -1378,7 +1378,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		auto path (nano::unique_path ());
 		auto store = nano::make_store (logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
-		nano::stat stats;
+		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -2093,7 +2093,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	auto path (nano::unique_path ());
 	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	boost::latch initialized_latch{ 0 };
@@ -2158,7 +2158,7 @@ TEST (confirmation_height, pruned_source)
 	auto path (nano::unique_path ());
 	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::write_database_queue write_database_queue (false);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -820,7 +820,7 @@ TEST (ledger, double_open)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
@@ -4108,7 +4108,7 @@ TEST (ledger, could_fit)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
@@ -4745,7 +4745,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -4935,7 +4935,7 @@ TEST (ledger, pruning_action)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5019,7 +5019,7 @@ TEST (ledger, pruning_large_chain)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5074,7 +5074,7 @@ TEST (ledger, pruning_source_rollback)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5162,7 +5162,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5275,7 +5275,7 @@ TEST (ledger, pruning_process_error)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5322,7 +5322,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::keypair key1;
@@ -5408,7 +5408,7 @@ TEST (ledger, pruning_safe_functions)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5469,7 +5469,7 @@ TEST (ledger, hash_root_random)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
@@ -5534,7 +5534,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	uint16_t port = 100;
 	nano::lmdb::store store{ logger, path / "data.ldb", nano::dev::constants };
 	nano::unchecked_map unchecked{ store, false };
-	nano::stat stats{};
+	nano::stats stats{};
 	nano::ledger ledger{ store, stats, nano::dev::constants };
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -745,7 +745,7 @@ TEST (node, port_mapping)
 
 TEST (message_buffer_manager, one_buffer)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 1);
 	auto buffer1 (buffer.allocate ());
 	ASSERT_NE (nullptr, buffer1);
@@ -759,7 +759,7 @@ TEST (message_buffer_manager, one_buffer)
 
 TEST (message_buffer_manager, two_buffers)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 2);
 	auto buffer1 (buffer.allocate ());
 	ASSERT_NE (nullptr, buffer1);
@@ -782,7 +782,7 @@ TEST (message_buffer_manager, two_buffers)
 
 TEST (message_buffer_manager, one_overflow)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 1);
 	auto buffer1 (buffer.allocate ());
 	ASSERT_NE (nullptr, buffer1);
@@ -793,7 +793,7 @@ TEST (message_buffer_manager, one_overflow)
 
 TEST (message_buffer_manager, two_overflow)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 2);
 	auto buffer1 (buffer.allocate ());
 	ASSERT_NE (nullptr, buffer1);
@@ -810,7 +810,7 @@ TEST (message_buffer_manager, two_overflow)
 
 TEST (message_buffer_manager, one_buffer_multithreaded)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 1);
 	boost::thread thread ([&buffer] () {
 		auto done (false);
@@ -835,7 +835,7 @@ TEST (message_buffer_manager, one_buffer_multithreaded)
 
 TEST (message_buffer_manager, many_buffers_multithreaded)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 16);
 	std::vector<boost::thread> threads;
 	for (auto i (0); i < 4; ++i)
@@ -883,7 +883,7 @@ TEST (message_buffer_manager, many_buffers_multithreaded)
 
 TEST (message_buffer_manager, stats)
 {
-	nano::stat stats;
+	nano::stats stats;
 	nano::message_buffer_manager buffer (stats, 512, 1);
 	auto buffer1 (buffer.allocate ());
 	buffer.enqueue (buffer1);

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -12,7 +12,7 @@ TEST (processor_service, bad_send_signature)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
@@ -38,7 +38,7 @@ TEST (processor_service, bad_receive_signature)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -247,15 +247,15 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.diagnostics_config.txn_tracking.min_read_txn_time, defaults.node.diagnostics_config.txn_tracking.min_read_txn_time);
 	ASSERT_EQ (conf.node.diagnostics_config.txn_tracking.min_write_txn_time, defaults.node.diagnostics_config.txn_tracking.min_write_txn_time);
 
-	ASSERT_EQ (conf.node.stat_config.sampling_enabled, defaults.node.stat_config.sampling_enabled);
-	ASSERT_EQ (conf.node.stat_config.interval, defaults.node.stat_config.interval);
-	ASSERT_EQ (conf.node.stat_config.capacity, defaults.node.stat_config.capacity);
-	ASSERT_EQ (conf.node.stat_config.log_rotation_count, defaults.node.stat_config.log_rotation_count);
-	ASSERT_EQ (conf.node.stat_config.log_interval_samples, defaults.node.stat_config.log_interval_samples);
-	ASSERT_EQ (conf.node.stat_config.log_interval_counters, defaults.node.stat_config.log_interval_counters);
-	ASSERT_EQ (conf.node.stat_config.log_headers, defaults.node.stat_config.log_headers);
-	ASSERT_EQ (conf.node.stat_config.log_counters_filename, defaults.node.stat_config.log_counters_filename);
-	ASSERT_EQ (conf.node.stat_config.log_samples_filename, defaults.node.stat_config.log_samples_filename);
+	ASSERT_EQ (conf.node.stats_config.sampling_enabled, defaults.node.stats_config.sampling_enabled);
+	ASSERT_EQ (conf.node.stats_config.interval, defaults.node.stats_config.interval);
+	ASSERT_EQ (conf.node.stats_config.capacity, defaults.node.stats_config.capacity);
+	ASSERT_EQ (conf.node.stats_config.log_rotation_count, defaults.node.stats_config.log_rotation_count);
+	ASSERT_EQ (conf.node.stats_config.log_interval_samples, defaults.node.stats_config.log_interval_samples);
+	ASSERT_EQ (conf.node.stats_config.log_interval_counters, defaults.node.stats_config.log_interval_counters);
+	ASSERT_EQ (conf.node.stats_config.log_headers, defaults.node.stats_config.log_headers);
+	ASSERT_EQ (conf.node.stats_config.log_counters_filename, defaults.node.stats_config.log_counters_filename);
+	ASSERT_EQ (conf.node.stats_config.log_samples_filename, defaults.node.stats_config.log_samples_filename);
 
 	ASSERT_EQ (conf.node.lmdb_config.sync, defaults.node.lmdb_config.sync);
 	ASSERT_EQ (conf.node.lmdb_config.max_databases, defaults.node.lmdb_config.max_databases);
@@ -664,15 +664,15 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.diagnostics_config.txn_tracking.min_read_txn_time, defaults.node.diagnostics_config.txn_tracking.min_read_txn_time);
 	ASSERT_NE (conf.node.diagnostics_config.txn_tracking.min_write_txn_time, defaults.node.diagnostics_config.txn_tracking.min_write_txn_time);
 
-	ASSERT_NE (conf.node.stat_config.sampling_enabled, defaults.node.stat_config.sampling_enabled);
-	ASSERT_NE (conf.node.stat_config.interval, defaults.node.stat_config.interval);
-	ASSERT_NE (conf.node.stat_config.capacity, defaults.node.stat_config.capacity);
-	ASSERT_NE (conf.node.stat_config.log_rotation_count, defaults.node.stat_config.log_rotation_count);
-	ASSERT_NE (conf.node.stat_config.log_interval_samples, defaults.node.stat_config.log_interval_samples);
-	ASSERT_NE (conf.node.stat_config.log_interval_counters, defaults.node.stat_config.log_interval_counters);
-	ASSERT_NE (conf.node.stat_config.log_headers, defaults.node.stat_config.log_headers);
-	ASSERT_NE (conf.node.stat_config.log_counters_filename, defaults.node.stat_config.log_counters_filename);
-	ASSERT_NE (conf.node.stat_config.log_samples_filename, defaults.node.stat_config.log_samples_filename);
+	ASSERT_NE (conf.node.stats_config.sampling_enabled, defaults.node.stats_config.sampling_enabled);
+	ASSERT_NE (conf.node.stats_config.interval, defaults.node.stats_config.interval);
+	ASSERT_NE (conf.node.stats_config.capacity, defaults.node.stats_config.capacity);
+	ASSERT_NE (conf.node.stats_config.log_rotation_count, defaults.node.stats_config.log_rotation_count);
+	ASSERT_NE (conf.node.stats_config.log_interval_samples, defaults.node.stats_config.log_interval_samples);
+	ASSERT_NE (conf.node.stats_config.log_interval_counters, defaults.node.stats_config.log_interval_counters);
+	ASSERT_NE (conf.node.stats_config.log_headers, defaults.node.stats_config.log_headers);
+	ASSERT_NE (conf.node.stats_config.log_counters_filename, defaults.node.stats_config.log_counters_filename);
+	ASSERT_NE (conf.node.stats_config.log_samples_filename, defaults.node.stats_config.log_samples_filename);
 
 	ASSERT_NE (conf.node.lmdb_config.sync, defaults.node.lmdb_config.sync);
 	ASSERT_NE (conf.node.lmdb_config.max_databases, defaults.node.lmdb_config.max_databases);

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(
   signal_manager.cpp
   stats.hpp
   stats.cpp
+  stats_enums.hpp
   stream.hpp
   threading.hpp
   threading.cpp

--- a/nano/lib/processing_queue.hpp
+++ b/nano/lib/processing_queue.hpp
@@ -30,7 +30,7 @@ public:
 	 * @param max_queue_size Max number of items enqueued, items beyond this value will be discarded
 	 * @param max_batch_size Max number of elements processed in single batch, 0 for unlimited (default)
 	 */
-	processing_queue (nano::stat & stats, nano::stat::type stat_type, nano::thread_role::name thread_role, std::size_t thread_count, std::size_t max_queue_size, std::size_t max_batch_size = 0) :
+	processing_queue (nano::stats & stats, nano::stat::type stat_type, nano::thread_role::name thread_role, std::size_t thread_count, std::size_t max_queue_size, std::size_t max_batch_size = 0) :
 		stats{ stats },
 		stat_type{ stat_type },
 		thread_role{ thread_role },
@@ -159,7 +159,7 @@ public:
 	std::function<void (std::deque<value_t> &)> process_batch{ [] (auto &) { debug_assert (false, "processing queue callback empty"); } };
 
 private:
-	nano::stat & stats;
+	nano::stats & stats;
 
 	const nano::stat::type stat_type;
 	const nano::thread_role::name thread_role;

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -10,7 +10,7 @@
 #include <fstream>
 #include <sstream>
 
-nano::error nano::stat_config::deserialize_toml (nano::tomlconfig & toml)
+nano::error nano::stats_config::deserialize_toml (nano::tomlconfig & toml)
 {
 	auto sampling_l (toml.get_optional_child ("sampling"));
 	if (sampling_l)
@@ -40,7 +40,7 @@ nano::error nano::stat_config::deserialize_toml (nano::tomlconfig & toml)
 	return toml.get_error ();
 }
 
-nano::error nano::stat_config::serialize_toml (nano::tomlconfig & toml) const
+nano::error nano::stats_config::serialize_toml (nano::tomlconfig & toml) const
 {
 	nano::tomlconfig sampling_l;
 	sampling_l.put ("enable", sampling_enabled, "Enable or disable sampling.\ntype:bool");
@@ -256,7 +256,7 @@ std::vector<nano::stat_histogram::bin> nano::stat_histogram::get_bins () const
  * stats
  */
 
-nano::stats::stats (nano::stat_config config) :
+nano::stats::stats (nano::stats_config config) :
 	config (config)
 {
 }

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -252,23 +252,27 @@ std::vector<nano::stat_histogram::bin> nano::stat_histogram::get_bins () const
 	return bins;
 }
 
-nano::stat::stat (nano::stat_config config) :
+/*
+ * stats
+ */
+
+nano::stats::stats (nano::stat_config config) :
 	config (config)
 {
 }
 
-std::shared_ptr<nano::stat_entry> nano::stat::get_entry (uint32_t key)
+std::shared_ptr<nano::stat_entry> nano::stats::get_entry (uint32_t key)
 {
 	return get_entry (key, config.interval, config.capacity);
 }
 
-std::shared_ptr<nano::stat_entry> nano::stat::get_entry (uint32_t key, size_t interval, size_t capacity)
+std::shared_ptr<nano::stat_entry> nano::stats::get_entry (uint32_t key, size_t interval, size_t capacity)
 {
 	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	return get_entry_impl (key, interval, capacity);
 }
 
-std::shared_ptr<nano::stat_entry> nano::stat::get_entry_impl (uint32_t key, size_t interval, size_t capacity)
+std::shared_ptr<nano::stat_entry> nano::stats::get_entry_impl (uint32_t key, size_t interval, size_t capacity)
 {
 	std::shared_ptr<nano::stat_entry> res;
 	auto entry = entries.find (key);
@@ -284,18 +288,18 @@ std::shared_ptr<nano::stat_entry> nano::stat::get_entry_impl (uint32_t key, size
 	return res;
 }
 
-std::unique_ptr<nano::stat_log_sink> nano::stat::log_sink_json () const
+std::unique_ptr<nano::stat_log_sink> nano::stats::log_sink_json () const
 {
 	return std::make_unique<json_writer> ();
 }
 
-void nano::stat::log_counters (stat_log_sink & sink)
+void nano::stats::log_counters (stat_log_sink & sink)
 {
 	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	log_counters_impl (sink);
 }
 
-void nano::stat::log_counters_impl (stat_log_sink & sink)
+void nano::stats::log_counters_impl (stat_log_sink & sink)
 {
 	sink.begin ();
 	if (sink.entries () >= config.log_rotation_count)
@@ -324,13 +328,13 @@ void nano::stat::log_counters_impl (stat_log_sink & sink)
 	sink.finalize ();
 }
 
-void nano::stat::log_samples (stat_log_sink & sink)
+void nano::stats::log_samples (stat_log_sink & sink)
 {
 	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	log_samples_impl (sink);
 }
 
-void nano::stat::log_samples_impl (stat_log_sink & sink)
+void nano::stats::log_samples_impl (stat_log_sink & sink)
 {
 	sink.begin ();
 	if (sink.entries () >= config.log_rotation_count)
@@ -362,27 +366,27 @@ void nano::stat::log_samples_impl (stat_log_sink & sink)
 	sink.finalize ();
 }
 
-void nano::stat::define_histogram (stat::type type, stat::detail detail, stat::dir dir, std::initializer_list<uint64_t> intervals_a, size_t bin_count_a /*=0*/)
+void nano::stats::define_histogram (stat::type type, stat::detail detail, stat::dir dir, std::initializer_list<uint64_t> intervals_a, size_t bin_count_a /*=0*/)
 {
 	auto entry (get_entry (key_of (type, detail, dir)));
 	entry->histogram = std::make_unique<nano::stat_histogram> (intervals_a, bin_count_a);
 }
 
-void nano::stat::update_histogram (stat::type type, stat::detail detail, stat::dir dir, uint64_t index_a, uint64_t addend_a)
+void nano::stats::update_histogram (stat::type type, stat::detail detail, stat::dir dir, uint64_t index_a, uint64_t addend_a)
 {
 	auto entry (get_entry (key_of (type, detail, dir)));
 	debug_assert (entry->histogram != nullptr);
 	entry->histogram->add (index_a, addend_a);
 }
 
-nano::stat_histogram * nano::stat::get_histogram (stat::type type, stat::detail detail, stat::dir dir)
+nano::stat_histogram * nano::stats::get_histogram (stat::type type, stat::detail detail, stat::dir dir)
 {
 	auto entry (get_entry (key_of (type, detail, dir)));
 	debug_assert (entry->histogram != nullptr);
 	return entry->histogram.get ();
 }
 
-void nano::stat::update (uint32_t key_a, uint64_t value)
+void nano::stats::update (uint32_t key_a, uint64_t value)
 {
 	static file_writer log_count (config.log_counters_filename);
 	static file_writer log_sample (config.log_samples_filename);
@@ -439,651 +443,42 @@ void nano::stat::update (uint32_t key_a, uint64_t value)
 	}
 }
 
-std::chrono::seconds nano::stat::last_reset ()
+std::chrono::seconds nano::stats::last_reset ()
 {
 	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	auto now (std::chrono::steady_clock::now ());
 	return std::chrono::duration_cast<std::chrono::seconds> (now - timestamp);
 }
 
-void nano::stat::stop ()
+void nano::stats::stop ()
 {
 	nano::lock_guard<nano::mutex> guard{ stat_mutex };
 	stopped = true;
 }
 
-void nano::stat::clear ()
+void nano::stats::clear ()
 {
 	nano::unique_lock<nano::mutex> lock{ stat_mutex };
 	entries.clear ();
 	timestamp = std::chrono::steady_clock::now ();
 }
 
-std::string nano::stat::type_to_string (uint32_t key)
+std::string nano::stats::type_to_string (uint32_t key)
 {
 	auto type = static_cast<stat::type> (key >> 16 & 0x000000ff);
-	return type_to_string (type);
+	return std::string{ nano::to_string (type) };
 }
 
-std::string nano::stat::type_to_string (stat::type type)
-{
-	std::string res;
-	switch (type)
-	{
-		case nano::stat::type::ipc:
-			res = "ipc";
-			break;
-		case nano::stat::type::block:
-			res = "block";
-			break;
-		case nano::stat::type::bootstrap:
-			res = "bootstrap";
-			break;
-		case nano::stat::type::tcp_server:
-			res = "tcp_server";
-			break;
-		case nano::stat::type::error:
-			res = "error";
-			break;
-		case nano::stat::type::http_callback:
-			res = "http_callback";
-			break;
-		case nano::stat::type::ledger:
-			res = "ledger";
-			break;
-		case nano::stat::type::tcp:
-			res = "tcp";
-			break;
-		case nano::stat::type::udp:
-			res = "udp";
-			break;
-		case nano::stat::type::peering:
-			res = "peering";
-			break;
-		case nano::stat::type::rollback:
-			res = "rollback";
-			break;
-		case nano::stat::type::traffic_udp:
-			res = "traffic_udp";
-			break;
-		case nano::stat::type::traffic_tcp:
-			res = "traffic_tcp";
-			break;
-		case nano::stat::type::vote:
-			res = "vote";
-			break;
-		case nano::stat::type::election:
-			res = "election";
-			break;
-		case nano::stat::type::message:
-			res = "message";
-			break;
-		case nano::stat::type::confirmation_observer:
-			res = "observer";
-			break;
-		case nano::stat::type::confirmation_height:
-			res = "confirmation_height";
-			break;
-		case nano::stat::type::drop:
-			res = "drop";
-			break;
-		case nano::stat::type::aggregator:
-			res = "aggregator";
-			break;
-		case nano::stat::type::requests:
-			res = "requests";
-			break;
-		case nano::stat::type::filter:
-			res = "filter";
-			break;
-		case nano::stat::type::telemetry:
-			res = "telemetry";
-			break;
-		case nano::stat::type::vote_generator:
-			res = "vote_generator";
-			break;
-		case nano::stat::type::vote_cache:
-			res = "vote_cache";
-			break;
-		case nano::stat::type::hinting:
-			res = "hinting";
-			break;
-		case nano::stat::type::blockprocessor:
-			res = "blockprocessor";
-			break;
-		case nano::stat::type::bootstrap_server:
-			res = "bootstrap_server";
-			break;
-		case nano::stat::type::active:
-			res = "active";
-			break;
-		case nano::stat::type::backlog:
-			res = "backlog";
-			break;
-	}
-	return res;
-}
-
-std::string nano::stat::detail_to_string (stat::detail detail)
-{
-	std::string res;
-	switch (detail)
-	{
-		case nano::stat::detail::all:
-			res = "all";
-			break;
-		case nano::stat::detail::loop:
-			res = "loop";
-			break;
-		case nano::stat::detail::total:
-			res = "total";
-			break;
-		case nano::stat::detail::queue:
-			res = "queue";
-			break;
-		case nano::stat::detail::overfill:
-			res = "overfill";
-			break;
-		case nano::stat::detail::batch:
-			res = "batch";
-			break;
-		case nano::stat::detail::bad_sender:
-			res = "bad_sender";
-			break;
-		case nano::stat::detail::bulk_pull:
-			res = "bulk_pull";
-			break;
-		case nano::stat::detail::bulk_pull_account:
-			res = "bulk_pull_account";
-			break;
-		case nano::stat::detail::bulk_pull_deserialize_receive_block:
-			res = "bulk_pull_deserialize_receive_block";
-			break;
-		case nano::stat::detail::bulk_pull_error_starting_request:
-			res = "bulk_pull_error_starting_request";
-			break;
-		case nano::stat::detail::bulk_pull_failed_account:
-			res = "bulk_pull_failed_account";
-			break;
-		case nano::stat::detail::bulk_pull_receive_block_failure:
-			res = "bulk_pull_receive_block_failure";
-			break;
-		case nano::stat::detail::bulk_pull_request_failure:
-			res = "bulk_pull_request_failure";
-			break;
-		case nano::stat::detail::bulk_push:
-			res = "bulk_push";
-			break;
-		case nano::stat::detail::active_quorum:
-			res = "observer_confirmation_active_quorum";
-			break;
-		case nano::stat::detail::active_conf_height:
-			res = "observer_confirmation_active_conf_height";
-			break;
-		case nano::stat::detail::inactive_conf_height:
-			res = "observer_confirmation_inactive";
-			break;
-		case nano::stat::detail::error_socket_close:
-			res = "error_socket_close";
-			break;
-		case nano::stat::detail::request_underflow:
-			res = "request_underflow";
-			break;
-		case nano::stat::detail::change:
-			res = "change";
-			break;
-		case nano::stat::detail::confirm_ack:
-			res = "confirm_ack";
-			break;
-		case nano::stat::detail::node_id_handshake:
-			res = "node_id_handshake";
-			break;
-		case nano::stat::detail::confirm_req:
-			res = "confirm_req";
-			break;
-		case nano::stat::detail::fork:
-			res = "fork";
-			break;
-		case nano::stat::detail::old:
-			res = "old";
-			break;
-		case nano::stat::detail::gap_previous:
-			res = "gap_previous";
-			break;
-		case nano::stat::detail::gap_source:
-			res = "gap_source";
-			break;
-		case nano::stat::detail::rollback_failed:
-			res = "rollback_failed";
-			break;
-		case nano::stat::detail::progress:
-			res = "progress";
-			break;
-		case nano::stat::detail::bad_signature:
-			res = "bad_signature";
-			break;
-		case nano::stat::detail::negative_spend:
-			res = "negative_spend";
-			break;
-		case nano::stat::detail::unreceivable:
-			res = "unreceivable";
-			break;
-		case nano::stat::detail::gap_epoch_open_pending:
-			res = "gap_epoch_open_pending";
-			break;
-		case nano::stat::detail::opened_burn_account:
-			res = "opened_burn_account";
-			break;
-		case nano::stat::detail::balance_mismatch:
-			res = "balance_mismatch";
-			break;
-		case nano::stat::detail::representative_mismatch:
-			res = "representative_mismatch";
-			break;
-		case nano::stat::detail::block_position:
-			res = "block_position";
-			break;
-		case nano::stat::detail::frontier_confirmation_failed:
-			res = "frontier_confirmation_failed";
-			break;
-		case nano::stat::detail::frontier_confirmation_successful:
-			res = "frontier_confirmation_successful";
-			break;
-		case nano::stat::detail::frontier_req:
-			res = "frontier_req";
-			break;
-		case nano::stat::detail::handshake:
-			res = "handshake";
-			break;
-		case nano::stat::detail::http_callback:
-			res = "http_callback";
-			break;
-		case nano::stat::detail::initiate:
-			res = "initiate";
-			break;
-		case nano::stat::detail::initiate_legacy_age:
-			res = "initiate_legacy_age";
-			break;
-		case nano::stat::detail::initiate_lazy:
-			res = "initiate_lazy";
-			break;
-		case nano::stat::detail::initiate_wallet_lazy:
-			res = "initiate_wallet_lazy";
-			break;
-		case nano::stat::detail::insufficient_work:
-			res = "insufficient_work";
-			break;
-		case nano::stat::detail::invalid:
-			res = "invalid";
-			break;
-		case nano::stat::detail::invocations:
-			res = "invocations";
-			break;
-		case nano::stat::detail::keepalive:
-			res = "keepalive";
-			break;
-		case nano::stat::detail::not_a_type:
-			res = "not_a_type";
-			break;
-		case nano::stat::detail::open:
-			res = "open";
-			break;
-		case nano::stat::detail::publish:
-			res = "publish";
-			break;
-		case nano::stat::detail::receive:
-			res = "receive";
-			break;
-		case nano::stat::detail::republish_vote:
-			res = "republish_vote";
-			break;
-		case nano::stat::detail::send:
-			res = "send";
-			break;
-		case nano::stat::detail::telemetry_req:
-			res = "telemetry_req";
-			break;
-		case nano::stat::detail::telemetry_ack:
-			res = "telemetry_ack";
-			break;
-		case nano::stat::detail::asc_pull_req:
-			res = "asc_pull_req";
-			break;
-		case nano::stat::detail::asc_pull_ack:
-			res = "asc_pull_ack";
-			break;
-		case nano::stat::detail::state_block:
-			res = "state_block";
-			break;
-		case nano::stat::detail::epoch_block:
-			res = "epoch_block";
-			break;
-		case nano::stat::detail::vote_valid:
-			res = "vote_valid";
-			break;
-		case nano::stat::detail::vote_replay:
-			res = "vote_replay";
-			break;
-		case nano::stat::detail::vote_indeterminate:
-			res = "vote_indeterminate";
-			break;
-		case nano::stat::detail::vote_invalid:
-			res = "vote_invalid";
-			break;
-		case nano::stat::detail::vote_overflow:
-			res = "vote_overflow";
-			break;
-		case nano::stat::detail::vote_new:
-			res = "vote_new";
-			break;
-		case nano::stat::detail::vote_processed:
-			res = "vote_processed";
-			break;
-		case nano::stat::detail::vote_cached:
-			res = "vote_cached";
-			break;
-		case nano::stat::detail::late_block:
-			res = "late_block";
-			break;
-		case nano::stat::detail::late_block_seconds:
-			res = "late_block_seconds";
-			break;
-		case nano::stat::detail::election_start:
-			res = "election_start";
-			break;
-		case nano::stat::detail::election_confirmed_all:
-			res = "election_confirmed_all";
-			break;
-		case nano::stat::detail::election_block_conflict:
-			res = "election_block_conflict";
-			break;
-		case nano::stat::detail::election_difficulty_update:
-			res = "election_difficulty_update";
-			break;
-		case nano::stat::detail::election_drop_expired:
-			res = "election_drop_expired";
-			break;
-		case nano::stat::detail::election_drop_overflow:
-			res = "election_drop_overflow";
-			break;
-		case nano::stat::detail::election_drop_all:
-			res = "election_drop_all";
-			break;
-		case nano::stat::detail::election_restart:
-			res = "election_restart";
-			break;
-		case nano::stat::detail::election_confirmed:
-			res = "election_confirmed";
-			break;
-		case nano::stat::detail::election_not_confirmed:
-			res = "election_not_confirmed";
-			break;
-		case nano::stat::detail::election_hinted_overflow:
-			res = "election_hinted_overflow";
-			break;
-		case nano::stat::detail::election_hinted_started:
-			res = "election_hinted_started";
-			break;
-		case nano::stat::detail::election_hinted_confirmed:
-			res = "election_hinted_confirmed";
-			break;
-		case nano::stat::detail::election_hinted_drop:
-			res = "election_hinted_drop";
-			break;
-		case nano::stat::detail::generate_vote:
-			res = "generate_vote";
-			break;
-		case nano::stat::detail::generate_vote_normal:
-			res = "generate_vote_normal";
-			break;
-		case nano::stat::detail::generate_vote_final:
-			res = "generate_vote_final";
-			break;
-		case nano::stat::detail::blocking:
-			res = "blocking";
-			break;
-		case nano::stat::detail::overflow:
-			res = "overflow";
-			break;
-		case nano::stat::detail::tcp_accept_success:
-			res = "accept_success";
-			break;
-		case nano::stat::detail::tcp_accept_failure:
-			res = "accept_failure";
-			break;
-		case nano::stat::detail::tcp_write_drop:
-			res = "tcp_write_drop";
-			break;
-		case nano::stat::detail::tcp_write_no_socket_drop:
-			res = "tcp_write_no_socket_drop";
-			break;
-		case nano::stat::detail::tcp_excluded:
-			res = "tcp_excluded";
-			break;
-		case nano::stat::detail::tcp_max_per_ip:
-			res = "tcp_max_per_ip";
-			break;
-		case nano::stat::detail::tcp_max_per_subnetwork:
-			res = "tcp_max_per_subnetwork";
-			break;
-		case nano::stat::detail::tcp_silent_connection_drop:
-			res = "tcp_silent_connection_drop";
-			break;
-		case nano::stat::detail::tcp_io_timeout_drop:
-			res = "tcp_io_timeout_drop";
-			break;
-		case nano::stat::detail::tcp_connect_error:
-			res = "tcp_connect_error";
-			break;
-		case nano::stat::detail::tcp_read_error:
-			res = "tcp_read_error";
-			break;
-		case nano::stat::detail::tcp_write_error:
-			res = "tcp_write_error";
-			break;
-		case nano::stat::detail::unreachable_host:
-			res = "unreachable_host";
-			break;
-		case nano::stat::detail::invalid_header:
-			res = "invalid_header";
-			break;
-		case nano::stat::detail::invalid_message_type:
-			res = "invalid_message_type";
-			break;
-		case nano::stat::detail::invalid_keepalive_message:
-			res = "invalid_keepalive_message";
-			break;
-		case nano::stat::detail::invalid_publish_message:
-			res = "invalid_publish_message";
-			break;
-		case nano::stat::detail::invalid_confirm_req_message:
-			res = "invalid_confirm_req_message";
-			break;
-		case nano::stat::detail::invalid_confirm_ack_message:
-			res = "invalid_confirm_ack_message";
-			break;
-		case nano::stat::detail::invalid_node_id_handshake_message:
-			res = "invalid_node_id_handshake_message";
-			break;
-		case nano::stat::detail::invalid_telemetry_req_message:
-			res = "invalid_telemetry_req_message";
-			break;
-		case nano::stat::detail::invalid_telemetry_ack_message:
-			res = "invalid_telemetry_ack_message";
-			break;
-		case nano::stat::detail::invalid_bulk_pull_message:
-			res = "invalid_bulk_pull_message";
-			break;
-		case nano::stat::detail::invalid_bulk_pull_account_message:
-			res = "invalid_bulk_pull_account_message";
-			break;
-		case nano::stat::detail::invalid_frontier_req_message:
-			res = "invalid_frontier_req_message";
-			break;
-		case nano::stat::detail::invalid_asc_pull_req_message:
-			res = "invalid_asc_pull_req_message";
-			break;
-		case nano::stat::detail::invalid_asc_pull_ack_message:
-			res = "invalid_asc_pull_ack_message";
-			break;
-		case nano::stat::detail::message_too_big:
-			res = "message_too_big";
-			break;
-		case nano::stat::detail::outdated_version:
-			res = "outdated_version";
-			break;
-		case nano::stat::detail::udp_max_per_ip:
-			res = "udp_max_per_ip";
-			break;
-		case nano::stat::detail::udp_max_per_subnetwork:
-			res = "udp_max_per_subnetwork";
-			break;
-		case nano::stat::detail::blocks_confirmed:
-			res = "blocks_confirmed";
-			break;
-		case nano::stat::detail::blocks_confirmed_unbounded:
-			res = "blocks_confirmed_unbounded";
-			break;
-		case nano::stat::detail::blocks_confirmed_bounded:
-			res = "blocks_confirmed_bounded";
-			break;
-		case nano::stat::detail::aggregator_accepted:
-			res = "aggregator_accepted";
-			break;
-		case nano::stat::detail::aggregator_dropped:
-			res = "aggregator_dropped";
-			break;
-		case nano::stat::detail::requests_cached_hashes:
-			res = "requests_cached_hashes";
-			break;
-		case nano::stat::detail::requests_generated_hashes:
-			res = "requests_generated_hashes";
-			break;
-		case nano::stat::detail::requests_cached_votes:
-			res = "requests_cached_votes";
-			break;
-		case nano::stat::detail::requests_generated_votes:
-			res = "requests_generated_votes";
-			break;
-		case nano::stat::detail::requests_cached_late_hashes:
-			res = "requests_cached_late_hashes";
-			break;
-		case nano::stat::detail::requests_cached_late_votes:
-			res = "requests_cached_late_votes";
-			break;
-		case nano::stat::detail::requests_cannot_vote:
-			res = "requests_cannot_vote";
-			break;
-		case nano::stat::detail::requests_unknown:
-			res = "requests_unknown";
-			break;
-		case nano::stat::detail::duplicate_publish:
-			res = "duplicate_publish";
-			break;
-		case nano::stat::detail::different_genesis_hash:
-			res = "different_genesis_hash";
-			break;
-		case nano::stat::detail::invalid_signature:
-			res = "invalid_signature";
-			break;
-		case nano::stat::detail::node_id_mismatch:
-			res = "node_id_mismatch";
-			break;
-		case nano::stat::detail::request_within_protection_cache_zone:
-			res = "request_within_protection_cache_zone";
-			break;
-		case nano::stat::detail::no_response_received:
-			res = "no_response_received";
-			break;
-		case nano::stat::detail::unsolicited_telemetry_ack:
-			res = "unsolicited_telemetry_ack";
-			break;
-		case nano::stat::detail::failed_send_telemetry_req:
-			res = "failed_send_telemetry_req";
-			break;
-		case nano::stat::detail::generator_broadcasts:
-			res = "generator_broadcasts";
-			break;
-		case nano::stat::detail::generator_replies:
-			res = "generator_replies";
-			break;
-		case nano::stat::detail::generator_replies_discarded:
-			res = "generator_replies_discarded";
-			break;
-		case nano::stat::detail::generator_spacing:
-			res = "generator_spacing";
-			break;
-		case nano::stat::detail::invalid_network:
-			res = "invalid_network";
-			break;
-		case nano::stat::detail::hinted:
-			res = "hinted";
-			break;
-		case nano::stat::detail::insert_failed:
-			res = "insert_failed";
-			break;
-		case nano::stat::detail::missing_block:
-			res = "missing_block";
-			break;
-		case nano::stat::detail::response:
-			res = "response";
-			break;
-		case nano::stat::detail::write_drop:
-			res = "write_drop";
-			break;
-		case nano::stat::detail::write_error:
-			res = "write_error";
-			break;
-		case nano::stat::detail::blocks:
-			res = "blocks";
-			break;
-		case nano::stat::detail::drop:
-			res = "drop";
-			break;
-		case nano::stat::detail::bad_count:
-			res = "bad_count";
-			break;
-		case nano::stat::detail::response_blocks:
-			res = "response_blocks";
-			break;
-		case nano::stat::detail::response_account_info:
-			res = "response_account_info";
-			break;
-		case nano::stat::detail::channel_full:
-			res = "channel_full";
-			break;
-		case nano::stat::detail::activated:
-			res = "activated";
-			break;
-	}
-	return res;
-}
-
-std::string nano::stat::detail_to_string (uint32_t key)
+std::string nano::stats::detail_to_string (uint32_t key)
 {
 	auto detail = static_cast<stat::detail> (key >> 8 & 0x000000ff);
-	return detail_to_string (detail);
+	return std::string{ nano::to_string (detail) };
 }
 
-std::string nano::stat::dir_to_string (uint32_t key)
+std::string nano::stats::dir_to_string (uint32_t key)
 {
 	auto dir = static_cast<stat::dir> (key & 0x000000ff);
-	return dir_to_string (dir);
-}
-
-std::string nano::stat::dir_to_string (dir dir)
-{
-	std::string res;
-	switch (dir)
-	{
-		case nano::stat::dir::in:
-			res = "in";
-			break;
-		case nano::stat::dir::out:
-			res = "out";
-			break;
-	}
-	return res;
+	return std::string{ nano::to_string (dir) };
 }
 
 nano::stat_datapoint::stat_datapoint (stat_datapoint const & other_a)

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -19,12 +19,13 @@ namespace nano
 class node;
 class tomlconfig;
 class jsonconfig;
+
 /**
  * Serialize and deserialize the 'statistics' node from config.json
  * All configuration values have defaults. In particular, file logging of statistics
  * is disabled by default.
  */
-class stat_config final
+class stats_config final
 {
 public:
 	/** Reads the JSON statistics node */
@@ -225,7 +226,7 @@ public:
 	 * Initialize stats with a config.
 	 * @param config Configuration object; deserialized from config.json
 	 */
-	stats (nano::stat_config config);
+	stats (nano::stats_config config);
 
 	/**
 	 * Call this to override the default sample interval and capacity, for a specific stat entry.
@@ -433,7 +434,7 @@ private:
 	std::chrono::steady_clock::time_point timestamp{ std::chrono::steady_clock::now () };
 
 	/** Configuration deserialized from config.json */
-	nano::stat_config config;
+	nano::stats_config config;
 
 	/** Stat entries are sorted by key to simplify processing of log output */
 	std::map<uint32_t, std::shared_ptr<nano::stat_entry>> entries;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/errors.hpp>
 #include <nano/lib/observer_set.hpp>
+#include <nano/lib/stats_enums.hpp>
 #include <nano/lib/utility.hpp>
 
 #include <boost/circular_buffer.hpp>
@@ -214,272 +215,17 @@ protected:
  * Stats can be queried and observed on a type level (such as message and ledger) as well as a more
  * specific detail level (such as send blocks)
  */
-class stat final
+class stats final
 {
 public:
-	/** Primary statistics type */
-	enum class type : uint8_t
-	{
-		traffic_udp,
-		traffic_tcp,
-		error,
-		message,
-		block,
-		ledger,
-		rollback,
-		bootstrap,
-		tcp_server,
-		vote,
-		election,
-		http_callback,
-		peering,
-		ipc,
-		tcp,
-		udp,
-		confirmation_height,
-		confirmation_observer,
-		drop,
-		aggregator,
-		requests,
-		filter,
-		telemetry,
-		vote_generator,
-		vote_cache,
-		hinting,
-		blockprocessor,
-		bootstrap_server,
-		active,
-		backlog,
-	};
-
-	/** Optional detail type */
-	enum class detail : uint8_t
-	{
-		all = 0,
-
-		// common
-		loop,
-		total,
-
-		// processing queue
-		queue,
-		overfill,
-		batch,
-
-		// error specific
-		bad_sender,
-		insufficient_work,
-		http_callback,
-		unreachable_host,
-		invalid_network,
-
-		// confirmation_observer specific
-		active_quorum,
-		active_conf_height,
-		inactive_conf_height,
-
-		// ledger, block, bootstrap
-		send,
-		receive,
-		open,
-		change,
-		state_block,
-		epoch_block,
-		fork,
-		old,
-		gap_previous,
-		gap_source,
-		rollback_failed,
-		progress,
-		bad_signature,
-		negative_spend,
-		unreceivable,
-		gap_epoch_open_pending,
-		opened_burn_account,
-		balance_mismatch,
-		representative_mismatch,
-		block_position,
-
-		// message specific
-		not_a_type,
-		invalid,
-		keepalive,
-		publish,
-		republish_vote,
-		confirm_req,
-		confirm_ack,
-		node_id_handshake,
-		telemetry_req,
-		telemetry_ack,
-		asc_pull_req,
-		asc_pull_ack,
-
-		// bootstrap, callback
-		initiate,
-		initiate_legacy_age,
-		initiate_lazy,
-		initiate_wallet_lazy,
-
-		// bootstrap specific
-		bulk_pull,
-		bulk_pull_account,
-		bulk_pull_deserialize_receive_block,
-		bulk_pull_error_starting_request,
-		bulk_pull_failed_account,
-		bulk_pull_receive_block_failure,
-		bulk_pull_request_failure,
-		bulk_push,
-		frontier_req,
-		frontier_confirmation_failed,
-		frontier_confirmation_successful,
-		error_socket_close,
-		request_underflow,
-
-		// vote specific
-		vote_valid,
-		vote_replay,
-		vote_indeterminate,
-		vote_invalid,
-		vote_overflow,
-
-		// election specific
-		vote_new,
-		vote_processed,
-		vote_cached,
-		late_block,
-		late_block_seconds,
-		election_start,
-		election_confirmed_all,
-		election_block_conflict,
-		election_difficulty_update,
-		election_drop_expired,
-		election_drop_overflow,
-		election_drop_all,
-		election_restart,
-		election_confirmed,
-		election_not_confirmed,
-		election_hinted_overflow,
-		election_hinted_started,
-		election_hinted_confirmed,
-		election_hinted_drop,
-		generate_vote,
-		generate_vote_normal,
-		generate_vote_final,
-
-		// udp
-		blocking,
-		overflow,
-		invalid_header,
-		invalid_message_type,
-		invalid_keepalive_message,
-		invalid_publish_message,
-		invalid_confirm_req_message,
-		invalid_confirm_ack_message,
-		invalid_node_id_handshake_message,
-		invalid_telemetry_req_message,
-		invalid_telemetry_ack_message,
-		invalid_bulk_pull_message,
-		invalid_bulk_pull_account_message,
-		invalid_frontier_req_message,
-		invalid_asc_pull_req_message,
-		invalid_asc_pull_ack_message,
-		message_too_big,
-		outdated_version,
-		udp_max_per_ip,
-		udp_max_per_subnetwork,
-
-		// tcp
-		tcp_accept_success,
-		tcp_accept_failure,
-		tcp_write_drop,
-		tcp_write_no_socket_drop,
-		tcp_excluded,
-		tcp_max_per_ip,
-		tcp_max_per_subnetwork,
-		tcp_silent_connection_drop,
-		tcp_io_timeout_drop,
-		tcp_connect_error,
-		tcp_read_error,
-		tcp_write_error,
-
-		// ipc
-		invocations,
-
-		// peering
-		handshake,
-
-		// confirmation height
-		blocks_confirmed,
-		blocks_confirmed_unbounded,
-		blocks_confirmed_bounded,
-
-		// [request] aggregator
-		aggregator_accepted,
-		aggregator_dropped,
-
-		// requests
-		requests_cached_hashes,
-		requests_generated_hashes,
-		requests_cached_votes,
-		requests_generated_votes,
-		requests_cached_late_hashes,
-		requests_cached_late_votes,
-		requests_cannot_vote,
-		requests_unknown,
-
-		// duplicate
-		duplicate_publish,
-
-		// telemetry
-		invalid_signature,
-		different_genesis_hash,
-		node_id_mismatch,
-		request_within_protection_cache_zone,
-		no_response_received,
-		unsolicited_telemetry_ack,
-		failed_send_telemetry_req,
-
-		// vote generator
-		generator_broadcasts,
-		generator_replies,
-		generator_replies_discarded,
-		generator_spacing,
-
-		// hinting
-		hinted,
-		insert_failed,
-		missing_block,
-
-		// bootstrap server
-		response,
-		write_drop,
-		write_error,
-		blocks,
-		drop,
-		bad_count,
-		response_blocks,
-		response_account_info,
-		channel_full,
-
-		// backlog
-		activated,
-	};
-
-	/** Direction of the stat. If the direction is irrelevant, use in */
-	enum class dir : uint8_t
-	{
-		in,
-		out
-	};
-
 	/** Constructor using the default config values */
-	stat () = default;
+	stats () = default;
 
 	/**
 	 * Initialize stats with a config.
 	 * @param config Configuration object; deserialized from config.json
 	 */
-	stat (nano::stat_config config);
+	stats (nano::stat_config config);
 
 	/**
 	 * Call this to override the default sample interval and capacity, for a specific stat entry.
@@ -520,7 +266,7 @@ public:
 	/** Adds \p value to the given counter */
 	void add (stat::type type, stat::dir dir, uint64_t value)
 	{
-		add (type, detail::all, dir, value);
+		add (type, stat::detail::all, dir, value);
 	}
 
 	/**
@@ -646,15 +392,6 @@ public:
 
 	/** Returns a new JSON log sink */
 	std::unique_ptr<stat_log_sink> log_sink_json () const;
-
-	/** Returns string representation of type */
-	static std::string type_to_string (stat::type type);
-
-	/** Returns string representation of detail */
-	static std::string detail_to_string (stat::detail detail);
-
-	/** Returns string representation of dir */
-	static std::string dir_to_string (stat::dir detail);
 
 	/** Stop stats being output */
 	void stop ();

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -1,0 +1,282 @@
+#pragma once
+
+#include <magic_enum.hpp>
+
+namespace nano::stat
+{
+/** Primary statistics type */
+enum class type : uint8_t
+{
+	traffic_udp,
+	traffic_tcp,
+	error,
+	message,
+	block,
+	ledger,
+	rollback,
+	bootstrap,
+	tcp_server,
+	vote,
+	election,
+	http_callback,
+	peering,
+	ipc,
+	tcp,
+	udp,
+	confirmation_height,
+	confirmation_observer,
+	drop,
+	aggregator,
+	requests,
+	filter,
+	telemetry,
+	vote_generator,
+	vote_cache,
+	hinting,
+	blockprocessor,
+	bootstrap_server,
+	active,
+	backlog,
+};
+
+/** Optional detail type */
+enum class detail : uint8_t
+{
+	all = 0,
+
+	// common
+	loop,
+	total,
+
+	// processing queue
+	queue,
+	overfill,
+	batch,
+
+	// error specific
+	bad_sender,
+	insufficient_work,
+	http_callback,
+	unreachable_host,
+	invalid_network,
+
+	// confirmation_observer specific
+	active_quorum,
+	active_conf_height,
+	inactive_conf_height,
+
+	// ledger, block, bootstrap
+	send,
+	receive,
+	open,
+	change,
+	state_block,
+	epoch_block,
+	fork,
+	old,
+	gap_previous,
+	gap_source,
+	rollback_failed,
+	progress,
+	bad_signature,
+	negative_spend,
+	unreceivable,
+	gap_epoch_open_pending,
+	opened_burn_account,
+	balance_mismatch,
+	representative_mismatch,
+	block_position,
+
+	// message specific
+	not_a_type,
+	invalid,
+	keepalive,
+	publish,
+	republish_vote,
+	confirm_req,
+	confirm_ack,
+	node_id_handshake,
+	telemetry_req,
+	telemetry_ack,
+	asc_pull_req,
+	asc_pull_ack,
+
+	// bootstrap, callback
+	initiate,
+	initiate_legacy_age,
+	initiate_lazy,
+	initiate_wallet_lazy,
+
+	// bootstrap specific
+	bulk_pull,
+	bulk_pull_account,
+	bulk_pull_deserialize_receive_block,
+	bulk_pull_error_starting_request,
+	bulk_pull_failed_account,
+	bulk_pull_receive_block_failure,
+	bulk_pull_request_failure,
+	bulk_push,
+	frontier_req,
+	frontier_confirmation_failed,
+	frontier_confirmation_successful,
+	error_socket_close,
+	request_underflow,
+
+	// vote specific
+	vote_valid,
+	vote_replay,
+	vote_indeterminate,
+	vote_invalid,
+	vote_overflow,
+
+	// election specific
+	vote_new,
+	vote_processed,
+	vote_cached,
+	late_block,
+	late_block_seconds,
+	election_start,
+	election_confirmed_all,
+	election_block_conflict,
+	election_difficulty_update,
+	election_drop_expired,
+	election_drop_overflow,
+	election_drop_all,
+	election_restart,
+	election_confirmed,
+	election_not_confirmed,
+	election_hinted_overflow,
+	election_hinted_started,
+	election_hinted_confirmed,
+	election_hinted_drop,
+	generate_vote,
+	generate_vote_normal,
+	generate_vote_final,
+
+	// udp
+	blocking,
+	overflow,
+	invalid_header,
+	invalid_message_type,
+	invalid_keepalive_message,
+	invalid_publish_message,
+	invalid_confirm_req_message,
+	invalid_confirm_ack_message,
+	invalid_node_id_handshake_message,
+	invalid_telemetry_req_message,
+	invalid_telemetry_ack_message,
+	invalid_bulk_pull_message,
+	invalid_bulk_pull_account_message,
+	invalid_frontier_req_message,
+	invalid_asc_pull_req_message,
+	invalid_asc_pull_ack_message,
+	message_too_big,
+	outdated_version,
+	udp_max_per_ip,
+	udp_max_per_subnetwork,
+
+	// tcp
+	tcp_accept_success,
+	tcp_accept_failure,
+	tcp_write_drop,
+	tcp_write_no_socket_drop,
+	tcp_excluded,
+	tcp_max_per_ip,
+	tcp_max_per_subnetwork,
+	tcp_silent_connection_drop,
+	tcp_io_timeout_drop,
+	tcp_connect_error,
+	tcp_read_error,
+	tcp_write_error,
+
+	// ipc
+	invocations,
+
+	// peering
+	handshake,
+
+	// confirmation height
+	blocks_confirmed,
+	blocks_confirmed_unbounded,
+	blocks_confirmed_bounded,
+
+	// [request] aggregator
+	aggregator_accepted,
+	aggregator_dropped,
+
+	// requests
+	requests_cached_hashes,
+	requests_generated_hashes,
+	requests_cached_votes,
+	requests_generated_votes,
+	requests_cached_late_hashes,
+	requests_cached_late_votes,
+	requests_cannot_vote,
+	requests_unknown,
+
+	// duplicate
+	duplicate_publish,
+
+	// telemetry
+	invalid_signature,
+	different_genesis_hash,
+	node_id_mismatch,
+	request_within_protection_cache_zone,
+	no_response_received,
+	unsolicited_telemetry_ack,
+	failed_send_telemetry_req,
+
+	// vote generator
+	generator_broadcasts,
+	generator_replies,
+	generator_replies_discarded,
+	generator_spacing,
+
+	// hinting
+	hinted,
+	insert_failed,
+	missing_block,
+
+	// bootstrap server
+	response,
+	write_drop,
+	write_error,
+	blocks,
+	drop,
+	bad_count,
+	response_blocks,
+	response_account_info,
+	channel_full,
+
+	// backlog
+	activated,
+};
+
+/** Direction of the stat. If the direction is irrelevant, use in */
+enum class dir : uint8_t
+{
+	in,
+	out
+};
+}
+
+namespace nano
+{
+/** Returns string representation of type */
+inline std::string_view to_string (stat::type type)
+{
+	return magic_enum::enum_name (type);
+}
+
+/** Returns string representation of detail */
+inline std::string_view to_string (stat::detail detail)
+{
+	return magic_enum::enum_name (detail);
+}
+
+/** Returns string representation of dir */
+inline std::string_view to_string (stat::dir dir)
+{
+	return magic_enum::enum_name (dir);
+}
+}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -30,7 +30,7 @@ class election_scheduler;
 class vote;
 class transaction;
 class confirmation_height_processor;
-class stat;
+class stats;
 
 class recently_confirmed_cache final
 {

--- a/nano/node/backlog_population.cpp
+++ b/nano/node/backlog_population.cpp
@@ -4,7 +4,7 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/secure/store.hpp>
 
-nano::backlog_population::backlog_population (const config & config_a, nano::store & store_a, nano::stat & stats_a) :
+nano::backlog_population::backlog_population (const config & config_a, nano::store & store_a, nano::stats & stats_a) :
 	config_m{ config_a },
 	store{ store_a },
 	stats{ stats_a }

--- a/nano/node/backlog_population.hpp
+++ b/nano/node/backlog_population.hpp
@@ -11,7 +11,7 @@
 
 namespace nano
 {
-class stat;
+class stats;
 class store;
 class election_scheduler;
 
@@ -30,7 +30,7 @@ public:
 		unsigned frequency;
 	};
 
-	backlog_population (const config &, nano::store &, nano::stat &);
+	backlog_population (const config &, nano::store &, nano::stats &);
 	~backlog_population ();
 
 	void start ();
@@ -51,7 +51,7 @@ public:
 
 private: // Dependencies
 	nano::store & store;
-	nano::stat & stats;
+	nano::stats & stats;
 
 	config config_m;
 

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -4,7 +4,7 @@
 #include <nano/secure/store.hpp>
 
 // TODO: Make threads configurable
-nano::bootstrap_server::bootstrap_server (nano::store & store_a, nano::ledger & ledger_a, nano::network_constants const & network_constants_a, nano::stat & stats_a) :
+nano::bootstrap_server::bootstrap_server (nano::store & store_a, nano::ledger & ledger_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
 	store{ store_a },
 	ledger{ ledger_a },
 	network_constants{ network_constants_a },
@@ -97,7 +97,7 @@ void nano::bootstrap_server::respond (nano::asc_pull_ack & response, std::shared
 	// Increase relevant stats depending on payload type
 	struct stat_visitor
 	{
-		nano::stat & stats;
+		nano::stats & stats;
 
 		void operator() (nano::empty_payload const &)
 		{

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -29,7 +29,7 @@ public:
 	using request_t = std::pair<nano::asc_pull_req, std::shared_ptr<nano::transport::channel>>; // <request, response channel>
 
 public:
-	bootstrap_server (nano::store &, nano::ledger &, nano::network_constants const &, nano::stat &);
+	bootstrap_server (nano::store &, nano::ledger &, nano::network_constants const &, nano::stats &);
 	~bootstrap_server ();
 
 	void start ();
@@ -74,7 +74,7 @@ private: // Dependencies
 	nano::store & store;
 	nano::ledger & ledger;
 	nano::network_constants const & network_constants;
-	nano::stat & stats;
+	nano::stats & stats;
 
 private:
 	processing_queue<request_t> request_queue;

--- a/nano/node/hinted_scheduler.cpp
+++ b/nano/node/hinted_scheduler.cpp
@@ -2,7 +2,7 @@
 #include <nano/node/hinted_scheduler.hpp>
 #include <nano/node/node.hpp>
 
-nano::hinted_scheduler::hinted_scheduler (config const & config_a, nano::node & node_a, nano::vote_cache & inactive_vote_cache_a, nano::active_transactions & active_a, nano::online_reps & online_reps_a, nano::stat & stats_a) :
+nano::hinted_scheduler::hinted_scheduler (config const & config_a, nano::node & node_a, nano::vote_cache & inactive_vote_cache_a, nano::active_transactions & active_a, nano::online_reps & online_reps_a, nano::stats & stats_a) :
 	config_m{ config_a },
 	node{ node_a },
 	inactive_vote_cache{ inactive_vote_cache_a },

--- a/nano/node/hinted_scheduler.hpp
+++ b/nano/node/hinted_scheduler.hpp
@@ -27,7 +27,7 @@ public: // Config
 	};
 
 public:
-	explicit hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stat &);
+	explicit hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stats &);
 	~hinted_scheduler ();
 
 	void start ();
@@ -49,7 +49,7 @@ private: // Dependencies
 	nano::vote_cache & inactive_vote_cache;
 	nano::active_transactions & active;
 	nano::online_reps & online_reps;
-	nano::stat & stats;
+	nano::stats & stats;
 
 private:
 	config const config_m;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -827,7 +827,7 @@ void nano::network::erase (nano::transport::channel const & channel_a)
 	}
 }
 
-nano::message_buffer_manager::message_buffer_manager (nano::stat & stats_a, std::size_t size, std::size_t count) :
+nano::message_buffer_manager::message_buffer_manager (nano::stats & stats_a, std::size_t size, std::size_t count) :
 	stats (stats_a),
 	free (count),
 	full (count),

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -39,7 +39,7 @@ public:
 	// Stats - Statistics
 	// Size - Size of each individual buffer
 	// Count - Number of buffers to allocate
-	message_buffer_manager (nano::stat & stats, std::size_t, std::size_t);
+	message_buffer_manager (nano::stats & stats, std::size_t, std::size_t);
 	// Return a buffer where message data can be put
 	// Method will attempt to return the first free buffer
 	// If there are no free buffers, an unserviced buffer will be dequeued and returned
@@ -58,7 +58,7 @@ public:
 	void stop ();
 
 private:
-	nano::stat & stats;
+	nano::stats & stats;
 	nano::mutex mutex;
 	nano::condition_variable condition;
 	boost::circular_buffer<nano::message_buffer *> free;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -150,7 +150,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	node_initialized_latch (1),
 	config (config_a),
 	network_params{ config.network_params },
-	stats (config.stat_config),
+	stats (config.stats_config),
 	workers (std::max (3u, config.io_threads / 4), nano::thread_role::name::worker),
 	bootstrap_workers{ config.bootstrap_serving_threads, nano::thread_role::name::bootstrap_worker },
 	flags (flags_a),

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -141,7 +141,7 @@ public:
 	boost::latch node_initialized_latch;
 	nano::node_config config;
 	nano::network_params & network_params;
-	nano::stat stats;
+	nano::stats stats;
 	nano::thread_pool workers;
 	nano::thread_pool bootstrap_workers;
 	std::shared_ptr<nano::websocket::listener> websocket_server;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -183,7 +183,7 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put_child ("diagnostics", diagnostics_l);
 
 	nano::tomlconfig stat_l;
-	stat_config.serialize_toml (stat_l);
+	stats_config.serialize_toml (stat_l);
 	toml.put_child ("statistics", stat_l);
 
 	nano::tomlconfig rocksdb_l;
@@ -235,8 +235,8 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 
 		if (toml.has_key ("statistics"))
 		{
-			auto stat_config_l (toml.get_required_child ("statistics"));
-			stat_config.deserialize_toml (stat_config_l);
+			auto stats_config_l (toml.get_required_child ("statistics"));
+			stats_config.deserialize_toml (stats_config_l);
 		}
 
 		if (toml.has_key ("rocksdb"))

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -74,7 +74,7 @@ public:
 	uint16_t callback_port{ 0 };
 	std::string callback_target;
 	bool allow_local_peers{ !(network_params.network.is_live_network () || network_params.network.is_test_network ()) }; // disable by default for live network
-	nano::stat_config stat_config;
+	nano::stats_config stats_config;
 	nano::ipc::ipc_config ipc_config;
 	std::string external_address;
 	uint16_t external_port{ 0 };

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -10,7 +10,7 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/store.hpp>
 
-nano::request_aggregator::request_aggregator (nano::node_config const & config_a, nano::stat & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
+nano::request_aggregator::request_aggregator (nano::node_config const & config_a, nano::stats & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
 	config{ config_a },
 	max_delay (config_a.network_params.network.is_dev_network () ? 50 : 300),
 	small_delay (config_a.network_params.network.is_dev_network () ? 10 : 50),

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -21,7 +21,7 @@ class active_transactions;
 class ledger;
 class local_vote_history;
 class node_config;
-class stat;
+class stats;
 class vote_generator;
 class wallets;
 /**
@@ -59,7 +59,7 @@ class request_aggregator final
 	// clang-format on
 
 public:
-	request_aggregator (nano::node_config const & config, nano::stat & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_transactions &);
+	request_aggregator (nano::node_config const & config, nano::stats & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_transactions &);
 
 	/** Add a new request by \p channel_a for hashes \p hashes_roots_a */
 	void add (std::shared_ptr<nano::transport::channel> const & channel_a, std::vector<std::pair<nano::block_hash, nano::root>> const & hashes_roots_a);
@@ -81,7 +81,7 @@ private:
 	std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr<nano::block>>> aggregate (std::vector<std::pair<nano::block_hash, nano::root>> const & requests_a, std::shared_ptr<nano::transport::channel> & channel_a) const;
 	void reply_action (std::shared_ptr<nano::vote> const & vote_a, std::shared_ptr<nano::transport::channel> const & channel_a) const;
 
-	nano::stat & stats;
+	nano::stats & stats;
 	nano::local_vote_history & local_votes;
 	nano::ledger & ledger;
 	nano::wallets & wallets;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -18,7 +18,7 @@
 
 using namespace std::chrono_literals;
 
-nano::telemetry::telemetry (nano::network & network_a, nano::thread_pool & workers_a, nano::observer_set<nano::telemetry_data const &, nano::endpoint const &> & observers_a, nano::stat & stats_a, nano::network_params & network_params_a, bool disable_ongoing_requests_a) :
+nano::telemetry::telemetry (nano::network & network_a, nano::thread_pool & workers_a, nano::observer_set<nano::telemetry_data const &, nano::endpoint const &> & observers_a, nano::stats & stats_a, nano::network_params & network_params_a, bool disable_ongoing_requests_a) :
 	network (network_a),
 	workers (workers_a),
 	observers (observers_a),

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -18,7 +18,7 @@ namespace mi = boost::multi_index;
 namespace nano
 {
 class network;
-class stat;
+class stats;
 class ledger;
 class thread_pool;
 class unchecked_map;
@@ -62,7 +62,7 @@ public:
 class telemetry : public std::enable_shared_from_this<telemetry>
 {
 public:
-	telemetry (nano::network &, nano::thread_pool &, nano::observer_set<nano::telemetry_data const &, nano::endpoint const &> &, nano::stat &, nano::network_params &, bool);
+	telemetry (nano::network &, nano::thread_pool &, nano::observer_set<nano::telemetry_data const &, nano::endpoint const &> &, nano::stats &, nano::network_params &, bool);
 	void start ();
 	void stop ();
 
@@ -108,7 +108,7 @@ private:
 	nano::network & network;
 	nano::thread_pool & workers;
 	nano::observer_set<nano::telemetry_data const &, nano::endpoint const &> & observers;
-	nano::stat & stats;
+	nano::stats & stats;
 	/* Important that this is a reference to the node network_params for tests which want to modify genesis block */
 	nano::network_params & network_params;
 	bool disable_ongoing_requests;

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -71,7 +71,7 @@ void nano::transport::channel::send (nano::message & message_a, std::function<vo
 		node.stats.inc (nano::stat::type::drop, detail, nano::stat::dir::out);
 		if (node.config.logging.network_packet_logging ())
 		{
-			node.logger.always_log (boost::str (boost::format ("%1% of size %2% dropped") % node.stats.detail_to_string (detail) % buffer.size ()));
+			node.logger.always_log (boost::str (boost::format ("%1% of size %2% dropped") % nano::to_string (detail) % buffer.size ()));
 		}
 	}
 }

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -17,7 +17,7 @@
 #include <chrono>
 using namespace std::chrono_literals;
 
-nano::vote_processor::vote_processor (nano::signature_checker & checker_a, nano::active_transactions & active_a, nano::node_observers & observers_a, nano::stat & stats_a, nano::node_config & config_a, nano::node_flags & flags_a, nano::logger_mt & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a) :
+nano::vote_processor::vote_processor (nano::signature_checker & checker_a, nano::active_transactions & active_a, nano::node_observers & observers_a, nano::stats & stats_a, nano::node_config & config_a, nano::node_flags & flags_a, nano::logger_mt & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a) :
 	checker (checker_a),
 	active (active_a),
 	observers (observers_a),

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -23,7 +23,7 @@ class rep_crawler;
 class ledger;
 class network_params;
 class node_flags;
-class stat;
+class stats;
 
 class transaction;
 namespace transport
@@ -34,14 +34,15 @@ namespace transport
 class vote_processor final
 {
 public:
-	explicit vote_processor (nano::signature_checker & checker_a, nano::active_transactions & active_a, nano::node_observers & observers_a, nano::stat & stats_a, nano::node_config & config_a, nano::node_flags & flags_a, nano::logger_mt & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a);
+	vote_processor (nano::signature_checker & checker_a, nano::active_transactions & active_a, nano::node_observers & observers_a, nano::stats & stats_a, nano::node_config & config_a, nano::node_flags & flags_a, nano::logger_mt & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a);
+
 	/** Returns false if the vote was processed */
 	bool vote (std::shared_ptr<nano::vote> const &, std::shared_ptr<nano::transport::channel> const &);
 	/** Note: node.active.mutex lock is required */
 	nano::vote_code vote_blocking (std::shared_ptr<nano::vote> const &, std::shared_ptr<nano::transport::channel> const &, bool = false);
 	void verify_votes (std::deque<std::pair<std::shared_ptr<nano::vote>, std::shared_ptr<nano::transport::channel>>> const &);
 	/** Function blocks until either the current queue size (a established flush boundary as it'll continue to increase)
-	  * is processed or the queue is empty (end condition or cutoff's guard, as it is positioned ahead) */
+	 * is processed or the queue is empty (end condition or cutoff's guard, as it is positioned ahead) */
 	void flush ();
 	std::size_t size ();
 	bool empty ();
@@ -56,7 +57,7 @@ private:
 	nano::signature_checker & checker;
 	nano::active_transactions & active;
 	nano::node_observers & observers;
-	nano::stat & stats;
+	nano::stats & stats;
 	nano::node_config & config;
 	nano::logger_mt & logger;
 	nano::online_reps & online_reps;

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (na
 	return composite;
 }
 
-nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stat & stats_a, bool is_final_a) :
+nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, bool is_final_a) :
 	config (config_a),
 	ledger (ledger_a),
 	wallets (wallets_a),

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -24,7 +24,7 @@ namespace nano
 class ledger;
 class network;
 class node_config;
-class stat;
+class stats;
 class vote_processor;
 class wallets;
 namespace transport
@@ -121,7 +121,7 @@ private:
 	using queue_entry_t = std::pair<nano::root, nano::block_hash>;
 
 public:
-	vote_generator (nano::node_config const & config_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stat & stats_a, bool is_final_a);
+	vote_generator (nano::node_config const & config_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, bool is_final_a);
 	~vote_generator ();
 
 	/** Queue items for vote generation, or broadcast votes already in cache */
@@ -157,7 +157,7 @@ private: // Dependencies
 	nano::local_vote_history & history;
 	nano::vote_spacing spacing;
 	nano::network & network;
-	nano::stat & stats;
+	nano::stats & stats;
 
 private:
 	processing_queue<queue_entry_t> vote_generation_queue;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -694,7 +694,7 @@ ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::write_transac
 }
 } // namespace
 
-nano::ledger::ledger (nano::store & store_a, nano::stat & stat_a, nano::ledger_constants & constants, nano::generate_cache const & generate_cache_a) :
+nano::ledger::ledger (nano::store & store_a, nano::stats & stat_a, nano::ledger_constants & constants, nano::generate_cache const & generate_cache_a) :
 	constants{ constants },
 	store{ store_a },
 	stats{ stat_a },

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -9,7 +9,7 @@
 namespace nano
 {
 class store;
-class stat;
+class stats;
 class write_transaction;
 
 // map of vote weight per block, ordered greater first
@@ -27,7 +27,7 @@ public:
 class ledger final
 {
 public:
-	ledger (nano::store &, nano::stat &, nano::ledger_constants & constants, nano::generate_cache const & = nano::generate_cache ());
+	ledger (nano::store &, nano::stats &, nano::ledger_constants & constants, nano::generate_cache const & = nano::generate_cache ());
 	/**
 	 * Return account containing hash, expects that block hash exists in ledger
 	 */
@@ -86,7 +86,7 @@ public:
 	nano::ledger_constants & constants;
 	nano::store & store;
 	nano::ledger_cache cache;
-	nano::stat & stats;
+	nano::stats & stats;
 	std::unordered_map<nano::account, nano::uint128_t> bootstrap_weights;
 	uint64_t bootstrap_weight_max_blocks{ 1 };
 	std::atomic<bool> check_bootstrap_weights;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -116,7 +116,7 @@ TEST (ledger, deep_account_compute)
 	nano::logger_mt logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
@@ -1223,7 +1223,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	auto path (nano::unique_path ());
 	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stat stats;
+	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -26,7 +26,7 @@ nano::store & nano::test::context::ledger_context::store ()
 	return *store_m;
 }
 
-nano::stat & nano::test::context::ledger_context::stats ()
+nano::stats & nano::test::context::ledger_context::stats ()
 {
 	return stats_m;
 }

--- a/nano/test_common/ledger.hpp
+++ b/nano/test_common/ledger.hpp
@@ -20,13 +20,13 @@ namespace test
 			ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks = std::deque<std::shared_ptr<nano::block>>{});
 			nano::ledger & ledger ();
 			nano::store & store ();
-			nano::stat & stats ();
+			nano::stats & stats ();
 			std::deque<std::shared_ptr<nano::block>> const & blocks () const;
 
 		private:
 			nano::logger_mt logger;
 			std::unique_ptr<nano::store> store_m;
-			nano::stat stats_m;
+			nano::stats stats_m;
 			nano::ledger ledger_m;
 			std::deque<std::shared_ptr<nano::block>> blocks_m;
 		};

--- a/nano/test_common/rate_observer.cpp
+++ b/nano/test_common/rate_observer.cpp
@@ -1,6 +1,9 @@
 #include <nano/lib/stats.hpp>
 #include <nano/node/node.hpp>
 #include <nano/test_common/rate_observer.hpp>
+
+#include <sstream>
+
 /*
  * rate_observer::counter
  */
@@ -21,7 +24,7 @@ std::pair<uint64_t, std::chrono::milliseconds> nano::test::rate_observer::counte
 	}
 }
 
-nano::test::rate_observer::stat_counter::stat_counter (nano::stat & stats_a, nano::stat::type type_a, nano::stat::detail detail_a, nano::stat::dir dir_a) :
+nano::test::rate_observer::stat_counter::stat_counter (nano::stats & stats_a, nano::stat::type type_a, nano::stat::detail detail_a, nano::stat::dir dir_a) :
 	stats{ stats_a },
 	type{ type_a },
 	detail{ detail_a },
@@ -43,7 +46,9 @@ uint64_t nano::test::rate_observer::stat_counter::count ()
 
 std::string nano::test::rate_observer::stat_counter::name ()
 {
-	return nano::stat::type_to_string (type) + "::" + nano::stat::detail_to_string (detail) + "::" + nano::stat::dir_to_string (dir);
+	std::stringstream ss;
+	ss << nano::to_string (type) << "::" << nano::to_string (detail) << "::" << nano::to_string (dir);
+	return ss.str ();
 }
 
 /*

--- a/nano/test_common/rate_observer.cpp
+++ b/nano/test_common/rate_observer.cpp
@@ -4,6 +4,8 @@
 
 #include <sstream>
 
+using namespace magic_enum::ostream_operators;
+
 /*
  * rate_observer::counter
  */
@@ -47,7 +49,7 @@ uint64_t nano::test::rate_observer::stat_counter::count ()
 std::string nano::test::rate_observer::stat_counter::name ()
 {
 	std::stringstream ss;
-	ss << nano::to_string (type) << "::" << nano::to_string (detail) << "::" << nano::to_string (dir);
+	ss << type << "::" << detail << "::" << dir;
 	return ss.str ();
 }
 

--- a/nano/test_common/rate_observer.hpp
+++ b/nano/test_common/rate_observer.hpp
@@ -38,7 +38,7 @@ public:
 	class stat_counter final : public counter
 	{
 	public:
-		explicit stat_counter (nano::stat & stats, nano::stat::type type, nano::stat::detail detail, nano::stat::dir dir);
+		stat_counter (nano::stats & stats, nano::stat::type type, nano::stat::detail detail, nano::stat::dir dir);
 
 		uint64_t count () override;
 		std::string name () override;
@@ -50,7 +50,7 @@ public:
 
 		uint64_t last_count{ 0 };
 
-		nano::stat & stats;
+		nano::stats & stats;
 	};
 
 public:

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -66,7 +66,7 @@ namespace test
 		boost::asio::io_context io_ctx;
 		std::vector<std::shared_ptr<nano::node>> nodes;
 		nano::logging logging;
-		nano::stat stats;
+		nano::stats stats;
 		nano::work_pool work{ nano::dev::network_params.network, std::max (nano::hardware_concurrency (), 1u) };
 		std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
 		double deadline_scaling_factor{ 1.0 };


### PR DESCRIPTION
It is cumbersome to convert between enum and string representations, because C++ standard does not provide any tools for that purpose. Currently our codebase requires writing manual conversion functions which is inefficient and inflexible. This PR introduces `magic_enum` (https://github.com/Neargye/magic_enum) library as a submodule, which ergonomically handles enum to string conversions without requiring any adaptations to existing enum definitions.

The PR only modifies stat related classes (`stat::type` and `stat::detail`). More conversions will be done in subsequent PRs.

Compiler compatibility for `magic_enum`:
```
Clang/LLVM >= 6
MSVC++ >= 14.11 / Visual Studio >= 2017
Xcode >= 10
GCC >= 9
MinGW >= 9
```