### PR TITLE
Remove wrong and needless code from test system.block_sequence

### DIFF
--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -2135,7 +2135,6 @@ TEST (system, block_sequence)
 	flags.disable_max_peers_per_ip = true;
 	flags.disable_ongoing_bootstrap = true;
 	auto root = system.add_node (config, flags);
-	config.preconfigured_peers.push_back ("::ffff:127.0.0.1:" + std::to_string (root->network.endpoint ().port ()));
 	auto wallet = root->wallets.items.begin ()->second;
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	for (auto rep : reps)


### PR DESCRIPTION
The code is wrong because preconfigured_peers does not support specifying port numbers and it appears to be needless anyway.