### PR TITLE
Fix accounts_balances RPC command on v24 release branch

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -899,20 +899,12 @@ void nano::json_handler::accounts_balances ()
 		auto account = account_impl (account_from_request.second.data ());
 		if (!ec)
 		{
-			nano::account_info info;
-			if (!node.store.account.get (transaction, account, info))
-			{
-				auto balance = node.balance_pending (account, false);
-				entry.put ("balance", balance.first.convert_to<std::string> ());
-				entry.put ("pending", balance.second.convert_to<std::string> ());
-				entry.put ("receivable", balance.second.convert_to<std::string> ());
-				balances.put_child (account_from_request.second.data (), entry);
-				continue;
-			}
-			else
-			{
-				ec = nano::error_common::account_not_found;
-			}
+			auto balance = node.balance_pending (account, false);
+			entry.put ("balance", balance.first.convert_to<std::string> ());
+			entry.put ("pending", balance.second.convert_to<std::string> ());
+			entry.put ("receivable", balance.second.convert_to<std::string> ());
+			balances.put_child (account_from_request.second.data (), entry);
+			continue;
 		}
 		entry.put ("error", ec.message ());
 		balances.put_child (account_from_request.second.data (), entry);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -899,7 +899,8 @@ void nano::json_handler::accounts_balances ()
 		auto account = account_impl (account_from_request.second.data ());
 		if (!ec)
 		{
-			auto balance = node.balance_pending (account, false);
+			bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+			auto balance = node.balance_pending (account, include_only_confirmed);
 			entry.put ("balance", balance.first.convert_to<std::string> ());
 			entry.put ("pending", balance.second.convert_to<std::string> ());
 			entry.put ("receivable", balance.second.convert_to<std::string> ());


### PR DESCRIPTION
* Return correct response unopened accounts with receivables (bugfix)
* Add include_only_confirmed option to rpc accounts_balances and make it return confirmed only data by default