### PR TITLE
Fix node deferred dependent elections

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4199,7 +4199,6 @@ TEST (node, deferred_dependent_elections)
 	node.work_generate_blocking (*open, nano::dev::network_params.work.difficulty (*open) + 1);
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 	node.process_local (open);
-	node.block_processor.flush ();
 	ASSERT_NEVER (1s, node.active.active (open->qualified_root ()));
 
 	// Drop both elections
@@ -4228,14 +4227,12 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), receive->hash ()));
 	ASSERT_FALSE (node.block (receive->hash ()));
 	node.process_local (receive);
-	node.block_processor.flush ();
 	ASSERT_TIMELY (5s, node.block (receive->hash ()));
 	ASSERT_NEVER (1s, node.active.active (receive->qualified_root ()));
 
 	// Processing a fork will also not start an election
 	ASSERT_EQ (nano::process_result::fork, node.process (*fork).code);
 	node.process_local (fork);
-	node.block_processor.flush ();
 	ASSERT_NEVER (1s, node.active.active (receive->qualified_root ()));
 
 	// Confirming the other dependency allows starting an election from a fork

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4174,14 +4174,14 @@ TEST (node, deferred_dependent_elections)
 	nano::test::process (node, { open, send2 });
 	ASSERT_TIMELY (5s, node.block (open->hash ()));
 	ASSERT_TIMELY (5s, node.block (send2->hash ()));
-	ASSERT_NEVER (1s, node.active.active (open->qualified_root ()) || node.active.active (send2->qualified_root ()));
+	ASSERT_NEVER (0.5s, node.active.active (open->qualified_root ()) || node.active.active (send2->qualified_root ()));
 	ASSERT_TIMELY (5s, node2.block (open->hash ()));
 	ASSERT_TIMELY (5s, node2.block (send2->hash ()));
 
 	// Re-processing older blocks with updated work also does not start an election
 	node.work_generate_blocking (*open, nano::dev::network_params.work.difficulty (*open) + 1);
 	node.process_local (open);
-	ASSERT_NEVER (1s, node.active.active (open->qualified_root ()));
+	ASSERT_NEVER (0.5s, node.active.active (open->qualified_root ()));
 
 	// It is however possible to manually start an election from elsewhere
 	ASSERT_TRUE (nano::test::start_election (system, node, open->hash ()));
@@ -4192,7 +4192,7 @@ TEST (node, deferred_dependent_elections)
 	node.work_generate_blocking (*open, nano::dev::network_params.work.difficulty (*open) + 1);
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 	node.process_local (open);
-	ASSERT_NEVER (1s, node.active.active (open->qualified_root ()));
+	ASSERT_NEVER (0.5s, node.active.active (open->qualified_root ()));
 
 	// Drop both elections
 	node.active.erase (*open);
@@ -4216,17 +4216,17 @@ TEST (node, deferred_dependent_elections)
 	election_open->force_confirm ();
 	ASSERT_TIMELY (5s, node.block_confirmed (open->hash ()));
 	ASSERT_FALSE (node.ledger.dependents_confirmed (node.store.tx_begin_read (), *receive));
-	ASSERT_NEVER (1s, node.active.active (receive->qualified_root ()));
+	ASSERT_NEVER (0.5s, node.active.active (receive->qualified_root ()));
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), receive->hash ()));
 	ASSERT_FALSE (node.block (receive->hash ()));
 	node.process_local (receive);
 	ASSERT_TIMELY (5s, node.block (receive->hash ()));
-	ASSERT_NEVER (1s, node.active.active (receive->qualified_root ()));
+	ASSERT_NEVER (0.5s, node.active.active (receive->qualified_root ()));
 
 	// Processing a fork will also not start an election
 	ASSERT_EQ (nano::process_result::fork, node.process (*fork).code);
 	node.process_local (fork);
-	ASSERT_NEVER (1s, node.active.active (receive->qualified_root ()));
+	ASSERT_NEVER (0.5s, node.active.active (receive->qualified_root ()));
 
 	// Confirming the other dependency allows starting an election from a fork
 	election_send2->force_confirm ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4190,8 +4190,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_NEVER (1s, node.active.active (open->qualified_root ()));
 
 	// It is however possible to manually start an election from elsewhere
-	node.block_confirm (open);
-	ASSERT_TRUE (node.active.active (open->qualified_root ()));
+	ASSERT_TRUE (nano::test::start_election (system, node, open->hash ()));
 	node.active.erase (*open);
 	ASSERT_FALSE (node.active.active (open->qualified_root ()));
 


### PR DESCRIPTION
Just fixed a race between block_confirm and ASSERT and tidied up some code.
I didn't;t spend time to understand the intention of the whole test case, so I have not added any comments. 