### PR TITLE
Encapsulate handshake parts into `query_payload` and `response_payload`

### DIFF
--- a/nano/core_test/message_deserializer.cpp
+++ b/nano/core_test/message_deserializer.cpp
@@ -178,7 +178,7 @@ TEST (message_deserializer, exact_bulk_push)
 
 TEST (message_deserializer, exact_node_id_handshake)
 {
-	nano::node_id_handshake message{ nano::dev::network_params.network, boost::none, boost::none };
+	nano::node_id_handshake message{ nano::dev::network_params.network, std::nullopt, std::nullopt };
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -238,32 +238,6 @@ bool nano::message_header::frontier_req_is_only_confirmed_present () const
 	return result;
 }
 
-bool nano::message_header::node_id_handshake_is_query () const
-{
-	auto result (false);
-	if (type == nano::message_type::node_id_handshake)
-	{
-		if (extensions.test (node_id_handshake_query_flag))
-		{
-			result = true;
-		}
-	}
-	return result;
-}
-
-bool nano::message_header::node_id_handshake_is_response () const
-{
-	auto result (false);
-	if (type == nano::message_type::node_id_handshake)
-	{
-		if (extensions.test (node_id_handshake_response_flag))
-		{
-			result = true;
-		}
-	}
-	return result;
-}
-
 std::size_t nano::message_header::payload_length_bytes () const
 {
 	switch (type)
@@ -1626,11 +1600,11 @@ nano::node_id_handshake::node_id_handshake (nano::network_constants const & cons
 {
 	if (query)
 	{
-		header.flag_set (nano::message_header::node_id_handshake_query_flag);
+		header.flag_set (query_flag);
 	}
 	if (response)
 	{
-		header.flag_set (nano::message_header::node_id_handshake_response_flag);
+		header.flag_set (response_flag);
 	}
 }
 
@@ -1654,14 +1628,14 @@ bool nano::node_id_handshake::deserialize (nano::stream & stream_a)
 	auto error (false);
 	try
 	{
-		if (header.node_id_handshake_is_query ())
+		if (is_query (header))
 		{
 			nano::uint256_union query_hash;
 			read (stream_a, query_hash);
 			query = query_hash;
 		}
 
-		if (header.node_id_handshake_is_response ())
+		if (is_response (header))
 		{
 			nano::account response_account;
 			read (stream_a, response_account);
@@ -1678,9 +1652,23 @@ bool nano::node_id_handshake::deserialize (nano::stream & stream_a)
 	return error;
 }
 
+bool nano::node_id_handshake::is_query (nano::message_header const & header)
+{
+	debug_assert (header.type == nano::message_type::node_id_handshake);
+	bool result = header.extensions.test (query_flag);
+	return result;
+}
+
+bool nano::node_id_handshake::is_response (nano::message_header const & header)
+{
+	debug_assert (header.type == nano::message_type::node_id_handshake);
+	bool result = header.extensions.test (response_flag);
+	return result;
+}
+
 bool nano::node_id_handshake::operator== (nano::node_id_handshake const & other_a) const
 {
-	auto result (*query == *other_a.query && *response == *other_a.response);
+	bool result = (*query == *other_a.query && *response == *other_a.response);
 	return result;
 }
 
@@ -1694,14 +1682,14 @@ std::size_t nano::node_id_handshake::size () const
 	return size (header);
 }
 
-std::size_t nano::node_id_handshake::size (nano::message_header const & header_a)
+std::size_t nano::node_id_handshake::size (nano::message_header const & header)
 {
-	std::size_t result (0);
-	if (header_a.node_id_handshake_is_query ())
+	std::size_t result = 0;
+	if (is_query (header))
 	{
 		result = sizeof (nano::uint256_union);
 	}
-	if (header_a.node_id_handshake_is_response ())
+	if (is_response (header))
 	{
 		result += sizeof (nano::account) + sizeof (nano::signature);
 	}

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -1586,17 +1586,15 @@ bool nano::telemetry_data::validate_signature () const
  */
 
 nano::node_id_handshake::node_id_handshake (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
-	message (header_a),
-	query (boost::none),
-	response (boost::none)
+	message (header_a)
 {
 	error_a = deserialize (stream_a);
 }
 
-nano::node_id_handshake::node_id_handshake (nano::network_constants const & constants, boost::optional<nano::uint256_union> query, boost::optional<std::pair<nano::account, nano::signature>> response) :
+nano::node_id_handshake::node_id_handshake (nano::network_constants const & constants, std::optional<query_payload> query_a, std::optional<response_payload> response_a) :
 	message (constants, nano::message_type::node_id_handshake),
-	query (query),
-	response (response)
+	query{ query_a },
+	response{ response_a }
 {
 	if (query)
 	{
@@ -1608,47 +1606,43 @@ nano::node_id_handshake::node_id_handshake (nano::network_constants const & cons
 	}
 }
 
-void nano::node_id_handshake::serialize (nano::stream & stream_a) const
+void nano::node_id_handshake::serialize (nano::stream & stream) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream);
 	if (query)
 	{
-		write (stream_a, *query);
+		query->serialize (stream);
 	}
 	if (response)
 	{
-		write (stream_a, response->first);
-		write (stream_a, response->second);
+		response->serialize (stream);
 	}
 }
 
-bool nano::node_id_handshake::deserialize (nano::stream & stream_a)
+bool nano::node_id_handshake::deserialize (nano::stream & stream)
 {
 	debug_assert (header.type == nano::message_type::node_id_handshake);
-	auto error (false);
+	bool error = false;
 	try
 	{
 		if (is_query (header))
 		{
-			nano::uint256_union query_hash;
-			read (stream_a, query_hash);
-			query = query_hash;
+			query_payload pld{};
+			pld.deserialize (stream);
+			query = pld;
 		}
 
 		if (is_response (header))
 		{
-			nano::account response_account;
-			read (stream_a, response_account);
-			nano::signature response_signature;
-			read (stream_a, response_signature);
-			response = std::make_pair (response_account, response_signature);
+			response_payload pld{};
+			pld.deserialize (stream);
+			response = pld;
 		}
 	}
 	catch (std::runtime_error const &)
 	{
 		error = true;
 	}
-
 	return error;
 }
 
@@ -1663,12 +1657,6 @@ bool nano::node_id_handshake::is_response (nano::message_header const & header)
 {
 	debug_assert (header.type == nano::message_type::node_id_handshake);
 	bool result = header.extensions.test (response_flag);
-	return result;
-}
-
-bool nano::node_id_handshake::operator== (nano::node_id_handshake const & other_a) const
-{
-	bool result = (*query == *other_a.query && *response == *other_a.response);
 	return result;
 }
 
@@ -1687,11 +1675,11 @@ std::size_t nano::node_id_handshake::size (nano::message_header const & header)
 	std::size_t result = 0;
 	if (is_query (header))
 	{
-		result = sizeof (nano::uint256_union);
+		result += query_payload::size;
 	}
 	if (is_response (header))
 	{
-		result += sizeof (nano::account) + sizeof (nano::signature);
+		result += response_payload::size;
 	}
 	return result;
 }
@@ -1699,19 +1687,46 @@ std::size_t nano::node_id_handshake::size (nano::message_header const & header)
 std::string nano::node_id_handshake::to_string () const
 {
 	std::string s = header.to_string ();
-
-	if (query.has_value ())
+	if (query)
 	{
-		s += "\ncookie=" + query->to_string ();
+		s += "\ncookie=" + query->cookie.to_string ();
 	}
-
-	if (response.has_value ())
+	if (response)
 	{
-		s += "\nresp_node_id=" + response->first.to_string ();
-		s += "\nresp_sig=" + response->second.to_string ();
+		s += "\nresp_node_id=" + response->node_id.to_string ();
+		s += "\nresp_sig=" + response->signature.to_string ();
 	}
-
 	return s;
+}
+
+/*
+ * node_id_handshake::query_payload
+ */
+
+void nano::node_id_handshake::query_payload::serialize (nano::stream & stream) const
+{
+	nano::write (stream, cookie);
+}
+
+void nano::node_id_handshake::query_payload::deserialize (nano::stream & stream)
+{
+	nano::read (stream, cookie);
+}
+
+/*
+ * node_id_handshake::response_payload
+ */
+
+void nano::node_id_handshake::response_payload::serialize (nano::stream & stream) const
+{
+	nano::write (stream, node_id);
+	nano::write (stream, signature);
+}
+
+void nano::node_id_handshake::response_payload::deserialize (nano::stream & stream)
+{
+	nano::read (stream, node_id);
+	nano::read (stream, signature);
 }
 
 /*

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -81,10 +81,6 @@ public:
 	bool bulk_pull_ascending () const;
 	static uint8_t constexpr frontier_req_only_confirmed = 1;
 	bool frontier_req_is_only_confirmed_present () const;
-	static uint8_t constexpr node_id_handshake_query_flag = 0;
-	static uint8_t constexpr node_id_handshake_response_flag = 1;
-	bool node_id_handshake_is_query () const;
-	bool node_id_handshake_is_response () const;
 
 	/** Size of the payload in bytes. For some messages, the payload size is based on header flags. */
 	std::size_t payload_length_bytes () const;
@@ -363,6 +359,14 @@ public:
 	std::size_t size () const;
 	static std::size_t size (nano::message_header const &);
 	std::string to_string () const;
+
+public: // Header
+	static uint8_t constexpr query_flag = 0;
+	static uint8_t constexpr response_flag = 1;
+
+	static bool is_query (nano::message_header const &);
+	static bool is_response (nano::message_header const &);
+
 };
 
 /**

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -347,15 +347,40 @@ public:
 
 class node_id_handshake final : public message
 {
+public: // Payload definitions
+	class query_payload
+	{
+	public:
+		void serialize (nano::stream &) const;
+		void deserialize (nano::stream &);
+
+		static std::size_t constexpr size = sizeof (nano::uint256_union);
+
+	public:
+		nano::uint256_union cookie;
+	};
+
+	class response_payload
+	{
+	public:
+		void serialize (nano::stream &) const;
+		void deserialize (nano::stream &);
+
+		static std::size_t constexpr size = sizeof (nano::account) + sizeof (nano::signature);
+
+	public:
+		nano::account node_id;
+		nano::signature signature;
+	};
+
 public:
+	explicit node_id_handshake (nano::network_constants const &, std::optional<query_payload> query = std::nullopt, std::optional<response_payload> response = std::nullopt);
 	node_id_handshake (bool &, nano::stream &, nano::message_header const &);
-	node_id_handshake (nano::network_constants const & constants, boost::optional<nano::uint256_union>, boost::optional<std::pair<nano::account, nano::signature>>);
+
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
+
 	void visit (nano::message_visitor &) const override;
-	bool operator== (nano::node_id_handshake const &) const;
-	boost::optional<nano::uint256_union> query;
-	boost::optional<std::pair<nano::account, nano::signature>> response;
 	std::size_t size () const;
 	static std::size_t size (nano::message_header const &);
 	std::string to_string () const;
@@ -367,6 +392,9 @@ public: // Header
 	static bool is_query (nano::message_header const &);
 	static bool is_response (nano::message_header const &);
 
+public: // Payload
+	std::optional<query_payload> query;
+	std::optional<response_payload> response;
 };
 
 /**

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -35,8 +35,8 @@ private:
 	friend class network_tcp_message_manager_Test;
 };
 /**
-  * Node ID cookies for node ID handshakes
-*/
+ * Node ID cookies for node ID handshakes
+ */
 class syn_cookies final
 {
 public:
@@ -87,7 +87,7 @@ public:
 	void merge_peer (nano::endpoint const &);
 	void send_keepalive (std::shared_ptr<nano::transport::channel> const &);
 	void send_keepalive_self (std::shared_ptr<nano::transport::channel> const &);
-	void send_node_id_handshake (std::shared_ptr<nano::transport::channel> const &, boost::optional<nano::uint256_union> const & query, boost::optional<nano::uint256_union> const & respond_to);
+	void send_node_id_handshake (std::shared_ptr<nano::transport::channel> const &, std::optional<nano::uint256_union> const & cookie, std::optional<nano::uint256_union> const & respond_to);
 	void send_confirm_req (std::shared_ptr<nano::transport::channel> const & channel_a, std::pair<nano::block_hash, nano::block_hash> const & hash_root_a);
 	void broadcast_confirm_req (std::shared_ptr<nano::block> const &);
 	void broadcast_confirm_req_base (std::shared_ptr<nano::block> const &, std::shared_ptr<std::vector<std::shared_ptr<nano::transport::channel>>> const &, unsigned, bool = false);

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -52,8 +52,6 @@ public:
 
 	void timeout ();
 
-	void send_handshake_response (nano::uint256_union query);
-
 	std::shared_ptr<nano::transport::socket> const socket;
 	std::shared_ptr<nano::node> const node;
 	nano::mutex mutex;
@@ -65,6 +63,8 @@ public:
 	std::chrono::steady_clock::time_point last_telemetry_req{};
 
 private:
+	void send_handshake_response (nano::node_id_handshake::query_payload const & query);
+
 	void receive_message ();
 	void received_message (std::unique_ptr<nano::message> message);
 	bool process_message (std::unique_ptr<nano::message> message);


### PR DESCRIPTION
Non-functional change that encapsulates two handshake message payloads into separate classes, with the goal of making the logic easier to work with when introducing upgraded handshake message versions.