### PR TITLE
Handshake V2

### DIFF
--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -509,7 +509,8 @@ TEST (telemetry, ongoing_broadcasts)
 	ASSERT_TIMELY (5s, node2.stats.count (nano::stat::type::telemetry, nano::stat::detail::process) >= 3)
 }
 
-TEST (telemetry, mismatched_genesis)
+// TODO: With handshake V2, nodes with mismatched genesis will refuse to connect while setting up the system
+TEST (telemetry, DISABLED_mismatched_genesis)
 {
 	// Only second node will broadcast telemetry
 	nano::test::system system;

--- a/nano/crypto_lib/random_pool.hpp
+++ b/nano/crypto_lib/random_pool.hpp
@@ -19,6 +19,22 @@ public:
 	static uint64_t generate_word64 (uint64_t min, uint64_t max);
 	static unsigned char generate_byte ();
 
+	/** Fills variable with random data */
+	template <class T>
+	static void generate (T & out)
+	{
+		generate_block (reinterpret_cast<uint8_t *> (&out), sizeof (T));
+	}
+	/** Returns variable with random data */
+	template <class T>
+	static T generate ()
+	{
+		T t;
+		generate (t);
+		return t;
+	}
+
+public:
 	random_pool () = delete;
 	random_pool (random_pool const &) = delete;
 	random_pool & operator= (random_pool const &) = delete;

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -43,6 +43,7 @@ enum class type : uint8_t
 	unchecked,
 	election_scheduler,
 	optimistic_scheduler,
+	handshake,
 
 	_last // Must be the last enum
 };
@@ -53,6 +54,7 @@ enum class detail : uint8_t
 	all = 0,
 
 	// common
+	ok,
 	loop,
 	total,
 	process,
@@ -272,6 +274,11 @@ enum class detail : uint8_t
 	insert_priority,
 	insert_priority_success,
 	erase_oldest,
+
+	// handshake
+	invalid_node_id,
+	missing_cookie,
+	invalid_genesis,
 
 	_last // Must be the last enum
 };

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -192,11 +192,11 @@ void nano::message_header::count_set (uint8_t count_a)
 	extensions |= std::bitset<16> (static_cast<unsigned long long> (count_a) << 12);
 }
 
-void nano::message_header::flag_set (uint8_t flag_a)
+void nano::message_header::flag_set (uint8_t flag_a, bool enable)
 {
 	// Flags from 8 are block_type & count
 	debug_assert (flag_a < 8);
-	extensions.set (flag_a, true);
+	extensions.set (flag_a, enable);
 }
 
 bool nano::message_header::bulk_pull_is_count_present () const
@@ -1599,10 +1599,12 @@ nano::node_id_handshake::node_id_handshake (nano::network_constants const & cons
 	if (query)
 	{
 		header.flag_set (query_flag);
+		header.flag_set (v2_flag); // Always indicate support for V2 handshake when querying, old peers will just ignore it
 	}
 	if (response)
 	{
 		header.flag_set (response_flag);
+		header.flag_set (v2_flag, response->v2.has_value ()); // We only use V2 handshake when replying to peers that indicated support for it
 	}
 }
 
@@ -1635,7 +1637,7 @@ bool nano::node_id_handshake::deserialize (nano::stream & stream)
 		if (is_response (header))
 		{
 			response_payload pld{};
-			pld.deserialize (stream);
+			pld.deserialize (stream, header);
 			response = pld;
 		}
 	}
@@ -1660,6 +1662,18 @@ bool nano::node_id_handshake::is_response (nano::message_header const & header)
 	return result;
 }
 
+bool nano::node_id_handshake::is_v2 (nano::message_header const & header)
+{
+	debug_assert (header.type == nano::message_type::node_id_handshake);
+	bool result = header.extensions.test (v2_flag);
+	return result;
+}
+
+bool nano::node_id_handshake::is_v2 () const
+{
+	return is_v2 (header);
+}
+
 void nano::node_id_handshake::visit (nano::message_visitor & visitor_a) const
 {
 	visitor_a.node_id_handshake (*this);
@@ -1679,7 +1693,7 @@ std::size_t nano::node_id_handshake::size (nano::message_header const & header)
 	}
 	if (is_response (header))
 	{
-		result += response_payload::size;
+		result += response_payload::size (header);
 	}
 	return result;
 }
