### PR TITLE
Add ledger::account_info as interface to access account information

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1677,8 +1677,8 @@ namespace lmdb
 			nano::ledger ledger (store, stats, nano::dev::constants);
 			auto transaction (store.tx_begin_write ());
 			store.initialize (transaction, ledger.cache, nano::dev::constants);
-			nano::account_info account_info;
-			ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis->account (), account_info));
+			auto account_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+			ASSERT_TRUE (account_info);
 			nano::confirmation_height_info confirmation_height_info;
 			ASSERT_FALSE (store.confirmation_height.get (transaction, nano::dev::genesis->account (),
 			confirmation_height_info));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -249,31 +249,34 @@ TEST (confirmation_height, multiple_accounts)
 
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
 
-		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
 		auto & store = node->store;
 		auto transaction = node->store.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
-		ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
+		auto account_info = node->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (4, confirmation_height_info.height);
 		ASSERT_EQ (send3->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (4, account_info.block_count);
-		ASSERT_FALSE (store.account.get (transaction, key1.pub, account_info));
+		ASSERT_EQ (4, account_info->block_count);
+		account_info = node->ledger.account_info (transaction, key1.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (2, confirmation_height_info.height);
 		ASSERT_EQ (send4->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (3, account_info.block_count);
-		ASSERT_FALSE (store.account.get (transaction, key2.pub, account_info));
+		ASSERT_EQ (3, account_info->block_count);
+		account_info = node->ledger.account_info (transaction, key2.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key2.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
 		ASSERT_EQ (send6->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (4, account_info.block_count);
-		ASSERT_FALSE (store.account.get (transaction, key3.pub, account_info));
+		ASSERT_EQ (4, account_info->block_count);
+		account_info = node->ledger.account_info (transaction, key3.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key3.pub, confirmation_height_info));
 		ASSERT_EQ (2, confirmation_height_info.height);
 		ASSERT_EQ (receive3->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (2, account_info.block_count);
+		ASSERT_EQ (2, account_info->block_count);
 
 		// The accounts for key1 and key2 have 1 more block in the chain than is confirmed.
 		// So this can be rolled back, but the one before that cannot. Check that this is the case
@@ -697,19 +700,20 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive4->hash ()));
-		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
+		auto account_info = node->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (6, confirmation_height_info.height);
 		ASSERT_EQ (send5->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (7, account_info.block_count);
+		ASSERT_EQ (7, account_info->block_count);
 
-		ASSERT_FALSE (node->store.account.get (transaction, key1.pub, account_info));
+		account_info = node->ledger.account_info (transaction, key1.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (5, confirmation_height_info.height);
 		ASSERT_EQ (receive4->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (5, account_info.block_count);
+		ASSERT_EQ (5, account_info->block_count);
 
 		ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 		ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, get_stats_detail (mode_a), nano::stat::dir::in));
@@ -814,13 +818,13 @@ TEST (confirmation_height, send_receive_self)
 
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
-		nano::account_info account_info;
-		ASSERT_FALSE (node->store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
+		auto account_info = node->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		ASSERT_TRUE (account_info);
 		nano::confirmation_height_info confirmation_height_info;
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (7, confirmation_height_info.height);
 		ASSERT_EQ (receive3->hash (), confirmation_height_info.frontier);
-		ASSERT_EQ (8, account_info.block_count);
+		ASSERT_EQ (8, account_info->block_count);
 		ASSERT_EQ (6, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 		ASSERT_EQ (6, node->stats.count (nano::stat::type::confirmation_height, get_stats_detail (mode_a), nano::stat::dir::in));
 		ASSERT_EQ (6, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out));
@@ -1060,25 +1064,27 @@ TEST (confirmation_height, all_block_types)
 
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, state_send2->hash ()));
-		nano::account_info account_info;
 		nano::confirmation_height_info confirmation_height_info;
-		ASSERT_FALSE (node->store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
+		auto account_info = node->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 		ASSERT_EQ (3, confirmation_height_info.height);
 		ASSERT_EQ (send1->hash (), confirmation_height_info.frontier);
-		ASSERT_LE (4, account_info.block_count);
+		ASSERT_LE (4, account_info->block_count);
 
-		ASSERT_FALSE (node->store.account.get (transaction, key1.pub, account_info));
+		account_info = node->ledger.account_info (transaction, key1.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 		ASSERT_EQ (state_send1->hash (), confirmation_height_info.frontier);
 		ASSERT_EQ (6, confirmation_height_info.height);
-		ASSERT_LE (7, account_info.block_count);
+		ASSERT_LE (7, account_info->block_count);
 
-		ASSERT_FALSE (node->store.account.get (transaction, key2.pub, account_info));
+		account_info = node->ledger.account_info (transaction, key2.pub);
+		ASSERT_TRUE (account_info);
 		ASSERT_FALSE (node->store.confirmation_height.get (transaction, key2.pub, confirmation_height_info));
 		ASSERT_EQ (7, confirmation_height_info.height);
 		ASSERT_EQ (state_send2->hash (), confirmation_height_info.frontier);
-		ASSERT_LE (8, account_info.block_count);
+		ASSERT_LE (8, account_info->block_count);
 
 		ASSERT_EQ (15, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 		ASSERT_EQ (15, node->stats.count (nano::stat::type::confirmation_height, get_stats_detail (mode_a), nano::stat::dir::in));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -45,12 +45,12 @@ TEST (ledger, genesis_balance)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, balance);
 	auto amount = ledger.amount (transaction, nano::dev::genesis->account ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount, amount);
-	nano::account_info info;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis->account (), info));
+	auto info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (info);
 	ASSERT_EQ (1, ledger.cache.account_count);
 	// Frontier time should have been updated when genesis balance was added
-	ASSERT_GE (nano::seconds_since_epoch (), info.modified);
-	ASSERT_LT (nano::seconds_since_epoch () - info.modified, 10);
+	ASSERT_GE (nano::seconds_since_epoch (), info->modified);
+	ASSERT_LT (nano::seconds_since_epoch () - info->modified, 10);
 	// Genesis block should be confirmed by default
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_FALSE (store.confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));
@@ -87,36 +87,36 @@ TEST (ledger, process_send)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::keypair key2;
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
-				.previous (info1.head)
+				.previous (info1->head)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1.head))
+				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 = send->hash ();
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1.head));
-	ASSERT_EQ (1, info1.block_count);
+	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1->head));
+	ASSERT_EQ (1, info1->block_count);
 	// This was a valid block, it should progress.
 	auto return1 = ledger.process (transaction, *send);
 	ASSERT_EQ (nano::dev::genesis_key.pub, send->sideband ().account);
 	ASSERT_EQ (2, send->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash1));
