### PR TITLE
Convert nano::test::start_election to take a hash rather than a block

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -630,7 +630,7 @@ TEST (active_transactions, dropped_cleanup)
 	ASSERT_FALSE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
 	ASSERT_TRUE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
 
-	auto election = nano::test::start_election (system, node, nano::dev::genesis);
+	auto election = nano::test::start_election (system, node, nano::dev::genesis->hash ());
 	ASSERT_NE (nullptr, election);
 
 	// Not yet removed
@@ -653,7 +653,7 @@ TEST (active_transactions, dropped_cleanup)
 	// Repeat test for a confirmed election
 	ASSERT_TRUE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
 
-	election = nano::test::start_election (system, node, nano::dev::genesis);
+	election = nano::test::start_election (system, node, nano::dev::genesis->hash ());
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 	ASSERT_TRUE (election->confirmed ());
@@ -1219,7 +1219,7 @@ TEST (active_transactions, activate_inactive)
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
 
-	auto election = nano::test::start_election (system, node, send2);
+	auto election = nano::test::start_election (system, node, send2->hash ());
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -241,7 +241,7 @@ TEST (confirmation_height, multiple_accounts)
 						.work (*system.work.generate (open3->hash ()))
 						.build_shared ();
 		node->process_active (receive3);
-		auto election = nano::test::start_election (system, *node, receive3);
+		auto election = nano::test::start_election (system, *node, receive3->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
@@ -533,7 +533,7 @@ TEST (confirmation_height, gap_live)
 		}
 
 		// Vote and confirm all existing blocks
-		nano::test::start_election (system, *node, send1);
+		nano::test::start_election (system, *node, send1->hash ());
 		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 3);
 
 		// Now complete the chain where the block comes in on the live network
@@ -688,7 +688,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		add_callback_stats (*node);
 
 		node->process_active (receive4);
-		auto election = nano::test::start_election (system, *node, receive4);
+		auto election = nano::test::start_election (system, *node, receive4->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
@@ -805,7 +805,7 @@ TEST (confirmation_height, send_receive_self)
 
 		add_callback_stats (*node);
 
-		auto election = nano::test::start_election (system, *node, receive3);
+		auto election = nano::test::start_election (system, *node, receive3->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
@@ -1050,7 +1050,7 @@ TEST (confirmation_height, all_block_types)
 		}
 
 		add_callback_stats (*node);
-		auto election = nano::test::start_election (system, *node, state_send2);
+		auto election = nano::test::start_election (system, *node, state_send2->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
@@ -1546,7 +1546,7 @@ TEST (confirmation_height, callback_confirmed_history)
 		add_callback_stats (*node);
 
 		node->process_active (send1);
-		ASSERT_NE (nano::test::start_election (system, *node, send1), nullptr);
+		ASSERT_NE (nano::test::start_election (system, *node, send1->hash ()), nullptr);
 		{
 			node->process_active (send);
 			node->block_processor.flush ();
@@ -1647,9 +1647,9 @@ TEST (confirmation_height, dependent_election)
 		add_callback_stats (*node);
 
 		// This election should be confirmed as active_conf_height
-		ASSERT_TRUE (nano::test::start_election (system, *node, send1));
+		ASSERT_TRUE (nano::test::start_election (system, *node, send1->hash ()));
 		// Start an election and confirm it
-		auto election = nano::test::start_election (system, *node, send2);
+		auto election = nano::test::start_election (system, *node, send2->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
@@ -1803,7 +1803,7 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		nano::mutex mutex;
 		add_callback_stats (*node, &observer_order, &mutex);
 
-		auto election = nano::test::start_election (system, *node, open1);
+		auto election = nano::test::start_election (system, *node, open1->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
@@ -1968,7 +1968,7 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 
 		add_callback_stats (*node);
 
-		auto election = nano::test::start_election (system, *node, open1);
+		auto election = nano::test::start_election (system, *node, open1->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 6);

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -111,7 +111,7 @@ TEST (gap_cache, gap_bootstrap)
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, node1.balance (nano::dev::genesis->account ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, node2.balance (nano::dev::genesis->account ()));
 	// Confirm send block, allowing voting on the upcoming block
-	auto election = nano::test::start_election (system, node1, send);
+	auto election = nano::test::start_election (system, node1, send->hash ());
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 	ASSERT_TIMELY (5s, node1.block_confirmed (send->hash ()));

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -67,7 +67,7 @@ TEST (vote_processor, invalid_signature)
 	vote_invalid->signature.bytes[0] ^= 1;
 	auto channel = std::make_shared<nano::transport::inproc::channel> (node, node);
 
-	auto election = nano::test::start_election (system, node, nano::dev::genesis);
+	auto election = nano::test::start_election (system, node, nano::dev::genesis->hash ());
 	ASSERT_NE (election, nullptr);
 	ASSERT_EQ (1, election->votes ().size ());
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5874,7 +5874,7 @@ TEST (rpc, confirmation_height_currently_processing)
 	{
 		// Write guard prevents the confirmation height processor writing the blocks, so that we can inspect contents during the response
 		auto write_guard = node->write_database_queue.wait (nano::writer::testing);
-		nano::test::start_election (system, *node, frontier);
+		nano::test::start_election (system, *node, frontier->hash ());
 
 		ASSERT_TIMELY (5s, node->confirmation_height_processor.current () == frontier->hash ());
 

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -408,10 +408,12 @@ namespace test
 	 */
 	std::shared_ptr<nano::transport::channel> fake_channel (nano::node & node, nano::account node_id = { 0 });
 	/*
-	 * Start an election on system system_a, node node_a and block block_a by adding the block to the manual election scheduler queue.
-	 * It waits up to 5 seconds for the election to start and calls the system poll function while waiting.
+	 * Start an election on system system_a, node node_a and hash hash_a by reading the block
+	 * out of the ledger and adding it to the manual election scheduler queue.
+	 * It waits up to 5 seconds for the block to appear in the ledger and the election to start
+	 * and calls the system poll function while waiting.
 	 * Returns nullptr if the election did not start within the timeframe.
 	 */
-	std::shared_ptr<nano::election> start_election (nano::test::system & system_a, nano::node & node_a, const std::shared_ptr<nano::block> & block_a);
+	std::shared_ptr<nano::election> start_election (nano::test::system & system_a, nano::node & node_a, const nano::block_hash & hash_a);
 }
 }


### PR DESCRIPTION
nano::test::start_election does need to take the block, a hash suffices and makes the function more flexible and reusable