### PR TITLE
Fix bootstrap server thread name typo

### DIFF
--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -103,7 +103,7 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 			thread_role_name_string = "Voting que";
 			break;
 		case nano::thread_role::name::bootstrap_server:
-			thread_role_name_string = "Bootstrp serv";
+			thread_role_name_string = "Bootstrap serv";
 			break;
 		case nano::thread_role::name::telemetry:
 			thread_role_name_string = "Telemetry";


### PR DESCRIPTION
`Bootstrp serv` to `Bootstrap serv`, the limit is 15 characters.