### PR TITLE
Bump Qt version to 5.15.2 for Windows builds

### DIFF
--- a/ci/actions/windows/configure.bat
+++ b/ci/actions/windows/configure.bat
@@ -10,7 +10,7 @@ cmake .. ^
   %CI% ^
   %ROCKS_LIB% ^
   -DPORTABLE=1 ^
-  -DQt5_DIR="c:\qt\5.13.1\msvc2017_64\lib\cmake\Qt5" ^
+  -DQt5_DIR="c:\qt\5.15.2\msvc2019_64\lib\cmake\Qt5" ^
   -DNANO_GUI=ON ^
   -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
   -DACTIVE_NETWORK=nano_%NETWORK_CFG%_network ^

--- a/ci/actions/windows/install_deps.ps1
+++ b/ci/actions/windows/install_deps.ps1
@@ -49,8 +49,8 @@ function Get-RedirectedUri {
     }
 }
 $qt5_root = "c:\qt"
-$qt5base_url = Get-RedirectedUri "https://repo.nano.org/artifacts/5.13.1-0-201909031231qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z"
-$qt5winextra_url = Get-RedirectedUri "https://repo.nano.org/artifacts/5.13.1-0-201909031231qtwinextras-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z"
+$qt5base_url = Get-RedirectedUri "https://repo.nano.org/artifacts/5.15.2-0-202011130602qtbase-Windows-Windows_10-MSVC2019-Windows-Windows_10-X86_64.7z"
+$qt5winextra_url = Get-RedirectedUri "https://repo.nano.org/artifacts/5.15.2-0-202011130602qtwinextras-Windows-Windows_10-MSVC2019-Windows-Windows_10-X86_64.7z"
 $qt5base_artifact = "${env:TMP}\qt5base.7z"
 $qt5winextra_artifact = "${env:TMP}\qt5winextra.7z"
 


### PR DESCRIPTION
Bumps the Qt version to 5.15.2 for Windows builds. This change makes the builds compatible with the recent compiler related upgrades for C++20.