### PR TITLE
Refactor nano::election::vote method

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -409,22 +409,24 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 
 		should_process = max_vote || past_cooldown;
 	}
-	if (should_process)
+	if (!should_process)
 	{
-		last_votes[rep] = { std::chrono::steady_clock::now (), timestamp_a, block_hash_a };
-		if (vote_source_a == vote_source::live)
-		{
-			live_vote_action (rep);
-		}
-
-		node.stats.inc (nano::stat::type::election, vote_source_a == vote_source::live ? nano::stat::detail::vote_new : nano::stat::detail::vote_cached);
-
-		if (!confirmed ())
-		{
-			confirm_if_quorum (lock);
-		}
+		return nano::election_vote_result (false, false);
 	}
-	return nano::election_vote_result (false, should_process);
+
+	last_votes[rep] = { std::chrono::steady_clock::now (), timestamp_a, block_hash_a };
+	if (vote_source_a == vote_source::live)
+	{
+		live_vote_action (rep);
+	}
+
+	node.stats.inc (nano::stat::type::election, vote_source_a == vote_source::live ? nano::stat::detail::vote_new : nano::stat::detail::vote_cached);
+
+	if (!confirmed ())
+	{
+		confirm_if_quorum (lock);
+	}
+	return nano::election_vote_result (false, true);
 }
 
 bool nano::election::publish (std::shared_ptr<nano::block> const & block_a)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -377,7 +377,6 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 	{
 		return nano::election_vote_result (false, false);
 	}
-	auto replay = false;
 	auto should_process = false;
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
@@ -425,7 +424,7 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 			confirm_if_quorum (lock);
 		}
 	}
-	return nano::election_vote_result (replay, should_process);
+	return nano::election_vote_result (false, should_process);
 }
 
 bool nano::election::publish (std::shared_ptr<nano::block> const & block_a)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -389,24 +389,26 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 	else
 	{
 		auto last_vote_l (last_vote_it->second);
-		if (last_vote_l.timestamp >= timestamp_a && !(last_vote_l.timestamp == timestamp_a && last_vote_l.hash < block_hash_a))
+		if (last_vote_l.timestamp > timestamp_a)
 		{
-			replay = true;
+			return nano::election_vote_result (true, false);
 		}
-		else
+		if (last_vote_l.timestamp == timestamp_a && block_hash_a < last_vote_l.hash)
 		{
-			auto max_vote = timestamp_a == std::numeric_limits<uint64_t>::max () && last_vote_l.timestamp < timestamp_a;
-
-			bool past_cooldown = true;
-			// Only cooldown live votes
-			if (vote_source_a == vote_source::live)
-			{
-				const auto cooldown = cooldown_time (weight);
-				past_cooldown = last_vote_l.time <= std::chrono::steady_clock::now () - cooldown;
-			}
-
-			should_process = max_vote || past_cooldown;
+			return nano::election_vote_result (true, false);
 		}
+
+		auto max_vote = timestamp_a == std::numeric_limits<uint64_t>::max () && last_vote_l.timestamp < timestamp_a;
+
+		bool past_cooldown = true;
+		// Only cooldown live votes
+		if (vote_source_a == vote_source::live)
+		{
+			const auto cooldown = cooldown_time (weight);
+			past_cooldown = last_vote_l.time <= std::chrono::steady_clock::now () - cooldown;
+		}
+
+		should_process = max_vote || past_cooldown;
 	}
 	if (should_process)
 	{

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -377,7 +377,6 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 	{
 		return nano::election_vote_result (false, false);
 	}
-	auto should_process = true;
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
 	auto last_vote_it (last_votes.find (rep));
@@ -403,11 +402,10 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 			past_cooldown = last_vote_l.time <= std::chrono::steady_clock::now () - cooldown;
 		}
 
