### PR TITLE
Log hashes of build artifacts

### DIFF
--- a/ci/actions/deploy.sh
+++ b/ci/actions/deploy.sh
@@ -26,44 +26,39 @@ if [[ "$OS" == 'Linux' && "$IS_RPM_DEPLOY" -eq "1" ]]; then
 
     for rpm in $RPMS; do
         SHA=$(sha256sum ${rpm})
-        echo "${rpm}: $SHA"
-        echo $SHA > "${rpm}.sha256"
+        echo $SHA
+        echo $SHA > ${GITHUB_WORKSPACE}/$(basename "${rpm}.sha256")
 
-        aws s3 cp "${rpm}" s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-        aws s3 cp "${rpm}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp ${rpm} s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp ${GITHUB_WORKSPACE}/$(basename "${rpm}.sha256") s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     done
-
+    
     for srpm in $SRPMS; do
         SHA=$(sha256sum ${srpm})
-        echo "${srpm}: $SHA"
-        echo $SHA > "${srpm}.sha256"
+        echo $SHA
+        echo $SHA > ${GITHUB_WORKSPACE}/$(basename "${srpm}).sha256")
 
-        aws s3 cp "${srpm}" s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-        aws s3 cp "${srpm}.sha256" s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp ${srpm} s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp ${GITHUB_WORKSPACE}/$(basename "${srpm}).sha256") s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     done
 elif [[ "$OS" == 'Linux' ]]; then
-    TAR_PATH=$GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2
-    DEB_PATH=$GITHUB_WORKSPACE/build/nano-node-*-Linux.deb
+    SHA=$(sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2)
+    echo $SHA
+    echo $SHA >$GITHUB_WORKSPACE/nano-node-$TAG-Linux.tar.bz2.sha256
 
-    SHA=$(sha256sum $TAR_PATH)
-    echo "${TAR_PATH}: $SHA"
-    echo $SHA > "${TAR_PATH}.sha256"
+    SHA=$(sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Linux.deb)
+    echo $SHA
+    echo $SHA >$GITHUB_WORKSPACE/nano-node-$TAG-Linux.deb.sha256
 
-    SHA=$(sha256sum $DEB_PATH)
-    echo "${DEB_PATH}: $SHA"
-    echo $SHA > "${DEB_PATH}.sha256"
-
-    aws s3 cp "${TAR_PATH}" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp "${TAR_PATH}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp "${DEB_PATH}" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp "${DEB_PATH}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp $GITHUB_WORKSPACE/nano-node-$TAG-Linux.tar.bz2.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Linux.deb s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp $GITHUB_WORKSPACE/nano-node-$TAG-Linux.deb.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 else
-    DMG_PATH=$GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg
+    SHA=$(sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg)
+    echo $SHA
+    echo $SHA >$GITHUB_WORKSPACE/build/nano-node-$TAG-Darwin.dmg.sha256
 
-    SHA=$(sha256sum $DMG_PATH)
-    echo "${DMG_PATH}: $SHA"
-    echo $SHA > "${DMG_PATH}.sha256"
-    
-    aws s3 cp "${DMG_PATH}" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp "${DMG_PATH}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-$TAG-Darwin.dmg.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 fi

--- a/ci/actions/deploy.sh
+++ b/ci/actions/deploy.sh
@@ -26,7 +26,7 @@ if [[ "$OS" == 'Linux' && "$IS_RPM_DEPLOY" -eq "1" ]]; then
 
     for rpm in $RPMS; do
         SHA=$(sha256sum ${rpm})
-        echo $SHA
+        echo "Hash: $SHA"
         echo $SHA > ${GITHUB_WORKSPACE}/$(basename "${rpm}.sha256")
 
         aws s3 cp ${rpm} s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
@@ -35,7 +35,7 @@ if [[ "$OS" == 'Linux' && "$IS_RPM_DEPLOY" -eq "1" ]]; then
     
     for srpm in $SRPMS; do
         SHA=$(sha256sum ${srpm})
-        echo $SHA
+        echo "Hash: $SHA"
         echo $SHA > ${GITHUB_WORKSPACE}/$(basename "${srpm}).sha256")
 
         aws s3 cp ${srpm} s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
@@ -43,11 +43,11 @@ if [[ "$OS" == 'Linux' && "$IS_RPM_DEPLOY" -eq "1" ]]; then
     done
 elif [[ "$OS" == 'Linux' ]]; then
     SHA=$(sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2)
-    echo $SHA
+    echo "Hash: $SHA"
     echo $SHA >$GITHUB_WORKSPACE/nano-node-$TAG-Linux.tar.bz2.sha256
 
     SHA=$(sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Linux.deb)
-    echo $SHA
+    echo "Hash: $SHA"
     echo $SHA >$GITHUB_WORKSPACE/nano-node-$TAG-Linux.deb.sha256
 
     aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
@@ -56,7 +56,7 @@ elif [[ "$OS" == 'Linux' ]]; then
     aws s3 cp $GITHUB_WORKSPACE/nano-node-$TAG-Linux.deb.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 else
     SHA=$(sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg)
-    echo $SHA
+    echo "Hash: $SHA"
     echo $SHA >$GITHUB_WORKSPACE/build/nano-node-$TAG-Darwin.dmg.sha256
 
     aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers

--- a/ci/actions/deploy.sh
+++ b/ci/actions/deploy.sh
@@ -23,25 +23,47 @@ fi
 if [[ "$OS" == 'Linux' && "$IS_RPM_DEPLOY" -eq "1" ]]; then
     RPMS=$(find ${GITHUB_WORKSPACE}/artifacts/RPMS -type f -name '*.rpm')
     SRPMS=$(find ${GITHUB_WORKSPACE}/artifacts/SRPMS -type f -name '*.src.rpm')
