### PR TITLE
Fix unit test rpc history pruning

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1425,38 +1425,38 @@ TEST (rpc, history_pruning)
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 	}
-	ASSERT_TIMELY (2s, node0->block_confirmed (change->hash ()) && node0->active.active (send->qualified_root ()));
+	ASSERT_TIMELY (5s, node0->block_confirmed (change->hash ()) && node0->active.active (send->qualified_root ()));
 	{
 		auto election = node0->active.election (send->qualified_root ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 	}
-	ASSERT_TIMELY (2s, node0->block_confirmed (send->hash ()) && node0->active.active (receive->qualified_root ()));
+	ASSERT_TIMELY (5s, node0->block_confirmed (send->hash ()) && node0->active.active (receive->qualified_root ()));
 	{
 		auto election = node0->active.election (receive->qualified_root ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 	}
-	ASSERT_TIMELY (2s, node0->block_confirmed (receive->hash ()) && node0->active.active (usend->qualified_root ()));
+	ASSERT_TIMELY (5s, node0->block_confirmed (receive->hash ()) && node0->active.active (usend->qualified_root ()));
 	{
 		auto election = node0->active.election (usend->qualified_root ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 	}
-	ASSERT_TIMELY (2s, node0->block_confirmed (usend->hash ()) && node0->active.active (ureceive->qualified_root ()));
+	ASSERT_TIMELY (5s, node0->block_confirmed (usend->hash ()) && node0->active.active (ureceive->qualified_root ()));
 	{
 		auto election = node0->active.election (ureceive->qualified_root ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 	}
-	ASSERT_TIMELY (2s, node0->block_confirmed (ureceive->hash ()) && node0->active.active (uchange->qualified_root ()));
+	ASSERT_TIMELY (5s, node0->block_confirmed (ureceive->hash ()) && node0->active.active (uchange->qualified_root ()));
 	{
 		auto election = node0->active.election (uchange->qualified_root ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 	}
-	ASSERT_TIMELY (2s, node0->active.empty () && node0->block_confirmed (uchange->hash ()));
-	ASSERT_TIMELY (2s, node0->ledger.cache.cemented_count == 7 && node0->confirmation_height_processor.current ().is_zero () && node0->confirmation_height_processor.awaiting_processing_size () == 0);
+	ASSERT_TIMELY (5s, node0->active.empty () && node0->block_confirmed (uchange->hash ()));
+	ASSERT_TIMELY (5s, node0->ledger.cache.cemented_count == 7 && node0->confirmation_height_processor.current ().is_zero () && node0->confirmation_height_processor.awaiting_processing_size () == 0);
 	// Pruning action
 	{
 		auto transaction (node0->store.tx_begin_write ());

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -80,7 +80,7 @@ bool nano::test::process_live (nano::node & node, std::vector<std::shared_ptr<na
 
 bool nano::test::confirm (nano::node & node, std::vector<nano::block_hash> hashes)
 {
-	// Finish processing all blocks
+	// Finish processing all blocks - FIXME: block processor flush is broken and should be removed
 	node.block_processor.flush ();
 	for (auto & hash : hashes)
 	{


### PR DESCRIPTION
Fix and tidy-up unit test rcp.history_pruning.
The test was failing intermittedly because it was depending on block processor flush.