@@ -1719,14 +1733,81 @@ void nano::node_id_handshake::query_payload::deserialize (nano::stream & stream)
 
 void nano::node_id_handshake::response_payload::serialize (nano::stream & stream) const
 {
-	nano::write (stream, node_id);
-	nano::write (stream, signature);
+	if (v2)
+	{
+		nano::write (stream, node_id);
+		nano::write (stream, v2->salt);
+		nano::write (stream, v2->genesis);
+		nano::write (stream, signature);
+	}
+	// TODO: Remove legacy handshake
+	else
+	{
+		nano::write (stream, node_id);
+		nano::write (stream, signature);
+	}
 }
 
-void nano::node_id_handshake::response_payload::deserialize (nano::stream & stream)
+void nano::node_id_handshake::response_payload::deserialize (nano::stream & stream, nano::message_header const & header)
 {
-	nano::read (stream, node_id);
-	nano::read (stream, signature);
+	if (is_v2 (header))
+	{
+		nano::read (stream, node_id);
+		v2_payload pld{};
+		nano::read (stream, pld.salt);
+		nano::read (stream, pld.genesis);
+		v2 = pld;
+		nano::read (stream, signature);
+	}
+	else
+	{
+		nano::read (stream, node_id);
+		nano::read (stream, signature);
+	}
+}
+
+std::size_t nano::node_id_handshake::response_payload::size (const nano::message_header & header)
+{
+	return is_v2 (header) ? size_v2 : size_v1;
+}
+
+std::vector<uint8_t> nano::node_id_handshake::response_payload::data_to_sign (const nano::uint256_union & cookie) const
+{
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+
+		if (v2)
+		{
+			nano::write (stream, cookie);
+			nano::write (stream, v2->salt);
+			nano::write (stream, v2->genesis);
+		}
+		// TODO: Remove legacy handshake
+		else
+		{
+			nano::write (stream, cookie);
+		}
+	}
+	return bytes;
+}
+
+void nano::node_id_handshake::response_payload::sign (const nano::uint256_union & cookie, nano::keypair const & key)
+{
+	debug_assert (key.pub == node_id);
+	auto data = data_to_sign (cookie);
+	signature = nano::sign_message (key.prv, key.pub, data.data (), data.size ());
+	debug_assert (validate (cookie));
+}
+
+bool nano::node_id_handshake::response_payload::validate (const nano::uint256_union & cookie) const
+{
+	auto data = data_to_sign (cookie);
+	if (nano::validate_message (node_id, data.data (), data.size (), signature)) // true => error
+	{
+		return false; // Fail
+	}
+	return true; // OK
 }
 
 /*

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -74,7 +74,7 @@ public:
 	std::bitset<16> extensions;
 	static std::size_t constexpr size = sizeof (nano::networks) + sizeof (version_max) + sizeof (version_using) + sizeof (version_min) + sizeof (type) + sizeof (/* extensions */ uint16_t);
 
-	void flag_set (uint8_t);
+	void flag_set (uint8_t, bool enable = true);
 	static uint8_t constexpr bulk_pull_count_present_flag = 0;
 	static uint8_t constexpr bulk_pull_ascending_flag = 1;
 	bool bulk_pull_is_count_present () const;
@@ -364,13 +364,30 @@ public: // Payload definitions
 	{
 	public:
 		void serialize (nano::stream &) const;
-		void deserialize (nano::stream &);
+		void deserialize (nano::stream &, nano::message_header const &);
 
-		static std::size_t constexpr size = sizeof (nano::account) + sizeof (nano::signature);
+		void sign (nano::uint256_union const & cookie, nano::keypair const &);
+		bool validate (nano::uint256_union const & cookie) const;
+
+	private:
+		std::vector<uint8_t> data_to_sign (nano::uint256_union const & cookie) const;
+
+	public:
+		struct v2_payload
+		{
+			nano::uint256_union salt;
+			nano::block_hash genesis;
+		};
 
 	public:
 		nano::account node_id;
 		nano::signature signature;
+		std::optional<v2_payload> v2;
+
+	public:
+		static std::size_t constexpr size_v1 = sizeof (nano::account) + sizeof (nano::signature);
+		static std::size_t constexpr size_v2 = sizeof (nano::account) + sizeof (nano::signature) + sizeof (v2_payload);
+		static std::size_t size (nano::message_header const &);
 	};
 
 public:
