### PR TITLE
Quality improvements for `accounts_balances` RPC

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -898,6 +898,7 @@ void nano::json_handler::account_weight ()
 void nano::json_handler::accounts_balances ()
 {
 	boost::property_tree::ptree balances;
+	boost::property_tree::ptree errors;
 	auto transaction = node.store.tx_begin_read ();
 	for (auto & account_from_request : request.get_child ("accounts"))
 	{
@@ -913,11 +914,18 @@ void nano::json_handler::accounts_balances ()
 			balances.put_child (account_from_request.second.data (), entry);
 			continue;
 		}
-		entry.put ("error", ec.message ());
-		balances.put_child (account_from_request.second.data (), entry);
+		debug_assert (ec);
+		errors.put (account_from_request.second.data (), ec.message ());
 		ec = {};
 	}
-	response_l.add_child ("balances", balances);
+	if (!balances.empty ())
+	{
+		response_l.add_child ("balances", balances);
+	}
+	if (!errors.empty ())
+	{
+		response_l.add_child ("errors", errors);
+	}
 	response_errors ();
 }
 


### PR DESCRIPTION
Address issue reported by https://github.com/nanocurrency/nano-docs/issues/665. Related to https://github.com/nanocurrency/nano-node/pull/4223, but this applies to `accounts_balances` RPC.

**accounts_balances**

Request:
```json
{  
  "action": "accounts_balances",  
  "accounts": ["nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3", "nano_36uccgpjzhjsdbj44wm1y5hyz8gefx3wjpp1jircxt84nopxkxti5bzq1rnz", "nano_1hrts7hcoozxccnffoq9hqhngnn9jz783usapejm57ejtqcyz9dpso1bibuy"]  
}
```

Response (note the second account number is a not found account -- it returns a 0 balance):
```json
{
    "balances": {
        "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {
            "balance": "325586539664609129644855132177",
            "pending": "2309370929000000000000000000000000",
            "receivable": "2309370929000000000000000000000000"
        },
        "nano_1hrts7hcoozxccnffoq9hqhngnn9jz783usapejm57ejtqcyz9dpso1bibuy": {
            "balance": "0",
            "pending": "0",
            "receivable": "0"
        }
    },
    "errors": {
        "nano_36uccgpjzhjsdbj44wm1y5hyz8gefx3wjpp1jircxt84nopxkxti5bzq1rnz": "Bad account number"
    }
}
```

Request & Response when there are no errors:

Request:
```json
{  
  "action": "accounts_frontiers",  
  "accounts": ["nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"]  
}
```

Response:
```json
{
    "balances": {
        "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {
            "balance": "325586539664609129644855132177",
            "pending": "2309370929000000000000000000000000",
            "receivable": "2309370929000000000000000000000000"
        }
    }
}
```

Request & Response when all entries return errors:

Request:
```json
{  
  "action": "accounts_frontiers",  
  "accounts": ["nano_36uccgpjzhjsdbj44wm1y5hyz8gefx3wjpp1jircxt84nopxkxti5bzq1rnz"]  
}
```

Response:
```json
{
    "errors": {
        "nano_36uccgpjzhjsdbj44wm1y5hyz8gefx3wjpp1jircxt84nopxkxti5bzq1rnz": "Bad account number"
    }
}
```
