### PR TITLE
Create namespace 'scheduler' and class scheduler::component

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1,5 +1,7 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
@@ -416,7 +418,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	ASSERT_TIMELY (5s, node.inactive_vote_cache.find (send1->hash ()));
 	ASSERT_TIMELY (5s, node.inactive_vote_cache.find (send1->hash ())->voters.size () == 2);
 	ASSERT_EQ (1, node.inactive_vote_cache.cache_size ());
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send1->qualified_root ()));
 	ASSERT_EQ (3, election->votes ().size ()); // 2 votes and 1 default not_an_acount
@@ -994,7 +996,7 @@ TEST (active_transactions, confirmation_consistency)
 		system.deadline_set (5s);
 		while (!node.ledger.block_confirmed (node.store.tx_begin_read (), block->hash ()))
 		{
-			node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+			node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 			ASSERT_NO_ERROR (system.poll (5ms));
 		}
 		ASSERT_NO_ERROR (system.poll_until_true (1s, [&node, &block, i] {
@@ -1138,19 +1140,19 @@ TEST (active_transactions, activate_account_chain)
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive).code);
 
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node.active.election (send->qualified_root ()));
 	auto election1 = node.active.election (send->qualified_root ());
 	ASSERT_EQ (1, node.active.size ());
 	ASSERT_EQ (1, election1->blocks ().count (send->hash ()));
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	auto election2 = node.active.election (send->qualified_root ());
 	ASSERT_EQ (election2, election1);
 	election1->force_confirm ();
 	ASSERT_TIMELY (3s, node.block_confirmed (send->hash ()));
 	// On cementing, the next election is started
 	ASSERT_TIMELY (3s, node.active.active (send2->qualified_root ()));
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	auto election3 = node.active.election (send2->qualified_root ());
 	ASSERT_NE (nullptr, election3);
 	ASSERT_EQ (1, election3->blocks ().count (send2->hash ()));
@@ -1159,11 +1161,11 @@ TEST (active_transactions, activate_account_chain)
 	// On cementing, the next election is started
 	ASSERT_TIMELY (3s, node.active.active (open->qualified_root ()));
 	ASSERT_TIMELY (3s, node.active.active (send3->qualified_root ()));
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	auto election4 = node.active.election (send3->qualified_root ());
 	ASSERT_NE (nullptr, election4);
 	ASSERT_EQ (1, election4->blocks ().count (send3->hash ()));
-	node.scheduler.activate (key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (key.pub, node.store.tx_begin_read ());
 	auto election5 = node.active.election (open->qualified_root ());
 	ASSERT_NE (nullptr, election5);
 	ASSERT_EQ (1, election5->blocks ().count (open->hash ()));
@@ -1171,7 +1173,7 @@ TEST (active_transactions, activate_account_chain)
 	ASSERT_TIMELY (3s, node.block_confirmed (open->hash ()));
 	// Until send3 is also confirmed, the receive block should not activate
 	std::this_thread::sleep_for (200ms);
-	node.scheduler.activate (key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (key.pub, node.store.tx_begin_read ());
 	election4->force_confirm ();
 	ASSERT_TIMELY (3s, node.block_confirmed (send3->hash ()));
 	ASSERT_TIMELY (3s, node.active.active (receive->qualified_root ()));
@@ -1312,7 +1314,7 @@ TEST (active_transactions, vacancy)
 		ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
 		ASSERT_EQ (1, node.active.vacancy ());
 		ASSERT_EQ (0, node.active.size ());
-		node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+		node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 		ASSERT_TIMELY (1s, updated);
 		updated = false;
 		ASSERT_EQ (0, node.active.vacancy ());
@@ -1391,11 +1393,11 @@ TEST (active_transactions, fifo)
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive2).code);
 
 	// Ensure first transaction becomes active
-	node.scheduler.manual (receive1);
+	node.scheduler.buckets.manual (receive1);
 	ASSERT_TIMELY (5s, node.active.election (receive1->qualified_root ()) != nullptr);
 
 	// Ensure second transaction becomes active
-	node.scheduler.manual (receive2);
+	node.scheduler.buckets.manual (receive2);
 	ASSERT_TIMELY (5s, node.active.election (receive2->qualified_root ()) != nullptr);
 
 	// Ensure excess transactions get trimmed
@@ -1501,7 +1503,7 @@ TEST (active_transactions, allow_limited_overflow)
 	// Insert the first part of the blocks into normal election scheduler
 	for (auto const & block : blocks1)
 	{
-		node.scheduler.activate (block->account (), node.store.tx_begin_read ());
+		node.scheduler.buckets.activate (block->account (), node.store.tx_begin_read ());
 	}
 
 	// Ensure number of active elections reaches AEC limit and there is no overfill
@@ -1563,7 +1565,7 @@ TEST (active_transactions, allow_limited_overflow_adapt)
 	// Insert the first part of the blocks into normal election scheduler
 	for (auto const & block : blocks1)
 	{
-		node.scheduler.activate (block->account (), node.store.tx_begin_read ());
+		node.scheduler.buckets.activate (block->account (), node.store.tx_begin_read ());
 	}
 
 	// Ensure number of active elections reaches AEC limit and there is no overfill

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -1,4 +1,6 @@
 #include <nano/node/election.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -25,7 +27,7 @@ TEST (conflicts, start_stop)
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (0, node1.active.size ());
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, node1.active.size ());
@@ -58,7 +60,7 @@ TEST (conflicts, add_existing)
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
 
 	// instruct the election scheduler to trigger an election for send1
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 
 	// wait for election to be started before processing send2
 	ASSERT_TIMELY (5s, node1.active.active (*send1));
