### PR TITLE
Remove assert for null block deserialization

### DIFF
--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1415,18 +1415,12 @@ std::shared_ptr<nano::block> nano::deserialize_block (nano::stream & stream_a, n
 			result = ::deserialize_block<nano::state_block> (stream_a);
 			break;
 		}
-		case nano::block_type::not_a_block:
+		default:
 		{
-			// Skip null block terminators
 			return {};
 		}
-		default:
-#ifndef NANO_FUZZER_TEST
-			debug_assert (false);
-#endif
-			break;
 	}
-	if (uniquer_a != nullptr)
+	if (result && uniquer_a != nullptr)
 	{
 		result = uniquer_a->unique (result);
 	}


### PR DESCRIPTION
The `nano::deserialize_block` already properly handles the case where deserialized block type is `block_type::not_a_block` or invalid, however it triggers a debug assertion for those cases. This is not necessary, since this is a normal condition that happens during normal node operation (eg. during bootstrapping). It also makes it impossible to run a debug node build on the live network.