### PR TITLE
Changes the semantics of election::confirmed and clean up several unit tests

### DIFF
--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>
+#include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -61,13 +62,14 @@ TEST (vote_processor, invalid_signature)
 {
 	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
+	auto chain = nano::test::setup_chain (system, node, 1, nano::dev::genesis_key, false);
 	nano::keypair key;
-	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
+	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ chain[0]->hash () });
 	auto vote_invalid = std::make_shared<nano::vote> (*vote);
 	vote_invalid->signature.bytes[0] ^= 1;
 	auto channel = std::make_shared<nano::transport::inproc::channel> (node, node);
 
-	auto election = nano::test::start_election (system, node, nano::dev::genesis->hash ());
+	auto election = nano::test::start_election (system, node, chain[0]->hash ());
 	ASSERT_NE (election, nullptr);
 	ASSERT_EQ (1, election->votes ().size ());
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -249,7 +249,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<nano::mutex> 
 		bool const confirmed_l (election_l->confirmed ());
 		unconfirmed_count_l += !confirmed_l;
 
-		if (election_l->transition_time (solicitor))
+		if (confirmed_l || election_l->transition_time (solicitor))
 		{
 			erase (election_l->qualified_root);
 		}
@@ -620,7 +620,8 @@ boost::optional<nano::election_status_type> nano::active_transactions::confirm_b
 		nano::unique_lock<nano::mutex> election_lock{ existing->second->mutex };
 		if (existing->second->status.winner && existing->second->status.winner->hash () == hash)
 		{
-			if (!existing->second->confirmed ())
+			// Determine if the block was confirmed explicitly via election confirmation or implicitly via confirmation height
+			if (!existing->second->status_confirmed ())
 			{
 				existing->second->confirm_once (election_lock, nano::election_status_type::active_confirmation_height);
 				status_type = nano::election_status_type::active_confirmation_height;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -158,6 +158,11 @@ void nano::election::transition_active ()
 
 bool nano::election::confirmed () const
 {
+	return node.block_confirmed (status.winner->hash ());
+}
+
+bool nano::election::status_confirmed () const
+{
 	return state_m == nano::election::state_t::confirmed || state_m == nano::election::state_t::expired_confirmed;
 }
 

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -116,6 +116,12 @@ public: // State transitions
 	void transition_active ();
 
 public: // Status
+	// Returns true when the election is confirmed in memory
+	// Elections will first confirm in memory once sufficient votes have been received
+	bool status_confirmed () const;
+	// Returns true when the winning block is durably confirmed in the ledger.
+	// Later once the confirmation height processor has updated the confirmation height it will be confirmed on disk
+	// It is possible for an election to be confirmed on disk but not in memory, for instance if implicitly confirmed via confirmation height
 	bool confirmed () const;
 	bool failed () const;
 	nano::election_extended_status current_status () const;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6829,6 +6829,7 @@ TEST (rpc, confirmation_active)
 	auto election (node1->active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
+	ASSERT_TIMELY (5s, election->confirmed ());
 
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_active");


### PR DESCRIPTION
Changes the semantics of election::confirmed to return if the block is durably confirmed on disk, rather than simply being confirmed in memory. This was causing subtle race conditions or unnecessary extra checking to ensure the confirmation has been committed to disk.

Rewriting test to use a block that is not confirmed on disk.
Cleaning up confirmation_height.conflict_rollback_cemented and reduce complexity.
Cleaning up election.quorum_minimum_confirm_success and fixing race condition where confirmation happens asynchronously.
Fixing race condition in election.quorum_minimum_update_weight_before_quorum_checks when checking asynchronous election confirmation.
Cleaning up and simplifying node.rollback_gap_source Removing some test calls to block_processor::flush which is being phased out.