@@ -165,7 +167,7 @@ TEST (conflicts, add_two)
 
 	// activate elections for the previous two send blocks (to account3) that we did not forcefully confirm
 	//
-	node->scheduler.activate (account3.pub, node->store.tx_begin_read ());
+	node->scheduler.buckets.activate (account3.pub, node->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node->active.election ((*send3)->qualified_root ()) != nullptr);
 	ASSERT_TIMELY (5s, node->active.election ((*send4)->qualified_root ()) != nullptr);
 

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -1,4 +1,6 @@
 #include <nano/node/election.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -148,7 +150,7 @@ TEST (election, quorum_minimum_confirm_success)
 				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	node1.process_active (send1);
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -1,4 +1,5 @@
-#include <nano/node/election_scheduler.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -27,7 +28,7 @@ TEST (election_scheduler, activate_one_timely)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	system.nodes[0]->ledger.process (system.nodes[0]->store.tx_begin_write (), *send1);
-	system.nodes[0]->scheduler.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
+	system.nodes[0]->scheduler.buckets.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, system.nodes[0]->active.election (send1->qualified_root ()));
 }
 
@@ -45,7 +46,7 @@ TEST (election_scheduler, activate_one_flush)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	system.nodes[0]->ledger.process (system.nodes[0]->store.tx_begin_write (), *send1);
-	system.nodes[0]->scheduler.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
+	system.nodes[0]->scheduler.buckets.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, system.nodes[0]->active.election (send1->qualified_root ()));
 }
 
@@ -114,7 +115,7 @@ TEST (election_scheduler, no_vacancy)
 	ASSERT_EQ (nano::process_result::progress, node.process (*block1).code);
 
 	// There is vacancy so it should be inserted
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	std::shared_ptr<nano::election> election{};
 	ASSERT_TIMELY (5s, (election = node.active.election (block1->qualified_root ())) != nullptr);
 
@@ -130,14 +131,14 @@ TEST (election_scheduler, no_vacancy)
 	ASSERT_EQ (nano::process_result::progress, node.process (*block2).code);
 
 	// There is no vacancy so it should stay queued
-	node.scheduler.activate (key.pub, node.store.tx_begin_read ());
-	ASSERT_TIMELY (5s, node.scheduler.size () == 1);
+	node.scheduler.buckets.activate (key.pub, node.store.tx_begin_read ());
+	ASSERT_TIMELY (5s, node.scheduler.buckets.size () == 1);
 	ASSERT_TRUE (node.active.election (block2->qualified_root ()) == nullptr);
 
 	// Election confirmed, next in queue should begin
 	election->force_confirm ();
 	ASSERT_TIMELY (5s, node.active.election (block2->qualified_root ()) != nullptr);
-	ASSERT_TRUE (node.scheduler.empty ());
+	ASSERT_TRUE (node.scheduler.buckets.empty ());
 }
 
 // Ensure that election_scheduler::flush terminates even if no elections can currently be queued e.g. shutdown or no active_transactions vacancy
@@ -161,9 +162,9 @@ TEST (election_scheduler, flush_vacancy)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
-	node.scheduler.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	// Ensure this call does not block, even though no elections can be activated.
-	node.scheduler.flush ();
+	node.scheduler.buckets.flush ();
 	ASSERT_EQ (0, node.active.size ());
-	ASSERT_EQ (1, node.scheduler.size ());
+	ASSERT_EQ (1, node.scheduler.buckets.size ());
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2,6 +2,8 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/ledger.hpp>
 #include <nano/test_common/system.hpp>
@@ -911,7 +913,7 @@ TEST (votes, check_signature)
 		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, election1->votes ().size ());
@@ -982,7 +984,7 @@ TEST (votes, add_existing)
 										 .build ();
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ send1->hash () }));

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,5 +1,7 @@
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/transport/socket.hpp>
 #include <nano/test_common/network.hpp>
@@ -416,7 +418,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 				  .build_shared ();
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	nano::keypair key1;
 	auto vote (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, 0, std::vector<nano::block_hash>{ block1->hash () }));
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
@@ -439,7 +441,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 				  .build_shared ();
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
-	node1.scheduler.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ block1->hash () }));
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,5 +1,7 @@
 #include <nano/lib/config.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/network.hpp>
@@ -982,7 +984,7 @@ TEST (node, fork_open_flip)
 	// give block open1 to node1, manually trigger an election for open1 and ensure it is in the ledger
 	node1.process_active (open1);
 	ASSERT_TIMELY (5s, node1.block (open1->hash ()) != nullptr);
-	node1.scheduler.manual (open1);
+	node1.scheduler.buckets.manual (open1);
 	ASSERT_TIMELY (5s, (election = node1.active.election (open1->qualified_root ())) != nullptr);
 	election->transition_active ();
 
@@ -995,7 +997,7 @@ TEST (node, fork_open_flip)
 
 	// ensure open2 is in node2 ledger (and therefore has sideband) and manually trigger an election for open2
 	ASSERT_TIMELY (5s, node2.block (open2->hash ()) != nullptr);
