### PR TITLE
Fix or suppress Windows build warnings

### DIFF
--- a/nano/core_test/message_deserializer.cpp
+++ b/nano/core_test/message_deserializer.cpp
@@ -22,11 +22,11 @@ auto message_deserializer_success_checker (message_type & message_original) -> v
 	// Data used to simulate the incoming buffer to be deserialized, the offset tracks how much has been read from the input_source
 	// as the read function is called first to read the header, then called again to read the payload.
 	std::vector<uint8_t> input_source;
-	auto offset = 0u;
+	std::size_t offset{ 0 };
 
 	// Message Deserializer with the query function tweaked to read from the `input_source`.
 	auto const message_deserializer = std::make_shared<nano::transport::message_deserializer> (nano::dev::network_params.network, filter, block_uniquer, vote_uniquer,
-	[&input_source, &offset] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
+	[&input_source, &offset] (std::shared_ptr<std::vector<uint8_t>> const & data_a, std::size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
 		debug_assert (input_source.size () >= size_a);
 		data_a->resize (size_a);
 		auto const copy_start = input_source.begin () + offset;

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -155,8 +155,8 @@ TEST (channels, fill_random_part)
 {
 	nano::test::system system{ 1 };
 	std::array<nano::endpoint, 8> target;
-	unsigned half{ target.size () / 2 };
-	for (unsigned i = 0; i < half; ++i)
+	std::size_t half = target.size () / 2;
+	for (std::size_t i = 0; i < half; ++i)
 	{
 		auto outer_node = nano::test::add_outer_node (system);
 		ASSERT_NE (nullptr, nano::test::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ()));

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -197,7 +197,7 @@ TEST (peer_container, list_fanout)
 	ASSERT_EQ (2, node->network.list (node->network.fanout ()).size ());
 
 	unsigned number_of_peers = 10;
-	for (auto i = 2; i < number_of_peers; ++i)
+	for (unsigned i = 2; i < number_of_peers; ++i)
 	{
 		add_peer ();
 	}

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -108,7 +108,7 @@ std::optional<nano::process_return> nano::block_processor::add_blocking (std::sh
 	{
 		result = future.get ();
 	}
-	catch (std::future_error const & e)
+	catch (std::future_error const &)
 	{
 	}
 	return result;

--- a/nano/node/bootstrap/bootstrap_ascending.cpp
+++ b/nano/node/bootstrap/bootstrap_ascending.cpp
@@ -445,8 +445,7 @@ void nano::bootstrap_ascending::send (std::shared_ptr<nano::transport::channel> 
 	nano::asc_pull_req::blocks_payload request_payload;
 	request_payload.start = tag.start;
 	request_payload.count = pull_count;
-	request_payload.start_type = tag.type == async_tag::query_type::blocks_by_hash ? nano::asc_pull_req::hash_type::block : nano::asc_pull_req::hash_type::account;
-
+	request_payload.start_type = (tag.type == async_tag::query_type::blocks_by_hash) ? nano::asc_pull_req::hash_type::block : nano::asc_pull_req::hash_type::account;
 	request.payload = request_payload;
 	request.update_header ();
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -881,7 +881,7 @@ void nano::node::ongoing_bootstrap ()
 			{
 				last_sample_time = last_record->first;
 			}
-			uint64_t time_since_last_sample = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count () - last_sample_time / std::pow (10, 9); // Nanoseconds to seconds
+			uint64_t time_since_last_sample = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count () - static_cast<uint64_t> (last_sample_time / std::pow (10, 9)); // Nanoseconds to seconds
 			if (time_since_last_sample + 60 * 60 < std::numeric_limits<uint32_t>::max ())
 			{
 				frontiers_age = std::max<uint32_t> (time_since_last_sample + 60 * 60, network_params.bootstrap.default_frontiers_age_seconds);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -884,7 +884,7 @@ void nano::node::ongoing_bootstrap ()
 			uint64_t time_since_last_sample = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count () - static_cast<uint64_t> (last_sample_time / std::pow (10, 9)); // Nanoseconds to seconds
 			if (time_since_last_sample + 60 * 60 < std::numeric_limits<uint32_t>::max ())
 			{
-				frontiers_age = std::max<uint32_t> (time_since_last_sample + 60 * 60, network_params.bootstrap.default_frontiers_age_seconds);
+				frontiers_age = std::max<uint32_t> (static_cast<uint32_t> (time_since_last_sample + 60 * 60), network_params.bootstrap.default_frontiers_age_seconds);
 			}
 		}
 		else if (previous_bootstrap_count % 4 != 0)

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -55,8 +55,8 @@ public:
  */
 void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a)
 {
-	auto offset = 0u;
-	auto const buffer_read_fn = [&offset, buffer_v = buffer_a.to_bytes ()] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
+	std::size_t offset{ 0 };
+	auto const buffer_read_fn = [&offset, buffer_v = buffer_a.to_bytes ()] (std::shared_ptr<std::vector<uint8_t>> const & data_a, std::size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {
 		debug_assert (buffer_v.size () >= (offset + size_a));
 		data_a->resize (size_a);
 		auto const copy_start = buffer_v.begin () + offset;

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -243,7 +243,7 @@ void nano::transport::socket::checkup ()
 	});
 }
 
-void nano::transport::socket::read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a)
+void nano::transport::socket::read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, std::size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a)
 {
 	// Increase timeout to receive TCP header (idle server socket)
 	auto const prev_timeout = get_default_timeout_value ();
@@ -352,29 +352,29 @@ void nano::transport::server_socket::close ()
 	}));
 }
 
