### PR TITLE
Cleaning up stat counters for active_transactions.

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -646,7 +646,7 @@ TEST (active_transactions, dropped_cleanup)
 	ASSERT_FALSE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
 
 	// An election was recently dropped
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_all));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_dropped, nano::stat::detail::normal));
 
 	// Block cleared from active
 	ASSERT_FALSE (node.active.active (nano::dev::genesis->hash ()));
@@ -664,7 +664,7 @@ TEST (active_transactions, dropped_cleanup)
 	ASSERT_TRUE (node.network.publish_filter.apply (block_bytes.data (), block_bytes.size ()));
 
 	// Not dropped
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_all));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_dropped, nano::stat::detail::normal));
 
 	// Block cleared from active
 	ASSERT_FALSE (node.active.active (nano::dev::genesis->hash ()));
@@ -1403,7 +1403,7 @@ TEST (active_transactions, fifo)
 	ASSERT_TIMELY (5s, node.active.size () == 1);
 
 	// Ensure overflow stats have been incremented
-	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_overflow));
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_dropped, nano::stat::detail::normal));
 
 	// Ensure the surviving transaction is the least recently inserted
 	ASSERT_TIMELY (1s, node.active.election (receive2->qualified_root ()) != nullptr);
@@ -1471,7 +1471,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 	ASSERT_TIMELY (5s, nano::test::active (node, { open1 }));
 
 	// Ensure there was no overflow of elections
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::election, nano::stat::detail::election_drop_overflow));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::active_dropped, nano::stat::detail::normal));
 }
 
 /*

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -35,6 +35,10 @@ enum class type : uint8_t
 	blockprocessor,
 	bootstrap_server,
 	active,
+	active_started,
+	active_confirmed,
+	active_dropped,
+	active_timeout,
 	backlog,
 	unchecked,
 
@@ -142,23 +146,19 @@ enum class detail : uint8_t
 	vote_cached,
 	late_block,
 	late_block_seconds,
-	election_start,
-	election_confirmed_all,
 	election_block_conflict,
-	election_difficulty_update,
-	election_drop_expired,
-	election_drop_overflow,
-	election_drop_all,
 	election_restart,
-	election_confirmed,
 	election_not_confirmed,
 	election_hinted_overflow,
-	election_hinted_started,
 	election_hinted_confirmed,
 	election_hinted_drop,
 	generate_vote,
 	generate_vote_normal,
 	generate_vote_final,
+
+	// election types
+	normal,
+	hinted,
 
 	// received messages
 	invalid_header,
@@ -240,7 +240,6 @@ enum class detail : uint8_t
 	generator_spacing,
 
 	// hinting
-	hinted,
 	insert_failed,
 	missing_block,
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -202,6 +202,7 @@ private:
 	void erase (nano::qualified_root const &);
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
+	nano::stat::type completion_type (nano::election const & election) const;
 	// Returns a list of elections sorted by difficulty, mutex must be locked
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
 	/**

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -634,6 +634,24 @@ std::vector<nano::vote_with_weight_info> nano::election::votes_with_weight () co
 	return result;
 }
 
+nano::stat::detail nano::to_stat_detail (nano::election_behavior behavior)
+{
+	switch (behavior)
+	{
+		case nano::election_behavior::normal:
+		{
+			return nano::stat::detail::normal;
+		}
+		case nano::election_behavior::hinted:
+		{
+			return nano::stat::detail::hinted;
+		}
+	}
+
+	debug_assert (false, "unknown election behavior");
+	return {};
+}
+
 nano::election_behavior nano::election::behavior () const
 {
 	return behavior_m;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -49,6 +49,8 @@ enum class election_behavior
 	hinted
 };
 
+nano::stat::detail to_stat_detail (nano::election_behavior);
+
 struct election_extended_status final
 {
 	nano::election_status status;


### PR DESCRIPTION
The stat type active tracks:
  - active_started for each behavior
  - active_confirmed/active_timeout/active_dropped for each behavior.