-	node2.scheduler.manual (open2);
+	node2.scheduler.buckets.manual (open2);
 	ASSERT_TIMELY (5s, (election = node2.active.election (open2->qualified_root ())) != nullptr);
 	election->transition_active ();
 
@@ -1410,7 +1412,7 @@ TEST (node, rep_self_vote)
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block0).code);
 	auto & active = node0->active;
 	auto & scheduler = node0->scheduler;
-	scheduler.activate (nano::dev::genesis_key.pub, node0->store.tx_begin_read ());
+	scheduler.buckets.activate (nano::dev::genesis_key.pub, node0->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, active.election (block0->qualified_root ()));
 	auto election1 = active.election (block0->qualified_root ());
 	ASSERT_NE (nullptr, election1);

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -86,14 +86,10 @@ add_library(
   election.hpp
   election.cpp
   election_insertion_result.hpp
-  election_scheduler.hpp
-  election_scheduler.cpp
   epoch_upgrader.hpp
   epoch_upgrader.cpp
   gap_cache.hpp
   gap_cache.cpp
-  hinted_scheduler.hpp
-  hinted_scheduler.cpp
   inactive_cache_information.hpp
   inactive_cache_information.cpp
   inactive_cache_status.hpp
@@ -163,8 +159,6 @@ add_library(
   openclconfig.cpp
   openclwork.hpp
   openclwork.cpp
-  optimistic_scheduler.hpp
-  optimistic_scheduler.cpp
   peer_exclusion.hpp
   peer_exclusion.cpp
   portmapping.hpp
@@ -202,6 +196,14 @@ add_library(
   rocksdb/rocksdb_iterator.hpp
   rocksdb/rocksdb_txn.hpp
   rocksdb/rocksdb_txn.cpp
+  scheduler/buckets.hpp
+  scheduler/buckets.cpp
+  scheduler/component.hpp
+  scheduler/component.cpp
+  scheduler/hinted.hpp
+  scheduler/hinted.cpp
+  scheduler/optimistic.hpp
+  scheduler/optimistic.cpp
   signatures.hpp
   signatures.cpp
   state_block_signature_verification.hpp

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -5,6 +5,8 @@
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/repcrawler.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/secure/store.hpp>
 
 #include <boost/format.hpp>
@@ -12,7 +14,6 @@
 using namespace std::chrono;
 
 nano::active_transactions::active_transactions (nano::node & node_a, nano::confirmation_height_processor & confirmation_height_processor_a) :
-	scheduler{ node_a.scheduler }, // Move dependencies requiring this circular reference
 	confirmation_height_processor{ confirmation_height_processor_a },
 	node{ node_a },
 	recently_confirmed{ 65536 },
@@ -150,13 +151,13 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 		if (cemented_bootstrap_count_reached && was_active)
 		{
 			// Start or vote for the next unconfirmed block
-			scheduler.activate (account, transaction);
+			node.scheduler.buckets.activate (account, transaction);
 
 			// Start or vote for the next unconfirmed block in the destination account
 			auto const & destination (node.ledger.block_destination (transaction, *block_a));
 			if (!destination.is_zero () && destination != account)
 			{
-				scheduler.activate (destination, transaction);
+				node.scheduler.buckets.activate (destination, transaction);
 			}
 		}
 	}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -27,11 +27,15 @@ class active_transactions;
 class block;
 class block_sideband;
 class election;
-class election_scheduler;
 class vote;
 class transaction;
 class confirmation_height_processor;
 class stats;
+
+namespace scheduler
+{
+	class buckets;
+}
 
 class recently_confirmed_cache final
 {
@@ -201,7 +205,6 @@ private:
 	void add_inactive_vote_cache (nano::block_hash const & hash, std::shared_ptr<nano::vote> vote);
 
 private: // Dependencies
-	nano::election_scheduler & scheduler;
 	nano::confirmation_height_processor & confirmation_height_processor;
 	nano::node & node;
 

--- a/nano/node/backlog_population.cpp
+++ b/nano/node/backlog_population.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/backlog_population.hpp>
-#include <nano/node/election_scheduler.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/scheduler/buckets.hpp>
 #include <nano/secure/store.hpp>
 
 nano::backlog_population::backlog_population (const config & config_a, nano::store & store_a, nano::stats & stats_a) :

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -5,6 +5,10 @@
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/hinted.hpp>
+#include <nano/node/scheduler/optimistic.hpp>
 #include <nano/node/telemetry.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/buffer.hpp>
@@ -46,13 +50,6 @@ nano::vote_cache::config nano::nodeconfig_to_vote_cache_config (node_config cons
 {
 	vote_cache::config cfg{};
 	cfg.max_size = flags.inactive_votes_cache_size;
-	return cfg;
-}
-
-nano::hinted_scheduler::config nano::nodeconfig_to_hinted_scheduler_config (const nano::node_config & config)
-{
-	hinted_scheduler::config cfg{};
-	cfg.vote_cache_check_interval_ms = config.network_params.network.is_dev_network () ? 100u : 1000u;
 	return cfg;
 }
 
@@ -195,9 +192,8 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	generator{ config, ledger, wallets, vote_processor, history, network, stats, /* non-final */ false },
 	final_generator{ config, ledger, wallets, vote_processor, history, network, stats, /* final */ true },
 	active (*this, confirmation_height_processor),
-	optimistic{ config.optimistic_scheduler, *this, ledger, active, network_params.network, stats },
-	scheduler{ *this, stats },
-	hinting{ nano::nodeconfig_to_hinted_scheduler_config (config), *this, inactive_vote_cache, active, online_reps, stats },
+	scheduler_impl{ std::make_unique<nano::scheduler::component> (*this) },
+	scheduler{ *scheduler_impl },
 	aggregator (config, stats, generator, final_generator, history, ledger, wallets, active),
 	wallets (wallets_store.init_error (), *this),
 	backlog{ nano::backlog_population_config (config), store, stats },
@@ -209,7 +205,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	block_broadcast{ network, block_arrival, !flags.disable_block_processor_republishing },
 	block_publisher{ active },
 	gap_tracker{ gap_cache },
-	process_live_dispatcher{ ledger, scheduler, inactive_vote_cache, websocket }
+	process_live_dispatcher{ ledger, scheduler.buckets, inactive_vote_cache, websocket }
 {
 	block_broadcast.connect (block_processor);
 	block_publisher.connect (block_processor);
@@ -224,17 +220,17 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	};
 
 	backlog.activate_callback.add ([this] (nano::transaction const & transaction, nano::account const & account, nano::account_info const & account_info, nano::confirmation_height_info const & conf_info) {
-		scheduler.activate (account, transaction);
-		optimistic.activate (account, account_info, conf_info);
+		scheduler.buckets.activate (account, transaction);
+		scheduler.optimistic.activate (account, account_info, conf_info);
 	});
 
 	if (!init_error ())
 	{
 		// Notify election schedulers when AEC frees election slot
 		active.vacancy_update = [this] () {
-			scheduler.notify ();
-			hinting.notify ();
-			optimistic.notify ();
+			scheduler.buckets.notify ();
+			scheduler.hinted.notify ();
+			scheduler.optimistic.notify ();
 		};
 
 		wallets.observer = [this] (bool active) {
@@ -580,7 +576,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.confirmation_height_processor, "confirmation_height_processor"));
 	composite->add_component (collect_container_info (node.distributed_work, "distributed_work"));
 	composite->add_component (collect_container_info (node.aggregator, "request_aggregator"));
-	composite->add_component (node.scheduler.collect_container_info ("election_scheduler"));
+	composite->add_component (node.scheduler.buckets.collect_container_info ("election_scheduler"));
 	composite->add_component (node.inactive_vote_cache.collect_container_info ("inactive_vote_cache"));
 	composite->add_component (collect_container_info (node.generator, "vote_generator"));
 	composite->add_component (collect_container_info (node.final_generator, "vote_generator_final"));
@@ -692,10 +688,10 @@ void nano::node::start ()
 	active.start ();
 	generator.start ();
 	final_generator.start ();
-	optimistic.start ();
-	scheduler.start ();
+	scheduler.optimistic.start ();
+	scheduler.buckets.start ();
 	backlog.start ();
-	hinting.start ();
+	scheduler.hinted.start ();
 	bootstrap_server.start ();
 	if (!flags.disable_ascending_bootstrap)
 	{
@@ -727,9 +723,9 @@ void nano::node::stop ()
 	block_processor.stop ();
 	aggregator.stop ();
 	vote_processor.stop ();
-	scheduler.stop ();
-	optimistic.stop ();
-	hinting.stop ();
+	scheduler.buckets.stop ();
+	scheduler.optimistic.stop ();
+	scheduler.hinted.stop ();
 	active.stop ();
 	generator.stop ();
 	final_generator.stop ();
@@ -1269,8 +1265,8 @@ void nano::node::add_initial_peers ()
 
 std::shared_ptr<nano::election> nano::node::block_confirm (std::shared_ptr<nano::block> const & block_a)
 {
-	scheduler.manual (block_a);
-	scheduler.flush ();
+	scheduler.buckets.manual (block_a);
+	scheduler.buckets.flush ();
 	auto election = active.election (block_a->qualified_root ());
 	if (election != nullptr)
 	{

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -17,16 +17,13 @@
 #include <nano/node/confirmation_height_processor.hpp>
 #include <nano/node/distributed_work_factory.hpp>
 #include <nano/node/election.hpp>
-#include <nano/node/election_scheduler.hpp>
 #include <nano/node/epoch_upgrader.hpp>
 #include <nano/node/gap_cache.hpp>
 #include <nano/node/gap_tracker.hpp>
-#include <nano/node/hinted_scheduler.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/online_reps.hpp>
-#include <nano/node/optimistic_scheduler.hpp>
 #include <nano/node/portmapping.hpp>
 #include <nano/node/process_live_dispatcher.hpp>
 #include <nano/node/repcrawler.hpp>
@@ -58,12 +55,16 @@ namespace rocksdb
 class node;
 class work_pool;
 
+namespace scheduler
+{
+	class component;
+}
+
 std::unique_ptr<container_info_component> collect_container_info (rep_crawler & rep_crawler, std::string const & name);
 
 // Configs
 backlog_population::config backlog_population_config (node_config const &);
 vote_cache::config nodeconfig_to_vote_cache_config (node_config const &, node_flags const &);
-hinted_scheduler::config nodeconfig_to_hinted_scheduler_config (node_config const &);
 outbound_bandwidth_limiter::config outbound_bandwidth_limiter_config (node_config const &);
 
 class node final : public std::enable_shared_from_this<nano::node>
@@ -186,9 +187,12 @@ public:
 	nano::vote_generator generator;
 	nano::vote_generator final_generator;
 	nano::active_transactions active;
-	nano::optimistic_scheduler optimistic;
-	nano::election_scheduler scheduler;
-	nano::hinted_scheduler hinting;
+
+private: // Placed here to maintain initialization order
+	std::unique_ptr<nano::scheduler::component> scheduler_impl;
+
+public:
+	nano::scheduler::component & scheduler;
 	nano::request_aggregator aggregator;
 	nano::wallets wallets;
 	nano::backlog_population backlog;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -10,7 +10,7 @@
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/ipc/ipc_config.hpp>
 #include <nano/node/logging.hpp>
-#include <nano/node/optimistic_scheduler.hpp>
+#include <nano/node/scheduler/optimistic.hpp>
 #include <nano/node/websocketconfig.hpp>
 #include <nano/secure/common.hpp>
 
@@ -46,7 +46,7 @@ public:
 	nano::account random_representative () const;
 	nano::network_params network_params;
 	std::optional<uint16_t> peering_port{};
-	nano::optimistic_scheduler_config optimistic_scheduler;
+	nano::scheduler::optimistic_config optimistic_scheduler;
 	nano::logging logging;
 	std::vector<std::pair<std::string, uint16_t>> work_peers;
 	std::vector<std::pair<std::string, uint16_t>> secondary_work_peers{ { "127.0.0.1", 8076 } }; /* Default of nano-pow-server */

--- a/nano/node/process_live_dispatcher.cpp
+++ b/nano/node/process_live_dispatcher.cpp
@@ -1,14 +1,14 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/blockprocessor.hpp>
-#include <nano/node/election_scheduler.hpp>
 #include <nano/node/process_live_dispatcher.hpp>
+#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/vote_cache.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/store.hpp>
 
-nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, nano::election_scheduler & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket) :
+nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, nano::scheduler::buckets & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket) :
 	ledger{ ledger },
 	scheduler{ scheduler },
 	inactive_vote_cache{ inactive_vote_cache },

--- a/nano/node/process_live_dispatcher.hpp
+++ b/nano/node/process_live_dispatcher.hpp
@@ -3,7 +3,6 @@
 namespace nano
 {
 class ledger;
-class election_scheduler;
 class vote_cache;
 class websocket_server;
 class block_processor;
@@ -11,11 +10,16 @@ class process_return;
 class block;
 class transaction;
 
+namespace scheduler
+{
+	class buckets;
+}
+
 // Observes confirmed blocks and dispatches the process_live function.
 class process_live_dispatcher
 {
 public:
-	process_live_dispatcher (nano::ledger & ledger, nano::election_scheduler & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket);
+	process_live_dispatcher (nano::ledger & ledger, nano::scheduler::buckets & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket);
 	void connect (nano::block_processor & block_processor);
 
 private:
@@ -24,7 +28,7 @@ private:
 	void process_live (nano::block const & block, nano::transaction const & transaction);
 
 	nano::ledger & ledger;
-	nano::election_scheduler & scheduler;
+	nano::scheduler::buckets & scheduler;
 	nano::vote_cache & inactive_vote_cache;
 	nano::websocket_server & websocket;
 };

--- a/nano/node/scheduler/buckets.cpp
+++ b/nano/node/scheduler/buckets.cpp
@@ -1,19 +1,19 @@
-#include <nano/node/election_scheduler.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/scheduler/buckets.hpp>
 
-nano::election_scheduler::election_scheduler (nano::node & node_a, nano::stats & stats_a) :
+nano::scheduler::buckets::buckets (nano::node & node_a, nano::stats & stats_a) :
 	node{ node_a },
 	stats{ stats_a }
 {
 }
 
-nano::election_scheduler::~election_scheduler ()
+nano::scheduler::buckets::~buckets ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
 }
 
-void nano::election_scheduler::start ()
+void nano::scheduler::buckets::start ()
 {
 	debug_assert (!thread.joinable ());
 
@@ -23,7 +23,7 @@ void nano::election_scheduler::start ()
 	} };
 }
 
-void nano::election_scheduler::stop ()
+void nano::scheduler::buckets::stop ()
 {
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
@@ -33,14 +33,14 @@ void nano::election_scheduler::stop ()
 	nano::join_or_pass (thread);
 }
 
-void nano::election_scheduler::manual (std::shared_ptr<nano::block> const & block_a, boost::optional<nano::uint128_t> const & previous_balance_a, nano::election_behavior election_behavior_a)
+void nano::scheduler::buckets::manual (std::shared_ptr<nano::block> const & block_a, boost::optional<nano::uint128_t> const & previous_balance_a, nano::election_behavior election_behavior_a)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	manual_queue.push_back (std::make_tuple (block_a, previous_balance_a, election_behavior_a));
 	notify ();
 }
 
-bool nano::election_scheduler::activate (nano::account const & account_a, nano::transaction const & transaction)
+bool nano::scheduler::buckets::activate (nano::account const & account_a, nano::transaction const & transaction)
 {
 	debug_assert (!account_a.is_zero ());
 	auto info = node.ledger.account_info (transaction, account_a);
@@ -69,7 +69,7 @@ bool nano::election_scheduler::activate (nano::account const & account_a, nano::
 	return false; // Not activated
 }
 
-void nano::election_scheduler::flush ()
+void nano::scheduler::buckets::flush ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	condition.wait (lock, [this] () {
@@ -77,44 +77,44 @@ void nano::election_scheduler::flush ()
 	});
 }
 
-void nano::election_scheduler::notify ()
+void nano::scheduler::buckets::notify ()
 {
 	condition.notify_all ();
 }
 
-std::size_t nano::election_scheduler::size () const
+std::size_t nano::scheduler::buckets::size () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return priority.size () + manual_queue.size ();
 }
 
-bool nano::election_scheduler::empty_locked () const
+bool nano::scheduler::buckets::empty_locked () const
 {
 	return priority.empty () && manual_queue.empty ();
 }
 
-bool nano::election_scheduler::empty () const
+bool nano::scheduler::buckets::empty () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return empty_locked ();
 }
 
