### PR TITLE
Add the process_live_dipatcher class

### DIFF
--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -160,6 +160,8 @@ add_library(
   portmapping.cpp
   prioritization.cpp
   prioritization.hpp
+  process_live_dispatcher.cpp
+  process_live_dispatcher.hpp
   repcrawler.hpp
   repcrawler.cpp
   request_aggregator.hpp

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -68,7 +68,6 @@ private:
 	nano::process_return process_one (nano::write_transaction const &, block_post_events &, std::shared_ptr<nano::block> block, bool const = false);
 	void queue_unchecked (nano::write_transaction const &, nano::hash_or_account const &);
 	std::deque<processed_t> process_batch (nano::unique_lock<nano::mutex> &);
-	void process_live (nano::transaction const &, std::shared_ptr<nano::block> const &);
 	void process_verified_state_blocks (std::deque<nano::state_block_signature_verification::value_type> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &);
 	void add_impl (std::shared_ptr<nano::block> block);
 	bool stopped{ false };

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -18,17 +18,6 @@ class transaction;
 class write_transaction;
 class write_database_queue;
 
-class block_post_events final
-{
-public:
-	explicit block_post_events (std::function<nano::read_transaction ()> &&);
-	~block_post_events ();
-	std::deque<std::function<void (nano::read_transaction const &)>> events;
-
-private:
-	std::function<nano::read_transaction ()> get_transaction;
-};
-
 /**
  * Processing blocks is a potentially long IO operation.
  * This class isolates block insertion from other operations like servicing network operations
@@ -65,7 +54,7 @@ private:
 	blocking_observer blocking;
 
 private:
-	nano::process_return process_one (nano::write_transaction const &, block_post_events &, std::shared_ptr<nano::block> block, bool const = false);
+	nano::process_return process_one (nano::write_transaction const &, std::shared_ptr<nano::block> block, bool const = false);
 	void queue_unchecked (nano::write_transaction const &, nano::hash_or_account const &);
 	std::deque<processed_t> process_batch (nano::unique_lock<nano::mutex> &);
 	void process_verified_state_blocks (std::deque<nano::state_block_signature_verification::value_type> &, std::vector<int> const &, std::vector<nano::block_hash> const &, std::vector<nano::signature> const &);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -207,11 +207,13 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	node_seq (seq),
 	block_broadcast{ network, block_arrival, !flags.disable_block_processor_republishing },
 	block_publisher{ active },
-	gap_tracker{ gap_cache }
+	gap_tracker{ gap_cache },
+	process_live_dispatcher{ ledger, scheduler, inactive_vote_cache, websocket }
 {
 	block_broadcast.connect (block_processor);
 	block_publisher.connect (block_processor);
 	gap_tracker.connect (block_processor);
+	process_live_dispatcher.connect (block_processor);
 	unchecked.use_memory = [this] () { return ledger.bootstrap_weight_reached (); };
 	unchecked.satisfied = [this] (nano::unchecked_info const & info) {
 		this->block_processor.add (info.block);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -27,6 +27,7 @@
 #include <nano/node/online_reps.hpp>
 #include <nano/node/optimistic_scheduler.hpp>
 #include <nano/node/portmapping.hpp>
+#include <nano/node/process_live_dispatcher.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/node/request_aggregator.hpp>
 #include <nano/node/signatures.hpp>
@@ -196,6 +197,7 @@ public:
 	nano::block_broadcast block_broadcast;
 	nano::block_publisher block_publisher;
 	nano::gap_tracker gap_tracker;
+	nano::process_live_dispatcher process_live_dispatcher;
 
 	std::chrono::steady_clock::time_point const startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week

--- a/nano/node/process_live_dispatcher.cpp
+++ b/nano/node/process_live_dispatcher.cpp
@@ -1,0 +1,59 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/node/blockprocessor.hpp>
+#include <nano/node/election_scheduler.hpp>
+#include <nano/node/process_live_dispatcher.hpp>
+#include <nano/node/vote_cache.hpp>
+#include <nano/node/websocket.hpp>
+#include <nano/secure/common.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/store.hpp>
+
+nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, nano::election_scheduler & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket) :
+	ledger{ ledger },
+	scheduler{ scheduler },
+	inactive_vote_cache{ inactive_vote_cache },
+	websocket{ websocket }
+{
+}
+
+void nano::process_live_dispatcher::connect (nano::block_processor & block_processor)
+{
+	block_processor.batch_processed.add ([this] (auto const & batch) {
+		auto const transaction = ledger.store.tx_begin_read ();
+		for (auto const & [result, block] : batch)
+		{
+			debug_assert (block != nullptr);
+			inspect (result, *block, transaction);
+		}
+	});
+}
+
+void nano::process_live_dispatcher::inspect (nano::process_return const & result, nano::block const & block, nano::transaction const & transaction)
+{
+	switch (result.code)
+	{
+		case nano::process_result::progress:
+			process_live (block, transaction);
+			break;
+		default:
+			break;
+	}
+}
+
+void nano::process_live_dispatcher::process_live (nano::block const & block, nano::transaction const & transaction)
+{
+	// Start collecting quorum on block
+	if (ledger.dependents_confirmed (transaction, block))
+	{
+		auto account = block.account ().is_zero () ? block.sideband ().account : block.account ();
+		scheduler.activate (account, transaction);
+	}
+
+	// Notify inactive vote cache about a new live block
+	inactive_vote_cache.trigger (block.hash ());
+
+	if (websocket.server && websocket.server->any_subscriber (nano::websocket::topic::new_unconfirmed_block))
+	{
+		websocket.server->broadcast (nano::websocket::message_builder ().new_block_arrived (block));
+	}
+}

--- a/nano/node/process_live_dispatcher.hpp
+++ b/nano/node/process_live_dispatcher.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace nano
+{
+class ledger;
+class election_scheduler;
+class vote_cache;
+class websocket_server;
+class block_processor;
+class process_return;
+class block;
+class transaction;
+
+// Observes confirmed blocks and dispatches the process_live function.
+class process_live_dispatcher
+{
+public:
+	process_live_dispatcher (nano::ledger & ledger, nano::election_scheduler & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket);
+	void connect (nano::block_processor & block_processor);
+
+private:
+	// Block_processor observer
+	void inspect (nano::process_return const & result, nano::block const & block, nano::transaction const & transaction);
+	void process_live (nano::block const & block, nano::transaction const & transaction);
+
+	nano::ledger & ledger;
+	nano::election_scheduler & scheduler;
+	nano::vote_cache & inactive_vote_cache;
+	nano::websocket_server & websocket;
+};
+}


### PR DESCRIPTION
Move the `process_live` function to the `process_live_dispatcher` class. This is an observer for the confirmed processed blocks, that also calls `process_live`.

Remove the `block_post_events` class.