### PR TITLE
Decouple message deserializer from the TCP socket

### DIFF
--- a/nano/node/transport/message_deserializer.cpp
+++ b/nano/node/transport/message_deserializer.cpp
@@ -1,12 +1,14 @@
 #include <nano/node/node.hpp>
 #include <nano/node/transport/message_deserializer.hpp>
 
-nano::transport::message_deserializer::message_deserializer (nano::network_constants const & network_constants_a, nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a) :
+nano::transport::message_deserializer::message_deserializer (nano::network_constants const & network_constants_a, nano::network_filter & publish_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a,
+channel_read_fn_type channel_read_fn_a) :
 	read_buffer{ std::make_shared<std::vector<uint8_t>> () },
 	network_constants_m{ network_constants_a },
 	publish_filter_m{ publish_filter_a },
 	block_uniquer_m{ block_uniquer_a },
-	vote_uniquer_m{ vote_uniquer_a }
+	vote_uniquer_m{ vote_uniquer_a },
+	channel_read_fn{ std::move (channel_read_fn_a) }
 {
 	read_buffer->resize (MAX_MESSAGE_SIZE);
 }
@@ -17,11 +19,7 @@ void nano::transport::message_deserializer::read (std::shared_ptr<nano::transpor
 
 	status = parse_status::none;
 
-	// Increase timeout to receive TCP header (idle server socket)
-	auto prev_timeout = socket->get_default_timeout_value ();
-	socket->set_default_timeout_value (network_constants_m.idle_timeout);
-
-	socket->async_read (read_buffer, HEADER_SIZE, [this_l = shared_from_this (), socket, callback = std::move (callback), prev_timeout] (boost::system::error_code const & ec, std::size_t size_a) {
+	channel_read_fn (read_buffer, HEADER_SIZE, [this_l = shared_from_this (), socket, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (ec)
 		{
 			callback (ec, nullptr);
@@ -32,10 +30,6 @@ void nano::transport::message_deserializer::read (std::shared_ptr<nano::transpor
 			callback (boost::asio::error::fault, nullptr);
 			return;
 		}
-
-		// Decrease timeout to default
-		socket->set_default_timeout_value (prev_timeout);
-
 		this_l->received_header (socket, std::move (callback));
 	});
 }
@@ -86,7 +80,7 @@ void nano::transport::message_deserializer::received_header (std::shared_ptr<nan
 	}
 	else
 	{
-		socket->async_read (read_buffer, payload_size, [this_l = shared_from_this (), payload_size, header, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
+		channel_read_fn (read_buffer, payload_size, [this_l = shared_from_this (), payload_size, header, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
 			if (ec)
 			{
 				callback (ec, nullptr);

--- a/nano/node/transport/message_deserializer.cpp
+++ b/nano/node/transport/message_deserializer.cpp
@@ -13,13 +13,13 @@ channel_read_fn_type channel_read_fn_a) :
 	read_buffer->resize (MAX_MESSAGE_SIZE);
 }
 
-void nano::transport::message_deserializer::read (std::shared_ptr<nano::transport::socket> socket, const nano::transport::message_deserializer::callback_type && callback)
+void nano::transport::message_deserializer::read (const nano::transport::message_deserializer::callback_type && callback)
 {
 	debug_assert (callback);
 
 	status = parse_status::none;
 
-	channel_read_fn (read_buffer, HEADER_SIZE, [this_l = shared_from_this (), socket, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
+	channel_read_fn (read_buffer, HEADER_SIZE, [this_l = shared_from_this (), callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (ec)
 		{
 			callback (ec, nullptr);
@@ -30,11 +30,11 @@ void nano::transport::message_deserializer::read (std::shared_ptr<nano::transpor
 			callback (boost::asio::error::fault, nullptr);
 			return;
 		}
-		this_l->received_header (socket, std::move (callback));
+		this_l->received_header (std::move (callback));
 	});
 }
 
-void nano::transport::message_deserializer::received_header (std::shared_ptr<nano::transport::socket> socket, const nano::transport::message_deserializer::callback_type && callback)
+void nano::transport::message_deserializer::received_header (const nano::transport::message_deserializer::callback_type && callback)
 {
 	nano::bufferstream stream{ read_buffer->data (), HEADER_SIZE };
 	auto error = false;

--- a/nano/node/transport/message_deserializer.cpp
+++ b/nano/node/transport/message_deserializer.cpp
@@ -21,7 +21,6 @@ void nano::transport::message_deserializer::read (const nano::transport::message
 
 	status = parse_status::none;
 
-
 	read_op (read_buffer, HEADER_SIZE, [this_l = shared_from_this (), callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (ec)
 		{

--- a/nano/node/transport/message_deserializer.cpp
+++ b/nano/node/transport/message_deserializer.cpp
@@ -19,6 +19,10 @@ void nano::transport::message_deserializer::read (const nano::transport::message
 
 	status = parse_status::none;
 
+	if (!channel_read_fn)
+	{
+		return;
+	}
 	channel_read_fn (read_buffer, HEADER_SIZE, [this_l = shared_from_this (), callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
 		if (ec)
 		{
@@ -80,6 +84,7 @@ void nano::transport::message_deserializer::received_header (const nano::transpo
 	}
 	else
 	{
+		debug_assert (channel_read_fn);
 		channel_read_fn (read_buffer, payload_size, [this_l = shared_from_this (), payload_size, header, callback = std::move (callback)] (boost::system::error_code const & ec, std::size_t size_a) {
 			if (ec)
 			{

--- a/nano/node/transport/message_deserializer.hpp
+++ b/nano/node/transport/message_deserializer.hpp
@@ -45,10 +45,11 @@ namespace transport
 
 		parse_status status;
 
-		message_deserializer (network_constants const &, network_filter &, block_uniquer &, vote_uniquer &);
+		using channel_read_fn_type = std::function<void (std::shared_ptr<std::vector<uint8_t>> const &, size_t, std::function<void (boost::system::error_code const &, std::size_t)>)>;
+		message_deserializer (network_constants const &, network_filter &, block_uniquer &, vote_uniquer &, channel_read_fn_type);
 
 		/*
-		 * Asynchronously read next message from socket.
+		 * Asynchronously read next message from the channel_read_fn.
 		 * If an irrecoverable error is encountered callback will be called with an error code set and null message.
 		 * If a 'soft' error is encountered (eg. duplicate block publish) error won't be set but message will be null. In that case, `status` field will be set to code indicating reason for failure.
 		 * If message is received successfully, error code won't be set and message will be non-null. `status` field will be set to `success`.
@@ -90,6 +91,7 @@ namespace transport
 		nano::network_filter & publish_filter_m;
 		nano::block_uniquer & block_uniquer_m;
 		nano::vote_uniquer & vote_uniquer_m;
+		channel_read_fn_type channel_read_fn;
 
 	public:
 		static stat::detail to_stat_detail (parse_status);

--- a/nano/node/transport/message_deserializer.hpp
+++ b/nano/node/transport/message_deserializer.hpp
@@ -42,8 +42,8 @@ namespace transport
 
 		parse_status status;
 
-		using channel_read_fn_type = std::function<void (std::shared_ptr<std::vector<uint8_t>> const &, size_t, std::function<void (boost::system::error_code const &, std::size_t)>)>;
-		message_deserializer (network_constants const &, network_filter &, block_uniquer &, vote_uniquer &, channel_read_fn_type);
+		using read_query = std::function<void (std::shared_ptr<std::vector<uint8_t>> const &, size_t, std::function<void (boost::system::error_code const &, std::size_t)>)>;
+		message_deserializer (network_constants const &, network_filter &, block_uniquer &, vote_uniquer &, read_query read_op);
 
 		/*
 		 * Asynchronously read next message from the channel_read_fn.
@@ -88,7 +88,7 @@ namespace transport
 		nano::network_filter & publish_filter_m;
 		nano::block_uniquer & block_uniquer_m;
 		nano::vote_uniquer & vote_uniquer_m;
-		channel_read_fn_type channel_read_fn;
+		read_query read_op;
 
 	public:
 		static stat::detail to_stat_detail (parse_status);

--- a/nano/node/transport/message_deserializer.hpp
+++ b/nano/node/transport/message_deserializer.hpp
@@ -2,15 +2,12 @@
 
 #include <nano/node/common.hpp>
 #include <nano/node/messages.hpp>
-#include <nano/node/transport/socket.hpp>
 
 #include <memory>
 #include <vector>
 
 namespace nano
 {
-class socket;
-
 namespace transport
 {
 	class message_deserializer : public std::enable_shared_from_this<nano::transport::message_deserializer>
@@ -55,10 +52,10 @@ namespace transport
 		 * If message is received successfully, error code won't be set and message will be non-null. `status` field will be set to `success`.
 		 * Should not be called until the previous invocation finishes and calls the callback.
 		 */
-		void read (std::shared_ptr<nano::transport::socket> socket, callback_type const && callback);
+		void read (callback_type const && callback);
 
 	private:
-		void received_header (std::shared_ptr<nano::transport::socket> socket, callback_type const && callback);
+		void received_header (callback_type const && callback);
 		void received_message (nano::message_header header, std::size_t payload_size, callback_type const && callback);
 
 		/*

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -243,6 +243,17 @@ void nano::transport::socket::checkup ()
 	});
 }
 
+void nano::transport::socket::read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a)
+{
+	// Increase timeout to receive TCP header (idle server socket)
+	auto const prev_timeout = get_default_timeout_value ();
+	set_default_timeout_value (node.network_params.network.idle_timeout);
+	async_read (data_a, size_a, [callback_l = std::move (callback_a), prev_timeout, this] (boost::system::error_code const & ec_a, std::size_t size_a) {
+	set_default_timeout_value (prev_timeout);
+		callback_l (ec_a, size_a);
+	});
+}
+
 bool nano::transport::socket::has_timed_out () const
 {
 	return timed_out;

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -248,8 +248,8 @@ void nano::transport::socket::read_impl (std::shared_ptr<std::vector<uint8_t>> c
 	// Increase timeout to receive TCP header (idle server socket)
 	auto const prev_timeout = get_default_timeout_value ();
 	set_default_timeout_value (node.network_params.network.idle_timeout);
-	async_read (data_a, size_a, [callback_l = std::move (callback_a), prev_timeout, this] (boost::system::error_code const & ec_a, std::size_t size_a) {
-	set_default_timeout_value (prev_timeout);
+	async_read (data_a, size_a, [callback_l = std::move (callback_a), prev_timeout, this_l = shared_from_this ()] (boost::system::error_code const & ec_a, std::size_t size_a) {
+		this_l->set_default_timeout_value (prev_timeout);
 		callback_l (ec_a, size_a);
 	});
 }

--- a/nano/node/transport/socket.hpp
+++ b/nano/node/transport/socket.hpp
@@ -38,6 +38,7 @@ class server_socket;
 class socket : public std::enable_shared_from_this<nano::transport::socket>
 {
 	friend class server_socket;
+	friend class tcp_server;
 
 public:
 	enum class type_t
@@ -171,6 +172,7 @@ protected:
 	void set_last_completion ();
 	void set_last_receive_time ();
 	void checkup ();
+	void read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a);
 
 private:
 	type_t type_m{ type_t::undefined };

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -125,7 +125,18 @@ nano::transport::tcp_server::tcp_server (std::shared_ptr<nano::transport::socket
 	socket{ std::move (socket_a) },
 	node{ std::move (node_a) },
 	allow_bootstrap{ allow_bootstrap_a },
-	message_deserializer{ std::make_shared<nano::transport::message_deserializer> (node->network_params.network, node->network.publish_filter, node->block_uniquer, node->vote_uniquer) }
+	message_deserializer{
+		std::make_shared<nano::transport::message_deserializer> (node->network_params.network, node->network.publish_filter, node->block_uniquer, node->vote_uniquer,
+		[this] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
+			// Increase timeout to receive TCP header (idle server socket)
+			auto const prev_timeout = socket->get_default_timeout_value ();
+			socket->set_default_timeout_value (node->network_params.network.idle_timeout);
+			socket->async_read (data_a, size_a, [callback_l = std::move (callback_a), prev_timeout, this] (boost::system::error_code const & ec_a, std::size_t size_a) {
+				socket->set_default_timeout_value (prev_timeout);
+				callback_l (ec_a, size_a);
+			});
+		})
+	}
 {
 	debug_assert (socket != nullptr);
 }

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -128,13 +128,7 @@ nano::transport::tcp_server::tcp_server (std::shared_ptr<nano::transport::socket
 	message_deserializer{
 		std::make_shared<nano::transport::message_deserializer> (node->network_params.network, node->network.publish_filter, node->block_uniquer, node->vote_uniquer,
 		[this] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
-			// Increase timeout to receive TCP header (idle server socket)
-			auto const prev_timeout = socket->get_default_timeout_value ();
-			socket->set_default_timeout_value (node->network_params.network.idle_timeout);
-			socket->async_read (data_a, size_a, [callback_l = std::move (callback_a), prev_timeout, this] (boost::system::error_code const & ec_a, std::size_t size_a) {
-				socket->set_default_timeout_value (prev_timeout);
-				callback_l (ec_a, size_a);
-			});
+			socket->read_impl (data_a, size_a, callback_a);
 		})
 	}
 {

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -129,8 +129,9 @@ nano::transport::tcp_server::tcp_server (std::shared_ptr<nano::transport::socket
 	allow_bootstrap{ allow_bootstrap_a },
 	message_deserializer{
 		std::make_shared<nano::transport::message_deserializer> (node->network_params.network, node->network.publish_filter, node->block_uniquer, node->vote_uniquer,
-		[this_l = shared_from_this ()] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
-			this_l->socket->read_impl (data_a, size_a, callback_a);
+		[socket_l = socket] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
+			debug_assert (socket_l != nullptr);
+			socket_l->read_impl (data_a, size_a, callback_a);
 		})
 	}
 {

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -197,7 +197,7 @@ void nano::transport::tcp_server::receive_message ()
 		return;
 	}
 
-	message_deserializer->read (socket, [this_l = shared_from_this ()] (boost::system::error_code ec, std::unique_ptr<nano::message> message) {
+	message_deserializer->read ([this_l = shared_from_this ()] (boost::system::error_code ec, std::unique_ptr<nano::message> message) {
 		if (ec)
 		{
 			// IO error or critical error when deserializing message

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -8,6 +8,8 @@
 
 #include <boost/format.hpp>
 
+#include <memory>
+
 nano::transport::tcp_listener::tcp_listener (uint16_t port_a, nano::node & node_a) :
 	node (node_a),
 	port (port_a)
@@ -127,8 +129,8 @@ nano::transport::tcp_server::tcp_server (std::shared_ptr<nano::transport::socket
 	allow_bootstrap{ allow_bootstrap_a },
 	message_deserializer{
 		std::make_shared<nano::transport::message_deserializer> (node->network_params.network, node->network.publish_filter, node->block_uniquer, node->vote_uniquer,
-		[this] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
-			socket->read_impl (data_a, size_a, callback_a);
+		[this_l = shared_from_this ()] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
+			this_l->socket->read_impl (data_a, size_a, callback_a);
 		})
 	}
 {


### PR DESCRIPTION
The message deserializer should not know about any socket class. If so, it would be bound to a specific channel implementation. Replaced this dependency by a function that reads and provides the required data. Modified the inproc channel to use the message deserializer instead of the old message parser, that will be removed.