### PR TITLE
Fix magic_enum range

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   distributed_work.cpp
   election.cpp
   election_scheduler.cpp
+  enums.cpp
   epochs.cpp
   frontiers_confirmation.cpp
   gap_cache.cpp

--- a/nano/core_test/enums.cpp
+++ b/nano/core_test/enums.cpp
@@ -1,0 +1,23 @@
+#include <nano/lib/stats_enums.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+TEST (enums, stat_type)
+{
+	ASSERT_FALSE (nano::to_string (static_cast<nano::stat::type> (0)).empty ());
+	ASSERT_FALSE (nano::to_string (nano::stat::type::_last).empty ());
+}
+
+TEST (enums, stat_detail)
+{
+	ASSERT_FALSE (nano::to_string (static_cast<nano::stat::detail> (0)).empty ());
+	ASSERT_FALSE (nano::to_string (nano::stat::detail::_last).empty ());
+}
+
+TEST (enums, stat_dir)
+{
+	ASSERT_FALSE (nano::to_string (static_cast<nano::stat::dir> (0)).empty ());
+	ASSERT_FALSE (nano::to_string (nano::stat::dir::_last).empty ());
+}

--- a/nano/lib/magic_enum.hpp
+++ b/nano/lib/magic_enum.hpp
@@ -1,0 +1,3 @@
+#define MAGIC_ENUM_RANGE_MIN 0
+#define MAGIC_ENUM_RANGE_MAX 256
+#include <magic_enum.hpp>

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <nano/lib/magic_enum.hpp>
 
 namespace nano::stat
 {
@@ -37,6 +37,8 @@ enum class type : uint8_t
 	bootstrap_server,
 	active,
 	backlog,
+
+	_last // Must be the last enum
 };
 
 /** Optional detail type */
@@ -250,13 +252,17 @@ enum class detail : uint8_t
 
 	// backlog
 	activated,
+
+	_last // Must be the last enum
 };
 
 /** Direction of the stat. If the direction is irrelevant, use in */
 enum class dir : uint8_t
 {
 	in,
-	out
+	out,
+
+	_last // Must be the last enum
 };
 }
 


### PR DESCRIPTION
Magic enum by default only looks up enums in [-128, 128] range. This PR fixes that to reflect enum ranges used in our codebase.