### PR TITLE
Move rpc.pending_exists in to the receivable.cpp file and renaming to rpc.receivable_exists

### DIFF
--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -547,3 +547,37 @@ TEST (rpc, accounts_receivable_confirmed)
 	}
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }
+
+TEST (rpc, receivable_exists)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	nano::keypair key1;
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	auto hash0 (node->latest (nano::dev::genesis->account ()));
+	auto block1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 100));
+	ASSERT_TIMELY (5s, node->block_confirmed (block1->hash ()));
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+
+	auto pending_exists = [&system, &rpc_ctx, &request] (char const * exists_a) {
+		auto response0 (wait_response (system, rpc_ctx, request));
+		std::string exists_text (response0.get<std::string> ("exists"));
+		return exists_a == exists_text;
+	};
+
+	request.put ("action", "pending_exists");
+	request.put ("hash", hash0.to_string ());
+	ASSERT_TRUE (pending_exists ("0"));
+
+	node->store.pending.exists (node->store.tx_begin_read (), nano::pending_key (nano::dev::genesis_key.pub, block1->hash ()));
+	request.put ("hash", block1->hash ().to_string ());
+	ASSERT_TRUE (pending_exists ("1"));
+
+	ASSERT_TRUE (pending_exists ("1"));
+	reset_confirmation_height (node->store, block1->account ());
+	ASSERT_TRUE (pending_exists ("0"));
+	request.put ("include_only_confirmed", "false");
+	ASSERT_TRUE (pending_exists ("1"));
+}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3231,40 +3231,6 @@ TEST (rpc, wallet_balances)
 	}
 }
 
-TEST (rpc, pending_exists)
-{
-	nano::test::system system;
-	auto node = add_ipc_enabled_node (system);
-	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto hash0 (node->latest (nano::dev::genesis->account ()));
-	auto block1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 100));
-	ASSERT_TIMELY (5s, node->block_confirmed (block1->hash ()));
-
-	auto const rpc_ctx = add_rpc (system, node);
-	boost::property_tree::ptree request;
-
-	auto pending_exists = [&system, &rpc_ctx, &request] (char const * exists_a) {
-		auto response0 (wait_response (system, rpc_ctx, request));
-		std::string exists_text (response0.get<std::string> ("exists"));
-		return exists_a == exists_text;
-	};
-
-	request.put ("action", "pending_exists");
-	request.put ("hash", hash0.to_string ());
-	ASSERT_TRUE (pending_exists ("0"));
-
-	node->store.pending.exists (node->store.tx_begin_read (), nano::pending_key (nano::dev::genesis_key.pub, block1->hash ()));
-	request.put ("hash", block1->hash ().to_string ());
-	ASSERT_TRUE (pending_exists ("1"));
-
-	ASSERT_TRUE (pending_exists ("1"));
-	reset_confirmation_height (node->store, block1->account ());
-	ASSERT_TRUE (pending_exists ("0"));
-	request.put ("include_only_confirmed", "false");
-	ASSERT_TRUE (pending_exists ("1"));
-}
-
 TEST (rpc, wallet_pending)
 {
 	nano::test::system system;


### PR DESCRIPTION
Cleaning up test using new test functionality and avoiding clearing confirmation heights which can be problematic while the node is running.