-	ASSERT_TRUE (store.frontier.get (transaction, info1.head).is_zero ());
+	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, hash1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account_calculated (*send));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
-	nano::account_info info2;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info2));
-	ASSERT_EQ (2, info2.block_count);
-	auto latest6 = store.block.get (transaction, info2.head);
+	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info2);
+	ASSERT_EQ (2, info2->block_count);
+	auto latest6 = store.block.get (transaction, info2->head);
 	ASSERT_NE (nullptr, latest6);
 	auto latest7 = dynamic_cast<nano::send_block *> (latest6.get ());
 	ASSERT_NE (nullptr, latest7);
@@ -146,24 +146,24 @@ TEST (ledger, process_send)
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
 	ASSERT_EQ (50, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (key2.pub));
-	nano::account_info info3;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info3));
-	auto latest2 = store.block.get (transaction, info3.head);
+	auto info3 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info3);
+	auto latest2 = store.block.get (transaction, info3->head);
 	ASSERT_NE (nullptr, latest2);
 	auto latest3 = dynamic_cast<nano::send_block *> (latest2.get ());
 	ASSERT_NE (nullptr, latest3);
 	ASSERT_EQ (*send, *latest3);
-	nano::account_info info4;
-	ASSERT_FALSE (store.account.get (transaction, key2.pub, info4));
-	auto latest4 = store.block.get (transaction, info4.head);
+	auto info4 = ledger.account_info (transaction, key2.pub);
+	ASSERT_TRUE (info4);
+	auto latest4 = store.block.get (transaction, info4->head);
 	ASSERT_NE (nullptr, latest4);
 	auto latest5 = dynamic_cast<nano::open_block *> (latest4.get ());
 	ASSERT_NE (nullptr, latest5);
 	ASSERT_EQ (*open, *latest5);
 	ASSERT_FALSE (ledger.rollback (transaction, hash2));
 	ASSERT_TRUE (store.frontier.get (transaction, hash2).is_zero ());
-	nano::account_info info5;
-	ASSERT_TRUE (ledger.store.account.get (transaction, key2.pub, info5));
+	auto info5 = ledger.account_info (transaction, key2.pub);
+	ASSERT_FALSE (info5);
 	nano::pending_info pending1;
 	ASSERT_FALSE (ledger.store.pending.get (transaction, nano::pending_key (key2.pub, hash1), pending1));
 	ASSERT_EQ (nano::dev::genesis_key.pub, pending1.source);
@@ -173,17 +173,17 @@ TEST (ledger, process_send)
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (50, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
-	nano::account_info info6;
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis_key.pub, info6));
-	ASSERT_EQ (hash1, info6.head);
-	ASSERT_FALSE (ledger.rollback (transaction, info6.head));
+	auto info6 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info6);
+	ASSERT_EQ (hash1, info6->head);
+	ASSERT_FALSE (ledger.rollback (transaction, info6->head));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1.head));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1->head));
 	ASSERT_TRUE (store.frontier.get (transaction, hash1).is_zero ());
-	nano::account_info info7;
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis_key.pub, info7));
-	ASSERT_EQ (1, info7.block_count);
-	ASSERT_EQ (info1.head, info7.head);
+	auto info7 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info7);
+	ASSERT_EQ (1, info7->block_count);
+	ASSERT_EQ (info1->head, info7->head);
 	nano::pending_info pending2;
 	ASSERT_TRUE (ledger.store.pending.get (transaction, nano::pending_key (key2.pub, hash1), pending2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
@@ -198,17 +198,17 @@ TEST (ledger, process_receive)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::keypair key2;
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
-				.previous (info1.head)
+				.previous (info1->head)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1.head))
+				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -286,17 +286,17 @@ TEST (ledger, rollback_receiver)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::keypair key2;
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
-				.previous (info1.head)
+				.previous (info1->head)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1.head))
+				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -323,11 +323,10 @@ TEST (ledger, rollback_receiver)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
-	nano::account_info info2;
-	ASSERT_TRUE (store.account.get (transaction, key2.pub, info2));
+	ASSERT_FALSE (ledger.account_info (transaction, key2.pub));
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
 	nano::pending_info pending1;
-	ASSERT_TRUE (store.pending.get (transaction, nano::pending_key{ key2.pub, info2.head }, pending1));
+	ASSERT_TRUE (store.pending.get (transaction, nano::pending_key{ key2.pub, hash1 }, pending1));
 }
 
 TEST (ledger, rollback_representation)
@@ -395,13 +394,13 @@ TEST (ledger, rollback_representation)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_EQ (1, ledger.weight (key3.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, ledger.weight (key4.pub));
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, key2.pub, info1));
-	ASSERT_EQ (key4.pub, info1.representative);
+	auto info1 = ledger.account_info (transaction, key2.pub);
+	ASSERT_TRUE (info1);
+	ASSERT_EQ (key4.pub, info1->representative);
 	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
-	nano::account_info info2;
-	ASSERT_FALSE (store.account.get (transaction, key2.pub, info2));
-	ASSERT_EQ (key4.pub, info2.representative);
+	auto info2 = ledger.account_info (transaction, key2.pub);
+	ASSERT_TRUE (info2);
+	ASSERT_EQ (key4.pub, info2->representative);
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (key4.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, open->hash ()));
@@ -409,13 +408,13 @@ TEST (ledger, rollback_representation)
 	ASSERT_EQ (0, ledger.weight (key4.pub));
 	ledger.rollback (transaction, send1->hash ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key3.pub));
-	nano::account_info info3;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info3));
-	ASSERT_EQ (key3.pub, info3.representative);
+	auto info3 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info3);
+	ASSERT_EQ (key3.pub, info3->representative);
 	ASSERT_FALSE (ledger.rollback (transaction, change2->hash ()));
-	nano::account_info info4;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info4));
-	ASSERT_EQ (key5.pub, info4.representative);
+	auto info4 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info4);
+	ASSERT_EQ (key5.pub, info4->representative);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key5.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
 }
@@ -455,17 +454,17 @@ TEST (ledger, process_duplicate)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::keypair key2;
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
-				.previous (info1.head)
+				.previous (info1->head)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1.head))
+				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -510,34 +509,34 @@ TEST (ledger, representative_change)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::block_builder builder;
 	auto block = builder
 				 .change ()
-				 .previous (info1.head)
+				 .previous (info1->head)
 				 .representative (key2.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1.head))
+				 .work (*pool.generate (info1->head))
 				 .build ();
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1.head));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1->head));
 	auto return1 (ledger.process (transaction, *block));
 	ASSERT_EQ (0, ledger.amount (transaction, block->hash ()));
