### PR TITLE
Fixes intermittent test failures in several RPC tests when querying setup blocks. 

### DIFF
--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -129,7 +129,9 @@ TEST (rpc, receivable_source_min_version)
 TEST (rpc, receivable_unconfirmed)
 {
 	nano::test::system system;
-	auto node = add_ipc_enabled_node (system);
+	nano::node_config config;
+	config.backlog_scan_batch_size = 0;
+	auto node = add_ipc_enabled_node (system, config);
 	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
 	auto block1 = chain[0];
 
@@ -525,7 +527,9 @@ TEST (rpc, accounts_receivable_source)
 TEST (rpc, accounts_receivable_confirmed)
 {
 	nano::test::system system;
-	auto node = add_ipc_enabled_node (system);
+	nano::node_config config;
+	config.backlog_scan_batch_size = 0;
+	auto node = add_ipc_enabled_node (system, config);
 	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
 	auto block1 = chain[0];
 	ASSERT_TIMELY (5s, !node->active.active (*block1));

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -132,6 +132,7 @@ TEST (rpc, receivable_unconfirmed)
 	auto node = add_ipc_enabled_node (system);
 	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
 	auto block1 = chain[0];
+
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "receivable");
@@ -141,9 +142,9 @@ TEST (rpc, receivable_unconfirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
-	{
-		node->store.confirmation_height.put (node->store.tx_begin_write (), nano::dev::genesis_key.pub, { 2, block1->hash () });
-	}
+	nano::test::confirm (*node, { block1->hash () });
+	ASSERT_TIMELY (5s, !node->active.active (*block1));
+	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }
 
@@ -527,6 +528,7 @@ TEST (rpc, accounts_receivable_confirmed)
 	auto node = add_ipc_enabled_node (system);
 	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
 	auto block1 = chain[0];
+	ASSERT_TIMELY (5s, !node->active.active (*block1));
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -542,8 +544,8 @@ TEST (rpc, accounts_receivable_confirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
-	{
-		node->store.confirmation_height.put (node->store.tx_begin_write (), nano::dev::genesis_key.pub, { 2, block1->hash () });
-	}
+	nano::test::confirm (*node, { block1->hash () });
+	ASSERT_TIMELY (5s, !node->active.active (*block1));
+	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -67,6 +67,7 @@ TEST (rpc, account_balance)
 				 .build ();
 
 	ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
+	ASSERT_TIMELY (5s, !node->active.active (*send1));
 
 	auto const rpc_ctx = add_rpc (system, node);
 
@@ -2967,6 +2968,7 @@ TEST (rpc, accounts_balances_unopened_account_with_receivables)
 		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 	}
 	ASSERT_TIMELY (5s, node->block (send->hash ()));
+	ASSERT_TIMELY (5s, !node->active.active (*send));
 
 	// create and send the rpc request for the unopened account and wait for the response
 	auto const rpc_ctx = add_rpc (system, node);
@@ -3240,6 +3242,7 @@ TEST (rpc, pending_exists)
 	auto hash0 (node->latest (nano::dev::genesis->account ()));
 	auto block1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 100));
 	ASSERT_TIMELY (5s, node->block_confirmed (block1->hash ()));
+	ASSERT_TIMELY (5s, !node->active.active (*block1));
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3297,6 +3300,7 @@ TEST (rpc, wallet_receivable)
 	auto iterations (0);
 	auto block1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 100));
 	ASSERT_TIMELY (5s, node->block_confirmed (block1->hash ()));
+	ASSERT_TIMELY (5s, !node->active.active (*block1));
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_receivable");
@@ -3844,6 +3848,8 @@ TEST (rpc, account_info)
 					.work (*node1->work_generate_blocking (key1.pub))
 					.build ();
 		ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+		ASSERT_TIMELY (5s, !node1->active.active (*state_change));
+		ASSERT_TIMELY (5s, !node1->active.active (*open));
 	}
 
 	{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2950,7 +2950,9 @@ TEST (rpc, accounts_balances)
 TEST (rpc, accounts_balances_unopened_account_with_receivables)
 {
 	nano::test::system system;
-	auto node = add_ipc_enabled_node (system);
+	nano::node_config config;
+	config.backlog_scan_batch_size = 0;
+	auto node = add_ipc_enabled_node (system, config);
 
 	// send a 1 raw to the unopened account which will have receivables
 	nano::keypair unopened_account;
@@ -3236,7 +3238,9 @@ TEST (rpc, wallet_balances)
 TEST (rpc, pending_exists)
 {
 	nano::test::system system;
-	auto node = add_ipc_enabled_node (system);
+	nano::node_config config;
+	config.backlog_scan_batch_size = 0;
+	auto node = add_ipc_enabled_node (system, config);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto hash0 (node->latest (nano::dev::genesis->account ()));
@@ -3293,7 +3297,9 @@ TEST (rpc, wallet_pending)
 TEST (rpc, wallet_receivable)
 {
 	nano::test::system system;
-	auto node = add_ipc_enabled_node (system);
+	nano::node_config config;
+	config.backlog_scan_batch_size = 0;
+	auto node = add_ipc_enabled_node (system, config);
 	nano::keypair key1;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key1.prv);


### PR DESCRIPTION
This issue is the result of these blocks being filtered out as include_active defaults to false.

The include_active flag has been superseded by include_only_confirmed and will be marked as deprecated.