### PR TITLE
Fix `processing_queue` stop

### DIFF
--- a/nano/core_test/processing_queue.cpp
+++ b/nano/core_test/processing_queue.cpp
@@ -30,6 +30,8 @@ TEST (processing_queue, process_one)
 	ASSERT_TIMELY (5s, processed == 1);
 	ASSERT_ALWAYS (1s, processed == 1);
 	ASSERT_EQ (queue.size (), 0);
+
+	queue.stop ();
 }
 
 TEST (processing_queue, process_many)
@@ -52,6 +54,8 @@ TEST (processing_queue, process_many)
 	ASSERT_TIMELY (5s, processed == count);
 	ASSERT_ALWAYS (1s, processed == count);
 	ASSERT_EQ (queue.size (), 0);
+
+	queue.stop ();
 }
 
 TEST (processing_queue, max_queue_size)
@@ -66,6 +70,8 @@ TEST (processing_queue, max_queue_size)
 	}
 
 	ASSERT_EQ (queue.size (), 1024);
+
+	queue.stop ();
 }
 
 TEST (processing_queue, max_batch_size)
@@ -92,6 +98,8 @@ TEST (processing_queue, max_batch_size)
 	ASSERT_TIMELY (5s, max_batch == 128);
 	ASSERT_ALWAYS (1s, max_batch == 128);
 	ASSERT_EQ (queue.size (), 0);
+
+	queue.stop ();
 }
 
 TEST (processing_queue, parallel)
@@ -116,4 +124,6 @@ TEST (processing_queue, parallel)
 	// If processing is done in parallel it should take ~2 seconds to process every item, but keep some margin for slow machines
 	ASSERT_TIMELY (3s, processed == count);
 	ASSERT_EQ (queue.size (), 0);
+
+	queue.stop ();
 }

--- a/nano/core_test/processing_queue.cpp
+++ b/nano/core_test/processing_queue.cpp
@@ -23,15 +23,13 @@ TEST (processing_queue, process_one)
 	queue.process_batch = [&] (auto & batch) {
 		processed += batch.size ();
 	};
-	queue.start ();
+	nano::test::start_stop_guard queue_guard{ queue };
 
 	queue.add (1);
 
 	ASSERT_TIMELY (5s, processed == 1);
 	ASSERT_ALWAYS (1s, processed == 1);
 	ASSERT_EQ (queue.size (), 0);
-
-	queue.stop ();
 }
 
 TEST (processing_queue, process_many)
@@ -43,7 +41,7 @@ TEST (processing_queue, process_many)
 	queue.process_batch = [&] (auto & batch) {
 		processed += batch.size ();
 	};
-	queue.start ();
+	nano::test::start_stop_guard queue_guard{ queue };
 
 	const int count = 1024;
 	for (int n = 0; n < count; ++n)
@@ -54,8 +52,6 @@ TEST (processing_queue, process_many)
 	ASSERT_TIMELY (5s, processed == count);
 	ASSERT_ALWAYS (1s, processed == count);
 	ASSERT_EQ (queue.size (), 0);
-
-	queue.stop ();
 }
 
 TEST (processing_queue, max_queue_size)
@@ -70,8 +66,6 @@ TEST (processing_queue, max_queue_size)
 	}
 
 	ASSERT_EQ (queue.size (), 1024);
-
-	queue.stop ();
 }
 
 TEST (processing_queue, max_batch_size)
@@ -93,13 +87,11 @@ TEST (processing_queue, max_batch_size)
 			max_batch = batch.size ();
 		}
 	};
-	queue.start ();
+	nano::test::start_stop_guard queue_guard{ queue };
 
 	ASSERT_TIMELY (5s, max_batch == 128);
 	ASSERT_ALWAYS (1s, max_batch == 128);
 	ASSERT_EQ (queue.size (), 0);
-
-	queue.stop ();
 }
 
 TEST (processing_queue, parallel)
@@ -112,7 +104,7 @@ TEST (processing_queue, parallel)
 		std::this_thread::sleep_for (2s);
 		processed += batch.size ();
 	};
-	queue.start ();
+	nano::test::start_stop_guard queue_guard{ queue };
 
 	const int count = 16;
 	for (int n = 0; n < count; ++n)
@@ -124,6 +116,4 @@ TEST (processing_queue, parallel)
 	// If processing is done in parallel it should take ~2 seconds to process every item, but keep some margin for slow machines
 	ASSERT_TIMELY (3s, processed == count);
 	ASSERT_EQ (queue.size (), 0);
-
-	queue.stop ();
 }

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -282,6 +282,28 @@ namespace test
 		std::atomic<unsigned> required_count;
 	};
 
+	/**
+	 * A helper that calls `start` from constructor and `stop` from destructor
+	 */
+	template <class T>
+	class start_stop_guard
+	{
+	public:
+		explicit start_stop_guard (T & ref_a) :
+			ref{ ref_a }
+		{
+			ref.start ();
+		}
+
+		~start_stop_guard ()
+		{
+			ref.stop ();
+		}
+
+	private:
+		T & ref;
+	};
+
 	void wait_peer_connections (nano::test::system &);
 
 	/**


### PR DESCRIPTION
Deadlocks were possible during node stopping due to invalid stop logic.