### PR TITLE
Refactor the enabled option of block_broadcast

### DIFF
--- a/nano/node/block_broadcast.cpp
+++ b/nano/node/block_broadcast.cpp
@@ -3,13 +3,14 @@
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/network.hpp>
 
-nano::block_broadcast::block_broadcast (nano::network & network, nano::block_arrival & block_arrival) :
+nano::block_broadcast::block_broadcast (nano::network & network, nano::block_arrival & block_arrival, bool enabled) :
 	network{ network },
-	block_arrival{ block_arrival }
+	block_arrival{ block_arrival },
+	enabled{ enabled }
 {
 }
 
-void nano::block_broadcast::connect (nano::block_processor & block_processor, bool enabled)
+void nano::block_broadcast::connect (nano::block_processor & block_processor)
 {
 	if (!enabled)
 	{
@@ -57,12 +58,20 @@ void nano::block_broadcast::observe (std::shared_ptr<nano::block> block)
 
 void nano::block_broadcast::set_local (std::shared_ptr<nano::block> block)
 {
+	if (!enabled)
+	{
+		return;
+	}
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	local.insert (block);
 }
 
 void nano::block_broadcast::erase (std::shared_ptr<nano::block> block)
 {
+	if (!enabled)
+	{
+		return;
+	}
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	local.erase (block);
 }

--- a/nano/node/block_broadcast.hpp
+++ b/nano/node/block_broadcast.hpp
@@ -14,19 +14,21 @@ class network;
 class block_broadcast
 {
 public:
-	block_broadcast (nano::network & network, nano::block_arrival & block_arrival);
+	block_broadcast (nano::network & network, nano::block_arrival & block_arrival, bool enabled = false);
 	// Add batch_processed observer to block_processor if enabled
-	void connect (nano::block_processor & block_processor, bool enabled);
-	// Block_processor observer
-	void observe (std::shared_ptr<nano::block> block);
+	void connect (nano::block_processor & block_processor);
 	// Mark a block as originating locally
 	void set_local (std::shared_ptr<nano::block> block);
 	void erase (std::shared_ptr<nano::block> block);
 
 private:
+	// Block_processor observer
+	void observe (std::shared_ptr<nano::block> block);
+
 	nano::network & network;
 	nano::block_arrival & block_arrival;
 	std::unordered_set<std::shared_ptr<nano::block>> local; // Blocks originated on this node
 	nano::mutex mutex;
+	bool enabled;
 };
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -205,9 +205,9 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	epoch_upgrader{ *this, ledger, store, network_params, logger },
 	startup_time (std::chrono::steady_clock::now ()),
 	node_seq (seq),
-	block_broadcast{ network, block_arrival }
+	block_broadcast{ network, block_arrival, !flags.disable_block_processor_republishing }
 {
-	block_broadcast.connect (block_processor, !flags.disable_block_processor_republishing);
+	block_broadcast.connect (block_processor);
 	unchecked.use_memory = [this] () { return ledger.bootstrap_weight_reached (); };
 	unchecked.satisfied = [this] (nano::unchecked_info const & info) {
 		this->block_processor.add (info.block);


### PR DESCRIPTION
The enabled option should be evaluated in both cases, to add new blocks (`set_local` function) and to erase blocks after observing them. Also, the connect function should take no effect on observing if the block broadcast is disabled.