-	ASSERT_TRUE (store.frontier.get (transaction, info1.head).is_zero ());
+	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, block->hash ()));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account_calculated (*block));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
-	nano::account_info info2;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info2));
-	ASSERT_EQ (block->hash (), info2.head);
-	ASSERT_FALSE (ledger.rollback (transaction, info2.head));
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1.head));
+	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info2);
+	ASSERT_EQ (block->hash (), info2->head);
+	ASSERT_FALSE (ledger.rollback (transaction, info2->head));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1->head));
 	ASSERT_TRUE (store.frontier.get (transaction, block->hash ()).is_zero ());
-	nano::account_info info3;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info3));
-	ASSERT_EQ (info1.head, info3.head);
+	auto info3 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info3);
+	ASSERT_EQ (info1->head, info3->head);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 }
@@ -551,25 +550,25 @@ TEST (ledger, send_fork)
 	nano::keypair key3;
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::block_builder builder;
 	auto block = builder
 				 .send ()
-				 .previous (info1.head)
+				 .previous (info1->head)
 				 .destination (key2.pub)
 				 .balance (100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1.head))
+				 .work (*pool.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
 	auto block2 = builder
 				  .send ()
-				  .previous (info1.head)
+				  .previous (info1->head)
 				  .destination (key3.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (info1.head))
+				  .work (*pool.generate (info1->head))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
 }
@@ -583,16 +582,16 @@ TEST (ledger, receive_fork)
 	nano::keypair key3;
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::block_builder builder;
 	auto block = builder
 				 .send ()
-				 .previous (info1.head)
+				 .previous (info1->head)
 				 .destination (key2.pub)
 				 .balance (100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1.head))
+				 .work (*pool.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
 	auto block2 = builder
@@ -640,16 +639,16 @@ TEST (ledger, open_fork)
 	nano::keypair key3;
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::block_builder builder;
 	auto block = builder
 				 .send ()
-				 .previous (info1.head)
+				 .previous (info1->head)
 				 .destination (key2.pub)
 				 .balance (100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1.head))
+				 .work (*pool.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
 	auto block2 = builder
@@ -2076,17 +2075,17 @@ TEST (ledger, send_open_receive_rollback)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info info1;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info1);
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
-				 .previous (info1.head)
+				 .previous (info1->head)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - 50)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1.head))
+				 .work (*pool.generate (info1->head))
 				 .build ();
 	auto return1 = ledger.process (transaction, *send1);
 	ASSERT_EQ (nano::process_result::progress, return1.code);
@@ -2163,20 +2162,20 @@ TEST (ledger, bootstrap_rep_weight)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	nano::account_info info1;
 	nano::keypair key2;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	{
 		auto transaction = store.tx_begin_write ();
-		ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+		auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		ASSERT_TRUE (info1);
 		nano::block_builder builder;
 		auto send = builder
 					.send ()
-					.previous (info1.head)
+					.previous (info1->head)
 					.destination (key2.pub)
 					.balance (std::numeric_limits<nano::uint128_t>::max () - 50)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (info1.head))
+					.work (*pool.generate (info1->head))
 					.build ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	}
@@ -2188,15 +2187,16 @@ TEST (ledger, bootstrap_rep_weight)
 	}
 	{
 		auto transaction = store.tx_begin_write ();
-		ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, info1));
+		auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		ASSERT_TRUE (info1);
 		nano::block_builder builder;
 		auto send = builder
 					.send ()
-					.previous (info1.head)
+					.previous (info1->head)
 					.destination (key2.pub)
 					.balance (std::numeric_limits<nano::uint128_t>::max () - 100)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (info1.head))
+					.work (*pool.generate (info1->head))
 					.build ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	}
@@ -3369,15 +3369,17 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .work (*pool.generate (epoch1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch2).code);
-	nano::account_info genesis_info;
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
-	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
+	auto genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (genesis_info);
+	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_1);
 	ASSERT_FALSE (ledger.rollback (transaction, epoch1->hash ()));
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
-	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_0);
+	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (genesis_info);
+	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
-	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
+	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (genesis_info);
+	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_1);
 	ASSERT_FALSE (epoch1->sideband ().details.is_send);
 	ASSERT_FALSE (epoch1->sideband ().details.is_receive);
 	ASSERT_TRUE (epoch1->sideband ().details.is_epoch);
@@ -3533,15 +3535,17 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .work (*pool.generate (epoch2->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch3).code);
-	nano::account_info genesis_info;
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
-	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_2);
+	auto genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (genesis_info);
+	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_2);
 	ASSERT_FALSE (ledger.rollback (transaction, epoch1->hash ()));
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
-	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_0);
+	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (genesis_info);
+	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_0);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
-	ASSERT_FALSE (ledger.store.account.get (transaction, nano::dev::genesis->account (), genesis_info));
-	ASSERT_EQ (genesis_info.epoch (), nano::epoch::epoch_1);
+	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
+	ASSERT_TRUE (genesis_info);
+	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_1);
 	auto change1 = builder
 				   .change ()
 				   .previous (epoch1->hash ())
@@ -3713,12 +3717,13 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
-	nano::account_info destination_info;
-	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
-	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
+	auto destination_info = ledger.account_info (transaction, destination.pub);
+	ASSERT_TRUE (destination_info);
+	ASSERT_EQ (destination_info->epoch (), nano::epoch::epoch_1);
 	ASSERT_FALSE (ledger.rollback (transaction, receive2->hash ()));
-	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
-	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_0);
+	destination_info = ledger.account_info (transaction, destination.pub);
+	ASSERT_TRUE (destination_info);
+	ASSERT_EQ (destination_info->epoch (), nano::epoch::epoch_0);
 	nano::pending_info pending_send2;
 	ASSERT_FALSE (ledger.store.pending.get (transaction, nano::pending_key (destination.pub, send2->hash ()), pending_send2));
 	ASSERT_EQ (nano::dev::genesis_key.pub, pending_send2.source);
@@ -3727,8 +3732,9 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
-	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
-	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
+	destination_info = ledger.account_info (transaction, destination.pub);
+	ASSERT_TRUE (destination_info);
+	ASSERT_EQ (destination_info->epoch (), nano::epoch::epoch_1);
 	nano::keypair destination2;
 	auto send3 = builder
 				 .state ()
@@ -3795,8 +3801,9 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .work (*pool.generate (send4->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send5).code);
-	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
-	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_1);
+	destination_info = ledger.account_info (transaction, destination.pub);
+	ASSERT_TRUE (destination_info);
+	ASSERT_EQ (destination_info->epoch (), nano::epoch::epoch_1);
 	auto receive3 = builder
 					.state ()
 					.account (destination.pub)
@@ -3810,8 +3817,9 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive3).code);
 	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().source_epoch);
-	ASSERT_FALSE (ledger.store.account.get (transaction, destination.pub, destination_info));
-	ASSERT_EQ (destination_info.epoch (), nano::epoch::epoch_2);
+	destination_info = ledger.account_info (transaction, destination.pub);
+	ASSERT_TRUE (destination_info);
+	ASSERT_EQ (destination_info->epoch (), nano::epoch::epoch_2);
 	// Upgrade an unopened account straight to epoch 2
 	nano::keypair destination4;
 	auto send6 = builder
