### PR TITLE
Support address:port format for preconfigured_peers entries.

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -974,6 +974,7 @@ TEST (toml, deserialize_address)
 	node_config.deserialize_address ("1.2.3.4:999", true, container);
 	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:999", true, container);
 	ASSERT_EQ (container.size (), 3);
+	ASSERT_EQ (container.at (2).first, "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
 
 	node_config.deserialize_address ("dev-peer.org", true, no_port_container);
 	node_config.deserialize_address ("1.2.3.4", true, no_port_container);
@@ -985,4 +986,5 @@ TEST (toml, deserialize_address)
 	node_config.deserialize_address ("1.2.3.4", false, no_port_container);
 	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", false, no_port_container);
 	ASSERT_EQ (no_port_container.size (), 3);
+	ASSERT_EQ (container.at (2).first, "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
 }

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -964,18 +964,18 @@ TEST (toml, tls_config_defaults)
 	ASSERT_EQ (conf.server_dh_path, defaults.server_dh_path);
 }
 
-TEST(toml, deserialize_address)
+TEST (toml, deserialize_address)
 {
 	nano::node_config node_config;
 	std::vector<std::pair<std::string, uint16_t>> container, no_port_container;
 
-	node_config.deserialize_address ("dev-peer.org:999", container);
-	node_config.deserialize_address ("1.2.3.4:999", container);
-	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:999", container);
+	node_config.deserialize_address ("dev-peer.org:999", true, container);
+	node_config.deserialize_address ("1.2.3.4:999", true, container);
+	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:999", true, container);
 	ASSERT_EQ (container.size (), 3);
 
-	node_config.deserialize_address ("dev-peer.org", no_port_container);
-	node_config.deserialize_address ("1.2.3.4", no_port_container);
-	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", no_port_container);
+	node_config.deserialize_address ("dev-peer.org", true, no_port_container);
+	node_config.deserialize_address ("1.2.3.4", true, no_port_container);
+	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", true, no_port_container);
 	ASSERT_TRUE (no_port_container.empty ());
 }

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -985,6 +985,8 @@ TEST (toml, deserialize_address)
 	node_config.deserialize_address ("dev-peer.org", false, no_port_container);
 	node_config.deserialize_address ("1.2.3.4", false, no_port_container);
 	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", false, no_port_container);
-	ASSERT_EQ (no_port_container.size (), 3);
-	ASSERT_EQ (container.at (2).first, "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
+	node_config.deserialize_address ("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210", false, no_port_container);
+	ASSERT_EQ (no_port_container.size (), 4);
+	ASSERT_EQ (no_port_container.at (2).first, "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
+	ASSERT_EQ (no_port_container.at (3).first, "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
 }

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -969,6 +969,7 @@ TEST (toml, deserialize_address)
 	nano::node_config node_config;
 	std::vector<std::pair<std::string, uint16_t>> container, no_port_container;
 
+	//Port required
 	node_config.deserialize_address ("dev-peer.org:999", true, container);
 	node_config.deserialize_address ("1.2.3.4:999", true, container);
 	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:999", true, container);
@@ -978,4 +979,10 @@ TEST (toml, deserialize_address)
 	node_config.deserialize_address ("1.2.3.4", true, no_port_container);
 	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", true, no_port_container);
 	ASSERT_TRUE (no_port_container.empty ());
+
+	//Port not required
+	node_config.deserialize_address ("dev-peer.org", false, no_port_container);
+	node_config.deserialize_address ("1.2.3.4", false, no_port_container);
+	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", false, no_port_container);
+	ASSERT_EQ (no_port_container.size (), 3);
 }

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -71,10 +71,11 @@ TEST (toml, daemon_config_update_array)
 	nano::tomlconfig t;
 	boost::filesystem::path data_path (".");
 	nano::daemon_config c{ data_path, nano::dev::network_params };
-	c.node.preconfigured_peers.push_back ("dev-peer.org");
+	c.node.preconfigured_peers.push_back (std::pair ("dev-peer.org", 999));
 	c.serialize_toml (t);
 	c.deserialize_toml (t);
-	ASSERT_EQ (c.node.preconfigured_peers[0], "dev-peer.org");
+	ASSERT_EQ (c.node.preconfigured_peers[0].first, "dev-peer.org");
+	ASSERT_EQ (c.node.preconfigured_peers[0].second, 999);
 }
 
 /** Empty rpc config file should match a default config object */
@@ -419,7 +420,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	password_fanout = 999
 	peering_port = 999
 	pow_sleep_interval= 999
