### PR TITLE
Fix magic enum slow compilation times

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(
   stats.hpp
   stats.cpp
   stats_enums.hpp
+  stats_enums.cpp
   stream.hpp
   threading.hpp
   threading.cpp

--- a/nano/lib/magic_enum.hpp
+++ b/nano/lib/magic_enum.hpp
@@ -1,3 +1,0 @@
-#define MAGIC_ENUM_RANGE_MIN 0
-#define MAGIC_ENUM_RANGE_MAX 256
-#include <magic_enum.hpp>

--- a/nano/lib/stats_enums.cpp
+++ b/nano/lib/stats_enums.cpp
@@ -1,0 +1,21 @@
+#include <nano/lib/stats_enums.hpp>
+
+#define MAGIC_ENUM_RANGE_MIN 0
+#define MAGIC_ENUM_RANGE_MAX 256
+
+#include <magic_enum.hpp>
+
+std::string_view nano::to_string (nano::stat::type type)
+{
+	return magic_enum::enum_name (type);
+}
+
+std::string_view nano::to_string (nano::stat::detail detail)
+{
+	return magic_enum::enum_name (detail);
+}
+
+std::string_view nano::to_string (nano::stat::dir dir)
+{
+	return magic_enum::enum_name (dir);
+}

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <nano/lib/magic_enum.hpp>
+#include <cstdint>
+#include <string_view>
 
 namespace nano::stat
 {
@@ -277,21 +278,7 @@ enum class dir : uint8_t
 
 namespace nano
 {
-/** Returns string representation of type */
-inline std::string_view to_string (stat::type type)
-{
-	return magic_enum::enum_name (type);
-}
-
-/** Returns string representation of detail */
-inline std::string_view to_string (stat::detail detail)
-{
-	return magic_enum::enum_name (detail);
-}
-
-/** Returns string representation of dir */
-inline std::string_view to_string (stat::dir dir)
-{
-	return magic_enum::enum_name (dir);
-}
+std::string_view to_string (stat::type type);
+std::string_view to_string (stat::detail detail);
+std::string_view to_string (stat::dir dir);
 }

--- a/nano/test_common/rate_observer.cpp
+++ b/nano/test_common/rate_observer.cpp
@@ -4,8 +4,6 @@
 
 #include <sstream>
 
-using namespace magic_enum::ostream_operators;
-
 /*
  * rate_observer::counter
  */
@@ -49,7 +47,7 @@ uint64_t nano::test::rate_observer::stat_counter::count ()
 std::string nano::test::rate_observer::stat_counter::name ()
 {
 	std::stringstream ss;
-	ss << type << "::" << detail << "::" << dir;
+	ss << nano::to_string (type) << "::" << nano::to_string (detail) << "::" << nano::to_string (dir);
 	return ss.str ();
 }
 


### PR DESCRIPTION
Introducing magic_enum slowed down our compilation times. The reason for that is that it's a library relying heavily on templates and it was used from inline methods in a header file. That resulted in a lot of unnecessary recompilations of the same code. This PR moves that implementation to a .cpp file, so it only needs to be compiled once. In addition it also solves the annoying macro redefinition warnings.