### PR TITLE
Bootstrap dynamic throttle

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(
   socket.cpp
   system.cpp
   telemetry.cpp
+  throttle.cpp
   toml.cpp
   timer.cpp
   uint256_union.cpp

--- a/nano/core_test/throttle.cpp
+++ b/nano/core_test/throttle.cpp
@@ -1,0 +1,39 @@
+#include <nano/node/bootstrap_ascending/throttle.hpp>
+
+#include <gtest/gtest.h>
+
+TEST (throttle, construction)
+{
+	nano::bootstrap_ascending::throttle throttle{ 2 };
+	ASSERT_FALSE (throttle.throttled ());
+}
+
+TEST (throttle, throttled)
+{
+	nano::bootstrap_ascending::throttle throttle{ 2 };
+	throttle.add (false);
+	ASSERT_FALSE (throttle.throttled ());
+	throttle.add (false);
+	ASSERT_TRUE (throttle.throttled ());
+}
+
+TEST (throttle, resize_up)
+{
+	nano::bootstrap_ascending::throttle throttle{ 2 };
+	throttle.add (false);
+	throttle.resize (4);
+	ASSERT_FALSE (throttle.throttled ());
+	throttle.add (false);
+	ASSERT_TRUE (throttle.throttled ());
+}
+
+TEST (throttle, resize_down)
+{
+	nano::bootstrap_ascending::throttle throttle{ 4 };
+	throttle.add (false);
+	ASSERT_FALSE (throttle.throttled ());
+	throttle.resize (2);
+	ASSERT_FALSE (throttle.throttled ());
+	throttle.add (false);
+	ASSERT_TRUE (throttle.throttled ());
+}

--- a/nano/node/bootstrap/bootstrap_config.cpp
+++ b/nano/node/bootstrap/bootstrap_config.cpp
@@ -33,7 +33,7 @@ nano::error nano::bootstrap_ascending_config::deserialize (nano::tomlconfig & to
 	toml.get ("database_requests_limit", database_requests_limit);
 	toml.get ("pull_count", pull_count);
 	toml.get ("timeout", timeout);
-	toml.get ("throttle_count", throttle_count);
+	toml.get ("throttle_coefficient", throttle_coefficient);
 	toml.get ("throttle_wait", throttle_wait);
 
 	if (toml.has_key ("account_sets"))
@@ -51,7 +51,7 @@ nano::error nano::bootstrap_ascending_config::serialize (nano::tomlconfig & toml
 	toml.put ("database_requests_limit", database_requests_limit, "Request limit for accounts from database after which requests will be dropped.\nNote: changing to unlimited (0) is not recommended as this operation competes for resources on querying the database.\ntype:uint64");
 	toml.put ("pull_count", pull_count, "Number of requested blocks for ascending bootstrap request.\ntype:uint64");
 	toml.put ("timeout", timeout, "Timeout in milliseconds for incoming ascending bootstrap messages to be processed.\ntype:milliseconds");
-	toml.put ("throttle_count", throttle_count, "Number of samples to track for bootstrap throttling.\ntype:uint64");
+	toml.put ("throttle_coefficient", throttle_coefficient, "Scales the number of samples to track for bootstrap throttling.\ntype:uint64");
 	toml.put ("throttle_wait", throttle_wait, "Length of time to wait between requests when throttled.\ntype:milliseconds");
 
 	nano::tomlconfig account_sets_l;

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -27,11 +27,11 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 	// Maximum number of un-responded requests per channel
-	std::size_t requests_limit{ 4 };
+	std::size_t requests_limit{ 1024 };
 	std::size_t database_requests_limit{ 1024 };
 	std::size_t pull_count{ nano::bootstrap_server::max_blocks };
 	nano::millis_t timeout{ 1000 * 3 };
-	std::size_t throttle_count{ 4 * 1024 };
+	std::size_t throttle_coefficient{ 16 };
 	nano::millis_t throttle_wait{ 100 };
 
 	nano::account_sets_config account_sets;

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -27,7 +27,7 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 	// Maximum number of un-responded requests per channel
-	std::size_t requests_limit{ 1024 };
+	std::size_t requests_limit{ 64 };
 	std::size_t database_requests_limit{ 1024 };
 	std::size_t pull_count{ nano::bootstrap_server::max_blocks };
 	nano::millis_t timeout{ 1000 * 3 };

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -13,10 +13,7 @@
 #include <nano/node/bootstrap_ascending/throttle.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/member.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index_container.hpp>
 
@@ -55,9 +52,9 @@ namespace bootstrap_ascending
 
 	public: // Container info
 		std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name);
-		size_t blocked_size () const;
-		size_t priority_size () const;
-		size_t score_size () const;
+		std::size_t blocked_size () const;
+		std::size_t priority_size () const;
+		std::size_t score_size () const;
 
 	private: // Dependencies
 		nano::node_config & config;
@@ -138,7 +135,7 @@ namespace bootstrap_ascending
 		nano::bootstrap_ascending::buffered_iterator iterator;
 		nano::bootstrap_ascending::throttle throttle;
 		// Calculates a lookback size based on the size of the ledger where larger ledgers have a larger sample count
-		size_t compute_throttle_size (nano::ledger_cache const & ledger);
+		std::size_t compute_throttle_size () const;
 
 		// clang-format off
 		class tag_sequenced {};

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -137,6 +137,8 @@ namespace bootstrap_ascending
 		nano::bootstrap_ascending::account_sets accounts;
 		nano::bootstrap_ascending::buffered_iterator iterator;
 		nano::bootstrap_ascending::throttle throttle;
+		// Calculates a lookback size based on the size of the ledger where larger ledgers have a larger sample count
+		size_t compute_throttle_size (nano::ledger_cache const & ledger);
 
 		// clang-format off
 		class tag_sequenced {};

--- a/nano/node/bootstrap_ascending/throttle.cpp
+++ b/nano/node/bootstrap_ascending/throttle.cpp
@@ -1,25 +1,61 @@
+#include <nano/lib/utility.hpp>
 #include <nano/node/bootstrap_ascending/throttle.hpp>
+#include <nano/secure/common.hpp>
 
-nano::bootstrap_ascending::throttle::throttle (std::size_t count) :
-	successes{ count },
-	samples{ count, true }
+nano::bootstrap_ascending::throttle::throttle (std::size_t size) :
+	successes_m{ size }
 {
+	samples.insert (samples.end (), size, true);
+	debug_assert (size > 0);
 }
 
 bool nano::bootstrap_ascending::throttle::throttled () const
 {
-	return successes == 0;
+	return successes_m == 0;
 }
 
 void nano::bootstrap_ascending::throttle::add (bool sample)
 {
-	if (samples.front ())
-	{
-		--successes;
-	}
+	debug_assert (!samples.empty ());
+	pop ();
 	samples.push_back (sample);
 	if (sample)
 	{
-		++successes;
+		++successes_m;
 	}
+	//dump ();
+}
+
+void nano::bootstrap_ascending::throttle::resize (size_t size)
+{
+	debug_assert (size > 0);
+	while (size < samples.size ())
+	{
+		pop ();
+	}
+	while (size > samples.size ())
+	{
+		samples.push_back (false);
+	}
+}
+
+size_t nano::bootstrap_ascending::throttle::size () const
+{
+	return samples.size ();
+}
+
+size_t nano::bootstrap_ascending::throttle::successes () const
+{
+	return successes_m;
+}
+
+void nano::bootstrap_ascending::throttle::pop ()
+{
+	//dump ();
+	if (samples.front ())
+	{
+		--successes_m;
+	}
+	samples.pop_front ();
+	//dump ();
 }

--- a/nano/node/bootstrap_ascending/throttle.cpp
+++ b/nano/node/bootstrap_ascending/throttle.cpp
@@ -1,6 +1,5 @@
 #include <nano/lib/utility.hpp>
 #include <nano/node/bootstrap_ascending/throttle.hpp>
-#include <nano/secure/common.hpp>
 
 nano::bootstrap_ascending::throttle::throttle (std::size_t size) :
 	successes_m{ size }
@@ -23,10 +22,9 @@ void nano::bootstrap_ascending::throttle::add (bool sample)
 	{
 		++successes_m;
 	}
-	//dump ();
 }
 
-void nano::bootstrap_ascending::throttle::resize (size_t size)
+void nano::bootstrap_ascending::throttle::resize (std::size_t size)
 {
 	debug_assert (size > 0);
 	while (size < samples.size ())
@@ -39,23 +37,21 @@ void nano::bootstrap_ascending::throttle::resize (size_t size)
 	}
 }
 