@@ -4297,9 +4305,9 @@ TEST (ledger, unchecked_epoch)
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
 		ASSERT_TIMELY (10s, 0 == node1.unchecked.count (node1.store.tx_begin_read ()));
-		nano::account_info info{};
-		ASSERT_FALSE (node1.store.account.get (node1.store.tx_begin_read (), destination.pub, info));
-		ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);
+		auto info = node1.ledger.account_info (node1.store.tx_begin_read (), destination.pub);
+		ASSERT_TRUE (info);
+		ASSERT_EQ (info->epoch (), nano::epoch::epoch_1);
 	}
 }
 
@@ -4375,9 +4383,9 @@ TEST (ledger, unchecked_epoch_invalid)
 		auto unchecked_count = node1.unchecked.count (transaction);
 		ASSERT_EQ (unchecked_count, 0);
 		ASSERT_EQ (unchecked_count, node1.unchecked.count (transaction));
-		nano::account_info info{};
-		ASSERT_FALSE (node1.store.account.get (transaction, destination.pub, info));
-		ASSERT_NE (info.epoch (), nano::epoch::epoch_1);
+		auto info = node1.ledger.account_info (transaction, destination.pub);
+		ASSERT_TRUE (info);
+		ASSERT_NE (info->epoch (), nano::epoch::epoch_1);
 		auto epoch2_store = node1.store.block.get (transaction, epoch2->hash ());
 		ASSERT_NE (nullptr, epoch2_store);
 		ASSERT_EQ (nano::epoch::epoch_0, epoch2_store->sideband ().details.epoch);
@@ -4516,17 +4524,17 @@ TEST (ledger, confirmation_height_not_updated)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	nano::account_info account_info;
-	ASSERT_FALSE (store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
+	auto account_info = ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (account_info);
 	nano::keypair key;
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
-				 .previous (account_info.head)
+				 .previous (account_info->head)
 				 .destination (key.pub)
 				 .balance (50)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (account_info.head))
