### PR TITLE
Add the gap_tracker class

### DIFF
--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(
   block_broadcast.hpp
   block_publisher.cpp
   block_publisher.hpp
+  gap_tracker.cpp
+  gap_tracker.hpp
   blocking_observer.cpp
   blocking_observer.hpp
   blockprocessor.hpp

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -373,7 +373,6 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 				node.logger.try_log (boost::str (boost::format ("Gap previous for: %1%") % hash.to_string ()));
 			}
 			node.unchecked.put (block->previous (), block);
-			events_a.events.emplace_back ([this, hash] (nano::transaction const & /* unused */) { this->node.gap_cache.add (hash); });
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_previous);
 			break;
 		}
@@ -384,7 +383,6 @@ nano::process_return nano::block_processor::process_one (nano::write_transaction
 				node.logger.try_log (boost::str (boost::format ("Gap source for: %1%") % hash.to_string ()));
 			}
 			node.unchecked.put (node.ledger.block_source (transaction_a, *block), block);
-			events_a.events.emplace_back ([this, hash] (nano::transaction const & /* unused */) { this->node.gap_cache.add (hash); });
 			node.stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
 			break;
 		}

--- a/nano/node/gap_tracker.cpp
+++ b/nano/node/gap_tracker.cpp
@@ -1,0 +1,29 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/node/blockprocessor.hpp>
+#include <nano/node/gap_cache.hpp>
+#include <nano/node/gap_tracker.hpp>
+
+nano::gap_tracker::gap_tracker (nano::gap_cache & gap_cache) :
+	gap_cache{ gap_cache }
+{
+}
+
+void nano::gap_tracker::connect (nano::block_processor & block_processor)
+{
+	block_processor.processed.add ([this] (auto const & result, auto const & block) {
+		switch (result.code)
+		{
+			case nano::process_result::gap_previous:
+			case nano::process_result::gap_source:
+				observe (block);
+				break;
+			default:
+				break;
+		}
+	});
+}
+
+void nano::gap_tracker::observe (std::shared_ptr<nano::block> block)
+{
+	gap_cache.add (block->hash ());
+}

--- a/nano/node/gap_tracker.hpp
+++ b/nano/node/gap_tracker.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+
+namespace nano
+{
+class gap_cache;
+class block_processor;
+class block;
+
+// Observes the processed blocks and tracks them (gap_cache) if they are gap blocks.
+class gap_tracker
+{
+public:
+	gap_tracker (nano::gap_cache & gap_cache);
+	void connect (nano::block_processor & block_processor);
+
+private:
+	// Block_processor observer
+	void observe (std::shared_ptr<nano::block> block);
+
+	nano::gap_cache & gap_cache;
+};
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -206,10 +206,12 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	startup_time (std::chrono::steady_clock::now ()),
 	node_seq (seq),
 	block_broadcast{ network, block_arrival, !flags.disable_block_processor_republishing },
-	block_publisher{ active }
+	block_publisher{ active },
+	gap_tracker{ gap_cache }
 {
 	block_broadcast.connect (block_processor);
 	block_publisher.connect (block_processor);
+	gap_tracker.connect (block_processor);
 	unchecked.use_memory = [this] () { return ledger.bootstrap_weight_reached (); };
 	unchecked.satisfied = [this] (nano::unchecked_info const & info) {
 		this->block_processor.add (info.block);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -19,6 +19,7 @@
 #include <nano/node/election_scheduler.hpp>
 #include <nano/node/epoch_upgrader.hpp>
 #include <nano/node/gap_cache.hpp>
+#include <nano/node/gap_tracker.hpp>
 #include <nano/node/hinted_scheduler.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node_observers.hpp>
@@ -194,6 +195,7 @@ public:
 	nano::epoch_upgrader epoch_upgrader;
 	nano::block_broadcast block_broadcast;
 	nano::block_publisher block_publisher;
+	nano::gap_tracker gap_tracker;
 
 	std::chrono::steady_clock::time_point const startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week


### PR DESCRIPTION
Move tracking the gap blocks (source and previous) from the `block_post_events` queue to the `gap_tracker` class. The `gap_tracker` class observes the blocks when they are processed, and adds them to the `gap_cache` container.