### PR TITLE
Do not use expose election dummy vote in non election related unit tests

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3619,15 +3619,15 @@ TEST (node, rollback_vote_self)
 		// The write guard prevents the block processor from performing the rollback
 		auto write_guard = node.write_database_queue.wait (nano::writer::testing);
 
-		// Insert genesis key in the wallet
-		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-
 		ASSERT_EQ (0, election->votes_with_weight ().size ());
 		// Vote with key to switch the winner
 		election->vote (key.pub, 0, fork->hash ());
 		ASSERT_EQ (1, election->votes_with_weight ().size ());
 		// The winner changed
 		ASSERT_EQ (election->winner ()->hash (), fork->hash ());
+
+		// Insert genesis key in the wallet
+		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
 		// Even without the rollback being finished, the aggregator must reply with a vote for the new winner, not the old one
 		ASSERT_TRUE (node.history.votes (send2->root (), send2->hash ()).empty ());


### PR DESCRIPTION
Election objects always have one dummy vote in them, they never have zero votes. However that is an implementation detail of the election class, which should not be leaked outside.

By using votes_with_weights, we filter out that dummy votes, which always has zero weight and we do not need to leak out its existence.

It also makes those unit tests easier to reason about. The dummy vote is often a confusing complication.