-std::size_t nano::election_scheduler::priority_queue_size () const
+std::size_t nano::scheduler::buckets::priority_queue_size () const
 {
 	return priority.size ();
 }
 
-bool nano::election_scheduler::priority_queue_predicate () const
+bool nano::scheduler::buckets::priority_queue_predicate () const
 {
 	return node.active.vacancy () > 0 && !priority.empty ();
 }
 
-bool nano::election_scheduler::manual_queue_predicate () const
+bool nano::scheduler::buckets::manual_queue_predicate () const
 {
 	return !manual_queue.empty ();
 }
 
-void nano::election_scheduler::run ()
+void nano::scheduler::buckets::run ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
@@ -161,7 +161,7 @@ void nano::election_scheduler::run ()
 	}
 }
 
-std::unique_ptr<nano::container_info_component> nano::election_scheduler::collect_container_info (std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::scheduler::buckets::collect_container_info (std::string const & name)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -15,12 +15,15 @@ namespace nano
 {
 class block;
 class node;
+}
 
-class election_scheduler final
+namespace nano::scheduler
+{
+class buckets final
 {
 public:
-	election_scheduler (nano::node &, nano::stats &);
-	~election_scheduler ();
+	buckets (nano::node &, nano::stats &);
+	~buckets ();
 
 	void start ();
 	void stop ();

--- a/nano/node/scheduler/component.cpp
+++ b/nano/node/scheduler/component.cpp
@@ -1,0 +1,15 @@
+#include <nano/node/node.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/hinted.hpp>
+#include <nano/node/scheduler/optimistic.hpp>
+
+nano::scheduler::component::component (nano::node & node) :
+	optimistic_impl{ std::make_unique<nano::scheduler::optimistic> (node.config.optimistic_scheduler, node, node.ledger, node.active, node.network_params.network, node.stats) },
+	buckets_impl{ std::make_unique<nano::scheduler::buckets> (node, node.stats) },
+	hinted_impl{ std::make_unique<nano::scheduler::hinted> (nano::scheduler::hinted::config{ node.config }, node, node.inactive_vote_cache, node.active, node.online_reps, node.stats) },
+	buckets{ *buckets_impl },
+	hinted{ *hinted_impl },
+	optimistic{ *optimistic_impl }
+{
+}

--- a/nano/node/scheduler/component.hpp
+++ b/nano/node/scheduler/component.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+
+namespace nano::scheduler
+{
+class buckets;
+class hinted;
+class node;
+class optimistic;
+
+class component
+{
+	std::unique_ptr<nano::scheduler::optimistic> optimistic_impl;
+	std::unique_ptr<nano::scheduler::buckets> buckets_impl;
+	std::unique_ptr<nano::scheduler::hinted> hinted_impl;
+
+public:
+	explicit component (nano::node & node);
+
+	nano::scheduler::buckets & buckets;
+	nano::scheduler::hinted & hinted;
+	nano::scheduler::optimistic & optimistic;
+};
+}

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -10,25 +10,29 @@
 namespace nano
 {
 class node;
+class node_config;
 class active_transactions;
 class vote_cache;
 class online_reps;
-
+}
+namespace nano::scheduler
+{
 /*
  * Monitors inactive vote cache and schedules elections with the highest observed vote tally.
  */
-class hinted_scheduler final
+class hinted final
 {
 public: // Config
 	struct config final
 	{
+		explicit config (node_config const & config);
 		// Interval of wakeup to check inactive vote cache when idle
 		uint64_t vote_cache_check_interval_ms;
 	};
 
 public:
-	hinted_scheduler (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stats &);
-	~hinted_scheduler ();
+	hinted (config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stats &);
+	~hinted ();
 
 	void start ();
 	void stop ();

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -1,9 +1,9 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/node.hpp>
-#include <nano/node/optimistic_scheduler.hpp>
+#include <nano/node/scheduler/optimistic.hpp>
 
-nano::optimistic_scheduler::optimistic_scheduler (optimistic_scheduler_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::active_transactions & active_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
+nano::scheduler::optimistic::optimistic (optimistic_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::active_transactions & active_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
 	config{ config_a },
 	node{ node_a },
 	ledger{ ledger_a },
@@ -13,13 +13,13 @@ nano::optimistic_scheduler::optimistic_scheduler (optimistic_scheduler_config co
 {
 }
 
-nano::optimistic_scheduler::~optimistic_scheduler ()
+nano::scheduler::optimistic::~optimistic ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
 }
 
-void nano::optimistic_scheduler::start ()
+void nano::scheduler::optimistic::start ()
 {
 	if (!config.enabled)
 	{
@@ -34,7 +34,7 @@ void nano::optimistic_scheduler::start ()
 	} };
 }
 
-void nano::optimistic_scheduler::stop ()
+void nano::scheduler::optimistic::stop ()
 {
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
@@ -44,12 +44,12 @@ void nano::optimistic_scheduler::stop ()
 	nano::join_or_pass (thread);
 }
 
-void nano::optimistic_scheduler::notify ()
+void nano::scheduler::optimistic::notify ()
 {
 	condition.notify_all ();
 }
 
-bool nano::optimistic_scheduler::activate_predicate (const nano::account_info & account_info, const nano::confirmation_height_info & conf_info) const
+bool nano::scheduler::optimistic::activate_predicate (const nano::account_info & account_info, const nano::confirmation_height_info & conf_info) const
 {
 	// Chain with a big enough gap between account frontier and confirmation frontier
 	if (account_info.block_count - conf_info.height > config.gap_threshold)
@@ -64,7 +64,7 @@ bool nano::optimistic_scheduler::activate_predicate (const nano::account_info & 
 	return false;
 }
 
-bool nano::optimistic_scheduler::activate (const nano::account & account, const nano::account_info & account_info, const nano::confirmation_height_info & conf_info)
+bool nano::scheduler::optimistic::activate (const nano::account & account, const nano::account_info & account_info, const nano::confirmation_height_info & conf_info)
 {
 	if (!config.enabled)
 	{
@@ -96,7 +96,7 @@ bool nano::optimistic_scheduler::activate (const nano::account & account, const 
 	return false; // Not activated
 }
 
-bool nano::optimistic_scheduler::predicate () const
+bool nano::scheduler::optimistic::predicate () const
 {
 	debug_assert (!mutex.try_lock ());
 
@@ -114,7 +114,7 @@ bool nano::optimistic_scheduler::predicate () const
 	return result;
 }
 
-void nano::optimistic_scheduler::run ()
+void nano::scheduler::optimistic::run ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
@@ -144,7 +144,7 @@ void nano::optimistic_scheduler::run ()
 	}
 }
 
-void nano::optimistic_scheduler::run_one (nano::transaction const & transaction, entry const & candidate)
+void nano::scheduler::optimistic::run_one (nano::transaction const & transaction, entry const & candidate)
 {
 	auto block = ledger.head_block (transaction, candidate.account);
 	if (block)
@@ -165,7 +165,7 @@ void nano::optimistic_scheduler::run_one (nano::transaction const & transaction,
  * optimistic_scheduler_config
  */
 
-nano::error nano::optimistic_scheduler_config::deserialize (nano::tomlconfig & toml)
+nano::error nano::scheduler::optimistic_config::deserialize (nano::tomlconfig & toml)
 {
 	toml.get ("enabled", enabled);
 	toml.get ("gap_threshold", gap_threshold);
@@ -174,7 +174,7 @@ nano::error nano::optimistic_scheduler_config::deserialize (nano::tomlconfig & t
 	return toml.get_error ();
 }
 
-nano::error nano::optimistic_scheduler_config::serialize (nano::tomlconfig & toml) const
+nano::error nano::scheduler::optimistic_config::serialize (nano::tomlconfig & toml) const
 {
 	toml.put ("enable", enabled, "Enable or disable optimistic elections\ntype:bool");
 	toml.put ("gap_threshold", gap_threshold, "Minimum difference between confirmation frontier and account frontier to become a candidate for optimistic confirmation\ntype:uint64");

--- a/nano/node/scheduler/optimistic.hpp
+++ b/nano/node/scheduler/optimistic.hpp
@@ -25,8 +25,11 @@ namespace nano
 class node;
 class ledger;
 class active_transactions;
+}
 
-class optimistic_scheduler_config final
+namespace nano::scheduler
+{
+class optimistic_config final
 {
 public:
 	nano::error deserialize (nano::tomlconfig & toml);
@@ -41,14 +44,13 @@ public:
 	/** Maximum number of candidates stored in memory */
 	std::size_t max_size{ 1024 * 64 };
 };
-
-class optimistic_scheduler final
+class optimistic final
 {
 	struct entry;
 
 public:
-	optimistic_scheduler (optimistic_scheduler_config const &, nano::node &, nano::ledger &, nano::active_transactions &, nano::network_constants const & network_constants, nano::stats &);
-	~optimistic_scheduler ();
+	optimistic (optimistic_config const &, nano::node &, nano::ledger &, nano::active_transactions &, nano::network_constants const & network_constants, nano::stats &);
+	~optimistic ();
 
 	void start ();
 	void stop ();
@@ -71,7 +73,7 @@ private:
 	void run_one (nano::transaction const &, entry const & candidate);
 
 private: // Dependencies
-	optimistic_scheduler_config const & config;
+	optimistic_config const & config;
 	nano::node & node;
 	nano::ledger & ledger;
 	nano::active_transactions & active;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5,6 +5,8 @@
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node_rpc_config.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc_test/common.hpp>
@@ -1557,7 +1559,7 @@ TEST (rpc, process_subtype_open)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
 	auto const rpc_ctx = add_rpc (system, node1);
-	node1->scheduler.manual (send);
+	node1->scheduler.buckets.manual (send);
 	auto open = builder
 				.state ()
 				.account (key.pub)
@@ -1606,7 +1608,7 @@ TEST (rpc, process_subtype_receive)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
 	auto const rpc_ctx = add_rpc (system, node1);
-	node1->scheduler.manual (send);
+	node1->scheduler.buckets.manual (send);
 	auto receive = builder
 				   .state ()
 				   .account (nano::dev::genesis_key.pub)
@@ -2446,7 +2448,7 @@ TEST (rpc, account_representative_set_epoch_2_insufficient_work)
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
 
 	// speed up the cementing process, otherwise the node waits for frontiers confirmation to notice the unconfirmed epoch blocks, which takes time
-	node->scheduler.activate (nano::dev::genesis_key.pub, node->store.tx_begin_read ());
+	node->scheduler.buckets.activate (nano::dev::genesis_key.pub, node->store.tx_begin_read ());
 
 	// wait for the epoch blocks to be cemented
 	ASSERT_TIMELY (5s, node->get_confirmation_height (node->store.tx_begin_read (), nano::dev::genesis_key.pub) == 3);
@@ -6962,7 +6964,7 @@ TEST (node, election_scheduler_container_info)
 
 	// process the block and wait for it to show up in the election scheduler
 	node->process_active (send1);
-	ASSERT_TIMELY (10s, node->scheduler.size () == 1);
+	ASSERT_TIMELY (10s, node->scheduler.buckets.size () == 1);
 
 	// now check the RPC call
 	boost::property_tree::ptree request;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1,6 +1,8 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/test_common/network.hpp>
@@ -675,7 +677,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	{
 		auto block = node->block (last_open_hash);
 		ASSERT_NE (nullptr, block);
-		node->scheduler.manual (block);
+		node->scheduler.buckets.manual (block);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (block->qualified_root ())) != nullptr);
 		election->force_confirm ();
@@ -758,7 +760,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	// Confirm all of the accounts
 	for (auto & open_block : open_blocks)
 	{
-		node->scheduler.manual (open_block);
+		node->scheduler.buckets.manual (open_block);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (open_block->qualified_root ())) != nullptr);
 		election->force_confirm ();
@@ -898,7 +900,7 @@ TEST (confirmation_height, long_chains)
 
 	// Call block confirm on the existing receive block on the genesis account which will confirm everything underneath on both accounts
 	{
-		node->scheduler.manual (receive1);
+		node->scheduler.buckets.manual (receive1);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (receive1->qualified_root ())) != nullptr);
 		election->force_confirm ();
@@ -2223,7 +2225,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 		// Call block confirm on the top level send block which will confirm everything underneath on both accounts.
 		{
 			auto block = node->store.block.get (node->store.tx_begin_read (), latest);
-			node->scheduler.manual (block);
+			node->scheduler.buckets.manual (block);
 			std::shared_ptr<nano::election> election;
 			ASSERT_TIMELY (10s, (election = node->active.election (block->qualified_root ())) != nullptr);
 			election->force_confirm ();
@@ -2317,7 +2319,7 @@ TEST (system, block_sequence)
 			std::string message;
 			for (auto i : system.nodes)
 			{
-				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.cache.block_count) % std::to_string (i->ledger.cache.cemented_count) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.size ()) % std::to_string (i->network.size ()));
+				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.cache.block_count) % std::to_string (i->ledger.cache.cemented_count) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.buckets.size ()) % std::to_string (i->network.size ()));
 				nano::lock_guard<nano::mutex> lock{ i->active.mutex };
 				for (auto const & j : i->active.roots)
 				{

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,4 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/component.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -154,7 +156,7 @@ bool nano::test::activate (nano::node & node, std::vector<nano::block_hash> hash
 			// Block does not exist in the ledger yet
 			return false;
 		}
-		node.scheduler.manual (disk_block);
+		node.scheduler.buckets.manual (disk_block);
 	}
 	return true;
 }
@@ -235,7 +237,7 @@ std::shared_ptr<nano::election> nano::test::start_election (nano::test::system &
 		block_l = node_a.block (hash_a);
 	}
 
-	node_a.scheduler.manual (block_l);
+	node_a.scheduler.buckets.manual (block_l);
 
 	// wait for the election to appear
 	std::shared_ptr<nano::election> election = node_a.active.election (block_l->qualified_root ());


### PR DESCRIPTION
This component encloses the buckets/hinted/optimistic schedulers. There are an increasing number of classes that are associated with election scheduling so there is a desire to put these related concepts in their own namespace and file folder.

Move optimistic_scheduler under scheduler/optimistic scheduler::optimistic node.scheduler.optimistic
Move hinted_scheduler under scheduler/hinted scheduler::hinted node.scheduler.hinted
Move election_scheduler under scheduler/component scheduler::component node.scheduler.buckets
Created scheduler::component which contains each of the separate schedulers as one component

Node and components use PIML pattern with convenience references.

Fixed circular reference between active_transactions and scheduler::buckets by using the nano::node & already inside active_transactions.