### PR TITLE
Fix thread names in `nano::thread_pool`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 # OSX compatibility needs to be set before project is declared
 set(CMAKE_OSX_DEPLOYMENT_TARGET
-    10.15
+    12
     CACHE STRING "")
 
 project(nano-node)

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/thread/thread.hpp>
 
+#include <latch>
 #include <thread>
 
 namespace nano
@@ -208,7 +209,9 @@ private:
 	std::unique_ptr<boost::asio::thread_pool> thread_pool_m;
 	relaxed_atomic_integral<uint64_t> num_tasks{ 0 };
 
-	void set_thread_names (unsigned num_threads, nano::thread_role::name thread_name);
+	/** Set the names of all the threads in the thread pool for easier identification */
+	std::latch thread_names_latch;
+	void set_thread_names (nano::thread_role::name thread_name);
 };
 
 std::unique_ptr<nano::container_info_component> collect_container_info (thread_pool & thread_pool, std::string const & name);


### PR DESCRIPTION
Thread names are very useful to quickly diagnose which threads are causing problems (eg. from htop). However, there were always a few threads whose name was missing, which was caused by buggy `set_thread_names` function. New version uses a counting latch to ensure each thread gets its name assigned, which requires bumping the target macOS version. Generally a thread pool can be implemented by using `boost::io_context` and a `nano::thread_runner` which would give us much better control of underlying threads and avoid some code duplication, but that is a TODO.