### PR TITLE
Socket write queue fixes and improvements

### DIFF
--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -459,11 +459,11 @@ TEST (socket, drop_policy)
 
 	// We're going to write twice the queue size + 1, and the server isn't reading
 	// The total number of drops should thus be 1 (the socket allows doubling the queue size for no_socket_drop)
-	func (nano::transport::socket::default_queue_size_max * 2 + 1, nano::transport::buffer_drop_policy::no_socket_drop);
+	func (nano::transport::socket::default_max_queue_size * 2 + 1, nano::transport::buffer_drop_policy::no_socket_drop);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_no_socket_drop, nano::stat::dir::out));
 	ASSERT_EQ (0, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out));
 
-	func (nano::transport::socket::default_queue_size_max + 1, nano::transport::buffer_drop_policy::limiter);
+	func (nano::transport::socket::default_max_queue_size + 1, nano::transport::buffer_drop_policy::limiter);
 	// The stats are accumulated from before
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_no_socket_drop, nano::stat::dir::out));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_drop, nano::stat::dir::out));

--- a/nano/node/bandwidth_limiter.cpp
+++ b/nano/node/bandwidth_limiter.cpp
@@ -57,3 +57,18 @@ void nano::outbound_bandwidth_limiter::reset (std::size_t limit, double burst_ra
 	auto & limiter = select_limiter (type);
 	limiter.reset (limit, burst_ratio);
 }
+
+nano::bandwidth_limit_type nano::to_bandwidth_limit_type (const nano::transport::traffic_type & traffic_type)
+{
+	switch (traffic_type)
+	{
+		case nano::transport::traffic_type::generic:
+			return nano::bandwidth_limit_type::standard;
+			break;
+		case nano::transport::traffic_type::bootstrap:
+			return nano::bandwidth_limit_type::bootstrap;
+			break;
+	}
+	debug_assert (false);
+	return {};
+}

--- a/nano/node/bandwidth_limiter.hpp
+++ b/nano/node/bandwidth_limiter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/rate_limiting.hpp>
+#include <nano/node/transport/traffic_type.hpp>
 
 namespace nano
 {
@@ -14,6 +15,8 @@ enum class bandwidth_limit_type
 	/** For bootstrap (asc_pull_ack, asc_pull_req) traffic */
 	bootstrap
 };
