### PR TITLE
Simplify the injected dependencies to bootstrap ascending

### DIFF
--- a/nano/node/bootstrap/bootstrap_ascending.hpp
+++ b/nano/node/bootstrap/bootstrap_ascending.hpp
@@ -25,6 +25,7 @@ namespace nano
 class block_processor;
 class ledger;
 class network;
+class node_config;
 
 namespace transport
 {
@@ -53,7 +54,7 @@ class bootstrap_ascending
 	};
 
 public:
-	bootstrap_ascending (nano::node &, nano::store &, nano::block_processor &, nano::ledger &, nano::network &, nano::stats &);
+	bootstrap_ascending (nano::node_config &, nano::block_processor &, nano::ledger &, nano::network &, nano::stats &);
 	~bootstrap_ascending ();
 
 	void start ();
@@ -70,8 +71,8 @@ public: // Container info
 	size_t priority_size () const;
 
 private: // Dependencies
-	nano::node & node;
-	nano::store & store;
+	nano::node_config & config;
+	nano::network_constants & network_consts;
 	nano::block_processor & block_processor;
 	nano::ledger & ledger;
 	nano::network & network;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -201,7 +201,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	aggregator (config, stats, generator, final_generator, history, ledger, wallets, active),
 	wallets (wallets_store.init_error (), *this),
 	backlog{ nano::backlog_population_config (config), store, stats },
-	ascendboot{ *this, store, block_processor, ledger, network, stats },
+	ascendboot{ config, block_processor, ledger, network, stats },
 	websocket{ config.websocket_config, observers, wallets, ledger, io_ctx, logger },
 	epoch_upgrader{ *this, ledger, store, network_params, logger },
 	startup_time (std::chrono::steady_clock::now ()),


### PR DESCRIPTION
Reduce the dependencies by letting only what is used by the current implementation. The previous version relied on full node dependency.