### PR TITLE
This change creates an scheduler::limiter class which tracks and limits how many elections can be spawned.

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(
   peer_container.cpp
   scheduler_buckets.cpp
   request_aggregator.cpp
+  scheduler_limiter.cpp
   signal_manager.cpp
   signing.cpp
   socket.cpp

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -17,6 +17,23 @@ TEST (election, construction)
 	node, nano::dev::genesis, [] (auto const &) {}, [] (auto const &) {}, nano::election_behavior::normal);
 }
 
+// This tests the election destruction event notification
+// Since the notification is signalled in the destructor, it needs to be freed
+TEST (election, destructor_observer)
+{
+	std::atomic<bool> destroyed{ false };
+	{
+		nano::test::system system (1);
+		auto & node = *system.nodes[0];
+		auto election = std::make_shared<nano::election> (
+		node, nano::dev::genesis, [] (auto const &) {}, [] (auto const &) {}, nano::election_behavior::normal);
+		election->destructor_observers.add ([&destroyed] (auto const & qualified_root) {
+			destroyed = true;
+		});
+	}
+	ASSERT_TRUE (destroyed);
+}
+
 TEST (election, behavior)
 {
 	nano::test::system system (1);

--- a/nano/core_test/scheduler_buckets.cpp
+++ b/nano/core_test/scheduler_buckets.cpp
@@ -110,7 +110,7 @@ TEST (buckets, construction)
 {
 	nano::scheduler::buckets buckets;
 	ASSERT_EQ (0, buckets.size ());
-	ASSERT_TRUE (buckets.empty ());
+	ASSERT_TRUE (buckets.empty () && !buckets.available ()); // Initial state
 	ASSERT_EQ (62, buckets.bucket_count ());
 }
 

--- a/nano/core_test/scheduler_buckets.cpp
+++ b/nano/core_test/scheduler_buckets.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/scheduler/buckets.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
 
@@ -108,7 +109,7 @@ std::shared_ptr<nano::state_block> & block3 ()
 
 TEST (buckets, construction)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	ASSERT_EQ (0, buckets.size ());
 	ASSERT_TRUE (buckets.empty () && !buckets.available ()); // Initial state
 	ASSERT_EQ (62, buckets.bucket_count ());
@@ -116,19 +117,19 @@ TEST (buckets, construction)
 
 TEST (buckets, index_min)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	ASSERT_EQ (0, buckets.index (std::numeric_limits<nano::uint128_t>::min ()));
 }
 
 TEST (buckets, index_max)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	ASSERT_EQ (buckets.bucket_count () - 1, buckets.index (std::numeric_limits<nano::uint128_t>::max ()));
 }
 
 TEST (buckets, insert_Gxrb)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
 	ASSERT_EQ (1, buckets.bucket_size (48));
@@ -136,7 +137,7 @@ TEST (buckets, insert_Gxrb)
 
 TEST (buckets, insert_Mxrb)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block1 (), nano::Mxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
 	ASSERT_EQ (1, buckets.bucket_size (13));
@@ -145,7 +146,7 @@ TEST (buckets, insert_Mxrb)
 // Test two blocks with the same priority
 TEST (buckets, insert_same_priority)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1000, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (2, buckets.size ());
@@ -155,7 +156,7 @@ TEST (buckets, insert_same_priority)
 // Test the same block inserted multiple times
 TEST (buckets, insert_duplicate)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
@@ -164,18 +165,18 @@ TEST (buckets, insert_duplicate)
 
 TEST (buckets, insert_older)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1100, block2 (), nano::Gxrb_ratio);
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 	buckets.pop ();
-	ASSERT_EQ (block2 (), buckets.top ());
+	ASSERT_EQ (block2 (), buckets.top ().first);
 	buckets.pop ();
 }
 
 TEST (buckets, pop)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	ASSERT_TRUE (buckets.empty ());
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_FALSE (buckets.empty ());
@@ -185,69 +186,69 @@ TEST (buckets, pop)
 
 TEST (buckets, top_one)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 }
 
 TEST (buckets, top_two)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1, block1 (), nano::Mxrb_ratio);
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 	buckets.pop ();
-	ASSERT_EQ (block1 (), buckets.top ());
+	ASSERT_EQ (block1 (), buckets.top ().first);
 	buckets.pop ();
 	ASSERT_TRUE (buckets.empty ());
 }
 
 TEST (buckets, top_round_robin)
 {
-	nano::scheduler::buckets buckets;
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null };
 	buckets.push (1000, blockzero (), 0);
