### PR TITLE
Fix submodule names

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,29 +1,29 @@
-[submodule "submodules/miniupnp"]
+[submodule "miniupnp"]
 	path = submodules/miniupnp
 	url = https://github.com/miniupnp/miniupnp.git
-[submodule "submodules/lmdb"]
+[submodule "lmdb"]
 	path = submodules/lmdb
 	url = https://github.com/nanocurrency/lmdb.git
 	branch = lmdb_0_9_23
-[submodule "submodules/cryptopp"]
+[submodule "cryptopp"]
 	path = submodules/cryptopp
 	url = https://github.com/weidai11/cryptopp.git
-[submodule "submodules/phc-winner-argon2"]
+[submodule "phc-winner-argon2"]
 	path = submodules/phc-winner-argon2
 	url = https://github.com/nanocurrency/phc-winner-argon2.git
-[submodule "submodules/gtest"]
+[submodule "gtest"]
 	path = submodules/gtest
 	url = https://github.com/google/googletest.git
-[submodule "submodules/cpptoml"]
+[submodule "cpptoml"]
 	path = submodules/cpptoml
 	url = https://github.com/cryptocode/cpptoml.git
-[submodule "submodules/flatbuffers"]
+[submodule "flatbuffers"]
 	path = submodules/flatbuffers
 	url = https://github.com/google/flatbuffers.git
-[submodule "submodules/rocksdb"]
+[submodule "rocksdb"]
 	path = submodules/rocksdb
 	url = https://github.com/facebook/rocksdb.git
-[submodule "submodules/diskhash"]
+[submodule "diskhash"]
 	path = submodules/diskhash
 	url = https://github.com/nanocurrency/diskhash.git
 [submodule "boost"]


### PR DESCRIPTION
The PR that moved submodules folder also changed the names of the submodules. This is a bit strange considering that `git mv old/submod new/submod` command only updates a submodule path, leaving names unchanged. The reason for having simple and standardized submodule names is ease of overwriting settings, like `git config submodule.boost.ignore all` which ignores specific submodule changes. This PR fixes that.