### PR TITLE
Internally check if the block processor needs to drop blocks.

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -97,6 +97,11 @@ void nano::block_processor::add (std::shared_ptr<nano::block> const & block_a)
 
 void nano::block_processor::add (nano::unchecked_info const & info_a)
 {
+	if (full ())
+	{
+		node.stats.inc (nano::stat::type::blockprocessor, nano::stat::detail::drop);
+		return;
+	}
 	auto const & block = info_a.block;
 	debug_assert (!node.network_params.work.validate_entry (*block));
 	if (block->type () == nano::block_type::state || block->type () == nano::block_type::open)
@@ -115,6 +120,11 @@ void nano::block_processor::add (nano::unchecked_info const & info_a)
 
 void nano::block_processor::add_local (nano::unchecked_info const & info_a)
 {
+	if (full ())
+	{
+		node.stats.inc (nano::stat::type::blockprocessor, nano::stat::detail::drop);
+		return;
+	}
 	debug_assert (!node.network_params.work.validate_entry (*info_a.block));
 	state_block_signature_verification.add ({ info_a.block });
 }


### PR DESCRIPTION
Internally check if the block processor needs to drop blocks, rather than making it a requirement of the caller.

Adds a stat counter when the block_processor drops a block as this is new behavior.