-size_t nano::bootstrap_ascending::throttle::size () const
+std::size_t nano::bootstrap_ascending::throttle::size () const
 {
 	return samples.size ();
 }
 
-size_t nano::bootstrap_ascending::throttle::successes () const
+std::size_t nano::bootstrap_ascending::throttle::successes () const
 {
 	return successes_m;
 }
 
 void nano::bootstrap_ascending::throttle::pop ()
 {
-	//dump ();
 	if (samples.front ())
 	{
 		--successes_m;
 	}
 	samples.pop_front ();
-	//dump ();
 }

--- a/nano/node/bootstrap_ascending/throttle.hpp
+++ b/nano/node/bootstrap_ascending/throttle.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/circular_buffer.hpp>
+#include <deque>
 
 namespace nano::bootstrap_ascending
 {
@@ -13,11 +13,17 @@ public:
 	explicit throttle (std::size_t size);
 	bool throttled () const;
 	void add (bool success);
+	// Resizes the number of samples tracked
+	// Drops the oldest samples if the size decreases
+	// Adds fals samples if the size increases
+	void resize (size_t size);
+	size_t size () const;
+	size_t successes () const;
 
 private:
-	// Rolling count of true samples in the sample buffer
-	std::size_t successes;
-	// Circular buffer that tracks sample results. True when something was retrieved, false otherwise
-	boost::circular_buffer<bool> samples;
+	void pop ();
+	// Bit set that tracks sample results. True when something was retrieved, false otherwise
+	std::deque<bool> samples;
+	size_t successes_m;
 };
 } // nano::boostrap_ascending

