### PR TITLE
Updating unit tests

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -928,8 +928,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	node0->block_processor.add (receive2);
 	node0->block_processor.add (send3);
 	node0->block_processor.add (receive3);
-	node0->block_processor.flush ();
-	ASSERT_EQ (9, node0->ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (5s, 9, node0->ledger.cache.block_count);
 	// Processing chain to prune for node1
 	config.peering_port = nano::test::get_available_port ();
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
@@ -938,9 +937,10 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	node1->process_active (receive1);
 	node1->process_active (change1);
 	node1->process_active (change2);
+	ASSERT_TIMELY (5s, node1->block (change2->hash ()) != nullptr);
 	// Confirm last block to prune previous
 	nano::test::blocks_confirm (*node1, { send1, receive1, change1, change2 }, true);
-	ASSERT_TIMELY (10s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()) && node1->block_confirmed (change1->hash ()) && node1->block_confirmed (change2->hash ()) && node1->active.empty ());
+	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()) && node1->block_confirmed (change1->hash ()) && node1->block_confirmed (change2->hash ()) && node1->active.empty ());
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
 	// Pruning action
@@ -953,9 +953,9 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
 	// Check processed blocks
-	ASSERT_TIMELY (10s, node1->ledger.cache.block_count == 9);
-	ASSERT_TIMELY (10s, node1->balance (key2.pub) != 0);
-	ASSERT_TIMELY (10s, !node1->bootstrap_initiator.in_progress ());
+	ASSERT_TIMELY (5s, node1->ledger.cache.block_count == 9);
+	ASSERT_TIMELY (5s, node1->balance (key2.pub) != 0);
+	ASSERT_TIMELY (5s, !node1->bootstrap_initiator.in_progress ());
 	node1->stop ();
 }
 
@@ -1319,9 +1319,10 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 					  .build_shared ();
 
 	node1->process_active (state_open);
+	ASSERT_TIMELY (5s, node1->block (state_open->hash ()) != nullptr);
 	// Confirm last block to prune previous
 	nano::test::blocks_confirm (*node1, { send1, send2, open, state_open }, true);
-	ASSERT_TIMELY (10s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (send2->hash ()) && node1->block_confirmed (open->hash ()) && node1->block_confirmed (state_open->hash ()) && node1->active.empty ());
+	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (send2->hash ()) && node1->block_confirmed (open->hash ()) && node1->block_confirmed (state_open->hash ()) && node1->active.empty ());
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
 	// Pruning action
@@ -1355,7 +1356,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	// Insert missing block
 	node2->process_active (send1);
 	node2->block_processor.flush ();
-	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
+	ASSERT_TIMELY (5s, !node2->bootstrap_initiator.in_progress ());
 	node2->block_processor.flush ();
 	ASSERT_EQ (3, node2->ledger.cache.block_count);
 	ASSERT_TRUE (node2->ledger.block_or_pruned_exists (send1->hash ()));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -385,7 +385,7 @@ TEST (confirmation_height, gap_bootstrap)
 		node1.block_processor.add (send2);
 		node1.block_processor.add (send3);
 		node1.block_processor.add (receive1);
-		node1.block_processor.flush ();
+		ASSERT_TIMELY (5s, node1.block (send3->hash ()) != nullptr);
 
 		add_callback_stats (node1);
 
@@ -395,7 +395,7 @@ TEST (confirmation_height, gap_bootstrap)
 		auto check_block_is_listed = [&] (nano::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 			return !node1.unchecked.get (transaction_a, block_hash_a).empty ();
 		};
-		ASSERT_TIMELY (15s, check_block_is_listed (node1.store.tx_begin_read (), receive2->previous ()));
+		ASSERT_TIMELY (5s, check_block_is_listed (node1.store.tx_begin_read (), receive2->previous ()));
 
 		// Confirmation heights should not be updated
 		{
@@ -412,7 +412,7 @@ TEST (confirmation_height, gap_bootstrap)
 		// Now complete the chain where the block comes in on the bootstrap network.
 		node1.block_processor.add (open1);
 
-		ASSERT_TIMELY (10s, node1.unchecked.count (node1.store.tx_begin_read ()) == 0);
+		ASSERT_TIMELY (5s, node1.unchecked.count (node1.store.tx_begin_read ()) == 0);
 		// Confirmation height should be unchanged and unchecked should now be 0
 		{
 			auto transaction = node1.store.tx_begin_read ();

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -212,6 +212,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 					   .work (*system.work.generate (latest))
 					   .build_shared ();
 	node1.process_active (send1);
+	ASSERT_TIMELY (5s, node1.block (send1->hash ()) != nullptr);
 
 	auto const open1 = nano::open_block_builder{}.make_block ().account (key1.pub).source (send1->hash ()).representative (key1.pub).sign (key1.prv, key1.pub).work (*system.work.generate (key1.pub)).build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*open1).code);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4430,17 +4430,18 @@ TEST (ledger, unchecked_open)
 				 .build_shared ();
 	node1.work_generate_blocking (*open2);
 	open2->signature.bytes[0] ^= 1;
+	node1.block_processor.add (open2); // Insert open2 in to the queue before open1
 	node1.block_processor.add (open1);
-	node1.block_processor.add (open2);
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
-		ASSERT_TIMELY (10s, 1 == node1.unchecked.count (node1.store.tx_begin_read ()));
+		ASSERT_TIMELY (5s, 1 == node1.unchecked.count (node1.store.tx_begin_read ()));
+		// When open1 existists in unchecked, we know open2 has been processed.
 		auto blocks = node1.unchecked.get (node1.store.tx_begin_read (), open1->source ());
 		ASSERT_EQ (blocks.size (), 1);
 	}
 	node1.block_processor.add (send1);
 	// Waits for the send1 block to pass through block_processor and unchecked.put queues
-	ASSERT_TIMELY (10s, node1.store.block.exists (node1.store.tx_begin_read (), open1->hash ()));
+	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), open1->hash ()));
 	ASSERT_EQ (0, node1.unchecked.count (node1.store.tx_begin_read ()));
 }
 


### PR DESCRIPTION
- Removes several calls to flush in favor of checking the block exists with an ASSERT_TIMELY
- Changing several ASSERT_TIMELY durations to a standard 5s
- Adding comments to clarify test steps