### PR TITLE
Convert node-wide request rate limiter to a per-channel outstanding request limiter.

### DIFF
--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(
   bootstrap_ascending/account_sets.cpp
   bootstrap_ascending/iterators.hpp
   bootstrap_ascending/iterators.cpp
+  bootstrap_ascending/peer_scoring.hpp
+  bootstrap_ascending/peer_scoring.cpp
   bootstrap_ascending/service.hpp
   bootstrap_ascending/service.cpp
   cli.hpp

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -26,7 +26,8 @@ public:
 	nano::error deserialize (nano::tomlconfig & toml);
 	nano::error serialize (nano::tomlconfig & toml) const;
 
-	std::size_t requests_limit{ 1024 };
+	// Maximum number of un-responded requests per channel
+	std::size_t requests_limit{ 4 };
 	std::size_t database_requests_limit{ 1024 };
 	std::size_t pull_count{ nano::bootstrap_server::max_blocks };
 	nano::millis_t timeout{ 1000 * 3 };

--- a/nano/node/bootstrap_ascending/peer_scoring.cpp
+++ b/nano/node/bootstrap_ascending/peer_scoring.cpp
@@ -1,0 +1,135 @@
+#include <nano/node/bootstrap/bootstrap_config.hpp>
+#include <nano/node/bootstrap_ascending/peer_scoring.hpp>
+#include <nano/node/transport/channel.hpp>
+
+/*
+ * peer_scoring
+ */
+
+nano::bootstrap_ascending::peer_scoring::peer_scoring (nano::bootstrap_ascending_config & config, nano::network_constants const & network_constants) :
+	network_constants{ network_constants },
+	config{ config }
+{
+}
+
+bool nano::bootstrap_ascending::peer_scoring::try_send_message (std::shared_ptr<nano::transport::channel> channel)
+{
+	auto & index = scoring.get<tag_channel> ();
+	auto existing = index.find (channel.get ());
+	if (existing == index.end ())
+	{
+		index.emplace (channel, 1, 1, 0);
+	}
+	else
+	{
+		if (existing->outstanding < config.requests_limit)
+		{
+			[[maybe_unused]] auto success = index.modify (existing, [] (auto & score) {
+				++score.outstanding;
+				++score.request_count_total;
+			});
+			debug_assert (success);
+		}
+		else
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+void nano::bootstrap_ascending::peer_scoring::received_message (std::shared_ptr<nano::transport::channel> channel)
+{
+	auto & index = scoring.get<tag_channel> ();
+	auto existing = index.find (channel.get ());
+	if (existing != index.end ())
+	{
+		if (existing->outstanding > 1)
+		{
+			[[maybe_unused]] auto success = index.modify (existing, [] (auto & score) {
+				--score.outstanding;
+				++score.response_count_total;
+			});
+			debug_assert (success);
+		}
+	}
+}
+
+std::shared_ptr<nano::transport::channel> nano::bootstrap_ascending::peer_scoring::channel ()
+{
+	auto & index = scoring.get<tag_outstanding> ();
+	for (auto const & score : index)
+	{
+		if (auto channel = score.shared ())
+		{
+			if (!channel->max ())
+			{
+				if (!try_send_message (channel))
+				{
+					return channel;
+				}
+			}
+		}
+	}
+	return nullptr;
+}
+
+std::size_t nano::bootstrap_ascending::peer_scoring::size () const
+{
+	return scoring.size ();
+}
+
+void nano::bootstrap_ascending::peer_scoring::timeout ()
+{
+	auto & index = scoring.get<tag_channel> ();
+	for (auto score = index.begin (), n = index.end (); score != n;)
+	{
+		if (auto channel = score->shared ())
+		{
+			if (channel->alive ())
+			{
+				++score;
+				continue;
+			}
+		}
+		score = index.erase (score);
+	}
+	for (auto score = scoring.begin (), n = scoring.end (); score != n; ++score)
+	{
+		scoring.modify (score, [] (auto & score_a) {
+			score_a.decay ();
+		});
+	}
+}
+
+void nano::bootstrap_ascending::peer_scoring::sync (std::deque<std::shared_ptr<nano::transport::channel>> const & list)
+{
+	auto & index = scoring.get<tag_channel> ();
+	for (auto const & channel : list)
+	{
+		if (channel->get_network_version () >= network_constants.bootstrap_protocol_version_min)
+		{
+			if (index.find (channel.get ()) == index.end ())
+			{
+				if (!channel->max (nano::transport::traffic_type::bootstrap))
+				{
+					index.emplace (channel, 1, 1, 0);
+				}
+			}
+		}
+	}
+}
+
+/*
+ * peer_score
+ */
+
+nano::bootstrap_ascending::peer_scoring::peer_score::peer_score (
+std::shared_ptr<nano::transport::channel> const & channel_a, uint64_t outstanding_a, uint64_t request_count_total_a, uint64_t response_count_total_a) :
+	channel{ channel_a },
+	channel_ptr{ channel_a.get () },
+	outstanding{ outstanding_a },
+	request_count_total{ request_count_total_a },
+	response_count_total{ response_count_total_a }
+{
+}

--- a/nano/node/bootstrap_ascending/peer_scoring.hpp
+++ b/nano/node/bootstrap_ascending/peer_scoring.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <nano/node/common.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <deque>
+#include <memory>
+
+namespace mi = boost::multi_index;
+
+namespace nano
+{
+class bootstrap_ascending_config;
+class network_constants;
+namespace transport
+{
+	class channel;
+}
+namespace bootstrap_ascending
+{
+	// Container for tracking and scoring peers with respect to bootstrapping
+	class peer_scoring
+	{
+	public:
+		peer_scoring (nano::bootstrap_ascending_config & config, nano::network_constants const & network_constants);
+		// Returns true if channel limit has been exceeded
+		bool try_send_message (std::shared_ptr<nano::transport::channel> channel);
+		void received_message (std::shared_ptr<nano::transport::channel> channel);
+		std::shared_ptr<nano::transport::channel> channel ();
+		[[nodiscard]] std::size_t size () const;
+		// Cleans up scores for closed channels
+		// Decays scores which become inaccurate over time due to message drops
+		void timeout ();
+		void sync (std::deque<std::shared_ptr<nano::transport::channel>> const & list);
+
+	private:
+		class peer_score
+		{
+		public:
+			explicit peer_score (std::shared_ptr<nano::transport::channel> const &, uint64_t, uint64_t, uint64_t);
+			std::weak_ptr<nano::transport::channel> channel;
+			// std::weak_ptr does not provide ordering so the naked pointer is also tracked and used for ordering channels
+			// This pointer may be invalid if the channel has been destroyed
+			nano::transport::channel * channel_ptr;
+			// Acquire reference to the shared channel object if it is still valid
+			[[nodiscard]] std::shared_ptr<nano::transport::channel> shared () const
+			{
+				auto result = channel.lock ();
+				if (result)
+				{
+					debug_assert (result.get () == channel_ptr);
+				}
+				return result;
+			}
+			void decay ()
+			{
+				outstanding = outstanding > 0 ? outstanding - 1 : 0;
+			}
+			// Number of outstanding requests to a peer
+			uint64_t outstanding{ 0 };
+			uint64_t request_count_total{ 0 };
+			uint64_t response_count_total{ 0 };
+		};
+		nano::network_constants const & network_constants;
+		nano::bootstrap_ascending_config & config;
+
+		// clang-format off
+		// Indexes scores by their shared channel pointer
+		class tag_channel {};
+		// Indexes scores by the number of outstanding requests in ascending order
+		class tag_outstanding {};
+
+		using scoring_t = boost::multi_index_container<peer_score,
+		mi::indexed_by<
+			mi::hashed_unique<mi::tag<tag_channel>,
+				mi::member<peer_score, nano::transport::channel *, &peer_score::channel_ptr>>,
+			mi::ordered_non_unique<mi::tag<tag_outstanding>,
+				mi::member<peer_score, uint64_t, &peer_score::outstanding>>>>;
+		// clang-format on
+		scoring_t scoring;
+	};
+}
+}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -510,7 +510,7 @@ public:
 
 	void asc_pull_ack (nano::asc_pull_ack const & message) override
 	{
-		node.ascendboot.process (message);
+		node.ascendboot.process (message, channel);
 	}
 
 private:


### PR DESCRIPTION
This patch adds channel scoring functionality to the ascending bootstrapper. It prioritises using the most responsive channels first, e.g. the channels with the lowest outstanding requests.

Since there is no guarantee requests will be responded to, the scores periodically "decay" when timeouts are calculated.

This scoring opens up future possibilities for additional metrics; an example would be tracking telemetry information and not requesting nodes that report low block counts.

Performance wise this looks to have ~2x improvement over randomly selecting channels as was done previously.