+
+nano::bandwidth_limit_type to_bandwidth_limit_type (nano::transport::traffic_type const &);
 
 /**
  * Class that tracks and manages bandwidth limits for IO operations

--- a/nano/node/bootstrap/bootstrap_ascending.cpp
+++ b/nano/node/bootstrap/bootstrap_ascending.cpp
@@ -455,7 +455,7 @@ void nano::bootstrap_ascending::send (std::shared_ptr<nano::transport::channel> 
 	// TODO: There is no feedback mechanism if bandwidth limiter starts dropping our requests
 	channel->send (
 	request, nullptr,
-	nano::transport::buffer_drop_policy::limiter, nano::bandwidth_limit_type::bootstrap);
+	nano::transport::buffer_drop_policy::limiter, nano::transport::traffic_type::bootstrap);
 }
 
 size_t nano::bootstrap_ascending::priority_size () const
@@ -561,7 +561,7 @@ std::shared_ptr<nano::transport::channel> nano::bootstrap_ascending::available_c
 	auto channels = network.random_set (32, node.network_params.network.bootstrap_protocol_version_min, /* include temporary channels */ true);
 	for (auto & channel : channels)
 	{
-		if (!channel->max ())
+		if (!channel->max (nano::transport::traffic_type::bootstrap))
 		{
 			return channel;
 		}

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -81,7 +81,7 @@ bool nano::bootstrap_server::request (nano::asc_pull_req const & message, std::s
 
 	// If channel is full our response will be dropped anyway, so filter that early
 	// TODO: Add per channel limits (this ideally should be done on the channel message processing side)
-	if (channel->max ())
+	if (channel->max (nano::transport::traffic_type::bootstrap))
 	{
 		stats.inc (nano::stat::type::bootstrap_server, nano::stat::detail::channel_full, nano::stat::dir::in);
 		return false;
@@ -125,7 +125,7 @@ void nano::bootstrap_server::respond (nano::asc_pull_ack & response, std::shared
 			stats.inc (nano::stat::type::bootstrap_server, nano::stat::detail::write_error, nano::stat::dir::out);
 		}
 	},
-	nano::transport::buffer_drop_policy::limiter, nano::bandwidth_limit_type::bootstrap);
+	nano::transport::buffer_drop_policy::limiter, nano::transport::traffic_type::bootstrap);
 }
 
 /*
@@ -138,7 +138,7 @@ void nano::bootstrap_server::process_batch (std::deque<request_t> & batch)
 
 	for (auto & [request, channel] : batch)
 	{
-		if (!channel->max ())
+		if (!channel->max (nano::transport::traffic_type::bootstrap))
 		{
 			auto response = process (transaction, request);
 			respond (response, channel);

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -14,15 +14,15 @@ nano::transport::channel::channel (nano::node & node_a) :
 	set_network_version (node_a.network_params.network.protocol_version);
 }
 
-void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a, nano::bandwidth_limit_type limiter_type)
+void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a, nano::transport::traffic_type traffic_type)
 {
 	auto buffer (message_a.to_shared_const_buffer ());
 	auto detail = nano::to_stat_detail (message_a.header.type);
 	auto is_droppable_by_limiter = (drop_policy_a == nano::transport::buffer_drop_policy::limiter);
-	auto should_pass (node.outbound_limiter.should_pass (buffer.size (), limiter_type));
+	auto should_pass (node.outbound_limiter.should_pass (buffer.size (), to_bandwidth_limit_type (traffic_type)));
 	if (!is_droppable_by_limiter || should_pass)
 	{
-		send_buffer (buffer, callback_a, drop_policy_a);
+		send_buffer (buffer, callback_a, drop_policy_a, traffic_type);
 		node.stats.inc (nano::stat::type::message, detail, nano::stat::dir::out);
 	}
 	else

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -27,15 +27,25 @@ public:
 
 	virtual std::size_t hash_code () const = 0;
 	virtual bool operator== (nano::transport::channel const &) const = 0;
-	void send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a = nullptr, nano::transport::buffer_drop_policy policy_a = nano::transport::buffer_drop_policy::limiter, nano::bandwidth_limit_type = nano::bandwidth_limit_type::standard);
+
+	void send (nano::message & message_a,
+	std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a = nullptr,
+	nano::transport::buffer_drop_policy policy_a = nano::transport::buffer_drop_policy::limiter,
+	nano::transport::traffic_type = nano::transport::traffic_type::generic);
+
 	// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
-	//
-	virtual void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter) = 0;
+	virtual void send_buffer (nano::shared_const_buffer const &,
+	std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr,
+	nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter,
+	nano::transport::traffic_type = nano::transport::traffic_type::generic)
+	= 0;
+
 	virtual std::string to_string () const = 0;
 	virtual nano::endpoint get_endpoint () const = 0;
 	virtual nano::tcp_endpoint get_tcp_endpoint () const = 0;
 	virtual nano::transport::transport_type get_type () const = 0;
-	virtual bool max ()
+
+	virtual bool max (nano::transport::traffic_type = nano::transport::traffic_type::generic)
 	{
 		return false;
 	}

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -13,10 +13,10 @@ nano::transport::fake::channel::channel (nano::node & node) :
 
 /**
  * The send function behaves like a null device, it throws the data away and returns success.
-*/
-void nano::transport::fake::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a)
+ */
+void nano::transport::fake::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a, nano::transport::traffic_type traffic_type)
 {
-	//auto bytes = buffer_a.to_bytes ();
+	// auto bytes = buffer_a.to_bytes ();
 	auto size = buffer_a.size ();
 	if (callback_a)
 	{

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -20,13 +20,11 @@ namespace transport
 			std::string to_string () const override;
 			std::size_t hash_code () const override;
 
-			// clang-format off
 			void send_buffer (
-				nano::shared_const_buffer const &,
-				std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr,
-				nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter
-			) override;
-			// clang-format on
+			nano::shared_const_buffer const &,
+			std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr,
+			nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter,
+			nano::transport::traffic_type = nano::transport::traffic_type::generic) override;
 
 			bool operator== (nano::transport::channel const &) const override;
 			bool operator== (nano::transport::fake::channel const & other_a) const;

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -53,7 +53,7 @@ public:
  * Send the buffer to the peer and call the callback function when done. The call never fails.
  * Note that the inbound message visitor will be called before the callback because it is called directly whereas the callback is spawned in the background.
  */
-void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a)
+void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a, nano::transport::traffic_type traffic_type)
 {
 	auto offset = 0u;
 	auto const buffer_read_fn = [&offset, buffer_v = buffer_a.to_bytes ()] (std::shared_ptr<std::vector<uint8_t>> const & data_a, size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a) {

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -18,9 +18,10 @@ namespace transport
 			explicit channel (nano::node & node, nano::node & destination);
 			std::size_t hash_code () const override;
 			bool operator== (nano::transport::channel const &) const override;
+
 			// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
-			//
-			void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter) override;
+			void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter, nano::transport::traffic_type = nano::transport::traffic_type::generic) override;
+
 			std::string to_string () const override;
 			bool operator== (nano::transport::inproc::channel const & other_a) const
 			{

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -36,7 +36,7 @@ bool is_temporary_error (boost::system::error_code const & ec_a)
  * socket
  */
 
-nano::transport::socket::socket (nano::node & node_a, endpoint_type_t endpoint_type_a) :
+nano::transport::socket::socket (nano::node & node_a, endpoint_type_t endpoint_type_a, std::size_t queue_size_max_a) :
 	strand{ node_a.io_ctx.get_executor () },
 	tcp_socket{ node_a.io_ctx },
 	write_timer{ node_a.io_ctx },
@@ -46,7 +46,8 @@ nano::transport::socket::socket (nano::node & node_a, endpoint_type_t endpoint_t
 	last_completion_time_or_init{ nano::seconds_since_epoch () },
 	last_receive_time_or_init{ nano::seconds_since_epoch () },
 	default_timeout{ node_a.config.tcp_io_timeout },
-	silent_connection_tolerance_time{ node_a.network_params.network.silent_connection_tolerance_time }
+	silent_connection_tolerance_time{ node_a.network_params.network.silent_connection_tolerance_time },
+	queue_size_max{ queue_size_max_a }
 {
 }
 

--- a/nano/node/transport/socket.cpp
+++ b/nano/node/transport/socket.cpp
@@ -36,8 +36,8 @@ bool is_temporary_error (boost::system::error_code const & ec_a)
  * socket
  */
 
-nano::transport::socket::socket (nano::node & node_a, endpoint_type_t endpoint_type_a, std::size_t queue_size_max_a) :
-	send_queue{ queue_size_max_a },
+nano::transport::socket::socket (nano::node & node_a, endpoint_type_t endpoint_type_a, std::size_t max_queue_size_a) :
+	send_queue{ max_queue_size_a },
 	strand{ node_a.io_ctx.get_executor () },
 	tcp_socket{ node_a.io_ctx },
 	write_timer{ node_a.io_ctx },
@@ -48,7 +48,7 @@ nano::transport::socket::socket (nano::node & node_a, endpoint_type_t endpoint_t
 	last_receive_time_or_init{ nano::seconds_since_epoch () },
 	default_timeout{ node_a.config.tcp_io_timeout },
 	silent_connection_tolerance_time{ node_a.network_params.network.silent_connection_tolerance_time },
-	queue_size_max{ queue_size_max_a }
+	max_queue_size{ max_queue_size_a }
 {
 }
 
@@ -202,12 +202,12 @@ void nano::transport::socket::ongoing_write ()
 
 bool nano::transport::socket::max (nano::transport::traffic_type traffic_type) const
 {
-	return send_queue.size (traffic_type) >= queue_size_max;
+	return send_queue.size (traffic_type) >= max_queue_size;
 }
 
 bool nano::transport::socket::full (nano::transport::traffic_type traffic_type) const
 {
-	return send_queue.size (traffic_type) >= 2 * queue_size_max;
+	return send_queue.size (traffic_type) >= 2 * max_queue_size;
 }
 
 /** Call set_timeout with default_timeout as parameter */

--- a/nano/node/transport/socket.hpp
+++ b/nano/node/transport/socket.hpp
@@ -48,7 +48,7 @@ class socket : public std::enable_shared_from_this<nano::transport::socket>
 	friend class tcp_channels;
 
 public:
-	static std::size_t constexpr default_queue_size_max = 128;
+	static std::size_t constexpr default_max_queue_size = 128;
 
 	enum class type_t
 	{
@@ -69,7 +69,7 @@ public:
 	 * @param node Owning node
 	 * @param endpoint_type_a The endpoint's type: either server or client
 	 */
-	explicit socket (nano::node & node, endpoint_type_t endpoint_type_a, std::size_t queue_size_max = default_queue_size_max);
+	explicit socket (nano::node & node, endpoint_type_t endpoint_type_a, std::size_t max_queue_size = default_max_queue_size);
 	virtual ~socket ();
 
 	void start ();
@@ -204,7 +204,7 @@ private:
 	endpoint_type_t endpoint_type_m;
 
 public:
-	std::size_t const queue_size_max;
+	std::size_t const max_queue_size;
 };
 
 std::string socket_type_to_string (socket::type_t type);
@@ -261,8 +261,8 @@ public:
 	 * Constructor
 	 * @param node_a Owning node
 	 */
-	explicit client_socket (nano::node & node_a, std::size_t queue_size_max = default_queue_size_max) :
-		socket{ node_a, endpoint_type_t::client, queue_size_max }
+	explicit client_socket (nano::node & node_a, std::size_t max_queue_size = default_max_queue_size) :
+		socket{ node_a, endpoint_type_t::client, max_queue_size }
 	{
 	}
 };

--- a/nano/node/transport/socket.hpp
+++ b/nano/node/transport/socket.hpp
@@ -47,6 +47,8 @@ class socket : public std::enable_shared_from_this<nano::transport::socket>
 	friend class tcp_channels;
 
 public:
+	static std::size_t constexpr default_queue_size_max = 128;
+
 	enum class type_t
 	{
 		undefined,
@@ -66,7 +68,7 @@ public:
 	 * @param node Owning node
 	 * @param endpoint_type_a The endpoint's type: either server or client
 	 */
-	explicit socket (nano::node & node, endpoint_type_t endpoint_type_a);
+	explicit socket (nano::node & node, endpoint_type_t endpoint_type_a, std::size_t queue_size_max = default_queue_size_max);
 	virtual ~socket ();
 
 	void start ();
@@ -189,8 +191,7 @@ private:
 	endpoint_type_t endpoint_type_m;
 
 public:
-	static std::size_t constexpr queue_size_max = 128;
-	static std::size_t constexpr singe_queue_size_max = 128;
+	std::size_t const queue_size_max;
 };
 
 std::string socket_type_to_string (socket::type_t type);
@@ -247,8 +248,8 @@ public:
 	 * Constructor
 	 * @param node_a Owning node
 	 */
-	explicit client_socket (nano::node & node_a) :
-		socket{ node_a, endpoint_type_t::client }
+	explicit client_socket (nano::node & node_a, std::size_t queue_size_max = default_queue_size_max) :
+		socket{ node_a, endpoint_type_t::client, queue_size_max }
 	{
 	}
 };

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -46,11 +46,11 @@ bool nano::transport::channel_tcp::operator== (nano::transport::channel const & 
 	return result;
 }
 
-void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy policy_a)
+void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy policy_a, nano::transport::traffic_type traffic_type)
 {
 	if (auto socket_l = socket.lock ())
 	{
-		if (!socket_l->max () || (policy_a == nano::transport::buffer_drop_policy::no_socket_drop && !socket_l->full ()))
+		if (!socket_l->max (traffic_type) || (policy_a == nano::transport::buffer_drop_policy::no_socket_drop && !socket_l->full (traffic_type)))
 		{
 			socket_l->async_write (
 			buffer_a, [endpoint_a = socket_l->remote_endpoint (), node = std::weak_ptr<nano::node> (node.shared ()), callback_a] (boost::system::error_code const & ec, std::size_t size_a) {
@@ -69,7 +69,8 @@ void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const 
 						callback_a (ec, size_a);
 					}
 				}
-			});
+			},
+			traffic_type);
 		}
 		else
 		{

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -37,11 +37,13 @@ namespace transport
 	public:
 		channel_tcp (nano::node &, std::weak_ptr<nano::transport::socket>);
 		~channel_tcp () override;
+
 		std::size_t hash_code () const override;
 		bool operator== (nano::transport::channel const &) const override;
-		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
-		//
-		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter) override;
+
+		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions//
+		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter, nano::transport::traffic_type = nano::transport::traffic_type::generic) override;
+
 		std::string to_string () const override;
 		bool operator== (nano::transport::channel_tcp const & other_a) const
 		{
@@ -70,12 +72,12 @@ namespace transport
 			return nano::transport::transport_type::tcp;
 		}
 
