### PR TITLE
Remove the call for signing.ps1 on Windows builds

### DIFF
--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -55,6 +55,7 @@ if (${LastExitCode} -ne 0) {
     throw "Failed to build ${env:RUN}"
 }
 
-. "$PSScriptRoot\signing.ps1"
+# TODO: fix the signing script.
+#. "$PSScriptRoot\signing.ps1"
 
 Pop-Location


### PR DESCRIPTION
This complements the changes made by the PR: https://github.com/nanocurrency/nano-node/pull/4242