### PR TITLE
Bugfix: max counting had reversed polarity, it counted successes not fails

### DIFF
--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -635,12 +635,12 @@ bool nano::transport::udp_channels::max_ip_connections (nano::endpoint const & e
 	}
 	auto const address (nano::transport::ipv4_address_or_ipv6_subnet (endpoint_a.address ()));
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	auto const result = channels.get<ip_address_tag> ().count (address) >= node.network_params.network.max_peers_per_ip;
-	if (!result)
+	auto const error = channels.get<ip_address_tag> ().count (address) >= node.network_params.network.max_peers_per_ip;
+	if (error)
 	{
 		node.stats.inc (nano::stat::type::udp, nano::stat::detail::udp_max_per_ip, nano::stat::dir::out);
 	}
-	return result;
+	return error;
 }
 
 bool nano::transport::udp_channels::max_subnetwork_connections (nano::endpoint const & endpoint_a)
@@ -651,12 +651,12 @@ bool nano::transport::udp_channels::max_subnetwork_connections (nano::endpoint c
 	}
 	auto const subnet (nano::transport::map_address_to_subnetwork (endpoint_a.address ()));
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	auto const result = channels.get<subnetwork_tag> ().count (subnet) >= node.network_params.network.max_peers_per_subnetwork;
-	if (!result)
+	auto const error = channels.get<subnetwork_tag> ().count (subnet) >= node.network_params.network.max_peers_per_subnetwork;
+	if (error)
 	{
 		node.stats.inc (nano::stat::type::udp, nano::stat::detail::udp_max_per_subnetwork, nano::stat::dir::out);
 	}
-	return result;
+	return error;
 }
 
 bool nano::transport::udp_channels::max_ip_or_subnetwork_connections (nano::endpoint const & endpoint_a)


### PR DESCRIPTION
The counters:
nano::stat::type::udp, nano::stat::detail::udp_max_per_subnetwork
nano::stat::type::udp, nano::stat::detail::udp_max_per_ip