### PR TITLE
Fixing threading errors from review and TSAN

### DIFF
--- a/nano/node/bootstrap/bootstrap_ascending.cpp
+++ b/nano/node/bootstrap/bootstrap_ascending.cpp
@@ -590,9 +590,10 @@ void nano::bootstrap_ascending::wait_blockprocessor ()
 
 void nano::bootstrap_ascending::wait_available_request ()
 {
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped && !limiter.should_pass (1))
 	{
-		std::this_thread::sleep_for (50ms); // Give it at least some time to cooldown to avoid hitting the limit too frequently
+		condition.wait_for (lock, 50ms, [this] () { return stopped; }); // Give it at least some time to cooldown to avoid hitting the limit too frequently
 	}
 }
 
@@ -612,9 +613,10 @@ std::shared_ptr<nano::transport::channel> nano::bootstrap_ascending::available_c
 std::shared_ptr<nano::transport::channel> nano::bootstrap_ascending::wait_available_channel ()
 {
 	std::shared_ptr<nano::transport::channel> channel;
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped && !(channel = available_channel ()))
 	{
-		std::this_thread::sleep_for (100ms);
+		condition.wait_for (lock, 100ms, [this] () { return stopped; });
 	}
 	return channel;
 }
@@ -719,10 +721,10 @@ bool nano::bootstrap_ascending::run_one ()
 
 void nano::bootstrap_ascending::throttle_if_needed ()
 {
+	nano::unique_lock<nano::mutex> lock{ mutex };
 	if (!iterator.warmup () && throttle.throttled ())
 	{
 		stats.inc (nano::stat::type::bootstrap_ascending, nano::stat::detail::throttled);
-		nano::unique_lock<nano::mutex> lock{ mutex };
 		condition.wait_for (lock, std::chrono::milliseconds{ node.config.bootstrap_ascending.throttle_wait }, [this] () { return stopped; });
 	}
 }


### PR DESCRIPTION
The rationale for not making throttle thread-safe itself is the fine-grained versus coarse-grained lock tradeoff.
Fine grained:
- Increased lock aquisition/release overhead
- Decreased lock aquisition latency
- Increased chance of deadlock
- More self-contained

Coarse grained:
- Decreased lock acquistion overhead
- Increased lock acquisition latency
- Decrease chance of deadlock
- Less self contained

I don't think there is a chance for deadlock here since throttle doesn't do any callbacks which may induce extra locking
I think the biggest concern is this is already a hot codepath and even the stat counters are starting to show up in profiles because of stat mutex aquisition overhead
I believe the reusability chance of the throttle class is low and it's highly associated with the ascending bootstrapper that already has a mutex that can be used.

The rationale on not using an atomic<bool> for stopped is because it can effectively silence data races when mixed with condition variables.
For instance the schedule:
T1: read stopped (false)
T2: acquire mutex
T2: write stopped (true)
T2: condition notify
T1: condition wait <- Waiting on notification that has already ocurred