+				 .work (*pool.generate (account_info->head))
 				 .build ();
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_FALSE (store.confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -353,9 +353,8 @@ void nano::bulk_pull_server::set_current_end ()
 	}
 	else
 	{
-		nano::account_info info;
-		auto no_address (connection->node->store.account.get (transaction, request->start.as_account (), info));
-		if (no_address)
+		auto info = connection->node->ledger.account_info (transaction, request->start.as_account ());
+		if (!info)
 		{
 			if (connection->node->config.logging.bulk_pull_logging ())
 			{
@@ -365,7 +364,7 @@ void nano::bulk_pull_server::set_current_end ()
 		}
 		else
 		{
-			current = ascending () ? info.open_block : info.head;
+			current = ascending () ? info->open_block : info->head;
 			if (!request->end.is_zero ())
 			{
 				auto account (connection->node->ledger.account (transaction, request->end));

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -184,7 +184,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (nano::transaction const & tr
 		break;
 		case asc_pull_req::hash_type::account:
 		{
-			auto info = store.account.get (transaction, request.start.as_account ());
+			auto info = ledger.account_info (transaction, request.start.as_account ());
 			if (info)
 			{
 				// Start from open block if pulling by account
@@ -278,7 +278,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (const nano::transaction & tr
 	nano::asc_pull_ack::account_info_payload response_payload{};
 	response_payload.account = target;
 
-	auto account_info = store.account.get (transaction, target);
+	auto account_info = ledger.account_info (transaction, target);
 	if (account_info)
 	{
 		response_payload.account_open = account_info->open_block;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -237,9 +237,9 @@ nano::block_hash nano::confirmation_height_bounded::get_least_unconfirmed_hash_f
 	else
 	{
 		// No blocks have been confirmed, so the first block will be the open block
-		nano::account_info account_info;
-		release_assert (!ledger.store.account.get (transaction_a, account_a, account_info));
-		least_unconfirmed_hash = account_info.open_block;
+		auto info = ledger.account_info (transaction_a, account_a);
+		release_assert (info);
+		least_unconfirmed_hash = info->open_block;
 		block_height_a = 1;
 	}
 	return least_unconfirmed_hash;

--- a/nano/node/epoch_upgrader.cpp
+++ b/nano/node/epoch_upgrader.cpp
@@ -128,18 +128,18 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 			for (auto i (accounts_list.get<modified_tag> ().begin ()), n (accounts_list.get<modified_tag> ().end ()); i != n && attempts < upgrade_batch_size && attempts < count_limit && !stopped; ++i)
 			{
 				auto transaction (store.tx_begin_read ());
-				nano::account_info info;
 				nano::account const & account (i->account);
-				if (!store.account.get (transaction, account, info) && info.epoch () < epoch_a)
+				auto info = ledger.account_info (transaction, account);
+				if (info && info->epoch () < epoch_a)
 				{
 					++attempts;
 					auto difficulty (node.network_params.work.threshold (nano::work_version::work_1, nano::block_details (epoch_a, false, false, true)));
-					nano::root const & root (info.head);
+					nano::root const & root (info->head);
 					std::shared_ptr<nano::block> epoch = builder.state ()
 														 .account (account)
-														 .previous (info.head)
-														 .representative (info.representative)
-														 .balance (info.balance)
+														 .previous (info->head)
+														 .representative (info->representative)
+														 .balance (info->balance)
 														 .link (link)
 														 .sign (raw_key, signer)
 														 .work (0)

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -261,10 +261,15 @@ nano::account_info nano::json_handler::account_info_impl (nano::transaction cons
 	nano::account_info result;
 	if (!ec)
 	{
-		if (node.store.account.get (transaction_a, account_a, result))
+		auto info = node.ledger.account_info (transaction_a, account_a);
+		if (!info)
 		{
 			ec = nano::error_common::account_not_found;
 			node.bootstrap_initiator.bootstrap_lazy (account_a, false, account_a.to_account ());
+		}
+		else
+		{
+			result = *info;
 		}
 	}
 	return result;
@@ -3377,14 +3382,14 @@ void nano::json_handler::receive ()
 					auto work (work_optional_impl ());
 					if (!ec && work)
 					{
-						nano::account_info info;
 						nano::root head;
 						nano::epoch epoch = pending_info.epoch;
-						if (!node.store.account.get (block_transaction, account, info))
+						auto info = node.ledger.account_info (block_transaction, account);
+						if (info)
 						{
-							head = info.head;
+							head = info->head;
 							// When receiving, epoch version is the higher between the previous and the source blocks
-							epoch = std::max (info.epoch (), epoch);
+							epoch = std::max (info->epoch (), epoch);
 						}
 						else
 						{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -783,11 +783,11 @@ nano::uint128_t nano::node::weight (nano::account const & account_a)
 nano::block_hash nano::node::rep_block (nano::account const & account_a)
 {
 	auto const transaction (store.tx_begin_read ());
-	nano::account_info info;
 	nano::block_hash result (0);
-	if (!store.account.get (transaction, account_a, info))
+	auto info = ledger.account_info (transaction, account_a);
+	if (info)
 	{
-		result = ledger.representative (transaction, info.head);
+		result = ledger.representative (transaction, info->head);
 	}
 	return result;
 }

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -242,11 +242,10 @@ std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr
 				// Search for account root
 				if (successor.is_zero ())
 				{
-					nano::account_info info;
-					auto error (ledger.store.account.get (transaction, root.as_account (), info));
-					if (!error)
+					auto info = ledger.account_info (transaction, root.as_account ());
+					if (info)
 					{
-						successor = info.open_block;
+						successor = info->open_block;
 					}
 				}
 				if (!successor.is_zero ())

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -849,12 +849,11 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 					{
 						store.work_get (transaction, account_a, work_a);
 					}
-					nano::account_info info;
-					auto new_account (wallets.node.ledger.store.account.get (block_transaction, account_a, info));
-					if (!new_account)
+					auto info = wallets.node.ledger.account_info (block_transaction, account_a);
+					if (info)
 					{
-						block = std::make_shared<nano::state_block> (account_a, info.head, info.representative, info.balance.number () + pending_info.amount.number (), send_hash_a, prv, account_a, work_a);
-						details.epoch = std::max (info.epoch (), pending_info.epoch);
+						block = std::make_shared<nano::state_block> (account_a, info->head, info->representative, info->balance.number () + pending_info.amount.number (), send_hash_a, prv, account_a, work_a);
+						details.epoch = std::max (info->epoch (), pending_info.epoch);
 					}
 					else
 					{
@@ -905,10 +904,8 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			auto existing (store.find (transaction, source_a));
 			if (existing != store.end () && !wallets.node.ledger.latest (block_transaction, source_a).is_zero ())
 			{
-				nano::account_info info;
-				auto error1 (wallets.node.ledger.store.account.get (block_transaction, source_a, info));
-				(void)error1;
-				debug_assert (!error1);
+				auto info = wallets.node.ledger.account_info (block_transaction, source_a);
+				debug_assert (info);
 				nano::raw_key prv;
 				auto error2 (store.fetch (transaction, source_a, prv));
 				(void)error2;
@@ -917,8 +914,8 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 				{
 					store.work_get (transaction, source_a, work_a);
 				}
-				block = std::make_shared<nano::state_block> (source_a, info.head, representative_a, info.balance, 0, prv, source_a, work_a);
-				details.epoch = info.epoch ();
+				block = std::make_shared<nano::state_block> (source_a, info->head, representative_a, info->balance, 0, prv, source_a, work_a);
+				details.epoch = info->epoch ();
 			}
 		}
 	}
@@ -977,10 +974,8 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					auto balance (wallets.node.ledger.account_balance (block_transaction, source_a));
 					if (!balance.is_zero () && balance >= amount_a)
 					{
-						nano::account_info info;
-						auto error1 (wallets.node.ledger.store.account.get (block_transaction, source_a, info));
-						(void)error1;
-						debug_assert (!error1);
+						auto info = wallets.node.ledger.account_info (block_transaction, source_a);
+						debug_assert (info);
 						nano::raw_key prv;
 						auto error2 (store.fetch (transaction, source_a, prv));
 						(void)error2;
@@ -989,8 +984,8 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						{
 							store.work_get (transaction, source_a, work_a);
 						}
-						block = std::make_shared<nano::state_block> (source_a, info.head, info.representative, balance - amount_a, account_a, prv, source_a, work_a);
-						details.epoch = info.epoch ();
+						block = std::make_shared<nano::state_block> (source_a, info->head, info->representative, balance - amount_a, account_a, prv, source_a, work_a);
+						details.epoch = info->epoch ();
 						if (id_mdb_val && block != nullptr)
 						{
 							auto status (mdb_put (wallets.env.tx (transaction), wallets.node.wallets.send_action_ids, *id_mdb_val, nano::mdb_val (block->hash ()), 0));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -7195,9 +7195,9 @@ TEST (rpc, receive)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		auto receive_text (response.get<std::string> ("block"));
-		nano::account_info info;
-		ASSERT_FALSE (node->store.account.get (node->store.tx_begin_read (), key1.pub, info));
-		ASSERT_EQ (info.head, nano::block_hash{ receive_text });
+		auto info = node->ledger.account_info (node->store.tx_begin_read (), key1.pub);
+		ASSERT_TRUE (info);
+		ASSERT_EQ (info->head, nano::block_hash{ receive_text });
 	}
 	// Trying to receive the same block should fail with unreceivable
 	{
@@ -7236,11 +7236,11 @@ TEST (rpc, receive_unopened)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		auto receive_text (response.get<std::string> ("block"));
-		nano::account_info info;
-		ASSERT_FALSE (node->store.account.get (node->store.tx_begin_read (), key1.pub, info));
-		ASSERT_EQ (info.head, info.open_block);
-		ASSERT_EQ (info.head.to_string (), receive_text);
-		ASSERT_EQ (info.representative, nano::dev::genesis_key.pub);
+		auto info = node->ledger.account_info (node->store.tx_begin_read (), key1.pub);
+		ASSERT_TRUE (info);
+		ASSERT_EQ (info->head, info->open_block);
+		ASSERT_EQ (info->head.to_string (), receive_text);
+		ASSERT_EQ (info->representative, nano::dev::genesis_key.pub);
 	}
 	rpc_ctx.io_scope->reset ();
 
@@ -7260,11 +7260,11 @@ TEST (rpc, receive_unopened)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		auto receive_text (response.get<std::string> ("block"));
-		nano::account_info info;
-		ASSERT_FALSE (node->store.account.get (node->store.tx_begin_read (), key2.pub, info));
-		ASSERT_EQ (info.head, info.open_block);
-		ASSERT_EQ (info.head.to_string (), receive_text);
-		ASSERT_EQ (info.representative, rep);
+		auto info = node->ledger.account_info (node->store.tx_begin_read (), key2.pub);
+		ASSERT_TRUE (info);
+		ASSERT_EQ (info->head, info->open_block);
+		ASSERT_EQ (info->head.to_string (), receive_text);
+		ASSERT_EQ (info->representative, rep);
 	}
 }
 
@@ -7345,9 +7345,9 @@ TEST (rpc, receive_pruned)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		auto receive_text (response.get<std::string> ("block"));
-		nano::account_info info;
-		ASSERT_FALSE (node2->store.account.get (node2->store.tx_begin_read (), key1.pub, info));
-		ASSERT_EQ (info.head, nano::block_hash{ receive_text });
+		auto info = node2->ledger.account_info (node2->store.tx_begin_read (), key1.pub);
+		ASSERT_TRUE (info);
+		ASSERT_EQ (info->head, nano::block_hash{ receive_text });
 	}
 	// Trying to receive the same block should fail with unreceivable
 	{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -730,10 +730,10 @@ TEST (rpc, wallet_representative_set_force)
 	while (representative != key.pub)
 	{
 		auto transaction (node->store.tx_begin_read ());
-		nano::account_info info;
-		if (!node->store.account.get (transaction, nano::dev::genesis_key.pub, info))
+		auto info = node->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		if (info)
 		{
-			representative = info.representative;
+			representative = info->representative;
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -583,9 +583,8 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 #ifdef NDEBUG
 											if (ledger.store.block.exists (transaction, block_a.hashables.source))
 											{
-												nano::account_info source_info;
-												[[maybe_unused]] auto error (ledger.store.account.get (transaction, pending.source, source_info));
-												debug_assert (!error);
+												auto info = ledger.account_info (transaction, pending.source);
+												debug_assert (info);
 											}
 #endif
 											ledger.store.pending.del (transaction, key);
@@ -1290,10 +1289,10 @@ std::shared_ptr<nano::block> nano::ledger::successor (nano::transaction const & 
 	auto get_from_previous = false;
 	if (root_a.previous ().is_zero ())
 	{
-		nano::account_info info;
-		if (!store.account.get (transaction_a, root_a.root ().as_account (), info))
+		auto info = account_info (transaction_a, root_a.root ().as_account ());
+		if (info)
 		{
-			successor = info.open_block;
+			successor = info->open_block;
 		}
 		else
 		{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -34,13 +34,12 @@ public:
 		}
 		if (!error)
 		{
-			nano::account_info info;
-			[[maybe_unused]] auto error (ledger.store.account.get (transaction, pending.source, info));
-			debug_assert (!error);
+			auto info = ledger.account_info (transaction, pending.source);
+			debug_assert (info);
 			ledger.store.pending.del (transaction, key);
-			ledger.cache.rep_weights.representation_add (info.representative, pending.amount.number ());
-			nano::account_info new_info (block_a.hashables.previous, info.representative, info.open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
-			ledger.update_account (transaction, pending.source, info, new_info);
+			ledger.cache.rep_weights.representation_add (info->representative, pending.amount.number ());
+			nano::account_info new_info (block_a.hashables.previous, info->representative, info->open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info->block_count - 1, nano::epoch::epoch_0);
+			ledger.update_account (transaction, pending.source, *info, new_info);
 			ledger.store.block.del (transaction, hash);
 			ledger.store.frontier.del (transaction, hash);
 			ledger.store.frontier.put (transaction, block_a.hashables.previous, pending.source);
@@ -56,12 +55,11 @@ public:
 		// Pending account entry can be incorrect if source block was pruned. But it's not affecting correct ledger processing
 		[[maybe_unused]] bool is_pruned (false);
 		auto source_account (ledger.account_safe (transaction, block_a.hashables.source, is_pruned));
-		nano::account_info info;
-		[[maybe_unused]] auto error (ledger.store.account.get (transaction, destination_account, info));
-		debug_assert (!error);
-		ledger.cache.rep_weights.representation_add (info.representative, 0 - amount);
-		nano::account_info new_info (block_a.hashables.previous, info.representative, info.open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
-		ledger.update_account (transaction, destination_account, info, new_info);
+		auto info = ledger.account_info (transaction, destination_account);
+		debug_assert (info);
+		ledger.cache.rep_weights.representation_add (info->representative, 0 - amount);
+		nano::account_info new_info (block_a.hashables.previous, info->representative, info->open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info->block_count - 1, nano::epoch::epoch_0);
+		ledger.update_account (transaction, destination_account, *info, new_info);
 		ledger.store.block.del (transaction, hash);
 		ledger.store.pending.put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account, amount, nano::epoch::epoch_0 });
 		ledger.store.frontier.del (transaction, hash);
@@ -90,17 +88,16 @@ public:
 		auto hash (block_a.hash ());
 		auto rep_block (ledger.representative (transaction, block_a.hashables.previous));
 		auto account (ledger.account (transaction, block_a.hashables.previous));
-		nano::account_info info;
-		[[maybe_unused]] auto error (ledger.store.account.get (transaction, account, info));
-		debug_assert (!error);
+		auto info = ledger.account_info (transaction, account);
+		debug_assert (info);
 		auto balance (ledger.balance (transaction, block_a.hashables.previous));
 		auto block = ledger.store.block.get (transaction, rep_block);
 		release_assert (block != nullptr);
 		auto representative = block->representative ();
 		ledger.cache.rep_weights.representation_add_dual (block_a.representative (), 0 - balance, representative, balance);
 		ledger.store.block.del (transaction, hash);
-		nano::account_info new_info (block_a.hashables.previous, representative, info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count - 1, nano::epoch::epoch_0);
-		ledger.update_account (transaction, account, info, new_info);
+		nano::account_info new_info (block_a.hashables.previous, representative, info->open_block, info->balance, nano::seconds_since_epoch (), info->block_count - 1, nano::epoch::epoch_0);
+		ledger.update_account (transaction, account, *info, new_info);
 		ledger.store.frontier.del (transaction, hash);
 		ledger.store.frontier.put (transaction, block_a.hashables.previous, account);
 		ledger.store.block.successor_clear (transaction, block_a.hashables.previous);
@@ -131,8 +128,8 @@ public:
 			ledger.cache.rep_weights.representation_add (block_a.representative (), 0 - block_a.hashables.balance.number ());
 		}
 
-		nano::account_info info;
-		auto error (ledger.store.account.get (transaction, block_a.hashables.account, info));
+		auto info = ledger.account_info (transaction, block_a.hashables.account);
+		debug_assert (info);
 
 		if (is_send)
 		{
@@ -156,8 +153,8 @@ public:
 
 		debug_assert (!error);
 		auto previous_version (ledger.store.block.version (transaction, block_a.hashables.previous));
-		nano::account_info new_info (block_a.hashables.previous, representative, info.open_block, balance, nano::seconds_since_epoch (), info.block_count - 1, previous_version);
-		ledger.update_account (transaction, block_a.hashables.account, info, new_info);
+		nano::account_info new_info (block_a.hashables.previous, representative, info->open_block, balance, nano::seconds_since_epoch (), info->block_count - 1, previous_version);
+		ledger.update_account (transaction, block_a.hashables.account, *info, new_info);
 
 		auto previous (ledger.store.block.get (transaction, block_a.hashables.previous));
 		if (previous != nullptr)
@@ -461,11 +458,9 @@ void ledger_processor::change_block (nano::change_block & block_a)
 				result.code = account.is_zero () ? nano::process_result::fork : nano::process_result::progress;
 				if (result.code == nano::process_result::progress)
 				{
-					nano::account_info info;
-					auto latest_error (ledger.store.account.get (transaction, account, info));
-					(void)latest_error;
-					debug_assert (!latest_error);
-					debug_assert (info.head == block_a.hashables.previous);
+					auto info = ledger.account_info (transaction, account);
+					debug_assert (info);
+					debug_assert (info->head == block_a.hashables.previous);
 					result.code = validate_message (account, hash, block_a.signature) ? nano::process_result::bad_signature : nano::process_result::progress; // Is this block signed correctly (Malformed)
 					if (result.code == nano::process_result::progress)
 					{
@@ -474,12 +469,12 @@ void ledger_processor::change_block (nano::change_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
-							block_a.sideband_set (nano::block_sideband (account, 0, info.balance, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+							block_a.sideband_set (nano::block_sideband (account, 0, info->balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 							ledger.store.block.put (transaction, hash, block_a);
 							auto balance (ledger.balance (transaction, block_a.hashables.previous));
-							ledger.cache.rep_weights.representation_add_dual (block_a.representative (), balance, info.representative, 0 - balance);
-							nano::account_info new_info (hash, block_a.representative (), info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
-							ledger.update_account (transaction, account, info, new_info);
+							ledger.cache.rep_weights.representation_add_dual (block_a.representative (), balance, info->representative, 0 - balance);
+							nano::account_info new_info (hash, block_a.representative (), info->open_block, info->balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
+							ledger.update_account (transaction, account, *info, new_info);
 							ledger.store.frontier.del (transaction, block_a.hashables.previous);
 							ledger.store.frontier.put (transaction, hash, account);
 							ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::change);
@@ -517,20 +512,18 @@ void ledger_processor::send_block (nano::send_block & block_a)
 						if (result.code == nano::process_result::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
-							nano::account_info info;
-							auto latest_error (ledger.store.account.get (transaction, account, info));
-							(void)latest_error;
-							debug_assert (!latest_error);
-							debug_assert (info.head == block_a.hashables.previous);
-							result.code = info.balance.number () >= block_a.hashables.balance.number () ? nano::process_result::progress : nano::process_result::negative_spend; // Is this trying to spend a negative amount (Malicious)
+							auto info = ledger.account_info (transaction, account);
+							debug_assert (info);
+							debug_assert (info->head == block_a.hashables.previous);
+							result.code = info->balance.number () >= block_a.hashables.balance.number () ? nano::process_result::progress : nano::process_result::negative_spend; // Is this trying to spend a negative amount (Malicious)
 							if (result.code == nano::process_result::progress)
 							{
-								auto amount (info.balance.number () - block_a.hashables.balance.number ());
-								ledger.cache.rep_weights.representation_add (info.representative, 0 - amount);
-								block_a.sideband_set (nano::block_sideband (account, 0, block_a.hashables.balance /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+								auto amount (info->balance.number () - block_a.hashables.balance.number ());
+								ledger.cache.rep_weights.representation_add (info->representative, 0 - amount);
+								block_a.sideband_set (nano::block_sideband (account, 0, block_a.hashables.balance /* unused */, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 								ledger.store.block.put (transaction, hash, block_a);
-								nano::account_info new_info (hash, info.representative, info.open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
-								ledger.update_account (transaction, account, info, new_info);
+								nano::account_info new_info (hash, info->representative, info->open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
+								ledger.update_account (transaction, account, *info, new_info);
 								ledger.store.pending.put (transaction, nano::pending_key (block_a.hashables.destination, hash), { account, amount, nano::epoch::epoch_0 });
 								ledger.store.frontier.del (transaction, block_a.hashables.previous);
 								ledger.store.frontier.put (transaction, hash, account);
@@ -569,9 +562,9 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 						result.code = ledger.block_or_pruned_exists (transaction, block_a.hashables.source) ? nano::process_result::progress : nano::process_result::gap_source; // Have we seen the source block already? (Harmless)
 						if (result.code == nano::process_result::progress)
 						{
-							nano::account_info info;
-							ledger.store.account.get (transaction, account, info);
-							result.code = info.head == block_a.hashables.previous ? nano::process_result::progress : nano::process_result::gap_previous; // Block doesn't immediately follow latest block (Harmless)
+							auto info = ledger.account_info (transaction, account);
+							debug_assert (info);
+							result.code = info->head == block_a.hashables.previous ? nano::process_result::progress : nano::process_result::gap_previous; // Block doesn't immediately follow latest block (Harmless)
 							if (result.code == nano::process_result::progress)
 							{
 								nano::pending_key key (account, block_a.hashables.source);
@@ -586,7 +579,7 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 										result.code = ledger.constants.work.difficulty (block_a) >= ledger.constants.work.threshold (block_a.work_version (), block_details) ? nano::process_result::progress : nano::process_result::insufficient_work; // Does this block have sufficient work? (Malformed)
 										if (result.code == nano::process_result::progress)
 										{
-											auto new_balance (info.balance.number () + pending.amount.number ());
+											auto new_balance (info->balance.number () + pending.amount.number ());
 #ifdef NDEBUG
 											if (ledger.store.block.exists (transaction, block_a.hashables.source))
 											{
@@ -596,11 +589,11 @@ void ledger_processor::receive_block (nano::receive_block & block_a)
 											}
 #endif
 											ledger.store.pending.del (transaction, key);
-											block_a.sideband_set (nano::block_sideband (account, 0, new_balance, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+											block_a.sideband_set (nano::block_sideband (account, 0, new_balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 											ledger.store.block.put (transaction, hash, block_a);
-											nano::account_info new_info (hash, info.representative, info.open_block, new_balance, nano::seconds_since_epoch (), info.block_count + 1, nano::epoch::epoch_0);
-											ledger.update_account (transaction, account, info, new_info);
-											ledger.cache.rep_weights.representation_add (info.representative, pending.amount.number ());
+											nano::account_info new_info (hash, info->representative, info->open_block, new_balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
+											ledger.update_account (transaction, account, *info, new_info);
+											ledger.cache.rep_weights.representation_add (info->representative, pending.amount.number ());
 											ledger.store.frontier.del (transaction, block_a.hashables.previous);
 											ledger.store.frontier.put (transaction, hash, account);
 											ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::receive);
@@ -779,11 +772,10 @@ nano::uint128_t nano::ledger::account_balance (nano::transaction const & transac
 	}
 	else
 	{
-		nano::account_info info;
-		auto none (store.account.get (transaction_a, account_a, info));
-		if (!none)
+		auto info = account_info (transaction_a, account_a);
+		if (info)
 		{
-			result = info.balance.number ();
+			result = info->balance.number ();
 		}
 	}
 	return result;
@@ -998,7 +990,6 @@ bool nano::ledger::rollback (nano::write_transaction const & transaction_a, nano
 	auto account_l (account (transaction_a, block_a));
 	auto block_account_height (store.block.account_height (transaction_a, block_a));
 	rollback_visitor rollback (transaction_a, *this, list_a);
-	nano::account_info account_info;
 	auto error (false);
 	while (!error && store.block.exists (transaction_a, block_a))
 	{
@@ -1006,9 +997,9 @@ bool nano::ledger::rollback (nano::write_transaction const & transaction_a, nano
 		store.confirmation_height.get (transaction_a, account_l, confirmation_height_info);
 		if (block_account_height > confirmation_height_info.height)
 		{
-			auto latest_error = store.account.get (transaction_a, account_l, account_info);
-			debug_assert (!latest_error);
-			auto block (store.block.get (transaction_a, account_info.head));
+			auto info = account_info (transaction_a, account_l);
+			debug_assert (info);
+			auto block (store.block.get (transaction_a, info->head));
 			list_a.push_back (block);
 			block->visit (rollback);
 			error = rollback.error;
@@ -1070,6 +1061,11 @@ nano::account nano::ledger::account_safe (const nano::transaction & transaction,
 	}
 }
 
+std::optional<nano::account_info> nano::ledger::account_info (nano::transaction const & transaction, nano::account const & account) const
+{
+	return store.account.get (transaction, account);
+}
+
 // Return amount decrease or increase for block
 nano::uint128_t nano::ledger::amount (nano::transaction const & transaction_a, nano::account const & account_a)
 {
@@ -1098,22 +1094,21 @@ nano::uint128_t nano::ledger::amount_safe (nano::transaction const & transaction
 // Return latest block for account
 nano::block_hash nano::ledger::latest (nano::transaction const & transaction_a, nano::account const & account_a)
 {
-	nano::account_info info;
-	auto latest_error (store.account.get (transaction_a, account_a, info));
-	return latest_error ? 0 : info.head;
+	auto info = account_info (transaction_a, account_a);
+	return !info ? 0 : info->head;
 }
 
 // Return latest root for account, account number if there are no blocks for this account.
 nano::root nano::ledger::latest_root (nano::transaction const & transaction_a, nano::account const & account_a)
 {
-	nano::account_info info;
-	if (store.account.get (transaction_a, account_a, info))
+	auto info = account_info (transaction_a, account_a);
+	if (!info)
 	{
 		return account_a;
 	}
 	else
 	{
-		return info.head;
+		return info->head;
 	}
 }
 
@@ -1331,11 +1326,9 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (nano::transaction const
 	auto result (store.block.get (transaction_a, store.block.successor (transaction_a, root.as_block_hash ())));
 	if (result == nullptr)
 	{
-		nano::account_info info;
-		auto error (store.account.get (transaction_a, root.as_account (), info));
-		(void)error;
-		debug_assert (!error);
-		result = store.block.get (transaction_a, info.open_block);
+		auto info = account_info (transaction_a, root.as_account ());
+		debug_assert (info);
+		result = store.block.get (transaction_a, info->open_block);
 		debug_assert (result != nullptr);
 	}
 	return result;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -32,7 +32,7 @@ public:
 	 * Return account containing hash, expects that block hash exists in ledger
 	 */
 	nano::account account (nano::transaction const &, nano::block_hash const &) const;
- 	std::optional<nano::account_info> account_info (nano::transaction const & transaction, nano::account const & account) const;
+	std::optional<nano::account_info> account_info (nano::transaction const & transaction, nano::account const & account) const;
 	/**
 	 * For non-prunning nodes same as `ledger::account()`
 	 * For prunning nodes ensures that block hash exists, otherwise returns zero account

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -32,6 +32,7 @@ public:
 	 * Return account containing hash, expects that block hash exists in ledger
 	 */
 	nano::account account (nano::transaction const &, nano::block_hash const &) const;
+ 	std::optional<nano::account_info> account_info (nano::transaction const & transaction, nano::account const & account) const;
 	/**
 	 * For non-prunning nodes same as `ledger::account()`
 	 * For prunning nodes ensures that block hash exists, otherwise returns zero account

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -907,17 +907,18 @@ TEST (confirmation_height, long_chains)
 	ASSERT_TIMELY (30s, node->ledger.block_confirmed (node->store.tx_begin_read (), receive1->hash ()));
 
 	auto transaction (node->store.tx_begin_read ());
-	nano::account_info account_info;
-	ASSERT_FALSE (node->store.account.get (transaction, nano::dev::genesis_key.pub, account_info));
+	auto info = node->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (info);
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_FALSE (node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 	ASSERT_EQ (num_blocks + 2, confirmation_height_info.height);
-	ASSERT_EQ (num_blocks + 3, account_info.block_count); // Includes the unpocketed send
+	ASSERT_EQ (num_blocks + 3, info->block_count); // Includes the unpocketed send
 
-	ASSERT_FALSE (node->store.account.get (transaction, key1.pub, account_info));
+	info = node->ledger.account_info (transaction, key1.pub);
+	ASSERT_TRUE (info);
 	ASSERT_FALSE (node->store.confirmation_height.get (transaction, key1.pub, confirmation_height_info));
 	ASSERT_EQ (num_blocks + 1, confirmation_height_info.height);
-	ASSERT_EQ (num_blocks + 1, account_info.block_count);
+	ASSERT_EQ (num_blocks + 1, info->block_count);
 
 	size_t cemented_count = 0;
 	for (auto i (node->ledger.store.confirmation_height.begin (transaction)), n (node->ledger.store.confirmation_height.end ()); i != n; ++i)

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -400,11 +400,10 @@ void nano::test::system::generate_rollback (nano::node & node_a, std::vector<nan
 	debug_assert (std::numeric_limits<CryptoPP::word32>::max () > accounts_a.size ());
 	auto index (random_pool::generate_word32 (0, static_cast<CryptoPP::word32> (accounts_a.size () - 1)));
 	auto account (accounts_a[index]);
-	nano::account_info info;
-	auto error (node_a.store.account.get (transaction, account, info));
-	if (!error)
+	auto info = node_a.ledger.account_info (transaction, account);
+	if (info)
 	{
-		auto hash (info.open_block);
+		auto hash (info->open_block);
 		if (hash != node_a.network_params.ledger.genesis->hash ())
 		{
 			accounts_a[index] = accounts_a[accounts_a.size () - 1];


### PR DESCRIPTION
Rather than directly accessing the block store, users should use the ledger::account_info interface to query for account information.

Result is returned as an std::optional instead of the less-obvious way it's currently reported through an error code.

Most though not all of the account_store::get references have been updated to use ledger::account_info.