@@ -388,9 +405,12 @@ public:
 public: // Header
 	static uint8_t constexpr query_flag = 0;
 	static uint8_t constexpr response_flag = 1;
+	static uint8_t constexpr v2_flag = 2;
 
 	static bool is_query (nano::message_header const &);
 	static bool is_response (nano::message_header const &);
+	static bool is_v2 (nano::message_header const &);
+	bool is_v2 () const;
 
 public: // Payload
 	std::optional<query_payload> query;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -810,6 +810,10 @@ void nano::tcp_message_manager::stop ()
 	producer_condition.notify_all ();
 }
 
+/*
+ * syn_cookies
+ */
+
 nano::syn_cookies::syn_cookies (std::size_t max_cookies_per_ip_a) :
 	max_cookies_per_ip (max_cookies_per_ip_a)
 {
@@ -886,6 +890,30 @@ void nano::syn_cookies::purge (std::chrono::steady_clock::time_point const & cut
 			++it;
 		}
 	}
+}
+
+std::optional<nano::uint256_union> nano::syn_cookies::cookie (const nano::endpoint & endpoint_a)
+{
+	auto ip_addr (endpoint_a.address ());
+	debug_assert (ip_addr.is_v6 ());
+	nano::lock_guard<nano::mutex> lock{ syn_cookie_mutex };
+	auto cookie_it (cookies.find (endpoint_a));
+	if (cookie_it != cookies.end ())
+	{
+		auto cookie = cookie_it->second.cookie;
+		cookies.erase (cookie_it);
+		unsigned & ip_cookies = cookies_per_ip[ip_addr];
+		if (ip_cookies > 0)
+		{
+			--ip_cookies;
+		}
+		else
+		{
+			debug_assert (false && "More SYN cookies deleted than created for IP");
+		}
+		return cookie;
+	}
+	return std::nullopt;
 }
 
 std::size_t nano::syn_cookies::cookies_size ()

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -759,6 +759,68 @@ void nano::network::exclude (std::shared_ptr<nano::transport::channel> const & c
 	erase (*channel);
 }
 
