### PR TITLE
Increase the timeout of Windows unit test workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -71,7 +71,7 @@ jobs:
 
   windows_test:
     name: Windows Unit Tests [TEST_USE_ROCKSDB=${{ matrix.TEST_USE_ROCKSDB }}]
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The windows workflow regurarly times-out.
Windows seem to be slower than other O/Ses.

Ideally, we would reduce the time it takes to build and test but for now I am simply increasing to 2 hours so that we start to get green ticks again.