--- a/nano/node/bootstrap_ascending/throttle.hpp
+++ b/nano/node/bootstrap_ascending/throttle.hpp
@@ -11,19 +11,19 @@ class throttle
 public:
 	// Initialized with all true samples
 	explicit throttle (std::size_t size);
-	bool throttled () const;
+	[[nodiscard]] bool throttled () const;
 	void add (bool success);
 	// Resizes the number of samples tracked
 	// Drops the oldest samples if the size decreases
-	// Adds fals samples if the size increases
-	void resize (size_t size);
-	size_t size () const;
-	size_t successes () const;
+	// Adds false samples if the size increases
+	void resize (std::size_t size);
+	[[nodiscard]] std::size_t size () const;
+	[[nodiscard]] std::size_t successes () const;
 
 private:
 	void pop ();
 	// Bit set that tracks sample results. True when something was retrieved, false otherwise
 	std::deque<bool> samples;
-	size_t successes_m;
+	std::size_t successes_m;
 };
 } // nano::boostrap_ascending


### PR DESCRIPTION
Adds ability for the bootstrap throttle to dynamically change the number of samples it tracks.

The issue with using a fixed number is it doesn't scale as the ledger scales and particularly causes high CPU usage in unit tests or prematurely stops bootstrapping with the live ledger.

This change dynamically changes the number of tracked samples as the ledger grows.

The formula used for selecting the throttle size is config.throttle_coefficient * sqrt(block_count) and the throttle coefficient uses a default value of 16 which is a good fit based on beta and live testing.