-	ASSERT_EQ (blockzero (), buckets.top ());
+	ASSERT_EQ (blockzero (), buckets.top ().first);
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1000, block1 (), nano::Mxrb_ratio);
 	buckets.push (1100, block3 (), nano::Mxrb_ratio);
 	buckets.pop (); // blockzero
-	EXPECT_EQ (block1 (), buckets.top ());
+	EXPECT_EQ (block1 (), buckets.top ().first);
 	buckets.pop ();
-	EXPECT_EQ (block0 (), buckets.top ());
+	EXPECT_EQ (block0 (), buckets.top ().first);
 	buckets.pop ();
-	EXPECT_EQ (block3 (), buckets.top ());
+	EXPECT_EQ (block3 (), buckets.top ().first);
 	buckets.pop ();
 	EXPECT_TRUE (buckets.empty ());
 }
 
 TEST (buckets, trim_normal)
 {
-	nano::scheduler::buckets buckets{ 1 };
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null, 1 };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1100, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 }
 
 TEST (buckets, trim_reverse)
 {
-	nano::scheduler::buckets buckets{ 1 };
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null, 1 };
 	buckets.push (1100, block2 (), nano::Gxrb_ratio);
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 }
 
 TEST (buckets, trim_even)
 {
-	nano::scheduler::buckets buckets{ 2 };
+	nano::scheduler::buckets buckets{ nano::test::active_transactions_insert_null, 2 };
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1100, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 	buckets.push (1000, block1 (), nano::Mxrb_ratio);
 	ASSERT_EQ (2, buckets.size ());
-	ASSERT_EQ (block0 (), buckets.top ());
+	ASSERT_EQ (block0 (), buckets.top ().first);
 	buckets.pop ();
-	ASSERT_EQ (block1 (), buckets.top ());
+	ASSERT_EQ (block1 (), buckets.top ().first);
 }

