### PR TITLE
Removing tracking weight from rep_crawler class.

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -79,7 +79,7 @@ TEST (active_transactions, confirm_election_by_request)
 	// Add representative (node1) to disabled rep crawler of node2
 	{
 		nano::lock_guard<nano::mutex> guard (node2.rep_crawler.probable_reps_mutex);
-		node2.rep_crawler.probable_reps.emplace (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, *peers.cbegin ());
+		node2.rep_crawler.probable_reps.emplace (nano::dev::genesis_key.pub, *peers.cbegin ());
 	}
 
 	// Expect a vote to come back
@@ -117,7 +117,7 @@ TEST (active_transactions, confirm_frontier)
 	ASSERT_FALSE (peers.empty ());
 	{
 		nano::lock_guard<nano::mutex> guard (node2.rep_crawler.probable_reps_mutex);
-		node2.rep_crawler.probable_reps.emplace (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, *peers.begin ());
+		node2.rep_crawler.probable_reps.emplace (nano::dev::genesis_key.pub, *peers.begin ());
 	}
 
 	nano::state_block_builder builder;

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -20,7 +20,7 @@ TEST (confirmation_solicitor, batches)
 	auto & node2 = *system.add_node (node_flags);
 	auto channel1 = nano::test::establish_tcp (system, node2, node1.network.endpoint ());
 	// Solicitor will only solicit from this representative
-	nano::representative representative (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, channel1);
+	nano::representative representative (nano::dev::genesis_key.pub, channel1);
 	std::vector<nano::representative> representatives{ representative };
 	nano::confirmation_solicitor solicitor (node2.network, node2.config);
 	solicitor.prepare (representatives);
@@ -70,7 +70,7 @@ TEST (confirmation_solicitor, different_hash)
 	auto & node2 = *system.add_node (node_flags);
 	auto channel1 = nano::test::establish_tcp (system, node2, node1.network.endpoint ());
 	// Solicitor will only solicit from this representative
-	nano::representative representative (nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount, channel1);
+	nano::representative representative (nano::dev::genesis_key.pub, channel1);
 	std::vector<nano::representative> representatives{ representative };
 	nano::confirmation_solicitor solicitor (node2.network, node2.config);
 	solicitor.prepare (representatives);
@@ -117,7 +117,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	{
 		// Make a temporary channel associated with node2
 		auto channel = std::make_shared<nano::transport::inproc::channel> (node2, node2);
-		nano::representative representative (nano::account (i), i, channel);
+		nano::representative representative{ nano::account (i), channel };
 		representatives.push_back (representative);
 	}
 	ASSERT_EQ (max_representatives + 1, representatives.size ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1679,10 +1679,10 @@ TEST (node, rep_list)
 	auto done (false);
 	while (!done)
 	{
-		auto reps (node1.rep_crawler.representatives (1));
+		auto reps = node1.rep_crawler.representatives (1);
 		if (!reps.empty ())
 		{
-			if (!reps[0].weight.is_zero ())
+			if (!node1.ledger.weight (reps[0].account).is_zero ())
 			{
 				done = true;
 			}
@@ -1771,9 +1771,9 @@ TEST (node, rep_weight)
 	node.rep_crawler.response (channel3, vote2);
 	ASSERT_TIMELY (5s, node.rep_crawler.representative_count () == 2);
 	// Make sure we get the rep with the most weight first
-	auto reps (node.rep_crawler.representatives (1));
+	auto reps = node.rep_crawler.representatives (1);
 	ASSERT_EQ (1, reps.size ());
-	ASSERT_EQ (node.balance (nano::dev::genesis_key.pub), reps[0].weight.number ());
+	ASSERT_EQ (node.balance (nano::dev::genesis_key.pub), node.ledger.weight (reps[0].account));
 	ASSERT_EQ (nano::dev::genesis_key.pub, reps[0].account);
 	ASSERT_EQ (*channel1, reps[0].channel_ref ());
 	ASSERT_TRUE (node.rep_crawler.is_pr (*channel1));
@@ -1856,7 +1856,7 @@ TEST (node, rep_remove)
 	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 1);
 	auto reps (searching_node.rep_crawler.representatives (1));
 	ASSERT_EQ (1, reps.size ());
-	ASSERT_EQ (searching_node.minimum_principal_weight () * 2, reps[0].weight.number ());
+	ASSERT_EQ (searching_node.minimum_principal_weight () * 2, searching_node.ledger.weight (reps[0].account));
 	ASSERT_EQ (keys_rep1.pub, reps[0].account);
 	ASSERT_EQ (*channel_rep1, reps[0].channel_ref ());
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2123,7 +2123,7 @@ void nano::json_handler::confirmation_quorum ()
 			boost::property_tree::ptree peer_node;
 			peer_node.put ("account", peer.account.to_account ());
 			peer_node.put ("ip", peer.channel->to_string ());
-			peer_node.put ("weight", peer.weight.to_string_dec ());
+			peer_node.put ("weight", nano::amount{ node.ledger.weight (peer.account) }.to_string_dec ());
 			peers.push_back (std::make_pair ("", peer_node));
 		}
 		response_l.add_child ("peers", peers);


### PR DESCRIPTION
This information is tracked accurately by nano::ledger and keeping the containers in sync is error prone.