-		should_process = max_vote || past_cooldown;
-	}
-	if (!should_process)
-	{
-		return nano::election_vote_result (false, false);
+		if (!max_vote && !past_cooldown)
+		{
+			return nano::election_vote_result (false, false);
+		}
 	}
 
 	last_votes[rep] = { std::chrono::steady_clock::now (), timestamp_a, block_hash_a };

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -389,7 +389,11 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 	else
 	{
 		auto last_vote_l (last_vote_it->second);
-		if (last_vote_l.timestamp < timestamp_a || (last_vote_l.timestamp == timestamp_a && last_vote_l.hash < block_hash_a))
+		if (last_vote_l.timestamp >= timestamp_a && !(last_vote_l.timestamp == timestamp_a && last_vote_l.hash < block_hash_a))
+		{
+			replay = true;
+		}
+		else
 		{
 			auto max_vote = timestamp_a == std::numeric_limits<uint64_t>::max () && last_vote_l.timestamp < timestamp_a;
 
@@ -402,10 +406,6 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 			}
 
 			should_process = max_vote || past_cooldown;
-		}
-		else
-		{
-			replay = true;
 		}
 	}
 	if (should_process)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -377,15 +377,11 @@ nano::election_vote_result nano::election::vote (nano::account const & rep, uint
 	{
 		return nano::election_vote_result (false, false);
 	}
-	auto should_process = false;
+	auto should_process = true;
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
 	auto last_vote_it (last_votes.find (rep));
-	if (last_vote_it == last_votes.end ())
-	{
-		should_process = true;
-	}
-	else
+	if (last_vote_it != last_votes.end ())
 	{
 		auto last_vote_l (last_vote_it->second);
 		if (last_vote_l.timestamp > timestamp_a)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -372,54 +372,55 @@ std::shared_ptr<nano::block> nano::election::find (nano::block_hash const & hash
 
 nano::election_vote_result nano::election::vote (nano::account const & rep, uint64_t timestamp_a, nano::block_hash const & block_hash_a, vote_source vote_source_a)
 {
-	auto replay = false;
 	auto weight = node.ledger.weight (rep);
-	auto should_process = false;
-	if (node.network_params.network.is_dev_network () || weight > node.minimum_principal_weight ())
+	if (!node.network_params.network.is_dev_network () && weight <= node.minimum_principal_weight ())
 	{
-		nano::unique_lock<nano::mutex> lock{ mutex };
+		return nano::election_vote_result (false, false);
+	}
+	auto replay = false;
+	auto should_process = false;
+	nano::unique_lock<nano::mutex> lock{ mutex };
 
-		auto last_vote_it (last_votes.find (rep));
-		if (last_vote_it == last_votes.end ())
+	auto last_vote_it (last_votes.find (rep));
+	if (last_vote_it == last_votes.end ())
+	{
+		should_process = true;
+	}
+	else
+	{
+		auto last_vote_l (last_vote_it->second);
+		if (last_vote_l.timestamp < timestamp_a || (last_vote_l.timestamp == timestamp_a && last_vote_l.hash < block_hash_a))
 		{
-			should_process = true;
+			auto max_vote = timestamp_a == std::numeric_limits<uint64_t>::max () && last_vote_l.timestamp < timestamp_a;
+
+			bool past_cooldown = true;
+			// Only cooldown live votes
+			if (vote_source_a == vote_source::live)
+			{
+				const auto cooldown = cooldown_time (weight);
+				past_cooldown = last_vote_l.time <= std::chrono::steady_clock::now () - cooldown;
+			}
+
+			should_process = max_vote || past_cooldown;
 		}
 		else
 		{
-			auto last_vote_l (last_vote_it->second);
-			if (last_vote_l.timestamp < timestamp_a || (last_vote_l.timestamp == timestamp_a && last_vote_l.hash < block_hash_a))
-			{
-				auto max_vote = timestamp_a == std::numeric_limits<uint64_t>::max () && last_vote_l.timestamp < timestamp_a;
-
-				bool past_cooldown = true;
-				// Only cooldown live votes
-				if (vote_source_a == vote_source::live)
-				{
-					const auto cooldown = cooldown_time (weight);
-					past_cooldown = last_vote_l.time <= std::chrono::steady_clock::now () - cooldown;
-				}
-
-				should_process = max_vote || past_cooldown;
-			}
-			else
-			{
-				replay = true;
-			}
+			replay = true;
 		}
-		if (should_process)
+	}
+	if (should_process)
+	{
+		last_votes[rep] = { std::chrono::steady_clock::now (), timestamp_a, block_hash_a };
+		if (vote_source_a == vote_source::live)
 		{
-			last_votes[rep] = { std::chrono::steady_clock::now (), timestamp_a, block_hash_a };
-			if (vote_source_a == vote_source::live)
-			{
-				live_vote_action (rep);
-			}
+			live_vote_action (rep);
+		}
 
-			node.stats.inc (nano::stat::type::election, vote_source_a == vote_source::live ? nano::stat::detail::vote_new : nano::stat::detail::vote_cached);
+		node.stats.inc (nano::stat::type::election, vote_source_a == vote_source::live ? nano::stat::detail::vote_new : nano::stat::detail::vote_cached);
 
-			if (!confirmed ())
-			{
-				confirm_if_quorum (lock);
-			}
+		if (!confirmed ())
+		{
+			confirm_if_quorum (lock);
 		}
 	}
 	return nano::election_vote_result (replay, should_process);


### PR DESCRIPTION
Refactoring nano::election::vote method according to #4108.
Main goals:
- Reduce nesting of if statements
- Use early returns
- Simplify longer if statement.