--- a/nano/core_test/scheduler_limiter.cpp
+++ b/nano/core_test/scheduler_limiter.cpp
@@ -1,0 +1,37 @@
+#include <nano/node/scheduler/limiter.hpp>
+#include <nano/secure/common.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+TEST (scheduler_limiter, construction)
+{
+	auto occupancy = std::make_shared<nano::scheduler::limiter> (nano::test::active_transactions_insert_null, 1, nano::election_behavior::normal);
+	ASSERT_EQ (1, occupancy->limit ());
+	ASSERT_TRUE (occupancy->available ());
+}
+
+TEST (scheduler_limiter, limit)
+{
+	auto occupancy = std::make_shared<nano::scheduler::limiter> (nano::test::active_transactions_insert_null, 1, nano::election_behavior::normal);
+	ASSERT_EQ (1, occupancy->limit ());
+	ASSERT_TRUE (occupancy->available ());
+}
+
+TEST (scheduler_limiter, election_activate_observer)
+{
+	nano::test::system system{ 1 };
+	auto occupancy = std::make_shared<nano::scheduler::limiter> ([&] (auto const & block, auto const & behavior) {
+		return system.node (0).active.insert (block, behavior);
+	},
+	1, nano::election_behavior::normal);
+	auto result = occupancy->activate (nano::dev::genesis);
+	ASSERT_TRUE (result.inserted);
+	auto elections = occupancy->elections ();
+	ASSERT_EQ (1, elections.size ());
+	ASSERT_EQ (1, elections.count (nano::dev::genesis->qualified_root ()));
+	ASSERT_FALSE (occupancy->available ());
+	result.election = nullptr; // Implicitly run election destructor notification by clearing the last reference
+	ASSERT_TIMELY (5s, occupancy->available ());
+}

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -202,6 +202,8 @@ add_library(
   scheduler/component.cpp
   scheduler/hinted.hpp
   scheduler/hinted.cpp
+  scheduler/limiter.hpp
+  scheduler/limiter.cpp
   scheduler/manual.hpp
   scheduler/manual.cpp
   scheduler/optimistic.hpp

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -373,6 +373,14 @@ nano::election_insertion_result nano::active_transactions::insert (const std::sh
 	return result;
 }
 
+std::function<nano::election_insertion_result (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior)> nano::active_transactions::insert_fn ()
+{
+	return [this] (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior) {
+		auto result = insert (block, behavior);
+		return result;
+	};
+}
+
 void nano::active_transactions::trim ()
 {
 	/*

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -142,6 +142,8 @@ public:
 	 * Starts new election with a specified behavior type
 	 */
 	nano::election_insertion_result insert (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior = nano::election_behavior::normal);
+	// Function wrapper around call to ::insert
+	std::function<nano::election_insertion_result (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior)> insert_fn ();
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
 	nano::vote_code vote (std::shared_ptr<nano::vote> const &);
 	// Is the root of this block in the roots container

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -32,6 +32,11 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> cons
 	last_blocks.emplace (block_a->hash (), block_a);
 }
 
+nano::election::~election ()
+{
+	destructor_observers.notify (qualified_root);
+}
+
 void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock_a, nano::election_status_type type_a)
 {
 	debug_assert (lock_a.owns_lock ());

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -138,7 +138,10 @@ public: // Status
 
 public: // Interface
 	election (nano::node &, std::shared_ptr<nano::block> const & block, std::function<void (std::shared_ptr<nano::block> const &)> const & confirmation_action, std::function<void (nano::account const &)> const & vote_action, nano::election_behavior behavior);
+	~election ();
+	nano::observer_set<nano::qualified_root const &> destructor_observers;
 
+public:
 	std::shared_ptr<nano::block> find (nano::block_hash const &) const;
 	/*
 	 * Process vote. Internally uses cooldown to throttle non-final votes

--- a/nano/node/scheduler/bucket.cpp
+++ b/nano/node/scheduler/bucket.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/scheduler/bucket.hpp>
+#include <nano/node/scheduler/limiter.hpp>
 
 bool nano::scheduler::bucket::value_type::operator< (value_type const & other_a) const
 {
@@ -11,20 +12,23 @@ bool nano::scheduler::bucket::value_type::operator== (value_type const & other_a
 	return time == other_a.time && block->hash () == other_a.block->hash ();
 }
 
-nano::scheduler::bucket::bucket (size_t maximum) :
-	maximum{ maximum }
+nano::scheduler::bucket::bucket (std::shared_ptr<nano::scheduler::limiter> limiter, size_t maximum) :
+	maximum{ maximum },
+	limiter{ limiter }
 {
 	debug_assert (maximum > 0);
+	debug_assert (limiter != nullptr);
 }
 
 nano::scheduler::bucket::~bucket ()
 {
 }
 
-std::shared_ptr<nano::block> nano::scheduler::bucket::top () const
+std::pair<std::shared_ptr<nano::block>, std::shared_ptr<nano::scheduler::limiter>> nano::scheduler::bucket::top () const
 {
 	debug_assert (!queue.empty ());
-	return queue.begin ()->block;
+	auto & first = *queue.begin ();
+	return { first.block, limiter };
 }
 
 void nano::scheduler::bucket::pop ()
@@ -55,7 +59,7 @@ bool nano::scheduler::bucket::empty () const
 
 bool nano::scheduler::bucket::available () const
 {
-	return !queue.empty ();
+	return !queue.empty () && limiter->available ();
 }
 
 void nano::scheduler::bucket::dump () const

--- a/nano/node/scheduler/bucket.cpp
+++ b/nano/node/scheduler/bucket.cpp
@@ -53,6 +53,11 @@ bool nano::scheduler::bucket::empty () const
 	return queue.empty ();
 }
 
+bool nano::scheduler::bucket::available () const
+{
+	return !queue.empty ();
+}
+
 void nano::scheduler::bucket::dump () const
 {
 	for (auto const & item : queue)

--- a/nano/node/scheduler/bucket.hpp
+++ b/nano/node/scheduler/bucket.hpp
@@ -34,6 +34,7 @@ public:
 	void push (uint64_t time, std::shared_ptr<nano::block> block);
 	size_t size () const;
 	bool empty () const;
+	bool available () const;
 	void dump () const;
 };
 } // namespace nano::scheduler

--- a/nano/node/scheduler/bucket.hpp
+++ b/nano/node/scheduler/bucket.hpp
@@ -11,6 +11,7 @@ class block;
 }
 namespace nano::scheduler
 {
+class limiter;
 /** A class which holds an ordered set of blocks to be scheduled, ordered by their block arrival time
  */
 class bucket final
@@ -25,11 +26,12 @@ class bucket final
 	};
 	std::set<value_type> queue;
 	size_t const maximum;
+	std::shared_ptr<nano::scheduler::limiter> limiter;
 
 public:
-	bucket (size_t maximum);
+	bucket (std::shared_ptr<nano::scheduler::limiter> limiter, size_t maximum);
 	~bucket ();