-	preconfigured_peers = ["dev.org"]
+	preconfigured_peers = ["dev.org:999"]
 	preconfigured_representatives = ["nano_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4"]
 	receive_minimum = "999"
 	signature_checker_threads = 999

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -11,6 +11,7 @@
 #include <numeric>
 #include <sstream>
 #include <string>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -961,4 +962,20 @@ TEST (toml, tls_config_defaults)
 	ASSERT_EQ (conf.server_key_path, defaults.server_key_path);
 	ASSERT_EQ (conf.server_key_passphrase, defaults.server_key_passphrase);
 	ASSERT_EQ (conf.server_dh_path, defaults.server_dh_path);
+}
+
+TEST(toml, deserialize_address)
+{
+	nano::node_config node_config;
+	std::vector<std::pair<std::string, uint16_t>> container, no_port_container;
+
+	node_config.deserialize_address ("dev-peer.org:999", container);
+	node_config.deserialize_address ("1.2.3.4:999", container);
+	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:999", container);
+	ASSERT_EQ (container.size (), 3);
+
+	node_config.deserialize_address ("dev-peer.org", no_port_container);
+	node_config.deserialize_address ("1.2.3.4", no_port_container);
+	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", no_port_container);
+	ASSERT_TRUE (no_port_container.empty ());
 }

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -979,6 +979,7 @@ TEST (toml, deserialize_address)
 	node_config.deserialize_address ("dev-peer.org", true, no_port_container);
 	node_config.deserialize_address ("1.2.3.4", true, no_port_container);
 	node_config.deserialize_address ("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", true, no_port_container);
+	node_config.deserialize_address ("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210", true, no_port_container);
 	ASSERT_TRUE (no_port_container.empty ());
 
 	//Port not required

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -731,14 +731,14 @@ void nano::node::stop ()
 	// work pool is not stopped on purpose due to testing setup
 }
 
