### PR TITLE
Fix `active_transactions` stop

### DIFF
--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -139,7 +139,7 @@ private: // Elections
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
 
 public:
-	explicit active_transactions (nano::node &, nano::confirmation_height_processor &);
+	active_transactions (nano::node &, nano::confirmation_height_processor &);
 	~active_transactions ();
 
 	void start ();
@@ -233,7 +233,7 @@ private:
 	int active_hinted_elections_count{ 0 };
 
 	nano::condition_variable condition;
-	std::atomic<bool> stopped{ false };
+	bool stopped{ false };
 	std::thread thread;
 
 	friend class election;


### PR DESCRIPTION
Deadlocks were possible during node stopping due to invalid stop logic.