-boost::asio::ip::network_v6 nano::transport::socket_functions::get_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, size_t network_prefix)
+boost::asio::ip::network_v6 nano::transport::socket_functions::get_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, std::size_t network_prefix)
 {
 	return boost::asio::ip::make_network_v6 (ip_address, network_prefix);
 }
 
-boost::asio::ip::address nano::transport::socket_functions::first_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, size_t network_prefix)
+boost::asio::ip::address nano::transport::socket_functions::first_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, std::size_t network_prefix)
 {
 	auto range = get_ipv6_subnet_address (ip_address, network_prefix).hosts ();
 	debug_assert (!range.empty ());
 	return *(range.begin ());
 }
 
-boost::asio::ip::address nano::transport::socket_functions::last_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, size_t network_prefix)
+boost::asio::ip::address nano::transport::socket_functions::last_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, std::size_t network_prefix)
 {
 	auto range = get_ipv6_subnet_address (ip_address, network_prefix).hosts ();
 	debug_assert (!range.empty ());
 	return *(--range.end ());
 }
 
-size_t nano::transport::socket_functions::count_subnetwork_connections (
+std::size_t nano::transport::socket_functions::count_subnetwork_connections (
 nano::transport::address_socket_mmap const & per_address_connections,
 boost::asio::ip::address_v6 const & remote_address,
-size_t network_prefix)
+std::size_t network_prefix)
 {
 	auto range = get_ipv6_subnet_address (remote_address, network_prefix).hosts ();
 	if (range.empty ())

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -8,6 +8,7 @@
 #include <boost/format.hpp>
 
 #include <cstdint>
+#include <cstdlib>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -412,7 +413,7 @@ bool nano::transport::server_socket::limit_reached_for_incoming_ip_connections (
 		return false;
 	}
 	auto const address_connections_range = connections_per_address.equal_range (new_connection->remote.address ());