-		virtual bool max () override
+		virtual bool max (nano::transport::traffic_type traffic_type) override
 		{
 			bool result = true;
 			if (auto socket_l = socket.lock ())
 			{
-				result = socket_l->max ();
+				result = socket_l->max (traffic_type);
 			}
 			return result;
 		}

--- a/nano/node/transport/traffic_type.hpp
+++ b/nano/node/transport/traffic_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace nano::transport
+{
+/**
+ * Used for message prioritization and bandwidth limits
+ */
+enum class traffic_type
+{
+	generic,
+	/** For bootstrap (asc_pull_ack, asc_pull_req) traffic */
+	bootstrap
+};
+}


### PR DESCRIPTION
The socket asynchronous write loop, first introduced in #1938 got broken by #2918. The problematic PR attempted to streamline logic, seemingly with the assumption that just a strand is enough to guarantee correct order of execution of async writes, however this assumption is not correct. A strand can only ensure that tasks are executed sequentially with other tasks, so an unfortunate call sequence of `async_write_1 > async_write_2 > async_write_1_complete > async_write_2_complete ...` is still possible. Here is a link to a brief discussion from the Boost ASIO mailing list that mentions this problem: https://boost-users.boost.narkive.com/MrmFQST2/multiple-async-operations-on-a-socket To correctly implement a multi-writer async write loop, both strand and a write queue of some sort is required. Failure to do so might result in data from multiple write requests being interleaved, which is exactly the issue observed during high load local tests. This could also explain why a drop in connected nodes is observed each time live network activity spikes.


A related improvement is that the newly introduced socket send queue is further split into multiple subqueues, based on traffic type. This allows for better prioritization of inter node communication when network throughtput is limited, eg. ensuring that bootstrap traffic won't preempt voting when network is experiencing a period of heightened activity. This should eliminate the need for aggressive throttling of ascending bootstrapper rate, as both client and server should now automatically throttle their rate in response to network back pressure (socket send queue being filled). This could be extended further to differently prioritize live voting / voting requests / voting responses / block publishing, which should give the network additional resiliency, but this is a TODO.