### PR TITLE
Add ledger::pending_info as interface to access pending information

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3376,14 +3376,14 @@ void nano::json_handler::receive ()
 			auto block_transaction (node.store.tx_begin_read ());
 			if (node.ledger.block_or_pruned_exists (block_transaction, hash))
 			{
-				nano::pending_info pending_info;
-				if (!node.store.pending.get (block_transaction, nano::pending_key (account, hash), pending_info))
+				auto pending_info = node.ledger.pending_info (block_transaction, nano::pending_key (account, hash));
+				if (pending_info)
 				{
 					auto work (work_optional_impl ());
 					if (!ec && work)
 					{
 						nano::root head;
-						nano::epoch epoch = pending_info.epoch;
+						nano::epoch epoch = pending_info->epoch;
 						auto info = node.ledger.account_info (block_transaction, account);
 						if (info)
 						{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1314,12 +1314,11 @@ void nano::node::receive_confirmed (nano::transaction const & block_transaction_
 		if (wallet->store.exists (wallet_transaction, destination_a))
 		{
 			nano::account representative;
-			nano::pending_info pending;
 			representative = wallet->store.representative (wallet_transaction);
-			auto error (store.pending.get (block_transaction_a, nano::pending_key (destination_a, hash_a), pending));
-			if (!error)
+			auto pending = ledger.pending_info (block_transaction_a, nano::pending_key (destination_a, hash_a));
+			if (pending)
 			{
-				auto amount (pending.amount.number ());
+				auto amount (pending->amount.number ());
 				wallet->receive_async (hash_a, representative, amount, destination_a, [] (std::shared_ptr<nano::block> const &) {});
 			}
 			else

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -837,10 +837,10 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 	{
 		auto block_transaction (wallets.node.ledger.store.tx_begin_read ());
 		auto transaction (wallets.tx_begin_read ());
-		nano::pending_info pending_info;
 		if (wallets.node.ledger.block_or_pruned_exists (block_transaction, send_hash_a))
 		{
-			if (!wallets.node.ledger.store.pending.get (block_transaction, nano::pending_key (account_a, send_hash_a), pending_info))
+			auto pending_info = wallets.node.ledger.pending_info (block_transaction, nano::pending_key (account_a, send_hash_a));
+			if (pending_info)
 			{
 				nano::raw_key prv;
 				if (!store.fetch (transaction, account_a, prv))
@@ -852,13 +852,13 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 					auto info = wallets.node.ledger.account_info (block_transaction, account_a);
 					if (info)
 					{
-						block = std::make_shared<nano::state_block> (account_a, info->head, info->representative, info->balance.number () + pending_info.amount.number (), send_hash_a, prv, account_a, work_a);
-						details.epoch = std::max (info->epoch (), pending_info.epoch);
+						block = std::make_shared<nano::state_block> (account_a, info->head, info->representative, info->balance.number () + pending_info->amount.number (), send_hash_a, prv, account_a, work_a);
+						details.epoch = std::max (info->epoch (), pending_info->epoch);
 					}
 					else
 					{
-						block = std::make_shared<nano::state_block> (account_a, 0, representative_a, pending_info.amount, reinterpret_cast<nano::link const &> (send_hash_a), prv, account_a, work_a);
-						details.epoch = pending_info.epoch;
+						block = std::make_shared<nano::state_block> (account_a, 0, representative_a, pending_info->amount, reinterpret_cast<nano::link const &> (send_hash_a), prv, account_a, work_a);
+						details.epoch = pending_info->epoch;
 					}
 				}
 				else

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6925,9 +6925,9 @@ TEST (rpc, epoch_upgrade)
 	{
 		// Check pending entry
 		auto transaction (node->store.tx_begin_read ());
-		nano::pending_info info;
-		ASSERT_FALSE (node->store.pending.get (transaction, nano::pending_key (key3.pub, send7->hash ()), info));
-		ASSERT_EQ (nano::epoch::epoch_1, info.epoch);
+		auto info = node->ledger.pending_info (transaction, nano::pending_key (key3.pub, send7->hash ()));
+		ASSERT_TRUE (info);
+		ASSERT_EQ (nano::epoch::epoch_1, info->epoch);
 	}
 
 	rpc_ctx.io_scope->renew ();
@@ -7091,9 +7091,9 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	{
 		// Check pending entry
 		auto transaction (node->store.tx_begin_read ());
-		nano::pending_info info;
-		ASSERT_FALSE (node->store.pending.get (transaction, nano::pending_key (key3.pub, send7->hash ()), info));
-		ASSERT_EQ (nano::epoch::epoch_1, info.epoch);
+		auto info = node->ledger.pending_info (transaction, nano::pending_key (key3.pub, send7->hash ()));
+		ASSERT_TRUE (info);
+		ASSERT_EQ (nano::epoch::epoch_1, info->epoch);
 	}
 
 	rpc_ctx.io_scope->renew ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -802,6 +802,16 @@ nano::uint128_t nano::ledger::account_receivable (nano::transaction const & tran
 	return result;
 }
 
+std::optional<nano::pending_info> nano::ledger::pending_info (nano::transaction const & transaction, nano::pending_key const & key) const
+{
+	nano::pending_info result;
+	if (!store.pending.get (transaction, key, result))
+	{
+		return result;
+	}
+	return std::nullopt;
+}
+
 nano::process_return nano::ledger::process (nano::write_transaction const & transaction_a, nano::block & block_a)
 {
 	debug_assert (!constants.work.validate_entry (block_a) || constants.genesis == nano::dev::genesis);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -67,6 +67,7 @@ public:
 	nano::account const & block_destination (nano::transaction const &, nano::block const &);
 	nano::block_hash block_source (nano::transaction const &, nano::block const &);
 	std::pair<nano::block_hash, nano::block_hash> hash_root_random (nano::transaction const &) const;
+	std::optional<nano::pending_info> pending_info (nano::transaction const & transaction, nano::pending_key const & key) const;
 	nano::process_return process (nano::write_transaction const &, nano::block &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (nano::write_transaction const &, nano::block_hash const &);


### PR DESCRIPTION
Rather than directly accessing the block store, users should use the ledger::pending_info interface to query for pending information.

Result is returned as an std::optional instead of the less-obvious way it's currently reported through an error code.

Most though not all of the pending_store::get references have been updated to use ledger::pending_info.