-	std::shared_ptr<nano::block> top () const;
+	std::pair<std::shared_ptr<nano::block>, std::shared_ptr<nano::scheduler::limiter>> top () const;
 	void pop ();
 	void push (uint64_t time, std::shared_ptr<nano::block> block);
 	size_t size () const;

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
+#include <nano/node/election.hpp>
+#include <nano/node/election_insertion_result.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -9,11 +11,13 @@
 
 namespace nano
 {
+class active_transactions;
 class block;
 }
 namespace nano::scheduler
 {
 class bucket;
+class limiter;
 /** A container for holding blocks and their arrival/creation time.
  *
  *  The container consists of a number of buckets. Each bucket holds an ordered set of 'value_type' items.
@@ -40,14 +44,16 @@ class buckets final
 	uint64_t const maximum;
 
 	void next ();
-	void seek ();
 
 public:
-	buckets (uint64_t maximum = 250000u);
+	using insert_t = std::function<nano::election_insertion_result (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior)>;
+
+	buckets (insert_t const & insert, uint64_t maximum = 250000u);
 	~buckets ();
 	void push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & priority);
-	std::shared_ptr<nano::block> top () const;
+	std::pair<std::shared_ptr<nano::block>, std::shared_ptr<nano::scheduler::limiter>> top () const;
 	void pop ();
+	void seek ();
 	std::size_t size () const;
 	std::size_t bucket_count () const;
 	std::size_t bucket_size (std::size_t index) const;

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -52,6 +52,7 @@ public:
 	std::size_t bucket_count () const;
 	std::size_t bucket_size (std::size_t index) const;
 	bool empty () const;
+	bool available () const;
 	void dump () const;
 	std::size_t index (nano::uint128_t const & balance) const;
 

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
+#include <nano/node/election_insertion_result.hpp>
 #include <nano/secure/common.hpp>
 
 #include <condition_variable>
@@ -17,6 +18,7 @@ class online_reps;
 }
 namespace nano::scheduler
 {
+class limiter;
 /*
  * Monitors inactive vote cache and schedules elections with the highest observed vote tally.
  */
@@ -53,7 +55,7 @@ private:
 private: // Dependencies
 	nano::node & node;
 	nano::vote_cache & inactive_vote_cache;
-	nano::active_transactions & active;
+	std::shared_ptr<nano::scheduler::limiter> limiter;
 	nano::online_reps & online_reps;
 	nano::stats & stats;
 

--- a/nano/node/scheduler/limiter.cpp
+++ b/nano/node/scheduler/limiter.cpp
@@ -1,0 +1,63 @@
+#include <nano/lib/locks.hpp>
+#include <nano/lib/stats.hpp>
+#include <nano/node/active_transactions.hpp>
+#include <nano/node/scheduler/limiter.hpp>
+
+#include <boost/format.hpp>
+
+nano::scheduler::limiter::limiter (insert_t const & insert, size_t limit, nano::election_behavior behavior) :
+	insert{ insert },
+	limit_m{ limit },
+	behavior{ behavior }
+{
+	debug_assert (limit > 0);
+}
+
+size_t nano::scheduler::limiter::limit () const
+{
+	return limit_m;
+}
+
+std::unordered_set<nano::qualified_root> nano::scheduler::limiter::elections () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return elections_m;
+}
+
+bool nano::scheduler::limiter::available () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	auto result = elections_m.size () < limit ();
+	return result;
+}
+
+nano::election_insertion_result nano::scheduler::limiter::activate (std::shared_ptr<nano::block> const & block)
+{
+	if (!available ())
+	{
+		return { nullptr, false };
+	}
+
+	// This code section is not synchronous with respect to available ()
+	// It is assumed 'sink' is thread safe and only one call to
+	auto result = insert (block, behavior);
+	if (result.inserted)
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		elections_m.insert (result.election->qualified_root);
+		// Capture via weak_ptr so we don't have to consider destruction order of nano::scheduler::limiter compared to nano::election.
+		result.election->destructor_observers.add ([this_w = std::weak_ptr<nano::scheduler::limiter>{ shared_from_this () }] (nano::qualified_root const & root) {
+			if (auto this_l = this_w.lock ())
+			{
+				this_l->election_destruction_notification (root);
+			}
+		});
+	}
+	return result;
+}
+
+size_t nano::scheduler::limiter::election_destruction_notification (nano::qualified_root const & root)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return elections_m.erase (root);
+}

