### PR TITLE
Bump nano-node image to ubuntu:22.04

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -21,7 +21,7 @@ make nano_rpc -j $(nproc) && \
 cd .. && \
 echo ${NETWORK} >/etc/nano-network
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN groupadd --gid 1000 nanocurrency && \
 useradd --uid 1000 --gid nanocurrency --shell /bin/bash --create-home nanocurrency


### PR DESCRIPTION
nanocurrency/nano-env has been updated to use ubuntu:2204

This change results in the nano-node failing to start with the following error message :
```nano_node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by nano_node)
nano_node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by nano_node)
nano_node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by nano_node)```

Upgrading the docker image to ubuntu:22.04 resolves the issue