### PR TITLE
Remove block processor flush from unit test and cleanup

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -242,29 +242,33 @@ TEST (active_transactions, inactive_votes_cache)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
+/**
+ * This test case confirms that a non final vote cannot cause an election to become confirmed
+ */
 TEST (active_transactions, inactive_votes_cache_non_final)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
-	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
-	nano::keypair key;
+
 	auto send = nano::send_block_builder ()
-				.previous (latest)
-				.destination (key.pub)
+				.previous (nano::dev::genesis->hash())
+				.destination (nano::keypair{}.pub)
 				.balance (nano::dev::constants.genesis_amount - 100)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*system.work.generate (latest))
+				.work (*system.work.generate (nano::dev::genesis->hash()))
 				.build_shared ();
-	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash> (1, send->hash ()))); // Non-final vote
+
+	// Non-final vote
+	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash> (1, send->hash ()));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
 	ASSERT_TIMELY (5s, node.inactive_vote_cache.cache_size () == 1);
+
 	node.process_active (send);
-	node.block_processor.flush ();
-	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached) == 1);
-	auto election = node.active.election (send->qualified_root ());
-	ASSERT_NE (nullptr, election);
+	std::shared_ptr<nano::election> election;
+	ASSERT_TIMELY(5s, election = node.active.election (send->qualified_root ()));
+	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached), 1);
+	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount - 100, election->tally ().begin ()->first);
 	ASSERT_FALSE (election->confirmed ());
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, election->tally ().begin ()->first);
 }
 
 TEST (active_transactions, inactive_votes_cache_fork)

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -251,11 +251,11 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 	auto & node = *system.nodes[0];
 
 	auto send = nano::send_block_builder ()
-				.previous (nano::dev::genesis->hash())
+				.previous (nano::dev::genesis->hash ())
 				.destination (nano::keypair{}.pub)
 				.balance (nano::dev::constants.genesis_amount - 100)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*system.work.generate (nano::dev::genesis->hash()))
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 
 	// Non-final vote
@@ -265,7 +265,7 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 
 	node.process_active (send);
 	std::shared_ptr<nano::election> election;
-	ASSERT_TIMELY(5s, election = node.active.election (send->qualified_root ()));
+	ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
 	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached), 1);
 	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount - 100, election->tally ().begin ()->first);
 	ASSERT_FALSE (election->confirmed ());


### PR DESCRIPTION
Tidy up and cleanup of a test case that uses block processor flush. Removed the flush.
The test case was possibly not broken because the flush was possibly needless due to the assert timely waiting for the vote_cached counter increment.