### PR TITLE
Lowering block_processor max transaction duration

### DIFF
--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -82,7 +82,7 @@ public:
 	nano::ipc::ipc_config ipc_config;
 	std::string external_address;
 	uint16_t external_port{ 0 };
-	std::chrono::milliseconds block_processor_batch_max_time{ network_params.network.is_dev_network () ? std::chrono::milliseconds (500) : std::chrono::milliseconds (5000) };
+	std::chrono::milliseconds block_processor_batch_max_time{ std::chrono::milliseconds (500) };
 	std::chrono::seconds unchecked_cutoff_time{ std::chrono::seconds (4 * 60 * 60) }; // 4 hours
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_dev_network () && !is_sanitizer_build ()) ? std::chrono::seconds (5) : std::chrono::seconds (15) };


### PR DESCRIPTION
Lowering block_processor max transaction duration to 500ms from 5s. This increases write transaction availability at the expense of slightly lower throughput.