-	auto const counted_connections = std::distance (address_connections_range.first, address_connections_range.second);
+	auto const counted_connections = static_cast<std::size_t> (std::abs (std::distance (address_connections_range.first, address_connections_range.second)));
 	return counted_connections >= node.network_params.network.max_peers_per_ip;
 }
 

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -354,7 +354,7 @@ void nano::transport::server_socket::close ()
 
 boost::asio::ip::network_v6 nano::transport::socket_functions::get_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, std::size_t network_prefix)
 {
-	return boost::asio::ip::make_network_v6 (ip_address, network_prefix);
+	return boost::asio::ip::make_network_v6 (ip_address, static_cast<unsigned short> (network_prefix));
 }
 
 boost::asio::ip::address nano::transport::socket_functions::first_ipv6_subnet_address (boost::asio::ip::address_v6 const & ip_address, std::size_t network_prefix)

--- a/nano/node/transport/socket.hpp
+++ b/nano/node/transport/socket.hpp
@@ -174,7 +174,7 @@ protected:
 	void set_last_completion ();
 	void set_last_receive_time ();
 	void checkup ();
-	void read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a);
+	void read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, std::size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a);
 
 private:
 	type_t type_m{ type_t::undefined };
@@ -190,10 +190,10 @@ using address_socket_mmap = std::multimap<boost::asio::ip::address, std::weak_pt
 
 namespace socket_functions
 {
-	boost::asio::ip::network_v6 get_ipv6_subnet_address (boost::asio::ip::address_v6 const &, size_t);
-	boost::asio::ip::address first_ipv6_subnet_address (boost::asio::ip::address_v6 const &, size_t);
-	boost::asio::ip::address last_ipv6_subnet_address (boost::asio::ip::address_v6 const &, size_t);
-	size_t count_subnetwork_connections (nano::transport::address_socket_mmap const &, boost::asio::ip::address_v6 const &, size_t);
+	boost::asio::ip::network_v6 get_ipv6_subnet_address (boost::asio::ip::address_v6 const &, std::size_t);
+	boost::asio::ip::address first_ipv6_subnet_address (boost::asio::ip::address_v6 const &, std::size_t);
+	boost::asio::ip::address last_ipv6_subnet_address (boost::asio::ip::address_v6 const &, std::size_t);
+	std::size_t count_subnetwork_connections (nano::transport::address_socket_mmap const &, boost::asio::ip::address_v6 const &, std::size_t);
 }
 
 /** Socket class for TCP servers */

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -740,51 +740,37 @@ void nano::generate_cache::enable_all ()
 
 nano::stat::detail nano::to_stat_detail (nano::process_result process_result)
 {
-	nano::stat::detail result;
 	switch (process_result)
 	{
 		case process_result::progress:
 			return nano::stat::detail::progress;
-			break;
 		case process_result::bad_signature:
 			return nano::stat::detail::bad_signature;
-			break;
 		case process_result::old:
 			return nano::stat::detail::old;
-			break;
 		case process_result::negative_spend:
 			return nano::stat::detail::negative_spend;
-			break;
 		case process_result::fork:
 			return nano::stat::detail::fork;
-			break;
 		case process_result::unreceivable:
 			return nano::stat::detail::unreceivable;
-			break;
 		case process_result::gap_previous:
 			return nano::stat::detail::gap_previous;
-			break;
 		case process_result::gap_source:
 			return nano::stat::detail::gap_source;
-			break;
 		case process_result::gap_epoch_open_pending:
 			return nano::stat::detail::gap_epoch_open_pending;
-			break;
 		case process_result::opened_burn_account:
 			return nano::stat::detail::opened_burn_account;
-			break;
 		case process_result::balance_mismatch:
 			return nano::stat::detail::balance_mismatch;
-			break;
 		case process_result::representative_mismatch:
 			return nano::stat::detail::representative_mismatch;
-			break;
 		case process_result::block_position:
 			return nano::stat::detail::block_position;
-			break;
 		case process_result::insufficient_work:
 			return nano::stat::detail::insufficient_work;
-			break;
 	}
-	return result;
+	debug_assert (false && "There should be always a defined nano::stat::detail that is not _last");
+	return nano::stat::detail::_last;
 }


### PR DESCRIPTION
Fixes Windows build warnings from nano source-code. This doesn't fix for the warnings for the submodules.