### PR TITLE
Add missing lib to nano_rpc build

### DIFF
--- a/nano/nano_rpc/CMakeLists.txt
+++ b/nano/nano_rpc/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(nano_rpc entry.cpp)
 target_link_libraries(
   nano_rpc
   rpc
+  node
   secure
   Boost::filesystem
   Boost::log_setup


### PR DESCRIPTION
Fixes build error:

```
CMakeFiles/nano_rpc.dir/entry.cpp.o: in function `(anonymous namespace)::endpoint_hash_raw(boost::asio::ip::basic_endpoint<boost::asio::ip::udp> const&)':
/workspace/nano/node/common.hpp:31: undefined reference to `nano::ip_address_hash_raw(boost::asio::ip::address const&, unsigned short)'
/usr/bin/ld: CMakeFiles/nano_rpc.dir/entry.cpp.o: in function `(anonymous
namespace)::endpoint_hash_raw(boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&)':
/workspace/nano/node/common.hpp:36: undefined reference to `nano::ip_address_hash_raw(boost::asio::ip::address const&, unsigned short)'
```