### PR TITLE
Separate Windows unit tests build and run stage

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -99,7 +99,10 @@ jobs:
       - name: Fetch Deps
         run: ci/actions/windows/install_deps.ps1
 
-      - name: Build & Run Tests
+      - name: Build Tests
         run: ci/actions/windows/build.ps1
+
+      - name: Run Tests [TEST_USE_ROCKSDB=${{ env.TEST_USE_ROCKSDB }}]
+        run: ci/actions/windows/run.ps1
         env:
           DEADLINE_SCALE_FACTOR: ${{ env.TEST_USE_ROCKSDB == 1 && '2' || '1' }}

--- a/ci/actions/windows/build.bat
+++ b/ci/actions/windows/build.bat
@@ -23,6 +23,12 @@ cmake --build . ^
   --config %BUILD_TYPE% ^
   -- /m:2
 set exit_code=%errorlevel%
+
+echo "Packaging NSIS"
+call "%cmake_path%\cpack.exe" -C %BUILD_TYPE%
+echo "Packaging ZIP"
+call "%cmake_path%\cpack.exe" -G ZIP -C %BUILD_TYPE%
+
 goto exit
 
 :exit

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -23,7 +23,7 @@ if (${env:artifact} -eq 1) {
     $env:RUN = "artifact"
 }
 else {
-    if ( ${env:RELEASE} -eq "true" -or ${env:TEST_USE_ROCKSDB} -eq 1 ) {
+    if (${env:RELEASE} -eq "true") {
         $env:BUILD_TYPE = "RelWithDebInfo"
     }
     else {

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -52,12 +52,8 @@ if (${env:RUN} -eq "artifact") {
 if (${LastExitCode} -ne 0) {
     throw "Failed to build ${env:RUN}"
 }
+
 $env:cmake_path = Split-Path -Path(get-command cmake.exe).Path
 . "$PSScriptRoot\signing.ps1"
-
-& ..\ci\actions\windows\run.bat
-if (${LastExitCode} -ne 0) {
-    throw "Failed to Pass Test ${env:RUN}"
-}
 
 Pop-Location

--- a/ci/actions/windows/run.bat
+++ b/ci/actions/windows/run.bat
@@ -18,9 +18,3 @@ echo Core Test %core_code%
 echo RPC Test %rpc_code%
 
 exit /B %core_code%
-
-:artifact
-echo "Packaging NSIS"
-call "%cmake_path%\cpack.exe" -C %BUILD_TYPE%
-echo "Packaging ZIP"
-call "%cmake_path%\cpack.exe" -G ZIP -C %BUILD_TYPE%

--- a/ci/actions/windows/run.bat
+++ b/ci/actions/windows/run.bat
@@ -1,20 +1,17 @@
 @echo off
-set exit_code=0
-set count=0
+setlocal
 
-goto %RUN%
-
-:test
-if %count% equ 10 goto rpc_test
 call %BUILD_TYPE%\core_test.exe
 set core_code=%errorlevel%
-set /a count=count+1
-if %core_code% neq 0 goto test
 
-:rpc_test
 call %BUILD_TYPE%\rpc_test.exe
 set rpc_code=%errorlevel%
-echo Core Test %core_code%
-echo RPC Test %rpc_code%
 
-exit /B %core_code%
+echo Core Test return code: %core_code%
+echo RPC Test return code: %rpc_code%
+
+if %core_code%==0 if %rpc_code%==0 (
+    exit /b 0
+) else (
+    exit /b 1
+)

--- a/ci/actions/windows/run.bat
+++ b/ci/actions/windows/run.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal
+set exit_code=0
 
 call %BUILD_TYPE%\core_test.exe
 set core_code=%errorlevel%
@@ -10,8 +11,20 @@ set rpc_code=%errorlevel%
 echo Core Test return code: %core_code%
 echo RPC Test return code: %rpc_code%
 
-if %core_code%==0 if %rpc_code%==0 (
+if not %core_code%==0 (
+    echo Core Test fail
+    set exit_code=1
+)
+
+if not %rpc_code%==0 (
+    echo RPC Test fail
+    set exit_code=1
+)
+
+if %exit_code%==0 (
+    echo Success
     exit /b 0
 ) else (
+    echo Failed
     exit /b 1
 )

--- a/ci/actions/windows/run.ps1
+++ b/ci/actions/windows/run.ps1
@@ -7,7 +7,7 @@ Push-Location build
 
 & ..\ci\actions\windows\run.bat
 if (${LastExitCode} -ne 0) {
-    throw "Failed to Pass Test ${env:RUN}"
+    throw "Failed to Pass Tests"
 }
 
 Pop-Location

--- a/ci/actions/windows/run.ps1
+++ b/ci/actions/windows/run.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = "Continue"
+
+$env:BUILD_TYPE = "Debug"
+$env:NETWORK_CFG = "dev"
+$env:RUN = "test"
+
+Push-Location build
+
+& ..\ci\actions\windows\run.bat
+if (${LastExitCode} -ne 0) {
+    throw "Failed to Pass Test ${env:RUN}"
+}
+
+Pop-Location

--- a/ci/actions/windows/run.ps1
+++ b/ci/actions/windows/run.ps1
@@ -2,7 +2,6 @@ $ErrorActionPreference = "Continue"
 
 $env:BUILD_TYPE = "Debug"
 $env:NETWORK_CFG = "dev"
-$env:RUN = "test"
 
 Push-Location build
 


### PR DESCRIPTION
Currently the build phase in windows workflow does both building and running. This is confusing. This PR separates those and additionally removes logic that would repeat core tests until they pass.