### PR TITLE
Add tip on optimizing cpu usage

### DIFF
--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -27,7 +27,7 @@ nano::error nano::daemon_config::serialize_toml (nano::tomlconfig & toml)
 
 	nano::tomlconfig opencl_l;
 	opencl.serialize_toml (opencl_l);
-	opencl_l.doc ("enable", "Enable or disable OpenCL work generation\ntype:bool");
+	opencl_l.doc ("enable", "Enable or disable OpenCL work generation\nIf enabled, consider freeing up CPU resources by setting [work_threads] to zero\ntype:bool");
 	opencl_l.put ("enable", opencl_enable);
 	toml.put_child ("opencl", opencl_l);
 


### PR DESCRIPTION
When OpenCl / GPU work generation is enabled the node will keep using CPU threads as well to generate pow. CPU threads are very limited and could be used more efficiently when a GPU is generating the POW
This PR updates the config file to highlight that CPU work generation can be disabled when openCl is used