### PR TITLE
Fix `hinted_scheduler` stop

### DIFF
--- a/nano/node/hinted_scheduler.hpp
+++ b/nano/node/hinted_scheduler.hpp
@@ -27,11 +27,12 @@ public: // Config
 	};
 
 public:
-	explicit hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stats &);
+	hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stats &);
 	~hinted_scheduler ();
 
 	void start ();
 	void stop ();
+
 	/*
 	 * Notify about changes in AEC vacancy
 	 */
@@ -54,7 +55,7 @@ private: // Dependencies
 private:
 	config const config_m;
 
-	bool stopped;
+	bool stopped{ false };
 	nano::condition_variable condition;
 	mutable nano::mutex mutex;
 	std::thread thread;


### PR DESCRIPTION
Deadlocks were possible during node stopping due to invalid stop function logic.