### PR TITLE
Specify that the IPv6 socket is used for IPv4 com

### DIFF
--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -324,7 +324,7 @@ TEST (telemetry, invalid_endpoint)
 	// Give some time for nodes to exchange telemetry
 	WAIT (1s);
 
-	nano::endpoint endpoint = *nano::parse_endpoint ("240.0.0.0:12345");
+	nano::endpoint endpoint = *nano::parse_endpoint ("::ffff:240.0.0.0:12345");
 	ASSERT_FALSE (node_client->telemetry.get_telemetry (endpoint));
 }
 


### PR DESCRIPTION
telemetry.invalid_endpoint unit test currently fails on windows. 
This is an attempt to fix this by specifying the ipv4 address as an ipv6 address (128 bit)
Edit: Unit test completed successfully on windows build with this PR