+bool nano::network::verify_handshake_response (const nano::node_id_handshake::response_payload & response, const nano::endpoint & remote_endpoint)
+{
+	// Prevent connection with ourselves
+	if (response.node_id == node.node_id.pub)
+	{
+		node.stats.inc (nano::stat::type::handshake, nano::stat::detail::invalid_node_id);
+		return false; // Fail
+	}
+
+	// Prevent mismatched genesis
+	if (response.v2 && response.v2->genesis != node.network_params.ledger.genesis->hash ())
+	{
+		node.stats.inc (nano::stat::type::handshake, nano::stat::detail::invalid_genesis);
+		return false; // Fail
+	}
+
+	auto cookie = syn_cookies.cookie (remote_endpoint);
+	if (!cookie)
+	{
+		node.stats.inc (nano::stat::type::handshake, nano::stat::detail::missing_cookie);
+		return false; // Fail
+	}
+
+	if (!response.validate (*cookie))
+	{
+		node.stats.inc (nano::stat::type::handshake, nano::stat::detail::invalid_signature);
+		return false; // Fail
+	}
+
+	node.stats.inc (nano::stat::type::handshake, nano::stat::detail::ok);
+	return true; // OK
+}
+
+std::optional<nano::node_id_handshake::query_payload> nano::network::prepare_handshake_query (const nano::endpoint & remote_endpoint)
+{
+	if (auto cookie = syn_cookies.assign (remote_endpoint); cookie)
+	{
+		nano::node_id_handshake::query_payload query{ *cookie };
+		return query;
+	}
+	return std::nullopt;
+}
+
+nano::node_id_handshake::response_payload nano::network::prepare_handshake_response (const nano::node_id_handshake::query_payload & query, bool v2) const
+{
+	nano::node_id_handshake::response_payload response{};
+	response.node_id = node.node_id.pub;
+	if (v2)
+	{
+		nano::node_id_handshake::response_payload::v2_payload response_v2{};
+		response_v2.salt = nano::random_pool::generate<uint256_union> ();
+		response_v2.genesis = node.network_params.ledger.genesis->hash ();
+		response.v2 = response_v2;
+	}
+	response.sign (query.cookie, node.node_id);
+	return response;
+}
+
+/*
+ * tcp_message_manager
+ */
+
 nano::tcp_message_manager::tcp_message_manager (unsigned incoming_connections_max_a) :
 	max_entries (incoming_connections_max_a * nano::tcp_message_manager::max_entries_per_connection + 1)
 {

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -14,6 +14,7 @@
 namespace nano
 {
 class node;
+
 class tcp_message_manager final
 {
 public:
@@ -34,13 +35,15 @@ private:
 
 	friend class network_tcp_message_manager_Test;
 };
+
 /**
  * Node ID cookies for node ID handshakes
  */
 class syn_cookies final
 {
 public:
-	syn_cookies (std::size_t);
+	explicit syn_cookies (std::size_t);
+
 	void purge (std::chrono::steady_clock::time_point const &);
 	// Returns boost::none if the IP is rate capped on syn cookie requests,
 	// or if the endpoint already has a syn cookie query
@@ -48,6 +51,9 @@ public:
 	// Returns false if valid, true if invalid (true on error convention)
 	// Also removes the syn cookie from the store if valid
 	bool validate (nano::endpoint const &, nano::account const &, nano::signature const &);
+	/** Get cookie associated with endpoint and erases that cookie from this container */
+	std::optional<nano::uint256_union> cookie (nano::endpoint const &);
+
 	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 	std::size_t cookies_size ();
 

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -128,6 +128,11 @@ public:
 	/** Disconnects and adds peer to exclusion list */
 	void exclude (std::shared_ptr<nano::transport::channel> const & channel);
 
+	/** Verifies that handshake response matches our query. @returns true if OK */
+	bool verify_handshake_response (nano::node_id_handshake::response_payload const & response, nano::endpoint const & remote_endpoint);
+	std::optional<nano::node_id_handshake::query_payload> prepare_handshake_query (nano::endpoint const & remote_endpoint);
+	nano::node_id_handshake::response_payload prepare_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2) const;
+
 	static std::string to_string (nano::networks);
 
 private:

--- a/nano/node/transport/socket.hpp
+++ b/nano/node/transport/socket.hpp
@@ -40,6 +40,7 @@ class socket : public std::enable_shared_from_this<nano::transport::socket>
 {
 	friend class server_socket;
 	friend class tcp_server;
+	friend class tcp_channels;
 
 public:
 	enum class type_t

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -63,7 +63,7 @@ public:
 	std::chrono::steady_clock::time_point last_telemetry_req{};
 
 private:
-	void send_handshake_response (nano::node_id_handshake::query_payload const & query);
+	void send_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2);
 
 	void receive_message ();
 	void received_message (std::unique_ptr<nano::message> message);


### PR DESCRIPTION
Upgrades the node id handshake exchange process. Currently when node connects it sends a so called 'cookie' (256 bit chunk of data), which it then expects to be signed by node id key of remote peer. This is done raw, without concatenating any random data (salt), which allows anyone to send any 256 bit payload and get it signed. It's worth to emphasize that **THIS IS NOT A CRITICAL VULNERABILITY**, because node id only use is distinguishing unique nodes on the network and signing telemetry data.

The new handshake v2 message adds salt and genesis block hash fields, which are concatenated to the cookie remote peer sent us. The upgrade is done in a backwards compatible way, we only reply with v2 handshake if peer indicated support for it in the first place. This means the update needs to be a two step process to come into full effect, first release just adds support, the next one, after sufficiently high portion of the network upgrades, disables legacy handshake.