### PR TITLE
Updating flatbuffer library version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ find_package(Threads)
 if(WIN32)
   find_library(PSAPI Psapi)
   add_definitions(-D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -DMINIUPNP_STATICLIB
-                  -D_CRT_SECURE_NO_WARNINGS /EHsc)
+                  -D_CRT_SECURE_NO_WARNINGS -DNOGDI /EHsc)
 
   if(${USING_TSAN}
      OR ${USING_ASAN}

--- a/ci/build-ci.sh
+++ b/ci/build-ci.sh
@@ -60,7 +60,7 @@ if [[ "$OS" == 'Linux' ]]; then
     if [[ ${LCOV:-0} == 1 ]]; then
         cmake --build ${PWD} --target generate_coverage -- -j2
     else
-        cmake --build ${PWD} --target ${build_target} -k -- -j2
+        cmake --build ${PWD} --target ${build_target} -- -j2
     fi
 else
     sudo cmake --build ${PWD} --target ${build_target} -- -j2

--- a/docker/ci/Dockerfile-base
+++ b/docker/ci/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,13 +6,16 @@ RUN apt-get update -qq && apt-get install -yqq \
 build-essential \
 g++ \
 wget \
-python \
+python3 \
 zlib1g-dev \
 cmake \
 git
 
 RUN apt-get update -qq && apt-get install -yqq \
-qt5-default \
+qtbase5-dev \
+qtchooser \
+qt5-qmake \
+qtbase5-dev-tools \
 valgrind \
 xorg xvfb xauth xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic
 

--- a/docker/ci/Dockerfile-gcc
+++ b/docker/ci/Dockerfile-gcc
@@ -1,8 +1,5 @@
 ARG ENV_REPOSITORY=nanocurrency/nano-env
 FROM ${ENV_REPOSITORY}:base
 
-RUN apt-get update -qq && apt-get install -yqq \
-..
-
 ARG REPOSITORY=nanocurrency/nano-node
 LABEL org.opencontainers.image.source https://github.com/$REPOSITORY


### PR DESCRIPTION
The file nano/ipc_flatbuffers_lib/generated/flatbuffers/nanoapi_generated.h will need to be regenerated by deleting the file and rebuilding.

An error like: error: no matching function for call to ‘nanoapi::Envelope::VerifyField<uint8_t> indicates the file has not been regenerated.