### PR TITLE
Add stats for `election_scheduler`

### DIFF
--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -41,6 +41,7 @@ enum class type : uint8_t
 	active_timeout,
 	backlog,
 	unchecked,
+	election_scheduler,
 
 	_last // Must be the last enum
 };
@@ -263,6 +264,12 @@ enum class detail : uint8_t
 	put,
 	satisfied,
 	trigger,
+
+	// election scheduler
+	insert_manual,
+	insert_priority,
+	insert_priority_success,
+	erase_oldest,
 
 	_last // Must be the last enum
 };

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -19,7 +19,7 @@ class node;
 class election_scheduler final
 {
 public:
-	election_scheduler (nano::node &);
+	election_scheduler (nano::node &, nano::stats &);
 	~election_scheduler ();
 
 	void start ();
@@ -43,6 +43,7 @@ public:
 
 private: // Dependencies
 	nano::node & node;
+	nano::stats & stats;
 
 private:
 	void run ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -195,7 +195,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	generator{ config, ledger, wallets, vote_processor, history, network, stats, /* non-final */ false },
 	final_generator{ config, ledger, wallets, vote_processor, history, network, stats, /* final */ true },
 	active (*this, confirmation_height_processor),
-	scheduler{ *this },
+	scheduler{ *this, stats },
 	hinting{ nano::nodeconfig_to_hinted_scheduler_config (config), *this, inactive_vote_cache, active, online_reps, stats },
 	aggregator (config, stats, generator, final_generator, history, ledger, wallets, active),
 	wallets (wallets_store.init_error (), *this),


### PR DESCRIPTION
Tracking metrics is critical for understanding what's happening inside the node. This PR adds stats for `election_scheduler`.