--- a/nano/node/scheduler/limiter.hpp
+++ b/nano/node/scheduler/limiter.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/stats_enums.hpp>
+#include <nano/node/election_insertion_result.hpp>
+
+#include <memory>
+#include <unordered_set>
+
+namespace nano
+{
+class block;
+class election;
+enum class election_behavior;
+class stats;
+}
+namespace nano::scheduler
+{
+/**
+	This class is a facade around active_transactions that limits the number of elections that can be inserted.
+*/
+class limiter : public std::enable_shared_from_this<limiter>
+{
+public:
+	using insert_t = std::function<nano::election_insertion_result (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior)>;
+
+	limiter (insert_t const & insert, size_t limit, nano::election_behavior behavior);
+	// Checks whether there is availability to insert an election for 'block' and if so, spawns a new election
+	nano::election_insertion_result activate (std::shared_ptr<nano::block> const & block);
+	// Returns whether there is availability to insert a new election
+	bool available () const;
+	// Returns the upper limit on the number of elections allowed to be started
+	size_t limit () const;
+	std::unordered_set<nano::qualified_root> elections () const;
+
+private:
+	size_t election_destruction_notification (nano::qualified_root const & root);
+
+	insert_t insert;
+	size_t const limit_m;
+	nano::election_behavior behavior;
+	// Tracks the elections that have been started through this facade
+	std::unordered_set<nano::qualified_root> elections_m;
+	std::function<nano::election_insertion_result (std::shared_ptr<nano::block> block)> start_election;
+
+	mutable nano::mutex mutex;
+};
+} // namespace nano::scheduler

--- a/nano/node/scheduler/optimistic.hpp
+++ b/nano/node/scheduler/optimistic.hpp
@@ -22,13 +22,14 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class node;
-class ledger;
 class active_transactions;
+class ledger;
+class node;
 }
 
 namespace nano::scheduler
 {
+class limiter;
 class optimistic_config final
 {
 public:
@@ -76,7 +77,7 @@ private: // Dependencies
 	optimistic_config const & config;
 	nano::node & node;
 	nano::ledger & ledger;
-	nano::active_transactions & active;
+	std::shared_ptr<nano::scheduler::limiter> limiter;
 	nano::network_constants const & network_constants;
 	nano::stats & stats;
 

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -88,7 +88,7 @@ bool nano::scheduler::priority::empty () const
 
 bool nano::scheduler::priority::predicate () const
 {
-	return node.active.vacancy () > 0 && !buckets->empty ();
+	return node.active.vacancy () > 0 && buckets->available ();
 }
 
 void nano::scheduler::priority::run ()

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -5,7 +5,7 @@
 nano::scheduler::priority::priority (nano::node & node_a, nano::stats & stats_a) :
 	node{ node_a },
 	stats{ stats_a },
-	buckets{ std::make_unique<scheduler::buckets> () }
+	buckets{ std::make_unique<scheduler::buckets> (node_a.active.insert_fn ()) }
 {
 }
 
@@ -110,7 +110,7 @@ void nano::scheduler::priority::run ()
 				buckets->pop ();
 				lock.unlock ();
 				stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::insert_priority);
-				auto result = node.active.insert (block);
+				auto result = node.active.insert (block.first);
 				if (result.inserted)
 				{
 					stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::insert_priority_success);

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -244,3 +244,5 @@ bool nano::test::start_elections (nano::test::system & system_a, nano::node & no
 {
 	return nano::test::start_elections (system_a, node_a, blocks_to_hashes (blocks_a), forced_a);
 }
+
+std::function<nano::election_insertion_result (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior)> nano::test::active_transactions_insert_null = [] (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior) { return nano::election_insertion_result{}; };

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/timer.hpp>
+#include <nano/node/election_insertion_result.hpp>
 #include <nano/node/transport/channel.hpp>
 #include <nano/node/transport/transport.hpp>
 
@@ -131,6 +132,7 @@ class network_params;
 class vote;
 class block;
 class election;
+enum class election_behavior;
 
 extern nano::uint128_t const & genesis_amount;
 
@@ -418,5 +420,6 @@ namespace test
 	 * NOTE: Each election is given 5 seconds to complete, if it does not complete in 5 seconds, it will return an error.
 	 */
 	[[nodiscard]] bool start_elections (nano::test::system &, nano::node &, std::vector<std::shared_ptr<nano::block>> const &, bool const forced_a = false);
+	extern std::function<nano::election_insertion_result (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior)> active_transactions_insert_null;
 }
 }


### PR DESCRIPTION
The class is a facade around the active_transactions class and exposes a query scheduler::limiter::available to see if there is capacity available and a method scheduler::limiter::insert which checks for availability before inserting an election. Elections are inserted and tracked by the scheduler::limiter class. Coherency is maintained in a lazy manor by holding weak_ptrs to nano::elections and removing them if the pointer has expired or the election is no longer active as reported by active_transactions.

Previous discussion was on this branch https://github.com/nanocurrency/nano-node/pull/4133