### PR TITLE
Moving responsibility of trimming active_transaction container

### DIFF
--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -182,6 +182,8 @@ public:
 	void remove_election_winner_details (nano::block_hash const &);
 
 private:
+	// Erase elections if we're over capacity
+	void trim ();
 	// Call action with confirmed block, may be different than what we started with
 	nano::election_insertion_result insert_impl (nano::unique_lock<nano::mutex> &, std::shared_ptr<nano::block> const &, nano::election_behavior = nano::election_behavior::normal, std::function<void (std::shared_ptr<nano::block> const &)> const & = nullptr);
 	void request_loop ();

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -50,7 +50,6 @@ private:
 	bool empty_locked () const;
 	bool priority_queue_predicate () const;
 	bool manual_queue_predicate () const;
-	bool overfill_predicate () const;
 
 	nano::prioritization priority;
 


### PR DESCRIPTION
Moving responsibility of trimming active_transaction container in to the container itself rather than in the election scheduler.