-void nano::node::keepalive_preconfigured (std::vector<std::string> const & peers_a)
+void nano::node::keepalive_preconfigured (std::vector<std::pair<std::string, uint16_t>> const & peers_a)
 {
 	for (auto i (peers_a.begin ()), n (peers_a.end ()); i != n; ++i)
 	{
 		// can't use `network.port` here because preconfigured peers are referenced
 		// just by their address, so we rely on them listening on the default port
 		//
-		keepalive (*i, network_params.network.default_node_port);
+		keepalive (i->first, i->second);
 	}
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -735,9 +735,6 @@ void nano::node::keepalive_preconfigured (std::vector<std::pair<std::string, uin
 {
 	for (auto i (peers_a.begin ()), n (peers_a.end ()); i != n; ++i)
 	{
-		// can't use `network.port` here because preconfigured peers are referenced
-		// just by their address, so we rely on them listening on the default port
-		//
 		keepalive (i->first, i->second);
 	}
 }

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -85,7 +85,7 @@ public:
 	void process_active (std::shared_ptr<nano::block> const &);
 	nano::process_return process_local (std::shared_ptr<nano::block> const &);
 	void process_local_async (std::shared_ptr<nano::block> const &);
-	void keepalive_preconfigured (std::vector<std::string> const &);
+	void keepalive_preconfigured (std::vector<std::pair<std::string, uint16_t>> const &);
 	std::shared_ptr<nano::block> block (nano::block_hash const &);
 	std::pair<nano::uint128_t, nano::uint128_t> balance_pending (nano::account const &, bool only_confirmed);
 	nano::uint128_t weight (nano::account const &);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -510,11 +510,14 @@ nano::frontiers_confirmation_mode nano::node_config::deserialize_frontiers_confi
 
 void nano::node_config::deserialize_address (std::string const & entry_a, std::vector<std::pair<std::string, uint16_t>> & container_a) const
 {
-	auto port_position (entry_a.rfind (':'));
+	// In case of IPv6 the format would be [address]:port, otherwise address:port.
+	const std::string separator = entry_a[0] == '[' ? "]:" : ":";
+
+	auto port_position (entry_a.rfind (separator));
 	bool result = (port_position == -1);
 	if (!result)
 	{
-		auto port_str (entry_a.substr (port_position + 1));
+		auto port_str (entry_a.substr (port_position + separator.length ()));
 		uint16_t port;
 		result |= parse_port (port_str, port);
 		if (!result)

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -523,7 +523,10 @@ void nano::node_config::deserialize_address (std::string const & entry_a, bool p
 		if (!is_ip_v6 && address.find (':') != -1)
 		{
 			//The whole entry_a is an IPv6 address without brackets.
-			container_a.emplace_back (entry_a, network_params.network.default_node_port);
+			if (!port_required)
+			{
+				container_a.emplace_back (entry_a, network_params.network.default_node_port);
+			}
 			return;
 		}
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -249,7 +249,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			work_peers.clear ();
 			toml.array_entries_required<std::string> ("work_peers", [this] (std::string const & entry_a) {
-				this->deserialize_address (entry_a, this->work_peers);
+				this->deserialize_address (entry_a, true, this->work_peers);
 			});
 		}
 
@@ -257,7 +257,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			preconfigured_peers.clear ();
 			toml.array_entries_required<std::string> (preconfigured_peers_key, [this] (std::string entry) {
-				this->deserialize_address (entry, this->preconfigured_peers); //TODO: Make port optional
+				this->deserialize_address (entry, false, this->preconfigured_peers);
 			});
 		}
 
@@ -410,7 +410,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 			{
 				secondary_work_peers.clear ();
 				experimental_config_l.array_entries_required<std::string> ("secondary_work_peers", [this] (std::string const & entry_a) {
-					this->deserialize_address (entry_a, this->secondary_work_peers);
+					this->deserialize_address (entry_a, true, this->secondary_work_peers);
 				});
 			}
 			auto max_pruning_age_l (max_pruning_age.count ());
@@ -508,7 +508,7 @@ nano::frontiers_confirmation_mode nano::node_config::deserialize_frontiers_confi
 	}
 }
 
-void nano::node_config::deserialize_address (std::string const & entry_a, std::vector<std::pair<std::string, uint16_t>> & container_a) const
+void nano::node_config::deserialize_address (std::string const & entry_a, bool port_required, std::vector<std::pair<std::string, uint16_t>> & container_a) const
 {
 	// In case of IPv6 the format would be [address]:port, otherwise address:port.
 	const std::string separator = entry_a[0] == '[' ? "]:" : ":";
@@ -525,6 +525,10 @@ void nano::node_config::deserialize_address (std::string const & entry_a, std::v
 			auto address (entry_a.substr (0, port_position));
 			container_a.emplace_back (address, port);
 		}
+	}
+	else if (!port_required)
+	{
+		container_a.emplace_back (entry_a, network_params.network.default_node_port);
 	}
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -511,7 +511,8 @@ nano::frontiers_confirmation_mode nano::node_config::deserialize_frontiers_confi
 void nano::node_config::deserialize_address (std::string const & entry_a, bool port_required, std::vector<std::pair<std::string, uint16_t>> & container_a) const
 {
 	// In case of IPv6 the format would be [address]:port, otherwise address:port.
-	const std::string separator = entry_a[0] == '[' ? "]:" : ":";
+	bool isIPv6 = entry_a[0] == '[';
+	const std::string separator = isIPv6 ? "]:" : ":";
 
 	auto port_position (entry_a.rfind (separator));
 	bool result = (port_position == -1);
@@ -522,13 +523,15 @@ void nano::node_config::deserialize_address (std::string const & entry_a, bool p
 		result |= parse_port (port_str, port);
 		if (!result)
 		{
-			auto address (entry_a.substr (0, port_position));
+			auto start_position = isIPv6 ? 1 : 0;
+			auto address (entry_a.substr (start_position, port_position - start_position));
 			container_a.emplace_back (address, port);
 		}
 	}
 	else if (!port_required)
 	{
-		container_a.emplace_back (entry_a, network_params.network.default_node_port);
+		auto address = isIPv6 ? entry_a.substr (1, entry_a.length () - 2) : entry_a;
+		container_a.emplace_back (address, network_params.network.default_node_port);
 	}
 }
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -117,7 +117,7 @@ public:
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;
 	nano::frontiers_confirmation_mode deserialize_frontiers_confirmation (std::string const &);
 	/** Entry is ignored if it cannot be parsed as a valid address:port */
-	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
+	void deserialize_address (std::string const &, bool port_required, std::vector<std::pair<std::string, uint16_t>> &) const;
 };
 
 class node_flags final

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -116,7 +116,7 @@ public:
 public:
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;
 	nano::frontiers_confirmation_mode deserialize_frontiers_confirmation (std::string const &);
-	/** Entry is ignored if it cannot be parsed as a valid address:port */
+	/** When `port_required` is true entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, bool port_required, std::vector<std::pair<std::string, uint16_t>> &) const;
 };
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -47,7 +47,7 @@ public:
 	nano::logging logging;
 	std::vector<std::pair<std::string, uint16_t>> work_peers;
 	std::vector<std::pair<std::string, uint16_t>> secondary_work_peers{ { "127.0.0.1", 8076 } }; /* Default of nano-pow-server */
-	std::vector<std::string> preconfigured_peers;
+	std::vector<std::pair<std::string, uint16_t>> preconfigured_peers;
 	std::vector<nano::account> preconfigured_representatives;
 	unsigned bootstrap_fraction_numerator{ 1 };
 	nano::amount receive_minimum{ nano::xrb_ratio };


### PR DESCRIPTION
Enable defining preconfigured_peers with port according to #3066 including IPv6 support.
The same method for parsing entries is used for work_peers with the difference that port is not required for preconfigured_peers to preserve backward compatibility.