### PR TITLE
Cleanup fixes for unit tests

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -733,9 +733,9 @@ TEST (active_transactions, republish_winner)
 	node1.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	node1.vote_processor.flush ();
 	node1.block_processor.flush ();
-	ASSERT_TIMELY (3s, election->confirmed ());
+	ASSERT_TIMELY (5s, election->confirmed ());
 	ASSERT_EQ (fork->hash (), election->status.winner->hash ());
-	ASSERT_TIMELY (3s, node2.block_confirmed (fork->hash ()));
+	ASSERT_TIMELY (5s, node2.block_confirmed (fork->hash ()));
 }
 
 TEST (active_transactions, fork_filter_cleanup)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1322,7 +1322,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	ASSERT_TIMELY (5s, node1->block (state_open->hash ()) != nullptr);
 	// Confirm last block to prune previous
 	nano::test::start_elections (system, *node1, { send1, send2, open, state_open }, true);
-	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (send2->hash ()) && node1->block_confirmed (open->hash ()) && node1->block_confirmed (state_open->hash ()) && node1->active.empty ());
+	ASSERT_TIMELY (5s, node1->block_confirmed (send2->hash ()) && node1->block_confirmed (open->hash ()) && node1->block_confirmed (state_open->hash ()));
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
 	// Pruning action

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3875,25 +3875,25 @@ TEST (rpc, pending_exists)
 	auto pending_exists = [&system, &rpc_ctx, &request] (char const * exists_a) {
 		auto response0 (wait_response (system, rpc_ctx, request));
 		std::string exists_text (response0.get<std::string> ("exists"));
-		ASSERT_EQ (exists_a, exists_text);
+		return exists_a == exists_text;
 	};
 
 	request.put ("action", "pending_exists");
 	request.put ("hash", hash0.to_string ());
-	pending_exists ("0");
+	ASSERT_TRUE (pending_exists ("0"));
 
 	node->store.pending.exists (node->store.tx_begin_read (), nano::pending_key (nano::dev::genesis_key.pub, block1->hash ()));
 	request.put ("hash", block1->hash ().to_string ());
-	pending_exists ("1");
+	ASSERT_TRUE (pending_exists ("1"));
 
-	pending_exists ("1");
+	ASSERT_TRUE (pending_exists ("1"));
 	rpc_ctx.io_scope->reset ();
 	reset_confirmation_height (node->store, block1->account ());
 	rpc_ctx.io_scope->renew ();
-	pending_exists ("0");
+	ASSERT_TRUE (pending_exists ("0"));
 	request.put ("include_only_confirmed", "false");
 	rpc_ctx.io_scope->renew ();
-	pending_exists ("1");
+	ASSERT_TRUE (pending_exists ("1"));
 }
 
 TEST (rpc, wallet_pending)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -184,11 +184,11 @@ boost::property_tree::ptree wait_response (nano::test::system & system, rpc_cont
 	return response_json;
 }
 
-void check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count)
+bool check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count)
 {
 	auto response (wait_response (system, rpc_ctx, request));
 	auto & blocks = response.get_child ("blocks");
-	ASSERT_EQ (size_count, blocks.size ());
+	return size_count == blocks.size ();
 }
 
 rpc_context add_rpc (nano::test::system & system, std::shared_ptr<nano::node> const & node_a)
@@ -1999,14 +1999,14 @@ TEST (rpc, pending)
 	request.put ("source", "false");
 	request.put ("min_version", "false");
 
-	check_block_response_count (system, rpc_ctx, request, 1);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 	rpc_ctx.io_scope->reset ();
 	reset_confirmation_height (system.nodes.front ()->store, block1->account ());
 	rpc_ctx.io_scope->renew ();
-	check_block_response_count (system, rpc_ctx, request, 0);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	rpc_ctx.io_scope->renew ();
-	check_block_response_count (system, rpc_ctx, request, 1);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 	request.put ("include_only_confirmed", "true");
 
 	// Sorting with a smaller count than total should give absolute sorted amounts
@@ -3740,14 +3740,14 @@ TEST (rpc, accounts_receivable)
 		ASSERT_EQ (sources[block1->hash ()], nano::dev::genesis_key.pub);
 	}
 
-	check_block_response_count (system, rpc_ctx, request, 1);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 	rpc_ctx.io_scope->reset ();
 	reset_confirmation_height (system.nodes.front ()->store, block1->account ());
 	rpc_ctx.io_scope->renew ();
-	check_block_response_count (system, rpc_ctx, request, 0);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	rpc_ctx.io_scope->renew ();
-	check_block_response_count (system, rpc_ctx, request, 1);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }
 
 TEST (rpc, blocks)
@@ -3991,14 +3991,14 @@ TEST (rpc, wallet_receivable)
 	ASSERT_EQ (amounts[block1->hash ()], 100);
 	ASSERT_EQ (sources[block1->hash ()], nano::dev::genesis_key.pub);
 
-	check_block_response_count (system, rpc_ctx, request, 1);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 	rpc_ctx.io_scope->reset ();
 	reset_confirmation_height (system.nodes.front ()->store, block1->account ());
 	rpc_ctx.io_scope->renew ();
-	check_block_response_count (system, rpc_ctx, request, 0);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	rpc_ctx.io_scope->renew ();
-	check_block_response_count (system, rpc_ctx, request, 1);
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }
 
 TEST (rpc, receive_minimum)


### PR DESCRIPTION
Fixing incorrect bounds check in check_block_response_count and removing some code duplication.

Replacing checks looking at ledger.cache counts with node::block_confirmed checks.

Move ASSERT_X checks out of functions which interferes with googletest line reporting.