+
     for rpm in $RPMS; do
-        sha256sum ${rpm} > ${GITHUB_WORKSPACE}/$(basename "${rpm}.sha256")
-        aws s3 cp ${rpm} s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-        aws s3 cp ${GITHUB_WORKSPACE}/$(basename "${rpm}.sha256") s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        SHA=$(sha256sum ${rpm})
+        echo "${rpm}: $SHA"
+        echo $SHA > "${rpm}.sha256"
+
+        aws s3 cp "${rpm}" s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp "${rpm}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/$(basename "${rpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     done
+
     for srpm in $SRPMS; do
-        sha256sum ${srpm} > ${GITHUB_WORKSPACE}/$(basename "${srpm}).sha256")
-        aws s3 cp ${srpm} s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-        aws s3 cp ${GITHUB_WORKSPACE}/$(basename "${srpm}).sha256") s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        SHA=$(sha256sum ${srpm})
+        echo "${srpm}: $SHA"
+        echo $SHA > "${srpm}.sha256"
+
+        aws s3 cp "${srpm}" s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp "${srpm}.sha256" s3://repo.nano.org/$DIRECTORY/source/$(basename "${srpm}.sha256") --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     done
 elif [[ "$OS" == 'Linux' ]]; then
-    sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2 >$GITHUB_WORKSPACE/nano-node-$TAG-Linux.tar.bz2.sha256
-    sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Linux.deb >$GITHUB_WORKSPACE/nano-node-$TAG-Linux.deb.sha256
-    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp $GITHUB_WORKSPACE/nano-node-$TAG-Linux.tar.bz2.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Linux.deb s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp $GITHUB_WORKSPACE/nano-node-$TAG-Linux.deb.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    TAR_PATH=$GITHUB_WORKSPACE/build/nano-node-*-Linux.tar.bz2
+    DEB_PATH=$GITHUB_WORKSPACE/build/nano-node-*-Linux.deb
+
+    SHA=$(sha256sum $TAR_PATH)
+    echo "${TAR_PATH}: $SHA"
+    echo $SHA > "${TAR_PATH}.sha256"
+
+    SHA=$(sha256sum $DEB_PATH)
+    echo "${DEB_PATH}: $SHA"
+    echo $SHA > "${DEB_PATH}.sha256"
+
+    aws s3 cp "${TAR_PATH}" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp "${TAR_PATH}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.tar.bz2.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp "${DEB_PATH}" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp "${DEB_PATH}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Linux.deb.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 else
-    sha256sum $GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg >$GITHUB_WORKSPACE/build/nano-node-$TAG-Darwin.dmg.sha256
-    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    aws s3 cp $GITHUB_WORKSPACE/build/nano-node-$TAG-Darwin.dmg.sha256 s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    DMG_PATH=$GITHUB_WORKSPACE/build/nano-node-*-Darwin.dmg
+
+    SHA=$(sha256sum $DMG_PATH)
+    echo "${DMG_PATH}: $SHA"
+    echo $SHA > "${DMG_PATH}.sha256"
+    
+    aws s3 cp "${DMG_PATH}" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    aws s3 cp "${DMG_PATH}.sha256" s3://repo.nano.org/$DIRECTORY/binaries/nano-node-$TAG-Darwin.dmg.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 fi

--- a/ci/actions/windows/deploy.ps1
+++ b/ci/actions/windows/deploy.ps1
@@ -20,10 +20,16 @@ else {
 $exe = Resolve-Path -Path $env:GITHUB_WORKSPACE\build\nano-node-*-win64.exe
 $zip = Resolve-Path -Path $env:GITHUB_WORKSPACE\build\nano-node-*-win64.zip
 
-((Get-FileHash $exe).hash)+" "+(split-path -Path $exe -Resolve -leaf) | Out-file -FilePath "$exe.sha256"
-((Get-FileHash $zip).hash)+" "+(split-path -Path $zip -Resolve -leaf) | Out-file -FilePath "$zip.sha256"
+$exe_hash = ((Get-FileHash $exe).hash)+" "+(split-path -Path $exe -Resolve -leaf)
+$zip_hash = ((Get-FileHash $zip).hash)+" "+(split-path -Path $zip -Resolve -leaf)
 
-aws s3 cp $exe s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.exe --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+$exe_hash | Out-file -FilePath "$exe.sha256"
+$zip_hash | Out-file -FilePath "$zip.sha256"
+
+Write-Output "Exe hash: $exe_hash"
+Write-Output "Zip hash: $zip_hash"
+
+aws s3 cp "$exe" s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.exe --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 aws s3 cp "$exe.sha256" s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.exe.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 aws s3 cp "$zip" s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.zip --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 aws s3 cp "$zip.sha256" s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.zip.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers

--- a/ci/actions/windows/deploy.ps1
+++ b/ci/actions/windows/deploy.ps1
@@ -26,8 +26,8 @@ $zip_hash = ((Get-FileHash $zip).hash)+" "+(split-path -Path $zip -Resolve -leaf
 $exe_hash | Out-file -FilePath "$exe.sha256"
 $zip_hash | Out-file -FilePath "$zip.sha256"
 
-Write-Output "Exe hash: $exe_hash"
-Write-Output "Zip hash: $zip_hash"
+Write-Output "Hash: $exe_hash"
+Write-Output "Hash: $zip_hash"
 
 aws s3 cp "$exe" s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.exe --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 aws s3 cp "$exe.sha256" s3://repo.nano.org/$directory/binaries/nano-node-$env:TAG-win64.exe.sha256 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers


### PR DESCRIPTION
Having access to original file hashes is necessary for auditing node releases.