### PR TITLE
Add to_string function to nano::stats class for convenience

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -456,6 +456,25 @@ void nano::stats::stop ()
 	stopped = true;
 }
 
+std::string nano::stats::to_string (std::string type)
+{
+	auto sink = log_sink_json ();
+	if (type == "counters")
+	{
+		log_counters (*sink);
+		return sink->to_string ();
+	}
+	else if (type == "samples")
+	{
+		log_samples (*sink);
+		return sink->to_string ();
+	}
+	else
+	{
+		return "type not supported: " + type;
+	}
+}
+
 void nano::stats::clear ()
 {
 	nano::unique_lock<nano::mutex> lock{ stat_mutex };

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -397,6 +397,9 @@ public:
 	/** Stop stats being output */
 	void stop ();
 
+	/** Return string showing stats counters (convenience function for debugging) */
+	std::string to_string (std::string type = "counters");
+
 private:
 	static std::string type_to_string (uint32_t key);
 	static std::string dir_to_string (uint32_t key);


### PR DESCRIPTION
It is useful to be able to print the stats easily from inside a debugging session.